### PR TITLE
feat(monocore): add overlayfs support and remove monofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,10 @@ private
 .DS_Store
 
 # monocore
-monocore.toml
-monocore.yaml
 ignore/
 build/
 monocore/build/
 libkrunfw.*
 libkrun.*
 .menv/
+Sandboxfile

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,6 @@ HOME_BIN := $(HOME)/.local/bin
 # -----------------------------------------------------------------------------
 MONOCORE_RELEASE_BIN := target/release/monocore
 MCRUN_RELEASE_BIN := target/release/mcrun
-MONOFS_RELEASE_BIN := target/release/monofs
-MFSRUN_RELEASE_BIN := target/release/mfsrun
 EXAMPLES_DIR := target/release/examples
 BENCHES_DIR := target/release
 BUILD_DIR := build
@@ -45,7 +43,7 @@ endif
 # -----------------------------------------------------------------------------
 # Phony Targets Declaration
 # -----------------------------------------------------------------------------
-.PHONY: all build install clean build_libkrun example bench bin _run_example _run_bench _run_bin help uninstall monocore monofs
+.PHONY: all build install clean build_libkrun example bench bin _run_example _run_bench _run_bin help uninstall monocore
 
 # -----------------------------------------------------------------------------
 # Main Targets
@@ -54,17 +52,11 @@ all: build
 
 build: build_libkrun
 	@$(MAKE) _build_monocore
-	@$(MAKE) _build_monofs
 
 _build_monocore: $(MONOCORE_RELEASE_BIN) $(MCRUN_RELEASE_BIN)
 	@cp $(MONOCORE_RELEASE_BIN) $(BUILD_DIR)/
 	@cp $(MCRUN_RELEASE_BIN) $(BUILD_DIR)/
 	@echo "Monocore build artifacts copied to $(BUILD_DIR)/"
-
-_build_monofs: $(MONOFS_RELEASE_BIN) $(MFSRUN_RELEASE_BIN)
-	@cp $(MONOFS_RELEASE_BIN) $(BUILD_DIR)/
-	@cp $(MFSRUN_RELEASE_BIN) $(BUILD_DIR)/
-	@echo "Monofs build artifacts copied to $(BUILD_DIR)/"
 
 # -----------------------------------------------------------------------------
 # Binary Building
@@ -87,12 +79,6 @@ else
 	RUSTFLAGS="-C link-args=-Wl,-rpath,\$$ORIGIN/../lib,-rpath,\$$ORIGIN" cargo build --release --bin mcrun $(FEATURES)
 endif
 
-$(MONOFS_RELEASE_BIN):
-	cd monofs && cargo build --release --bin monofs $(FEATURES)
-
-$(MFSRUN_RELEASE_BIN):
-	cd monofs && cargo build --release --bin mfsrun $(FEATURES)
-
 # -----------------------------------------------------------------------------
 # Installation
 # -----------------------------------------------------------------------------
@@ -101,8 +87,6 @@ install: build
 	install -d $(HOME_LIB)
 	install -m 755 $(BUILD_DIR)/monocore $(HOME_BIN)/monocore
 	install -m 755 $(BUILD_DIR)/mcrun $(HOME_BIN)/mcrun
-	install -m 755 $(BUILD_DIR)/monofs $(HOME_BIN)/monofs
-	install -m 755 $(BUILD_DIR)/mfsrun $(HOME_BIN)/mfsrun
 	ln -sf $(HOME_BIN)/monocore $(HOME_BIN)/mc
 	@if [ -n "$(LIBKRUNFW_FILE)" ]; then \
 		install -m 755 $(LIBKRUNFW_FILE) $(HOME_LIB)/; \
@@ -155,8 +139,6 @@ clean:
 uninstall:
 	rm -f $(HOME_BIN)/monocore
 	rm -f $(HOME_BIN)/mcrun
-	rm -f $(HOME_BIN)/monofs
-	rm -f $(HOME_BIN)/mfsrun
 	rm -f $(HOME_BIN)/mc
 	rm -f $(HOME_LIB)/libkrunfw.dylib
 	rm -f $(HOME_LIB)/libkrun.dylib
@@ -182,7 +164,7 @@ help:
 	@echo "======================"
 	@echo
 	@echo "Main Targets:"
