### PR TITLE
feat(sandbox): apply OCI image defaults to sandbox configuration

### DIFF
--- a/monocore/bin/monocore/handlers.rs
+++ b/monocore/bin/monocore/handlers.rs
@@ -180,6 +180,7 @@ pub async fn run_subcommand(
         args,
         detach,
         exec.as_deref(),
+        true,
     )
     .await?;
 
@@ -221,6 +222,7 @@ pub async fn script_run_subcommand(
         args,
         detach,
         exec.as_deref(),
+        true,
     )
     .await
 }
@@ -263,6 +265,7 @@ pub async fn tmp_subcommand(
         workdir,
         exec.as_deref(),
         args,
+        true,
     )
     .await
 }

--- a/monocore/lib/config/defaults.rs
+++ b/monocore/lib/config/defaults.rs
@@ -33,9 +33,6 @@ sandboxes: []
 /// The default shell to use for the sandbox.
 pub const DEFAULT_SHELL: &str = "/bin/sh";
 
-/// The default script to use for the sandbox.
-pub const DEFAULT_SCRIPT: &str = "start";
-
 /// The default path to the mcrun binary.
 pub static DEFAULT_MCRUN_EXE_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     let current_exe = std::env::current_exe().unwrap();

--- a/monocore/lib/config/monocore/builder.rs
+++ b/monocore/lib/config/monocore/builder.rs
@@ -8,7 +8,7 @@ use crate::{
     MonocoreResult,
 };
 
-use super::{Build, Group, Meta, Module, Monocore, Proxy, Sandbox, SandboxGroup, NetworkScope};
+use super::{Build, Group, Meta, Module, Monocore, NetworkScope, Proxy, Sandbox, SandboxGroup};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/monocore/lib/config/monocore/config.rs
+++ b/monocore/lib/config/monocore/config.rs
@@ -714,7 +714,10 @@ mod tests {
         // Test sandbox with explicit start script
         let sandbox2 = sandboxes.get("test2").unwrap();
         let scripts2 = sandbox2.get_full_scripts();
-        assert_eq!(scripts2.get(START_SCRIPT_NAME).unwrap(), "echo 'custom start'");
+        assert_eq!(
+            scripts2.get(START_SCRIPT_NAME).unwrap(),
+            "echo 'custom start'"
+        );
     }
 
     #[test]

--- a/monocore/lib/management/db.rs
+++ b/monocore/lib/management/db.rs
@@ -739,16 +739,16 @@ pub(crate) async fn get_image_config(
         architecture: row.get("architecture"),
         os: row.get("os"),
         os_variant: row.get("os_variant"),
-        config_env_json: row.get("config_env_json"),
-        config_cmd_json: row.get("config_cmd_json"),
+        config_env_json: null_to_none(row.get("config_env_json")),
+        config_cmd_json: null_to_none(row.get("config_cmd_json")),
         config_working_dir: row.get("config_working_dir"),
-        config_entrypoint_json: row.get("config_entrypoint_json"),
-        config_volumes_json: row.get("config_volumes_json"),
-        config_exposed_ports_json: row.get("config_exposed_ports_json"),
+        config_entrypoint_json: null_to_none(row.get("config_entrypoint_json")),
+        config_volumes_json: null_to_none(row.get("config_volumes_json")),
+        config_exposed_ports_json: null_to_none(row.get("config_exposed_ports_json")),
         config_user: row.get("config_user"),
         rootfs_type: row.get("rootfs_type"),
         rootfs_diff_ids_json: row.get("rootfs_diff_ids_json"),
-        history_json: row.get("history_json"),
+        history_json: null_to_none(row.get("history_json")),
         created_at: parse_sqlite_datetime(&row.get::<String, _>("created_at")),
         modified_at: parse_sqlite_datetime(&row.get::<String, _>("modified_at")),
     }))
