### PR TITLE
feat(monofs): add create_entity method to Dir

### DIFF
--- a/monofs/lib/filesystem/dir.rs
+++ b/monofs/lib/filesystem/dir.rs
@@ -254,11 +254,11 @@ where
 
     /// Adds an [`Entity`] and its associated name in the directory's entries.
     #[inline]
-    pub fn put_entity(&mut self, name: impl AsRef<str>, entity: Entity<S>) -> FsResult<()>
+    pub fn put_entity(&mut self, name: impl AsRef<str>, entity: impl Into<Entity<S>>) -> FsResult<()>
     where
         S: Send + Sync,
     {
-        self.put_entry(name, EntityCidLink::from(entity))
+        self.put_entry(name, EntityCidLink::from(entity.into()))
     }
 
     /// Adds a [`Dir`] and its associated name in the directory's entries.


### PR DESCRIPTION
Add a new method `create_entity` to the Dir struct that creates an entity at a specified path without creating intermediate directories. This provides more granular control over entity creation compared to find_or_create.

- Add create_entity method with comprehensive documentation and examples
- Update put_entity to accept impl Into<Entity<S>> for better ergonomics
- Add extensive test coverage for the new functionality
