### PR TITLE
fix(network): send RST on upstream connect failure instead of FIN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,6 +2678,7 @@ dependencies = [
  "ipnetwork",
  "libc",
  "lru",
+ "microsandbox-protocol",
  "microsandbox-utils",
  "msb_krun",
  "pem",

--- a/crates/agentd/lib/config.rs
+++ b/crates/agentd/lib/config.rs
@@ -17,8 +17,8 @@ use std::env;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use microsandbox_protocol::{
-    ENV_BLOCK_ROOT, ENV_DIR_MOUNTS, ENV_FILE_MOUNTS, ENV_HOSTNAME, ENV_NET, ENV_NET_IPV4,
-    ENV_NET_IPV6, ENV_RLIMITS, ENV_TMPFS, ENV_USER, exec::ExecRlimit,
+    ENV_BLOCK_ROOT, ENV_DIR_MOUNTS, ENV_FILE_MOUNTS, ENV_HOST_ALIAS, ENV_HOSTNAME, ENV_NET,
+    ENV_NET_IPV4, ENV_NET_IPV6, ENV_RLIMITS, ENV_TMPFS, ENV_USER, exec::ExecRlimit,
 };
 
 use crate::error::{AgentdError, AgentdResult};
@@ -51,6 +51,11 @@ pub struct BootParams {
 
     /// `MSB_HOSTNAME` — guest hostname.
     pub(crate) hostname: Option<String>,
+
+    /// `MSB_HOST_ALIAS` — DNS name (e.g. `host.microsandbox.internal`)
+    /// the guest uses to reach the sandbox host. Written into
+    /// `/etc/hosts` pointing at the gateway IPs.
+    pub(crate) host_alias: Option<String>,
 
     /// Parsed `MSB_NET` — network interface config.
     pub(crate) net: Option<NetSpec>,
@@ -183,6 +188,7 @@ impl BootParams {
                 .transpose()?
                 .unwrap_or_default(),
             hostname: read_env(ENV_HOSTNAME),
+            host_alias: read_env(ENV_HOST_ALIAS),
             net: read_env(ENV_NET).map(|v| parse_net(&v)).transpose()?,
             net_ipv4: read_env(ENV_NET_IPV4)
                 .map(|v| parse_net_ipv4(&v))

--- a/crates/agentd/lib/init.rs
+++ b/crates/agentd/lib/init.rs
@@ -26,7 +26,12 @@ pub fn init(params: BootParams) -> AgentdResult<()> {
     }
     linux::apply_dir_mounts(&params.dir_mounts)?;
     linux::apply_file_mounts(&params.file_mounts)?;
-    network::apply_hostname(params.hostname.as_deref())?;
+    network::apply_hostname(
+        params.hostname.as_deref(),
+        params.host_alias.as_deref(),
+        params.net_ipv4.as_ref().map(|v4| v4.gateway),
+        params.net_ipv6.as_ref().map(|v6| v6.gateway),
+    )?;
     linux::apply_tmpfs_mounts(&params.tmpfs)?;
     linux::ensure_standard_tmp_permissions()?;
     network::apply_network_config(params.network())?;

--- a/crates/agentd/lib/network.rs
+++ b/crates/agentd/lib/network.rs
@@ -3,6 +3,8 @@
 //! Configures the guest network interface using ioctls and netlink, following
 //! the parameters from host.
 
+use std::net::{Ipv4Addr, Ipv6Addr};
+
 use crate::config::NetConfig;
 use crate::error::AgentdResult;
 
@@ -10,12 +12,31 @@ use crate::error::AgentdResult;
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Sets the guest hostname.
+/// Set the guest hostname and provision `/etc/hosts`. Each argument is
+/// optional; omitted pieces are skipped.
 ///
-/// Calls `sethostname()`, writes `/etc/hostname`, and provisions
-/// `/etc/hosts` with localhost aliases and the hostname entry.
-pub(crate) fn apply_hostname(hostname: Option<&str>) -> AgentdResult<()> {
-    linux::write_hosts_file(hostname)?;
+/// # Arguments
+///
+/// * `hostname` - Guest hostname. When set, calls `sethostname()` and writes
+///   `/etc/hostname`.
+/// * `host_alias` - DNS name the guest uses to reach the sandbox host
+///   (typically `host.microsandbox.internal`). Written to `/etc/hosts`
+///   alongside whichever gateway IPs are present.
+/// * `gateway_ipv4` - Gateway IPv4 the alias points at.
+/// * `gateway_ipv6` - Gateway IPv6 the alias points at.
+///
+/// # Errors
+///
+/// Returns [`AgentdError::Init`][crate::error::AgentdError::Init] when `/etc`
+/// cannot be created, `/etc/hosts` or `/etc/hostname` cannot be written, or
+/// `sethostname(2)` fails.
+pub(crate) fn apply_hostname(
+    hostname: Option<&str>,
+    host_alias: Option<&str>,
+    gateway_ipv4: Option<Ipv4Addr>,
+    gateway_ipv6: Option<Ipv6Addr>,
+) -> AgentdResult<()> {
+    linux::write_hosts_file(hostname, host_alias, gateway_ipv4, gateway_ipv6)?;
 
     if let Some(name) = hostname {
         linux::set_hostname(name)?;
@@ -24,10 +45,23 @@ pub(crate) fn apply_hostname(hostname: Option<&str>) -> AgentdResult<()> {
     Ok(())
 }
 
-/// Applies network configuration.
+/// Apply the guest-side network configuration.
 ///
-/// Always provisions loopback, even when no external network interface is
-/// requested. Missing `net` is not an error (no networking requested).
+/// Always provisions loopback first so the guest has a working `lo` interface
+/// even when the sandbox was booted with networking disabled. When `cfg.net`
+/// is `None`, nothing further is configured.
+///
+/// # Arguments
+///
+/// * `cfg` - Parsed `MSB_NET*` specs bundled by
+///   [`BootParams::network`][crate::config::BootParams::network]: interface
+///   name/MAC/MTU plus optional IPv4 and IPv6 addressing.
+///
+/// # Errors
+///
+/// Returns [`AgentdError::Init`][crate::error::AgentdError::Init] when bringing
+/// up `lo` fails, or any of the interface ioctls / netlink messages for the
+/// main interface fail.
 pub(crate) fn apply_network_config(cfg: NetConfig<'_>) -> AgentdResult<()> {
     linux::configure_loopback()?;
 
@@ -38,7 +72,24 @@ pub(crate) fn apply_network_config(cfg: NetConfig<'_>) -> AgentdResult<()> {
     linux::configure_interface(net, cfg.ipv4, cfg.ipv6)
 }
 
-fn hosts_file_contents(hostname: Option<&str>) -> String {
+/// Render the `/etc/hosts` contents.
+///
+/// # Arguments
+///
+/// * `hostname` - Guest hostname; when `Some`, appended as an alias on the
+///   `127.0.0.1` and `::1` lines.
+/// * `host_alias` - Name like `host.microsandbox.internal`; when `Some` and a
+///   gateway IP is set for the matching family, emits `<gw>\t<alias>` lines.
+/// * `gateway_ipv4` - IPv4 the alias resolves to. The IPv4 alias line is
+///   skipped when `None` (or when `host_alias` is `None`).
+/// * `gateway_ipv6` - IPv6 the alias resolves to. The IPv6 alias line is
+///   skipped when `None` (or when `host_alias` is `None`).
+fn hosts_file_contents(
+    hostname: Option<&str>,
+    host_alias: Option<&str>,
+    gateway_ipv4: Option<Ipv4Addr>,
+    gateway_ipv6: Option<Ipv6Addr>,
+) -> String {
     let mut s = String::new();
 
     // Localhost entries — always include hostname aliases when set.
@@ -50,6 +101,17 @@ fn hosts_file_contents(hostname: Option<&str>) -> String {
     } else {
         s.push_str("127.0.0.1\tlocalhost\n");
         s.push_str("::1\tlocalhost ip6-localhost ip6-loopback\n");
+    }
+
+    // `<host_alias>` → gateway IP mapping. Emits both address families
+    // so v4-only and v6-only resolvers find the alias.
+    if let Some(alias) = host_alias {
+        if let Some(gw_v4) = gateway_ipv4 {
+            s.push_str(&format!("{gw_v4}\t{alias}\n"));
+        }
+        if let Some(gw_v6) = gateway_ipv6 {
+            s.push_str(&format!("{gw_v6}\t{alias}\n"));
+        }
     }
 
     s.push_str("fe00::\tip6-localnet\n");
@@ -475,11 +537,19 @@ mod linux {
     }
 
     /// Writes `/etc/hosts` with localhost aliases and an optional hostname entry.
-    pub fn write_hosts_file(hostname: Option<&str>) -> AgentdResult<()> {
+    pub fn write_hosts_file(
+        hostname: Option<&str>,
+        host_alias: Option<&str>,
+        gateway_ipv4: Option<Ipv4Addr>,
+        gateway_ipv6: Option<Ipv6Addr>,
+    ) -> AgentdResult<()> {
         fs::create_dir_all("/etc")
             .map_err(|e| AgentdError::Init(format!("failed to create /etc: {e}")))?;
-        fs::write("/etc/hosts", super::hosts_file_contents(hostname))
-            .map_err(|e| AgentdError::Init(format!("failed to write /etc/hosts: {e}")))?;
+        fs::write(
+            "/etc/hosts",
+            super::hosts_file_contents(hostname, host_alias, gateway_ipv4, gateway_ipv6),
+        )
+        .map_err(|e| AgentdError::Init(format!("failed to write /etc/hosts: {e}")))?;
         Ok(())
     }
 
@@ -575,7 +645,7 @@ mod tests {
     #[test]
     fn test_hosts_file_without_hostname() {
         assert_eq!(
-            hosts_file_contents(None),
+            hosts_file_contents(None, None, None, None),
             concat!(
                 "127.0.0.1\tlocalhost\n",
                 "::1\tlocalhost ip6-localhost ip6-loopback\n",
@@ -590,7 +660,7 @@ mod tests {
     #[test]
     fn test_hosts_file_with_hostname() {
         assert_eq!(
-            hosts_file_contents(Some("worker-01")),
+            hosts_file_contents(Some("worker-01"), None, None, None),
             concat!(
                 "127.0.0.1\tlocalhost worker-01\n",
                 "::1\tlocalhost ip6-localhost ip6-loopback worker-01\n",
@@ -600,5 +670,52 @@ mod tests {
                 "ff02::2\tip6-allrouters\n",
             )
         );
+    }
+
+    #[test]
+    fn test_hosts_file_with_host_alias_both_families() {
+        assert_eq!(
+            hosts_file_contents(
+                Some("worker-01"),
+                Some("host.microsandbox.internal"),
+                Some(Ipv4Addr::new(100, 96, 0, 1)),
+                Some("fd42:6d73:62::1".parse().unwrap()),
+            ),
+            concat!(
+                "127.0.0.1\tlocalhost worker-01\n",
+                "::1\tlocalhost ip6-localhost ip6-loopback worker-01\n",
+                "100.96.0.1\thost.microsandbox.internal\n",
+                "fd42:6d73:62::1\thost.microsandbox.internal\n",
+                "fe00::\tip6-localnet\n",
+                "ff00::\tip6-mcastprefix\n",
+                "ff02::1\tip6-allnodes\n",
+                "ff02::2\tip6-allrouters\n",
+            )
+        );
+    }
+
+    #[test]
+    fn test_hosts_file_with_host_alias_v4_only() {
+        let out = hosts_file_contents(
+            None,
+            Some("host.microsandbox.internal"),
+            Some(Ipv4Addr::new(100, 96, 0, 1)),
+            None,
+        );
+        assert!(out.contains("100.96.0.1\thost.microsandbox.internal\n"));
+        assert!(!out.contains("fd42"));
+    }
+
+    #[test]
+    fn test_hosts_file_omits_alias_when_name_missing() {
+        let out = hosts_file_contents(
+            None,
+            None,
+            Some(Ipv4Addr::new(100, 96, 0, 1)),
+            Some("fd42:6d73:62::1".parse().unwrap()),
+        );
+        assert!(!out.contains("host.microsandbox.internal"));
+        assert!(!out.contains("100.96.0.1"));
+        assert!(!out.contains("fd42"));
     }
 }

--- a/crates/microsandbox/tests/host_access.rs
+++ b/crates/microsandbox/tests/host_access.rs
@@ -1,0 +1,357 @@
+//! Integration tests for the `host.microsandbox.internal` alias.
+
+use std::io;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
+
+use ipnetwork::{IpNetwork, Ipv4Network};
+use microsandbox::{NetworkPolicy, Sandbox};
+use microsandbox_network::policy::{Action, Destination, DestinationGroup, Rule};
+use test_utils::msb_test;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+//--------------------------------------------------------------------------------------------------
+// Host HTTP fixture
+//--------------------------------------------------------------------------------------------------
+
+/// Minimal HTTP server bound to `127.0.0.1` and `::1` on the same port. Dual-family avoids
+/// flakes when the guest's happy-eyeballs picks v6 and the listener only lives on v4.
+struct HostHttp {
+    port: u16,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl HostHttp {
+    async fn start(body: &'static str) -> io::Result<Self> {
+        let v4_listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+        let port = v4_listener.local_addr()?.port();
+        let v6_listener = TcpListener::bind(SocketAddr::from((Ipv6Addr::LOCALHOST, port))).await?;
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let body = Arc::new(body.to_owned());
+
+        let handle = tokio::spawn(async move {
+            let mut shutdown_rx = shutdown_rx;
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => return,
+                    accept = v4_listener.accept() => Self::handle_accept(accept, &body),
+                    accept = v6_listener.accept() => Self::handle_accept(accept, &body),
+                }
+            }
+        });
+
+        Ok(Self {
+            port,
+            shutdown: Some(shutdown_tx),
+            handle: Some(handle),
+        })
+    }
+
+    fn handle_accept(accept: io::Result<(tokio::net::TcpStream, SocketAddr)>, body: &Arc<String>) {
+        let Ok((mut stream, _)) = accept else { return };
+        let body = body.clone();
+        tokio::spawn(async move {
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body,
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+            let _ = stream.shutdown().await;
+        });
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+impl Drop for HostHttp {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.handle.take() {
+            h.abort();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Boot an alpine sandbox with the given policy (or the default when `None`).
+async fn spawn_sandbox(name: &str, policy: Option<NetworkPolicy>) -> Sandbox {
+    let builder = Sandbox::builder(name)
+        .image("alpine")
+        .cpus(1)
+        .memory(256)
+        .replace();
+    match policy {
+        Some(p) => builder.network(|n| n.policy(p)).create(),
+        None => builder.create(),
+    }
+    .await
+    .expect("create sandbox")
+}
+
+/// Stop the sandbox and remove it.
+async fn teardown(sb: Sandbox, name: &str) {
+    sb.stop_and_wait().await.expect("stop");
+    let _ = Sandbox::remove(name).await;
+}
+
+/// Read the sandbox gateway IPv4 from the guest's `/etc/resolv.conf`.
+async fn read_gateway_ip(sb: &Sandbox) -> String {
+    let out = sb
+        .shell("awk '/^nameserver /{print $2; exit}' /etc/resolv.conf")
+        .await
+        .expect("read resolv.conf");
+    out.stdout().expect("utf8").trim().to_owned()
+}
+
+/// Allow host only; deny everything else.
+fn allow_host_only_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        default_action: Action::Deny,
+        rules: vec![Rule::allow_outbound(Destination::Group(
+            DestinationGroup::Host,
+        ))],
+    }
+}
+
+/// Deny host only; allow everything else.
+fn deny_host_group_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        default_action: Action::Allow,
+        rules: vec![Rule::deny_outbound(Destination::Group(
+            DestinationGroup::Host,
+        ))],
+    }
+}
+
+/// Deny the given gateway IPv4 `/32`; allow everything else.
+fn deny_gateway_cidr_policy(gateway_ip: &str) -> NetworkPolicy {
+    let addr: Ipv4Addr = gateway_ip.parse().expect("valid gateway ipv4");
+    NetworkPolicy {
+        default_action: Action::Allow,
+        rules: vec![Rule::deny_outbound(Destination::Cidr(IpNetwork::V4(
+            Ipv4Network::new(addr, 32).expect("valid /32"),
+        )))],
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+/// Baseline reachability by hostname and by raw gateway IPv4, plus `/etc/hosts` entry.
+#[msb_test]
+async fn host_alias_reachable_by_hostname_and_gateway_ip() {
+    let server = HostHttp::start("hello from host")
+        .await
+        .expect("http fixture");
+    let port = server.port();
+
+    let name = "host-alias-baseline";
+    let sb = spawn_sandbox(name, Some(NetworkPolicy::allow_all())).await;
+
+    let out = sb
+        .shell(format!(
+            "wget -qO- --timeout=10 http://host.microsandbox.internal:{port}/"
+        ))
+        .await
+        .expect("wget hostname");
+    assert_eq!(
+        out.stdout().unwrap().trim(),
+        "hello from host",
+        "hostname path body mismatch (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+
+    let gw = read_gateway_ip(&sb).await;
+    let out = sb
+        .shell(format!("wget -qO- --timeout=10 http://{gw}:{port}/"))
+        .await
+        .expect("wget gateway");
+    assert_eq!(
+        out.stdout().unwrap().trim(),
+        "hello from host",
+        "gateway-IP path body mismatch (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+
+    let hosts = sb
+        .shell("cat /etc/hosts")
+        .await
+        .expect("cat /etc/hosts")
+        .stdout()
+        .unwrap()
+        .to_owned();
+    assert!(
+        hosts.contains("host.microsandbox.internal"),
+        "expected host.microsandbox.internal in /etc/hosts, got:\n{hosts}"
+    );
+    assert!(
+        hosts.contains(&gw),
+        "expected gateway IPv4 {gw} in /etc/hosts, got:\n{hosts}"
+    );
+
+    teardown(sb, name).await;
+}
+
+/// `dig` skips `/etc/hosts`, so a successful answer proves the forwarder synthesises the alias.
+#[msb_test]
+async fn host_alias_dns_synth_bypasses_hosts_file() {
+    let name = "host-alias-dns-synth";
+    let sb = spawn_sandbox(name, None).await;
+
+    sb.shell("apk add --quiet --no-progress bind-tools >/dev/null 2>&1")
+        .await
+        .expect("install bind-tools");
+
+    let gw = read_gateway_ip(&sb).await;
+    let out = sb
+        .shell("dig +short +time=3 +tries=1 host.microsandbox.internal A")
+        .await
+        .expect("dig alias");
+    let answer = out.stdout().unwrap().trim().to_owned();
+    assert_eq!(
+        answer,
+        gw,
+        "expected DNS synth to return gateway {gw}, got {answer:?} (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+
+    teardown(sb, name).await;
+}
+
+/// CIDR deny on the gateway `/32` blocks host access (policy fires before the proxy rewrite).
+#[msb_test]
+async fn host_alias_denied_by_gateway_cidr_policy() {
+    let server = HostHttp::start("should not see")
+        .await
+        .expect("http fixture");
+    let port = server.port();
+
+    // Boot once to read the gateway, tear down, then boot again with the CIDR policy.
+    let probe_name = "host-alias-policy-probe";
+    let probe = spawn_sandbox(probe_name, None).await;
+    let gw = read_gateway_ip(&probe).await;
+    teardown(probe, probe_name).await;
+
+    let name = "host-alias-policy-deny";
+    let sb = spawn_sandbox(name, Some(deny_gateway_cidr_policy(&gw))).await;
+
+    // Dial v4 directly; via the hostname, happy-eyeballs could pick the v6 entry (not covered).
+    let out = sb
+        .shell(format!(
+            "wget -qO- --timeout=5 http://{gw}:{port}/; echo status=$?"
+        ))
+        .await
+        .expect("wget");
+    let stdout = out.stdout().unwrap();
+    assert!(
+        stdout.contains("status=") && !stdout.trim_end().ends_with("status=0"),
+        "expected wget to fail when gateway denied by policy; got: {stdout:?} (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+
+    teardown(sb, name).await;
+}
+
+/// Default `public_only` must block host access; users opt in explicitly.
+#[msb_test]
+async fn host_alias_denied_by_default_policy() {
+    let server = HostHttp::start("should not see")
+        .await
+        .expect("http fixture");
+    let port = server.port();
+
+    let name = "host-alias-default-deny";
+    let sb = spawn_sandbox(name, None).await;
+
+    let out = sb
+        .shell(format!(
+            "wget -qO- --timeout=5 http://host.microsandbox.internal:{port}/; echo status=$?"
+        ))
+        .await
+        .expect("wget");
+    let stdout = out.stdout().unwrap();
+    assert!(
+        stdout.contains("status=") && !stdout.trim_end().ends_with("status=0"),
+        "expected wget to fail under default public_only policy; got: {stdout:?} (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+    assert!(
+        !stdout.contains("should not see"),
+        "host body leaked through default-denied policy: {stdout:?}"
+    );
+
+    teardown(sb, name).await;
+}
+
+/// `Group::Host` allow on a deny-all base: host reachable, everything else denied.
+#[msb_test]
+async fn group_host_allow_narrows_to_gateway() {
+    let server = HostHttp::start("host ok").await.expect("http fixture");
+    let port = server.port();
+
+    let name = "group-host-allow";
+    let sb = spawn_sandbox(name, Some(allow_host_only_policy())).await;
+
+    let out = sb
+        .shell(format!(
+            "wget -qO- --timeout=5 http://host.microsandbox.internal:{port}/"
+        ))
+        .await
+        .expect("wget host");
+    assert_eq!(
+        out.stdout().unwrap().trim(),
+        "host ok",
+        "group host allow should let guest reach the host (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+
+    let out = sb
+        .shell("wget -qO- --timeout=5 http://8.8.8.8/ ; echo status=$?")
+        .await
+        .expect("wget external");
+    let stdout = out.stdout().unwrap();
+    assert!(
+        !stdout.trim_end().ends_with("status=0"),
+        "non-host traffic should be denied under allow-host-only policy; got: {stdout:?}"
+    );
+
+    teardown(sb, name).await;
+}
+
+/// `Group::Host` deny on an allow-all base: host blocked, rest still works.
+#[msb_test]
+async fn group_host_deny_blocks_host_only() {
+    let server = HostHttp::start("unreachable").await.expect("http fixture");
+    let port = server.port();
+
+    let name = "group-host-deny";
+    let sb = spawn_sandbox(name, Some(deny_host_group_policy())).await;
+
+    let out = sb
+        .shell(format!(
+            "wget -qO- --timeout=5 http://host.microsandbox.internal:{port}/ ; echo status=$?"
+        ))
+        .await
+        .expect("wget host");
+    let stdout = out.stdout().unwrap();
+    assert!(
+        !stdout.trim_end().ends_with("status=0"),
+        "host should be denied by group-host deny rule; got: {stdout:?}"
+    );
+
+    teardown(sb, name).await;
+}

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -23,6 +23,7 @@ hickory-proto = { workspace = true, features = ["tls-ring"] }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
+microsandbox-protocol = { version = "0.3.14", path = "../protocol" }
 microsandbox-utils = { version = "0.3.14", path = "../utils" }
 msb_krun = { version = "0.1.10", features = ["net"] }
 pem = "3"

--- a/crates/network/lib/conn.rs
+++ b/crates/network/lib/conn.rs
@@ -6,6 +6,8 @@
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use bytes::Bytes;
 use smoltcp::iface::{SocketHandle, SocketSet};
@@ -74,6 +76,13 @@ struct Connection {
     proxy_channels: Option<ProxyChannels>,
     /// Whether a proxy task has been spawned for this connection.
     proxy_spawned: bool,
+    /// Set `true` by the proxy task once its `TcpStream::connect` to
+    /// the upstream succeeds. If the task exits with this still
+    /// `false`, the smoltcp socket is aborted (RST) so the guest
+    /// client gets ECONNREFUSED and happy-eyeballs clients fall back
+    /// to another address family, instead of being stuck on a
+    /// half-open connection that closed cleanly with FIN.
+    upstream_connected: Arc<AtomicBool>,
     /// Partial data from proxy that couldn't be fully written to smoltcp socket.
     write_buf: Option<(Bytes, usize)>,
     /// Data read from smoltcp socket that couldn't be sent to proxy (channel full).
@@ -103,6 +112,10 @@ pub struct NewConnection {
     pub from_smoltcp: mpsc::Receiver<Bytes>,
     /// Send data to smoltcp socket (proxy task → guest).
     pub to_smoltcp: mpsc::Sender<Bytes>,
+    /// Flag the proxy task flips to `true` after a successful upstream
+    /// connect. Read by the connection tracker on proxy exit to decide
+    /// between FIN (clean close) and RST (upstream never reached).
+    pub upstream_connected: Arc<AtomicBool>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -182,6 +195,7 @@ impl ConnectionTracker {
                     to_smoltcp: from_proxy_tx,
                 }),
                 proxy_spawned: false,
+                upstream_connected: Arc::new(AtomicBool::new(false)),
                 write_buf: None,
                 read_buf: None,
                 close_attempts: 0,
@@ -206,9 +220,29 @@ impl ConnectionTracker {
 
             let socket = sockets.get_mut::<tcp::Socket>(handle);
 
+            // Already torn down (e.g. abort fired on a previous pass).
+            // Leave it for `cleanup_closed` to evict.
+            if matches!(socket.state(), tcp::State::Closed) {
+                continue;
+            }
+
             // Detect proxy task exit: when the proxy drops its channel
             // ends, close the smoltcp socket so the guest gets a FIN.
+            //
+            // If the proxy never successfully reached the upstream,
+            // an RST via `abort()` is instead sent so happy-eyeballs
+            // clients fall back to another family instead of committing
+            // to this half-open connection.
             if conn.to_proxy.is_closed() {
+                if !conn.upstream_connected.load(Ordering::Acquire) {
+                    tracing::debug!(
+                        src = %conn.src,
+                        dst = %conn.dst,
+                        "upstream never connected; aborting smoltcp socket (RST to guest)"
+                    );
+                    socket.abort();
+                    continue;
+                }
                 write_proxy_data(socket, conn);
                 if conn.write_buf.is_none() {
                     socket.close();
@@ -271,6 +305,7 @@ impl ConnectionTracker {
                         dst: conn.dst,
                         from_smoltcp: channels.from_smoltcp,
                         to_smoltcp: channels.to_smoltcp,
+                        upstream_connected: conn.upstream_connected.clone(),
                     });
                 }
             }

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -32,7 +32,8 @@ use bytes::Bytes;
 use futures::StreamExt;
 use hickory_client::client::Client;
 use hickory_client::proto::op::{Message, MessageType, ResponseCode};
-use hickory_client::proto::rr::RData;
+use hickory_client::proto::rr::rdata::{A, AAAA};
+use hickory_client::proto::rr::{RData, Record, RecordType};
 use hickory_client::proto::serialize::binary::{BinDecodable, BinEncodable};
 use hickory_client::proto::xfer::{DnsHandle, DnsRequest};
 use tokio::sync::{OnceCell, watch};
@@ -42,7 +43,18 @@ use super::common::config::NormalizedDnsConfig;
 use super::common::filter::{is_domain_blocked, is_private_ipv4, is_private_ipv6};
 use super::common::transport::Transport;
 use super::nameserver::{read_host_dns_servers, resolve_nameservers};
-use crate::policy::NetworkPolicy;
+use crate::policy::PolicyEvaluator;
+use crate::stack::GatewayIps;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// TTL for locally-synthesized `host.microsandbox.internal` answers.
+/// Short enough that the guest re-resolves often (in case we ever
+/// expose a way to change the alias at runtime), long enough to avoid
+/// hammering the forwarder on each connection.
+const HOST_ALIAS_TTL_SECS: u32 = 60;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -75,9 +87,12 @@ pub(crate) struct DnsForwarder {
     /// the configured upstream; queries to other IPs go through the
     /// direct path subject to network egress policy.
     gateway_ips: Arc<HashSet<IpAddr>>,
-    /// Network policy. Direct-path queries consult this for outbound
+    /// Policy evaluator. Direct-path queries consult this for outbound
     /// permission to the chosen `@target` resolver IP.
-    network_policy: Arc<NetworkPolicy>,
+    evaluator: Arc<PolicyEvaluator>,
+    /// Gateway IPs returned as A / AAAA answers when the guest asks
+    /// for `host.microsandbox.internal`.
+    gateway: GatewayIps,
     config: Arc<NormalizedDnsConfig>,
 }
 
@@ -132,6 +147,18 @@ impl DnsForwarder {
         if is_domain_blocked(&domain, &self.config) {
             tracing::debug!(domain = %domain, "DNS query blocked by domain policy");
             return build_status_response(&query_msg, ResponseCode::Refused);
+        }
+
+        // Host alias (`host.microsandbox.internal`): answer locally
+        // with the gateway IPs instead of going upstream. The proxy
+        // dial-time rewrite (stack.rs) then maps those IPs back to
+        // loopback so the guest reaches host services.
+        if is_host_alias_query(&domain) {
+            let qtype = question.query_type();
+            if let Some(bytes) = synthesize_host_alias_response(&query_msg, self.gateway, qtype) {
+                tracing::debug!(domain = %domain, ?qtype, "DNS host alias synthesised locally");
+                return Some(bytes);
+            }
         }
 
         // Pick upstream client based on where the guest aimed and the
@@ -221,12 +248,7 @@ impl DnsForwarder {
         transport: Transport,
         sni: Option<&str>,
     ) -> UpstreamChoice {
-        match decide_upstream(
-            &self.gateway_ips,
-            &self.network_policy,
-            original_dst,
-            transport,
-        ) {
+        match decide_upstream(&self.gateway_ips, &self.evaluator, original_dst, transport) {
             UpstreamDecision::Configured => self.configured_client(transport).await,
             UpstreamDecision::Refused => UpstreamChoice::Refused,
             UpstreamDecision::Direct(addr) => {
@@ -272,15 +294,39 @@ impl DnsForwarder {
     /// TCP/53 proxy ([`super::proxies::tcp::TcpProxy`]) clone the
     /// handle and [`Self::wait`] before serving any query, so they
     /// share one configured upstream + policy across transports.
+    /// Spawn the forwarder init task on the given tokio runtime.
+    ///
+    /// Connects to the configured upstream asynchronously and publishes
+    /// the resulting [`DnsForwarder`] on the returned handle. Both the
+    /// UDP and TCP/53 proxies clone the handle and `wait` before
+    /// serving any query, so they share one configured upstream + policy
+    /// across transports.
+    ///
+    /// # Arguments
+    ///
+    /// * `handle` - Tokio runtime the init task is spawned on.
+    /// * `config` - Normalised DNS config (block lists, timeout,
+    ///   upstream specs).
+    /// * `gateway_ips` - Set of gateway IPs (v4 + v6) used to
+    ///   distinguish "guest queried the gateway resolver" from
+    ///   "guest queried a specific `@resolver`" on the direct path.
+    /// * `evaluator` - Policy evaluator consulted for egress permission
+    ///   on direct-path queries to a guest-chosen `@resolver`.
+    /// * `gateway` - Gateway IPs returned as A / AAAA answers for
+    ///   `host.microsandbox.internal`. Expected to match the pair in
+    ///   `gateway_ips`.
     pub(super) fn spawn(
         handle: &tokio::runtime::Handle,
         config: Arc<NormalizedDnsConfig>,
         gateway_ips: Arc<HashSet<IpAddr>>,
-        network_policy: Arc<NetworkPolicy>,
+        net_policy_evaluator: Arc<PolicyEvaluator>,
+        gateway: GatewayIps,
     ) -> DnsForwarderHandle {
         let (forwarder_tx, forwarder_rx) = watch::channel(None);
         handle.spawn(async move {
-            let Some(forwarder) = Self::build(config, gateway_ips, network_policy).await else {
+            let Some(forwarder) =
+                Self::build(config, gateway_ips, net_policy_evaluator, gateway).await
+            else {
                 // Drop forwarder_tx by returning; waiters observe init
                 // failure as `Self::wait().await == None`.
                 return;
@@ -296,7 +342,8 @@ impl DnsForwarder {
     async fn build(
         config: Arc<NormalizedDnsConfig>,
         gateway_ips: Arc<HashSet<IpAddr>>,
-        network_policy: Arc<NetworkPolicy>,
+        net_policy_evaluator: Arc<PolicyEvaluator>,
+        gateway: GatewayIps,
     ) -> Option<Arc<Self>> {
         let upstreams = if !config.nameservers.is_empty() {
             match resolve_nameservers(&config.nameservers).await {
@@ -335,7 +382,8 @@ impl DnsForwarder {
             configured_tcp: OnceCell::new(),
             configured_upstream: upstream,
             gateway_ips,
-            network_policy,
+            evaluator: net_policy_evaluator,
+            gateway,
             config,
         }))
     }
@@ -367,7 +415,7 @@ impl DnsForwarder {
 /// the rule logic is testable without a real upstream client.
 fn decide_upstream(
     gateway_ips: &HashSet<IpAddr>,
-    policy: &NetworkPolicy,
+    evaluator: &PolicyEvaluator,
     original_dst: Option<IpAddr>,
     transport: Transport,
 ) -> UpstreamDecision {
@@ -383,7 +431,7 @@ fn decide_upstream(
     // the egress policy for that resolver IP over the transport's
     // corresponding port and protocol.
     let policy_dst = SocketAddr::new(dst, transport.upstream_port());
-    if policy
+    if evaluator
         .evaluate_egress(policy_dst, transport.policy_protocol())
         .is_deny()
     {
@@ -407,6 +455,64 @@ fn build_status_response(query: &Message, rcode: ResponseCode) -> Option<Bytes> 
     if let Some(q) = query.queries().first() {
         response.add_query(q.clone());
     }
+    response.to_bytes().ok().map(Bytes::from)
+}
+
+/// Case-insensitive match against [`crate::HOST_ALIAS`] with
+/// trailing-dot tolerance.
+///
+/// DNS names arrive from the wire with a trailing `.` and arbitrary
+/// case. Using `eq_ignore_ascii_case` avoids allocating a lowercased
+/// copy on every query.
+///
+/// # Arguments
+///
+/// * `query_name` - Domain name pulled from the DNS question section.
+fn is_host_alias_query(query_name: &str) -> bool {
+    query_name
+        .trim_end_matches('.')
+        .eq_ignore_ascii_case(crate::HOST_ALIAS)
+}
+
+/// Synthesize an A/AAAA response for `host.microsandbox.internal`.
+///
+/// Returns `None` for query types other than A/AAAA so the caller keeps
+/// forwarding upstream (e.g. MX or TXT queries, which this alias
+/// doesn't serve).
+///
+/// # Arguments
+///
+/// * `query` - The incoming DNS query; its ID, opcode, RD bit, and
+///   question are echoed into the response.
+/// * `gateway` - Gateway IPs; the IPv4 answers an A query, the IPv6
+///   answers an AAAA query.
+/// * `qtype` - Record type the guest asked for. Only `A` and `AAAA`
+///   produce a response.
+fn synthesize_host_alias_response(
+    query: &Message,
+    gateway: GatewayIps,
+    qtype: RecordType,
+) -> Option<Bytes> {
+    let question = query.queries().first()?;
+    let name = question.name().clone();
+
+    let rdata = match qtype {
+        RecordType::A => RData::A(A::from(gateway.ipv4)),
+        RecordType::AAAA => RData::AAAA(AAAA::from(gateway.ipv6)),
+        _ => return None,
+    };
+
+    let mut response = Message::new();
+    response.set_id(query.id());
+    response.set_op_code(query.op_code());
+    response.set_recursion_desired(query.recursion_desired());
+    response.set_message_type(MessageType::Response);
+    response.set_response_code(ResponseCode::NoError);
+    response.set_recursion_available(true);
+    response.set_authoritative(true);
+    response.add_query(question.clone());
+    response.add_answer(Record::from_rdata(name, HOST_ALIAS_TTL_SECS, rdata));
+
     response.to_bytes().ok().map(Bytes::from)
 }
 
@@ -435,7 +541,7 @@ fn build_truncated_response(query: &Message) -> Option<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::policy::Protocol;
+    use crate::policy::{NetworkPolicy, Protocol};
     use hickory_client::proto::op::{Edns, MessageType, OpCode, Query};
     use hickory_client::proto::rr::{DNSClass, Name, RecordType};
 
@@ -477,6 +583,63 @@ mod tests {
         let msg = Message::from_bytes(&bytes).expect("parse response");
         assert_eq!(msg.response_code(), ResponseCode::ServFail);
         assert_eq!(msg.answers().len(), 0);
+    }
+
+    fn test_gateway() -> GatewayIps {
+        GatewayIps {
+            ipv4: std::net::Ipv4Addr::new(100, 96, 0, 1),
+            ipv6: "fd42:6d73:62::1".parse().unwrap(),
+        }
+    }
+
+    #[test]
+    fn synthesize_host_alias_returns_gateway_ipv4_for_a_query() {
+        let query = make_query("host.microsandbox.internal.", RecordType::A);
+        let gw = test_gateway();
+
+        let bytes =
+            synthesize_host_alias_response(&query, gw, RecordType::A).expect("synth returns bytes");
+        let msg = Message::from_bytes(&bytes).expect("parse synthesized response");
+
+        assert_eq!(msg.id(), 0x4242);
+        assert_eq!(msg.response_code(), ResponseCode::NoError);
+        assert_eq!(msg.message_type(), MessageType::Response);
+        assert_eq!(msg.answers().len(), 1);
+
+        let answer = &msg.answers()[0];
+        let RData::A(a) = answer.data() else {
+            panic!("expected A record");
+        };
+        assert_eq!(std::net::Ipv4Addr::from(*a), gw.ipv4);
+    }
+
+    #[test]
+    fn synthesize_host_alias_returns_gateway_ipv6_for_aaaa_query() {
+        let query = make_query("host.microsandbox.internal.", RecordType::AAAA);
+        let gw = test_gateway();
+
+        let bytes = synthesize_host_alias_response(&query, gw, RecordType::AAAA)
+            .expect("synth returns bytes");
+        let msg = Message::from_bytes(&bytes).expect("parse synthesized response");
+
+        let RData::AAAA(aaaa) = msg.answers()[0].data() else {
+            panic!("expected AAAA record");
+        };
+        assert_eq!(std::net::Ipv6Addr::from(*aaaa), gw.ipv6);
+    }
+
+    #[test]
+    fn synthesize_host_alias_returns_none_for_other_qtypes() {
+        let query = make_query("host.microsandbox.internal.", RecordType::MX);
+        assert!(synthesize_host_alias_response(&query, test_gateway(), RecordType::MX).is_none());
+    }
+
+    #[test]
+    fn is_host_alias_query_is_case_insensitive_and_trailing_dot_tolerant() {
+        assert!(is_host_alias_query("host.microsandbox.internal"));
+        assert!(is_host_alias_query("HOST.MICROSANDBOX.internal"));
+        assert!(is_host_alias_query("host.microsandbox.internal."));
+        assert!(!is_host_alias_query("other.microsandbox.internal"));
     }
 
     #[test]
@@ -531,10 +694,20 @@ mod tests {
         ])
     }
 
+    fn evaluator(policy: NetworkPolicy) -> PolicyEvaluator {
+        PolicyEvaluator::new(
+            policy,
+            GatewayIps {
+                ipv4: std::net::Ipv4Addr::new(10, 0, 0, 1),
+                ipv6: std::net::Ipv6Addr::LOCALHOST,
+            },
+        )
+    }
+
     #[test]
     fn decide_upstream_configured_when_dst_is_gateway_v4() {
         let gw = gateway_set();
-        let policy = NetworkPolicy::allow_all();
+        let policy = evaluator(NetworkPolicy::allow_all());
         let dst = Some(IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)));
         assert_eq!(
             decide_upstream(&gw, &policy, dst, Transport::Udp),
@@ -545,7 +718,7 @@ mod tests {
     #[test]
     fn decide_upstream_configured_when_dst_is_gateway_v6() {
         let gw = gateway_set();
-        let policy = NetworkPolicy::allow_all();
+        let policy = evaluator(NetworkPolicy::allow_all());
         let dst = Some(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST));
         assert_eq!(
             decide_upstream(&gw, &policy, dst, Transport::Tcp),
@@ -559,7 +732,7 @@ mod tests {
         // to fall back to the configured upstream, never accidentally
         // forward to whoever the guest happens to be aiming at.
         let gw = gateway_set();
-        let policy = NetworkPolicy::allow_all();
+        let policy = evaluator(NetworkPolicy::allow_all());
         assert_eq!(
             decide_upstream(&gw, &policy, None, Transport::Udp),
             UpstreamDecision::Configured
@@ -569,7 +742,7 @@ mod tests {
     #[test]
     fn decide_upstream_direct_when_dst_external_and_policy_allows() {
         let gw = gateway_set();
-        let policy = NetworkPolicy::allow_all();
+        let policy = evaluator(NetworkPolicy::allow_all());
         let dst = Some(IpAddr::V4(std::net::Ipv4Addr::new(1, 1, 1, 1)));
         assert_eq!(
             decide_upstream(&gw, &policy, dst, Transport::Udp),
@@ -583,7 +756,7 @@ mod tests {
         // a private resolver should get REFUSED rather than silently
         // hitting the configured upstream instead.
         let gw = gateway_set();
-        let policy = NetworkPolicy::public_only();
+        let policy = evaluator(NetworkPolicy::public_only());
         let dst = Some(IpAddr::V4(std::net::Ipv4Addr::new(192, 168, 1, 53)));
         assert_eq!(
             decide_upstream(&gw, &policy, dst, Transport::Udp),
@@ -597,7 +770,7 @@ mod tests {
         // still reach the configured upstream. Direct queries get
         // REFUSED.
         let gw = gateway_set();
-        let policy = NetworkPolicy::none();
+        let policy = evaluator(NetworkPolicy::none());
         let dst = Some(IpAddr::V4(std::net::Ipv4Addr::new(1, 1, 1, 1)));
         assert_eq!(
             decide_upstream(&gw, &policy, dst, Transport::Tcp),
@@ -619,7 +792,7 @@ mod tests {
         use crate::policy::{Action, Destination, Direction, Rule};
         let gw = gateway_set();
         let dst_ip = std::net::Ipv4Addr::new(8, 8, 8, 8);
-        let policy = NetworkPolicy {
+        let policy = evaluator(NetworkPolicy {
             default_action: Action::Allow,
             rules: vec![Rule {
                 direction: Direction::Outbound,
@@ -628,7 +801,7 @@ mod tests {
                 ports: None,
                 action: Action::Deny,
             }],
-        };
+        });
         let dst = Some(IpAddr::V4(dst_ip));
         assert_eq!(
             decide_upstream(&gw, &policy, dst, Transport::Udp),
@@ -643,7 +816,7 @@ mod tests {
     #[test]
     fn decide_upstream_dot_configured_when_dst_is_gateway() {
         let gw = gateway_set();
-        let policy = NetworkPolicy::allow_all();
+        let policy = evaluator(NetworkPolicy::allow_all());
         let dst = Some(IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)));
         assert_eq!(
             decide_upstream(&gw, &policy, dst, Transport::Dot),
@@ -654,7 +827,7 @@ mod tests {
     #[test]
     fn decide_upstream_dot_direct_targets_port_853() {
         let gw = gateway_set();
-        let policy = NetworkPolicy::allow_all();
+        let policy = evaluator(NetworkPolicy::allow_all());
         let dst = Some(IpAddr::V4(std::net::Ipv4Addr::new(1, 1, 1, 1)));
         assert_eq!(
             decide_upstream(&gw, &policy, dst, Transport::Dot),
@@ -668,7 +841,7 @@ mod tests {
         // regardless of port, since DoT rides TCP.
         use crate::policy::{Action, Destination, Direction, Rule};
         let gw = gateway_set();
-        let policy = NetworkPolicy {
+        let policy = evaluator(NetworkPolicy {
             default_action: Action::Allow,
             rules: vec![Rule {
                 direction: Direction::Outbound,
@@ -677,7 +850,7 @@ mod tests {
                 ports: None,
                 action: Action::Deny,
             }],
-        };
+        });
         let dst = Some(IpAddr::V4(std::net::Ipv4Addr::new(1, 1, 1, 1)));
         assert_eq!(
             decide_upstream(&gw, &policy, dst, Transport::Dot),

--- a/crates/network/lib/dns/interceptor.rs
+++ b/crates/network/lib/dns/interceptor.rs
@@ -25,8 +25,9 @@ use super::common::config::NormalizedDnsConfig;
 use super::forwarder::{DnsForwarder, DnsForwarderHandle};
 use super::proxies::udp::UdpProxy;
 use crate::config::DnsConfig;
-use crate::policy::NetworkPolicy;
+use crate::policy::PolicyEvaluator;
 use crate::shared::SharedState;
+use crate::stack::GatewayIps;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -102,17 +103,32 @@ impl DnsInterceptor {
     /// spawns the background forwarder task. Returns the interceptor and
     /// the shared [`DnsForwarderHandle`] used by the TCP/53 proxy.
     ///
-    /// `gateway_ips` (the v4 + v6 addresses the gateway responds to) and
-    /// `network_policy` are forwarded to the per-query upstream selector:
-    /// queries to the gateway use the configured upstream; queries to
-    /// other IPs are routed directly subject to the policy.
+    /// Create the DNS interceptor.
+    ///
+    /// Binds a smoltcp UDP socket to port 53, creates the channel pair,
+    /// and spawns the background forwarder task. Returns the interceptor
+    /// and the shared [`DnsForwarderHandle`] used by the TCP/53 proxy.
+    ///
+    /// # Arguments
+    ///
+    /// * `sockets` - Smoltcp socket set the UDP/53 socket is added to.
+    /// * `dns_config` - Operator DNS config (block lists, upstreams, timeout).
+    /// * `shared` - Stack-wide shared state used by the forwarder's UDP proxy for wake-ups.
+    /// * `tokio_handle` - Runtime the forwarder + proxy tasks are spawned on.
+    /// * `gateway_ips` - Set of gateway IPs (v4 + v6) used to distinguish "guest
+    ///   queried the gateway resolver" from "guest queried a specific `@resolver`"
+    ///   when routing upstream.
+    /// * `evaluator` - Policy evaluator consulted on direct-path queries to a guest-chosen `@resolver`.
+    /// * `gateway` - Gateway IPs returned as A / AAAA answers for `host.microsandbox.internal`.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         sockets: &mut SocketSet<'_>,
         dns_config: DnsConfig,
         shared: Arc<SharedState>,
         tokio_handle: &tokio::runtime::Handle,
         gateway_ips: Arc<HashSet<IpAddr>>,
-        network_policy: Arc<NetworkPolicy>,
+        net_policy_evaluator: Arc<PolicyEvaluator>,
+        gateway: GatewayIps,
     ) -> (Self, DnsForwarderHandle) {
         // Create and bind the smoltcp UDP socket.
         let rx_meta = vec![PacketMetadata::EMPTY; DNS_SOCKET_PACKET_SLOTS];
@@ -146,8 +162,13 @@ impl DnsInterceptor {
         //      interceptor's channel and routes them through the
         //      forwarder, mirroring how `tcp.rs` handles per-connection
         //      TCP/53 traffic.
-        let forwarder_handle =
-            DnsForwarder::spawn(tokio_handle, normalized, gateway_ips, network_policy);
+        let forwarder_handle = DnsForwarder::spawn(
+            tokio_handle,
+            normalized,
+            gateway_ips,
+            net_policy_evaluator,
+            gateway,
+        );
         UdpProxy::spawn(
             tokio_handle,
             query_rx,

--- a/crates/network/lib/dns/proxies/tcp.rs
+++ b/crates/network/lib/dns/proxies/tcp.rs
@@ -46,7 +46,7 @@ const IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 /// guest, extracts length-prefixed DNS messages, dispatches each
 /// through the shared [`DnsForwarder`] in its own sub-task, and writes
 /// length-prefixed responses back as they arrive.
-pub(crate) struct TcpProxy {
+pub(crate) struct DnsTcpProxy {
     /// The (resolver-IP, 53) the guest aimed at — passed to the
     /// forwarder for upstream selection.
     dst: SocketAddr,
@@ -66,7 +66,7 @@ pub(crate) struct TcpProxy {
 // Methods
 //--------------------------------------------------------------------------------------------------
 
-impl TcpProxy {
+impl DnsTcpProxy {
     /// Spawn a DNS-over-TCP proxy task for a newly established TCP/53
     /// connection. Waits for the forwarder, constructs a [`TcpProxy`],
     /// and drives it to completion.

--- a/crates/network/lib/icmp_relay.rs
+++ b/crates/network/lib/icmp_relay.rs
@@ -16,7 +16,7 @@ use smoltcp::wire::{
     Icmpv6Packet, Icmpv6Repr, IpProtocol, Ipv4Packet, Ipv4Repr, Ipv6Packet, Ipv6Repr,
 };
 
-use crate::policy::{NetworkPolicy, Protocol};
+use crate::policy::{PolicyEvaluator, Protocol};
 use crate::shared::SharedState;
 use crate::stack::PollLoopConfig;
 
@@ -116,7 +116,7 @@ impl IcmpRelay {
         &self,
         frame: &[u8],
         config: &PollLoopConfig,
-        policy: &NetworkPolicy,
+        evaluator: &PolicyEvaluator,
     ) -> bool {
         let Ok(eth) = EthernetFrame::new_checked(frame) else {
             return false;
@@ -124,10 +124,10 @@ impl IcmpRelay {
 
         match eth.ethertype() {
             EthernetProtocol::Ipv4 if matches!(self.backend_v4, EchoBackend::Available) => {
-                self.try_relay_icmpv4(&eth, config, policy)
+                self.try_relay_icmpv4(&eth, config, evaluator)
             }
             EthernetProtocol::Ipv6 if matches!(self.backend_v6, EchoBackend::Available) => {
-                self.try_relay_icmpv6(&eth, config, policy)
+                self.try_relay_icmpv6(&eth, config, evaluator)
             }
             _ => false,
         }
@@ -140,7 +140,7 @@ impl IcmpRelay {
         &self,
         eth: &EthernetFrame<&[u8]>,
         config: &PollLoopConfig,
-        policy: &NetworkPolicy,
+        evaluator: &PolicyEvaluator,
     ) -> bool {
         let Ok(ipv4) = Ipv4Packet::new_checked(eth.payload()) else {
             return false;
@@ -151,7 +151,7 @@ impl IcmpRelay {
 
         // Gateway echo is already handled upstream — skip.
         let dst_ip: Ipv4Addr = ipv4.dst_addr();
-        if dst_ip == config.gateway_ipv4 {
+        if dst_ip == config.gateway.ipv4 {
             return false;
         }
 
@@ -168,7 +168,7 @@ impl IcmpRelay {
         };
 
         // Policy check.
-        if policy
+        if evaluator
             .evaluate_egress_ip(IpAddr::V4(dst_ip), Protocol::Icmpv4)
             .is_deny()
         {
@@ -211,7 +211,7 @@ impl IcmpRelay {
         &self,
         eth: &EthernetFrame<&[u8]>,
         config: &PollLoopConfig,
-        policy: &NetworkPolicy,
+        evaluator: &PolicyEvaluator,
     ) -> bool {
         let Ok(ipv6) = Ipv6Packet::new_checked(eth.payload()) else {
             return false;
@@ -222,7 +222,7 @@ impl IcmpRelay {
 
         // Gateway echo is already handled upstream — skip.
         let dst_ip: Ipv6Addr = ipv6.dst_addr();
-        if dst_ip == config.gateway_ipv6 {
+        if dst_ip == config.gateway.ipv6 {
             return false;
         }
 
@@ -244,7 +244,7 @@ impl IcmpRelay {
         };
 
         // Policy check.
-        if policy
+        if evaluator
             .evaluate_egress_ip(IpAddr::V6(dst_ip), Protocol::Icmpv6)
             .is_deny()
         {

--- a/crates/network/lib/lib.rs
+++ b/crates/network/lib/lib.rs
@@ -17,3 +17,9 @@ pub mod shared;
 pub mod stack;
 pub mod tls;
 pub mod udp_relay;
+
+/// Static hostname the guest uses to reach the sandbox host.
+///
+/// The host-side DNS interceptor matches guest queries against this
+/// name, and agentd writes the same name into `/etc/hosts`.
+pub(crate) const HOST_ALIAS: &str = "host.microsandbox.internal";

--- a/crates/network/lib/network.rs
+++ b/crates/network/lib/network.rs
@@ -9,12 +9,13 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
+use microsandbox_protocol::{ENV_HOST_ALIAS, ENV_NET, ENV_NET_IPV4, ENV_NET_IPV6};
 use msb_krun::backends::net::NetBackend;
 
 use crate::backend::SmoltcpBackend;
 use crate::config::NetworkConfig;
 use crate::shared::{DEFAULT_QUEUE_CAPACITY, SharedState};
-use crate::stack::{self, PollLoopConfig};
+use crate::stack::{self, GatewayIps, PollLoopConfig};
 use crate::tls::state::TlsState;
 
 //--------------------------------------------------------------------------------------------------
@@ -134,6 +135,14 @@ impl SmoltcpNetwork {
         }
     }
 
+    /// Get the gateway IPs for virtio-net configuration and domain-based policy rules.
+    fn gateway_ips(&self) -> GatewayIps {
+        GatewayIps {
+            ipv4: self.gateway_ipv4,
+            ipv6: self.gateway_ipv6,
+        }
+    }
+
     /// Start the smoltcp poll thread.
     ///
     /// Must be called before VM boot. Requires a tokio runtime handle for
@@ -143,9 +152,8 @@ impl SmoltcpNetwork {
         let poll_config = PollLoopConfig {
             gateway_mac: self.gateway_mac,
             guest_mac: self.guest_mac,
-            gateway_ipv4: self.gateway_ipv4,
+            gateway: self.gateway_ips(),
             guest_ipv4: self.guest_ipv4,
-            gateway_ipv6: self.gateway_ipv6,
             mtu: self.mtu as usize,
         };
         let network_policy = self.config.policy.clone();
@@ -190,7 +198,7 @@ impl SmoltcpNetwork {
     pub fn guest_env_vars(&self) -> Vec<(String, String)> {
         let mut vars = vec![
             (
-                "MSB_NET".into(),
+                ENV_NET.into(),
                 format!(
                     "iface=eth0,mac={},mtu={}",
                     format_mac(self.guest_mac),
@@ -198,19 +206,20 @@ impl SmoltcpNetwork {
                 ),
             ),
             (
-                "MSB_NET_IPV4".into(),
+                ENV_NET_IPV4.into(),
                 format!(
                     "addr={}/30,gw={},dns={}",
                     self.guest_ipv4, self.gateway_ipv4, self.gateway_ipv4,
                 ),
             ),
             (
-                "MSB_NET_IPV6".into(),
+                ENV_NET_IPV6.into(),
                 format!(
                     "addr={}/64,gw={},dns={}",
                     self.guest_ipv6, self.gateway_ipv6, self.gateway_ipv6,
                 ),
             ),
+            (ENV_HOST_ALIAS.into(), crate::HOST_ALIAS.into()),
         ];
 
         // Auto-expose secret placeholders as environment variables.
@@ -387,12 +396,14 @@ mod tests {
         let net = SmoltcpNetwork::new(config, 0);
         let vars = net.guest_env_vars();
 
-        assert_eq!(vars.len(), 3);
-        assert_eq!(vars[0].0, "MSB_NET");
+        assert_eq!(vars.len(), 4);
+        assert_eq!(vars[0].0, ENV_NET);
         assert!(vars[0].1.contains("iface=eth0"));
-        assert_eq!(vars[1].0, "MSB_NET_IPV4");
+        assert_eq!(vars[1].0, ENV_NET_IPV4);
         assert!(vars[1].1.contains("/30"));
-        assert_eq!(vars[2].0, "MSB_NET_IPV6");
+        assert_eq!(vars[2].0, ENV_NET_IPV6);
         assert!(vars[2].1.contains("/64"));
+        assert_eq!(vars[3].0, ENV_HOST_ALIAS);
+        assert_eq!(vars[3].1, crate::HOST_ALIAS);
     }
 }

--- a/crates/network/lib/policy/destination.rs
+++ b/crates/network/lib/policy/destination.rs
@@ -12,6 +12,9 @@ use super::DestinationGroup;
 //--------------------------------------------------------------------------------------------------
 
 /// Returns `true` if `addr` belongs to the given destination group.
+///
+/// `DestinationGroup::Host` is handled by the policy-level matcher
+/// because it needs per-sandbox gateway IPs; it returns `false` here.
 pub fn matches_group(group: DestinationGroup, addr: IpAddr) -> bool {
     match group {
         DestinationGroup::Loopback => is_loopback(addr),
@@ -19,6 +22,7 @@ pub fn matches_group(group: DestinationGroup, addr: IpAddr) -> bool {
         DestinationGroup::LinkLocal => is_link_local(addr),
         DestinationGroup::Metadata => is_metadata(addr),
         DestinationGroup::Multicast => is_multicast(addr),
+        DestinationGroup::Host => false,
     }
 }
 

--- a/crates/network/lib/policy/evaluator.rs
+++ b/crates/network/lib/policy/evaluator.rs
@@ -1,0 +1,280 @@
+//! Runtime policy evaluator.
+//!
+//! Binds a [`NetworkPolicy`] to the per-sandbox gateway IPs needed to resolve
+//! [`DestinationGroup::Host`] rules. Keeping this separate from `NetworkPolicy`
+//! lets the policy stay pure serialisable config.
+
+use std::net::{IpAddr, SocketAddr};
+
+use super::destination::{matches_cidr, matches_group};
+use super::types::{Action, Destination, DestinationGroup, Direction, NetworkPolicy, Protocol};
+use crate::stack::GatewayIps;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Per-sandbox policy evaluator.
+///
+/// Wraps a [`NetworkPolicy`] plus the gateway IPs that [`DestinationGroup::Host`] resolves to.
+#[derive(Debug, Clone)]
+pub struct PolicyEvaluator {
+    policy: NetworkPolicy,
+    gateway: GatewayIps,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl PolicyEvaluator {
+    /// Build an evaluator from a user-provided policy and the sandbox's gateway IPs.
+    ///
+    /// # Arguments
+    ///
+    /// * `policy` - The declarative rules the user authored.
+    /// * `gateway` - Per-sandbox gateway addresses (v4 + v6);
+    ///   `DestinationGroup::Host` rules match either family.
+    pub fn new(policy: NetworkPolicy, gateway: GatewayIps) -> Self {
+        Self { policy, gateway }
+    }
+
+    /// Borrow the underlying declarative policy.
+    pub fn policy(&self) -> &NetworkPolicy {
+        &self.policy
+    }
+
+    /// Default action returned when no rule matches an outbound packet.
+    pub fn default_action(&self) -> Action {
+        self.policy.default_action
+    }
+
+    /// Evaluate an outbound TCP/UDP connection against the policy.
+    ///
+    /// Returns the action from the first matching rule, or the default action if no rule matches.
+    ///
+    /// # Arguments
+    ///
+    /// * `dst` - Destination socket address (IP + port) of the outbound connection.
+    /// * `protocol` - Transport protocol; rules with a `protocol` filter only match when
+    ///   it equals this value.
+    pub fn evaluate_egress(&self, dst: SocketAddr, protocol: Protocol) -> Action {
+        for rule in &self.policy.rules {
+            if rule.direction != Direction::Outbound {
+                continue;
+            }
+            if let Some(ref rule_proto) = rule.protocol
+                && *rule_proto != protocol
+            {
+                continue;
+            }
+            if let Some(ref ports) = rule.ports
+                && !ports.contains(dst.port())
+            {
+                continue;
+            }
+            if !self.matches_destination(&rule.destination, dst.ip()) {
+                continue;
+            }
+            return rule.action;
+        }
+        self.policy.default_action
+    }
+
+    /// Evaluate an outbound ICMP packet against the policy.
+    ///
+    /// Same first-match-wins logic as [`Self::evaluate_egress`] but without port
+    /// matching — ICMP has no ports. Rules with a `ports` filter are skipped since
+    /// applying a port range to a portless protocol would be semantically incorrect.
+    ///
+    /// # Arguments
+    ///
+    /// * `dst` - Destination IP.
+    /// * `protocol` - Either [`Protocol::Icmpv4`] or [`Protocol::Icmpv6`].
+    pub fn evaluate_egress_ip(&self, dst: IpAddr, protocol: Protocol) -> Action {
+        for rule in &self.policy.rules {
+            if rule.direction != Direction::Outbound {
+                continue;
+            }
+            if let Some(ref rule_proto) = rule.protocol
+                && *rule_proto != protocol
+            {
+                continue;
+            }
+            if rule.ports.is_some() {
+                continue;
+            }
+            if !self.matches_destination(&rule.destination, dst) {
+                continue;
+            }
+            return rule.action;
+        }
+        self.policy.default_action
+    }
+
+    /// Check whether `addr` matches `dest`, resolving [`DestinationGroup::Host`]
+    /// against the evaluator's gateway IPs.
+    fn matches_destination(&self, dest: &Destination, addr: IpAddr) -> bool {
+        match dest {
+            Destination::Any => true,
+            Destination::Cidr(network) => matches_cidr(network, addr),
+            Destination::Group(DestinationGroup::Host) => match addr {
+                IpAddr::V4(v4) => v4 == self.gateway.ipv4,
+                IpAddr::V6(v6) => v6 == self.gateway.ipv6,
+            },
+            Destination::Group(group) => matches_group(*group, addr),
+            // Domain and DomainSuffix require a DNS pin set for IP→domain
+            // reverse lookup. Without pins, they don't match by IP alone.
+            Destination::Domain(_) | Destination::DomainSuffix(_) => false,
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use super::*;
+    use crate::policy::Rule;
+
+    fn test_gateway() -> GatewayIps {
+        GatewayIps {
+            ipv4: Ipv4Addr::new(100, 96, 0, 1),
+            ipv6: Ipv6Addr::new(0xfd42, 0x6d73, 0x62, 0, 0, 0, 0, 1),
+        }
+    }
+
+    fn host_rule() -> Rule {
+        Rule::deny_outbound(Destination::Group(DestinationGroup::Host))
+    }
+
+    #[test]
+    fn group_host_matches_gateway_v4() {
+        let policy = NetworkPolicy {
+            default_action: Action::Allow,
+            rules: vec![host_rule()],
+        };
+        let gw = test_gateway();
+        let evaluator = PolicyEvaluator::new(policy, gw);
+
+        let dst = SocketAddr::new(IpAddr::V4(gw.ipv4), 80);
+        assert_eq!(evaluator.evaluate_egress(dst, Protocol::Tcp), Action::Deny);
+    }
+
+    #[test]
+    fn group_host_matches_gateway_v6() {
+        let policy = NetworkPolicy {
+            default_action: Action::Allow,
+            rules: vec![host_rule()],
+        };
+        let gw = test_gateway();
+        let evaluator = PolicyEvaluator::new(policy, gw);
+
+        let dst = SocketAddr::new(IpAddr::V6(gw.ipv6), 80);
+        assert_eq!(evaluator.evaluate_egress(dst, Protocol::Tcp), Action::Deny);
+    }
+
+    #[test]
+    fn group_host_does_not_match_other_ips() {
+        let policy = NetworkPolicy {
+            default_action: Action::Allow,
+            rules: vec![host_rule()],
+        };
+        let evaluator = PolicyEvaluator::new(policy, test_gateway());
+
+        let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 80);
+        assert_eq!(evaluator.evaluate_egress(dst, Protocol::Tcp), Action::Allow);
+    }
+
+    #[test]
+    fn public_only_preset_denies_host_gateway() {
+        // `public_only` is the default policy. Users who don't configure a
+        // policy cannot reach `host.microsandbox.internal` — the gateway
+        // sits inside CGNAT (100.64/10), which `DestinationGroup::Private`
+        // covers. Changing this (e.g. adding a `Host` allow rule to the
+        // preset) must be a deliberate decision; this test pins it.
+        let evaluator = PolicyEvaluator::new(NetworkPolicy::public_only(), test_gateway());
+        let gw = test_gateway();
+
+        let v4 = SocketAddr::new(IpAddr::V4(gw.ipv4), 80);
+        assert_eq!(
+            evaluator.evaluate_egress(v4, Protocol::Tcp),
+            Action::Deny,
+            "default policy should deny host via IPv4 gateway"
+        );
+
+        let v6 = SocketAddr::new(IpAddr::V6(gw.ipv6), 80);
+        assert_eq!(
+            evaluator.evaluate_egress(v6, Protocol::Tcp),
+            Action::Deny,
+            "default policy should deny host via IPv6 gateway (ULA fd42::/8)"
+        );
+    }
+
+    #[test]
+    fn allow_all_preset_permits_host_gateway() {
+        let evaluator = PolicyEvaluator::new(NetworkPolicy::allow_all(), test_gateway());
+        let gw = test_gateway();
+
+        let v4 = SocketAddr::new(IpAddr::V4(gw.ipv4), 80);
+        assert_eq!(evaluator.evaluate_egress(v4, Protocol::Tcp), Action::Allow);
+    }
+
+    #[test]
+    fn group_host_allow_overrides_private_deny_when_ordered_first() {
+        // Practical recipe for users who want public_only semantics plus
+        // host access: prepend a `Group(Host) → Allow` rule. First-match-
+        // wins means the host request hits the allow before the Private
+        // deny fires.
+        let mut policy = NetworkPolicy::public_only();
+        policy.rules.insert(
+            0,
+            Rule::allow_outbound(Destination::Group(DestinationGroup::Host)),
+        );
+        let evaluator = PolicyEvaluator::new(policy, test_gateway());
+        let gw = test_gateway();
+
+        let v4 = SocketAddr::new(IpAddr::V4(gw.ipv4), 80);
+        assert_eq!(evaluator.evaluate_egress(v4, Protocol::Tcp), Action::Allow);
+
+        // Non-gateway private IPs are still denied by the Private rule.
+        let other_private = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)), 80);
+        assert_eq!(
+            evaluator.evaluate_egress(other_private, Protocol::Tcp),
+            Action::Deny,
+            "non-host private destinations should still be blocked"
+        );
+    }
+
+    #[test]
+    fn default_action_returned_when_no_rule_matches() {
+        let policy = NetworkPolicy::allow_all();
+        let evaluator = PolicyEvaluator::new(policy, test_gateway());
+        let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 443);
+        assert_eq!(evaluator.evaluate_egress(dst, Protocol::Tcp), Action::Allow);
+    }
+
+    #[test]
+    fn evaluate_egress_ip_skips_port_filtered_rules() {
+        let policy = NetworkPolicy {
+            default_action: Action::Allow,
+            rules: vec![Rule {
+                direction: Direction::Outbound,
+                destination: Destination::Any,
+                protocol: Some(Protocol::Icmpv4),
+                ports: Some(super::super::PortRange::single(0)),
+                action: Action::Deny,
+            }],
+        };
+        let evaluator = PolicyEvaluator::new(policy, test_gateway());
+        let dst = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+        assert_eq!(
+            evaluator.evaluate_egress_ip(dst, Protocol::Icmpv4),
+            Action::Allow
+        );
+    }
+}

--- a/crates/network/lib/policy/mod.rs
+++ b/crates/network/lib/policy/mod.rs
@@ -5,6 +5,7 @@
 //! destination IPs back to domain names.
 
 pub mod destination;
+mod evaluator;
 mod types;
 
 //--------------------------------------------------------------------------------------------------
@@ -12,4 +13,5 @@ mod types;
 //--------------------------------------------------------------------------------------------------
 
 pub use destination::*;
+pub use evaluator::PolicyEvaluator;
 pub use types::*;

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -1,11 +1,11 @@
 //! Policy types: rules, actions, destinations, and protocol matching.
-
-use std::net::SocketAddr;
+//!
+//! These are the declarative configuration types a user serialises as
+//! YAML/JSON. Runtime evaluation — which needs per-sandbox context like
+//! the gateway IPs — lives on [`super::evaluator::PolicyEvaluator`].
 
 use ipnetwork::IpNetwork;
 use serde::{Deserialize, Serialize};
-
-use super::destination::{matches_cidr, matches_group};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -14,7 +14,9 @@ use super::destination::{matches_cidr, matches_group};
 /// Network policy with ordered rules.
 ///
 /// Rules are evaluated in first-match-wins order. If no rule matches,
-/// the default action is applied.
+/// the default action is applied. Evaluation itself is performed by
+/// [`super::evaluator::PolicyEvaluator`], which binds this config to
+/// the sandbox's runtime context (gateway IPs, etc.).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkPolicy {
     /// Default action for traffic not matching any rule.
@@ -104,6 +106,11 @@ pub enum DestinationGroup {
 
     /// Multicast addresses (`224.0.0.0/4`, `ff00::/8`).
     Multicast,
+
+    /// The sandbox host itself, reachable via the gateway IP and
+    /// `host.microsandbox.internal`. Resolved by
+    /// [`super::evaluator::PolicyEvaluator`] against the per-sandbox gateway IPs.
+    Host,
 }
 
 /// Protocol filter.
@@ -179,60 +186,6 @@ impl NetworkPolicy {
             ],
         }
     }
-
-    /// Evaluate an outbound connection against the policy.
-    ///
-    /// Returns the action from the first matching rule, or the default
-    /// action if no rule matches.
-    pub fn evaluate_egress(&self, dst: SocketAddr, protocol: Protocol) -> Action {
-        for rule in &self.rules {
-            if rule.direction != Direction::Outbound {
-                continue;
-            }
-            if let Some(ref rule_proto) = rule.protocol
-                && *rule_proto != protocol
-            {
-                continue;
-            }
-            if let Some(ref ports) = rule.ports
-                && !ports.contains(dst.port())
-            {
-                continue;
-            }
-            if !matches_destination(&rule.destination, dst.ip()) {
-                continue;
-            }
-            return rule.action;
-        }
-        self.default_action
-    }
-
-    /// Evaluate an outbound ICMP packet against the policy.
-    ///
-    /// Same first-match-wins logic as [`Self::evaluate_egress`] but without port
-    /// matching — ICMP has no ports. Rules with a `ports` filter are
-    /// skipped since applying a port range to a portless protocol would
-    /// be semantically incorrect.
-    pub fn evaluate_egress_ip(&self, dst: std::net::IpAddr, protocol: Protocol) -> Action {
-        for rule in &self.rules {
-            if rule.direction != Direction::Outbound {
-                continue;
-            }
-            if let Some(ref rule_proto) = rule.protocol
-                && *rule_proto != protocol
-            {
-                continue;
-            }
-            if rule.ports.is_some() {
-                continue;
-            }
-            if !matches_destination(&rule.destination, dst) {
-                continue;
-            }
-            return rule.action;
-        }
-        self.default_action
-    }
 }
 
 impl Action {
@@ -294,21 +247,5 @@ impl PortRange {
     /// Returns `true` if the port falls within this range.
     pub fn contains(&self, port: u16) -> bool {
         port >= self.start && port <= self.end
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-// Functions
-//--------------------------------------------------------------------------------------------------
-
-/// Check if an IP address matches a destination specification.
-fn matches_destination(dest: &Destination, addr: std::net::IpAddr) -> bool {
-    match dest {
-        Destination::Any => true,
-        Destination::Cidr(network) => matches_cidr(network, addr),
-        Destination::Group(group) => matches_group(*group, addr),
-        // Domain and DomainSuffix require a DNS pin set for IP→domain
-        // reverse lookup. Without pins, they don't match by IP alone.
-        Destination::Domain(_) | Destination::DomainSuffix(_) => false,
     }
 }

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -8,6 +8,7 @@
 use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use bytes::Bytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -32,15 +33,29 @@ const SERVER_READ_BUF_SIZE: usize = 16384;
 /// Connects to `dst` via tokio, then bidirectionally relays data between
 /// the smoltcp socket (via channels) and the real server. Wakes the poll
 /// thread via `shared.proxy_wake` whenever data is sent toward the guest.
+///
+/// # Arguments
+///
+/// * `handle` - Tokio runtime the task is spawned on.
+/// * `dst` - Host-side destination the proxy dials.
+/// * `from_smoltcp` / `to_smoltcp` - Channels to the smoltcp socket.
+/// * `shared` - Stack-wide shared state; used to wake the poll thread.
+/// * `upstream_connected` - Flag the task flips to `true` after the
+///   upstream `TcpStream::connect` succeeds. The connection tracker
+///   reads this on proxy exit to decide between FIN (clean close) and
+///   RST (upstream never reached).
 pub fn spawn_tcp_proxy(
     handle: &tokio::runtime::Handle,
     dst: SocketAddr,
     from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
+    upstream_connected: Arc<AtomicBool>,
 ) {
     handle.spawn(async move {
-        if let Err(e) = tcp_proxy_task(dst, from_smoltcp, to_smoltcp, shared).await {
+        if let Err(e) =
+            tcp_proxy_task(dst, from_smoltcp, to_smoltcp, shared, upstream_connected).await
+        {
             tracing::debug!(dst = %dst, error = %e, "TCP proxy task ended");
         }
     });
@@ -52,8 +67,10 @@ async fn tcp_proxy_task(
     mut from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
+    upstream_connected: Arc<AtomicBool>,
 ) -> io::Result<()> {
     let stream = TcpStream::connect(dst).await?;
+    upstream_connected.store(true, Ordering::Release);
     let (mut server_rx, mut server_tx) = stream.into_split();
 
     let mut server_buf = vec![0u8; SERVER_READ_BUF_SIZE];

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -418,10 +418,19 @@ pub fn smoltcp_poll_loop(
                     conn.to_smoltcp,
                     shared.clone(),
                     tls_state.clone(),
+                    conn.upstream_connected,
                 );
                 continue;
             }
             if conn.dst.port() == 53 {
+                // DNS proxies have no guest-visible
+                // "upstream-unreachable" failure mode — even an
+                // upstream DNS failure yields SERVFAIL responses
+                // rather than a silently-closed connection. Mark the
+                // connection as upstream-connected so normal task exit
+                // produces FIN, not RST.
+                conn.upstream_connected.store(true, Ordering::Release);
+
                 // DNS over TCP: route through the same forwarder the UDP
                 // path uses. The forwarder applies the domain block list
                 // and rebind protection to every query and routes
@@ -444,6 +453,9 @@ pub fn smoltcp_poll_loop(
             if conn.dst.port() == 853
                 && let Some(ref tls_state) = tls_state
             {
+                // Same "always upstream-connected" reasoning as plain DNS over TCP.
+                conn.upstream_connected.store(true, Ordering::Release);
+
                 // DNS over TLS: terminate TLS at the gateway with a
                 // per-domain cert, hand the inner DNS frames to the
                 // same forwarder plain DNS uses. Policy for the
@@ -468,6 +480,7 @@ pub fn smoltcp_poll_loop(
                 conn.from_smoltcp,
                 conn.to_smoltcp,
                 shared.clone(),
+                conn.upstream_connected,
             );
         }
 

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -8,10 +8,10 @@
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::time::Instant;
-use std::sync::atomic::Ordering;
 
 use smoltcp::wire::{
     EthernetAddress, EthernetFrame, EthernetProtocol, HardwareAddress, Icmpv4Packet, Icmpv4Repr,
@@ -25,10 +25,10 @@ use crate::device::SmoltcpDevice;
 use crate::dns::common::ports::DnsPortType;
 use crate::dns::{
     interceptor::DnsInterceptor,
-    proxies::{dot::DotProxy, tcp::TcpProxy},
+    proxies::{dot::DotProxy, tcp::DnsTcpProxy},
 };
 use crate::icmp_relay::IcmpRelay;
-use crate::policy::{NetworkPolicy, Protocol};
+use crate::policy::{NetworkPolicy, PolicyEvaluator, Protocol};
 use crate::proxy;
 use crate::publisher::PortPublisher;
 use crate::shared::SharedState;
@@ -69,14 +69,24 @@ pub struct PollLoopConfig {
     pub gateway_mac: [u8; 6],
     /// Guest MAC address.
     pub guest_mac: [u8; 6],
-    /// Gateway IPv4 address.
-    pub gateway_ipv4: Ipv4Addr,
+    /// Gateway addresses (IPv4 + IPv6) owned by the smoltcp virtual
+    /// stack.
+    pub gateway: GatewayIps,
     /// Guest IPv4 address.
     pub guest_ipv4: Ipv4Addr,
-    /// Gateway IPv6 address.
-    pub gateway_ipv6: Ipv6Addr,
     /// IP-level MTU (e.g. 1500).
     pub mtu: usize,
+}
+
+/// Per-sandbox gateway addresses (v4 + v6) owned by the smoltcp virtual stack.
+/// Both families are always assigned. The proxy's `resolve_host_dst` helper uses
+/// these to rewrite gateway-bound connections to loopback at dial time.
+#[derive(Debug, Clone, Copy)]
+pub struct GatewayIps {
+    /// Gateway IPv4.
+    pub ipv4: Ipv4Addr,
+    /// Gateway IPv6.
+    pub ipv6: Ipv6Addr,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -115,24 +125,24 @@ pub fn create_interface(device: &mut SmoltcpDevice, config: &PollLoopConfig) -> 
     iface.update_ip_addrs(|addrs| {
         addrs
             .push(IpCidr::new(
-                IpAddress::Ipv4(config.gateway_ipv4),
+                IpAddress::Ipv4(config.gateway.ipv4),
                 // /30 subnet: gateway + guest.
                 30,
             ))
             .expect("failed to add gateway IPv4 address");
         addrs
-            .push(IpCidr::new(IpAddress::Ipv6(config.gateway_ipv6), 64))
+            .push(IpCidr::new(IpAddress::Ipv6(config.gateway.ipv6), 64))
             .expect("failed to add gateway IPv6 address");
     });
 
     // Default routes so smoltcp accepts traffic for all destinations.
     iface
         .routes_mut()
-        .add_default_ipv4_route(config.gateway_ipv4)
+        .add_default_ipv4_route(config.gateway.ipv4)
         .expect("failed to add default IPv4 route");
     iface
         .routes_mut()
-        .add_default_ipv6_route(config.gateway_ipv6)
+        .add_default_ipv6_route(config.gateway.ipv6)
         .expect("failed to add default IPv6 route");
 
     // Accept traffic destined for any IP, not just gateway addresses.
@@ -143,8 +153,8 @@ pub fn create_interface(device: &mut SmoltcpDevice, config: &PollLoopConfig) -> 
 
 /// Main smoltcp poll loop. Runs on a dedicated OS thread.
 ///
-/// Processes guest frames with pre-inspection, drives smoltcp's TCP/IP
-/// stack, and sleeps via `poll(2)` between events.
+/// Processes guest frames with pre-inspection, drives smoltcp's TCP/IP stack,
+/// and sleeps via `poll(2)` between events.
 ///
 /// # Phases per iteration
 ///
@@ -154,6 +164,23 @@ pub fn create_interface(device: &mut SmoltcpDevice, config: &PollLoopConfig) -> 
 ///    tasks (added by later tasks).
 /// 4. **Sleep** — `poll(2)` on `tx_wake` + `proxy_wake` pipes with smoltcp's
 ///    requested timeout.
+///
+/// # Arguments
+///
+/// * `shared` - Stack-wide shared state: `tx_ring` / `rx_ring` for the virtio-net boundary
+///   and the wake eventfds.
+/// * `config` - Resolved per-sandbox parameters (gateway / guest MAC + IPv4 + IPv6, MTU).
+/// * `network_policy` - User-provided egress policy; wrapped in a [`PolicyEvaluator`] here
+///   with the sandbox's gateway IPs so `DestinationGroup::Host` rules match the right address.
+/// * `dns_config` - DNS interception settings (block lists, upstreams, timeout).
+/// * `tls_state` - Optional TLS MITM state; drives interception of intercepted ports and DoT
+///   when present.
+/// * `published_ports` - Host → guest port publishes; the publisher accepts inbound
+///   connections on the host-bind address and forwards into the guest.
+/// * `max_connections` - Optional cap on concurrent guest connections tracked by
+///   [`ConnectionTracker`]; `None` uses the default.
+/// * `tokio_handle` - Runtime handle used for proxy tasks, DNS forwarding, port publishing,
+///   and ICMP relays.
 #[allow(clippy::too_many_arguments)]
 pub fn smoltcp_poll_loop(
     shared: Arc<SharedState>,
@@ -172,14 +199,17 @@ pub fn smoltcp_poll_loop(
 
     // The DNS forwarder needs to know which IPs count as "the gateway"
     // (so it routes guest queries to those addresses through the
-    // configured upstream) and the network policy (so guest-chosen
+    // configured upstream) and a policy evaluator (so guest-chosen
     // `@target` resolvers are gated by egress rules just like any
     // other outbound).
     let gateway_ips: Arc<HashSet<IpAddr>> = Arc::new(HashSet::from([
-        IpAddr::V4(config.gateway_ipv4),
-        IpAddr::V6(config.gateway_ipv6),
+        IpAddr::V4(config.gateway.ipv4),
+        IpAddr::V6(config.gateway.ipv6),
     ]));
-    let network_policy = Arc::new(network_policy);
+    // Wrap the user-provided policy with the per-sandbox context so
+    // `DestinationGroup::Host` resolves to the gateway IPs that
+    // `host.microsandbox.internal` points at.
+    let policy_evaluator = Arc::new(PolicyEvaluator::new(network_policy, config.gateway));
 
     let (mut dns_interceptor, dns_forwarder_handle) = DnsInterceptor::new(
         &mut sockets,
@@ -187,7 +217,8 @@ pub fn smoltcp_poll_loop(
         shared.clone(),
         &tokio_handle,
         gateway_ips,
-        network_policy.clone(),
+        policy_evaluator.clone(),
+        config.gateway,
     );
     let mut port_publisher = PortPublisher::new(&published_ports, config.guest_ipv4, &tokio_handle);
     let mut udp_relay = UdpRelay::new(
@@ -230,7 +261,7 @@ pub fn smoltcp_poll_loop(
                 continue;
             }
 
-            if icmp_relay.relay_outbound_if_echo(frame, &config, &network_policy) {
+            if icmp_relay.relay_outbound_if_echo(frame, &config, &policy_evaluator) {
                 device.drop_staged_frame();
                 continue;
             }
@@ -268,7 +299,7 @@ pub fn smoltcp_poll_loop(
                             false
                         }
                         // Other: regular outbound — apply egress policy.
-                        DnsPortType::Other => network_policy
+                        DnsPortType::Other => policy_evaluator
                             .evaluate_egress(dst, Protocol::Tcp)
                             .is_allow(),
                     };
@@ -318,12 +349,19 @@ pub fn smoltcp_poll_loop(
                     }
 
                     // Policy check.
-                    if network_policy.evaluate_egress(dst, Protocol::Udp).is_deny() {
+                    if policy_evaluator
+                        .evaluate_egress(dst, Protocol::Udp)
+                        .is_deny()
+                    {
                         device.drop_staged_frame();
                         continue;
                     }
 
-                    udp_relay.relay_outbound(frame, src, dst);
+                    // Resolve the host-side destination for the dial.
+                    // `dst` stays unchanged so reply frames are stamped
+                    // with the IP the guest expects.
+                    let host_dst = resolve_host_dst(dst, config.gateway);
+                    udp_relay.relay_outbound(frame, src, dst, host_dst);
                     device.drop_staged_frame();
                 }
 
@@ -372,9 +410,10 @@ pub fn smoltcp_poll_loop(
                     .contains(&conn.dst.port())
             {
                 // TLS-intercepted port — spawn TLS MITM proxy.
+                let conn_dst = resolve_host_dst(conn.dst, config.gateway);
                 tls_proxy::spawn_tls_proxy(
                     &tokio_handle,
-                    conn.dst,
+                    conn_dst,
                     conn.from_smoltcp,
                     conn.to_smoltcp,
                     shared.clone(),
@@ -389,8 +428,10 @@ pub fn smoltcp_poll_loop(
                 // upstream based on `conn.dst.ip()` — the configured
                 // upstream for queries to the gateway, direct forward
                 // to the chosen `@target` (subject to egress policy)
-                // otherwise.
-                TcpProxy::spawn(
+                // otherwise. No gateway→loopback rewrite here: the
+                // forwarder dials the configured upstream, not the
+                // gateway.
+                DnsTcpProxy::spawn(
                     &tokio_handle,
                     conn.dst,
                     conn.from_smoltcp,
@@ -420,9 +461,10 @@ pub fn smoltcp_poll_loop(
                 continue;
             }
             // Plain TCP proxy.
+            let dst = resolve_host_dst(conn.dst, config.gateway);
             proxy::spawn_tcp_proxy(
                 &tokio_handle,
-                conn.dst,
+                dst,
                 conn.from_smoltcp,
                 conn.to_smoltcp,
                 shared.clone(),
@@ -480,6 +522,27 @@ pub fn smoltcp_poll_loop(
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
+/// Map a guest-wire destination to its host-socket equivalent.
+///
+/// Gateway IPs rewrite to loopback (`127.0.0.1` / `::1`); everything else
+/// passes through. Shared by the TCP proxy dispatch and the UDP relay.
+///
+/// # Arguments
+///
+/// * `dst` - Destination from the guest's packet.
+/// * `gateway` - Per-sandbox gateway IPs that trigger the loopback rewrite.
+pub(crate) fn resolve_host_dst(dst: SocketAddr, gateway: GatewayIps) -> SocketAddr {
+    match dst.ip() {
+        IpAddr::V4(v4) if v4 == gateway.ipv4 => {
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), dst.port())
+        }
+        IpAddr::V6(v6) if v6 == gateway.ipv6 => {
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), dst.port())
+        }
+        _ => dst,
+    }
+}
+
 /// Get the current time as a smoltcp [`Instant`] using a monotonic clock.
 ///
 /// Uses `std::time::Instant` (monotonic) instead of `SystemTime` (wall
@@ -527,7 +590,7 @@ fn gateway_icmpv4_echo_reply(
     config: &PollLoopConfig,
 ) -> Option<Vec<u8>> {
     let ipv4 = Ipv4Packet::new_checked(eth.payload()).ok()?;
-    if ipv4.dst_addr() != config.gateway_ipv4 || ipv4.next_header() != IpProtocol::Icmp {
+    if ipv4.dst_addr() != config.gateway.ipv4 || ipv4.next_header() != IpProtocol::Icmp {
         return None;
     }
 
@@ -542,7 +605,7 @@ fn gateway_icmpv4_echo_reply(
     };
 
     let ipv4_repr = Ipv4Repr {
-        src_addr: config.gateway_ipv4,
+        src_addr: config.gateway.ipv4,
         dst_addr: ipv4.src_addr(),
         next_header: IpProtocol::Icmp,
         payload_len: 8 + data.len(),
@@ -578,7 +641,7 @@ fn gateway_icmpv6_echo_reply(
     config: &PollLoopConfig,
 ) -> Option<Vec<u8>> {
     let ipv6 = Ipv6Packet::new_checked(eth.payload()).ok()?;
-    if ipv6.dst_addr() != config.gateway_ipv6 || ipv6.next_header() != IpProtocol::Icmpv6 {
+    if ipv6.dst_addr() != config.gateway.ipv6 || ipv6.next_header() != IpProtocol::Icmpv6 {
         return None;
     }
 
@@ -599,7 +662,7 @@ fn gateway_icmpv6_echo_reply(
     };
 
     let ipv6_repr = Ipv6Repr {
-        src_addr: config.gateway_ipv6,
+        src_addr: config.gateway.ipv6,
         dst_addr: ipv6.src_addr(),
         next_header: IpProtocol::Icmpv6,
         payload_len: icmp_repr_buffer_len_v6(data),
@@ -620,7 +683,7 @@ fn gateway_icmpv6_echo_reply(
 
     ipv6_repr.emit(&mut Ipv6Packet::new_unchecked(&mut reply[14..54]));
     icmp_repr.emit(
-        &config.gateway_ipv6,
+        &config.gateway.ipv6,
         &ipv6.src_addr(),
         &mut Icmpv6Packet::new_unchecked(&mut reply[54..]),
         &smoltcp::phy::ChecksumCapabilities::default(),
@@ -934,9 +997,11 @@ mod tests {
         let poll_config = PollLoopConfig {
             gateway_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
             guest_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x02],
-            gateway_ipv4: Ipv4Addr::new(100, 96, 0, 1),
+            gateway: GatewayIps {
+                ipv4: Ipv4Addr::new(100, 96, 0, 1),
+                ipv6: Ipv6Addr::LOCALHOST,
+            },
             guest_ipv4: Ipv4Addr::new(100, 96, 0, 2),
-            gateway_ipv6: Ipv6Addr::LOCALHOST,
             mtu: 1500,
         };
         let mut device = SmoltcpDevice::new(shared.clone(), poll_config.mtu);
@@ -951,7 +1016,7 @@ mod tests {
             .push(build_arp_request_frame(
                 poll_config.guest_mac,
                 poll_config.guest_ipv4.octets(),
-                poll_config.gateway_ipv4.octets(),
+                poll_config.gateway.ipv4.octets(),
             ))
             .unwrap();
         shared
@@ -960,7 +1025,7 @@ mod tests {
                 poll_config.guest_mac,
                 poll_config.gateway_mac,
                 poll_config.guest_ipv4.octets(),
-                poll_config.gateway_ipv4.octets(),
+                poll_config.gateway.ipv4.octets(),
                 0x1234,
                 0xABCD,
                 b"ping",
@@ -993,7 +1058,7 @@ mod tests {
         assert_eq!(eth.ethertype(), EthernetProtocol::Ipv4);
 
         let ipv4 = Ipv4Packet::new_checked(eth.payload()).expect("valid IPv4 packet");
-        assert_eq!(Ipv4Addr::from(ipv4.src_addr()), poll_config.gateway_ipv4);
+        assert_eq!(Ipv4Addr::from(ipv4.src_addr()), poll_config.gateway.ipv4);
         assert_eq!(Ipv4Addr::from(ipv4.dst_addr()), poll_config.guest_ipv4);
         assert_eq!(ipv4.next_header(), IpProtocol::Icmp);
 
@@ -1008,6 +1073,40 @@ mod tests {
                 data: b"ping",
             }
         );
+    }
+
+    fn test_gateway() -> GatewayIps {
+        GatewayIps {
+            ipv4: Ipv4Addr::new(100, 96, 0, 1),
+            ipv6: "fd42:6d73:62::1".parse().unwrap(),
+        }
+    }
+
+    #[test]
+    fn resolve_host_dst_matches_ipv4() {
+        let gw = test_gateway();
+        let dst = SocketAddr::new(IpAddr::V4(gw.ipv4), 8080);
+        assert_eq!(
+            resolve_host_dst(dst, gw),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
+        );
+    }
+
+    #[test]
+    fn resolve_host_dst_matches_ipv6() {
+        let gw = test_gateway();
+        let dst = SocketAddr::new(IpAddr::V6(gw.ipv6), 8080);
+        assert_eq!(
+            resolve_host_dst(dst, gw),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080)
+        );
+    }
+
+    #[test]
+    fn resolve_host_dst_passes_through_non_gateway() {
+        let gw = test_gateway();
+        let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 443);
+        assert_eq!(resolve_host_dst(dst, gw), dst);
     }
 
     #[test]
@@ -1033,9 +1132,11 @@ mod tests {
         let poll_config = PollLoopConfig {
             gateway_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
             guest_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x02],
-            gateway_ipv4: Ipv4Addr::new(100, 96, 0, 1),
+            gateway: GatewayIps {
+                ipv4: Ipv4Addr::new(100, 96, 0, 1),
+                ipv6: Ipv6Addr::LOCALHOST,
+            },
             guest_ipv4: Ipv4Addr::new(100, 96, 0, 2),
-            gateway_ipv6: Ipv6Addr::LOCALHOST,
             mtu: 1500,
         };
         let mut device = SmoltcpDevice::new(shared.clone(), poll_config.mtu);
@@ -1048,7 +1149,7 @@ mod tests {
             .push(build_arp_request_frame(
                 poll_config.guest_mac,
                 poll_config.guest_ipv4.octets(),
-                poll_config.gateway_ipv4.octets(),
+                poll_config.gateway.ipv4.octets(),
             ))
             .unwrap();
         shared

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -8,6 +8,7 @@
 use std::io::{self, Read, Write};
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use bytes::Bytes;
 use rustls::pki_types::ServerName;
@@ -35,6 +36,11 @@ const RELAY_BUF_SIZE: usize = 16384;
 //--------------------------------------------------------------------------------------------------
 
 /// Spawn a TLS proxy task for a connection to an intercepted port.
+///
+/// See [`crate::proxy::spawn_tcp_proxy`] for the `upstream_connected`
+/// contract — this task flips the flag after its upstream
+/// `TcpStream::connect` succeeds (in either bypass or intercept mode).
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_tls_proxy(
     handle: &tokio::runtime::Handle,
     dst: SocketAddr,
@@ -42,9 +48,19 @@ pub fn spawn_tls_proxy(
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
     tls_state: Arc<TlsState>,
+    upstream_connected: Arc<AtomicBool>,
 ) {
     handle.spawn(async move {
-        if let Err(e) = tls_proxy_task(dst, from_smoltcp, to_smoltcp, shared, tls_state).await {
+        if let Err(e) = tls_proxy_task(
+            dst,
+            from_smoltcp,
+            to_smoltcp,
+            shared,
+            tls_state,
+            upstream_connected,
+        )
+        .await
+        {
             tracing::debug!(dst = %dst, error = %e, "TLS proxy task ended");
         }
     });
@@ -57,6 +73,7 @@ async fn tls_proxy_task(
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
     tls_state: Arc<TlsState>,
+    upstream_connected: Arc<AtomicBool>,
 ) -> io::Result<()> {
     // Phase 0: Buffer initial data to extract SNI from ClientHello.
     // Timeout prevents a slow/malicious guest from holding a proxy slot indefinitely.
@@ -70,7 +87,15 @@ async fn tls_proxy_task(
 
     if tls_state.should_bypass(&sni_name) {
         tracing::debug!(sni = %sni_name, dst = %dst, "TLS bypass");
-        bypass_relay(dst, initial_buf, from_smoltcp, to_smoltcp, shared).await
+        bypass_relay(
+            dst,
+            initial_buf,
+            from_smoltcp,
+            to_smoltcp,
+            shared,
+            upstream_connected,
+        )
+        .await
     } else {
         tracing::debug!(sni = %sni_name, dst = %dst, "TLS intercept");
         intercept_relay(
@@ -81,6 +106,7 @@ async fn tls_proxy_task(
             to_smoltcp,
             shared,
             tls_state,
+            upstream_connected,
         )
         .await
     }
@@ -93,8 +119,10 @@ async fn bypass_relay(
     mut from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
+    upstream_connected: Arc<AtomicBool>,
 ) -> io::Result<()> {
     let mut server = TcpStream::connect(dst).await?;
+    upstream_connected.store(true, Ordering::Release);
     server.write_all(&initial_buf).await?;
 
     let (mut server_rx, mut server_tx) = server.into_split();
@@ -127,6 +155,7 @@ async fn bypass_relay(
 }
 
 /// Intercept mode: MITM with guest-facing rustls + server-facing tokio_rustls.
+#[allow(clippy::too_many_arguments)]
 async fn intercept_relay(
     dst: SocketAddr,
     sni_name: &str,
@@ -135,6 +164,7 @@ async fn intercept_relay(
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
     tls_state: Arc<TlsState>,
+    upstream_connected: Arc<AtomicBool>,
 ) -> io::Result<()> {
     // Create secrets handler for this connection (filters by SNI).
     // tls_intercepted = true because we're in intercept_relay (not bypass).
@@ -187,6 +217,7 @@ async fn intercept_relay(
 
     // Connect to real server with TLS.
     let server_stream = TcpStream::connect(dst).await?;
+    upstream_connected.store(true, Ordering::Release);
     let server_name = ServerName::try_from(sni_name.to_string())
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
     let mut server_tls = tls_state

--- a/crates/network/lib/udp_relay.rs
+++ b/crates/network/lib/udp_relay.rs
@@ -76,7 +76,15 @@ struct UdpSession {
 //--------------------------------------------------------------------------------------------------
 
 impl UdpRelay {
-    /// Create a new UDP relay.
+    /// Build a new UDP relay.
+    ///
+    /// # Arguments
+    ///
+    /// * `shared` - Stack-wide shared state used to inject response frames into `rx_ring`
+    ///   and wake the poll thread.
+    /// * `gateway_mac` - MAC address stamped as the source on synthesized response frames.
+    /// * `guest_mac` - MAC address stamped as the destination on synthesized response frames.
+    /// * `tokio_handle` - Runtime the per-session relay tasks are spawned on.
     pub fn new(
         shared: Arc<SharedState>,
         gateway_mac: [u8; 6],
@@ -94,15 +102,28 @@ impl UdpRelay {
 
     /// Relay an outbound UDP datagram from the guest.
     ///
-    /// Extracts the UDP payload from the raw ethernet frame, looks up or
-    /// creates a session, and sends the payload to the relay task.
-    pub fn relay_outbound(&mut self, frame: &[u8], src: SocketAddr, dst: SocketAddr) {
+    /// # Arguments
+    ///
+    /// * `frame` - Raw ethernet frame captured from the guest.
+    /// * `src` - Guest source address; keys the session and becomes the destination on
+    ///   response frames.
+    /// * `guest_dst` - Destination the guest wrote on the datagram. Retained as the session
+    ///   key and the source IP on replies.
+    /// * `host_dst` - Address the host socket actually connects to. Usually equal to
+    ///   `guest_dst`; the caller substitutes loopback when `guest_dst` matches the gateway IP.
+    pub fn relay_outbound(
+        &mut self,
+        frame: &[u8],
+        src: SocketAddr,
+        guest_dst: SocketAddr,
+        host_dst: SocketAddr,
+    ) {
         // Extract UDP payload from the ethernet frame.
         let Some(payload) = extract_udp_payload(frame) else {
             return;
         };
 
-        let key = (src, dst);
+        let key = (src, guest_dst);
 
         // Create session if it doesn't exist or has expired.
         if self
@@ -111,7 +132,7 @@ impl UdpRelay {
             .is_none_or(|s| s.last_active.elapsed() > SESSION_TIMEOUT)
         {
             self.sessions.remove(&key);
-            if let Some(session) = self.create_session(src, dst) {
+            if let Some(session) = self.create_session(src, guest_dst, host_dst) {
                 self.sessions.insert(key, session);
             } else {
                 return;
@@ -135,7 +156,12 @@ impl UdpRelay {
 
 impl UdpRelay {
     /// Create a new relay session: bind a host UDP socket and spawn a task.
-    fn create_session(&self, guest_src: SocketAddr, guest_dst: SocketAddr) -> Option<UdpSession> {
+    fn create_session(
+        &self,
+        guest_src: SocketAddr,
+        guest_dst: SocketAddr,
+        host_dst: SocketAddr,
+    ) -> Option<UdpSession> {
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_CHANNEL_CAPACITY);
 
         let shared = self.shared.clone();
@@ -147,6 +173,7 @@ impl UdpRelay {
                 outbound_rx,
                 guest_src,
                 guest_dst,
+                host_dst,
                 shared,
                 gateway_mac,
                 guest_mac,
@@ -173,24 +200,53 @@ impl UdpRelay {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Async task that relays UDP between a host socket and the guest.
+/// Per-session UDP relay loop: forwards guest datagrams to a host socket, stamps the replies
+/// back into frames the guest accepts, and exits on idle timeout or channel close.
+///
+/// Binds an ephemeral host UDP socket in the address family of `host_dst` and `connect()`s it
+/// to that peer. The `connect` restricts the socket to that peer's datagrams, which both sets
+/// the default send target and filters spoofed inbound traffic. Responses are wrapped in a
+/// synthesised ethernet frame (src IP = `guest_dst`, dst = `guest_src`) and pushed into
+/// `rx_ring`.
+///
+/// # Arguments
+///
+/// * `outbound_rx` - Receives UDP payloads from the poll-loop side. Channel close signals
+///   session drop.
+/// * `guest_src` - Guest source address; stamped as the destination on reply frames.
+/// * `guest_dst` - Destination the guest wrote on the datagram. Stamped as the source IP on
+///   reply frames so the guest sees replies from the same address it dialed.
+/// * `host_dst` - Address the host socket connects to. Equal to `guest_dst` for external
+///   destinations; rewritten to loopback by [`crate::stack::resolve_host_dst`] when the guest
+///   addressed the gateway.
+/// * `shared` - Shared state; reply frames go into `rx_ring` and wake the poll thread.
+/// * `gateway_mac` - Source MAC on reply frames (guest sees replies from the gateway's MAC).
+/// * `guest_mac` - Destination MAC on reply frames.
+///
+/// # Errors
+///
+/// Returns [`std::io::Error`] when the initial `bind` or `connect` on
+/// the host UDP socket fails, or when the host-side `recv` fails after
+/// the socket was established.
+#[allow(clippy::too_many_arguments)]
 async fn udp_relay_task(
     mut outbound_rx: mpsc::Receiver<Bytes>,
     guest_src: SocketAddr,
     guest_dst: SocketAddr,
+    host_dst: SocketAddr,
     shared: Arc<SharedState>,
     gateway_mac: EthernetAddress,
     guest_mac: EthernetAddress,
 ) -> std::io::Result<()> {
-    // Bind a host UDP socket. Use the same address family as the destination.
-    let bind_addr: SocketAddr = match guest_dst {
+    // Bind a host UDP socket. Use the same address family as the host destination.
+    let bind_addr: SocketAddr = match host_dst {
         SocketAddr::V4(_) => (Ipv4Addr::UNSPECIFIED, 0u16).into(),
         SocketAddr::V6(_) => (std::net::Ipv6Addr::UNSPECIFIED, 0u16).into(),
     };
     let socket = UdpSocket::bind(bind_addr).await?;
     // Connect to the destination to restrict accepted source addresses,
     // preventing host-network entities from injecting spoofed datagrams.
-    socket.connect(guest_dst).await?;
+    socket.connect(host_dst).await?;
 
     let mut recv_buf = vec![0u8; RECV_BUF_SIZE];
     let timeout = SESSION_TIMEOUT;

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -161,6 +161,16 @@ pub const ENV_USER: &str = "MSB_USER";
 /// Defaults to the sandbox name when not explicitly set.
 pub const ENV_HOSTNAME: &str = "MSB_HOSTNAME";
 
+/// Environment variable carrying the DNS name the guest uses to reach
+/// the sandbox host (Docker's `host.docker.internal` equivalent).
+///
+/// The host-side network stack emits this value via its
+/// `guest_env_vars()` method; agentd reads it into
+/// [`crate::exec`]-adjacent boot params and writes the mapping into
+/// `/etc/hosts`. The value the network stack emits is a fixed
+/// protocol constant — today always `host.microsandbox.internal`.
+pub const ENV_HOST_ALIAS: &str = "MSB_HOST_ALIAS";
+
 /// Environment variable carrying sandbox-wide resource limits.
 ///
 /// Format: `resource=limit[:hard][;resource=limit[:hard];...]`

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -197,6 +197,49 @@ msb create python --name api -p 8080:80
 
 </CodeGroup>
 
+## Reaching the host
+
+From inside the sandbox, `host.microsandbox.internal` resolves to the host machine, same idea as Docker's `host.docker.internal`. Use it to call a dev server, database, or other process running on your machine without hard-coding an IP.
+
+```bash
+# Inside the sandbox:
+curl http://host.microsandbox.internal:8080
+```
+
+The name is wired through `/etc/hosts` and the DNS interceptor, so both standard resolvers and tools that bypass `/etc/hosts` (like `dig`) find it.
+
+The default `public_only` preset denies host access — the sandbox gateway sits in a private range, same as any other local destination. Switch to `allow_all` (or a custom policy with `DestinationGroup::Host`) to open it:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::NetworkPolicy;
+use microsandbox_network::policy::{Action, Destination, DestinationGroup, Rule};
+
+// Deny everything except the host.
+let policy = NetworkPolicy {
+    default_action: Action::Deny,
+    rules: vec![Rule::allow_outbound(Destination::Group(DestinationGroup::Host))],
+};
+```
+
+```typescript TypeScript
+const policy = {
+    defaultAction: "deny",
+    rules: [{ action: "allow", direction: "outbound", destination: "host" }],
+}
+```
+
+```python Python
+from microsandbox import Action, NetworkPolicy, Rule
+
+policy = NetworkPolicy(
+    default_action=Action.DENY,
+    rules=(Rule.allow(destination="host"),),
+)
+```
+
+</CodeGroup>
+
 ## Protocol support
 
 For most sandboxed workloads, networking behaves the way you'd expect:

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -298,3 +298,4 @@ String enum for well-known destination groups used in [`Rule.destination`](#rule
 | `"link-local"` | Link-local addresses (`169.254.0.0/16`, `fe80::/10`) |
 | `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
 | `"multicast"` | Multicast addresses (`224.0.0.0/4`, `ff00::/8`) |
+| `"host"` | The host machine, reached via `host.microsandbox.internal` |

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -381,6 +381,7 @@ Control whether the TLS proxy verifies the upstream server's certificate. When `
 
 | Value | Description |
 |-------|-------------|
+| `Host` | The host machine, reached via `host.microsandbox.internal` |
 | `LinkLocal` | `169.254.0.0/16`, `fe80::/10` |
 | `Loopback` | `127.0.0.0/8`, `::1` |
 | `Metadata` | Cloud metadata endpoints (`169.254.169.254`) |

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -118,7 +118,7 @@ A single network policy rule.
 | Field | Type | Description |
 |-------|------|-------------|
 | action | [`PolicyAction`](#policyaction) | What to do when this rule matches |
-| destination? | `string` | Target filter: `'any'`, `'private'`, `'loopback'`, `'metadata'`, `'multicast'`, `'link-local'`, or a CIDR like `'10.0.0.0/8'` |
+| destination? | `string` | Target filter: `'any'`, `'private'`, `'loopback'`, `'metadata'`, `'multicast'`, `'link-local'`, `'host'` (the host machine, reached via `host.microsandbox.internal`), or a CIDR like `'10.0.0.0/8'` |
 | direction? | [`PolicyDirection`](#policydirection) | Traffic direction |
 | port? | `string` | Single port (`"443"`) or range (`"8000-9000"`) |
 | protocol? | [`PolicyProtocol`](#policyprotocol) | Protocol filter |

--- a/sdk/node-ts/index.d.ts
+++ b/sdk/node-ts/index.d.ts
@@ -616,7 +616,7 @@ export interface PolicyRule {
    * - "1.2.3.4/24" — CIDR notation
    * - "example.com" — exact domain
    * - ".example.com" — domain suffix
-   * - "loopback", "private", "link-local", "metadata", "multicast" — destination group
+   * - "loopback", "private", "link-local", "metadata", "multicast", "host" — destination group
    */
   destination?: string
   /** Protocol filter: "tcp", "udp", "icmpv4", "icmpv6". */

--- a/sdk/node-ts/lib/sandbox.rs
+++ b/sdk/node-ts/lib/sandbox.rs
@@ -818,6 +818,7 @@ fn convert_policy_rule(rule: &PolicyRule) -> Option<Rule> {
         Some("link-local") => Destination::Group(DestinationGroup::LinkLocal),
         Some("metadata") => Destination::Group(DestinationGroup::Metadata),
         Some("multicast") => Destination::Group(DestinationGroup::Multicast),
+        Some("host") => Destination::Group(DestinationGroup::Host),
         Some(s) if s.starts_with('.') => Destination::DomainSuffix(s.to_string()),
         Some(s) if s.contains('/') => {
             // CIDR notation

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -60,6 +60,7 @@ class DestGroup(enum.StrEnum):
     LINK_LOCAL = "link-local"
     METADATA = "metadata"
     MULTICAST = "multicast"
+    HOST = "host"
 
 class ViolationAction(enum.StrEnum):
     BLOCK = "block"

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -420,6 +420,9 @@ fn apply_network(
                         "multicast" => microsandbox_network::policy::Destination::Group(
                             microsandbox_network::policy::DestinationGroup::Multicast,
                         ),
+                        "host" => microsandbox_network::policy::Destination::Group(
+                            microsandbox_network::policy::DestinationGroup::Host,
+                        ),
                         s if s.starts_with('.') => {
                             microsandbox_network::policy::Destination::DomainSuffix(s.to_string())
                         }


### PR DESCRIPTION
## problem

when a proxy task's `TcpStream::connect` to the host-side upstream fails (e.g. the guest dialed a port where nothing is listening), the smoltcp socket currently closes cleanly with FIN. the guest sees "connection accepted then closed" rather than "connection refused", and happy-eyeballs clients that picked the wrong family stall instead of falling back.

## solution

tracked a per-connection `upstream_connected: Arc<AtomicBool>` that the proxy task flips to `true` after a successful upstream connect. when the tracker detects a dead proxy task with the flag still `false`, it aborts the smoltcp socket (RST) instead of closing it (FIN). wired through the plain tcp proxy, the tls bypass relay, and the tls intercept relay. dns / dot tasks skip the flag since they never produce a guest-visible unreachable upstream (servfail is synthesised locally).

## test plan

- [x] `cargo check --workspace --tests` clean
- [ ] manual: start a sandbox with `allow_all`, run `nc -vz host.microsandbox.internal <port-with-no-listener>`; expect immediate connection-refused rather than "succeeded" followed by a silent close
- [ ] manual: same but with a live listener on the host; expect normal clean close (FIN, not RST)

## note

stacked on top of #602 (uses `host.microsandbox.internal` as the easiest manual repro); can be rebased onto main after that merges.