### PR TITLE
refactor(config): restructure monocore configuration

### DIFF
--- a/monocore/bin/monocore.rs
+++ b/monocore/bin/monocore.rs
@@ -509,20 +509,18 @@ async fn main() -> MonocoreResult<()> {
 
             handle_log_subcommand(&sandbox, path, config.as_deref(), follow, tail).await?;
         }
-        Some(MonocoreSubcommand::Server { subcommand }) => {
-            match subcommand {
-                ServerSubcommand::Start {
-                    port,
-                    path,
-                    disable_default,
-                } => {
-                    server::start(port, path, disable_default, true).await?;
-                }
-                ServerSubcommand::Stop => {
-                    server::stop().await?;
-                }
+        Some(MonocoreSubcommand::Server { subcommand }) => match subcommand {
+            ServerSubcommand::Start {
+                port,
+                path,
+                disable_default,
+            } => {
+                server::start(port, path, disable_default, true).await?;
             }
-        }
+            ServerSubcommand::Stop => {
+                server::stop().await?;
+            }
+        },
         Some(_) => (), // TODO: implement other subcommands
         None => {
             MonocoreArgs::command().print_help()?;


### PR DESCRIPTION
- Changed requires field to modules with new Module type
- Changed Vec collections to HashMap for builds, sandboxes, and groups
- Removed name fields from Build, Sandbox and Group structs (now used as HashMap keys)
- Updated SandboxBuilder to remove name generic parameter
- Changed SandboxGroupNetwork to use hostname instead of domains
- Removed envs field from SandboxGroup and Group
- Updated orchestra and sandbox management code to work with new HashMap structure

The changes simplify the configuration structure by using HashMaps with names as keys rather than embedding names in the structs themselves. This removes redundancy and makes lookups more efficient. The Module type replaces the Require type for a cleaner module system.
