### PR TITLE
feat(config): add exec command and make shell optional

### DIFF
--- a/microsandbox-cli/bin/msb/main.rs
+++ b/microsandbox-cli/bin/msb/main.rs
@@ -55,6 +55,7 @@ async fn main() -> MicrosandboxCliResult<()> {
             workdir,
             shell,
             scripts,
+            start,
             imports,
             exports,
             scope,
@@ -63,7 +64,7 @@ async fn main() -> MicrosandboxCliResult<()> {
         }) => {
             handlers::add_subcommand(
                 sandbox, build, group, names, image, memory, cpus, volumes, ports, envs, env_file,
-                depends_on, workdir, shell, scripts, imports, exports, scope, path, config,
+                depends_on, workdir, shell, scripts, start, imports, exports, scope, path, config,
             )
             .await?;
         }

--- a/microsandbox-cli/lib/args/msb.rs
+++ b/microsandbox-cli/lib/args/msb.rs
@@ -120,6 +120,10 @@ pub enum MicrosandboxSubcommand {
         #[arg(long = "script", name = "SCRIPT", value_parser = parse_key_val::<String, String>)]
         scripts: Vec<(String, String)>,
 
+        /// Start script
+        #[arg(long)]
+        start: Option<String>,
+
         /// Files to import, format: <name>=<path>
         #[arg(long = "import", name = "IMPORT", value_parser = parse_key_val::<String, String>)]
         imports: Vec<(String, String)>,

--- a/microsandbox-core/lib/error.rs
+++ b/microsandbox-core/lib/error.rs
@@ -262,7 +262,7 @@ pub enum MicrosandboxError {
     NotImplemented(String),
 
     /// An error that occurred when a sandbox was not found in the configuration
-    #[error("cannot find sandbox: '{0}' at '{1}'")]
+    #[error("cannot find sandbox: '{0}' in '{1}'")]
     SandboxNotFoundInConfig(String, PathBuf),
 
     /// An error that occurs when an invalid log level is used.
@@ -288,6 +288,10 @@ pub enum MicrosandboxError {
     /// An error that occurred when an invalid network scope was used.
     #[error("invalid network scope: {0}")]
     InvalidNetworkScope(String),
+
+    /// An error that occurred when a start script or exec command or shell is missing.
+    #[error("missing start script or exec command or shell")]
+    MissingStartOrExecOrShell,
 }
 
 /// An error that occurred when an invalid MicroVm configuration was used.

--- a/microsandbox-core/lib/management/rootfs.rs
+++ b/microsandbox-core/lib/management/rootfs.rs
@@ -5,7 +5,6 @@
 //! Container Initiative) specifications.
 
 use std::{
-    borrow::Cow,
     collections::HashMap,
     fs::Permissions,
     os::unix::fs::PermissionsExt,
@@ -86,7 +85,7 @@ impl Drop for PermissionGuard {
 /// * `shell_path` - Path to the shell binary within the rootfs (e.g. "/bin/sh")
 pub async fn patch_with_sandbox_scripts(
     scripts_dir: &Path,
-    scripts: Cow<'_, HashMap<String, String>>,
+    scripts: &HashMap<String, String>,
     shell_path: impl AsRef<Path>,
 ) -> MicrosandboxResult<()> {
     // Remove the scripts directory if it exists


### PR DESCRIPTION
- Add `exec` field to sandbox configuration to support direct command execution
- Make `shell` field optional in sandbox configuration
- Remove automatic shell fallback behavior for start script
- Add validation to ensure at least one of start script, exec, or shell is defined
- Update sandbox builder to support new exec field and optional shell
- Simplify script handling in sandbox configuration
- Add new error type for missing start/exec/shell configuration
