### PR TITLE
fix(db): make SQLite migrations idempotent and enable WAL mode

### DIFF
--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -31,6 +31,10 @@ pub struct SandboxArgs {
     #[arg(long = "db-path")]
     pub sandbox_db_path: PathBuf,
 
+    /// Pool acquire timeout for the sandbox database, in seconds.
+    #[arg(long = "db-connect-timeout")]
+    pub sandbox_db_connect_timeout_secs: u64,
+
     /// Directory for log files.
     #[arg(long)]
     pub log_dir: PathBuf,
@@ -173,6 +177,7 @@ pub fn run(args: SandboxArgs, log_level: Option<LogLevel>) -> ! {
         sandbox_id: args.sandbox_id,
         log_level,
         sandbox_db_path: args.sandbox_db_path,
+        sandbox_db_connect_timeout_secs: args.sandbox_db_connect_timeout_secs,
         log_dir: args.log_dir,
         runtime_dir: args.runtime_dir,
         agent_sock_path: args.agent_sock,

--- a/crates/microsandbox/lib/config/mod.rs
+++ b/crates/microsandbox/lib/config/mod.rs
@@ -29,6 +29,9 @@ const DEFAULT_MEMORY_MIB: u32 = 512;
 /// Default database max connections.
 pub(crate) const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 
+/// Default database pool connect timeout in seconds.
+pub(crate) const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 30;
+
 /// Service name for microsandbox-managed registry credentials in the OS keyring.
 const REGISTRY_KEYRING_SERVICE: &str = "dev.microsandbox.registry";
 
@@ -72,6 +75,13 @@ pub struct DatabaseConfig {
 
     /// Maximum connection pool size.
     pub max_connections: u32,
+
+    /// Pool acquire timeout in seconds.
+    ///
+    /// How long a caller waits for a free connection from the pool before
+    /// the acquire fails. On a healthy local DB this should never fire —
+    /// raising it masks contention rather than fixing it.
+    pub connect_timeout_secs: u64,
 }
 
 /// Path overrides for runtime binaries and data directories.
@@ -328,6 +338,7 @@ impl Default for DatabaseConfig {
         Self {
             url: None,
             max_connections: DEFAULT_MAX_CONNECTIONS,
+            connect_timeout_secs: DEFAULT_CONNECT_TIMEOUT_SECS,
         }
     }
 }

--- a/crates/microsandbox/lib/db/mod.rs
+++ b/crates/microsandbox/lib/db/mod.rs
@@ -6,7 +6,10 @@
 
 pub use microsandbox_db::entity;
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use microsandbox_migration::{Migrator, MigratorTrait};
 use sea_orm::{ConnectOptions, Database, DatabaseConnection};
@@ -123,12 +126,27 @@ async fn connect_and_migrate(
     let db_url = format!("sqlite://{db_path_str}?mode=rwc");
 
     let mut opts = ConnectOptions::new(&db_url);
-    opts.max_connections(max_connections);
+    configure_sqlite_connect_options(&mut opts, max_connections);
 
     let conn = Database::connect(opts).await?;
     Migrator::up(&conn, None).await?;
 
     Ok(conn)
+}
+
+fn configure_sqlite_connect_options(opts: &mut ConnectOptions, max_connections: u32) {
+    // The global microsandbox DB is shared across short-lived CLI processes and
+    // long-lived sandbox runtimes. WAL mode plus a busy timeout makes that
+    // multi-process pattern much more reliable than the default rollback
+    // journal on Linux hosts.
+    opts.max_connections(max_connections)
+        .connect_timeout(Duration::from_secs(30))
+        .map_sqlx_sqlite_opts(|sqlx_opts| {
+            sqlx_opts
+                .foreign_keys(true)
+                .busy_timeout(Duration::from_secs(5))
+                .pragma("journal_mode", "WAL")
+        });
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -137,7 +155,7 @@ async fn connect_and_migrate(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{ConnectionTrait, Statement};
+    use sea_orm::{ConnectionTrait, Database, Statement};
 
     use super::*;
 
@@ -192,5 +210,92 @@ mod tests {
 
         // Running migrations again on the same DB should succeed.
         Migrator::up(&conn1, None).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_connect_and_migrate_recovers_from_partial_storage_migration() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_dir = tmp.path().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+
+        let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+        let conn = Database::connect(&db_url).await.unwrap();
+
+        Migrator::up(&conn, Some(2)).await.unwrap();
+
+        conn.execute_unprepared(
+            r#"
+            CREATE TABLE IF NOT EXISTS "volume" (
+                "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+                "name" text NOT NULL UNIQUE,
+                "quota_mib" integer,
+                "size_bytes" bigint,
+                "labels" text,
+                "created_at" datetime_text,
+                "updated_at" datetime_text
+            );
+            CREATE TABLE IF NOT EXISTS "snapshot" (
+                "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+                "name" text NOT NULL,
+                "sandbox_id" integer,
+                "size_bytes" bigint,
+                "description" text,
+                "created_at" datetime_text,
+                FOREIGN KEY ("sandbox_id") REFERENCES "sandbox" ("id") ON DELETE SET NULL
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS "idx_snapshots_name_sandbox_unique" ON "snapshot" ("name", "sandbox_id");
+            "#,
+        )
+        .await
+        .unwrap();
+
+        drop(conn);
+
+        let conn = connect_and_migrate(&db_dir, 1).await.unwrap();
+
+        let migrations = conn
+            .query_all(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT version FROM seaql_migrations ORDER BY version",
+            ))
+            .await
+            .unwrap();
+
+        let migration_names: Vec<String> = migrations
+            .iter()
+            .map(|row| row.try_get_by_index::<String>(0).unwrap())
+            .collect();
+
+        assert_eq!(
+            migration_names,
+            vec![
+                "m20260305_000001_create_image_tables",
+                "m20260305_000002_create_sandbox_tables",
+                "m20260305_000003_create_storage_tables",
+                "m20260305_000004_create_sandbox_images_table",
+            ]
+        );
+
+        let indexes = conn
+            .query_all(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_snapshots%' ORDER BY name",
+            ))
+            .await
+            .unwrap();
+
+        let index_names: Vec<String> = indexes
+            .iter()
+            .map(|row| row.try_get_by_index::<String>(0).unwrap())
+            .collect();
+
+        assert_eq!(
+            index_names,
+            vec![
+                "idx_snapshots_name_sandbox_unique",
+                "idx_snapshots_name_unique_no_sandbox",
+            ]
+        );
     }
 }

--- a/crates/microsandbox/lib/db/mod.rs
+++ b/crates/microsandbox/lib/db/mod.rs
@@ -31,10 +31,9 @@ static PROJECT_POOL: OnceCell<(PathBuf, DatabaseConnection)> = OnceCell::const_n
 /// Initialize the global database connection pool at `~/.microsandbox/db/msb.db`.
 ///
 /// Migrations are applied automatically. This is idempotent — calling it
-/// multiple times returns the existing pool.
-pub async fn init_global(
-    max_connections: Option<u32>,
-) -> MicrosandboxResult<&'static DatabaseConnection> {
+/// multiple times returns the existing pool. Pool settings are read from
+/// `config::config().database`.
+pub async fn init_global() -> MicrosandboxResult<&'static DatabaseConnection> {
     GLOBAL_POOL
         .get_or_try_init(|| async {
             let base = dirs::home_dir().ok_or_else(|| {
@@ -45,9 +44,11 @@ pub async fn init_global(
                 .join(microsandbox_utils::BASE_DIR_NAME)
                 .join(microsandbox_utils::DB_SUBDIR);
 
+            let db_cfg = &crate::config::config().database;
             connect_and_migrate(
                 &db_dir,
-                max_connections.unwrap_or(crate::config::DEFAULT_MAX_CONNECTIONS),
+                db_cfg.max_connections,
+                Duration::from_secs(db_cfg.connect_timeout_secs),
             )
             .await
         })
@@ -61,7 +62,6 @@ pub async fn init_global(
 /// with a different project directory than the first call.
 pub async fn init_project(
     project_dir: impl AsRef<Path>,
-    max_connections: Option<u32>,
 ) -> MicrosandboxResult<&'static DatabaseConnection> {
     let requested = project_dir.as_ref().to_path_buf();
 
@@ -71,9 +71,11 @@ pub async fn init_project(
                 .join(microsandbox_utils::BASE_DIR_NAME)
                 .join(microsandbox_utils::DB_SUBDIR);
 
+            let db_cfg = &crate::config::config().database;
             let conn = connect_and_migrate(
                 &db_dir,
-                max_connections.unwrap_or(crate::config::DEFAULT_MAX_CONNECTIONS),
+                db_cfg.max_connections,
+                Duration::from_secs(db_cfg.connect_timeout_secs),
             )
             .await?;
             Ok::<_, crate::MicrosandboxError>((requested.clone(), conn))
@@ -113,6 +115,7 @@ pub fn project() -> Option<&'static DatabaseConnection> {
 async fn connect_and_migrate(
     db_dir: &Path,
     max_connections: u32,
+    connect_timeout: Duration,
 ) -> MicrosandboxResult<DatabaseConnection> {
     tokio::fs::create_dir_all(db_dir).await?;
 
@@ -126,7 +129,7 @@ async fn connect_and_migrate(
     let db_url = format!("sqlite://{db_path_str}?mode=rwc");
 
     let mut opts = ConnectOptions::new(&db_url);
-    configure_sqlite_connect_options(&mut opts, max_connections);
+    configure_sqlite_connect_options(&mut opts, max_connections, connect_timeout);
 
     let conn = Database::connect(opts).await?;
     Migrator::up(&conn, None).await?;
@@ -134,13 +137,17 @@ async fn connect_and_migrate(
     Ok(conn)
 }
 
-fn configure_sqlite_connect_options(opts: &mut ConnectOptions, max_connections: u32) {
+fn configure_sqlite_connect_options(
+    opts: &mut ConnectOptions,
+    max_connections: u32,
+    connect_timeout: Duration,
+) {
     // The global microsandbox DB is shared across short-lived CLI processes and
     // long-lived sandbox runtimes. WAL mode plus a busy timeout makes that
     // multi-process pattern much more reliable than the default rollback
     // journal on Linux hosts.
     opts.max_connections(max_connections)
-        .connect_timeout(Duration::from_secs(30))
+        .connect_timeout(connect_timeout)
         .map_sqlx_sqlite_opts(|sqlx_opts| {
             sqlx_opts
                 .foreign_keys(true)
@@ -164,7 +171,9 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db_dir = tmp.path().join("db");
 
-        let conn = connect_and_migrate(&db_dir, 1).await.unwrap();
+        let conn = connect_and_migrate(&db_dir, 1, Duration::from_secs(30))
+            .await
+            .unwrap();
 
         // DB file should exist on disk.
         assert!(db_dir.join(microsandbox_utils::DB_FILENAME).exists());
@@ -206,7 +215,9 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db_dir = tmp.path().join("db");
 
-        let conn1 = connect_and_migrate(&db_dir, 1).await.unwrap();
+        let conn1 = connect_and_migrate(&db_dir, 1, Duration::from_secs(30))
+            .await
+            .unwrap();
 
         // Running migrations again on the same DB should succeed.
         Migrator::up(&conn1, None).await.unwrap();
@@ -252,7 +263,9 @@ mod tests {
 
         drop(conn);
 
-        let conn = connect_and_migrate(&db_dir, 1).await.unwrap();
+        let conn = connect_and_migrate(&db_dir, 1, Duration::from_secs(30))
+            .await
+            .unwrap();
 
         let migrations = conn
             .query_all(Statement::from_string(

--- a/crates/microsandbox/lib/image/mod.rs
+++ b/crates/microsandbox/lib/image/mod.rs
@@ -153,8 +153,7 @@ impl Image {
         reference: &str,
         metadata: microsandbox_image::CachedImageMetadata,
     ) -> MicrosandboxResult<i32> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         let reference = reference.to_string();
 
@@ -216,8 +215,7 @@ impl Image {
 
     /// Get an image handle by reference.
     pub async fn get(reference: &str) -> MicrosandboxResult<ImageHandle> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         let image_model = image_entity::Entity::find()
             .filter(image_entity::Column::Reference.eq(reference))
@@ -230,8 +228,7 @@ impl Image {
 
     /// List all cached images, ordered by creation time (newest first).
     pub async fn list() -> MicrosandboxResult<Vec<ImageHandle>> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         let image_models = image_entity::Entity::find()
             .order_by_desc(image_entity::Column::CreatedAt)
@@ -247,8 +244,7 @@ impl Image {
 
     /// Get full detail for an image (config + layers).
     pub async fn inspect(reference: &str) -> MicrosandboxResult<ImageDetail> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         let image_model = image_entity::Entity::find()
             .filter(image_entity::Column::Reference.eq(reference))
@@ -353,8 +349,7 @@ impl Image {
     /// If `force` is false and the image is referenced by any sandbox, returns
     /// [`MicrosandboxError::ImageInUse`].
     pub async fn remove(reference: &str, force: bool) -> MicrosandboxResult<()> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         let image_model = image_entity::Entity::find()
             .filter(image_entity::Column::Reference.eq(reference))

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -418,6 +418,10 @@ fn sandbox_cli_args(
     args.push(OsString::from(sandbox_id.to_string()));
     args.push(OsString::from("--db-path"));
     args.push(db_path.as_os_str().to_os_string());
+    args.push(OsString::from("--db-connect-timeout"));
+    args.push(OsString::from(
+        config::config().database.connect_timeout_secs.to_string(),
+    ));
     args.push(OsString::from("--log-dir"));
     args.push(log_dir.as_os_str().to_os_string());
     args.push(OsString::from("--runtime-dir"));

--- a/crates/microsandbox/lib/sandbox/handle.rs
+++ b/crates/microsandbox/lib/sandbox/handle.rs
@@ -94,8 +94,7 @@ impl SandboxHandle {
             )));
         }
 
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
         super::metrics::metrics_for_sandbox(
             db,
             self.db_id,
@@ -179,8 +178,7 @@ impl SandboxHandle {
         let all_dead = pids.is_empty() || pids.iter().all(|pid| !super::pid_is_alive(*pid));
 
         if all_dead {
-            let db = crate::db::init_global(Some(crate::config::config().database.max_connections))
-                .await?;
+            let db = crate::db::init_global().await?;
             if let Err(e) =
                 super::update_sandbox_status(db, self.db_id, SandboxStatus::Stopped).await
             {
@@ -204,8 +202,7 @@ impl SandboxHandle {
             )));
         }
 
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         super::remove_dir_if_exists(&crate::config::config().sandboxes_dir().join(&self.name))?;
         sandbox_entity::Entity::delete_by_id(self.db_id)

--- a/crates/microsandbox/lib/sandbox/metrics.rs
+++ b/crates/microsandbox/lib/sandbox/metrics.rs
@@ -47,8 +47,7 @@ pub struct SandboxMetrics {
 impl Sandbox {
     /// Get the latest metrics snapshot for this running sandbox.
     pub async fn metrics(&self) -> MicrosandboxResult<SandboxMetrics> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
         metrics_for_sandbox(db, self.db_id, memory_limit_bytes(&self.config)).await
     }
 
@@ -69,9 +68,7 @@ impl Sandbox {
             tokio::time::interval(interval),
             move |mut ticker| async move {
                 ticker.tick().await;
-                let db =
-                    crate::db::init_global(Some(crate::config::config().database.max_connections))
-                        .await;
+                let db = crate::db::init_global().await;
                 let item = match db {
                     Ok(db) => metrics_for_sandbox(db, db_id, memory_limit_bytes).await,
                     Err(err) => Err(err),
@@ -88,7 +85,7 @@ impl Sandbox {
 
 /// Get the latest metrics snapshot for every running sandbox.
 pub async fn all_sandbox_metrics() -> MicrosandboxResult<HashMap<String, SandboxMetrics>> {
-    let db = crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+    let db = crate::db::init_global().await?;
     let sandboxes = sandbox_entity::Entity::find()
         .filter(
             sandbox_entity::Column::Status.is_in([SandboxStatus::Running, SandboxStatus::Draining]),

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -181,8 +181,7 @@ impl Sandbox {
 
         // Initialize the database before any expensive image pull so we can
         // fail fast on conflicting persisted sandbox state.
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
         let sandbox_dir = crate::config::config().sandboxes_dir().join(&config.name);
         prepare_create_target(db, &config, &sandbox_dir).await?;
 
@@ -267,8 +266,7 @@ impl Sandbox {
 
     pub(super) async fn start_with_mode(name: &str, mode: SpawnMode) -> MicrosandboxResult<Self> {
         tracing::debug!(sandbox = name, ?mode, "start_with_mode: loading record");
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
         let model = load_sandbox_record_reconciled(db, name).await?;
         tracing::debug!(sandbox = name, status = ?model.status, "start_with_mode: current status");
 
@@ -327,8 +325,7 @@ impl Sandbox {
 
     /// Get a sandbox handle by name from the database.
     pub async fn get(name: &str) -> MicrosandboxResult<SandboxHandle> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         let model = sandbox_entity::Entity::find()
             .filter(sandbox_entity::Column::Name.eq(name))
@@ -342,8 +339,7 @@ impl Sandbox {
 
     /// List all sandboxes from the database.
     pub async fn list() -> MicrosandboxResult<Vec<SandboxHandle>> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         let sandboxes = sandbox_entity::Entity::find()
             .order_by_desc(sandbox_entity::Column::CreatedAt)
@@ -374,8 +370,7 @@ impl Sandbox {
 impl Sandbox {
     /// Remove this sandbox's persisted state after it has fully stopped.
     pub async fn remove_persisted(self) -> MicrosandboxResult<()> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         remove_dir_if_exists(
             &crate::config::config()
@@ -1178,7 +1173,7 @@ pub(super) async fn update_sandbox_status(
 /// from updating the database on exit are cleaned up without blocking the
 /// main path.
 pub async fn reap_stale_sandboxes() -> MicrosandboxResult<()> {
-    let db = crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+    let db = crate::db::init_global().await?;
 
     let stale = sandbox_entity::Entity::find()
         .filter(

--- a/crates/microsandbox/lib/volume/mod.rs
+++ b/crates/microsandbox/lib/volume/mod.rs
@@ -123,8 +123,7 @@ impl VolumeHandle {
     /// Deletes the DB record first, then the directory. An orphaned directory
     /// is easier to detect and clean up than an orphaned DB record.
     pub async fn remove(&self) -> MicrosandboxResult<()> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         // Delete the DB record first.
         volume_entity::Entity::delete_by_id(self.db_id)
@@ -159,8 +158,7 @@ impl Volume {
         tracing::debug!(name = %config.name, quota_mib = ?config.quota_mib, "Volume::create");
         validate_volume_name(&config.name)?;
 
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         // Check for existing volume.
         let existing = volume_entity::Entity::find()
@@ -215,8 +213,7 @@ impl Volume {
     ///
     /// Returns a lightweight handle for metadata and management operations.
     pub async fn get(name: &str) -> MicrosandboxResult<VolumeHandle> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         let model = volume_entity::Entity::find()
             .filter(volume_entity::Column::Name.eq(name))
@@ -229,8 +226,7 @@ impl Volume {
 
     /// List all volumes, ordered by creation time (newest first).
     pub async fn list() -> MicrosandboxResult<Vec<VolumeHandle>> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?;
 
         let models = volume_entity::Entity::find()
             .order_by_desc(volume_entity::Column::CreatedAt)

--- a/crates/migration/lib/m20260305_000003_create_storage_tables.rs
+++ b/crates/migration/lib/m20260305_000003_create_storage_tables.rs
@@ -110,6 +110,7 @@ impl MigrationTrait for Migration {
         manager
             .create_index(
                 Index::create()
+                    .if_not_exists()
                     .name("idx_snapshots_name_sandbox_unique")
                     .table(Snapshot::Table)
                     .col(Snapshot::Name)
@@ -125,7 +126,7 @@ impl MigrationTrait for Migration {
         manager
             .get_connection()
             .execute_unprepared(
-                "CREATE UNIQUE INDEX idx_snapshots_name_unique_no_sandbox ON snapshot (name) WHERE sandbox_id IS NULL",
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_snapshots_name_unique_no_sandbox ON snapshot (name) WHERE sandbox_id IS NULL",
             )
             .await?;
 

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -56,6 +56,9 @@ pub struct Config {
     /// Path to the sandbox database file.
     pub sandbox_db_path: PathBuf,
 
+    /// Pool acquire timeout for the sandbox database, in seconds.
+    pub sandbox_db_connect_timeout_secs: u64,
+
     /// Directory for log files.
     pub log_dir: PathBuf,
 
@@ -241,7 +244,10 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     std::fs::create_dir_all(config.runtime_dir.join("scripts"))?;
 
     // Connect to DB and insert records.
-    let db = tokio_rt.block_on(connect_db(&config.sandbox_db_path))?;
+    let db = tokio_rt.block_on(connect_db(
+        &config.sandbox_db_path,
+        Duration::from_secs(config.sandbox_db_connect_timeout_secs),
+    ))?;
     let run_db_id = tokio_rt.block_on(insert_run(&db, config.sandbox_id, pid))?;
 
     // Shared termination reason — background tasks store the reason before
@@ -639,11 +645,14 @@ fn write_startup_info(json: &str) -> RuntimeResult<()> {
 }
 
 /// Connect to the sandbox database.
-async fn connect_db(db_path: &std::path::Path) -> RuntimeResult<DatabaseConnection> {
+async fn connect_db(
+    db_path: &std::path::Path,
+    connect_timeout: Duration,
+) -> RuntimeResult<DatabaseConnection> {
     let url = format!("sqlite://{}?mode=rwc", db_path.display());
     let mut opts = ConnectOptions::new(url);
     opts.max_connections(1)
-        .connect_timeout(Duration::from_secs(30))
+        .connect_timeout(connect_timeout)
         .map_sqlx_sqlite_opts(|sqlx_opts| {
             sqlx_opts
                 .foreign_keys(true)

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -641,7 +641,15 @@ fn write_startup_info(json: &str) -> RuntimeResult<()> {
 /// Connect to the sandbox database.
 async fn connect_db(db_path: &std::path::Path) -> RuntimeResult<DatabaseConnection> {
     let url = format!("sqlite://{}?mode=rwc", db_path.display());
-    let opts = ConnectOptions::new(url).max_connections(1).to_owned();
+    let mut opts = ConnectOptions::new(url);
+    opts.max_connections(1)
+        .connect_timeout(Duration::from_secs(30))
+        .map_sqlx_sqlite_opts(|sqlx_opts| {
+            sqlx_opts
+                .foreign_keys(true)
+                .busy_timeout(Duration::from_secs(5))
+                .pragma("journal_mode", "WAL")
+        });
     let db = Database::connect(opts)
         .await
         .map_err(|e| RuntimeError::Custom(format!("database connect: {e}")))?;


### PR DESCRIPTION
## Summary
- Make storage migration 3 idempotent by adding `IF NOT EXISTS` to both snapshot index creations, preventing failures when indexes already exist from a prior partial migration run
- Enable WAL journal mode, 5-second busy timeout, and foreign key enforcement on all SQLite connections (global DB pool in `db/mod.rs` and sandbox runtime in `vm.rs`)
- This fixes `SQLITE_BUSY` errors that occurred when multiple processes (CLI commands + long-lived sandbox runtimes) accessed the shared `~/.microsandbox/db/msb.db` concurrently
- Add a regression test that simulates a half-applied migration 3 (tables and first index exist but migration not recorded) and verifies recovery

## Test Plan
- [x] Run `cargo test -p microsandbox` to verify the new `test_connect_and_migrate_recovers_from_partial_storage_migration` test passes
- [x] Run `cargo test` to ensure no regressions across the workspace
- [x] Run `cargo build` to verify successful compilation
- [x] On a Linux host, delete `~/.microsandbox` and run `msb run bash` to verify fresh DB creation with WAL mode works end-to-end
- [x] Verify concurrent access: run `msb run bash` in one terminal while running `msb sandbox list` in another to confirm no SQLITE_BUSY errors