### PR TITLE
feat: add clean subcommand for global and local environments

### DIFF
--- a/microsandbox-core/README.md
+++ b/microsandbox-core/README.md
@@ -24,7 +24,7 @@
   </p>
 </div>
 
-**`microsandbox`** is the engine behind the microsandbox platform, providing a robust foundation for running AI workloads in isolated microVMs. It handles everything from VM lifecycle management to OCI image distribution, making it easy to deploy and orchestrate code sandboxes securely.
+**`microsandbox-core`** is the engine behind the microsandbox platform, providing a robust foundation for running AI workloads in isolated microVMs. It handles everything from VM lifecycle management to OCI image distribution, making it easy to deploy and orchestrate code sandboxes securely.
 
 > [!WARNING]
 > This project is undergoing major refactoring. The API is unstable and subject to breaking changes.

--- a/microsandbox-core/bin/msb/handlers.rs
+++ b/microsandbox-core/bin/msb/handlers.rs
@@ -3,7 +3,7 @@ use microsandbox_core::{
     cli::{AnsiStyles, MicrosandboxArgs},
     management::{
         config::{self, Component, ComponentType},
-        menv, orchestra, sandbox, server,
+        home, menv, orchestra, sandbox, server,
     },
     oci::Reference,
     MicrosandboxError, MicrosandboxResult,
@@ -382,6 +382,26 @@ pub async fn log_subcommand(
         for line in lines_to_print {
             println!("{}", line);
         }
+    }
+
+    Ok(())
+}
+
+/// Handles the clean subcommand, which removes the .menv directory from a project
+pub async fn clean_subcommand(
+    global: bool,
+    all: bool,
+    path: Option<PathBuf>,
+) -> MicrosandboxResult<()> {
+    if global || all {
+        // Global cleanup - clean the microsandbox home directory
+        home::clean().await?;
+        tracing::info!("Global microsandbox home directory cleaned");
+    }
+
+    if !global || all {
+        // Local project cleanup - clean the .menv directory
+        menv::clean(path).await?;
     }
 
     Ok(())

--- a/microsandbox-core/bin/msb/main.rs
+++ b/microsandbox-core/bin/msb/main.rs
@@ -2,12 +2,12 @@
 mod msb;
 
 use clap::{CommandFactory, Parser};
-use msb::handlers;
 use microsandbox_core::{
     cli::{MicrosandboxArgs, MicrosandboxSubcommand, ServerSubcommand},
     management::{image, orchestra, server},
     MicrosandboxResult,
 };
+use msb::handlers;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -195,6 +195,9 @@ async fn main() -> MicrosandboxResult<()> {
         }) => {
             handlers::log_subcommand(sandbox, build, group, name, path, config, follow, tail)
                 .await?;
+        }
+        Some(MicrosandboxSubcommand::Clean { global, all, path }) => {
+            handlers::clean_subcommand(global, all, path).await?;
         }
         Some(MicrosandboxSubcommand::Server { subcommand }) => match subcommand {
             ServerSubcommand::Start {

--- a/microsandbox-core/lib/cli/args/msb.rs
+++ b/microsandbox-core/lib/cli/args/msb.rs
@@ -517,9 +517,21 @@ pub enum MicrosandboxSubcommand {
         config: Option<String>,
     },
 
-    /// Clean project data
+    /// Clean cached sandbox layers, metadata, etc.
     #[command(name = "clean")]
-    Clean,
+    Clean {
+        /// Clean globally. This cleans $MICROSANDBOX_HOME
+        #[arg(long)]
+        global: bool,
+
+        /// Clean all
+        #[arg(long)]
+        all: bool,
+
+        /// Project path
+        #[arg(short, long)]
+        path: Option<PathBuf>,
+    },
 
     /// Build images
     #[command(name = "build")]

--- a/microsandbox-core/lib/management/home.rs
+++ b/microsandbox-core/lib/management/home.rs
@@ -1,0 +1,48 @@
+//! Home directory management for Microsandbox.
+//!
+//! This module provides functionality for managing the global microsandbox home directory,
+//! which contains cached images, layers, and databases. It also includes functions for
+//! cleaning up the home directory and checking its existence.
+
+use crate::{utils::env, MicrosandboxResult};
+use tokio::fs;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Clean up the global microsandbox home directory
+///
+/// This removes the entire microsandbox home directory and all its contents, effectively
+/// cleaning up all global microsandbox data including cached images, layers, and databases.
+///
+/// ## Example
+/// ```no_run
+/// use microsandbox_core::management::home;
+///
+/// # async fn example() -> anyhow::Result<()> {
+/// home::clean().await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn clean() -> MicrosandboxResult<()> {
+    // Get the microsandbox home path from environment or default
+    let home_path = env::get_microsandbox_home_path();
+
+    // Check if home directory exists
+    if home_path.exists() {
+        // Remove the home directory and all its contents
+        fs::remove_dir_all(&home_path).await?;
+        tracing::info!(
+            "Removed microsandbox home directory at {}",
+            home_path.display()
+        );
+    } else {
+        tracing::info!(
+            "No microsandbox home directory found at {}",
+            home_path.display()
+        );
+    }
+
+    Ok(())
+}

--- a/microsandbox-core/lib/management/menv.rs
+++ b/microsandbox-core/lib/management/menv.rs
@@ -61,6 +61,51 @@ pub async fn initialize(project_dir: Option<PathBuf>) -> MicrosandboxResult<()> 
     Ok(())
 }
 
+/// Clean up the microsandbox environment for a project
+///
+/// This removes the .menv directory and all its contents, effectively
+/// cleaning up all microsandbox data for the project.
+///
+/// ## Arguments
+/// * `project_dir` - Optional path where the microsandbox environment should be cleaned.
+///                   If None, uses current directory
+///
+/// ## Example
+/// ```no_run
+/// use microsandbox_core::management::menv;
+///
+/// # async fn example() -> anyhow::Result<()> {
+/// // Clean in current directory
+/// menv::clean(None).await?;
+///
+/// // Clean in specific directory
+/// menv::clean(Some("my_project".into())).await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn clean(project_dir: Option<PathBuf>) -> MicrosandboxResult<()> {
+    // Get the target path, defaulting to current directory if none specified
+    let project_dir = project_dir.unwrap_or_else(|| PathBuf::from("."));
+    let menv_path = project_dir.join(MICROSANDBOX_ENV_DIR);
+
+    // Check if .menv directory exists
+    if menv_path.exists() {
+        // Remove the .menv directory and all its contents
+        fs::remove_dir_all(&menv_path).await?;
+        tracing::info!(
+            "Removed microsandbox environment at {}",
+            menv_path.display()
+        );
+    } else {
+        tracing::info!(
+            "No microsandbox environment found at {}",
+            menv_path.display()
+        );
+    }
+
+    Ok(())
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------

--- a/microsandbox-core/lib/management/mod.rs
+++ b/microsandbox-core/lib/management/mod.rs
@@ -12,6 +12,7 @@
 //! - `rootfs`: Root filesystem operations for containers
 //! - `sandbox`: Sandbox creation and management
 //! - `orchestra`: Orchestra management for sandboxes
+//! - `home`: Home directory management
 
 //--------------------------------------------------------------------------------------------------
 // Exports
@@ -25,3 +26,4 @@ pub mod orchestra;
 pub mod rootfs;
 pub mod sandbox;
 pub mod server;
+pub mod home;


### PR DESCRIPTION
- Add new clean subcommand with --global and --all flags
- Implement home::clean() to remove global microsandbox home directory
- Implement menv::clean() to remove local .menv project directory
- Update CLI args to support new clean command options
