### PR TITLE
feat(cli): add list subcommand for sandboxes

### DIFF
--- a/monocore/bin/monocore/handlers.rs
+++ b/monocore/bin/monocore/handlers.rs
@@ -87,6 +87,23 @@ pub async fn remove_subcommand(
     .await
 }
 
+pub async fn list_subcommand(
+    sandbox: bool,
+    build: bool,
+    group: bool,
+    path: Option<PathBuf>,
+    config: Option<String>,
+) -> MonocoreResult<()> {
+    trio_conflict_error(build, sandbox, group, "list", "[NAMES]");
+    unsupported_build_group_error(build, group, "list", "[NAMES]");
+    let names = config::list(ComponentType::Sandbox, path.as_deref(), config.as_deref()).await?;
+    for name in names {
+        println!("{}", name);
+    }
+
+    Ok(())
+}
+
 pub async fn init_subcommand(
     path: Option<PathBuf>,
     path_with_flag: Option<PathBuf>,

--- a/monocore/bin/monocore/main.rs
+++ b/monocore/bin/monocore/main.rs
@@ -71,6 +71,15 @@ async fn main() -> MonocoreResult<()> {
         }) => {
             handlers::remove_subcommand(sandbox, build, group, names, path, config).await?;
         }
+        Some(MonocoreSubcommand::List {
+            sandbox,
+            build,
+            group,
+            path,
+            config,
+        }) => {
+            handlers::list_subcommand(sandbox, build, group, path, config).await?;
+        }
         Some(MonocoreSubcommand::Pull {
             image,
             image_group,

--- a/monocore/lib/cli/args/monocore.rs
+++ b/monocore/lib/cli/args/monocore.rs
@@ -166,6 +166,14 @@ pub enum MonocoreSubcommand {
         /// Whether to list groups
         #[arg(short, long)]
         group: bool,
+
+        /// Project path
+        #[arg(short, long)]
+        path: Option<PathBuf>,
+
+        /// Config path
+        #[arg(short, long)]
+        config: Option<String>,
     },
 
     /// Show logs of a running build, sandbox, or group

--- a/monocore/lib/management/config.rs
+++ b/monocore/lib/management/config.rs
@@ -364,6 +364,35 @@ pub async fn remove(
     Ok(())
 }
 
+/// Lists components in the Monocore configuration.
+///
+/// Retrieves and displays information about components defined in the Monocore configuration.
+///
+/// ## Arguments
+///
+/// * `component_type` - The type of component to list
+/// * `project_dir` - Optional path to the project directory. If None, defaults to current directory
+/// * `config_file` - Optional path to the Monocore config file. If None, uses default filename
+///
+/// ## Returns
+///
+/// * `Ok(())` on success, or error if the file cannot be found/read/written,
+///   contains invalid YAML, or the component does not exist
+pub async fn list(
+    component_type: ComponentType,
+    project_dir: Option<&Path>,
+    config_file: Option<&str>,
+) -> MonocoreResult<Vec<String>> {
+    let (config, _, _) = load_config(project_dir, config_file).await?;
+
+    match component_type {
+        ComponentType::Sandbox => {
+            return Ok(config.get_sandboxes().keys().cloned().collect());
+        }
+        _ => return Ok(vec![]),
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Add new `list` subcommand to monocore CLI that displays all configured sandboxes. The command supports optional path and config flags to specify custom project/config locations.
