### PR TITLE
feat(cli): add interactive multi-select to `msb self uninstall`

### DIFF
--- a/crates/cli/lib/commands/install.rs
+++ b/crates/cli/lib/commands/install.rs
@@ -121,7 +121,7 @@ pub async fn run(args: InstallArgs) -> anyhow::Result<()> {
     // PATH hint.
     if !is_in_path(&bin_dir) {
         eprintln!(
-            "\n  Add to your shell profile:\n    export PATH=\"{}:$PATH\"\n",
+            "  Add to your shell profile:\n    export PATH=\"{}:$PATH\"",
             bin_dir.display()
         );
     }

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -255,7 +255,12 @@ struct SigintGuard {
 
 impl SigintGuard {
     fn install() -> Self {
-        let prev = unsafe { libc::signal(libc::SIGINT, sigint_show_cursor as libc::sighandler_t) };
+        let prev = unsafe {
+            libc::signal(
+                libc::SIGINT,
+                sigint_show_cursor as *const () as libc::sighandler_t,
+            )
+        };
         Self { prev }
     }
 }

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -1,9 +1,12 @@
 //! `msb self` subcommands for managing the msb installation itself.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use clap::{Args, Subcommand};
+use console::{Key, Term, style};
 
+use super::install::MARKER as INSTALL_MARKER;
 use crate::ui;
 
 //--------------------------------------------------------------------------------------------------
@@ -49,9 +52,61 @@ pub struct SelfUpdateArgs {
 /// Arguments for `msb self uninstall`.
 #[derive(Debug, Args)]
 pub struct SelfUninstallArgs {
-    /// Skip confirmation prompt.
+    /// Skip confirmation prompt and remove everything.
     #[arg(long, short)]
     pub yes: bool,
+}
+
+/// A category of data that can be removed during uninstall.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UninstallCategory {
+    All,
+    Sandboxes,
+    Volumes,
+    Cache,
+    Installs,
+    Database,
+    Logs,
+    Secrets,
+}
+
+impl UninstallCategory {
+    const ITEMS: &[Self] = &[
+        Self::All,
+        Self::Sandboxes,
+        Self::Volumes,
+        Self::Cache,
+        Self::Installs,
+        Self::Database,
+        Self::Logs,
+        Self::Secrets,
+    ];
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::All => "All — remove everything and clean shell config",
+            Self::Sandboxes => "Sandboxes — sandbox state and rootfs",
+            Self::Volumes => "Volumes — named volumes",
+            Self::Cache => "Cache — OCI image layers",
+            Self::Installs => "Installs — installed command aliases",
+            Self::Database => "Database — metadata store",
+            Self::Logs => "Logs — log files",
+            Self::Secrets => "Secrets — secrets, TLS certs, and SSH keys",
+        }
+    }
+
+    fn short_name(&self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Sandboxes => "sandboxes",
+            Self::Volumes => "volumes",
+            Self::Cache => "cache",
+            Self::Installs => "installs",
+            Self::Database => "database",
+            Self::Logs => "logs",
+            Self::Secrets => "secrets",
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -77,7 +132,7 @@ async fn run_update(args: SelfUpdateArgs) -> anyhow::Result<()> {
 
     let latest_clean = latest.strip_prefix('v').unwrap_or(&latest);
     if !args.force && latest_clean == CURRENT_VERSION {
-        success("Already up to date.");
+        done("Already up to date.");
         return Ok(());
     }
 
@@ -97,8 +152,8 @@ async fn run_update(args: SelfUpdateArgs) -> anyhow::Result<()> {
     match result {
         Ok(()) => {
             spinner.finish_clear();
-            success(&format!("Updated msb in {}", bin_dir.display()));
-            success(&format!("Updated libkrunfw in {}/", lib_dir.display()));
+            done(&format!("Updated msb in {}", bin_dir.display()));
+            done(&format!("Updated libkrunfw in {}/", lib_dir.display()));
         }
         Err(e) => {
             spinner.finish_error();
@@ -117,31 +172,200 @@ async fn run_uninstall(args: SelfUninstallArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    if !args.yes {
-        eprintln!(
-            "{} This will remove {} and clean shell configuration.",
-            console::style("warn").yellow().bold(),
-            base_dir.display(),
-        );
-        eprint!("Continue? [y/N] ");
-        let mut input = String::new();
-        std::io::stdin().read_line(&mut input)?;
-        if !input.trim().eq_ignore_ascii_case("y") {
-            info("Aborted.");
-            return Ok(());
+    // Non-interactive: remove everything.
+    if args.yes {
+        return uninstall_all(&base_dir);
+    }
+
+    let term = Term::stderr();
+    if !term.is_term() {
+        anyhow::bail!("non-interactive terminal; use --yes to remove everything");
+    }
+
+    ui::warn(&format!(
+        "this will modify your {} installation",
+        base_dir.display(),
+    ));
+
+    let labels: Vec<&str> = UninstallCategory::ITEMS.iter().map(|c| c.label()).collect();
+    let selections = multi_select(&term, &labels)?;
+
+    if selections.is_empty() {
+        info("Nothing selected.");
+        return Ok(());
+    }
+
+    let selected: Vec<UninstallCategory> = selections
+        .iter()
+        .map(|&i| UninstallCategory::ITEMS[i])
+        .collect();
+
+    let is_all = selected.contains(&UninstallCategory::All);
+
+    // Confirmation.
+    let prompt = if is_all {
+        "Remove everything?".to_string()
+    } else {
+        let names: Vec<&str> = selected.iter().map(|c| c.short_name()).collect();
+        format!("Remove {}?", names.join(", "))
+    };
+    eprint!("{prompt} [y/N] ");
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    if !input.trim().eq_ignore_ascii_case("y") {
+        info("Aborted.");
+        return Ok(());
+    }
+
+    if is_all {
+        uninstall_all(&base_dir)?;
+    } else {
+        for category in &selected {
+            remove_category(&base_dir, *category)?;
         }
     }
 
-    // Remove shell configuration first.
-    clean_shell_config()?;
-
-    // Remove the installation directory.
-    std::fs::remove_dir_all(&base_dir)?;
-    success(&format!("Removed {}", base_dir.display()));
-
-    success("Uninstall complete. Restart your shell to apply changes.");
-
     Ok(())
+}
+
+/// Remove everything: shell config + entire base directory.
+fn uninstall_all(base_dir: &Path) -> anyhow::Result<()> {
+    clean_shell_config()?;
+    std::fs::remove_dir_all(base_dir)?;
+    ui::success("Removed", &base_dir.display().to_string());
+    done("Uninstall complete. Restart your shell to apply changes.");
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Multi-Select
+//--------------------------------------------------------------------------------------------------
+
+/// SIGINT handler that restores cursor visibility before exiting.
+extern "C" fn sigint_show_cursor(_: libc::c_int) {
+    let _ = std::io::stderr().write_all(b"\x1b[?25h");
+    unsafe { libc::_exit(130) };
+}
+
+/// RAII guard that installs a SIGINT handler to restore cursor visibility
+/// and restores the previous handler on drop.
+struct SigintGuard {
+    prev: libc::sighandler_t,
+}
+
+impl SigintGuard {
+    fn install() -> Self {
+        let prev = unsafe { libc::signal(libc::SIGINT, sigint_show_cursor as libc::sighandler_t) };
+        Self { prev }
+    }
+}
+
+impl Drop for SigintGuard {
+    fn drop(&mut self) {
+        unsafe {
+            libc::signal(libc::SIGINT, self.prev);
+        }
+    }
+}
+
+/// Interactive multi-select prompt. Returns indices of selected items.
+///
+/// Index 0 is treated as an "All" toggle: selecting it checks every item,
+/// deselecting it unchecks every item. When all individual items are checked,
+/// "All" is auto-checked; unchecking any individual item unchecks "All".
+fn multi_select(term: &Term, items: &[&str]) -> anyhow::Result<Vec<usize>> {
+    let mut selected = vec![false; items.len()];
+    let mut cursor = 0usize;
+
+    let _sigint = SigintGuard::install();
+    term.hide_cursor()?;
+    let mut lines = render_select(term, items, &selected, cursor)?;
+
+    loop {
+        match term.read_key()? {
+            Key::ArrowUp | Key::Char('k') => {
+                cursor = cursor.saturating_sub(1);
+            }
+            Key::ArrowDown | Key::Char('j') => {
+                cursor = (cursor + 1).min(items.len() - 1);
+            }
+            Key::Char(' ') => {
+                toggle_select(&mut selected, cursor);
+            }
+            Key::Enter => break,
+            Key::Escape => {
+                selected.fill(false);
+                break;
+            }
+            _ => continue,
+        }
+
+        term.clear_last_lines(lines)?;
+        lines = render_select(term, items, &selected, cursor)?;
+    }
+
+    term.clear_last_lines(lines)?;
+    term.show_cursor()?;
+
+    Ok(selected
+        .iter()
+        .enumerate()
+        .filter(|&(_, &s)| s)
+        .map(|(i, _)| i)
+        .collect())
+}
+
+/// Render the multi-select list. Returns the number of lines written.
+fn render_select(
+    term: &Term,
+    items: &[&str],
+    selected: &[bool],
+    cursor: usize,
+) -> anyhow::Result<usize> {
+    let mut lines = 0;
+
+    for (i, item) in items.iter().enumerate() {
+        let pointer = if i == cursor { ">" } else { " " };
+        let check = if selected[i] {
+            format!("{}", style("[x]").green())
+        } else {
+            format!("{}", style("[ ]").dim())
+        };
+        let label = if i == cursor {
+            style(*item).bold().to_string()
+        } else {
+            item.to_string()
+        };
+        term.write_line(&format!("  {pointer} {check} {label}"))?;
+        lines += 1;
+    }
+
+    term.write_line(&format!(
+        "  {}",
+        style("↑↓ navigate · space select · enter confirm · esc cancel").dim(),
+    ))?;
+    lines += 1;
+
+    Ok(lines)
+}
+
+/// Toggle selection at the given cursor position, with "All" (index 0) linkage.
+fn toggle_select(selected: &mut [bool], cursor: usize) {
+    selected[cursor] = !selected[cursor];
+
+    if cursor == 0 {
+        // "All" toggled — propagate to every individual item.
+        let state = selected[0];
+        for s in selected.iter_mut().skip(1) {
+            *s = state;
+        }
+    } else if !selected[cursor] {
+        // Unchecked an individual → uncheck "All".
+        selected[0] = false;
+    } else if selected[1..].iter().all(|&s| s) {
+        // All individuals now checked → auto-check "All".
+        selected[0] = true;
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -180,11 +404,73 @@ fn resolve_base_dir() -> anyhow::Result<PathBuf> {
 }
 
 fn info(msg: &str) {
-    eprintln!("{} {msg}", console::style("info").cyan().bold());
+    eprintln!("{} {msg}", style("info").cyan().bold());
 }
 
-fn success(msg: &str) {
-    eprintln!("{} {msg}", console::style("done").green().bold());
+fn done(msg: &str) {
+    eprintln!("{} {msg}", style("done").green().bold());
+}
+
+/// Remove a single uninstall category from the base directory.
+fn remove_category(base_dir: &Path, category: UninstallCategory) -> anyhow::Result<()> {
+    match category {
+        UninstallCategory::All => unreachable!("handled before calling remove_category"),
+        UninstallCategory::Sandboxes => {
+            remove_subdir(base_dir, microsandbox_utils::SANDBOXES_SUBDIR, "sandboxes")
+        }
+        UninstallCategory::Volumes => {
+            remove_subdir(base_dir, microsandbox_utils::VOLUMES_SUBDIR, "volumes")
+        }
+        UninstallCategory::Cache => {
+            remove_subdir(base_dir, microsandbox_utils::CACHE_SUBDIR, "cache")
+        }
+        UninstallCategory::Installs => remove_installed_aliases(base_dir),
+        UninstallCategory::Database => {
+            remove_subdir(base_dir, microsandbox_utils::DB_SUBDIR, "database")
+        }
+        UninstallCategory::Logs => remove_subdir(base_dir, microsandbox_utils::LOGS_SUBDIR, "logs"),
+        UninstallCategory::Secrets => {
+            remove_subdir(base_dir, microsandbox_utils::SECRETS_SUBDIR, "secrets")?;
+            remove_subdir(base_dir, microsandbox_utils::TLS_SUBDIR, "tls")?;
+            remove_subdir(base_dir, microsandbox_utils::SSH_SUBDIR, "ssh")
+        }
+    }
+}
+
+/// Remove a subdirectory within the base directory.
+fn remove_subdir(base_dir: &Path, subdir: &str, label: &str) -> anyhow::Result<()> {
+    let path = base_dir.join(subdir);
+    if path.exists() {
+        std::fs::remove_dir_all(&path)?;
+        ui::success("Removed", label);
+    }
+    Ok(())
+}
+
+/// Remove only msb-install-generated alias scripts from the bin directory,
+/// leaving core binaries (msb, agentd) intact.
+fn remove_installed_aliases(base_dir: &Path) -> anyhow::Result<()> {
+    let bin_dir = base_dir.join(microsandbox_utils::BIN_SUBDIR);
+    if !bin_dir.is_dir() {
+        return Ok(());
+    }
+
+    for entry in std::fs::read_dir(&bin_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if let Ok(content) = std::fs::read_to_string(&path)
+            && content.lines().nth(1) == Some(INSTALL_MARKER)
+        {
+            std::fs::remove_file(&path)?;
+            let name = entry.file_name().to_string_lossy().to_string();
+            ui::success("Removed", &format!("alias {name}"));
+        }
+    }
+
+    Ok(())
 }
 
 /// Remove microsandbox marker blocks from shell config files.
@@ -194,14 +480,14 @@ fn clean_shell_config() -> anyhow::Result<()> {
     for rc in [".profile", ".bash_profile", ".bashrc", ".zshrc"] {
         let path = home.join(rc);
         if path.exists() && remove_marker_block(&path)? {
-            success(&format!("Cleaned ~/{rc}"));
+            ui::success("Cleaned", &format!("~/{rc}"));
         }
     }
 
     let fish_conf = home.join(".config/fish/conf.d/microsandbox.fish");
     if fish_conf.exists() {
         std::fs::remove_file(&fish_conf)?;
-        success("Removed ~/.config/fish/conf.d/microsandbox.fish");
+        ui::success("Removed", "~/.config/fish/conf.d/microsandbox.fish");
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Replace the all-or-nothing `msb self uninstall` prompt with an interactive multi-select UI that lets users choose which categories to remove: sandboxes, volumes, cache, installs, database, logs, secrets, or all at once
- "All" toggle automatically checks/unchecks every individual item; unchecking any individual item unchecks "All"; checking all individuals auto-checks "All"
- Custom multi-select widget built entirely on the existing `console` crate with no new runtime dependencies -- uses `Term::read_key()` for input and ANSI rendering for the checkbox UI
- Install a SIGINT guard so Ctrl+C during the multi-select restores terminal cursor visibility before exiting
- Partial removal only deletes the selected subdirectories while leaving core binaries (msb, agentd, libkrunfw) intact; `--yes` flag still performs a full uninstall for scripting
- Remove unnecessary blank lines from `msb install` PATH hint output and `msb self uninstall` flow for tighter CLI output

## Test Plan
- [x] Run `msb self uninstall` interactively -- verify the multi-select appears with all 8 categories (All, Sandboxes, Volumes, Cache, Installs, Database, Logs, Secrets)
- [x] Toggle "All" on with space -- verify all other items become checked; toggle "All" off -- verify all items become unchecked
- [x] Select individual items, confirm with enter, then verify only the selected subdirectories under `~/.microsandbox` are removed
- [x] Press Ctrl+C during the multi-select -- verify the terminal cursor is restored and the process exits cleanly
- [x] Press Escape during the multi-select -- verify it exits with "Nothing selected" and no data is removed
- [x] Run `msb self uninstall --yes` -- verify it removes everything without prompting (same as previous behavior)
- [x] Run `msb self uninstall` in a non-TTY context (e.g. piped) -- verify it errors with a message to use `--yes`
- [x] Run `msb install python` when `~/.microsandbox/bin` is not in PATH -- verify no extra blank lines in the output