### PR TITLE
feat(viz): standardize progress spinners and more viz

### DIFF
--- a/microsandbox-core/lib/management/home.rs
+++ b/microsandbox-core/lib/management/home.rs
@@ -5,7 +5,16 @@
 //! cleaning up the home directory and checking its existence.
 
 use crate::{utils::env, MicrosandboxResult};
+
+#[cfg(feature = "cli-viz")]
+use crate::utils::viz;
 use tokio::fs;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const REMOVE_HOME_DIR_MSG: &str = "Remove microsandbox home";
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -29,6 +38,9 @@ pub async fn clean() -> MicrosandboxResult<()> {
     // Get the microsandbox home path from environment or default
     let home_path = env::get_microsandbox_home_path();
 
+    #[cfg(feature = "cli-viz")]
+    let remove_home_dir_sp = viz::create_spinner(REMOVE_HOME_DIR_MSG.to_string(), None, None);
+
     // Check if home directory exists
     if home_path.exists() {
         // Remove the home directory and all its contents
@@ -43,6 +55,9 @@ pub async fn clean() -> MicrosandboxResult<()> {
             home_path.display()
         );
     }
+
+    #[cfg(feature = "cli-viz")]
+    remove_home_dir_sp.finish_with_message(REMOVE_HOME_DIR_MSG);
 
     Ok(())
 }

