### PR TITLE
fix(network): suppress external AAAA when host IPv6 egress is unavailable

### DIFF
--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -25,7 +25,7 @@
 //! [`DnsInterceptor`]: super::interceptor::DnsInterceptor
 
 use std::collections::HashSet;
-use std::net::{IpAddr, Ipv6Addr, SocketAddr, TcpStream};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -545,12 +545,14 @@ fn should_suppress_aaaa(domain: &str, query_type: RecordType, host_ipv6_egress: 
 
 /// Probe whether the host has an external IPv6 route.
 fn host_has_ipv6_egress() -> bool {
-    let probe_addr = Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111);
-    TcpStream::connect_timeout(
-        &SocketAddr::new(IpAddr::V6(probe_addr), 443),
-        Duration::from_millis(250),
-    )
-    .is_ok()
+    let probe_addr = SocketAddr::new(
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1)),
+        443,
+    );
+
+    std::net::UdpSocket::bind("[::]:0")
+        .and_then(|socket| socket.connect(probe_addr))
+        .is_ok()
 }
 
 /// Synthesize an A/AAAA response for `host.microsandbox.internal`. Returns

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -25,7 +25,7 @@
 //! [`DnsInterceptor`]: super::interceptor::DnsInterceptor
 
 use std::collections::HashSet;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr, TcpStream};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -109,6 +109,8 @@ pub(crate) struct DnsForwarder {
     /// Gateway IPs returned as A / AAAA answers when the guest asks for
     /// `host.microsandbox.internal`.
     gateway: GatewayIps,
+    /// Whether the host can route external IPv6 traffic.
+    host_ipv6_egress: bool,
     config: Arc<NormalizedDnsConfig>,
 }
 
