### PR TITLE
refactor: rename ram to memory for clarity

### DIFF
--- a/microsandbox-core/bin/msb/handlers.rs
+++ b/microsandbox-core/bin/msb/handlers.rs
@@ -29,7 +29,7 @@ pub async fn add_subcommand(
     group: bool,
     names: Vec<String>,
     image: String,
-    ram: Option<u32>,
+    memory: Option<u32>,
     cpus: Option<u32>,
     volumes: Vec<String>,
     ports: Vec<String>,
@@ -50,7 +50,7 @@ pub async fn add_subcommand(
 
     let component = Component::Sandbox {
         image,
-        ram,
+        memory,
         cpus,
         volumes,
         ports,
@@ -230,7 +230,7 @@ pub async fn script_run_subcommand(
 pub async fn tmp_subcommand(
     name: String,
     cpus: Option<u8>,
-    ram: Option<u32>,
+    memory: Option<u32>,
     volumes: Vec<String>,
     ports: Vec<String>,
     envs: Vec<String>,
@@ -258,7 +258,7 @@ pub async fn tmp_subcommand(
         &image,
         script,
         cpus,
-        ram,
+        memory,
         volumes,
         ports,
         envs,

--- a/microsandbox-core/bin/msb/main.rs
+++ b/microsandbox-core/bin/msb/main.rs
@@ -39,7 +39,7 @@ async fn main() -> MicrosandboxResult<()> {
             group,
             names,
             image,
-            ram,
+            memory,
             cpus,
             volumes,
             ports,
@@ -56,7 +56,7 @@ async fn main() -> MicrosandboxResult<()> {
             config,
         }) => {
             handlers::add_subcommand(
-                sandbox, build, group, names, image, ram, cpus, volumes, ports, envs, env_file,
+                sandbox, build, group, names, image, memory, cpus, volumes, ports, envs, env_file,
                 depends_on, workdir, shell, scripts, imports, exports, reach, path, config,
             )
             .await?;
@@ -149,7 +149,7 @@ async fn main() -> MicrosandboxResult<()> {
             image: _image,
             name,
             cpus,
-            ram,
+            memory,
             volumes,
             ports,
             envs,
@@ -157,7 +157,7 @@ async fn main() -> MicrosandboxResult<()> {
             exec,
             args,
         }) => {
-            handlers::tmp_subcommand(name, cpus, ram, volumes, ports, envs, workdir, exec, args)
+            handlers::tmp_subcommand(name, cpus, memory, volumes, ports, envs, workdir, exec, args)
                 .await?;
         }
         Some(MicrosandboxSubcommand::Apply { path, config }) => {

--- a/microsandbox-core/bin/msbrun.rs
+++ b/microsandbox-core/bin/msbrun.rs
@@ -18,7 +18,7 @@
 //!     --native-rootfs=/path/to/rootfs \
 //!     --overlayfs-rootfs=/path/to/rootfs \
 //!     --num-vcpus=2 \
-//!     --ram-mib=1024 \
+//!     --memory-mib=1024 \
 //!     --workdir-path=/app \
 //!     --exec-path=/usr/bin/python3 \
 //!     --mapped-dirs=/host/path:/guest/path \
@@ -42,7 +42,7 @@
 //!     --native-rootfs=/path/to/rootfs \
 //!     --overlayfs-rootfs=/path/to/rootfs \
 //!     --num-vcpus=2 \
-//!     --ram-mib=1024 \
+//!     --memory-mib=1024 \
 //!     --workdir-path=/app \
 //!     --exec-path=/usr/bin/python3 \
 //!     --mapped-dirs=/host/path:/guest/path \
@@ -97,7 +97,7 @@ async fn main() -> Result<()> {
             native_rootfs,
             overlayfs_layer,
             num_vcpus,
-            ram_mib,
+            memory_mib,
             workdir_path,
             exec_path,
             env,
@@ -114,7 +114,7 @@ async fn main() -> Result<()> {
             tracing::debug!("native_rootfs: {:#?}", native_rootfs);
             tracing::debug!("overlayfs_layer: {:#?}", overlayfs_layer);
             tracing::debug!("num_vcpus: {:#?}", num_vcpus);
-            tracing::debug!("ram_mib: {:#?}", ram_mib);
+            tracing::debug!("memory_mib: {:#?}", memory_mib);
             tracing::debug!("workdir_path: {:#?}", workdir_path);
             tracing::debug!("exec_path: {:#?}", exec_path);
             tracing::debug!("env: {:#?}", env);
@@ -162,9 +162,9 @@ async fn main() -> Result<()> {
                 builder = builder.num_vcpus(num_vcpus);
             }
 
-            // Set ram mib if provided
-            if let Some(ram_mib) = ram_mib {
-                builder = builder.ram_mib(ram_mib);
+            // Set memory mib if provided
+            if let Some(memory_mib) = memory_mib {
+                builder = builder.memory_mib(memory_mib);
             }
 
             // Set log level if provided
@@ -229,7 +229,7 @@ async fn main() -> Result<()> {
             native_rootfs,
             overlayfs_layer,
             num_vcpus,
-            ram_mib,
+            memory_mib,
             workdir_path,
             exec_path,
             env,
@@ -282,9 +282,9 @@ async fn main() -> Result<()> {
                 child_args.push(format!("--num-vcpus={}", num_vcpus));
             }
 
-            // Set ram mib if provided
-            if let Some(ram_mib) = ram_mib {
-                child_args.push(format!("--ram-mib={}", ram_mib));
+            // Set memory mib if provided
+            if let Some(memory_mib) = memory_mib {
+                child_args.push(format!("--memory-mib={}", memory_mib));
             }
 
             // Set workdir path if provided

--- a/microsandbox-core/lib/cli/args/msb.rs
+++ b/microsandbox-core/lib/cli/args/msb.rs
@@ -63,9 +63,9 @@ pub enum MicrosandboxSubcommand {
         #[arg(short, long)]
         image: String,
 
-        /// RAM in MiB
+        /// Memory in MiB
         #[arg(long)]
-        ram: Option<u32>,
+        memory: Option<u32>,
 
         /// Number of CPUs
         #[arg(long, alias = "cpu")]
@@ -351,9 +351,9 @@ pub enum MicrosandboxSubcommand {
         #[arg(long, alias = "cpu")]
         cpus: Option<u8>,
 
-        /// RAM in MB
+        /// Memory in MB
         #[arg(long)]
-        ram: Option<u32>,
+        memory: Option<u32>,
 
         /// Volume mappings, format: <host_path>:<container_path>
         #[arg(long = "volume", name = "VOLUME")]

--- a/microsandbox-core/lib/cli/args/msbrun.rs
+++ b/microsandbox-core/lib/cli/args/msbrun.rs
@@ -39,9 +39,9 @@ pub enum McrunSubcommand {
         #[arg(long)]
         num_vcpus: Option<u8>,
 
-        /// RAM size in MiB
+        /// Memory size in MiB
         #[arg(long)]
-        ram_mib: Option<u32>,
+        memory_mib: Option<u32>,
 
         /// Working directory path
         #[arg(long)]
@@ -122,9 +122,9 @@ pub enum McrunSubcommand {
         #[arg(long)]
         num_vcpus: Option<u8>,
 
-        /// RAM size in MiB
+        /// Memory size in MiB
         #[arg(long)]
-        ram_mib: Option<u32>,
+        memory_mib: Option<u32>,
 
         /// Working directory path
         #[arg(long)]

--- a/microsandbox-core/lib/config/defaults.rs
+++ b/microsandbox-core/lib/config/defaults.rs
@@ -9,8 +9,8 @@ use crate::utils::MICROSANDBOX_HOME_DIR;
 /// The default number of vCPUs to use for the MicroVm.
 pub const DEFAULT_NUM_VCPUS: u8 = 1;
 
-/// The default amount of RAM in MiB to use for the MicroVm.
-pub const DEFAULT_RAM_MIB: u32 = 1024;
+/// The default amount of memory in MiB to use for the MicroVm.
+pub const DEFAULT_MEMORY_MIB: u32 = 1024;
 
 /// The path where all microsandbox global data is stored.
 pub static DEFAULT_MICROSANDBOX_HOME: LazyLock<PathBuf> =

--- a/microsandbox-core/lib/config/microsandbox/builder.rs
+++ b/microsandbox-core/lib/config/microsandbox/builder.rs
@@ -40,7 +40,7 @@ pub struct MicrosandboxBuilder {
 /// ### Optional fields:
 /// - `version`: The version of the sandbox
 /// - `meta`: The metadata for the sandbox
-/// - `ram`: The maximum amount of RAM allowed for the sandbox
+/// - `memory`: The maximum amount of memory allowed for the sandbox
 /// - `cpus`: The maximum number of CPUs allowed for the sandbox
 /// - `volumes`: The volumes to mount
 /// - `ports`: The ports to expose
@@ -59,7 +59,7 @@ pub struct SandboxBuilder<I, S> {
     version: Option<Version>,
     meta: Option<Meta>,
     image: I,
-    ram: Option<u32>,
+    memory: Option<u32>,
     cpus: Option<u8>,
     volumes: Vec<PathPair>,
     ports: Vec<PortPair>,
@@ -149,7 +149,7 @@ impl<I, S> SandboxBuilder<I, S> {
             version: self.version,
             meta: self.meta,
             image: image.into(),
-            ram: self.ram,
+            memory: self.memory,
             cpus: self.cpus,
             volumes: self.volumes,
             ports: self.ports,
@@ -167,9 +167,9 @@ impl<I, S> SandboxBuilder<I, S> {
         }
     }
 
-    /// Sets the maximum amount of RAM allowed for the sandbox
-    pub fn ram(mut self, ram: u32) -> SandboxBuilder<I, S> {
-        self.ram = Some(ram);
+    /// Sets the maximum amount of memory allowed for the sandbox
+    pub fn memory(mut self, memory: u32) -> SandboxBuilder<I, S> {
+        self.memory = Some(memory);
         self
     }
 
@@ -233,7 +233,7 @@ impl<I, S> SandboxBuilder<I, S> {
             version: self.version,
             meta: self.meta,
             image: self.image,
-            ram: self.ram,
+            memory: self.memory,
             cpus: self.cpus,
             volumes: self.volumes,
             ports: self.ports,
@@ -298,7 +298,7 @@ impl SandboxBuilder<ReferenceOrPath, String> {
             version: self.version,
             meta: self.meta,
             image: self.image,
-            ram: self.ram,
+            memory: self.memory,
             cpus: self.cpus,
             volumes: self.volumes,
             ports: self.ports,
@@ -327,7 +327,7 @@ impl Default for SandboxBuilder<(), String> {
             version: None,
             meta: None,
             image: (),
-            ram: None,
+            memory: None,
             cpus: None,
             volumes: Vec::new(),
             ports: Vec::new(),

--- a/microsandbox-core/lib/config/microsandbox/config.rs
+++ b/microsandbox-core/lib/config/microsandbox/config.rs
@@ -129,10 +129,10 @@ pub struct Build {
     /// The image to use. This can be a path to a local rootfs or an OCI image reference.
     pub(crate) image: ReferenceOrPath,
 
-    /// The amount of RAM in MiB to use.
+    /// The amount of memory in MiB to use.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[builder(default, setter(strip_option))]
-    pub(crate) ram: Option<u32>,
+    pub(crate) memory: Option<u32>,
 
     /// The number of vCPUs to use.
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -309,9 +309,9 @@ pub struct Sandbox {
     /// The image to use. This can be a path to a local rootfs or an OCI image reference.
     pub(crate) image: ReferenceOrPath,
 
-    /// The amount of RAM in MiB to use.
+    /// The amount of memory in MiB to use.
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub(crate) ram: Option<u32>,
+    pub(crate) memory: Option<u32>,
 
     /// The number of vCPUs to use.
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -677,7 +677,7 @@ mod tests {
         let sandbox = sandboxes.get("test").unwrap();
 
         assert!(sandbox.version.is_none());
-        assert!(sandbox.ram.is_none());
+        assert!(sandbox.memory.is_none());
         assert!(sandbox.cpus.is_none());
         assert!(sandbox.volumes.is_empty());
         assert!(sandbox.ports.is_empty());
@@ -763,7 +763,7 @@ mod tests {
               test_sandbox:
                 version: "1.0.0"
                 image: "alpine:latest"
-                ram: 1024
+                memory: 1024
                 cpus: 2
                 volumes:
                   - "./src:/app/src"
@@ -805,7 +805,7 @@ mod tests {
         let sandboxes = &config.sandboxes;
         let sandbox = sandboxes.get("test_sandbox").unwrap();
         assert_eq!(sandbox.version.as_ref().unwrap().to_string(), "1.0.0");
-        assert_eq!(sandbox.ram.unwrap(), 1024);
+        assert_eq!(sandbox.memory.unwrap(), 1024);
         assert_eq!(sandbox.cpus.unwrap(), 2);
         assert_eq!(sandbox.volumes[0].to_string(), "./src:/app/src");
         assert_eq!(sandbox.ports[0].to_string(), "8080:80");
@@ -837,7 +837,7 @@ mod tests {
             builds:
               base_build:
                 image: "python:3.11-slim"
-                ram: 2048
+                memory: 2048
                 cpus: 2
                 volumes:
                   - "./requirements.txt:/build/requirements.txt"
@@ -860,7 +860,7 @@ mod tests {
               api:
                 version: "1.0.0"
                 image: "python:3.11-slim"
-                ram: 1024
+                memory: 1024
                 cpus: 1
                 volumes:
                   - "./api:/app/src"
@@ -909,7 +909,7 @@ mod tests {
         // Test builds
         let builds = &config.builds;
         let base_build = builds.get("base_build").unwrap();
-        assert_eq!(base_build.ram.unwrap(), 2048);
+        assert_eq!(base_build.memory.unwrap(), 2048);
         assert_eq!(base_build.cpus.unwrap(), 2);
         assert_eq!(
             base_build.workdir.as_ref().unwrap(),
@@ -933,7 +933,7 @@ mod tests {
         let sandboxes = &config.sandboxes;
         let api = sandboxes.get("api").unwrap();
         assert_eq!(api.version.as_ref().unwrap().to_string(), "1.0.0");
-        assert_eq!(api.ram.unwrap(), 1024);
+        assert_eq!(api.memory.unwrap(), 1024);
         assert_eq!(api.cpus.unwrap(), 1);
         assert_eq!(api.depends_on, vec!["database", "cache"]);
         assert_eq!(api.scope, NetworkScope::Public);

--- a/microsandbox-core/lib/error.rs
+++ b/microsandbox-core/lib/error.rs
@@ -305,9 +305,9 @@ pub enum InvalidMicroVMConfigError {
     #[error("number of vCPUs is zero")]
     NumVCPUsIsZero,
 
-    /// The amount of RAM is zero.
-    #[error("amount of RAM is zero")]
-    RamIsZero,
+    /// The amount of memory is zero.
+    #[error("amount of memory is zero")]
+    MemoryIsZero,
 
     /// The command line contains invalid characters. Only printable ASCII characters (space through tilde) are allowed.
     #[error("command line contains invalid characters (only ASCII characters between space and tilde are allowed): {0}")]

--- a/microsandbox-core/lib/management/config.rs
+++ b/microsandbox-core/lib/management/config.rs
@@ -33,8 +33,8 @@ pub enum Component {
         /// The image to use for the sandbox.
         image: String,
 
-        /// The amount of RAM in MiB to use.
-        ram: Option<u32>,
+        /// The amount of memory in MiB to use.
+        memory: Option<u32>,
 
         /// The number of CPUs to use.
         cpus: Option<u32>,
@@ -128,7 +128,7 @@ pub async fn add(
         match component {
             Component::Sandbox {
                 image,
-                ram,
+                memory,
                 cpus,
                 volumes,
                 ports,
@@ -174,8 +174,8 @@ pub async fn add(
                 sandbox_mapping.insert_str("image", image.to_string());
 
                 // Add optional fields
-                if let Some(ram_value) = ram {
-                    sandbox_mapping.insert_u32("ram", *ram_value);
+                if let Some(memory_value) = memory {
+                    sandbox_mapping.insert_u32("memory", *memory_value);
                 }
 
                 if let Some(cpus_value) = cpus {

--- a/microsandbox-core/lib/management/sandbox.rs
+++ b/microsandbox-core/lib/management/sandbox.rs
@@ -201,9 +201,9 @@ pub async fn run(
         command.arg("--num-vcpus").arg(cpus.to_string());
     }
 
-    // RAM
-    if let Some(ram) = sandbox_config.get_ram() {
-        command.arg("--ram-mib").arg(ram.to_string());
+    // Memory
+    if let Some(memory) = sandbox_config.get_memory() {
+        command.arg("--memory-mib").arg(memory.to_string());
     }
 
     // Workdir
@@ -327,7 +327,7 @@ pub async fn run(
 /// * `image` - The OCI image reference to use as the base for the sandbox
 /// * `script` - The name of the script to execute within the sandbox
 /// * `cpus` - Optional number of virtual CPUs to allocate to the sandbox
-/// * `ram` - Optional amount of RAM in MiB to allocate to the sandbox
+/// * `memory` - Optional amount of memory in MiB to allocate to the sandbox
 /// * `volumes` - List of volume mappings in the format "host_path:guest_path"
 /// * `ports` - List of port mappings in the format "host_port:guest_port"
 /// * `envs` - List of environment variables in the format "KEY=VALUE"
@@ -382,7 +382,7 @@ pub async fn run_temp(
     image: &Reference,
     script: Option<&str>,
     cpus: Option<u8>,
-    ram: Option<u32>,
+    memory: Option<u32>,
     volumes: Vec<String>,
     ports: Vec<String>,
     envs: Vec<String>,
@@ -411,8 +411,8 @@ pub async fn run_temp(
             b = b.cpus(cpus);
         }
 
-        if let Some(ram) = ram {
-            b = b.ram(ram);
+        if let Some(memory) = memory {
+            b = b.memory(memory);
         }
 
         if let Some(workdir) = workdir {

--- a/microsandbox-core/lib/management/server.rs
+++ b/microsandbox-core/lib/management/server.rs
@@ -62,9 +62,13 @@ pub async fn start(
             let process_running = unsafe { libc::kill(pid, 0) == 0 };
 
             if process_running {
-                return Err(MicrosandboxError::SandboxServerError(
-                    format!("A sandbox server is already running (PID: {}). Use 'msb server stop' to stop it first.", pid)
-                ));
+                // Server is already running - this is OK for idempotent behavior
+                tracing::info!(
+                    "A sandbox server is already running (PID: {}). No action needed.",
+                    pid
+                );
+                println!("A sandbox server is already running (PID: {}). Use 'msb server stop' to stop it if needed.", pid);
+                return Ok(());
             } else {
                 // Process not running, clean up stale PID file
                 tracing::warn!("Found stale PID file for process {}. Cleaning up.", pid);

--- a/microsandbox-core/lib/vm/builder.rs
+++ b/microsandbox-core/lib/vm/builder.rs
@@ -4,7 +4,7 @@ use ipnetwork::Ipv4Network;
 use typed_path::Utf8UnixPathBuf;
 
 use crate::{
-    config::{EnvPair, NetworkScope, PathPair, PortPair, DEFAULT_NUM_VCPUS, DEFAULT_RAM_MIB},
+    config::{EnvPair, NetworkScope, PathPair, PortPair, DEFAULT_MEMORY_MIB, DEFAULT_NUM_VCPUS},
     MicrosandboxResult,
 };
 
@@ -22,7 +22,7 @@ use super::{LinuxRlimit, LogLevel, MicroVm, MicroVmConfig, Rootfs};
 ///
 /// ## Optional Fields
 /// - `num_vcpus`: The number of virtual CPUs to use for the MicroVm.
-/// - `ram_mib`: The amount of RAM in MiB to use for the MicroVm.
+/// - `memory_mib`: The amount of memory in MiB to use for the MicroVm.
 /// - `mapped_dirs`: The directories to mount in the MicroVm.
 /// - `port_map`: The ports to map in the MicroVm.
 /// - `rlimits`: The resource limits to use for the MicroVm.
@@ -35,7 +35,7 @@ pub struct MicroVmConfigBuilder<R, E> {
     log_level: LogLevel,
     rootfs: R,
     num_vcpus: u8,
-    ram_mib: u32,
+    memory_mib: u32,
     mapped_dirs: Vec<PathPair>,
     port_map: Vec<PortPair>,
     scope: NetworkScope,
@@ -53,7 +53,7 @@ pub struct MicroVmConfigBuilder<R, E> {
 ///
 /// This struct provides a fluent interface for configuring and creating a `MicroVm` instance.
 /// It allows you to set various parameters such as the log level, root path, number of vCPUs,
-/// RAM size, virtio-fs mounts, port mappings, resource limits, working directory, executable path,
+/// memory size, virtio-fs mounts, port mappings, resource limits, working directory, executable path,
 /// arguments, environment variables, and console output.
 ///
 /// ## Required Fields
@@ -62,7 +62,7 @@ pub struct MicroVmConfigBuilder<R, E> {
 ///
 /// ## Optional Fields
 /// - `num_vcpus`: The number of virtual CPUs to use for the MicroVm.
-/// - `ram_mib`: The amount of RAM in MiB to use for the MicroVm.
+/// - `memory_mib`: The amount of memory in MiB to use for the MicroVm.
 /// - `mapped_dirs`: The directories to mount in the MicroVm.
 /// - `port_map`: The ports to map in the MicroVm.
 /// - `scope`: The network scope to use for the MicroVm.
@@ -86,7 +86,7 @@ pub struct MicroVmConfigBuilder<R, E> {
 ///     .log_level(LogLevel::Debug)
 ///     .rootfs(Rootfs::Native(PathBuf::from("/tmp")))
 ///     .num_vcpus(2)
-///     .ram_mib(1024)
+///     .memory_mib(1024)
 ///     .mapped_dirs(["/home:/guest/mount".parse()?])
 ///     .port_map(["8080:80".parse()?])
 ///     .scope(NetworkScope::Public)
@@ -170,7 +170,7 @@ impl<R, M> MicroVmConfigBuilder<R, M> {
             log_level: self.log_level,
             rootfs,
             num_vcpus: self.num_vcpus,
-            ram_mib: self.ram_mib,
+            memory_mib: self.memory_mib,
             mapped_dirs: self.mapped_dirs,
             port_map: self.port_map,
             scope: self.scope,
@@ -207,7 +207,7 @@ impl<R, M> MicroVmConfigBuilder<R, M> {
         self
     }
 
-    /// Sets the amount of RAM in MiB for the MicroVm.
+    /// Sets the amount of memory in MiB for the MicroVm.
     ///
     /// This determines how much memory is available to the guest system.
     ///
@@ -217,15 +217,15 @@ impl<R, M> MicroVmConfigBuilder<R, M> {
     /// use microsandbox_core::vm::MicroVmConfigBuilder;
     ///
     /// let config = MicroVmConfigBuilder::default()
-    ///     .ram_mib(1024);  // Allocate 1 GiB of RAM
+    ///     .memory_mib(1024);  // Allocate 1 GiB of memory
     /// ```
     ///
     /// ## Notes
     /// - The value is in MiB (1 GiB = 1024 MiB)
     /// - Consider the host's available memory when setting this value
     /// - Common values: 512 MiB for minimal systems, 1024-2048 MiB for typical workloads
-    pub fn ram_mib(mut self, ram_mib: u32) -> Self {
-        self.ram_mib = ram_mib;
+    pub fn memory_mib(mut self, memory_mib: u32) -> Self {
+        self.memory_mib = memory_mib;
         self
     }
 
@@ -471,7 +471,7 @@ impl<R, M> MicroVmConfigBuilder<R, M> {
             log_level: self.log_level,
             rootfs: self.rootfs,
             num_vcpus: self.num_vcpus,
-            ram_mib: self.ram_mib,
+            memory_mib: self.memory_mib,
             mapped_dirs: self.mapped_dirs,
             port_map: self.port_map,
             scope: self.scope,
@@ -591,7 +591,7 @@ impl<R, M> MicroVmBuilder<R, M> {
     /// let vm = MicroVmBuilder::default()
     ///     .log_level(LogLevel::Debug)  // Enable debug logging
     ///     .rootfs(Rootfs::Native(temp_dir.path().to_path_buf()))
-    ///     .ram_mib(1024)
+    ///     .memory_mib(1024)
     ///     .exec_path("/bin/echo")
     ///     .build()?;
     /// # Ok(())
@@ -662,7 +662,7 @@ impl<R, M> MicroVmBuilder<R, M> {
     /// let temp_dir = TempDir::new()?;
     /// let vm = MicroVmBuilder::default()
     ///     .rootfs(Rootfs::Native(temp_dir.path().to_path_buf()))
-    ///     .ram_mib(1024)
+    ///     .memory_mib(1024)
     ///     .num_vcpus(2)  // Allocate 2 virtual CPU cores
     ///     .exec_path("/bin/echo")
     ///     .build()?;
@@ -678,7 +678,7 @@ impl<R, M> MicroVmBuilder<R, M> {
         self
     }
 
-    /// Sets the amount of RAM in MiB for the MicroVm.
+    /// Sets the amount of memory in MiB for the MicroVm.
     ///
     /// This determines how much memory is available to the guest system.
     ///
@@ -692,7 +692,7 @@ impl<R, M> MicroVmBuilder<R, M> {
     /// let temp_dir = TempDir::new()?;
     /// let vm = MicroVmBuilder::default()
     ///     .rootfs(Rootfs::Native(temp_dir.path().to_path_buf()))
-    ///     .ram_mib(1024)  // Allocate 1 GiB of RAM
+    ///     .memory_mib(1024)  // Allocate 1 GiB of memory
     ///     .exec_path("/bin/echo")
     ///     .build()?;
     /// # Ok(())
@@ -703,8 +703,8 @@ impl<R, M> MicroVmBuilder<R, M> {
     /// - The value is in MiB (1 GiB = 1024 MiB)
     /// - Consider the host's available memory when setting this value
     /// - This is a required field - the build will fail if not set
-    pub fn ram_mib(mut self, ram_mib: u32) -> Self {
-        self.inner = self.inner.ram_mib(ram_mib);
+    pub fn memory_mib(mut self, memory_mib: u32) -> Self {
+        self.inner = self.inner.memory_mib(memory_mib);
         self
     }
 
@@ -1008,7 +1008,7 @@ impl MicroVmConfigBuilder<Rootfs, Utf8UnixPathBuf> {
             log_level: self.log_level,
             rootfs: self.rootfs,
             num_vcpus: self.num_vcpus,
-            ram_mib: self.ram_mib,
+            memory_mib: self.memory_mib,
             mapped_dirs: self.mapped_dirs,
             port_map: self.port_map,
             scope: self.scope,
@@ -1040,7 +1040,7 @@ impl MicroVmBuilder<Rootfs, Utf8UnixPathBuf> {
     /// let temp_dir = TempDir::new()?;
     /// let vm = MicroVmBuilder::default()
     ///     .rootfs(Rootfs::Native(temp_dir.path().to_path_buf()))
-    ///     .ram_mib(1024)
+    ///     .memory_mib(1024)
     ///     .exec_path("/usr/bin/python3")
     ///     .args(["-c", "print('Hello from MicroVm!')"])
     ///     .build()?;
@@ -1054,14 +1054,14 @@ impl MicroVmBuilder<Rootfs, Utf8UnixPathBuf> {
     /// ## Notes
     /// - The build will fail if required configuration is missing
     /// - The build will fail if the root path doesn't exist
-    /// - The build will fail if RAM or vCPU values are invalid
+    /// - The build will fail if memory value is invalid
     /// - After building, use `start()` to run the MicroVm
     pub fn build(self) -> MicrosandboxResult<MicroVm> {
         MicroVm::from_config(MicroVmConfig {
             log_level: self.inner.log_level,
             rootfs: self.inner.rootfs,
             num_vcpus: self.inner.num_vcpus,
-            ram_mib: self.inner.ram_mib,
+            memory_mib: self.inner.memory_mib,
             mapped_dirs: self.inner.mapped_dirs,
             port_map: self.inner.port_map,
             scope: self.inner.scope,
@@ -1087,7 +1087,7 @@ impl Default for MicroVmConfigBuilder<(), ()> {
             log_level: LogLevel::default(),
             rootfs: (),
             num_vcpus: DEFAULT_NUM_VCPUS,
-            ram_mib: DEFAULT_RAM_MIB,
+            memory_mib: DEFAULT_MEMORY_MIB,
             mapped_dirs: vec![],
             port_map: vec![],
             scope: NetworkScope::Group,
@@ -1131,7 +1131,7 @@ mod tests {
             .log_level(LogLevel::Debug)
             .rootfs(rootfs.clone())
             .num_vcpus(2)
-            .ram_mib(1024)
+            .memory_mib(1024)
             .mapped_dirs(["/guest/mount:/host/mount".parse()?])
             .port_map(["8080:80".parse()?])
             .rlimits(["RLIMIT_NOFILE=1024:1024".parse()?])
@@ -1144,7 +1144,7 @@ mod tests {
         assert_eq!(builder.inner.log_level, LogLevel::Debug);
         assert_eq!(builder.inner.rootfs, rootfs);
         assert_eq!(builder.inner.num_vcpus, 2);
-        assert_eq!(builder.inner.ram_mib, 1024);
+        assert_eq!(builder.inner.memory_mib, 1024);
         assert_eq!(
             builder.inner.mapped_dirs,
             ["/guest/mount:/host/mount".parse()?]
@@ -1171,19 +1171,19 @@ mod tests {
     #[test]
     fn test_microvm_builder_minimal() -> anyhow::Result<()> {
         let rootfs = Rootfs::Native(PathBuf::from("/tmp"));
-        let ram_mib = 1024;
+        let memory_mib = 1024;
 
         let builder = MicroVmBuilder::default()
             .rootfs(rootfs.clone())
             .exec_path("/bin/echo");
 
         assert_eq!(builder.inner.rootfs, rootfs);
-        assert_eq!(builder.inner.ram_mib, ram_mib);
+        assert_eq!(builder.inner.memory_mib, memory_mib);
 
         // Check that other fields have default values
         assert_eq!(builder.inner.log_level, LogLevel::default());
         assert_eq!(builder.inner.num_vcpus, DEFAULT_NUM_VCPUS);
-        assert_eq!(builder.inner.ram_mib, DEFAULT_RAM_MIB);
+        assert_eq!(builder.inner.memory_mib, DEFAULT_MEMORY_MIB);
         assert!(builder.inner.mapped_dirs.is_empty());
         assert!(builder.inner.port_map.is_empty());
         assert!(builder.inner.rlimits.is_empty());

--- a/microsandbox-core/lib/vm/errors.rs
+++ b/microsandbox-core/lib/vm/errors.rs
@@ -1,0 +1,22 @@
+#[derive(Debug, Error)]
+pub enum InvalidMicroVMConfigError {
+    /// The root path for the MicroVm does not exist.
+    #[error("The root path {0} does not exist")]
+    RootPathDoesNotExist(PathBuf),
+
+    /// The specified memory is zero.
+    #[error("The specified memory is zero")]
+    MemoryIsZero,
+
+    /// The specified executable path does not exist.
+    #[error("The executable path {0} does not exist")]
+    ExecutablePathDoesNotExist(Utf8UnixPathBuf),
+
+    /// The command line string contains invalid characters.
+    #[error("The command line string '{0}' contains invalid characters")]
+    InvalidCommandLineString(String),
+
+    /// The specified guest paths conflict.
+    #[error("The guest paths {0} and {1} conflict")]
+    ConflictingGuestPaths(String, String),
+}


### PR DESCRIPTION
Consistently rename RAM-related variables and fields to "memory" throughout the codebase to improve clarity and match common terminology. This includes:

- Rename `ram` to `memory` in Component, MicroVmConfig and related structs
- Update CLI args from `--ram-mib` to `--memory-mib`
- Rename builder methods from `ram_mib()` to `memory_mib()`
- Update error variants and messages to use "memory" terminology
- Update related documentation and comments