@@ -858,4 +858,10 @@ fn parse_sqlite_datetime(s: &str) -> DateTime<Utc> {
     let naive_dt = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
         .unwrap_or_else(|e| panic!("Failed to parse datetime string '{}': {:?}", s, e));
     DateTime::from_naive_utc_and_offset(naive_dt, Utc)
+}
+
+/// Sometimes the json columns in the database can have literal "null" values.
+/// This function converts those to None.
+fn null_to_none(value: Option<String>) -> Option<String> {
+    value.filter(|v| v != "null")
 }

--- a/monocore/lib/management/orchestra.rs
+++ b/monocore/lib/management/orchestra.rs
@@ -17,7 +17,7 @@ use nix::{
 use std::path::Path;
 
 use crate::{
-    config::{Monocore, DEFAULT_SCRIPT},
+    config::{Monocore, START_SCRIPT_NAME},
     management::{config, sandbox},
     utils::{MONOCORE_ENV_DIR, SANDBOX_DB_FILENAME},
     MonocoreError, MonocoreResult,
@@ -99,12 +99,13 @@ pub async fn apply(project_dir: Option<&Path>, config_file: Option<&str>) -> Mon
             tracing::info!("Starting sandbox: {}", name);
             sandbox::run(
                 name,
-                Some(DEFAULT_SCRIPT),
+                Some(START_SCRIPT_NAME),
                 Some(&canonical_project_dir),
                 Some(&config_file),
                 vec![],
                 true,
                 None,
+                true,
             )
             .await?;
         }
@@ -203,12 +204,13 @@ pub async fn up(
             tracing::info!("Starting sandbox: {}", sandbox_name);
             sandbox::run(
                 sandbox_name,
-                Some(DEFAULT_SCRIPT),
+                Some(START_SCRIPT_NAME),
                 Some(&canonical_project_dir),
                 Some(&config_file),
                 vec![],
                 true,
                 None,
+                true,
             )
             .await?;
         }

--- a/monocore/lib/management/sandbox.rs
+++ b/monocore/lib/management/sandbox.rs
@@ -118,15 +118,7 @@ pub async fn run(
         ));
     };
 
-    // Apply image configuration defaults if enabled and it's an image-based rootfs
-    if use_image_defaults {
-        if let ReferenceOrPath::Reference(reference) = sandbox_config.get_image() {
-            let reference = reference.clone();
-            apply_image_defaults(&mut sandbox_config, &reference, script_name).await?;
-        }
-    }
-
-    tracing::debug!("sandbox_config: {:?}", sandbox_config);
+    tracing::debug!("Original sandbox config: {:#?}", sandbox_config);
 
     // Sandbox database path
     let sandbox_db_path = menv_path.join(SANDBOX_DB_FILENAME);
