### PR TITLE
ci: switch node sdk to npm ci, add post-publish lockfile refresh

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Build Node SDK
         working-directory: sdk/node-ts
-        run: npm install && npm run build
+        run: npm ci && npm run build
 
       # -- Checks (Python SDK) --
       - uses: astral-sh/setup-uv@v3
@@ -425,7 +425,7 @@ jobs:
       # -- Install deps & run tests --
       - name: Install Node.js dependencies
         working-directory: sdk/node-ts
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       - name: Run SDK smoke tests
         working-directory: sdk/node-ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Build Node SDK
         working-directory: sdk/node-ts
         run: |
-          npm install
+          npm ci
           npm run build -- --target ${{ matrix.napi_target }}
 
       - name: Upload Node SDK artifacts
@@ -385,6 +385,45 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: sdk/node-ts
         run: npm publish --access public
+
+  # ---------------------------------------------------------------------------
+  # Refresh sdk/node-ts/package-lock.json against the just-published platform
+  # packages, so main always has lockfile integrity hashes that satisfy
+  # `npm ci`. Opens a PR that the maintainer merges manually.
+  # ---------------------------------------------------------------------------
+  refresh-lockfile:
+    name: Refresh npm lockfile
+    needs: npm-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Wait for npm to index platform packages
+        run: sleep 60
+
+      - name: Regenerate lockfile
+        working-directory: sdk/node-ts
+        run: npm install --package-lock-only --ignore-scripts
+
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          title: "chore: refresh npm lockfile after ${{ github.ref_name }}"
+          body: |
+            Regenerates `sdk/node-ts/package-lock.json` against the platform packages published for ${{ github.ref_name }}, so `npm ci` keeps working on main.
+          branch: refresh-lockfile-${{ github.ref_name }}
+          commit-message: "chore: refresh npm lockfile after ${{ github.ref_name }}"
+          base: main
+          add-paths: sdk/node-ts/package-lock.json
+          delete-branch: true
 
   # ---------------------------------------------------------------------------
   # Publish MCP server to npm


### PR DESCRIPTION
switches the `sdk/node-ts` install steps in `check.yml` and `release.yml` from `npm install` to `npm ci`, so the committed lockfile becomes load-bearing.

adds a `refresh-lockfile` job to `release.yml` that runs after `npm-publish`. it regenerates `sdk/node-ts/package-lock.json` against the just-published platform packages and opens a follow-up pr against main, so the lockfile's integrity hashes never drift across releases.

## sequencing

`npm ci` requires the lockfile's integrity hashes to match what's on the npm registry. the lockfile committed in #627 has 0.4.0 version strings but the hashes still point at 0.3.14's tarball bytes, so this pr should land **after** #627 ships and the first refresh-lockfile pr merges. otherwise prs and main pushes will fail at the `npm ci` step.

## repo setting

the auto-pr step uses `peter-evans/create-pull-request@v7`, which needs **settings → actions → general → workflow permissions → "allow github actions to create and approve pull requests"** enabled. enable it before the first 0.4.0 release tag, otherwise the refresh job will fail on the pr-open step.

## leaves alone

- `check.yml` mcp install (`npm install --no-package-lock --ignore-scripts`): runs after manually editing the mcp `package.json` to point microsandbox at `file:../sdk/node-ts`, so the lockfile is intentionally bypassed.
- `release.yml` mcp publish (`rm package-lock.json && npm install`): same reason; the lockfile is intentionally regenerated against the freshly published microsandbox version.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/superradcompany/codesmith/microsandbox/pr/628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->