### PR TITLE
feat(sandbox): add tmpfs mount support via MSB_TMPFS env var

### DIFF
--- a/crates/agentd/lib/init.rs
+++ b/crates/agentd/lib/init.rs
@@ -1,9 +1,23 @@
-//! PID 1 init: mount filesystems, prepare runtime directories.
+//! PID 1 init: mount filesystems, apply tmpfs mounts, prepare runtime directories.
 //!
 //! This module only performs real work on Linux. On other platforms, `init()` is a no-op
 //! to allow the crate to compile for development purposes.
 
-use crate::error::AgentdResult;
+use crate::error::{AgentdError, AgentdResult};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Parsed tmpfs mount specification.
+#[derive(Debug)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+struct TmpfsSpec<'a> {
+    path: &'a str,
+    size_mib: Option<u32>,
+    mode: Option<u32>,
+    noexec: bool,
+}
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -11,11 +25,13 @@ use crate::error::AgentdResult;
 
 /// Performs synchronous PID 1 initialization.
 ///
-/// Mounts essential filesystems and prepares runtime directories.
+/// Mounts essential filesystems, applies tmpfs mounts from `MSB_TMPFS` env var,
+/// and prepares runtime directories.
 #[cfg(target_os = "linux")]
 pub fn init() -> AgentdResult<()> {
     linux::mount_filesystems()?;
     linux::mount_runtime()?;
+    linux::apply_tmpfs_mounts()?;
     linux::create_run_dir()?;
     Ok(())
 }
