### PR TITLE
refactor: reorganize sandbox scripts directory structure 

### DIFF
--- a/microsandbox-cli/bin/msb/handlers.rs
+++ b/microsandbox-cli/bin/msb/handlers.rs
@@ -430,19 +430,19 @@ pub async fn log_subcommand(
 pub async fn clean_subcommand(
     _sandbox: bool,
     name: Option<String>,
-    global: bool,
+    user: bool,
     all: bool,
     path: Option<PathBuf>,
     config: Option<String>,
     force: bool,
 ) -> MicrosandboxCliResult<()> {
-    if global || all {
-        // Global cleanup - clean the microsandbox home directory
+    if user || all {
+        // User-level cleanup - clean the microsandbox home directory
         home::clean().await?;
-        tracing::info!("global microsandbox home directory cleaned");
+        tracing::info!("user microsandbox home directory cleaned");
     }
 
-    if !global || all {
+    if !user || all {
         // Local project cleanup
         if let Some(sandbox_name) = name {
             // Clean specific sandbox if sandbox name is provided

--- a/microsandbox-cli/bin/msb/main.rs
+++ b/microsandbox-cli/bin/msb/main.rs
@@ -185,13 +185,13 @@ async fn main() -> MicrosandboxCliResult<()> {
         Some(MicrosandboxSubcommand::Clean {
             sandbox,
             name,
-            global,
+            user,
             all,
             path,
             config,
             force,
         }) => {
-            handlers::clean_subcommand(sandbox, name, global, all, path, config, force).await?;
+            handlers::clean_subcommand(sandbox, name, user, all, path, config, force).await?;
         }
         Some(MicrosandboxSubcommand::Self_ { action }) => {
             handlers::self_subcommand(action).await?;

--- a/microsandbox-cli/lib/args/msb.rs
+++ b/microsandbox-cli/lib/args/msb.rs
@@ -535,12 +535,12 @@ pub enum MicrosandboxSubcommand {
         #[arg()]
         name: Option<String>,
 
-        /// Clean globally. This cleans $MICROSANDBOX_HOME
-        #[arg(long)]
-        global: bool,
+        /// Clean user-level caches. This cleans $MICROSANDBOX_HOME
+        #[arg(short, long)]
+        user: bool,
 
         /// Clean all
-        #[arg(long)]
+        #[arg(short, long)]
         all: bool,
 
         /// Project path

--- a/microsandbox-utils/lib/path.rs
+++ b/microsandbox-utils/lib/path.rs
@@ -50,7 +50,12 @@ pub const SANDBOX_DB_FILENAME: &str = "sandbox.db";
 pub const OCI_DB_FILENAME: &str = "oci.db";
 
 /// The directory on the microvm where sandbox scripts are stored
-pub const SANDBOX_SCRIPT_DIR: &str = ".sandbox_scripts";
+pub const SANDBOX_DIR: &str = ".sandbox";
+
+/// The directory on the microvm where sandbox scripts are stored
+///
+/// Example: <SANDBOX_DIR>/<SCRIPTS_DIR>
+pub const SCRIPTS_DIR: &str = "scripts";
 
 /// The suffix added to extracted layer directories
 ///


### PR DESCRIPTION
- Move sandbox scripts from /.sandbox_scripts to /.sandbox/scripts to provide a more organized directory structure for sandbox-related files.
- Rename --global flag to --user for better clarity in clean subcommand
- Add short flags (-u, -a) for user and all options
- Update related documentation and log messages