### PR TITLE
feat(auth): implement smart auth middleware for MCP requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "atty",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-portal"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-server"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Team MicroSandbox <team@microsandbox.dev>"]
 repository = "https://github.com/microsandbox/microsandbox"
-version = "0.2.3"
+version = "0.2.4"
 license = "Apache-2.0"
 edition = "2021"
 
@@ -47,9 +47,9 @@ rand = "0.9"
 reqwest = { version = "0.12", features = ["stream", "json"] }
 reqwest-middleware = "0.3" # Cannot upgrade to 0.4 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
 reqwest-retry = "0.6"      # Cannot upgrade to 0.7 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
-microsandbox-utils = { version = "0.2.3", path = "./microsandbox-utils" }
-microsandbox-core = { version = "0.2.3", path = "./microsandbox-core" }
-microsandbox-server = { version = "0.2.3", path = "./microsandbox-server" }
+microsandbox-utils = { version = "0.2.4", path = "./microsandbox-utils" }
+microsandbox-core = { version = "0.2.4", path = "./microsandbox-core" }
+microsandbox-server = { version = "0.2.4", path = "./microsandbox-server" }
 multihash = "0.19"
 multihash-codetable = "0.1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/MSB_V_DOCKER.md
+++ b/MSB_V_DOCKER.md
@@ -14,10 +14,10 @@ Microsandbox fundamentally reimagines isolation security through hardware-virtua
 │  Your application    │                       │  Your application    │
 ├──────────────────────┤                       ├──────────────────────┤
 │  Host **kernel**     │◀── escapes here       │  **Guest kernel**    │
-└──────────────────────┘    - CVE‑2024‑21626   ├──────────────────────┤
-                            - CVE‑2024‑23653   │  VMM (KVM / Apple HV)│
+└──────────────────────┘    - CVE‑2024‑23653   ├──────────────────────┤
+                            - CVE‑2024‑21626   │  VMM (KVM / Apple HV)│
                             - CVE‑2023‑27561   ├──────────────────────┤
-                                               │  Host kernel         │ ✔ host is *never*
+                            - CVE-2024-26584   │  Host kernel         │ ✔ host is *never*
                                                └──────────────────────┘   directly reachable
 ```
 
@@ -46,7 +46,7 @@ Even with **full root access inside a Microsandbox**, attackers remain contained
 - macOS/Windows: Hidden Linux VM running in the background
 - Production: Often Linux-based with different kernel settings
 
-**Microsandbox** delivers perfect environment parity:
+**Microsandbox** delivers consistent environments across platforms:
 
 - **Identical kernels everywhere** — same microVM technology on all platforms
 - **Deterministic builds** with identical underlying systems
@@ -56,7 +56,7 @@ Even with **full root access inside a Microsandbox**, attackers remain contained
 
 ## 3. Unified Configuration Model: The Sandboxfile
 
-**Docker** requires managing separate Dockerfile, docker-compose.yml, and often .env files—creating a disjointed configuration experience and synchronization challenges.
+**Docker** requires managing separate Dockerfile and docker-compose.yml files, creating a disjointed configuration experience and synchronization challenges.
 
 **Microsandbox** consolidates everything into a single, declarative `Sandboxfile`:
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ msb server start --dev
 
 > [!TIP]
 >
-> microsandbox server is also an [MCP server](./MCP.md), so it works directly with Cursor, Agno, and other MCP-enabled AI tools and agents.
+> microsandbox server is also an [MCP server](./MCP.md), so it works directly with Claude, and other MCP-enabled AI tools and agents.
 >
 > For more information on setting up the server, see the [self-hosting guide](./SELF_HOSTING.md).
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Ever needed to run code you don't fully trust? Whether it's AI-generated code, u
 - **Running locally** - One malicious script and your entire system is compromised
 - **Using containers** - Shared kernels mean sophisticated attacks can still break out
 - **Traditional VMs** - Waiting 10+ seconds for a VM to boot kills productivity and performance
-- **Cloud solutions** - Can get expensive fast and at the whim of the cloud provider
+- **Cloud solutions** - Not as flexible, at the whim of the cloud provider
 
 **microsandbox** combines the best of all worlds:
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -38,7 +38,7 @@ msb server start --dev
 ```
 
 !!!info MCP Server