@@ -24,6 +40,47 @@ pub fn init() -> AgentdResult<()> {
 #[cfg(not(target_os = "linux"))]
 pub fn init() -> AgentdResult<()> {
     Ok(())
+}
+
+/// Parses a single tmpfs entry: `path[,size=N][,mode=N][,noexec]`
+///
+/// Mode is parsed as octal (e.g. `mode=1777`).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_tmpfs_entry(entry: &str) -> AgentdResult<TmpfsSpec<'_>> {
+    let mut parts = entry.split(',');
+    let path = parts.next().unwrap(); // always at least one element
+    if path.is_empty() {
+        return Err(AgentdError::Init("tmpfs entry has empty path".into()));
+    }
+
+    let mut size_mib = None;
+    let mut mode = None;
+    let mut noexec = false;
+
+    for opt in parts {
+        if opt == "noexec" {
+            noexec = true;
+        } else if let Some(val) = opt.strip_prefix("size=") {
+            size_mib = Some(val.parse::<u32>().map_err(|_| {
+                AgentdError::Init(format!("invalid tmpfs size: {val}"))
+            })?);
+        } else if let Some(val) = opt.strip_prefix("mode=") {
+            mode = Some(u32::from_str_radix(val, 8).map_err(|_| {
+                AgentdError::Init(format!("invalid octal tmpfs mode: {val}"))
+            })?);
+        } else {
+            return Err(AgentdError::Init(format!(
+                "unknown tmpfs option: {opt}"
+            )));
+        }
+    }
+
+    Ok(TmpfsSpec {
+        path,
+        size_mib,
+        mode,
+        noexec,
+    })
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -40,6 +97,8 @@ mod linux {
     use nix::unistd::mkdir;
 
     use crate::error::{AgentdError, AgentdResult};
+
+    use super::TmpfsSpec;
 
     /// Mounts essential Linux filesystems.
     pub fn mount_filesystems() -> AgentdResult<()> {
@@ -131,6 +190,73 @@ mod linux {
         Ok(())
     }
 
+    /// Reads `MSB_TMPFS` env var and mounts each tmpfs entry.
+    ///
+    /// Missing env var is not an error (no tmpfs mounts requested).
+    /// Parse failures and mount failures are hard errors.
+    pub fn apply_tmpfs_mounts() -> AgentdResult<()> {
+        let val = match std::env::var(microsandbox_protocol::ENV_TMPFS) {
+            Ok(v) if !v.is_empty() => v,
+            _ => return Ok(()),
+        };
+
+        for entry in val.split(';') {
+            if entry.is_empty() {
+                continue;
+            }
+
+            let spec = super::parse_tmpfs_entry(entry)?;
+            mount_tmpfs(&spec)?;
+        }
+
+        Ok(())
+    }
+
+    /// Mounts a single tmpfs from a parsed spec.
+    fn mount_tmpfs(spec: &TmpfsSpec<'_>) -> AgentdResult<()> {
+        let path = spec.path;
+
+        // Determine the permission mode.
+        let mode = spec.mode.unwrap_or(if path == "/tmp" || path == "/var/tmp" {
+            0o1777
+        } else {
+            0o755
+        });
+
+        // Create the target directory.
+        std::fs::create_dir_all(path).map_err(|e| {
+            AgentdError::Init(format!("failed to create directory {path}: {e}"))
+        })?;
+
+        // Flags: nosuid + nodev (sensible safety defaults).
+        let mut flags =
+            MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_RELATIME;
+        if spec.noexec {
+            flags |= MsFlags::MS_NOEXEC;
+        }
+
+        // Mount data: size and mode options.
+        let mut data = String::new();
+        if let Some(mib) = spec.size_mib {
+            data.push_str(&format!("size={}", u64::from(mib) * 1024 * 1024));
+        }
+        if !data.is_empty() {
+            data.push(',');
+        }
+        data.push_str(&format!("mode={mode:o}"));
+
+        mount(
+            Some("tmpfs"),
+            path,
+            Some("tmpfs"),
+            flags,
+            Some(data.as_str()),
+        )
+        .map_err(|e| AgentdError::Init(format!("failed to mount tmpfs at {path}: {e}")))?;
+
+        Ok(())
+    }
+
     /// Creates the `/run` directory.
     pub fn create_run_dir() -> AgentdResult<()> {
         mkdir_ignore_exists("/run")?;
@@ -159,5 +285,79 @@ mod linux {
             Err(nix::Error::EBUSY) => Ok(()),
             Err(e) => Err(AgentdError::Init(format!("failed to mount {target}: {e}"))),
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_path_only() {
+        let spec = parse_tmpfs_entry("/tmp").unwrap();
+        assert_eq!(spec.path, "/tmp");
+        assert_eq!(spec.size_mib, None);
+        assert_eq!(spec.mode, None);
+        assert!(!spec.noexec);
+    }
+
+    #[test]
+    fn test_parse_with_size() {
+        let spec = parse_tmpfs_entry("/tmp,size=256").unwrap();
+        assert_eq!(spec.path, "/tmp");
+        assert_eq!(spec.size_mib, Some(256));
+    }
+
+    #[test]
+    fn test_parse_with_noexec() {
+        let spec = parse_tmpfs_entry("/tmp,noexec").unwrap();
+        assert_eq!(spec.path, "/tmp");
+        assert!(spec.noexec);
+    }
+
+    #[test]
+    fn test_parse_with_octal_mode() {
+        let spec = parse_tmpfs_entry("/tmp,mode=1777").unwrap();
+        assert_eq!(spec.mode, Some(0o1777));
+
+        let spec = parse_tmpfs_entry("/data,mode=755").unwrap();
+        assert_eq!(spec.mode, Some(0o755));
+    }
+
+    #[test]
+    fn test_parse_multi_options() {
+        let spec = parse_tmpfs_entry("/tmp,size=256,mode=1777,noexec").unwrap();
+        assert_eq!(spec.path, "/tmp");
+        assert_eq!(spec.size_mib, Some(256));
+        assert_eq!(spec.mode, Some(0o1777));
+        assert!(spec.noexec);
+    }
+
+    #[test]
+    fn test_parse_unknown_option_errors() {
+        let err = parse_tmpfs_entry("/tmp,bogus=42").unwrap_err();
+        assert!(err.to_string().contains("unknown tmpfs option"));
+    }
+
+    #[test]
+    fn test_parse_invalid_size_errors() {
+        let err = parse_tmpfs_entry("/tmp,size=abc").unwrap_err();
+        assert!(err.to_string().contains("invalid tmpfs size"));
+    }
+
+    #[test]
+    fn test_parse_invalid_mode_errors() {
+        let err = parse_tmpfs_entry("/tmp,mode=zzz").unwrap_err();
+        assert!(err.to_string().contains("invalid octal tmpfs mode"));
+    }
+
+    #[test]
+    fn test_parse_empty_path_errors() {
+        let err = parse_tmpfs_entry(",size=256").unwrap_err();
+        assert!(err.to_string().contains("empty path"));
     }
 }

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -218,6 +218,22 @@ fn shutdown_mode_str(mode: &microsandbox_runtime::policy::ShutdownMode) -> &'sta
     }
 }
 
+/// Push a `--mount tag:host_path[:ro]` arg pair.
+fn push_mount_arg(
+    args: &mut Vec<OsString>,
+    guest: &str,
+    host_display: &impl std::fmt::Display,
+    readonly: bool,
+) {
+    let tag = guest_mount_tag(guest);
+    let mut arg = format!("{tag}:{host_display}");
+    if readonly {
+        arg.push_str(":ro");
+    }
+    args.push(OsString::from("--mount"));
+    args.push(OsString::from(arg));
+}
+
 /// Generate a virtiofs tag from a guest mount path.
 ///
 /// Replaces `/` with `_` and strips leading underscores to produce a
@@ -332,11 +348,8 @@ fn supervisor_cli_args(
         }
     }
 
-    for (key, value) in &config.env {
-        args.push(OsString::from("--env"));
-        args.push(OsString::from(format!("{key}={value}")));
-    }
-
+    // Process mounts: emit --mount args for virtiofs mounts, collect tmpfs specs.
+    let mut tmpfs_val = String::new();
     for mount in &config.mounts {
         match mount {
             VolumeMount::Bind {
@@ -344,13 +357,7 @@ fn supervisor_cli_args(
                 guest,
                 readonly,
             } => {
-                let tag = guest_mount_tag(guest);
-                let mut arg = format!("{tag}:{}", host.display());
-                if *readonly {
-                    arg.push_str(":ro");
-                }
-                args.push(OsString::from("--mount"));
-                args.push(OsString::from(arg));
+                push_mount_arg(&mut args, guest, &host.display(), *readonly);
             }
             VolumeMount::Named {
                 name,
@@ -358,22 +365,35 @@ fn supervisor_cli_args(
                 readonly,
             } => {
                 let vol_path = config::config().volumes_dir().join(name);
-                let tag = guest_mount_tag(guest);
-                let mut arg = format!("{tag}:{}", vol_path.display());
-                if *readonly {
-                    arg.push_str(":ro");
-                }
-                args.push(OsString::from("--mount"));
-                args.push(OsString::from(arg));
+                push_mount_arg(&mut args, guest, &vol_path.display(), *readonly);
             }
-            VolumeMount::Tmpfs { .. } => {
-                // Tmpfs mounts are handled by the guest kernel, not virtiofs.
+            VolumeMount::Tmpfs { guest, size_mib } => {
+                if !tmpfs_val.is_empty() {
+                    tmpfs_val.push(';');
+                }
+                tmpfs_val.push_str(guest);
+                if let Some(s) = size_mib {
+                    tmpfs_val.push_str(&format!(",size={s}"));
+                }
             }
             VolumeMount::Backend { .. } => {
                 // Backend mounts are guarded at Sandbox::create() — they cannot
                 // reach this point in the subprocess path. If they do, skip them.
             }
         }
+    }
+
+    if !tmpfs_val.is_empty() {
+        args.push(OsString::from("--env"));
+        args.push(OsString::from(format!(
+            "{}={tmpfs_val}",
+            microsandbox_protocol::ENV_TMPFS
+        )));
+    }
+
+    for (key, value) in &config.env {
+        args.push(OsString::from("--env"));
+        args.push(OsString::from(format!("{key}={value}")));
     }
 
     if let Some(ref workdir) = config.workdir {
@@ -577,5 +597,63 @@ mod tests {
         assert!(!rendered.contains(&"--rootfs-path".to_string()));
         assert!(rendered.contains(&"--rootfs-lower".to_string()));
         assert!(rendered.contains(&"/tmp/rootfs-base".to_string()));
+    }
+
+    #[test]
+    fn test_supervisor_cli_args_inject_tmpfs_env_var() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/tmp", |m| m.tmpfs().size(256u32))
+            .volume("/var/tmp", |m| m.tmpfs())
+            .build()
+            .unwrap();
+
+        let args = supervisor_cli_args(
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/rootfs-base"),
+            Path::new("/tmp/rw"),
+            Path::new("/tmp/staging"),
+            9,
+            Path::new("/tmp/libkrunfw.dylib"),
+        );
+
+        let rendered = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(rendered.contains(&"MSB_TMPFS=/tmp,size=256;/var/tmp".to_string()));
+    }
+
+    #[test]
+    fn test_supervisor_cli_args_omit_tmpfs_env_var_when_no_tmpfs() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .build()
+            .unwrap();
+
+        let args = supervisor_cli_args(
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/rootfs-base"),
+            Path::new("/tmp/rw"),
+            Path::new("/tmp/staging"),
+            9,
+            Path::new("/tmp/libkrunfw.dylib"),
+        );
+
+        let rendered = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(!rendered.iter().any(|a| a.starts_with("MSB_TMPFS=")));
     }
 }

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -19,6 +19,29 @@ pub const RUNTIME_FS_TAG: &str = "msb_runtime";
 pub const RUNTIME_MOUNT_POINT: &str = "/.msb";
 
 //--------------------------------------------------------------------------------------------------
+// Constants: Guest Init Environment Variables
+//--------------------------------------------------------------------------------------------------
+
+/// Environment variable carrying tmpfs mount specs for guest init.
+///
+/// Format: `path[,key=value,...][;path[,key=value,...];...]`
+///
+/// - `path` — guest mount path (required, always the first element)
+/// - `size=N` — size limit in MiB (optional)
+/// - `noexec` — mount with noexec flag (optional)
+/// - `mode=N` — permission mode as octal integer (optional, e.g. `mode=1777`)
+///
+/// Entries are separated by `;`. Within an entry, the path comes first
+/// followed by comma-separated options.
+///
+/// Examples:
+/// - `MSB_TMPFS=/tmp,size=256` — 256 MiB tmpfs at `/tmp`
+/// - `MSB_TMPFS=/tmp,size=256;/var/tmp,size=128` — two tmpfs mounts
+/// - `MSB_TMPFS=/tmp` — tmpfs at `/tmp` with defaults
+/// - `MSB_TMPFS=/tmp,size=256,noexec` — with noexec flag
+pub const ENV_TMPFS: &str = "MSB_TMPFS";
+
+//--------------------------------------------------------------------------------------------------
 // Exports
 //--------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add guest-side tmpfs mount support using an environment variable instead of a file-based init config
- The host SDK encodes VolumeMount::Tmpfs entries as MSB_TMPFS env var in supervisor CLI args, which flows through to the guest VM process environment
- agentd reads the env var during PID 1 init and mounts tmpfs using the guest kernel -- zero file I/O, zero JSON parsing, zero new dependencies in the boot hot path
- Extensible format supports size, mode (octal), and noexec options with sensible defaults (nosuid+nodev always on, sticky bit for /tmp)

## Changes

- **crates/protocol/lib/lib.rs**: Add `ENV_TMPFS` constant with documented format spec (`path[,key=value,...][;...]`)
- **crates/microsandbox/lib/runtime/spawn.rs**: Collect tmpfs mounts during the existing mount iteration loop and inject `--env MSB_TMPFS=...` into supervisor CLI args. Extract `push_mount_arg` helper to deduplicate Bind/Named mount arm logic. Add 2 tests for tmpfs env var injection and omission
- **crates/agentd/lib/init.rs**: Add `apply_tmpfs_mounts()` step to PID 1 init sequence. Parse `MSB_TMPFS` env var with zero-dep string splitting. Mount tmpfs with nosuid+nodev flags, pass size and mode directly in mount data. Auto-detect 0o1777 for /tmp and /var/tmp. Add 9 unit tests for the parser covering all branches (path-only, size, mode, noexec, multi-option, error cases, empty path rejection)

## Test Plan

- Run `cargo test -p microsandbox --lib -- runtime::spawn` to verify host-side env var injection (8 tests)
- Run `cd crates/agentd && cargo test` to verify guest-side parser (9 tests)
- Run `cargo check --all` from workspace root to verify full compilation
- Verify format: `.volume("/tmp", |m| m.tmpfs().size(256))` should produce `MSB_TMPFS=/tmp,size=256`