### PR TITLE
feat: add detached mode for sandbox execution

### DIFF
--- a/microsandbox-cli/bin/msb/handlers.rs
+++ b/microsandbox-cli/bin/msb/handlers.rs
@@ -298,12 +298,13 @@ pub async fn up_subcommand(
     group: bool,
     names: Vec<String>,
     file: Option<PathBuf>,
+    detach: bool,
 ) -> MicrosandboxCliResult<()> {
     trio_conflict_error(build, sandbox, group, "up", Some("[NAMES]"));
     unsupported_build_group_error(build, group, "up", Some("[NAMES]"));
 
     let (path, config) = parse_file_path(file);
-    orchestra::up(names, path.as_deref(), config.as_deref()).await?;
+    orchestra::up(names, path.as_deref(), config.as_deref(), detach).await?;
 
     Ok(())
 }

--- a/microsandbox-cli/bin/msb/main.rs
+++ b/microsandbox-cli/bin/msb/main.rs
@@ -161,9 +161,9 @@ async fn main() -> MicrosandboxCliResult<()> {
         Some(MicrosandboxSubcommand::Uninstall { script }) => {
             handlers::uninstall_subcommand(script).await?;
         }
-        Some(MicrosandboxSubcommand::Apply { file }) => {
+        Some(MicrosandboxSubcommand::Apply { file, detach }) => {
             let (path, config) = handlers::parse_file_path(file);
-            orchestra::apply(path.as_deref(), config.as_deref()).await?;
+            orchestra::apply(path.as_deref(), config.as_deref(), detach).await?;
         }
         Some(MicrosandboxSubcommand::Up {
             sandbox,
@@ -171,8 +171,9 @@ async fn main() -> MicrosandboxCliResult<()> {
             group,
             names,
             file,
+            detach,
         }) => {
-            handlers::up_subcommand(sandbox, build, group, names, file).await?;
+            handlers::up_subcommand(sandbox, build, group, names, file, detach).await?;
         }
         Some(MicrosandboxSubcommand::Down {
             sandbox,

--- a/microsandbox-cli/lib/args/msb.rs
+++ b/microsandbox-cli/lib/args/msb.rs
@@ -410,6 +410,10 @@ pub enum MicrosandboxSubcommand {
         /// Path to the sandbox file or the project directory
         #[arg(short, long)]
         file: Option<PathBuf>,
+
+        /// Run sandboxes in the background
+        #[arg(short, long)]
+        detach: bool,
     },
 
     /// Run a project's sandboxes
@@ -427,13 +431,16 @@ pub enum MicrosandboxSubcommand {
         #[arg(short, long)]
         group: bool,
 
-        /// Names of components to start
-        #[arg(required = true)]
+        /// Names of components to start. If omitted, starts all sandboxes defined in the configuration.
         names: Vec<String>,
 
         /// Path to the sandbox file or the project directory
         #[arg(short, long)]
         file: Option<PathBuf>,
+
+        /// Run sandboxes in the background
+        #[arg(short, long)]
+        detach: bool,
     },
 
     /// Stop a project's sandboxes

--- a/microsandbox-cli/lib/args/msb.rs
+++ b/microsandbox-cli/lib/args/msb.rs
@@ -458,8 +458,7 @@ pub enum MicrosandboxSubcommand {
         #[arg(short, long)]
         group: bool,
 
-        /// Names of components to stop
-        #[arg(required = true)]
+        /// Names of components to stop. If omitted, stops all sandboxes defined in the configuration.
         names: Vec<String>,
 
         /// Path to the sandbox file or the project directory

--- a/microsandbox-server/lib/handler.rs
+++ b/microsandbox-server/lib/handler.rs
@@ -577,6 +577,7 @@ async fn sandbox_start_impl(state: AppState, params: SandboxStartParams) -> Serv
         vec![sandbox.clone()],
         Some(&namespace_dir),
         Some(config_file),
+        false,
     )
     .await
     .map_err(|e| {


### PR DESCRIPTION
- Add `--detach` flag to `up` and `apply` commands
- Implement multiplexed output with colored prefixes for non-detached mode
- Make sandbox names optional in `up` command, defaulting to all sandboxes
- Add helper functions for running multiple sandboxes with prefixed output
- Update documentation and function signatures to support detached mode