### PR TITLE
fix(release): add version to microsandbox-utils build-dep

### DIFF
--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -59,7 +59,7 @@ which.workspace = true
 
 [build-dependencies]
 flate2.workspace = true
-microsandbox-utils = { path = "../utils" }
+microsandbox-utils = { version = "0.4.4", path = "../utils" }
 tar.workspace = true
 ureq.workspace = true
 


### PR DESCRIPTION
## TL;DR
The `microsandbox` crate failed to publish on the v0.4.4 release because its build-dependency on `microsandbox-utils` was path-only. This adds the missing `version` field so `cargo publish` accepts the manifest.

## Description
- `cargo publish` requires every dependency entry, including build-dependencies, to specify a version.
- The runtime dep on `microsandbox-utils` already had `version = "0.4.4"`, but the `[build-dependencies]` entry was path-only and tripped manifest verification.
- v0.4.4's release CI failed at the `microsandbox` step in `crates-publish` with: `dependency 'microsandbox-utils' does not specify a version`.
- Fix matches the runtime dep shape so the next release publishes cleanly.
- `cargo publish -p microsandbox --dry-run --no-verify` now passes manifest verification locally.

## Test Plan
- [ ] `cargo publish -p microsandbox --dry-run --no-verify` reaches the upload step without manifest errors
- [ ] Next tagged release runs the `crates-publish` job to completion past the `microsandbox` crate