### PR TITLE
fix(net): --no-net actually air-gaps the guest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -96,7 +96,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1362,7 +1362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2814,7 +2814,7 @@ dependencies = [
 [[package]]
 name = "msb_krun"
 version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -2833,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_arch"
 version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -2848,12 +2848,12 @@ dependencies = [
 [[package]]
 name = "msb_krun_arch_gen"
 version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
 
 [[package]]
 name = "msb_krun_cpuid"
 version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_devices"
 version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_hvf"
 version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -2901,7 +2901,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_kernel"
 version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -2910,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_polly"
 version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -2919,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_smbios"
 version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
 dependencies = [
  "vm-memory 0.16.2",
 ]
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_utils"
 version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_vmm"
 version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
 dependencies = [
  "bzip2",
  "crossbeam-channel",
@@ -3731,7 +3731,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4084,7 +4084,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4152,7 +4152,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4640,7 +4640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4994,7 +4994,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5359,7 +5359,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -96,7 +96,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1219,7 +1219,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1362,7 +1362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2814,8 +2814,7 @@ dependencies = [
 [[package]]
 name = "msb_krun"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b8f3d7adbbbc31586a1fb029fe3d1bac9bad568d557c109bfe1fd1d7101dbf"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -2834,8 +2833,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_arch"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a6a547d8b842d1b32ad6c4eb87e17f58ed4b38ebd9596351ff417a6bb36eea"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -2850,14 +2848,12 @@ dependencies = [
 [[package]]
 name = "msb_krun_arch_gen"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68378a023e8819d21f9af4b72c7f81f1135dfe7be819cb41644abc09602cd43"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
 
 [[package]]
 name = "msb_krun_cpuid"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48576155e584c2663ed8e1ac044398da56019a7ebd65d55ba082f967a28bdab"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -2867,8 +2863,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_devices"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2020a2924399eed580b08346ab9e72124261cefeaeca25c5415ba27c5c12b06"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -2895,8 +2890,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_hvf"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd6e638a87780d399551471ede6ecd9048c300520060ecafb6f2e9280889749"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -2907,8 +2901,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_kernel"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd7e388762552e18bd29a10b9fd500dceb77c615cffabbfbdebb5bad51176a"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -2917,8 +2910,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_polly"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a868b1ea8c2fa2dd66265ed9a319484e950d42ca85b35d7e62cc9577b7ea2c"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -2927,8 +2919,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_smbios"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30867f42e999ec9d74776586efe3edea4590687701ec274f24f7380ebf337d0"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
 dependencies = [
  "vm-memory 0.16.2",
 ]
@@ -2936,8 +2927,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_utils"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4799941aab9f9af0a56b8ebfa4be3f076973c962e758f095e9d7947f2155d8f9"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -2951,8 +2941,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_vmm"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4331f49986546a3eb0404c79d0981a6c31e3d75cc68925affa01cdb5987cccc1"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=toks%2Fdisable-inet-hijack#35be9f49b43347a2c0a5077348e5de7af0b7608b"
 dependencies = [
  "bzip2",
  "crossbeam-channel",
@@ -3159,7 +3148,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4095,7 +4084,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4163,7 +4152,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4651,7 +4640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5005,7 +4994,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5370,7 +5359,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5828,7 +5817,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1362,7 +1362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2813,8 +2813,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c29ba9c9c8a38cd001c0c9af16bd3c75be328ab8c95a3aa933b125c1d93f41c"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -2832,8 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb4327e3efe423f3bcdca0390589193834b9f73eb54bb13b90f48f1755b499e"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -2847,13 +2849,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc7dbc08509138172ccd3b40df5c1501ad498ba12f2643eb013320205f9c987"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d88b81a52ae5b3fe1afb1692b0785a4fe946c77bbc9e43a030e84e90627819"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -2862,8 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f6d808b3c4d5a7c24fba02a64f2f704da973cf6820deedd2811c2ec795b9fc"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -2889,8 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce2de785e2cceda28ce03f20a9eeb895ac947ab66b09db31077a070bd6dda86"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -2900,8 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047a3f886330138dd6a681ef96b0b2257b494f295535bdd641841068f5847bc"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -2909,8 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db57f147c6e1aca9a14d137ada76b6df78b538a0673d86b33652be78e9784499"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -2918,16 +2926,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c0c3a0923f194852028fd0e809a8d26c5465bc550f59c08b25bae5dd9885457"
 dependencies = [
  "vm-memory 0.16.2",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbae5590c539ee8b9ed0e2d4c50c6ee5b546f03f9eb2408b885628514ddb9a6"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -2940,8 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.11"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=krun#f18a38367465de2e557c66b1d51a36436e22fc90"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd62153e5ffe89a76b775c89b9c01b65d38c67a32ca8d516a910d4cb497d367"
 dependencies = [
  "bzip2",
  "crossbeam-channel",
@@ -3148,7 +3159,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3731,7 +3742,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4084,7 +4095,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4152,7 +4163,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4994,7 +5005,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5817,7 +5828,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib/lib.rs"
 [dependencies]
 libc.workspace = true
 microsandbox-utils = { version = "0.4.2", path = "../utils" }
-msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "krun" }
+msb_krun = "0.1.12"
 scopeguard.workspace = true
 tempfile.workspace = true
 tracing.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib/lib.rs"
 [dependencies]
 libc.workspace = true
 microsandbox-utils = { version = "0.4.2", path = "../utils" }
-msb_krun = "0.1.11"
+msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "toks/disable-inet-hijack" }
 scopeguard.workspace = true
 tempfile.workspace = true
 tracing.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib/lib.rs"
 [dependencies]
 libc.workspace = true
 microsandbox-utils = { version = "0.4.2", path = "../utils" }
-msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "toks/disable-inet-hijack" }
+msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "krun" }
 scopeguard.workspace = true
 tempfile.workspace = true
 tracing.workspace = true

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -25,7 +25,7 @@ libc = { workspace = true }
 lru = { workspace = true }
 microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
 microsandbox-utils = { version = "0.4.2", path = "../utils" }
-msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "toks/disable-inet-hijack", features = ["net"] }
+msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "krun", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"
 rcgen = { workspace = true }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -25,7 +25,7 @@ libc = { workspace = true }
 lru = { workspace = true }
 microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
 microsandbox-utils = { version = "0.4.2", path = "../utils" }
-msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "krun", features = ["net"] }
+msb_krun = { version = "0.1.12", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"
 rcgen = { workspace = true }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -25,7 +25,7 @@ libc = { workspace = true }
 lru = { workspace = true }
 microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
 microsandbox-utils = { version = "0.4.2", path = "../utils" }
-msb_krun = { version = "0.1.11", features = ["net"] }
+msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "toks/disable-inet-hijack", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"
 rcgen = { workspace = true }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -27,7 +27,7 @@ microsandbox-filesystem = { version = "0.4.2", path = "../filesystem", default-f
 microsandbox-network = { version = "0.4.2", path = "../network", optional = true }
 microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
 microsandbox-utils = { version = "0.4.2", path = "../utils" }
-msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "krun", features = ["blk"] }
+msb_krun = { version = "0.1.12", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }
 sea-orm.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -27,7 +27,7 @@ microsandbox-filesystem = { version = "0.4.2", path = "../filesystem", default-f
 microsandbox-network = { version = "0.4.2", path = "../network", optional = true }
 microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
 microsandbox-utils = { version = "0.4.2", path = "../utils" }
-msb_krun = { version = "0.1.11", features = ["blk"] }
+msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "toks/disable-inet-hijack", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }
 sea-orm.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -27,7 +27,7 @@ microsandbox-filesystem = { version = "0.4.2", path = "../filesystem", default-f
 microsandbox-network = { version = "0.4.2", path = "../network", optional = true }
 microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
 microsandbox-utils = { version = "0.4.2", path = "../utils" }
-msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "toks/disable-inet-hijack", features = ["blk"] }
+msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "krun", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }
 sea-orm.workspace = true


### PR DESCRIPTION
## problem

`--no-net` was not actually air-gapping the guest. with no virtio-net attached, libkrun silently bridged the guest's tcp/udp sockets to the host, so traffic still reached the network even though `ip a` showed only `lo`.

fixes #645.

## fix

bumped `msb_krun` to a libkrun fork that flips the default: guests with no virtio-net are air-gapped, and the host-bridge fallback is opt-in.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/superradcompany/codesmith/microsandbox/pr/647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->