### PR TITLE
fix(node-sdk): ship libkrunfw under canonical name in npm platform package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,18 +238,14 @@ jobs:
           cache-dependency-glob: "sdk/python/uv.lock"
 
       - name: Stage runtime bundle (Python SDK)
+        # Ship only the canonical libkrunfw filename — _runtime.py resolves
+        # to that exact name. Maturin would dereference symlinks and bloat
+        # the wheel by ~40MB on Linux / ~20MB on macOS for no benefit.
         run: |
           mkdir -p sdk/python/microsandbox/_bundled/bin
           mkdir -p sdk/python/microsandbox/_bundled/lib
           cp build/msb sdk/python/microsandbox/_bundled/bin/
           cp build/${{ matrix.libkrunfw_file }} sdk/python/microsandbox/_bundled/lib/
-          cd sdk/python/microsandbox/_bundled/lib
-          if [ "${{ matrix.os }}" = "darwin" ]; then
-            ln -sf ${{ matrix.libkrunfw_file }} libkrunfw.dylib
-          else
-            ln -sf ${{ matrix.libkrunfw_file }} libkrunfw.so.${{ env.LIBKRUNFW_ABI }}
-            ln -sf libkrunfw.so.${{ env.LIBKRUNFW_ABI }} libkrunfw.so
-          fi
 
       - name: Build Python wheel
         uses: PyO3/maturin-action@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2615,14 +2615,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "sea-orm",
 ]
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2662,14 +2662,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "sea-orm-migration",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bytes",
  "core-foundation 0.9.4",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "futures",
  "ipnetwork",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "libc",
  "scopeguard",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "test-macros"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.4.2"
