### PR TITLE
refactor(monocore): improve sandbox management and configuration 

### DIFF
--- a/monocore/bin/mcrun.rs
+++ b/monocore/bin/mcrun.rs
@@ -166,8 +166,9 @@ async fn main() -> Result<()> {
         }
         McrunSubcommand::Supervisor {
             log_dir,
-            child_name,
             sandbox_db_path,
+            sandbox_name,
+            config_file,
             log_level,
             forward_output,
             native_rootfs,
@@ -206,6 +207,8 @@ async fn main() -> Result<()> {
             let process_monitor = MicroVmMonitor::new(
                 supervisor_pid,
                 sandbox_db_path,
+                sandbox_name,
+                config_file,
                 log_dir.clone(),
                 rootfs.clone(),
                 Duration::days(1),
@@ -287,14 +290,8 @@ async fn main() -> Result<()> {
             }
 
             // Create and start supervisor
-            let mut supervisor = Supervisor::new(
-                child_exe,
-                child_args,
-                child_envs,
-                child_name,
-                log_dir,
-                process_monitor,
-            );
+            let mut supervisor =
+                Supervisor::new(child_exe, child_args, child_envs, log_dir, process_monitor);
 
             supervisor.start().await?;
         }

--- a/monocore/bin/monocore.rs
+++ b/monocore/bin/monocore.rs
@@ -40,7 +40,7 @@ async fn main() -> MonocoreResult<()> {
                 }
                 (None, None) => None,
             };
-            menv::init_menv(path).await?;
+            menv::initialize(path).await?;
         }
         Some(MonocoreSubcommand::Pull {
             image,
@@ -48,7 +48,7 @@ async fn main() -> MonocoreResult<()> {
             name,
             layer_path,
         }) => {
-            image::pull_image(name, image, image_group, layer_path).await?;
+            image::pull(name, image, image_group, layer_path).await?;
         }
         Some(MonocoreSubcommand::Run {
             sandbox_script,
@@ -64,7 +64,7 @@ async fn main() -> MonocoreResult<()> {
             )?;
             let (sandbox, script) = parse_name_and_script(&sandbox_script);
 
-            sandbox::run_sandbox(&sandbox, script, path, config, args).await?;
+            sandbox::run(&sandbox, script, path, config.as_deref(), args).await?;
         }
         Some(MonocoreSubcommand::Start {
             sandbox,
@@ -75,7 +75,7 @@ async fn main() -> MonocoreResult<()> {
         }) => {
             let sandbox =
                 determine_name_from_positional_or_flag_args(sandbox, sandbox_with_flag, "sandbox")?;
-            sandbox::run_sandbox(&sandbox, START_SCRIPT, path, config, args).await?;
+            sandbox::run(&sandbox, START_SCRIPT, path, config.as_deref(), args).await?;
         }
         Some(MonocoreSubcommand::Shell {
             sandbox,
@@ -86,7 +86,7 @@ async fn main() -> MonocoreResult<()> {
         }) => {
             let sandbox =
                 determine_name_from_positional_or_flag_args(sandbox, sandbox_with_flag, "sandbox")?;
-            sandbox::run_sandbox(&sandbox, SHELL_SCRIPT, path, config, args).await?;
+            sandbox::run(&sandbox, SHELL_SCRIPT, path, config.as_deref(), args).await?;
         }
         Some(MonocoreSubcommand::Tmp {
             image_script,
@@ -105,8 +105,7 @@ async fn main() -> MonocoreResult<()> {
             )?;
             let (image, script) = parse_name_and_script(&image_script);
             let image = image.parse::<Reference>()?;
-            sandbox::run_temp_sandbox(&image, script, cpus, ram, volumes, ports, envs, workdir)
-                .await?;
+            sandbox::run_temp(&image, script, cpus, ram, volumes, ports, envs, workdir).await?;
         }
         Some(_) => (), // TODO: implement other subcommands
         None => {

--- a/monocore/lib/cli/args/mcrun.rs
+++ b/monocore/lib/cli/args/mcrun.rs
@@ -72,13 +72,17 @@ pub enum McrunSubcommand {
         #[arg(long)]
         log_dir: PathBuf,
 
-        /// Name of the child process
-        #[arg(long)]
-        child_name: String,
-
         /// Path to the sandbox metrics and metadata database file
         #[arg(long)]
         sandbox_db_path: PathBuf,
+
+        /// Name of the child process
+        #[arg(long)]
+        sandbox_name: String,
+
+        /// Path to the sandbox config file
+        #[arg(long)]
+        config_file: String,
 
         /// Log level
         #[arg(long)]

--- a/monocore/lib/cli/args/monocore.rs
+++ b/monocore/lib/cli/args/monocore.rs
@@ -230,7 +230,7 @@ pub enum MonocoreSubcommand {
 
         /// Config path
         #[arg(short, long)]
-        config: Option<PathBuf>,
+        config: Option<String>,
 
         /// Additional arguments after `--`
         #[arg(last = true)]
@@ -254,7 +254,7 @@ pub enum MonocoreSubcommand {
 
         /// Config path
         #[arg(short, long)]
-        config: Option<PathBuf>,
+        config: Option<String>,
 
         /// Additional arguments
         #[arg(last = true)]
@@ -278,7 +278,7 @@ pub enum MonocoreSubcommand {
 
         /// Config path
         #[arg(short, long)]
-        config: Option<PathBuf>,
+        config: Option<String>,
 
         /// Additional arguments
         #[arg(last = true)]

--- a/monocore/lib/config/defaults.rs
+++ b/monocore/lib/config/defaults.rs
@@ -33,9 +33,6 @@ pub(crate) const DEFAULT_CONFIG: &str = r#"# Sandbox configurations
 sandboxes: []
 "#;
 
-/// The default namespace for the menv patch and rootfs directories.
-pub const DEFAULT_MENV_NAMESPACE: &str = "default";
-
 /// The default shell to use for the sandbox.
 pub const DEFAULT_SHELL: &str = "/bin/sh";
 

--- a/monocore/lib/config/mod.rs
+++ b/monocore/lib/config/mod.rs
@@ -4,9 +4,9 @@ mod defaults;
 mod env_pair;
 mod monocore;
 mod path_pair;
+mod path_segment;
 mod port_pair;
 mod reference_path;
-
 //--------------------------------------------------------------------------------------------------
 // Exports
 //--------------------------------------------------------------------------------------------------
@@ -15,5 +15,6 @@ pub use defaults::*;
 pub use env_pair::*;
 pub use monocore::*;
 pub use path_pair::*;
+pub use path_segment::*;
 pub use port_pair::*;
 pub use reference_path::*;

--- a/monocore/lib/config/path_segment.rs
+++ b/monocore/lib/config/path_segment.rs
@@ -1,0 +1,263 @@
+use std::{
+    ffi::{OsStr, OsString},
+    fmt::{self, Display},
+    path::{Component, Path, PathBuf},
+    str::FromStr,
+};
+
+use crate::MonocoreError;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Represents a single segment of a path.
+///
+/// This struct provides a way to represent and manipulate individual components
+/// of a path, ensuring they are valid path segments.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PathSegment(OsString);
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl PathSegment {
+    /// Returns the OS string representation of the segment.
+    pub fn as_os_str(&self) -> &OsStr {
+        &self.0
+    }
+
+    /// Returns the bytes representation of the segment.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.as_os_str().as_encoded_bytes()
+    }
+
+    /// Returns the length of the segment in bytes.
+    pub fn len(&self) -> usize {
+        self.as_bytes().len()
+    }
+
+    /// Returns `true` if the segment is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl FromStr for PathSegment {
+    type Err = MonocoreError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        PathSegment::try_from(s)
+    }
+}
+
+impl Display for PathSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.to_string_lossy())
+    }
+}
+
+impl TryFrom<&str> for PathSegment {
+    type Error = MonocoreError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            return Err(MonocoreError::EmptyPathSegment);
+        }
+
+        #[cfg(unix)]
+        {
+            if value.contains('/') {
+                return Err(MonocoreError::InvalidPathComponent(value.to_string()));
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            if value.contains('/') || value.contains('\\') {
+                return Err(MonocoreError::InvalidPathComponent(value.to_string()));
+            }
+        }
+
+        // At this point the string does not contain any separator characters
+        let mut components = Path::new(value).components();
+        let component = components
+            .next()
+            .ok_or_else(|| MonocoreError::InvalidPathComponent(value.to_string()))?;
+
+        // Ensure there are no additional components
+        if components.next().is_some() {
+            return Err(MonocoreError::InvalidPathComponent(value.to_string()));
+        }
+
+        match component {
+            Component::Normal(comp) => Ok(PathSegment(comp.to_os_string())),
+            _ => Err(MonocoreError::InvalidPathComponent(value.to_string())),
+        }
+    }
+}
+
+impl<'a> TryFrom<Component<'a>> for PathSegment {
+    type Error = MonocoreError;
+
+    fn try_from(component: Component<'a>) -> Result<Self, Self::Error> {
+        PathSegment::try_from(&component)
+    }
+}
+
+impl<'a> TryFrom<&Component<'a>> for PathSegment {
+    type Error = MonocoreError;
+
+    fn try_from(component: &Component<'a>) -> Result<Self, Self::Error> {
+        match component {
+            Component::Normal(component) => Ok(PathSegment(component.to_os_string())),
+            _ => Err(MonocoreError::InvalidPathComponent(
+                component.as_os_str().to_string_lossy().into_owned(),
+            )),
+        }
+    }
+}
+
+impl<'a> From<&'a PathSegment> for Component<'a> {
+    fn from(segment: &'a PathSegment) -> Self {
+        Component::Normal(segment.as_os_str())
+    }
+}
+
+impl From<PathSegment> for PathBuf {
+    #[inline]
+    fn from(segment: PathSegment) -> Self {
+        PathBuf::from(segment.0)
+    }
+}
+
+impl AsRef<[u8]> for PathSegment {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl AsRef<OsStr> for PathSegment {
+    #[inline]
+    fn as_ref(&self) -> &OsStr {
+        self.as_os_str()
+    }
+}
+
+impl AsRef<Path> for PathSegment {
+    #[inline]
+    fn as_ref(&self) -> &Path {
+        Path::new(self.as_os_str())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_segment_as_os_str() {
+        let segment = PathSegment::from_str("example").unwrap();
+        assert_eq!(segment.as_os_str(), OsStr::new("example"));
+    }
+
+    #[test]
+    fn test_segment_as_bytes() {
+        let segment = PathSegment::from_str("example").unwrap();
+        assert_eq!(segment.as_bytes(), b"example");
+    }
+
+    #[test]
+    fn test_segment_len() {
+        let segment = PathSegment::from_str("example").unwrap();
+        assert_eq!(segment.len(), 7);
+    }
+
+    #[test]
+    fn test_segment_display() {
+        let segment = PathSegment::from_str("example").unwrap();
+        assert_eq!(format!("{}", segment), "example");
+    }
+
+    #[test]
+    fn test_segment_try_from_str() {
+        assert!(PathSegment::try_from("example").is_ok());
+        assert!(PathSegment::from_str("example").is_ok());
+        assert!("example".parse::<PathSegment>().is_ok());
+
+        // Negative cases
+        assert!(PathSegment::from_str("").is_err());
+        assert!(PathSegment::from_str(".").is_err());
+        assert!(PathSegment::from_str("..").is_err());
+        assert!(".".parse::<PathSegment>().is_err());
+        assert!("..".parse::<PathSegment>().is_err());
+        assert!("".parse::<PathSegment>().is_err());
+        assert!(PathSegment::try_from(".").is_err());
+        assert!(PathSegment::try_from("..").is_err());
+        assert!(PathSegment::try_from("/").is_err());
+        assert!(PathSegment::try_from("").is_err());
+    }
+
+    #[test]
+    fn test_segment_from_path_segment_to_component() {
+        let segment = PathSegment::from_str("example").unwrap();
+        assert_eq!(
+            Component::from(&segment),
+            Component::Normal(OsStr::new("example"))
+        );
+    }
+
+    #[test]
+    fn test_segment_from_path_segment_to_path_buf() {
+        let segment = PathSegment::from_str("example").unwrap();
+        assert_eq!(PathBuf::from(segment), PathBuf::from("example"));
+    }
+
+    #[test]
+    fn test_segment_normal_with_special_characters() {
+        assert!(PathSegment::try_from("file.txt").is_ok());
+        assert!(PathSegment::try_from("file-name").is_ok());
+        assert!(PathSegment::try_from("file_name").is_ok());
+        assert!(PathSegment::try_from("file name").is_ok());
+        assert!(PathSegment::try_from("file:name").is_ok());
+        assert!(PathSegment::try_from("file*name").is_ok());
+        assert!(PathSegment::try_from("file?name").is_ok());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_segment_with_unix_separator() {
+        // On Unix systems, forward slash is the main separator
+        assert!(PathSegment::try_from("file/name").is_err());
+        assert!(PathSegment::try_from("/").is_err());
+        assert!(PathSegment::try_from("///").is_err());
+        assert!(PathSegment::try_from("name/").is_err());
+        assert!(PathSegment::try_from("/name").is_err());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_segment_with_windows_separators() {
+        // On Windows, both forward slash and backslash are separators
+        assert!(PathSegment::try_from("file\\name").is_err());
+        assert!(PathSegment::try_from("file/name").is_err());
+        assert!(PathSegment::try_from("\\").is_err());
+        assert!(PathSegment::try_from("/").is_err());
+        assert!(PathSegment::try_from("\\\\\\").is_err());
+        assert!(PathSegment::try_from("///").is_err());
+        assert!(PathSegment::try_from("name\\").is_err());
+        assert!(PathSegment::try_from("name/").is_err());
+        assert!(PathSegment::try_from("\\name").is_err());
+        assert!(PathSegment::try_from("/name").is_err());
+    }
+}

--- a/monocore/lib/error.rs
+++ b/monocore/lib/error.rs
@@ -281,6 +281,18 @@ pub enum MonocoreError {
     /// An error that occurs when an invalid log level is used.
     #[error("invalid log level: {0}")]
     InvalidLogLevel(u8),
+
+    /// Empty path segment
+    #[error("empty path segment")]
+    EmptyPathSegment,
+
+    /// Invalid path component (e.g. ".", "..", "/")
+    #[error("invalid path component: {0}")]
+    InvalidPathComponent(String),
+
+    /// Script not found in sandbox configuration
+    #[error("script '{0}' not found in sandbox configuration '{1}'")]
+    ScriptNotFoundInSandbox(String, String),
 }
 
 /// An error that occurred when an invalid MicroVm configuration was used.

--- a/monocore/lib/management/migrations/sandbox/20250128014823_create_sandboxes.up.sql
+++ b/monocore/lib/management/migrations/sandbox/20250128014823_create_sandboxes.up.sql
@@ -4,6 +4,7 @@
 CREATE TABLE IF NOT EXISTS sandboxes (
     id INTEGER PRIMARY KEY,
     name TEXT NOT NULL,
+    config_file TEXT NOT NULL,
     supervisor_pid INTEGER,
     microvm_pid INTEGER,
     status TEXT NOT NULL,
@@ -17,5 +18,5 @@ CREATE TABLE IF NOT EXISTS sandboxes (
 );
 
 -- Create indexes
-CREATE INDEX IF NOT EXISTS idx_sandboxes_name ON sandboxes(name);
+CREATE INDEX IF NOT EXISTS idx_sandboxes_name ON sandboxes(name, config_file);
 CREATE INDEX IF NOT EXISTS idx_sandboxes_group_id ON sandboxes(group_id);

--- a/monocore/lib/management/mod.rs
+++ b/monocore/lib/management/mod.rs
@@ -11,19 +11,15 @@
 //! - `menv`: Monocore environment management
 //! - `rootfs`: Root filesystem operations for containers
 //! - `sandbox`: Sandbox creation and management
-
-pub mod db;
-pub mod image;
-pub mod menv;
-pub mod rootfs;
-pub mod sandbox;
+//! - `orchestra`: Orchestra management for sandboxes
 
 //--------------------------------------------------------------------------------------------------
 // Exports
 //--------------------------------------------------------------------------------------------------
 
-pub use db::*;
-pub use image::*;
-pub use menv::*;
-pub use rootfs::*;
-pub use sandbox::*;
+pub mod db;
+pub mod image;
+pub mod menv;
+pub mod orchestra;
+pub mod rootfs;
+pub mod sandbox;

--- a/monocore/lib/management/orchestra.rs
+++ b/monocore/lib/management/orchestra.rs
@@ -1,0 +1,34 @@
+//! Orchestra management functionality for Monocore.
+//!
+//! This module provides functionality for managing collections of sandboxes in a coordinated way,
+//! similar to how container orchestration tools manage multiple containers. It handles the lifecycle
+//! of multiple sandboxes defined in configuration, including starting them up, shutting them down,
+//! and applying configuration changes.
+//!
+//! The main operations provided by this module are:
+//! - `up`: Start up all sandboxes defined in configuration
+//! - `down`: Gracefully shut down all running sandboxes
+//! - `apply`: Apply configuration changes to running sandboxes
+
+use crate::{config::Monocore, MonocoreResult};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Applies configuration changes to all sandboxes defined in configuration.
+///
+/// This function iterates through all sandboxes defined in the configuration and applies the
+/// configuration changes to each sandbox. It ensures that the sandboxes are updated
+/// according to their configuration specifications.
+///
+/// ## Arguments
+///
+/// * `config` - The configuration to apply to the sandboxes
+///
+/// ## Returns
+///
+/// Returns `MonocoreResult<()>` indicating success or failure
+pub async fn apply(_config: &Monocore) -> MonocoreResult<()> {
+    Ok(())
+}

--- a/monocore/lib/management/rootfs.rs
+++ b/monocore/lib/management/rootfs.rs
@@ -36,11 +36,7 @@ pub const WHITEOUT_PREFIX: &str = ".wh.";
 /// * `root_path` - Path to the root of the filesystem to patch
 /// * `scripts` - HashMap containing script names and their contents
 /// * `shell_path` - Path to the shell binary within the rootfs (e.g. "/bin/sh")
-///
-/// ## Returns
-///
-/// Returns `MonocoreResult<()>` indicating success or failure
-pub fn patch_rootfs_with_sandbox_scripts(
+pub fn patch_with_sandbox_scripts(
     scripts_dir: &Path,
     scripts: Cow<HashMap<String, String>>,
     shell_path: impl AsRef<Path>,
@@ -109,10 +105,7 @@ pub fn patch_rootfs_with_sandbox_scripts(
 /// - Cannot create directories in the rootfs
 /// - Cannot read or write the fstab file
 /// - Cannot set permissions on the fstab file
-fn patch_rootfs_with_virtiofs_mounts(
-    root_path: &Path,
-    mapped_dirs: &[PathPair],
-) -> MonocoreResult<()> {
+fn patch_with_virtiofs_mounts(root_path: &Path, mapped_dirs: &[PathPair]) -> MonocoreResult<()> {
     let fstab_path = root_path.join("etc/fstab");
 
     // Create parent directories if they don't exist
@@ -203,7 +196,7 @@ mod tests {
         ];
 
         // Update fstab
-        patch_rootfs_with_virtiofs_mounts(root_path, &mapped_dirs)?;
+        patch_with_virtiofs_mounts(root_path, &mapped_dirs)?;
 
         // Verify fstab file was created with correct content
         let fstab_path = root_path.join("etc/fstab");
@@ -240,7 +233,7 @@ mod tests {
         ];
 
         // Update fstab again
-        patch_rootfs_with_virtiofs_mounts(root_path, &new_mapped_dirs)?;
+        patch_with_virtiofs_mounts(root_path, &new_mapped_dirs)?;
 
         // Verify updated content
         let updated_content = fs::read_to_string(&fstab_path)?;
@@ -285,7 +278,7 @@ mod tests {
             vec![format!("{}:/container/data", host_path.display()).parse::<PathPair>()?];
 
         // Function should detect it cannot write to /etc/fstab and return an error
-        let result = patch_rootfs_with_virtiofs_mounts(readonly_path, &mapped_dirs);
+        let result = patch_with_virtiofs_mounts(readonly_path, &mapped_dirs);
 
         // Detailed error reporting for debugging
         if result.is_ok() {

--- a/monofs/bin/mfsrun.rs
+++ b/monofs/bin/mfsrun.rs
@@ -128,9 +128,14 @@ async fn main() -> Result<()> {
             let supervisor_pid = std::process::id();
 
             // Create nfs server monitor
-            let process_monitor =
-                NfsServerMonitor::new(supervisor_pid, fs_db_path, mount_dir, log_dir.clone())
-                    .await?;
+            let process_monitor = NfsServerMonitor::new(
+                supervisor_pid,
+                fs_db_path,
+                child_name,
+                mount_dir,
+                log_dir.clone(),
+            )
+            .await?;
 
             // Compose child arguments
             let child_args = vec![
@@ -144,14 +149,8 @@ async fn main() -> Result<()> {
             let child_envs = vec![("RUST_LOG", "info")];
 
             // Create and start supervisor
-            let mut supervisor = Supervisor::new(
-                child_exe,
-                child_args,
-                child_envs,
-                child_name,
-                log_dir,
-                process_monitor,
-            );
+            let mut supervisor =
+                Supervisor::new(child_exe, child_args, child_envs, log_dir, process_monitor);
 
             supervisor.start().await?;
         }

--- a/monoutils/lib/runtime/monitor.rs
+++ b/monoutils/lib/runtime/monitor.rs
@@ -43,7 +43,7 @@ pub enum ChildIo {
 #[async_trait]
 pub trait ProcessMonitor {
     /// Start monitoring a process
-    async fn start(&mut self, pid: u32, name: String, child_io: ChildIo) -> MonoutilsResult<()>;
+    async fn start(&mut self, pid: u32, child_io: ChildIo) -> MonoutilsResult<()>;
 
     /// Stop monitoring
     async fn stop(&mut self) -> MonoutilsResult<()>;

--- a/monoutils/lib/runtime/supervisor.rs
+++ b/monoutils/lib/runtime/supervisor.rs
@@ -34,9 +34,6 @@ where
     /// Arguments to pass to the child executable
     child_args: Vec<String>,
 
-    /// Name of the child process
-    child_name: String,
-
     /// The managed child process ID
     child_pid: Option<u32>,
 
@@ -64,7 +61,6 @@ where
     ///
     /// * `child_exe` - Path to the child executable
     /// * `child_args` - Arguments to pass to the child executable
-    /// * `child_name` - Name of the child process
     /// * `log_dir` - Path to the supervisor's log directory
     /// * `process_monitor` - The process monitor to use
     /// * `child_envs` - Environment variables for the child process
@@ -72,7 +68,6 @@ where
         child_exe: impl Into<PathBuf>,
         child_args: impl IntoIterator<Item = impl Into<String>>,
         child_envs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
-        child_name: impl Into<String>,
         log_dir: impl Into<PathBuf>,
         process_monitor: M,
     ) -> Self {
@@ -83,7 +78,6 @@ where
                 .into_iter()
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect(),
-            child_name: child_name.into(),
             child_pid: None,
             log_dir: log_dir.into(),
             process_monitor,
@@ -191,9 +185,7 @@ where
         self.child_pid = Some(child_pid);
 
         // Start monitoring
-        self.process_monitor
-            .start(child_pid, self.child_name.clone(), child_io)
-            .await?;
+        self.process_monitor.start(child_pid, child_io).await?;
 
         // Setup signal handlers
         let mut sigterm = signal(SignalKind::terminate())?;


### PR DESCRIPTION
- Add PathSegment type for safe path component handling
- Add sandbox name and config file tracking in database
- Add script validation before sandbox execution
- Add orchestra module for managing multiple sandboxes
- Rename management functions to be more concise (e.g. init_db -> initialize)
- Remove child_name from Supervisor constructor
- Update ProcessMonitor trait to remove name parameter from start()
- Change config path type from PathBuf to String
- Remove DEFAULT_MENV_NAMESPACE constant
- Fix path handling in sandbox configuration
- Fix database connection management
- Fix log file naming consistency
