### PR TITLE
feat(server): daemonize sandbox server

### DIFF
--- a/monocore/lib/cli/args/mcrun.rs
+++ b/monocore/lib/cli/args/mcrun.rs
@@ -138,4 +138,18 @@ pub enum McrunSubcommand {
         #[arg(last = true)]
         args: Vec<String>,
     },
+    /// Start the sandbox server
+    Server {
+        /// Port to listen on
+        #[arg(long)]
+        port: Option<u16>,
+
+        /// Path to the namespace directory
+        #[arg(long)]
+        path: Option<PathBuf>,
+
+        /// Disable default namespace
+        #[arg(long, default_value_t = false)]
+        disable_default: bool,
+    },
 }

--- a/monocore/lib/cli/args/monocore.rs
+++ b/monocore/lib/cli/args/monocore.rs
@@ -545,7 +545,7 @@ pub enum MonocoreSubcommand {
 #[derive(Debug, Parser)]
 pub enum ServerSubcommand {
     /// Start the sandbox server
-    Up {
+    Start {
         /// Port to listen on
         #[arg(long)]
         port: Option<u16>,
@@ -560,7 +560,7 @@ pub enum ServerSubcommand {
     },
 
     /// Stop the sandbox server
-    Down,
+    Stop,
 }
 
 /// Actions for the self subcommand

--- a/monocore/lib/error.rs
+++ b/monocore/lib/error.rs
@@ -152,7 +152,7 @@ pub enum MonocoreError {
     #[error("process wait error: {0}")]
     ProcessWaitError(String),
 
-    /// An error that occurred when the supervisor task failed
+    /// An error that occurred running the supervisor.
     #[error("supervisor error: {0}")]
     SupervisorError(String),
 
@@ -293,6 +293,10 @@ pub enum MonocoreError {
     /// Script not found in sandbox configuration
     #[error("script '{0}' not found in sandbox configuration '{1}'")]
     ScriptNotFoundInSandbox(String, String),
+
+    /// An error that occurred running the sandbox server.
+    #[error("sandbox server error: {0}")]
+    SandboxServerError(String),
 }
 
 /// An error that occurred when an invalid MicroVm configuration was used.

--- a/monocore/lib/management/menv.rs
+++ b/monocore/lib/management/menv.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     config::DEFAULT_CONFIG,
-    utils::{MONOCORE_CONFIG_FILENAME, ORCHESTRA_LOCK_FILE, RW_SUBDIR},
+    utils::{MONOCORE_CONFIG_FILENAME, RW_SUBDIR},
     MonocoreResult,
 };
 use std::path::{Path, PathBuf};
@@ -75,10 +75,6 @@ pub(crate) async fn ensure_menv_files(menv_path: &PathBuf) -> MonocoreResult<()>
 
     // Get the sandbox database path
     let db_path = menv_path.join(SANDBOX_DB_FILENAME);
-
-    // Create the orchestra lock file
-    let lock_path = menv_path.join(ORCHESTRA_LOCK_FILE);
-    fs::File::create(&lock_path).await?;
 
     // Initialize sandbox database
     let _ = db::initialize(&db_path, &db::SANDBOX_DB_MIGRATOR).await?;

--- a/monocore/lib/management/mod.rs
+++ b/monocore/lib/management/mod.rs
@@ -23,3 +23,4 @@ pub mod menv;
 pub mod orchestra;
 pub mod rootfs;
 pub mod sandbox;
+pub mod server;

--- a/monocore/lib/management/sandbox.rs
+++ b/monocore/lib/management/sandbox.rs
@@ -249,6 +249,7 @@ pub async fn run(
             });
         }
 
+        // TODO: Redirect to log file
         // Redirect the i/o to /dev/null
         command.stdout(Stdio::null());
         command.stderr(Stdio::null());

--- a/monocore/lib/management/server.rs
+++ b/monocore/lib/management/server.rs
@@ -1,0 +1,149 @@
+//! Server management for the Monocore runtime.
+
+use std::{path::PathBuf, process::Stdio};
+
+use tokio::{fs, process::Command};
+
+use crate::{
+    config::DEFAULT_MCRUN_EXE_PATH,
+    utils::{self, MCRUN_EXE_ENV_VAR, SERVER_PID_FILE},
+    MonocoreError, MonocoreResult,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Start the sandbox server
+pub async fn start(
+    port: Option<u16>,
+    path: Option<PathBuf>,
+    disable_default: bool,
+    detach: bool,
+) -> MonocoreResult<()> {
+    let mcrun_path =
+        monoutils::path::resolve_env_path(MCRUN_EXE_ENV_VAR, &*DEFAULT_MCRUN_EXE_PATH)?;
+
+    let mut command = Command::new(mcrun_path);
+    command.arg("server");
+
+    if let Some(port) = port {
+        command.arg("--port").arg(port.to_string());
+    }
+
+    if let Some(path) = path {
+        command.arg("--path").arg(path);
+    }
+
+    if disable_default {
+        command.arg("--disable-default");
+    }
+
+    if detach {
+        unsafe {
+            command.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+
+        // TODO: Redirect to log file
+        // Redirect the i/o to /dev/null
+        command.stdout(Stdio::null());
+        command.stderr(Stdio::null());
+        command.stdin(Stdio::null());
+    }
+
+    let mut child = command.spawn()?;
+
+    let pid = child.id().unwrap_or(0);
+    tracing::info!("started sandbox server process with PID: {}", pid);
+
+    // Create PID file
+    let monocore_home_path = utils::get_monocore_home_path();
+    let pid_file_path = monocore_home_path.join(SERVER_PID_FILE);
+
+    // Ensure monocore home directory exists
+    fs::create_dir_all(&monocore_home_path).await?;
+
+    // Write PID to file
+    fs::write(&pid_file_path, pid.to_string())
+        .await
+        .map_err(|e| {
+            MonocoreError::SandboxServerError(format!(
+                "failed to write PID file {}: {}",
+                pid_file_path.display(),
+                e
+            ))
+        })?;
+
+    if detach {
+        return Ok(());
+    }
+
+    // Wait for the child process to complete
+    let status = child.wait().await?;
+    if !status.success() {
+        tracing::error!(
+            "child process — sandbox server — exited with status: {}",
+            status
+        );
+        // Clean up PID file if process fails
+        if pid_file_path.exists() {
+            let _ = fs::remove_file(&pid_file_path).await;
+        }
+        return Err(MonocoreError::SandboxServerError(format!(
+            "child process — sandbox server — failed with exit status: {}",
+            status
+        )));
+    }
+
+    // Clean up PID file on successful exit
+    if pid_file_path.exists() {
+        let _ = fs::remove_file(&pid_file_path).await;
+    }
+
+    Ok(())
+}
+
+/// Stop the sandbox server
+pub async fn stop() -> MonocoreResult<()> {
+    let monocore_home_path = utils::get_monocore_home_path();
+    let pid_file_path = monocore_home_path.join(SERVER_PID_FILE);
+
+    // Check if PID file exists
+    if !pid_file_path.exists() {
+        return Err(MonocoreError::SandboxServerError(
+            "server is not running (PID file not found)".to_string(),
+        ));
+    }
+
+    // Read PID from file
+    let pid_str = fs::read_to_string(&pid_file_path).await?;
+    let pid = pid_str.trim().parse::<i32>().map_err(|_| {
+        MonocoreError::SandboxServerError("invalid PID found in server.pid file".to_string())
+    })?;
+
+    // Send SIGTERM to the process
+    unsafe {
+        if libc::kill(pid, libc::SIGTERM) != 0 {
+            // If process doesn't exist, clean up PID file and return error
+            if std::io::Error::last_os_error().raw_os_error().unwrap() == libc::ESRCH {
+                fs::remove_file(&pid_file_path).await?;
+                return Err(MonocoreError::SandboxServerError(
+                    "server process not found (stale PID file removed)".to_string(),
+                ));
+            }
+            return Err(MonocoreError::SandboxServerError(format!(
+                "failed to stop server process (PID: {})",
+                pid
+            )));
+        }
+    }
+
+    // Delete PID file
+    fs::remove_file(&pid_file_path).await?;
+
+    tracing::info!("stopped sandbox server process (PID: {})", pid);
+    Ok(())
+}

--- a/monocore/lib/utils/path.rs
+++ b/monocore/lib/utils/path.rs
@@ -15,54 +15,71 @@ pub const MONOCORE_ENV_DIR: &str = ".menv";
 pub const MONOCORE_HOME_DIR: &str = ".monocore";
 
 /// The directory where project read-write layers are stored
+///
+/// Example: <PROJECT_ROOT>/<MONOCORE_ENV_DIR>/<RW_SUBDIR>
 pub const RW_SUBDIR: &str = "rw";
 
 /// The directory where project patch layers are stored
+///
+/// Example: <PROJECT_ROOT>/<MONOCORE_ENV_DIR>/<PATCH_SUBDIR>
 pub const PATCH_SUBDIR: &str = "patch";
 
 /// The directory where base store blocks are stored
+///
+/// Example: <PROJECT_ROOT>/<MONOCORE_ENV_DIR>/<BLOCKS_SUBDIR>
 pub const BLOCKS_SUBDIR: &str = "blocks";
 
 /// The directory where project logs are stored
+///
+/// Example: <PROJECT_ROOT>/<MONOCORE_ENV_DIR>/<LOG_SUBDIR>
 pub const LOG_SUBDIR: &str = "log";
 
 /// The directory where global image layers are stored
+///
+/// Example: <MONOCORE_HOME_DIR>/<LAYERS_SUBDIR>
 pub const LAYERS_SUBDIR: &str = "layers";
 
 /// The directory where monocore's installed binaries are stored
+///
+/// Example: <MONOCORE_HOME_DIR>/<BIN_SUBDIR>
 pub const BIN_SUBDIR: &str = "bin";
 
 /// The filename for the project active sandbox database
+///
+/// Example: <PROJECT_ROOT>/<MONOCORE_ENV_DIR>/<SANDBOX_DB_FILENAME>
 pub const SANDBOX_DB_FILENAME: &str = "sandbox.db";
 
 /// The filename for the global OCI database
+///
+/// Example: <MONOCORE_HOME_DIR>/<OCI_DB_FILENAME>
 pub const OCI_DB_FILENAME: &str = "oci.db";
-
-/// The filename for the monoimage database
-pub const MONOIMAGE_DB_FILENAME: &str = "monoimage.db";
-
-/// The prefix for mcrun log files
-pub const MCRUN_LOG_PREFIX: &str = "mcrun";
 
 /// The directory on the microvm where sandbox scripts are stored
 pub const SANDBOX_SCRIPT_DIR: &str = ".sandbox_scripts";
 
 /// The suffix added to extracted layer directories
+///
+/// Example: <MONOCORE_HOME_DIR>/<LAYERS_SUBDIR>/<LAYER_ID>.<EXTRACTED_LAYER_SUFFIX>
 pub const EXTRACTED_LAYER_SUFFIX: &str = "extracted";
 
 /// The monocore config file name.
+///
+/// Example: <PROJECT_ROOT>/<MONOCORE_ENV_DIR>/<SANDBOX_DB_FILENAME>
 pub const MONOCORE_CONFIG_FILENAME: &str = "Sandboxfile";
 
 /// The shell script name.
+///
+/// Example: <PROJECT_ROOT>/<MONOCORE_ENV_DIR>/<PATCH_SUBDIR>/<CONFIG_NAME>/<SHELL_SCRIPT_NAME>
 pub const SHELL_SCRIPT_NAME: &str = "shell";
 
-/// The file lock for the orchestra
-pub const ORCHESTRA_LOCK_FILE: &str = "orchestra.lock";
-
 /// The directory for server namespaces
+///
+/// Example: <MONOCORE_HOME_DIR>/<NAMESPACES_SUBDIR>
 pub const NAMESPACES_SUBDIR: &str = "namespaces";
 
 /// The PID file for the server
+///
+/// Example: <MONOCORE_HOME_DIR>/<SERVER_PID_FILE>
 pub const SERVER_PID_FILE: &str = "server.pid";
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Add new server mode to mcrun binary for orchestrating sandboxes
- Implement server management functions (start/stop) in new management/server.rs
- Update CLI args to support server mode in both mcrun and monocore binaries
- Remove log retention logic from MicroVmMonitor
- Clean up path constants documentation
- Remove unused constants (MCRUN_LOG_PREFIX, ORCHESTRA_LOCK_FILE, etc.)

The sandbox server provides a new way to orchestrate sandboxes through a centralized service, accessible via the mcrun server command or through the monocore server subcommands.