@@ -175,6 +177,16 @@ impl DnsForwarder {
                 synthesize_host_alias_response(&query_msg, self.gateway, query_type)
         {
             return Some(response);
+        }
+
+        if should_suppress_aaaa(&domain, query_type, self.host_ipv6_egress) {
+            tracing::debug!(
+                domain = %domain,
+                "suppressing external AAAA response because host IPv6 egress is unavailable"
+            );
+            self.shared
+                .clear_resolved_hostname(&domain, ResolvedHostnameFamily::Ipv6);
+            return build_empty_noerror_response(&query_msg);
         }
 
         // Pick upstream client based on where the guest aimed and the
@@ -392,6 +404,8 @@ impl DnsForwarder {
         // nameserver.
         let upstream = upstreams[0];
         let configured_udp = build_udp_client(upstream, config.query_timeout).await?;
+        let host_ipv6_egress = host_has_ipv6_egress();
+        tracing::debug!(host_ipv6_egress, "detected host IPv6 egress capability");
 
         Some(Arc::new(Self {
             configured_udp,
@@ -401,6 +415,7 @@ impl DnsForwarder {
             network_policy,
             shared,
             gateway,
+            host_ipv6_egress,
             config,
         }))
     }
@@ -476,6 +491,11 @@ fn build_status_response(query: &Message, rcode: ResponseCode) -> Option<Bytes> 
     response.to_bytes().ok().map(Bytes::from)
 }
 
+/// Build a NoError response with the original question but no answers.
+fn build_empty_noerror_response(query: &Message) -> Option<Bytes> {
+    build_status_response(query, ResponseCode::NoError)
+}
+
 /// Map a DNS query type to a [`ResolvedHostnameFamily`] for policy caching.
 fn family_for_query_type(query_type: RecordType) -> Option<ResolvedHostnameFamily> {
     match query_type {
@@ -516,6 +536,21 @@ fn is_host_alias_query(query_name: &str) -> bool {
     query_name
         .trim_end_matches('.')
         .eq_ignore_ascii_case(crate::HOST_ALIAS)
+}
+
+/// Returns true when an external AAAA query should be hidden from the guest.
+fn should_suppress_aaaa(domain: &str, query_type: RecordType, host_ipv6_egress: bool) -> bool {
+    query_type == RecordType::AAAA && !host_ipv6_egress && !is_host_alias_query(domain)
+}
+
+/// Probe whether the host has an external IPv6 route.
+fn host_has_ipv6_egress() -> bool {
+    let probe_addr = Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111);
+    TcpStream::connect_timeout(
+        &SocketAddr::new(IpAddr::V6(probe_addr), 443),
+        Duration::from_millis(250),
+    )
+    .is_ok()
 }
 
 /// Synthesize an A/AAAA response for `host.microsandbox.internal`. Returns
@@ -592,11 +627,15 @@ mod tests {
         msg
     }
 
+    fn parse_response(bytes: Bytes) -> Message {
+        Message::from_bytes(&bytes).expect("parse response")
+    }
+
     #[test]
     fn build_status_response_preserves_header_and_question() {
         let query = make_query("slack.com.", RecordType::AAAA);
         let bytes = build_status_response(&query, ResponseCode::Refused).expect("built");
-        let msg = Message::from_bytes(&bytes).expect("parse response");
+        let msg = parse_response(bytes);
         assert_eq!(msg.id(), 0x4242);
         assert_eq!(msg.response_code(), ResponseCode::Refused);
         assert_eq!(msg.message_type(), MessageType::Response);
@@ -612,9 +651,26 @@ mod tests {
     fn build_status_response_servfail_variant() {
         let query = make_query("example.com.", RecordType::A);
         let bytes = build_status_response(&query, ResponseCode::ServFail).expect("built");
-        let msg = Message::from_bytes(&bytes).expect("parse response");
+        let msg = parse_response(bytes);
         assert_eq!(msg.response_code(), ResponseCode::ServFail);
         assert_eq!(msg.answers().len(), 0);
+    }
+
+    #[test]
+    fn build_empty_noerror_response_preserves_question_without_answers() {
+        let query = make_query("openrouter.ai.", RecordType::AAAA);
+        let bytes = build_empty_noerror_response(&query).expect("built");
+        let msg = parse_response(bytes);
+
+        assert_eq!(msg.id(), 0x4242);
+        assert_eq!(msg.response_code(), ResponseCode::NoError);
+        assert_eq!(msg.message_type(), MessageType::Response);
+        assert_eq!(msg.op_code(), OpCode::Query);
+        assert!(msg.recursion_desired());
+        assert!(msg.recursion_available());
+        assert_eq!(msg.queries().len(), 1);
+        assert_eq!(msg.queries()[0].query_type(), RecordType::AAAA);
+        assert!(msg.answers().is_empty());
     }
 
     #[test]
@@ -660,6 +716,80 @@ mod tests {
         let query = make_query("example.com.", RecordType::A);
         assert!(query.extensions().is_none());
         assert_eq!(query.max_payload(), 512);
+    }
+
+    #[test]
+    fn should_suppress_external_aaaa_when_host_ipv6_unavailable() {
+        assert!(should_suppress_aaaa(
+            "openrouter.ai",
+            RecordType::AAAA,
+            false
+        ));
+    }
+
+    #[test]
+    fn should_not_suppress_a_records_when_host_ipv6_unavailable() {
+        assert!(!should_suppress_aaaa("openrouter.ai", RecordType::A, false));
+    }
+
+    #[test]
+    fn should_not_suppress_external_aaaa_when_host_ipv6_available() {
+        assert!(!should_suppress_aaaa(
+            "openrouter.ai",
+            RecordType::AAAA,
+            true
+        ));
+    }
+
+    #[test]
+    fn should_not_suppress_host_alias_aaaa() {
+        assert!(!should_suppress_aaaa(
+            crate::HOST_ALIAS,
+            RecordType::AAAA,
+            false
+        ));
+    }
+
+    #[test]
+    fn host_ipv6_egress_probe_returns_a_boolean() {
+        let _ = host_has_ipv6_egress();
+    }
+
+    #[test]
+    fn suppressed_external_aaaa_returns_nodata_shape() {
+        let query = make_query("openrouter.ai.", RecordType::AAAA);
+        assert!(should_suppress_aaaa(
+            "openrouter.ai",
+            RecordType::AAAA,
+            false
+        ));
+
+        let msg = parse_response(build_empty_noerror_response(&query).expect("built"));
+
+        assert_eq!(msg.response_code(), ResponseCode::NoError);
+        assert_eq!(msg.queries()[0].query_type(), RecordType::AAAA);
+        assert!(msg.answers().is_empty());
+    }
+
+    #[test]
+    fn host_alias_aaaa_is_not_suppressed_without_host_ipv6_egress() {
+        let query = make_query(crate::HOST_ALIAS, RecordType::AAAA);
+        assert!(!should_suppress_aaaa(
+            crate::HOST_ALIAS,
+            RecordType::AAAA,
+            false
+        ));
+
+        let gateway = GatewayIps {
+            ipv4: std::net::Ipv4Addr::new(100, 96, 0, 1),
+            ipv6: "fd42:6d73:62::1".parse().unwrap(),
+        };
+        let bytes =
+            synthesize_host_alias_response(&query, gateway, RecordType::AAAA).expect("built");
+        let msg = parse_response(bytes);
+
+        assert_eq!(msg.response_code(), ResponseCode::NoError);
+        assert_eq!(msg.answers().len(), 1);
     }
 
     fn gateway_set() -> HashSet<IpAddr> {

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -96,10 +96,8 @@ async fn tls_proxy_task(
     }
 
     if tls_state.should_bypass(&sni_name) {
-        tracing::debug!(sni = %sni_name, dst = %dst, "TLS bypass");
         bypass_relay(dst, initial_buf, from_smoltcp, to_smoltcp, shared).await
     } else {
-        tracing::debug!(sni = %sni_name, dst = %dst, "TLS intercept");
         intercept_relay(
             dst,
             &sni_name,


### PR DESCRIPTION
## Summary

Fixes #607 

This PR prevents guests from receiving external AAAA DNS answers when the host cannot route external IPv6 traffic. In that case, the DNS forwarder now returns a successful NODATA response for external AAAA queries, allowing clients such as `httpx.AsyncClient` to fall back to IPv4.

The internal `host.microsandbox.internal` AAAA response is preserved.

## Motivation

Async HTTP clients may attempt IPv6 connections when the guest receives AAAA records. On hosts without usable external IPv6 routing, those connections fail before the client reaches the working IPv4 path, causing errors such as:

`httpx.RemoteProtocolError: Server disconnected without sending a response`

Synchronous clients often avoid the issue by using IPv4 first, which is why the failure was client-dependent.

## Changes

- Probe host IPv6 egress once when building the DNS forwarder.
- Suppress external AAAA responses with DNS `NoError` and no answers when IPv6 egress is unavailable.
- Keep A records and `host.microsandbox.internal` AAAA behavior unchanged.
- Add unit tests for:
  - NODATA response shape.
  - AAAA suppression decision logic.
  - IPv4 queries remaining unaffected.
  - Host alias AAAA remaining available.

## Test Plan

- [x] `cargo fmt --all --check`
- [x] `cargo build -p microsandbox-cli`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo doc --workspace --no-deps`
- [x] `pre-commit run --all-files`
  - Passed all hooks except `no-commit-to-branch`, because the local branch was protected.
- [x] Manual local repro with signed `msb`:
  - `requests` client succeeds.
  - `httpx.AsyncClient` client succeeds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/superradcompany/codesmith/microsandbox/pr/637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->