-The microsandbox server is also an [MCP server](https://modelcontextprotocol.io), which means it works directly with Cursor, Claude, and other MCP-enabled AI tools out of the box!
+The microsandbox server is also an [MCP server](https://modelcontextprotocol.io), which means it works directly with Claude and other MCP-enabled AI tools out of the box!
 
 [!ref See how to use microsandbox as an MCP server](/guides/mcp)
 !!!

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -347,26 +347,6 @@ Ask Claude: "Can you start a Python sandbox and run a simple calculation?"
    - Call `sandbox_run_code` to execute your calculation
    - Return the results in a natural language response
 
-#### Advanced Usage
-
-**Data Analysis Workflow:**
-
-```
-"Create a Python sandbox, install pandas, and analyze this CSV data: [paste data]"
-```
-
-**Web Development:**
-
-```
-"Start a Node.js sandbox and create a simple HTML generator script"
-```
-
-**Multi-step Processing:**
-
-```
-"Create a sandbox, download some data, process it, and create a visualization"
-```
-
 ---
 
 ### Next Steps

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -12,7 +12,7 @@ Learn how to integrate microsandbox with AI tools using the Model Context Protoc
 
 ### Overview
 
-The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard that enables AI applications to securely connect to external data sources and tools. microsandbox implements MCP as a built-in server, making it compatible with AI tools like Claude Desktop, Cursor, and other MCP-enabled applications.
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard that enables AI applications to securely connect to external data sources and tools. microsandbox implements MCP as a built-in server, making it compatible with AI tools like Claude, and other MCP-enabled applications.
 
 ---
 
@@ -319,7 +319,7 @@ asyncio.run(main())
 
 microsandbox works with any MCP-compatible application:
 
-- **Cursor** - AI-powered code editor
+- **Claude** - AI chat application
 - **Custom MCP clients** - Build your own integrations
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ asyncio.run(main())
 +++
 
 !!!info AI Integration Ready
-microsandbox server speaks [MCP](https://modelcontextprotocol.io) natively - connect it to **Cursor**, **Claude**, or any MCP-compatible AI tool in seconds!
+microsandbox server speaks [MCP](https://modelcontextprotocol.io) natively - connect it to **Claude**, or any MCP-compatible AI tool in seconds!
 
 [!ref See how to use microsandbox as a MCP server](/guides/mcp)
 !!!

--- a/docs/references/api.md
+++ b/docs/references/api.md
@@ -384,7 +384,7 @@ Execute a shell command in a running sandbox. This method is forwarded to the sa
 
 ### MCP (Model Context Protocol) Support
 
-The microsandbox server also implements the Model Context Protocol, making it compatible with AI tools like Cursor and Claude.
+The microsandbox server also implements the Model Context Protocol, making it compatible with AI tools like Claude.
 
 ==- MCP Methods
 The server supports the following MCP methods:

--- a/microsandbox-portal/lib/handler.rs
+++ b/microsandbox-portal/lib/handler.rs
@@ -251,7 +251,10 @@ async fn sandbox_command_run_impl(state: SharedState, params: Value) -> Result<V
 //--------------------------------------------------------------------------------------------------
 
 /// Helper function to create a JSON-RPC error response from a PortalError
-fn create_error_response(error: PortalError, id: Value) -> (StatusCode, Json<JsonRpcResponse>) {
+fn create_error_response(
+    error: PortalError,
+    id: Option<Value>,
+) -> (StatusCode, Json<JsonRpcResponse>) {
     // Determine appropriate JSON-RPC error code
     let code = match &error {
         PortalError::JsonRpc(_) => -32600,        // Invalid Request

--- a/microsandbox-server/lib/mcp.rs
+++ b/microsandbox-server/lib/mcp.rs
@@ -78,7 +78,7 @@ pub async fn handle_mcp_list_tools(
         "tools": [
             {
                 "name": "sandbox_start",
-                "description": "Start a new sandbox with specified configuration. This creates an isolated environment for code execution. IMPORTANT: Always stop the sandbox when done to prevent it from running indefinitely and consuming resources.",
+                "description": "Start a new sandbox with specified configuration. This creates an isolated environment for code execution. IMPORTANT: Always stop the sandbox when done to prevent it from running indefinitely and consuming resources. SUPPORTED IMAGES: Only 'microsandbox/python' (for Python code) and 'microsandbox/node' (for Node.js code) are currently supported.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -96,7 +96,8 @@ pub async fn handle_mcp_list_tools(
                             "properties": {
                                 "image": {
                                     "type": "string",
-                                    "description": "Docker image to use"
+                                    "description": "Docker image to use. Only 'microsandbox/python' and 'microsandbox/node' are supported.",
+                                    "enum": ["microsandbox/python", "microsandbox/node"]
                                 },
                                 "memory": {
                                     "type": "integer",

--- a/microsandbox-server/lib/mcp.rs
+++ b/microsandbox-server/lib/mcp.rs
@@ -18,8 +18,9 @@ use crate::{
         forward_rpc_to_portal, sandbox_get_metrics_impl, sandbox_start_impl, sandbox_stop_impl,
     },
     payload::{
-        JsonRpcError, JsonRpcRequest, JsonRpcResponse, SandboxMetricsGetParams, SandboxStartParams,
-        SandboxStopParams, JSONRPC_VERSION,
+        JsonRpcError, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseOrNotification,
+        ProcessedNotification, SandboxMetricsGetParams, SandboxStartParams, SandboxStopParams,
+        JSONRPC_VERSION,
     },
     state::AppState,
     ServerResult,
@@ -30,7 +31,7 @@ use crate::{
 //--------------------------------------------------------------------------------------------------
 
 /// MCP protocol version
-const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
 
 /// Server information
 const SERVER_NAME: &str = "microsandbox-server";
@@ -555,17 +556,48 @@ pub async fn handle_mcp_call_tool(
     Ok(JsonRpcResponse::success(mcp_result, request.id))
 }
 
+/// Handle MCP notifications/initialized request
+pub async fn handle_mcp_notifications_initialized(
+    _state: AppState,
+    _request: JsonRpcRequest,
+) -> ServerResult<ProcessedNotification> {
+    debug!("Handling MCP notifications/initialized");
+
+    // This is a notification - no response is expected
+    // The client is indicating it has finished initialization
+    Ok(ProcessedNotification::processed())
+}
+
 /// Handle MCP methods
 pub async fn handle_mcp_method(
     state: AppState,
     request: JsonRpcRequest,
-) -> ServerResult<JsonRpcResponse> {
+) -> ServerResult<JsonRpcResponseOrNotification> {
     match request.method.as_str() {
-        "initialize" => handle_mcp_initialize(state, request).await,
-        "tools/list" => handle_mcp_list_tools(state, request).await,
-        "tools/call" => handle_mcp_call_tool(state, request).await,
-        "prompts/list" => handle_mcp_list_prompts(state, request).await,
-        "prompts/get" => handle_mcp_get_prompt(state, request).await,
+        "initialize" => {
+            let response = handle_mcp_initialize(state, request).await?;
+            Ok(JsonRpcResponseOrNotification::response(response))
+        }
+        "tools/list" => {
+            let response = handle_mcp_list_tools(state, request).await?;
+            Ok(JsonRpcResponseOrNotification::response(response))
+        }
+        "tools/call" => {
+            let response = handle_mcp_call_tool(state, request).await?;
+            Ok(JsonRpcResponseOrNotification::response(response))
+        }
+        "prompts/list" => {
+            let response = handle_mcp_list_prompts(state, request).await?;
+            Ok(JsonRpcResponseOrNotification::response(response))
+        }
+        "prompts/get" => {
+            let response = handle_mcp_get_prompt(state, request).await?;
+            Ok(JsonRpcResponseOrNotification::response(response))
+        }
+        "notifications/initialized" => {
+            let notification = handle_mcp_notifications_initialized(state, request).await?;
+            Ok(JsonRpcResponseOrNotification::notification(notification))
+        }
         _ => Err(ServerError::NotFound(format!(
             "MCP method '{}' not found",
             request.method

--- a/microsandbox-server/lib/route.rs
+++ b/microsandbox-server/lib/route.rs
@@ -37,12 +37,13 @@ pub fn create_router(state: AppState) -> Router {
         ));
 
     // Create MCP routes - separate endpoint for Model Context Protocol
+    // Uses smart auth middleware that handles protocol vs tool methods differently
     let mcp_api =
         Router::new()
             .route("/", post(handler::mcp_handler))
             .layer(middleware::from_fn_with_state(
                 state.clone(),
-                app_middleware::auth_middleware,
+                app_middleware::mcp_smart_auth_middleware,
             ));
 
     // Combine all routes with logging middleware

--- a/scripts/install_microsandbox.sh
+++ b/scripts/install_microsandbox.sh
@@ -8,7 +8,7 @@
 #   ./install_microsandbox.sh [options]
 #
 # Options:
-#   --version       Specify version to install (default: 0.2.3)
+#   --version       Specify version to install (default: 0.2.4)
 #   --no-cleanup   Skip cleanup of temporary files after installation
 #
 # The script performs the following tasks:
@@ -43,7 +43,7 @@ error() {
 }
 
 # Default values
-VERSION="0.2.3"
+VERSION="0.2.4"
 NO_CLEANUP=false
 TEMP_DIR="/tmp/microsandbox-install"
 GITHUB_REPO="microsandbox/microsandbox"


### PR DESCRIPTION
Add specialized authentication middleware for Model Context Protocol (MCP) that handles protocol and tool methods differently:
- Protocol methods (initialize, tools/list, prompts/list, prompts/get) skip namespace validation
- Tool methods (tools/call) require namespace validation
- Update MCP router to use new smart auth middleware