### PR TITLE
fix(image): unblock layer pulls and detect case collisions

### DIFF
--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -160,9 +160,10 @@ fn run_async_command(
     command: Commands,
     _log_level: Option<microsandbox::LogLevel>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // CLI commands are foreground and short-lived, so a current-thread
-    // runtime avoids worker startup overhead on each invocation.
-    let runtime = tokio::runtime::Builder::new_current_thread()
+    // Pulls, extraction, and indexing fan out across layers, so the CLI
+    // needs worker threads to realize that parallelism without one task
+    // stalling all others.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
 

--- a/crates/image/lib/layer/extraction.rs
+++ b/crates/image/lib/layer/extraction.rs
@@ -5,7 +5,7 @@
 //! platform-aware symlinks, special file handling, and whiteout markers.
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashMap},
     io::Read,
     path::{Component, Path, PathBuf},
     pin::Pin,
@@ -196,6 +196,11 @@ pub(crate) async fn extract_layer(
     let mut implicit_dirs: BTreeSet<PathBuf> = BTreeSet::new();
     let mut total_size: u64 = 0;
     let mut entry_count: u64 = 0;
+    let mut casefold_paths = if host_path_is_case_sensitive(dest, tar_path)? {
+        None
+    } else {
+        Some(HashMap::new())
+    };
 
     let mut entries = archive.entries().map_err(|e| ImageError::Extraction {
         digest: tar_path.display().to_string(),
@@ -231,6 +236,10 @@ pub(crate) async fn extract_layer(
                 source: Some(Box::new(e)),
             })?
             .into_owned();
+
+        if let Some(ref mut seen) = casefold_paths {
+            record_casefold_path(seen, &entry_path, tar_path)?;
+        }
 
         // Validate path.
         let full_path = validate_entry_path(dest, &entry_path, tar_path)?;
@@ -494,6 +503,64 @@ fn clear_implicit_entry(path: &Path, dest: &Path, implicit_dirs: &mut BTreeSet<P
     }
 }
 
+fn host_path_is_case_sensitive(dest: &Path, tar_path: &Path) -> ImageResult<bool> {
+    let probe_name = format!(".__msb_case_probe_{}_abcdef", std::process::id());
+    let lower = dest.join(&probe_name);
+    let upper = dest.join(probe_name.to_uppercase());
+
+    std::fs::File::create(&lower).map_err(|e| ImageError::Extraction {
+        digest: tar_path.display().to_string(),
+        message: format!(
+            "failed to create case-sensitivity probe {}: {e}",
+            lower.display()
+        ),
+        source: Some(Box::new(e)),
+    })?;
+
+    let case_sensitive = !upper.exists();
+    let _ = std::fs::remove_file(&lower);
+
+    Ok(case_sensitive)
+}
+
+fn record_casefold_path(
+    seen: &mut HashMap<String, PathBuf>,
+    entry_path: &Path,
+    tar_path: &Path,
+) -> ImageResult<()> {
+    let key = path_casefold_key(entry_path);
+    if let Some(existing) = seen.get(&key) {
+        if existing != entry_path {
+            return Err(ImageError::Extraction {
+                digest: tar_path.display().to_string(),
+                message: format!(
+                    "layer contains paths that differ only by case on a case-insensitive host filesystem: {} and {}. Move the microsandbox cache to a case-sensitive volume to extract this image on macOS.",
+                    existing.display(),
+                    entry_path.display()
+                ),
+                source: None,
+            });
+        }
+        return Ok(());
+    }
+
+    seen.insert(key, entry_path.to_path_buf());
+    Ok(())
+}
+
+fn path_casefold_key(path: &Path) -> String {
+    path.components()
+        .map(|component| match component {
+            Component::Normal(part) => part.to_string_lossy().to_lowercase(),
+            Component::CurDir => ".".to_string(),
+            Component::ParentDir => "..".to_string(),
+            Component::RootDir => "/".to_string(),
+            Component::Prefix(prefix) => prefix.as_os_str().to_string_lossy().to_lowercase(),
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 /// Set host file permissions (minimum readable/writable by owner).
 fn set_host_permissions(path: &Path, mode: u32) -> ImageResult<()> {
     use std::os::unix::fs::PermissionsExt;
@@ -728,13 +795,13 @@ fn detect_layer_compression(
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{collections::HashMap, path::Path};
 
     use tempfile::tempdir;
 
     use super::{
         LayerCompression, OVERRIDE_XATTR_KEY, detect_layer_compression, extract_layer,
-        validate_entry_path,
+        host_path_is_case_sensitive, record_casefold_path, validate_entry_path,
     };
 
     #[test]
@@ -937,5 +1004,92 @@ mod tests {
         for &(_, _, total) in &progress_events {
             assert_eq!(total, tar_size);
         }
+    }
+
+    #[test]
+    fn test_record_casefold_path_rejects_case_only_collisions() {
+        let mut seen = HashMap::new();
+        let tar_path = Path::new("layer.tar");
+
+        record_casefold_path(
+            &mut seen,
+            Path::new("usr/share/man/man2/_Exit.2.gz"),
+            tar_path,
+        )
+        .unwrap();
+        let err = record_casefold_path(
+            &mut seen,
+            Path::new("usr/share/man/man2/_exit.2.gz"),
+            tar_path,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("differ only by case"));
+        assert!(err.to_string().contains("_Exit.2.gz"));
+        assert!(err.to_string().contains("_exit.2.gz"));
+    }
+
+    #[test]
+    fn test_extract_layer_rejects_case_only_collisions_on_case_insensitive_fs() {
+        let temp = tempdir().unwrap();
+        let tar_path = temp.path().join("layer.tar");
+        let dest = temp.path().join("dest");
+        std::fs::create_dir(&dest).unwrap();
+
+        if host_path_is_case_sensitive(&dest, &tar_path).unwrap() {
+            return;
+        }
+
+        let tar_file = std::fs::File::create(&tar_path).unwrap();
+        let mut builder = tar::Builder::new(tar_file);
+
+        let mut symlink_header = tar::Header::new_gnu();
+        symlink_header.set_entry_type(tar::EntryType::Symlink);
+        symlink_header.set_size(0);
+        symlink_header.set_mode(0o777);
+        symlink_header.set_uid(0);
+        symlink_header.set_gid(0);
+        symlink_header.set_link_name("_exit.2.gz").unwrap();
+        symlink_header.set_cksum();
+        builder
+            .append_data(
+                &mut symlink_header,
+                "usr/share/man/man2/_Exit.2.gz",
+                std::io::empty(),
+            )
+            .unwrap();
+
+        let contents = b"man page";
+        let mut file_header = tar::Header::new_gnu();
+        file_header.set_size(contents.len() as u64);
+        file_header.set_mode(0o644);
+        file_header.set_uid(0);
+        file_header.set_gid(0);
+        file_header.set_cksum();
+        builder
+            .append_data(
+                &mut file_header,
+                "usr/share/man/man2/_exit.2.gz",
+                &contents[..],
+            )
+            .unwrap();
+        builder.finish().unwrap();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let err = match runtime.block_on(extract_layer(
+            &tar_path,
+            &dest,
+            Some("application/vnd.oci.image.layer.v1.tar"),
+            None,
+            0,
+        )) {
+            Ok(_) => panic!("expected case-collision extraction failure"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("differ only by case"));
     }
 }

--- a/crates/image/lib/layer/mod.rs
+++ b/crates/image/lib/layer/mod.rs
@@ -6,7 +6,6 @@ pub(crate) mod index;
 use std::{
     fs::{File, OpenOptions},
     io::{self, Read, Write},
-    os::fd::AsRawFd,
     path::{Path, PathBuf},
 };
 
@@ -16,6 +15,7 @@ use sha2::{Digest as Sha2Digest, Sha256};
 use crate::{
     digest::Digest,
     error::{ImageError, ImageResult},
+    lock::{flock_exclusive_async, flock_unlock, open_lock_file},
     store::{self, GlobalCache},
 };
 
@@ -110,8 +110,7 @@ impl Layer {
         let part_path = &self.part_path;
 
         // Acquire cross-process download lock.
-        let lock_file = open_lock_file(&self.download_lock_path)?;
-        flock_exclusive(&lock_file)?;
+        let lock_file = flock_exclusive_async(open_lock_file(&self.download_lock_path)?).await?;
         let download_lock_path = self.download_lock_path.clone();
         let _guard = scopeguard::guard(lock_file, |f| {
             let _ = flock_unlock(&f);
@@ -244,7 +243,7 @@ impl Layer {
         drop(file);
 
         // Verify hash.
-        let actual_hash = compute_sha256_file(part_path)?;
+        let actual_hash = compute_sha256_file_async(part_path.to_path_buf()).await?;
         if actual_hash != expected_hex {
             let _ = std::fs::remove_file(part_path);
             return Err(ImageError::DigestMismatch {
@@ -285,8 +284,7 @@ impl Layer {
         force: bool,
     ) -> ImageResult<extraction::ExtractionResult> {
         // Cross-process lock.
-        let lock_file = open_lock_file(&self.lock_path)?;
-        flock_exclusive(&lock_file)?;
+        let lock_file = flock_exclusive_async(open_lock_file(&self.lock_path)?).await?;
         let lock_path = self.lock_path.clone();
         let _flock_guard = scopeguard::guard(lock_file, |f| {
             let _ = flock_unlock(&f);
@@ -391,37 +389,6 @@ impl Layer {
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
-/// Open or create a lock file.
-fn open_lock_file(path: &Path) -> ImageResult<File> {
-    OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .write(true)
-        .open(path)
-        .map_err(|e| ImageError::Cache {
-            path: path.to_path_buf(),
-            source: e,
-        })
-}
-
-/// Acquire an exclusive `flock()`.
-fn flock_exclusive(file: &File) -> ImageResult<()> {
-    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
-    if ret != 0 {
-        return Err(ImageError::Io(io::Error::last_os_error()));
-    }
-    Ok(())
-}
-
-/// Release a `flock()`.
-fn flock_unlock(file: &File) -> ImageResult<()> {
-    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
-    if ret != 0 {
-        return Err(ImageError::Io(io::Error::last_os_error()));
-    }
-    Ok(())
-}
-
 /// Compute the SHA-256 hex digest of a file.
 fn compute_sha256_file(path: &Path) -> ImageResult<String> {
     let mut file = File::open(path).map_err(|e| ImageError::Cache {
@@ -441,6 +408,12 @@ fn compute_sha256_file(path: &Path) -> ImageResult<String> {
         hasher.update(&buf[..n]);
     }
     Ok(hex::encode(hasher.finalize()))
+}
+
+async fn compute_sha256_file_async(path: PathBuf) -> ImageResult<String> {
+    tokio::task::spawn_blocking(move || compute_sha256_file(&path))
+        .await
+        .map_err(|error| ImageError::Io(io::Error::other(format!("hash task failed: {error}"))))?
 }
 
 fn remove_file_if_exists(path: &Path) -> ImageResult<()> {

--- a/crates/image/lib/lib.rs
+++ b/crates/image/lib/lib.rs
@@ -11,6 +11,7 @@ mod config;
 mod digest;
 mod error;
 pub(crate) mod layer;
+mod lock;
 mod manifest;
 mod platform;
 mod progress;

--- a/crates/image/lib/lock.rs
+++ b/crates/image/lib/lock.rs
@@ -1,0 +1,55 @@
+//! Cross-process file locking utilities based on `flock(2)`.
+
+use std::{
+    fs::{File, OpenOptions},
+    io,
+    os::fd::AsRawFd,
+    path::Path,
+};
+
+use crate::error::{ImageError, ImageResult};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Open or create a lock file.
+pub(crate) fn open_lock_file(path: &Path) -> ImageResult<File> {
+    OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(path)
+        .map_err(|e| ImageError::Cache {
+            path: path.to_path_buf(),
+            source: e,
+        })
+}
+
+/// Acquire an exclusive `flock()` on a blocking thread pool.
+pub(crate) async fn flock_exclusive_async(file: File) -> ImageResult<File> {
+    tokio::task::spawn_blocking(move || {
+        flock_exclusive(&file)?;
+        Ok::<_, ImageError>(file)
+    })
+    .await
+    .map_err(|error| ImageError::Io(io::Error::other(format!("lock task failed: {error}"))))?
+}
+
+/// Release a `flock()`.
+pub(crate) fn flock_unlock(file: &File) -> ImageResult<()> {
+    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    if ret != 0 {
+        return Err(ImageError::Io(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+/// Acquire an exclusive `flock()`.
+fn flock_exclusive(file: &File) -> ImageResult<()> {
+    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if ret != 0 {
+        return Err(ImageError::Io(io::Error::last_os_error()));
+    }
+    Ok(())
+}

--- a/crates/image/lib/registry.rs
+++ b/crates/image/lib/registry.rs
@@ -2,13 +2,7 @@
 //!
 //! Wraps `oci-client` with platform resolution, caching, and progress reporting.
 
-use std::{
-    fs::{File, OpenOptions},
-    io,
-    os::fd::AsRawFd,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use oci_client::{Client, client::ClientConfig, manifest::ImageIndexEntry};
 use tokio::task::JoinHandle;
@@ -19,6 +13,7 @@ use crate::{
     digest::Digest,
     error::{ImageError, ImageResult},
     layer::Layer,
+    lock::{flock_exclusive_async, flock_unlock, open_lock_file},
     manifest::OciManifest,
     platform::Platform,
     progress::{self, PullProgress, PullProgressHandle, PullProgressSender},
@@ -191,8 +186,7 @@ impl Registry {
         let ref_str: Arc<str> = reference.to_string().into();
         let oci_ref = reference;
         let image_lock_path = self.cache.image_lock_path(reference);
-        let image_lock_file = open_lock_file(&image_lock_path)?;
-        flock_exclusive(&image_lock_file)?;
+        let image_lock_file = flock_exclusive_async(open_lock_file(&image_lock_path)?).await?;
         let _image_lock_guard = scopeguard::guard(image_lock_file, |file| {
             let _ = flock_unlock(&file);
             drop(file);
@@ -254,6 +248,7 @@ impl Registry {
 
         // Step 4: Get layer descriptors.
         let layer_descriptors = self.extract_layer_digests(&manifest)?;
+        log_duplicate_layer_digests(reference, &layer_descriptors);
 
         let layer_count = layer_descriptors.len();
         let total_bytes: Option<u64> = {
@@ -715,32 +710,20 @@ fn resolve_cached_pull_result(
     Ok(Some(CachedPullInfo { result, metadata }))
 }
 
-fn open_lock_file(path: &Path) -> ImageResult<File> {
-    OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .write(true)
-        .open(path)
-        .map_err(|e| ImageError::Cache {
-            path: path.to_path_buf(),
-            source: e,
-        })
-}
-
-fn flock_exclusive(file: &File) -> ImageResult<()> {
-    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
-    if ret != 0 {
-        return Err(ImageError::Io(io::Error::last_os_error()));
+fn log_duplicate_layer_digests(reference: &oci_client::Reference, layers: &[LayerDescriptor]) {
+    let mut counts: HashMap<&Digest, usize> = HashMap::new();
+    for layer in layers {
+        *counts.entry(&layer.digest).or_default() += 1;
     }
-    Ok(())
-}
 
-fn flock_unlock(file: &File) -> ImageResult<()> {
-    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
-    if ret != 0 {
-        return Err(ImageError::Io(io::Error::last_os_error()));
+    for (digest, count) in counts.into_iter().filter(|(_, count)| *count > 1) {
+        tracing::warn!(
+            reference = %reference,
+            digest = %digest,
+            occurrences = count,
+            "manifest contains duplicate layer digest; layer processing will be serialized"
+        );
     }
-    Ok(())
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Switch the CLI from a current-thread Tokio runtime to a multi-thread runtime so layer download, extract, and index pipelines can actually progress in parallel
- Extract `flock()` helpers into a new `crates/image/lib/lock.rs` module and run lock acquisition via `spawn_blocking`, so a parked lock waiter no longer pins a runtime worker
- Move post-download SHA-256 verification onto `spawn_blocking` as well, keeping multi-hundred-MB hashing off the async worker threads
- Log a warning when a manifest contains duplicate layer digests so the serialized per-layer processing becomes observable
- Probe the extraction destination for case sensitivity and fail fast with a clear error when a layer contains paths that differ only by case on a case-insensitive host filesystem

Motivation: `msb pull ghcr.io/boldsoftware/exeuntu` stalled at "resolving layer". The amd64 manifest lists the same layer digest three times; on the single-threaded runtime the first pipeline took the per-layer `flock()` and moved to async I/O, while the second pipeline blocked the one runtime thread inside a synchronous `flock()` call, preventing the first from ever resuming — a self-deadlock. A stale prior `msb` holding the per-image lock reproduced the same hang on any repeat pull. Even after the hang was gone, `exeuntu` still failed on default macOS because one of its layers contains both `usr/share/man/man2/_Exit.2.gz` and `usr/share/man/man2/_exit.2.gz`, which collapse onto the same path on case-insensitive APFS and surfaced as an opaque `ELOOP` error.

Impact: image pulls with duplicate layer digests no longer deadlock the CLI; hashing and lock waits no longer starve runtime workers; and users hitting the APFS case-collision case now get an actionable error pointing them at a case-sensitive cache volume instead of "Too many levels of symbolic links". Note: this is diagnostic only for the case-collision path — a proper fix (extraction onto a case-sensitive backing store such as an APFS sparse image) is still required to actually pull images like `exeuntu` on default macOS.

## Test Plan
- [x] `cargo build -p microsandbox-image` and `cargo build -p microsandbox` build cleanly
- [x] `cargo test -p microsandbox-image` passes, including the new `test_record_casefold_path_rejects_case_only_collisions` and `test_extract_layer_rejects_case_only_collisions_on_case_insensitive_fs` tests
- [x] `cargo clippy --workspace --all-targets` is clean
- [x] `msb pull ghcr.io/library/alpine` still succeeds end to end (baseline, no duplicate layers, case-sensitive-safe)
- [x] `msb pull ghcr.io/boldsoftware/exeuntu` no longer stalls at "resolving layer"; on macOS it fails fast with the "differ only by case" error message instead of hanging or returning `ELOOP`
- [x] With a stale lock file present at the per-image lock path, a second `msb pull` of the same reference blocks on the flock but does not freeze the runtime — other concurrent layer tasks in the same process continue to make progress
- [x] Trace logs (`RUST_LOG=microsandbox_image=warn`) emit the "manifest contains duplicate layer digest" warning when pulling an image with duplicated layers