+version = "0.4.3"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/crates/agentd/Cargo.lock
+++ b/crates/agentd/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "ciborium",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "ciborium",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -5,7 +5,7 @@ members = ["."]
 [workspace.package]
 authors = ["Super Rad Company <developemnt@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.4.2"
+version = "0.4.3"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -46,7 +46,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
+microsandbox-protocol = { version = "0.4.3", path = "../protocol" }
 nix = { workspace = true, features = [
     "fs",
     "hostname",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,12 +36,12 @@ dirs.workspace = true
 indicatif.workspace = true
 ipnetwork = { workspace = true, optional = true }
 libc.workspace = true
-microsandbox = { version = "0.4.2", path = "../microsandbox", default-features = false }
-microsandbox-image = { version = "0.4.2", path = "../image" }
-microsandbox-network = { version = "0.4.2", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
-microsandbox-runtime = { version = "0.4.2", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.4.2", path = "../utils" }
+microsandbox = { version = "0.4.3", path = "../microsandbox", default-features = false }
+microsandbox-image = { version = "0.4.3", path = "../image" }
+microsandbox-network = { version = "0.4.3", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.3", path = "../protocol" }
+microsandbox-runtime = { version = "0.4.3", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.4.3", path = "../utils" }
 rand.workspace = true
 reqwest.workspace = true
 rpassword.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { version = "0.4.2", path = "../utils" }
+microsandbox-utils = { version = "0.4.3", path = "../utils" }
 msb_krun = "0.1.11"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,5 +23,5 @@ default = ["prebuilt"]
 prebuilt = ["dep:ureq"]
 
 [build-dependencies]
-microsandbox-utils = { version = "0.4.2", path = "../utils" }
+microsandbox-utils = { version = "0.4.3", path = "../utils" }
 ureq = { workspace = true, optional = true }

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { version = "0.4.2", path = "../utils" }
+microsandbox-utils = { version = "0.4.3", path = "../utils" }
 oci-client.workspace = true
 rustls-pemfile.workspace = true
 oci-spec.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -30,14 +30,14 @@ docker_credential = "1.3.2"
 flate2.workspace = true
 futures.workspace = true
 libc.workspace = true
-microsandbox-db = { version = "0.4.2", path = "../db" }
-microsandbox-filesystem = { version = "0.4.2", path = "../filesystem", default-features = false }
-microsandbox-image = { version = "0.4.2", path = "../image" }
-microsandbox-migration = { version = "0.4.2", path = "../migration" }
-microsandbox-network = { version = "0.4.2", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
-microsandbox-runtime = { version = "0.4.2", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.4.2", path = "../utils" }
+microsandbox-db = { version = "0.4.3", path = "../db" }
+microsandbox-filesystem = { version = "0.4.3", path = "../filesystem", default-features = false }
+microsandbox-image = { version = "0.4.3", path = "../image" }
+microsandbox-migration = { version = "0.4.3", path = "../migration" }
+microsandbox-network = { version = "0.4.3", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.3", path = "../protocol" }
+microsandbox-runtime = { version = "0.4.3", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.4.3", path = "../utils" }
 nix = { workspace = true, features = ["process", "signal"] }
 rand.workspace = true
 reqwest.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -16,8 +16,8 @@ name = "microsandbox"
 path = "bin/main.rs"
 
 [features]
-default = ["prebuilt", "net", "keyring"]
-keyring = ["dep:keyring", "dep:dbus"]
+default = ["keyring", "net", "prebuilt"]
+keyring = ["dep:dbus", "dep:keyring"]
 prebuilt = ["microsandbox-filesystem/prebuilt", "microsandbox-runtime/prebuilt"]
 net = ["dep:microsandbox-network", "microsandbox-runtime/net"]
 
@@ -25,8 +25,8 @@ net = ["dep:microsandbox-network", "microsandbox-runtime/net"]
 bytes.workspace = true
 chrono.workspace = true
 crossterm.workspace = true
-docker_credential = "1.3.2"
 dirs.workspace = true
+docker_credential = "1.3.2"
 flate2.workspace = true
 futures.workspace = true
 libc.workspace = true
@@ -42,12 +42,12 @@ nix = { workspace = true, features = ["process", "signal"] }
 rand.workspace = true
 reqwest.workspace = true
 scopeguard.workspace = true
-sha2.workspace = true
-tar.workspace = true
-tempfile.workspace = true
 sea-orm.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
+tar.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
@@ -56,6 +56,7 @@ which.workspace = true
 
 [build-dependencies]
 flate2.workspace = true
+microsandbox-utils = { path = "../utils" }
 tar.workspace = true
 ureq.workspace = true
 
@@ -76,4 +77,7 @@ keyring = { version = "3.6.3", features = ["windows-native"], optional = true }
 # Transitive dep via keyring's Secret Service backend; declared here only to force the `vendored` feature
 # so libdbus is built from source and statically linked (avoids needing libdbus-1-dev at build time).
 dbus = { version = "0.9.10", features = ["vendored"], optional = true }
-keyring = { version = "3.6.3", features = ["linux-native-sync-persistent", "crypto-rust"], optional = true }
+keyring = { version = "3.6.3", features = [
+    "crypto-rust",
+    "linux-native-sync-persistent",
+], optional = true }

--- a/crates/microsandbox/bin/main.rs
+++ b/crates/microsandbox/bin/main.rs
@@ -19,16 +19,9 @@ use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
-//--------------------------------------------------------------------------------------------------
-// Constants
-//--------------------------------------------------------------------------------------------------
-
-const PREBUILT_VERSION: &str = env!("CARGO_PKG_VERSION");
-const LIBKRUNFW_ABI: &str = "5";
-const LIBKRUNFW_VERSION: &str = "5.2.1";
-const GITHUB_ORG: &str = "superradcompany";
-const REPO: &str = "microsandbox";
-const MSB_BINARY: &str = "msb";
+use microsandbox_utils::{
+    LIBKRUNFW_ABI, MSB_BINARY, PREBUILT_VERSION, bundle_download_url, libkrunfw_filename,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -141,8 +134,8 @@ fn install_runtime(bin_dir: &Path, lib_dir: &Path) -> Result<(), String> {
     fs::create_dir_all(bin_dir).map_err(|e| format!("mkdir {}: {e}", bin_dir.display()))?;
     fs::create_dir_all(lib_dir).map_err(|e| format!("mkdir {}: {e}", lib_dir.display()))?;
 
-    let target_os = if cfg!(target_os = "macos") {
-        "darwin"
+    let os = if cfg!(target_os = "macos") {
+        "macos"
     } else if cfg!(target_os = "linux") {
         "linux"
     } else {
@@ -155,16 +148,8 @@ fn install_runtime(bin_dir: &Path, lib_dir: &Path) -> Result<(), String> {
         other => return Err(format!("unsupported architecture: {other}")),
     };
 
-    let libkrunfw_name = if target_os == "darwin" {
-        format!("libkrunfw.{LIBKRUNFW_ABI}.dylib")
-    } else {
-        format!("libkrunfw.so.{LIBKRUNFW_VERSION}")
-    };
-
-    let url = format!(
-        "https://github.com/{GITHUB_ORG}/{REPO}/releases/download/v{PREBUILT_VERSION}/\
-         {REPO}-{target_os}-{arch}.tar.gz"
-    );
+    let libkrunfw_name = libkrunfw_filename(os);
+    let url = bundle_download_url(PREBUILT_VERSION, arch, os);
 
     let tmp_dir = env::temp_dir().join(format!(
         "microsandbox-install-{}-{}",
@@ -231,7 +216,7 @@ fn install_runtime(bin_dir: &Path, lib_dir: &Path) -> Result<(), String> {
     // libkrunfw symlinks.
     #[cfg(unix)]
     {
-        let symlinks: Vec<(String, String)> = if target_os == "darwin" {
+        let symlinks: Vec<(String, String)> = if os == "macos" {
             vec![("libkrunfw.dylib".into(), libkrunfw_name.clone())]
         } else {
             let soname = format!("libkrunfw.so.{LIBKRUNFW_ABI}");

--- a/crates/microsandbox/build.rs
+++ b/crates/microsandbox/build.rs
@@ -5,12 +5,10 @@ use std::io::{self, Cursor, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const PREBUILT_VERSION: &str = env!("CARGO_PKG_VERSION");
-const LIBKRUNFW_ABI: &str = "5";
-const LIBKRUNFW_VERSION: &str = "5.2.1";
-const GITHUB_ORG: &str = "superradcompany";
-const REPO: &str = "microsandbox";
-const MSB_BINARY: &str = "msb";
+use microsandbox_utils::{
+    LIBKRUNFW_ABI, MSB_BINARY, PREBUILT_VERSION, bundle_download_url,
+    libkrunfw_filename as utils_libkrunfw_filename,
+};
 
 fn main() {
     // Re-run if the binaries are deleted so we can re-download.
@@ -92,23 +90,22 @@ fn home_dir() -> Option<PathBuf> {
 }
 
 fn libkrunfw_filename() -> String {
-    if cfg!(target_os = "macos") {
-        format!("libkrunfw.{LIBKRUNFW_ABI}.dylib")
+    let os = if cfg!(target_os = "macos") {
+        "macos"
     } else {
-        format!("libkrunfw.so.{LIBKRUNFW_VERSION}")
-    }
+        "linux"
+    };
+    utils_libkrunfw_filename(os)
 }
 
 fn bundle_url() -> String {
     let arch = std::env::consts::ARCH;
-    let target_os = if cfg!(target_os = "macos") {
-        "darwin"
+    let os = if cfg!(target_os = "macos") {
+        "macos"
     } else {
         "linux"
     };
-    format!(
-        "https://github.com/{GITHUB_ORG}/{REPO}/releases/download/v{PREBUILT_VERSION}/{REPO}-{target_os}-{arch}.tar.gz"
-    )
+    bundle_download_url(PREBUILT_VERSION, arch, os)
 }
 
 fn installed_msb_version(path: &Path) -> Option<String> {

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -23,8 +23,8 @@ hickory-proto = { workspace = true, features = ["tls-ring"] }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
-microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
-microsandbox-utils = { version = "0.4.2", path = "../utils" }
+microsandbox-protocol = { version = "0.4.3", path = "../protocol" }
+microsandbox-utils = { version = "0.4.3", path = "../utils" }
 msb_krun = { version = "0.1.11", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,11 +22,11 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
-microsandbox-db = { version = "0.4.2", path = "../db" }
-microsandbox-filesystem = { version = "0.4.2", path = "../filesystem", default-features = false }
-microsandbox-network = { version = "0.4.2", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
-microsandbox-utils = { version = "0.4.2", path = "../utils" }
+microsandbox-db = { version = "0.4.3", path = "../db" }
+microsandbox-filesystem = { version = "0.4.3", path = "../filesystem", default-features = false }
+microsandbox-network = { version = "0.4.3", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.3", path = "../protocol" }
+microsandbox-utils = { version = "0.4.3", path = "../utils" }
 msb_krun = { version = "0.1.11", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/shell-attach/package-lock.json
+++ b/examples/typescript/shell-attach/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "attach",
+  "name": "shell-attach",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "attach",
+      "name": "shell-attach",
       "version": "0.1.0",
       "dependencies": {
         "microsandbox": "file:../../../sdk/node-ts"
@@ -16,19 +16,25 @@
     },
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.4.2",
-      "hasInstallScript": true,
+      "version": "0.4.3",
       "license": "Apache-2.0",
+      "bin": {
+        "microsandbox": "bin/microsandbox.cjs",
+        "msb": "bin/microsandbox.cjs"
+      },
       "devDependencies": {
-        "@napi-rs/cli": "^3"
+        "@napi-rs/cli": "^3",
+        "@types/node": "^25.5.2",
+        "typescript": "^5.6",
+        "vitest": "^4.1"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.2",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.2",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.2"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.3",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.3",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.2"
+    "microsandbox": "0.4.3"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/sdk/node-ts/Cargo.toml
+++ b/sdk/node-ts/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 path = "native/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.4.2", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.4.2", path = "../../crates/network" }
+microsandbox = { version = "0.4.3", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.4.3", path = "../../crates/network" }
 napi = { version = "3", default-features = false, features = [
     "async",
     "tokio_rt",

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -8,8 +8,7 @@
   "files": [
     "microsandbox.darwin-arm64.node",
     "bin/msb",
-    "lib/libkrunfw.dylib",
-    "lib/libkrunfw.5.dylib"
+    "lib/libkrunfw.*.dylib"
   ],
   "license": "Apache-2.0",
   "engines": {

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -9,8 +9,7 @@
   "files": [
     "microsandbox.linux-arm64-gnu.node",
     "bin/msb",
-    "lib/libkrunfw.so",
-    "lib/libkrunfw.so.5"
+    "lib/libkrunfw.so.*"
   ],
   "license": "Apache-2.0",
   "engines": {

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -9,8 +9,7 @@
   "files": [
     "microsandbox.linux-x64-gnu.node",
     "bin/msb",
-    "lib/libkrunfw.so",
-    "lib/libkrunfw.so.5"
+    "lib/libkrunfw.so.*"
   ],
   "license": "Apache-2.0",
   "engines": {

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "microsandbox",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "bin": {
-        "microsandbox": "bin/microsandbox.cjs"
+        "microsandbox": "bin/microsandbox.cjs",
+        "msb": "bin/microsandbox.cjs"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3",
@@ -21,9 +22,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.2",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.2",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.2"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.3",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.3",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.3"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1848,58 +1849,13 @@
       "license": "MIT"
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.4.2.tgz",
-      "integrity": "sha512-btMp45x6W1DLYSjm1H5VfkbFzK4D6FBEgKL+qv26kzM9wpsMjgH4jsvseZfpiCV6zAPNC54e6TqZ/5J5wu/fGA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.4.2.tgz",
-      "integrity": "sha512-elvUACdCjUtbzYrqfH7U6peI9IMuxLmWaxfW4UlykPTaYCKEh/aB1tfJpMNkpsUXSt+S3mI7/h4qjezkRBAEQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.4.2.tgz",
-      "integrity": "sha512-HfZdG+qzRWjeleWGRA1vNYmhgmTTlAZXBYTu9MzHpq/KsmJvLd+5dYros5Y0wzNQB8HlcoR8glwOPMUgVidT/w==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -48,9 +48,9 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.4.2",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.2",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.4.2"
+    "@superradcompany/microsandbox-darwin-arm64": "0.4.3",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.3",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.4.3"
   },
   "files": [
     "dist",

--- a/sdk/node-ts/scripts/prepare-platform-package.mjs
+++ b/sdk/node-ts/scripts/prepare-platform-package.mjs
@@ -4,16 +4,25 @@
 // npm run build:native`) and CI (run on each matrix runner before publish).
 //
 // Layout produced:
-//   npm/<triple>/microsandbox.<triple>.node    (the napi binding)
-//   npm/<triple>/bin/msb                        (the msb CLI)
-//   npm/<triple>/lib/libkrunfw.{dylib|so}       (the krun shared library)
+//   npm/<triple>/microsandbox.<triple>.node            (the napi binding)
+//   npm/<triple>/bin/msb                                (the msb CLI)
+//   npm/<triple>/lib/libkrunfw.<ABI>.dylib              (macOS only)
+//   npm/<triple>/lib/libkrunfw.so.<VERSION>             (Linux only)
 //
 // Refuses to run when the host triple doesn't match the requested target,
 // since we don't cross-compile here — CI orchestrates that matrix.
 
 import { execFileSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -69,8 +78,8 @@ const msbSrc = msbCandidates.find((p) => existsSync(p));
 if (!msbSrc) {
   console.error(
     `missing msb binary; run \`just build\` from the repo root first.\n` +
-      `looked in:\n` +
-      msbCandidates.map((p) => `  ${p}`).join("\n"),
+    `looked in:\n` +
+    msbCandidates.map((p) => `  ${p}`).join("\n"),
   );
   process.exit(1);
 }
@@ -96,40 +105,36 @@ if (triple === "darwin-arm64") {
 }
 
 // 3. libkrunfw shared library --------------------------------------------
-// `just build` lands these in build/. Match the {dylib,so} filename for the host.
+// `just build` lays down one real file (e.g. libkrunfw.so.5.2.1 or
+// libkrunfw.5.dylib) plus SONAME / unversioned symlinks pointing at it.
+// We pick any matching entry, follow symlinks to the real file, and ship
+// it under its canonical name — no version constants in this script.
+// libkrunfw bumps already touch enough places (Rust constants, install.sh,
+// CI env, vendor submodule); this script doesn't need to be one of them.
+// Reset libDir first so prior runs don't leave a stale file behind that
+// the package.json `files` glob would then pick up.
 const buildDir = join(repoRoot, "build");
-let krunfw;
-let krunfwVersioned; // e.g. libkrunfw.5.dylib or libkrunfw.so.5
-if (existsSync(buildDir)) {
-  const entries = readdirSync(buildDir);
-  // Pick the ABI-versioned name that the npm package manifest includes.
-  const real = entries
-    .filter((e) =>
-      process.platform === "darwin"
-        ? /^libkrunfw\.\d+\.dylib$/.test(e)
-        : /^libkrunfw\.so\.\d+$/.test(e),
-    )
-    .sort()
-    .reverse()[0];
-  if (real) {
-    krunfwVersioned = real;
-    krunfw = process.platform === "darwin" ? "libkrunfw.dylib" : "libkrunfw.so";
-  }
-}
-if (!krunfwVersioned) {
+rmSync(libDir, { recursive: true, force: true });
+mkdirSync(libDir, { recursive: true });
+
+const krunfwPattern =
+  process.platform === "darwin"
+    ? /^libkrunfw\..+\.dylib$/
+    : /^libkrunfw\.so\..+$/;
+const krunfwEntry = existsSync(buildDir)
+  ? readdirSync(buildDir).find((entry) => krunfwPattern.test(entry))
+  : undefined;
+if (!krunfwEntry) {
   console.error(
     `missing libkrunfw in ${buildDir}; run \`just build-libkrunfw\` first.`,
   );
   process.exit(1);
 }
-
-// Copy the versioned dylib AND a duplicate under the unversioned name.
-// We can't ship a symlink because `npm pack` doesn't preserve them.
-copyFileSync(join(buildDir, krunfwVersioned), join(libDir, krunfwVersioned));
-const unversionedPath = join(libDir, krunfw);
-if (existsSync(unversionedPath)) unlinkSync(unversionedPath);
-copyFileSync(join(buildDir, krunfwVersioned), unversionedPath);
-console.log(`copied ${krunfwVersioned} + ${krunfw} (duplicate)`);
+const krunfwSrc = realpathSync(join(buildDir, krunfwEntry));
+const krunfwName = basename(krunfwSrc);
+const krunfwDst = join(libDir, krunfwName);
+copyFileSync(krunfwSrc, krunfwDst);
+console.log(`copied ${krunfwName}`);
 
 // 4. Summary --------------------------------------------------------------
 function du(p) {
@@ -138,4 +143,4 @@ function du(p) {
 console.log(`\npopulated npm/${triple}:`);
 console.log(`  ${nodeFile}     ${du(join(pkgDir, nodeFile))} KiB`);
 console.log(`  bin/msb         ${du(msbDst)} KiB`);
-console.log(`  lib/${krunfwVersioned}  ${du(join(libDir, krunfwVersioned))} KiB`);
+console.log(`  lib/${krunfwName}  ${du(krunfwDst)} KiB`);

--- a/sdk/node-ts/src/internal/resolve-binary.ts
+++ b/sdk/node-ts/src/internal/resolve-binary.ts
@@ -44,34 +44,25 @@ function resolvePlatformRoot(): string | null {
   return null;
 }
 
-let cached: { binDir: string; libDir: string } | null = null;
+let cachedBinDir: string | null = null;
 
-function resolvePlatformPaths(): { binDir: string; libDir: string } {
-  if (cached) return cached;
+function resolveBinDir(): string {
+  if (cachedBinDir) return cachedBinDir;
   const root = resolvePlatformRoot();
   if (root) {
-    cached = { binDir: join(root, "bin"), libDir: join(root, "lib") };
-    return cached;
+    cachedBinDir = join(root, "bin");
+    return cachedBinDir;
   }
   // Fall back to ~/.microsandbox if no platform package carries binaries.
   const home = process.env.HOME ?? "";
-  const fallback = join(home, ".microsandbox");
-  cached = { binDir: join(fallback, "bin"), libDir: join(fallback, "lib") };
-  return cached;
+  cachedBinDir = join(home, ".microsandbox", "bin");
+  return cachedBinDir;
 }
 
 /** Path to the bundled `msb` binary, or null if not yet installed. */
 export function msbPath(): string | null {
   const explicit = process.env.MSB_PATH;
   if (explicit) return existsSync(explicit) ? explicit : null;
-  const p = join(resolvePlatformPaths().binDir, "msb");
-  return existsSync(p) ? p : null;
-}
-
-/** Path to the bundled `libkrunfw` shared library, or null. */
-export function libkrunfwPath(): string | null {
-  const filename =
-    process.platform === "darwin" ? "libkrunfw.dylib" : "libkrunfw.so";
-  const p = join(resolvePlatformPaths().libDir, filename);
+  const p = join(resolveBinDir(), "msb");
   return existsSync(p) ? p : null;
 }

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.4.2", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.4.2", path = "../../crates/network" }
+microsandbox = { version = "0.4.3", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.4.3", path = "../../crates/network" }
 ipnetwork = { version = "0.21.0", features = ["serde"] }
 pyo3 = { version = "0.24", features = ["abi3-py310", "extension-module"] }
 pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }


### PR DESCRIPTION
## Summary
- the platform package's prepare script picked the SONAME symlink instead of the real versioned file, so the published 0.4.2 npm tarballs landed `lib/libkrunfw.so` + `lib/libkrunfw.so.5` but never `lib/libkrunfw.so.5.2.1`, the name the rust resolver looks for.
- switched to realpath-based discovery and globs in the platform `files` allowlist. also slimmed the python wheel by dropping the symlink chain (~40MB on linux) and deduped the libkrunfw constants in microsandbox-cli's `build.rs` + bin shim.
- bumped to 0.4.3.

## Test plan
- [x] `cargo check --workspace`
- [x] local pack + install of the darwin-arm64 platform tarball into a fresh consumer
- [x] linux-x86_64 packaging verified via docker against the v0.4.2 release bundle