@@ -137,7 +129,7 @@ pub async fn run(
     // Get the config last modified timestamp
     let config_last_modified: DateTime<Utc> = fs::metadata(&config_file).await?.modified()?.into();
 
-    let rootfs = match sandbox_config.get_image() {
+    let rootfs = match sandbox_config.get_image().clone() {
         ReferenceOrPath::Path(root_path) => {
             setup_native_rootfs(
                 &canonical_project_dir.join(root_path),
@@ -150,16 +142,17 @@ pub async fn run(
             )
             .await?
         }
-        ReferenceOrPath::Reference(reference) => {
+        ReferenceOrPath::Reference(ref reference) => {
             setup_image_rootfs(
                 reference,
                 sandbox_name,
-                &sandbox_config,
+                &mut sandbox_config,
                 &menv_path,
                 &config_file,
                 &config_last_modified,
                 &sandbox_pool,
                 script_name,
+                use_image_defaults,
             )
             .await?
         }
@@ -201,16 +194,34 @@ pub async fn run(
         .arg("--exec-path")
         .arg(&exec_path);
 
+    // CPU
     if let Some(cpus) = sandbox_config.get_cpus() {
         command.arg("--num-vcpus").arg(cpus.to_string());
     }
 
+    // RAM
     if let Some(ram) = sandbox_config.get_ram() {
         command.arg("--ram-mib").arg(ram.to_string());
     }
 
+    // Workdir
     if let Some(workdir) = sandbox_config.get_workdir() {
         command.arg("--workdir-path").arg(workdir);
+    }
+
+    // Env
+    for env in sandbox_config.get_envs() {
+        command.arg("--env").arg(env.to_string());
+    }
+
+    // Ports
+    for port in sandbox_config.get_ports() {
+        command.arg("--port").arg(port.to_string());
+    }
+
+    // Volumes
+    for volume in sandbox_config.get_volumes() {
+        command.arg("--mapped-dir").arg(volume.to_string());
     }
 
     // Pass the rootfs
@@ -457,16 +468,19 @@ pub async fn run_temp(
 async fn setup_image_rootfs(
     image: &Reference,
     sandbox_name: &str,
-    sandbox_config: &Sandbox,
+    sandbox_config: &mut Sandbox,
     menv_path: &Path,
     config_file: &str,
     config_last_modified: &DateTime<Utc>,
     sandbox_pool: &Pool<Sqlite>,
     script_name: &str,
+    use_image_defaults: bool,
 ) -> MonocoreResult<Rootfs> {
     // Pull the image from the registry
     tracing::info!("pulling image: {}", image);
     image::pull(image.clone(), true, false, None).await?;
+
+    tracing::debug!("Updated sandbox config: {:#?}", sandbox_config);
 
     // Get the monocore home path and database path
     let monocore_home_path = env::get_monocore_home_path();
@@ -475,6 +489,11 @@ async fn setup_image_rootfs(
 
     // Get or create a connection pool to the database
     let pool = db::get_or_create_pool(&db_path, &db::OCI_DB_MIGRATOR).await?;
+
+    // Apply image configuration defaults if enabled.
+    if use_image_defaults {
+        config::apply_image_defaults(sandbox_config, image, &pool).await?;
+    }
 
     // Get the layers for the image
     let layers = db::get_image_layers(&pool, &image.to_string()).await?;
@@ -536,8 +555,7 @@ async fn setup_image_rootfs(
             fs::remove_dir_all(&rw_scripts_dir).await?;
         }
 
-        rootfs::patch_with_sandbox_scripts(&script_dir, scripts, sandbox_config.get_shell())
-            .await?;
+        rootfs::patch_with_sandbox_scripts(&script_dir, scripts, &sandbox_config.shell).await?;
     } else {
         tracing::info!("skipping sandbox scripts patch - config unchanged");
     }
@@ -610,197 +628,4 @@ async fn has_sandbox_config_changed(
         }
         None => true, // No existing sandbox, need to patch
     })
-}
-
-/// Applies defaults from an OCI image configuration to a sandbox configuration.
-///
-/// This function enhances the sandbox configuration with defaults from the OCI image
-/// configuration when they are not explicitly defined in the sandbox config.
-///
-/// The following defaults are applied:
-/// - Script: Uses the entrypoint and cmd from the image if a script is missing
-/// - Environment variables: Combines image env variables with sandbox env variables
-/// - Working directory: Uses the image's working directory if not specified
-/// - Exposed ports: Combines image exposed ports with sandbox ports
-///
-/// ## Arguments
-///
-/// * `sandbox_config` - Mutable reference to the sandbox configuration to enhance
-/// * `reference` - OCI image reference to get defaults from
-/// * `script_name` - The name of the script we're trying to run
-///
-/// ## Returns
-///
-/// Returns `Ok(())` if defaults were successfully applied, or a `MonocoreError` if:
-/// - The image configuration could not be retrieved
-/// - Any conversion or parsing operations fail
-async fn apply_image_defaults(
-    sandbox_config: &mut Sandbox,
-    reference: &Reference,
-    script_name: &str,
-) -> MonocoreResult<()> {
-    // Get the monocore home path and database path
-    let monocore_home_path = env::get_monocore_home_path();
-    let db_path = monocore_home_path.join(OCI_DB_FILENAME);
-
-    // Get or create a connection pool to the database
-    let pool = db::get_or_create_pool(&db_path, &db::OCI_DB_MIGRATOR).await?;
-
-    // Get the image configuration
-    if let Some(config) = db::get_image_config(&pool, &reference.to_string()).await? {
-        tracing::info!("Applying defaults from image configuration");
-
-        // Apply working directory if not set in sandbox
-        if sandbox_config.get_workdir().is_none() && config.config_working_dir.is_some() {
-            let workdir = config.config_working_dir.unwrap();
-            tracing::debug!("Using image working directory: {}", workdir);
-            let workdir_path = Utf8UnixPathBuf::from(workdir);
-            sandbox_config.workdir = Some(workdir_path);
-        }
-
-        // Combine environment variables
-        if let Some(config_env_json) = config.config_env_json {
-            if let Ok(image_env_vars) = serde_json::from_str::<Vec<String>>(&config_env_json) {
-                let mut image_env_pairs = Vec::new();
-                for env_var in image_env_vars {
-                    if let Ok(env_pair) = env_var.parse::<EnvPair>() {
-                        image_env_pairs.push(env_pair);
-                    }
-                }
-
-                // Combine image env vars with sandbox env vars (image vars come first)
-                let mut combined_env = image_env_pairs;
-                combined_env.extend_from_slice(sandbox_config.get_envs());
-                sandbox_config.envs = combined_env;
-            }
-        }
-
-        // Apply entrypoint and cmd as start script if no scripts are defined for this script name
-        if !sandbox_config.scripts.contains_key(script_name) && script_name == START_SCRIPT_NAME {
-            let mut script_content = String::new();
-
-            // Try to use entrypoint and cmd from image config
-            let mut has_entrypoint_or_cmd = false;
-
-            if let Some(entrypoint_json) = &config.config_entrypoint_json {
-                if let Ok(entrypoint) = serde_json::from_str::<Vec<String>>(entrypoint_json) {
-                    if !entrypoint.is_empty() {
-                        has_entrypoint_or_cmd = true;
-                        script_content.push_str("#!/bin/sh\n\n");
-
-                        // Format the entrypoint command with proper escaping
-                        let mut cmd_line = String::new();
-                        for (i, arg) in entrypoint.iter().enumerate() {
-                            if i > 0 {
-                                cmd_line.push(' ');
-                            }
-                            // Simple shell escaping for arguments
-                            if arg.contains(' ') || arg.contains('"') || arg.contains('\'') {
-                                cmd_line.push_str(&format!("'{}'", arg.replace('\'', "'\\''")));
-                            } else {
-                                cmd_line.push_str(arg);
-                            }
-                        }
-
-                        // Add CMD args if they exist
-                        if let Some(cmd_json) = &config.config_cmd_json {
-                            if let Ok(cmd) = serde_json::from_str::<Vec<String>>(cmd_json) {
-                                if !cmd.is_empty() {
-                                    for arg in cmd {
-                                        cmd_line.push(' ');
-                                        if arg.contains(' ')
-                                            || arg.contains('"')
-                                            || arg.contains('\'')
-                                        {
-                                            cmd_line.push_str(&format!(
-                                                "'{}'",
-                                                arg.replace('\'', "'\\''")
-                                            ));
-                                        } else {
-                                            cmd_line.push_str(&arg);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        script_content.push_str(&format!("exec {}\n", cmd_line));
-                    }
-                }
-            } else if let Some(cmd_json) = &config.config_cmd_json {
-                if let Ok(cmd) = serde_json::from_str::<Vec<String>>(cmd_json) {
-                    if !cmd.is_empty() {
-                        has_entrypoint_or_cmd = true;
-                        script_content.push_str("#!/bin/sh\n\n");
-
-                        // Format the cmd command with proper escaping
-                        let mut cmd_line = String::new();
-                        for (i, arg) in cmd.iter().enumerate() {
-                            if i > 0 {
-                                cmd_line.push(' ');
-                            }
-                            // Simple shell escaping for arguments
-                            if arg.contains(' ') || arg.contains('"') || arg.contains('\'') {
-                                cmd_line.push_str(&format!("'{}'", arg.replace('\'', "'\\''")));
-                            } else {
-                                cmd_line.push_str(arg);
-                            }
-                        }
-
-                        script_content.push_str(&format!("exec {}\n", cmd_line));
-                    }
-                }
-            }
-
-            // If no entrypoint or cmd, use shell as fallback
-            if !has_entrypoint_or_cmd {
-                script_content = "#!/bin/sh\nexec /bin/sh\n".to_string();
-            }
-
-            // Add the script to the sandbox config
-            sandbox_config
-                .scripts
-                .insert(START_SCRIPT_NAME.to_string(), script_content);
-        }
-
-        // Combine exposed ports
-        if let Some(exposed_ports_json) = &config.config_exposed_ports_json {
-            if let Ok(exposed_ports_map) =
-                serde_json::from_str::<serde_json::Value>(exposed_ports_json)
-            {
-                if let Some(exposed_ports_obj) = exposed_ports_map.as_object() {
-                    let mut additional_ports = Vec::new();
-
-                    for port_key in exposed_ports_obj.keys() {
-                        // Port keys in OCI format are like "80/tcp"
-                        if let Some(container_port) = port_key.split('/').next() {
-                            if let Ok(port_num) = container_port.parse::<u16>() {
-                                // Create a port mapping from host port to container port
-                                // We'll use the same port on both sides
-                                let port_pair =
-                                    format!("{}:{}", port_num, port_num).parse::<PortPair>();
-                                if let Ok(port_pair) = port_pair {
-                                    // Only add if not already defined in sandbox config
-                                    let existing_ports = sandbox_config.get_ports();
-                                    if !existing_ports
-                                        .iter()
-                                        .any(|p| p.get_guest() == port_pair.get_guest())
-                                    {
-                                        additional_ports.push(port_pair);
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // Add new ports to existing ones
-                    let mut combined_ports = sandbox_config.get_ports().to_vec();
-                    combined_ports.extend(additional_ports);
-                    sandbox_config.ports = combined_ports;
-                }
-            }
-        }
-    }
-
-    Ok(())
 }

--- a/monocore/lib/vm/vm.rs
+++ b/monocore/lib/vm/vm.rs
@@ -275,6 +275,7 @@ impl MicroVm {
         Ok(status)
     }
 
+    /// Creates a new MicroVm context.
     fn create_ctx() -> u32 {
         let ctx_id = unsafe { ffi::krun_create_ctx() };
         assert!(ctx_id >= 0, "failed to create microvm context: {}", ctx_id);
@@ -339,6 +340,8 @@ impl MicroVm {
             }
         }
 
+        tracing::debug!("Applying config: {:#?}", config);
+
         // Add mapped directories using virtio-fs
         let mapped_dirs = &config.mapped_dirs;
         for (idx, dir) in mapped_dirs.iter().enumerate() {
@@ -365,7 +368,8 @@ impl MicroVm {
 
         // Set network scope
         unsafe {
-            let status = ffi::krun_set_tsi_scope(ctx_id, ptr::null(), ptr::null(), config.scope as u8);
+            let status =
+                ffi::krun_set_tsi_scope(ctx_id, ptr::null(), ptr::null(), config.scope as u8);
             assert!(status >= 0, "failed to set network scope: {}", status);
         }
 


### PR DESCRIPTION
- Add new `use_image_defaults` parameter to sandbox run functions
- Implement `apply_image_defaults` function to enhance sandbox config with:
  - Working directory from image config
  - Environment variables from image config
  - Entrypoint/CMD as start script
  - Exposed ports from image config
- Replace DEFAULT_SCRIPT constant with START_SCRIPT_NAME
- Update sandbox visibility modifiers from pub(super) to pub(crate)
- Add get_image_config database function
