### PR TITLE
feat(install): add Homebrew tap support for macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,6 +283,23 @@ jobs:
             release-artifacts/*
 
   # ---------------------------------------------------------------------------
+  # Update Homebrew formula in the tap repo
+  # ---------------------------------------------------------------------------
+  update-homebrew:
+    name: Update Homebrew Formula
+    needs: assemble
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to homebrew tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_PAT }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh api repos/superradcompany/homebrew-microsandbox/dispatches \
+            -f event_type=update-formula \
+            -f "client_payload[version]=$VERSION"
+
+  # ---------------------------------------------------------------------------
   # Publish Node SDK to npm
   # ---------------------------------------------------------------------------
   npm-publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,6 +429,23 @@ jobs:
             --body "Releasing ${{ github.ref_name }} could not merge into mintlify cleanly. mintlify carries docs that conflict with this release. Resolve the conflicts and merge to publish the released docs."
 
   # ---------------------------------------------------------------------------
+  # Update Homebrew formula in the tap repo
+  # ---------------------------------------------------------------------------
+  update-homebrew:
+    name: Update Homebrew Formula
+    needs: assemble
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to homebrew tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_PAT }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh api repos/superradcompany/homebrew-tap/dispatches \
+            -f event_type=update-formula \
+            -f "client_payload[version]=$VERSION"
+
+  # ---------------------------------------------------------------------------
   # Publish Node SDK to npm
   # ---------------------------------------------------------------------------
   npm-publish:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Today, AI agents operate with whatever permissions you give them, and that's usu
 
 The SDK works on its own without the CLI. The `msb` CLI is a separate tool for managing sandboxes, images, and volumes from the terminal, and for giving AI agents direct access to microsandbox:
 
+> **macOS**:
+> ```sh
+> brew tap superradcompany/microsandbox
+> brew install microsandbox
+> ```
+
+> **macOS / Linux**:
 > ```sh
 > curl -fsSL https://install.microsandbox.dev | sh
 > ```

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@
 > curl -fsSL https://install.microsandbox.dev | sh
 > ```
 >
+> On macOS you can also install with Homebrew:
+>
+> ```sh
+> brew install superradcompany/tap/microsandbox
+> ```
+>
 > ```sh
 > msb run debian
 > ```


### PR DESCRIPTION
## Summary
- Add an `update-homebrew` job to the release workflow that dispatches a formula update to [`superradcompany/homebrew-tap`](https://github.com/superradcompany/homebrew-tap) on each release
- Update README with Homebrew install instructions alongside the existing install script

The tap repo already has the receiving `update-formula` workflow, the `microsandbox.rb` formula, and the `HOMEBREW_TAP_GITHUB_PAT` secret is configured, so this closes the loop end to end. The dispatch runs after `assemble` so the GitHub release and `checksums.sha256` exist before the tap pulls them.

## Install
```sh
brew install superradcompany/tap/microsandbox
```

Closes #531