### PR TITLE
feat: implement remove subcommand for sandboxes

### DIFF
--- a/monocore/bin/monocore/main.rs
+++ b/monocore/bin/monocore/main.rs
@@ -61,6 +61,16 @@ async fn main() -> MonocoreResult<()> {
             )
             .await?;
         }
+        Some(MonocoreSubcommand::Remove {
+            sandbox,
+            build,
+            group,
+            names,
+            path,
+            config,
+        }) => {
+            handlers::remove_subcommand(sandbox, build, group, names, path, config).await?;
+        }
         Some(MonocoreSubcommand::Pull {
             image,
             image_group,

--- a/monocore/lib/cli/args/monocore.rs
+++ b/monocore/lib/cli/args/monocore.rs
@@ -142,6 +142,14 @@ pub enum MonocoreSubcommand {
         /// Names of components to remove
         #[arg(required = true)]
         names: Vec<String>,
+
+        /// Project path
+        #[arg(short, long)]
+        path: Option<PathBuf>,
+
+        /// Config path
+        #[arg(short, long)]
+        config: Option<String>,
     },
 
     /// List build, sandbox, or group components in the project


### PR DESCRIPTION
- Add remove_subcommand handler to remove sandbox components
- Implement config::remove function to modify YAML config
- Add ComponentType enum to specify component types
- Extract trio_conflict_error helper function for flag validation
- Update CLI args to include path and config options for remove command
