### PR TITLE
chore(release): bump version to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2637,14 +2637,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "sea-orm",
 ]
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2684,14 +2684,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "sea-orm-migration",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "core-foundation 0.9.4",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "chrono",
  "futures",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "libc",
  "reflink-copy",
@@ -5055,14 +5055,14 @@ dependencies = [
 
 [[package]]
 name = "test-init"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "test-macros"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.4.3"
+version = "0.4.4"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/crates/agentd/Cargo.lock
+++ b/crates/agentd/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "chrono",
  "ciborium",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "chrono",
  "ciborium",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -5,7 +5,7 @@ members = ["."]
 [workspace.package]
 authors = ["Super Rad Company <developemnt@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.4.3"
+version = "0.4.4"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -46,7 +46,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { version = "0.4.3", path = "../protocol" }
+microsandbox-protocol = { version = "0.4.4", path = "../protocol" }
 nix = { workspace = true, features = [
     "fs",
     "hostname",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,12 +36,12 @@ dirs.workspace = true
 indicatif.workspace = true
 ipnetwork = { workspace = true, optional = true }
 libc.workspace = true
-microsandbox = { version = "0.4.3", path = "../microsandbox", default-features = false }
-microsandbox-image = { version = "0.4.3", path = "../image" }
-microsandbox-network = { version = "0.4.3", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.3", path = "../protocol" }
-microsandbox-runtime = { version = "0.4.3", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.4.3", path = "../utils" }
+microsandbox = { version = "0.4.4", path = "../microsandbox", default-features = false }
+microsandbox-image = { version = "0.4.4", path = "../image" }
+microsandbox-network = { version = "0.4.4", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.4", path = "../protocol" }
+microsandbox-runtime = { version = "0.4.4", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.4.4", path = "../utils" }
 rand.workspace = true
 regex = "1"
 reqwest.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { version = "0.4.3", path = "../utils" }
+microsandbox-utils = { version = "0.4.4", path = "../utils" }
 msb_krun = "0.1.12"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,5 +23,5 @@ default = ["prebuilt"]
 prebuilt = ["dep:ureq"]
 
 [build-dependencies]
-microsandbox-utils = { version = "0.4.3", path = "../utils" }
+microsandbox-utils = { version = "0.4.4", path = "../utils" }
 ureq = { workspace = true, optional = true }

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { version = "0.4.3", path = "../utils" }
+microsandbox-utils = { version = "0.4.4", path = "../utils" }
 oci-client.workspace = true
 rustls-pemfile.workspace = true
 oci-spec.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -33,14 +33,14 @@ flate2.workspace = true
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-db = { version = "0.4.3", path = "../db" }
-microsandbox-filesystem = { version = "0.4.3", path = "../filesystem", default-features = false }
-microsandbox-image = { version = "0.4.3", path = "../image" }
-microsandbox-migration = { version = "0.4.3", path = "../migration" }
-microsandbox-network = { version = "0.4.3", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.3", path = "../protocol" }
-microsandbox-runtime = { version = "0.4.3", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.4.3", path = "../utils" }
+microsandbox-db = { version = "0.4.4", path = "../db" }
+microsandbox-filesystem = { version = "0.4.4", path = "../filesystem", default-features = false }
+microsandbox-image = { version = "0.4.4", path = "../image" }
+microsandbox-migration = { version = "0.4.4", path = "../migration" }
+microsandbox-network = { version = "0.4.4", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.4", path = "../protocol" }
+microsandbox-runtime = { version = "0.4.4", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.4.4", path = "../utils" }
 nix = { workspace = true, features = ["process", "signal"] }
 rand.workspace = true
 reqwest.workspace = true

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -23,8 +23,8 @@ hickory-proto = { workspace = true, features = ["tls-ring"] }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
-microsandbox-protocol = { version = "0.4.3", path = "../protocol" }
-microsandbox-utils = { version = "0.4.3", path = "../utils" }
+microsandbox-protocol = { version = "0.4.4", path = "../protocol" }
+microsandbox-utils = { version = "0.4.4", path = "../utils" }
 msb_krun = { version = "0.1.12", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,11 +22,11 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
-microsandbox-db = { version = "0.4.3", path = "../db" }
-microsandbox-filesystem = { version = "0.4.3", path = "../filesystem", default-features = false }
-microsandbox-network = { version = "0.4.3", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.3", path = "../protocol" }
-microsandbox-utils = { version = "0.4.3", path = "../utils" }
+microsandbox-db = { version = "0.4.4", path = "../db" }
+microsandbox-filesystem = { version = "0.4.4", path = "../filesystem", default-features = false }
+microsandbox-network = { version = "0.4.4", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.4", path = "../protocol" }
+microsandbox-utils = { version = "0.4.4", path = "../utils" }
 msb_krun = { version = "0.1.12", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/init-handoff/package-lock.json
+++ b/examples/typescript/init-handoff/package-lock.json
@@ -8,7 +8,7 @@
       "name": "init-handoff",
       "version": "0.1.0",
       "dependencies": {
-        "microsandbox": "0.4.3"
+        "microsandbox": "0.4.4"
       },
       "devDependencies": {
         "tsx": "^4"
@@ -457,8 +457,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.4.3.tgz",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.4.4.tgz",
       "integrity": "sha512-g9yU8UMwt9fcbG3CvCu16S7SZnH/q2eryKr/kNbBV3SjiGHOBJtvFhG+jD11i0HBnnje3ClszKvAvrXDTIEt+Q==",
       "cpu": [
         "arm64"
@@ -473,8 +473,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.4.3.tgz",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.4.4.tgz",
       "integrity": "sha512-YBS6Uuml4drOk8Dt+bAiNO6AO3dbKYF6JdUSVtYmbN3DFnA02JTvnxU01G7nfMVlq/nFySWY6801vqKMjRj75A==",
       "cpu": [
         "arm64"
@@ -492,8 +492,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.4.3.tgz",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.4.4.tgz",
       "integrity": "sha512-UXvLnjHFYdS1z8/sXiMxBzOBepQlOqIvry3xIjhT791+207fhAjcaRyhelf7r6amKHPDTo7w0Dah9xN6jNM0Qw==",
       "cpu": [
         "x64"
@@ -581,8 +581,8 @@
       }
     },
     "node_modules/microsandbox": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/microsandbox/-/microsandbox-0.4.3.tgz",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/microsandbox/-/microsandbox-0.4.4.tgz",
       "integrity": "sha512-qoNss8p0MQjR7R3Gwb8jVZPO7b99nkPBGATF6oTwVORL4f/0xPa8oEi2zMVM6GpxhJ/oBiALFK9T1mQdp3z0zA==",
       "license": "Apache-2.0",
       "bin": {
@@ -593,9 +593,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.3",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.3",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.3"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.4",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.4",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.4"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/examples/typescript/init-handoff/package.json
+++ b/examples/typescript/init-handoff/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/logs-read/package-lock.json
+++ b/examples/typescript/logs-read/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -32,9 +32,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.3",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.3",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.3"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.4",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.4",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/shell-attach/package-lock.json
+++ b/examples/typescript/shell-attach/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -32,9 +32,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.3",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.3",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.3"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.4",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.4",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/snapshot-fork/package.json
+++ b/examples/typescript/snapshot-fork/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.3"
+    "microsandbox": "0.4.4"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/sdk/node-ts/Cargo.toml
+++ b/sdk/node-ts/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 path = "native/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.4.3", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.4.3", path = "../../crates/network" }
+microsandbox = { version = "0.4.4", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.4.4", path = "../../crates/network" }
 napi = { version = "3", default-features = false, features = [
     "async",
     "tokio_rt",

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.4.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -22,9 +22,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.3",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.3",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.3"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.4",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.4",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1849,8 +1849,8 @@
       "license": "MIT"
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.4.3.tgz",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.4.4.tgz",
       "integrity": "sha512-g9yU8UMwt9fcbG3CvCu16S7SZnH/q2eryKr/kNbBV3SjiGHOBJtvFhG+jD11i0HBnnje3ClszKvAvrXDTIEt+Q==",
       "cpu": [
         "arm64"
@@ -1865,8 +1865,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.4.3.tgz",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.4.4.tgz",
       "integrity": "sha512-YBS6Uuml4drOk8Dt+bAiNO6AO3dbKYF6JdUSVtYmbN3DFnA02JTvnxU01G7nfMVlq/nFySWY6801vqKMjRj75A==",
       "cpu": [
         "arm64"
@@ -1881,8 +1881,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.4.3.tgz",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.4.4.tgz",
       "integrity": "sha512-UXvLnjHFYdS1z8/sXiMxBzOBepQlOqIvry3xIjhT791+207fhAjcaRyhelf7r6amKHPDTo7w0Dah9xN6jNM0Qw==",
       "cpu": [
         "x64"

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -48,9 +48,9 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.4.3",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.3",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.4.3"
+    "@superradcompany/microsandbox-darwin-arm64": "0.4.4",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.4",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.4.4"
   },
   "files": [
     "dist",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.4.3", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.4.3", path = "../../crates/network" }
+microsandbox = { version = "0.4.4", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.4.4", path = "../../crates/network" }
 chrono = { workspace = true }
 ipnetwork = { version = "0.21.0", features = ["serde"] }
 pyo3 = { version = "0.24", features = ["abi3-py310", "extension-module"] }


### PR DESCRIPTION
## TL;DR
Bump every microsandbox crate, the node-ts and Python SDKs, the mcp submodule, and the TypeScript example pins from 0.4.3 to 0.4.4 in preparation for the next release.

## Description
- Workspace `Cargo.toml` and all internal `microsandbox-*` path-dep version pins moved to 0.4.4 (cli, microsandbox, runtime, network, image, filesystem, agentd).
- node-ts SDK package version, three `npm/<target>/package.json` binaries, `package-lock.json`, and the `native/index.cjs` version-check guards updated to 0.4.4.
- Python SDK and node-ts SDK Cargo manifests bumped to depend on `microsandbox 0.4.4` and `microsandbox-network 0.4.4`.
- mcp submodule pointer advanced to its own 0.4.4 bump (server `version`, package `version`, and `microsandbox` dep).
- All 15 TypeScript example `package.json` files plus the three checked-in `package-lock.json` files (init-handoff, logs-read, shell-attach) bumped from 0.4.3 to 0.4.4.
- Cargo lockfiles regenerated for both the workspace and the standalone `crates/agentd` workspace.

Changelog since v0.4.3:
- feat(agentd): hand off PID 1 to a guest init binary (#653)
- feat(snapshot): file-first disk snapshots across cli, rust, ts, python (#652)
- feat(logs): exec.log capture, boot-error.json, typed ExecFailed (#650)
- fix(net): --no-net actually air-gaps the guest (#647)
- fix(node-sdk): ship libkrunfw under canonical name in npm platform package (#648)

## Test Plan
- [x] `cargo build --workspace` exits 0
- [x] `cargo build` inside `crates/agentd` exits 0
- [x] `npm publish --dry-run` in `sdk/node-ts` reports `microsandbox@0.4.4`
- [x] `npm publish --dry-run` in `mcp` reports `microsandbox-mcp@0.4.4`
- [x] `grep -r '"0\.4\.3"' .` returns no microsandbox-related hits