### PR TITLE
chore: bump version to 0.3.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "bytes",
  "chrono",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2530,14 +2530,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "sea-orm",
 ]
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2575,14 +2575,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "sea-orm-migration",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "bytes",
  "crossbeam-queue",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "bytes",
  "chrono",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "bytes",
  "chrono",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "crc32c",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.3.10"
+version = "0.3.11"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/crates/agentd/Cargo.lock
+++ b/crates/agentd/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "chrono",
  "ciborium",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "chrono",
  "ciborium",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -5,7 +5,7 @@ members = ["."]
 [workspace.package]
 authors = ["Super Rad Company <developemnt@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.3.10"
+version = "0.3.11"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -46,7 +46,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { version = "0.3.10", path = "../protocol" }
+microsandbox-protocol = { version = "0.3.11", path = "../protocol" }
 nix = { workspace = true, features = [
     "fs",
     "hostname",

--- a/crates/agentd/lib/session.rs
+++ b/crates/agentd/lib/session.rs
@@ -855,8 +855,8 @@ mod tests {
         let req = ExecRequest {
             cmd: "/bin/sh".to_string(),
             args: vec![
-                "-lc".to_string(),
-                "i=0; while [ $i -lt 1024 ]; do printf AAAA; i=$((i+1)); done; printf SECOND; sleep 1; printf '<END>\\n'; sleep 1"
+                "-c".to_string(),
+                "i=0; while [ $i -lt 1024 ]; do printf AAAA; i=$((i+1)); done; printf SECOND; sleep 1; printf '<END>\\n'; sleep 1; exit 0"
                     .to_string(),
             ],
             env: vec!["PATH=/usr/local/bin:/usr/bin:/bin".to_string()],

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,11 +28,11 @@ console.workspace = true
 dirs.workspace = true
 indicatif.workspace = true
 libc.workspace = true
-microsandbox = { version = "0.3.10", path = "../microsandbox", default-features = false }
-microsandbox-image = { version = "0.3.10", path = "../image" }
-microsandbox-network = { version = "0.3.10", path = "../network", optional = true }
-microsandbox-runtime = { version = "0.3.10", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.3.10", path = "../utils" }
+microsandbox = { version = "0.3.11", path = "../microsandbox", default-features = false }
+microsandbox-image = { version = "0.3.11", path = "../image" }
+microsandbox-network = { version = "0.3.11", path = "../network", optional = true }
+microsandbox-runtime = { version = "0.3.11", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.3.11", path = "../utils" }
 rand.workspace = true
 reqwest.workspace = true
 rpassword.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { version = "0.3.10", path = "../utils" }
+microsandbox-utils = { version = "0.3.11", path = "../utils" }
 msb_krun = "0.1.9"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,5 +23,5 @@ default = ["prebuilt"]
 prebuilt = ["dep:ureq"]
 
 [build-dependencies]
-microsandbox-utils = { version = "0.3.10", path = "../utils" }
+microsandbox-utils = { version = "0.3.11", path = "../utils" }
 ureq = { workspace = true, optional = true }

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { version = "0.3.10", path = "../utils" }
+microsandbox-utils = { version = "0.3.11", path = "../utils" }
 oci-client.workspace = true
 oci-spec.workspace = true
 scopeguard.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -25,14 +25,14 @@ dirs.workspace = true
 flate2.workspace = true
 futures.workspace = true
 libc.workspace = true
-microsandbox-db = { version = "0.3.10", path = "../db" }
-microsandbox-filesystem = { version = "0.3.10", path = "../filesystem", default-features = false }
-microsandbox-image = { version = "0.3.10", path = "../image" }
-microsandbox-migration = { version = "0.3.10", path = "../migration" }
-microsandbox-network = { version = "0.3.10", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.3.10", path = "../protocol" }
-microsandbox-runtime = { version = "0.3.10", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.3.10", path = "../utils" }
+microsandbox-db = { version = "0.3.11", path = "../db" }
+microsandbox-filesystem = { version = "0.3.11", path = "../filesystem", default-features = false }
+microsandbox-image = { version = "0.3.11", path = "../image" }
+microsandbox-migration = { version = "0.3.11", path = "../migration" }
+microsandbox-network = { version = "0.3.11", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.3.11", path = "../protocol" }
+microsandbox-runtime = { version = "0.3.11", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.3.11", path = "../utils" }
 nix = { workspace = true, features = ["process", "signal"] }
 reqwest.workspace = true
 scopeguard.workspace = true

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -19,7 +19,7 @@ hickory-resolver = { workspace = true }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
-microsandbox-utils = { version = "0.3.10", path = "../utils" }
+microsandbox-utils = { version = "0.3.11", path = "../utils" }
 msb_krun = { version = "0.1.9", features = ["net"] }
 rcgen = { workspace = true }
 rustls = { workspace = true }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,11 +22,11 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
-microsandbox-db = { version = "0.3.10", path = "../db" }
-microsandbox-filesystem = { version = "0.3.10", path = "../filesystem", default-features = false }
-microsandbox-network = { version = "0.3.10", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.3.10", path = "../protocol" }
-microsandbox-utils = { version = "0.3.10", path = "../utils" }
+microsandbox-db = { version = "0.3.11", path = "../db" }
+microsandbox-filesystem = { version = "0.3.11", path = "../filesystem", default-features = false }
+microsandbox-network = { version = "0.3.11", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.3.11", path = "../protocol" }
+microsandbox-utils = { version = "0.3.11", path = "../utils" }
 msb_krun = { version = "0.1.9", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.10"
+    "microsandbox": "0.3.11"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.10"
+    "microsandbox": "0.3.11"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.10"
+    "microsandbox": "0.3.11"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.10"
+    "microsandbox": "0.3.11"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.10"
+    "microsandbox": "0.3.11"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.10"
+    "microsandbox": "0.3.11"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.10"
+    "microsandbox": "0.3.11"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.10"
+    "microsandbox": "0.3.11"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.10"
+    "microsandbox": "0.3.11"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.10"
+    "microsandbox": "0.3.11"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.10"
+    "microsandbox": "0.3.11"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/sdk/node-ts/Cargo.toml
+++ b/sdk/node-ts/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 path = "lib/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.3.10", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.3.10", path = "../../crates/network" }
+microsandbox = { version = "0.3.11", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.3.11", path = "../../crates/network" }
 napi = { version = "3", default-features = false, features = [
     "async",
     "tokio_rt",

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "microsandbox.darwin-arm64.node",

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "microsandbox.linux-arm64-gnu.node",

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "microsandbox.linux-x64-gnu.node",

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "main": "index.cjs",
   "module": "index.mjs",
   "types": "index.d.cts",
@@ -26,9 +26,9 @@
     "@napi-rs/cli": "^3"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.3.10",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.3.10",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.10"
+    "@superradcompany/microsandbox-darwin-arm64": "0.3.11",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.3.11",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.11"
   },
   "files": [
     "index.cjs",


### PR DESCRIPTION
## Summary
- Bump all microsandbox Cargo crates from 0.3.10 to 0.3.11 (workspace version, all internal dependency references, and agentd's separate workspace)
- Bump all microsandbox npm packages from 0.3.10 to 0.3.11 (microsandbox SDK, microsandbox-mcp, platform-specific binary packages, and all TypeScript examples)
- Includes a minor test fix in agentd session tests (use `-c` instead of `-lc` shell flag and add explicit `exit 0`)

Changes since 0.3.10:
- refactor(filesystem): extract shared dir snapshot logic and add inject_init config (#495)
- fix(filesystem): fix symlink xattr ops, init listxattr, and update docs (#493)
- docs: replace broken DEVELOPMENT.md references with `just setup` workflow (#482)

## Test Plan
- [x] Run `cargo build` to verify successful compilation with new version
- [x] Run `cargo clippy` to verify no warnings
- [x] Verify agentd builds: `cd crates/agentd && cargo build`
- [x] Confirm no remaining references to 0.3.10: `grep -r "0.3.10" --include="*.toml" --include="*.json"`