### PR TITLE
feat(monofs): improve NFS mount reliability and filesystem tracking

### DIFF
--- a/monofs/lib/runtime/monitor.rs
+++ b/monofs/lib/runtime/monitor.rs
@@ -88,7 +88,7 @@ impl ProcessMonitor for NfsServerMonitor {
         mut stderr: ChildStderr,
     ) -> MonoutilsResult<()> {
         // Setup child's log
-        let log_name = self.generate_log_name(pid, name);
+        let log_name = self.generate_log_name(pid, &name);
         let log_path = self.log_dir.join(&log_name);
 
         let nfs_server_log = RotatingLog::new(&log_path).await?;
@@ -100,10 +100,11 @@ impl ProcessMonitor for NfsServerMonitor {
         // Insert filesystem entry into fs_db
         sqlx::query(
             r#"
-            INSERT INTO filesystems (mount_dir, supervisor_pid, nfsserver_pid)
-            VALUES (?, ?, ?)
+            INSERT INTO filesystems (name, mount_dir, supervisor_pid, nfsserver_pid)
+            VALUES (?, ?, ?, ?)
             "#,
         )
+        .bind(name)
         .bind(self.mount_dir.to_string_lossy().to_string())
         .bind(self.supervisor_pid)
         .bind(pid)


### PR DESCRIPTION
- Add wait_for_port helper to ensure NFS port is ready before mounting
- Track mount operation timing and add logging
- Store filesystem name in database
- Fix --fs-db-path argument name
- Add timing metrics for mount operations

The main improvement is preventing premature mount attempts that would
cause long retry loops, particularly on macOS. This is achieved by actively
checking port availability before attempting to mount.