-	@echo "  make build                  - Build all components (monocore and monofs)"
+	@echo "  make build                  - Build monocore components"
 	@echo "  make install                - Install binaries and libraries to ~/.local/{bin,lib}"
 	@echo "  make uninstall              - Remove all installed components"
 	@echo "  make clean                  - Remove build artifacts"

--- a/monocore/bin/monocore.rs
+++ b/monocore/bin/monocore.rs
@@ -1,8 +1,15 @@
 use clap::{CommandFactory, Parser};
 use monocore::{
     cli::{MonocoreArgs, MonocoreSubcommand},
-    management, MonocoreResult,
+    config::DEFAULT_SCRIPT,
+    management, MonocoreError, MonocoreResult,
 };
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const SANDBOX_SCRIPT_SEPARATOR: char = '~';
 
 //--------------------------------------------------------------------------------------------------
 // Functions: main
@@ -15,7 +22,21 @@ async fn main() -> MonocoreResult<()> {
     // Parse command line arguments
     let args = MonocoreArgs::parse();
     match args.subcommand {
-        Some(MonocoreSubcommand::Init { path }) => {
+        Some(MonocoreSubcommand::Init {
+            path,
+            path_with_flag,
+        }) => {
+            let path = match (path, path_with_flag) {
+                (Some(path), None) => Some(path),
+                (None, Some(path)) => Some(path),
+                (Some(_), Some(_)) => {
+                    return Err(MonocoreError::InvalidArgument(
+                        "Please use only one method to specify the path.".to_string(),
+                    ));
+                }
+                (None, None) => None,
+            };
+
             tracing::trace!("initializing monocore project: path={path:?}");
             management::init_menv(path).await?;
         }
@@ -29,15 +50,35 @@ async fn main() -> MonocoreResult<()> {
             management::pull_image(name, image, image_group, layer_path).await?;
         }
         Some(MonocoreSubcommand::Run {
-            sandbox,
-            name,
-            script,
+            sandbox_script,
+            sandbox_script_with_flag,
             args,
             path,
             config,
         }) => {
-            tracing::trace!("running sandbox: name={name}, sandbox={sandbox}, script={script:?}, args={args:?}, path={path:?}");
-            management::run_sandbox(&name, script, args, path, config).await?;
+            let sandbox_script = match (sandbox_script, sandbox_script_with_flag) {
+                (Some(name), None) => name,
+                (None, Some(name)) => name,
+                (Some(_), Some(_)) => {
+                    return Err(MonocoreError::InvalidArgument(
+                        "Please use only one method to specify the sandbox.".to_string(),
+                    ));
+                }
+                (None, None) => {
+                    return Err(MonocoreError::InvalidArgument(
+                        "Must specify a sandbox name".to_string(),
+                    ));
+                }
+            };
+
+            // Split the sandbox script into sandbox name and script name
+            let (sandbox, script) = match sandbox_script.split_once(SANDBOX_SCRIPT_SEPARATOR) {
+                Some((sandbox, script)) => (sandbox.to_string(), script.to_string()),
+                None => (sandbox_script, DEFAULT_SCRIPT.to_string()),
+            };
+
+            tracing::trace!("running sandbox: sandbox={sandbox}, script={script:?}, args={args:?}, path={path:?}");
+            management::run_sandbox(&sandbox, script, args, path, config).await?;
         }
         Some(_) => (), // TODO: implement other subcommands
         None => {

--- a/monocore/lib/cli/args/mcrun.rs
+++ b/monocore/lib/cli/args/mcrun.rs
@@ -26,9 +26,13 @@ pub enum McrunSubcommand {
         #[arg(long)]
         log_level: Option<u8>,
 
-        /// Root filesystem path
+        /// Native root filesystem path
         #[arg(long)]
-        root_path: PathBuf,
+        native_rootfs: Option<PathBuf>,
+
+        /// Overlayfs root filesystem layers
+        #[arg(long)]
+        overlayfs_layer: Vec<PathBuf>,
 
         /// Number of virtual CPUs
         #[arg(long)]
@@ -47,15 +51,15 @@ pub enum McrunSubcommand {
         exec_path: String,
 
         /// Environment variables (KEY=VALUE format)
-        #[arg(long, use_value_delimiter = true, value_delimiter = ',')]
+        #[arg(long)]
         env: Vec<String>,
 
         /// Directory mappings (host:guest format)
-        #[arg(long, use_value_delimiter = true, value_delimiter = ',')]
-        mapped_dirs: Vec<String>,
+        #[arg(long)]
+        mapped_dir: Vec<String>,
 
         /// Port mappings (host:guest format)
-        #[arg(long, use_value_delimiter = true, value_delimiter = ',')]
+        #[arg(long)]
         port_map: Vec<String>,
 
         /// Additional arguments after `--`
@@ -85,9 +89,13 @@ pub enum McrunSubcommand {
         forward_output: bool,
 
         // Sandbox specific arguments
-        /// Root filesystem path
+        /// Native root filesystem path
         #[arg(long)]
-        root_path: PathBuf,
+        native_rootfs: Option<PathBuf>,
+
+        /// Overlayfs root filesystem layers
+        #[arg(long)]
+        overlayfs_layer: Vec<PathBuf>,
 
         /// Number of virtual CPUs
         #[arg(long)]
@@ -106,15 +114,15 @@ pub enum McrunSubcommand {
         exec_path: String,
 
         /// Environment variables (KEY=VALUE format)
-        #[arg(long, use_value_delimiter = true, value_delimiter = ',')]
+        #[arg(long)]
         env: Vec<String>,
 
         /// Directory mappings (host:guest format)
-        #[arg(long, use_value_delimiter = true, value_delimiter = ',')]
-        mapped_dirs: Vec<String>,
+        #[arg(long)]
+        mapped_dir: Vec<String>,
 
         /// Port mappings (host:guest format)
-        #[arg(long, use_value_delimiter = true, value_delimiter = ',')]
+        #[arg(long)]
         port_map: Vec<String>,
 
         /// Additional arguments after `--`

--- a/monocore/lib/cli/args/monocore.rs
+++ b/monocore/lib/cli/args/monocore.rs
@@ -31,9 +31,17 @@ pub enum MonocoreSubcommand {
     /// Initialize a new monocore project
     #[command(name = "init")]
     Init {
-        /// Path to initialize the project in
-        #[arg(short, long)]
+        /// A positional argument for specifying the directory to initialize the project in
+        ///
+        /// This argument is mutually exclusive with the `--path` flag
+        #[arg(required = false, conflicts_with = "path_with_flag", name = "PATH")]
         path: Option<PathBuf>,
+
+        /// A flag for specifying the directory to initialize the project in
+        ///
+        /// This flag is mutually exclusive with the positional argument
+        #[arg(short, long = "path", conflicts_with = "path", name = "PATH")]
+        path_with_flag: Option<PathBuf>,
     },
 
     /// Add a new build, sandbox, or group component to the project
@@ -203,17 +211,18 @@ pub enum MonocoreSubcommand {
     /// Run a sandbox script
     #[command(name = "run")]
     Run {
-        /// Target sandbox
-        #[arg(short, long, default_value_t = true)]
-        sandbox: bool,
+        /// Positional argument for specifying the sandbox and script to run
+        #[arg(conflicts_with = "sandbox_script_with_flag", name = "SANDBOX~SCRIPT")]
+        sandbox_script: Option<String>,
 
-        /// Name of the sandbox
-        #[arg(required = true)]
-        name: String,
-
-        /// Script to run
-        #[arg(default_value = DEFAULT_SCRIPT)]
-        script: String,
+        /// Flag for specifying the sandbox and script to run
+        #[arg(
+            short,
+            long = "sandbox",
+            conflicts_with = "sandbox_script",
+            name = "SANDBOX~SCRIPT"
+        )]
+        sandbox_script_with_flag: Option<String>,
 
         /// Additional arguments after `--`
         #[arg(last = true)]

--- a/monocore/lib/config/defaults.rs
+++ b/monocore/lib/config/defaults.rs
@@ -17,7 +17,10 @@ pub static DEFAULT_MONOCORE_HOME: LazyLock<PathBuf> =
     LazyLock::new(|| dirs::home_dir().unwrap().join(MONOCORE_HOME_DIR));
 
 /// The default OCI registry domain.
-pub const DEFAULT_OCI_REGISTRY: &str = "docker.io";
+pub const DEFAULT_OCI_REGISTRY: &str = "sandboxes.io";
+
+/// The default monocore config file name.
+pub const DEFAULT_MONOCORE_CONFIG_FILENAME: &str = "Sandboxfile";
 
 /// The default OCI reference tag.
 pub const DEFAULT_OCI_REFERENCE_TAG: &str = "latest";
@@ -29,6 +32,9 @@ pub const DEFAULT_OCI_REFERENCE_REPO_NAMESPACE: &str = "library";
 pub(crate) const DEFAULT_CONFIG: &str = r#"# Sandbox configurations
 sandboxes: []
 "#;
+
+/// The default namespace for the menv patch and rootfs directories.
+pub const DEFAULT_MENV_NAMESPACE: &str = "default";
 
 /// The default shell to use for the sandbox.
 pub const DEFAULT_SHELL: &str = "/bin/sh";

--- a/monocore/lib/management/migrations/sandbox/20250128014823_create_sandboxes.up.sql
+++ b/monocore/lib/management/migrations/sandbox/20250128014823_create_sandboxes.up.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS sandboxes (
     supervisor_pid INTEGER,
     microvm_pid INTEGER,
     status TEXT NOT NULL,
-    root_path TEXT NOT NULL,
+    rootfs_paths TEXT NOT NULL,
     group_id INTEGER,
     group_ip TEXT,
     config TEXT,

--- a/monocore/lib/management/rootfs.rs
+++ b/monocore/lib/management/rootfs.rs
@@ -64,7 +64,6 @@ pub fn patch_rootfs_with_sandbox_scripts(
 
     // Get shell path as string for shebang
     let shell_path = shell_path.as_ref().to_string_lossy();
-
     for (script_name, script_content) in scripts.iter() {
         // Create script file path
         let script_path = scripts_dir.join(script_name);

--- a/monocore/lib/utils/path.rs
+++ b/monocore/lib/utils/path.rs
@@ -26,8 +26,8 @@ pub const LOG_SUBDIR: &str = "log";
 /// The directory where global image layers are stored
 pub const LAYERS_SUBDIR: &str = "layers";
 
-/// The directory where project scripts are stored
-pub const SCRIPTS_SUBDIR: &str = "scripts";
+/// The directory where the rootfs patches are stored
+pub const PATCH_SUBDIR: &str = "patch";
 
 /// The directory where monocore's installed binaries are stored
 pub const BIN_SUBDIR: &str = "bin";
@@ -40,9 +40,6 @@ pub const OCI_DB_FILENAME: &str = "oci.db";
 
 /// The filename for the monoimage database
 pub const MONOIMAGE_DB_FILENAME: &str = "monoimage.db";
-
-/// The filename for the monocore config file
-pub const MONOCORE_CONFIG_FILENAME: &str = "monocore.yaml";
 
 /// The prefix for mcrun log files
 pub const MCRUN_LOG_PREFIX: &str = "mcrun";

--- a/monocore/lib/vm/ffi.rs
+++ b/monocore/lib/vm/ffi.rs
@@ -43,13 +43,51 @@ extern "C" {
     /// * `ram_mib` - The amount of RAM in MiB.
     pub(crate) fn krun_set_vm_config(ctx_id: u32, num_vcpus: u8, ram_mib: u32) -> i32;
 
-    /// Sets the path to be use as root for the MicroVm. Not available in libkrun-SEV.
+    /// Sets the path to be used as root for the MicroVm.
+    ///
+    /// Not available in libkrun-SEV.
     ///
     /// ## Arguments
     ///
     /// * `ctx_id` - The configuration context ID.
     /// * `root_path` - The path to be used as root.
+    ///
+    /// ## Returns
+    ///
+    /// Returns 0 on success or a negative error code on failure.
+    ///
+    /// ## Errors
+    ///
+    /// * `-EEXIST` - A root device is already set
+    ///
+    /// ## Notes
+    ///
+    /// This function is mutually exclusive with `krun_set_overlayfs_root`.
     pub(crate) fn krun_set_root(ctx_id: u32, root_path: *const c_char) -> i32;
+
+    /// Sets up an OverlayFS to be used as root for the MicroVm.
+    ///
+    /// Not available in libkrun-SEV.
+    ///
+    /// ## Arguments
+    ///
+    /// * `ctx_id` - The configuration context ID.
+    /// * `root_layers` - A null-terminated array of string pointers representing filesystem paths
+    ///   to be used as layers for the OverlayFS. Must contain at least one layer.
+    ///
+    /// ## Returns
+    ///
+    /// Returns 0 on success or a negative error code on failure.
+    ///
+    /// ## Errors
+    ///
+    /// * `-EINVAL` - No layers are provided
+    /// * `-EEXIST` - A root device is already set
+    ///
+    /// ## Notes
+    ///
+    /// This function is mutually exclusive with `krun_set_root`.
+    pub(crate) fn krun_set_overlayfs_root(ctx_id: u32, root_layers: *const *const c_char) -> i32;
 
     /// Adds a disk image to be used as a general partition for the MicroVm.
     ///

--- a/roadmap.md
+++ b/roadmap.md
@@ -35,7 +35,7 @@
 |                   | • `list`               |  ⬜️   | List sandboxes, builds, or groups                        |
 |                   | • `log`                |  ⬜️   | View component logs with filtering                       |
 |                   | • `tree`               |  ⬜️   | Display component layer hierarchy                        |
-|                   | • `run`                |  ⬜️   | Execute defined component scripts                        |
+|                   | • `run`                |  ✅  | Execute defined component scripts                        |
 |                   | • `start`              |  ⬜️   | Execute component start scripts                          |
 |                   | • `shell`              |  ⬜️   | Interactive sandbox shell access                         |
 |                   | • `tmp`                |  ⬜️   | Temporary sandbox creation from images                   |
@@ -73,7 +73,7 @@
 |                   | ghcr Registry          |  ⬜️   | Integration with GitHub Container Registry               |
 |                   | Quay Registry          |  ⬜️   | Integration with Red Hat Quay registry                   |
 | **📊 Web UI**     |
-|                   | Dashboard                |  ⬜️   | Sandbox dashboard                                            |
+|                   | Dashboard              |  ⬜️   | Sandbox dashboard                                        |
 | **🔌 SDK**        |
 |                   | Python SDK             |  ⬜️   | Sandbox orchestration with Python                        |
 |                   | TypeScript SDK         |  ⬜️   | Sandbox orchestration with TypeScript                    |

--- a/scripts/build_libkrun.sh
+++ b/scripts/build_libkrun.sh
@@ -216,12 +216,13 @@ clone_repo() {
 
   local repo_url="$1"
   local repo_name="$2"
+  shift 2  # Remove the first two arguments, leaving any additional args
 
   if [ -d "$repo_name" ]; then
     info "$repo_name directory already exists. Skipping cloning..."
   else
     info "Cloning $repo_name repository..."
-    git clone "$repo_url"
+    git clone "$repo_url" "$@"  # Pass any remaining arguments to git clone
     check_success "Failed to clone $repo_name repository"
   fi
 }
@@ -350,7 +351,7 @@ fi
 check_existing_lib "libkrun"
 if [ $? -eq 0 ]; then
     create_build_directory
-    clone_repo "$LIBKRUN_REPO" "libkrun"
+    clone_repo "$LIBKRUN_REPO" "libkrun" -b appcypher/overlayfs-macos-api --single-branch
     build_libkrun
 fi
 


### PR DESCRIPTION
This commit adds overlayfs support to monocore and removes monofs components.

Key changes:
- Added Rootfs enum with Native and Overlayfs variants
- Updated libkrun FFI to support overlayfs root configuration
- Simplified sandbox namespace handling in .menv directory
- Updated build scripts to use libkrun branch with overlayfs support
- Removed monocore.toml/yaml in favor of Sandboxfile
- Added automatic .menv directory to gitignore during init
- Removed monofs components and related build targets
- Changed MicroVM builder API to use Rootfs enum instead of root_path
- Updated mcrun CLI arguments to support both native and overlayfs rootfs
- Changed monocore CLI to use sandbox~script format for run command
- Changed environment variables and port maps to use repeated flags