--- a/microsandbox-core/lib/management/image.rs
+++ b/microsandbox-core/lib/management/image.rs
@@ -193,7 +193,11 @@ pub async fn pull_from_docker_registry(
     let layer_paths = collect_layer_files(download_dir).await?;
 
     #[cfg(feature = "cli-viz")]
-    let extract_layers_sp = viz::create_spinner(EXTRACT_LAYERS_MSG.to_string(), None, Some(layer_paths.len() as u64));
+    let extract_layers_sp = viz::create_spinner(
+        EXTRACT_LAYERS_MSG.to_string(),
+        None,
+        Some(layer_paths.len() as u64),
+    );
 
     let extraction_futures: Vec<_> = layer_paths
         .into_iter()

--- a/microsandbox-core/lib/management/image.rs
+++ b/microsandbox-core/lib/management/image.rs
@@ -5,14 +5,13 @@
 //! handling image layers, and managing the local image cache.
 
 #[cfg(feature = "cli-viz")]
-use crate::utils::viz::MULTI_PROGRESS;
+use crate::utils::viz::{self, MULTI_PROGRESS};
 use crate::{
     management::db::{self, OCI_DB_MIGRATOR},
     oci::{DockerRegistry, OciRegistryPull, Reference},
     utils::{
         env::get_microsandbox_home_path,
         path::{LAYERS_SUBDIR, OCI_DB_FILENAME},
-        viz::TICK_STRINGS,
         EXTRACTED_LAYER_SUFFIX,
     },
     MicrosandboxError, MicrosandboxResult,
@@ -30,6 +29,8 @@ use std::path::{Path, PathBuf};
 use tar::Archive;
 use tempfile::tempdir;
 use tokio::fs;
+#[cfg(not(feature = "cli-viz"))]
+use tokio::process::Command;
 #[cfg(feature = "cli-viz")]
 use tokio::task::spawn_blocking;
 
@@ -42,6 +43,9 @@ const DOCKER_REGISTRY: &str = "docker.io";
 
 /// The domain name for the Sandboxes registry.
 const SANDBOXES_REGISTRY: &str = "sandboxes.io";
+
+/// Spinner message used for extracting layers.
+const EXTRACT_LAYERS_MSG: &str = "Extracting layers";
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -181,47 +185,27 @@ pub async fn pull_from_docker_registry(
         return Ok(());
     }
 
-    #[cfg(feature = "cli-viz")]
-    let header_pb = {
-        let pb = MULTI_PROGRESS.insert(0, ProgressBar::new_spinner());
-        pb.set_style(
-            ProgressStyle::with_template("{spinner} {msg}")
-                .unwrap()
-                .tick_strings(&*TICK_STRINGS),
-        );
-        pb.set_message("Download layers");
-        pb.enable_steady_tick(std::time::Duration::from_millis(80));
-        pb
-    };
-
     docker_registry
         .pull_image(image.get_repository(), image.get_selector().clone())
         .await?;
-
-    #[cfg(feature = "cli-viz")]
-    header_pb.finish_with_message("Download layers");
 
     // Find and extract layers in parallel
     let layer_paths = collect_layer_files(download_dir).await?;
 
     #[cfg(feature = "cli-viz")]
-    let header_extract_pb = {
-        let pb = MULTI_PROGRESS.add(ProgressBar::new_spinner());
-        pb.set_style(
-            ProgressStyle::with_template("{spinner} {msg}")
-                .unwrap()
-                .tick_strings(&*TICK_STRINGS),
-        );
-        pb.set_message("Extract layers");
-        pb.enable_steady_tick(std::time::Duration::from_millis(80));
-        pb
-    };
+    let extract_layers_sp = viz::create_spinner(EXTRACT_LAYERS_MSG.to_string(), None, Some(layer_paths.len() as u64));
 
     let extraction_futures: Vec<_> = layer_paths
         .into_iter()
         .map(|path| {
             let layers_dir = layers_dir.clone();
-            async move { extract_layer(path, &layers_dir).await }
+            let extract_layers_sp = extract_layers_sp.clone();
+            async move {
+                let result = extract_layer(path, &layers_dir).await;
+                #[cfg(feature = "cli-viz")]
+                extract_layers_sp.inc(1);
+                result
+            }
         })
         .collect();
 
@@ -231,7 +215,7 @@ pub async fn pull_from_docker_registry(
     }
 
     #[cfg(feature = "cli-viz")]
-    header_extract_pb.finish_with_message("Extract layers");
+    extract_layers_sp.finish_with_message(EXTRACT_LAYERS_MSG);
 
     Ok(())
 }

--- a/microsandbox-core/lib/oci/implementations/docker.rs
+++ b/microsandbox-core/lib/oci/implementations/docker.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 #[cfg(feature = "cli-viz")]
-use crate::utils::viz::MULTI_PROGRESS;
+use crate::utils::viz::{self, MULTI_PROGRESS};
 #[cfg(feature = "cli-viz")]
 use indicatif::{ProgressBar, ProgressStyle};
 
@@ -63,6 +63,12 @@ const DOCKER_CONFIG_MIME_TYPE: &str = "application/vnd.docker.container.image.v1
 
 /// The annotation key used to identify attestation manifests in the Docker Registry.
 const DOCKER_REFERENCE_TYPE_ANNOTATION: &str = "vnd.docker.reference.type";
+
+/// Spinner message used for fetching image details.
+const FETCH_IMAGE_DETAILS_MSG: &str = "Fetch image details";
+
+/// Spinner message used for downloading layers.
+const DOWNLOAD_LAYER_MSG: &str = "Download layers";
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -334,7 +340,11 @@ impl OciRegistryPull for DockerRegistry {
         selector: ReferenceSelector,
     ) -> MicrosandboxResult<()> {
         // Calculate total size and save image record
+        #[cfg(feature = "cli-viz")]
+        let fetch_details_sp = viz::create_spinner(FETCH_IMAGE_DETAILS_MSG.to_string(), None, None);
+
         let index = self.fetch_index(repository, selector.clone()).await?;
+
         let total_size: i64 = index.manifests().iter().map(|m| m.size() as i64).sum();
 
         // Construct reference based on selector type
@@ -382,22 +392,29 @@ impl OciRegistryPull for DockerRegistry {
             })
             .ok_or(MicrosandboxError::ManifestNotFound)?;
 
-        // Fetch and save manifest
         let manifest = self
             .fetch_manifest(repository, manifest_desc.digest())
             .await?;
+
         let manifest_id =
             db::save_manifest(&self.oci_db, image_id, Some(index_id), &manifest).await?;
 
-        // Fetch and save config
         let config = self
             .fetch_config(repository, manifest.config().digest())
             .await?;
+
         db::save_config(&self.oci_db, manifest_id, &config).await?;
 
+        #[cfg(feature = "cli-viz")]
+        fetch_details_sp.finish_with_message(FETCH_IMAGE_DETAILS_MSG);
+
+        let layers = manifest.layers();
+
+        #[cfg(feature = "cli-viz")]
+        let download_layers_sp = viz::create_spinner(DOWNLOAD_LAYER_MSG.to_string(), None, Some(layers.len() as u64));
+
         // Download layers concurrently and save to database
-        let layer_futures: Vec<_> = manifest
-            .layers()
+        let layer_futures: Vec<_> = layers
             .iter()
             .zip(config.rootfs().diff_ids())
             .map(|(layer_desc, diff_id)| async {
@@ -406,6 +423,9 @@ impl OciRegistryPull for DockerRegistry {
                 let layer_downloaded = self
                     .download_image_blob(repository, layer_desc.digest(), layer_desc.size())
                     .await?;
+
+                #[cfg(feature = "cli-viz")]
+                download_layers_sp.inc(1);
 
                 // Get or create layer record in database
                 let layer_id = if layer_downloaded {
@@ -461,6 +481,9 @@ impl OciRegistryPull for DockerRegistry {
         for result in future::join_all(layer_futures).await {
             result?;
         }
+
+        #[cfg(feature = "cli-viz")]
+        download_layers_sp.finish_with_message(DOWNLOAD_LAYER_MSG);
 
         Ok(())
     }

--- a/microsandbox-core/lib/oci/implementations/docker.rs
+++ b/microsandbox-core/lib/oci/implementations/docker.rs
@@ -411,7 +411,11 @@ impl OciRegistryPull for DockerRegistry {
         let layers = manifest.layers();
 
         #[cfg(feature = "cli-viz")]
-        let download_layers_sp = viz::create_spinner(DOWNLOAD_LAYER_MSG.to_string(), None, Some(layers.len() as u64));
+        let download_layers_sp = viz::create_spinner(
+            DOWNLOAD_LAYER_MSG.to_string(),
+            None,
+            Some(layers.len() as u64),
+        );
 
         // Download layers concurrently and save to database
         let layer_futures: Vec<_> = layers


### PR DESCRIPTION
- Add create_spinner utility function to standardize spinner creation
- Implement consistent progress visualization for:
  - Home directory operations
  - Image layer extraction and downloads
  - Menv directory operations
  - Docker registry operations
- Add descriptive constants for spinner messages
- Improve progress tracking with operation counts where applicable