### PR TITLE
Optimize Image persistance queries

### DIFF
--- a/crates/microsandbox/lib/image/mod.rs
+++ b/crates/microsandbox/lib/image/mod.rs
@@ -727,14 +727,16 @@ async fn upsert_layer_record<C: ConnectionTrait>(
         })
 }
 
-/// Attempt to satisfy `Image::persist` with a single bulk UPDATE.
+/// Attempt to satisfy `Image::persist` with a couple of bulk UPDATEs.
 ///
 /// Returns `Some(image_ref_id)` when the database is already consistent with
-/// `metadata` (i.e. the `image_ref` row exists and points to a manifest whose
-/// digest matches `metadata.manifest_digest`). In that case the only write
-/// performed is a bulk `UPDATE layer SET last_used_at` for LRU bookkeeping —
-/// the manifest, config, layer, and junction rows are content-addressed and
-/// guaranteed to be unchanged for a given manifest digest.
+/// `metadata` (i.e. the `image_ref` row exists, points to a manifest whose
+/// digest matches `metadata.manifest_digest`, and every expected `layer` row
+/// is present). In that case the only writes performed are a bulk
+/// `UPDATE layer SET last_used_at` and an `UPDATE image_ref SET updated_at`
+/// for LRU bookkeeping — the manifest, config, layer, and junction rows are
+/// content-addressed and guaranteed to be unchanged for a given manifest
+/// digest.
 ///
 /// Returns `None` when the caller must fall through to the full transactional
 /// upsert (fresh DB, manifest digest changed, partially persisted state).
@@ -756,22 +758,38 @@ async fn try_persist_fast_path(
         return Ok(None);
     }
 
-    // Refresh layer.last_used_at in a single statement so the layer GC
-    // policy still treats this image as recently used.
+    let now = chrono::Utc::now().naive_utc();
+
     if !metadata.layers.is_empty() {
-        let now = chrono::Utc::now().naive_utc();
         let diff_ids: Vec<String> = metadata
             .layers
             .iter()
             .map(|layer| layer.diff_id.clone())
             .collect();
 
+        // Sanity count check to verify all layers exist in the database.
+        let existing_layer_count = layer_entity::Entity::find()
+            .filter(layer_entity::Column::DiffId.is_in(diff_ids.clone()))
+            .count(db)
+            .await?;
+        if existing_layer_count != metadata.layers.len() as u64 {
+            return Ok(None);
+        }
+
+        // Refresh layer.last_used_at
         layer_entity::Entity::update_many()
             .col_expr(layer_entity::Column::LastUsedAt, Expr::value(now))
             .filter(layer_entity::Column::DiffId.is_in(diff_ids))
             .exec(db)
             .await?;
     }
+
+    // Refresh image_ref.updated_at
+    image_ref_entity::Entity::update_many()
+        .col_expr(image_ref_entity::Column::UpdatedAt, Expr::value(now))
+        .filter(image_ref_entity::Column::Id.eq(image_ref_model.id))
+        .exec(db)
+        .await?;
 
     Ok(Some(image_ref_model.id))
 }

--- a/crates/microsandbox/lib/image/mod.rs
+++ b/crates/microsandbox/lib/image/mod.rs
@@ -5,8 +5,9 @@
 //! by [`microsandbox_image::GlobalCache`]; this module owns the DB lifecycle.
 
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, EntityTrait, JoinType, PaginatorTrait, QueryFilter, QueryOrder,
-    QuerySelect, RelationTrait, Set, TransactionTrait, sea_query::OnConflict,
+    ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, JoinType, PaginatorTrait,
+    QueryFilter, QueryOrder, QuerySelect, RelationTrait, Set, TransactionTrait,
+    sea_query::{Expr, OnConflict},
 };
 
 use microsandbox_image::{
@@ -151,6 +152,12 @@ impl Image {
     ///
     /// Upserts the manifest, config, layers, junction records, and image_ref
     /// inside a single transaction.
+    ///
+    /// Fast path: when the `image_ref` already points to a manifest whose
+    /// digest matches `metadata.manifest_digest`, skip the transactional
+    /// upsert entirely and only refresh `layer.last_used_at` for LRU GC.
+    /// This avoids ~25–30 redundant write statements per cached create
+    /// and keeps SQLite's single-writer lock free for other work.
     pub async fn persist(
         reference: &str,
         metadata: CachedImageMetadata,
@@ -159,6 +166,10 @@ impl Image {
             crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
 
         let reference = reference.to_string();
+
+        if let Some(image_ref_id) = try_persist_fast_path(db, &reference, &metadata).await? {
+            return Ok(image_ref_id);
+        }
 
         db.transaction::<_, i32, MicrosandboxError>(|txn| {
             Box::pin(async move {
@@ -714,4 +725,53 @@ async fn upsert_layer_record<C: ConnectionTrait>(
                 layer_meta.diff_id
             ))
         })
+}
+
+/// Attempt to satisfy `Image::persist` with a single bulk UPDATE.
+///
+/// Returns `Some(image_ref_id)` when the database is already consistent with
+/// `metadata` (i.e. the `image_ref` row exists and points to a manifest whose
+/// digest matches `metadata.manifest_digest`). In that case the only write
+/// performed is a bulk `UPDATE layer SET last_used_at` for LRU bookkeeping —
+/// the manifest, config, layer, and junction rows are content-addressed and
+/// guaranteed to be unchanged for a given manifest digest.
+///
+/// Returns `None` when the caller must fall through to the full transactional
+/// upsert (fresh DB, manifest digest changed, partially persisted state).
+async fn try_persist_fast_path(
+    db: &DatabaseConnection,
+    reference: &str,
+    metadata: &CachedImageMetadata,
+) -> MicrosandboxResult<Option<i32>> {
+    let Some((image_ref_model, Some(manifest))) = image_ref_entity::Entity::find()
+        .filter(image_ref_entity::Column::Reference.eq(reference))
+        .find_also_related(manifest_entity::Entity)
+        .one(db)
+        .await?
+    else {
+        return Ok(None);
+    };
+
+    if manifest.digest != metadata.manifest_digest {
+        return Ok(None);
+    }
+
+    // Refresh layer.last_used_at in a single statement so the layer GC
+    // policy still treats this image as recently used.
+    if !metadata.layers.is_empty() {
+        let now = chrono::Utc::now().naive_utc();
+        let diff_ids: Vec<String> = metadata
+            .layers
+            .iter()
+            .map(|layer| layer.diff_id.clone())
+            .collect();
+
+        layer_entity::Entity::update_many()
+            .col_expr(layer_entity::Column::LastUsedAt, Expr::value(now))
+            .filter(layer_entity::Column::DiffId.is_in(diff_ids))
+            .exec(db)
+            .await?;
+    }
+
+    Ok(Some(image_ref_model.id))
 }

--- a/crates/utils/lib/lib.rs
+++ b/crates/utils/lib/lib.rs
@@ -81,11 +81,20 @@ pub const DB_FILENAME: &str = "msb.db";
 
 /// SQLite PRAGMAs applied to every connection for concurrent-access safety.
 ///
-/// - WAL mode prevents `SQLITE_BUSY` when multiple processes access the DB
-/// - 5-second busy timeout retries on transient lock contention
-/// - Foreign key enforcement is off by default in SQLite
-pub const SQLITE_PRAGMAS: &str =
-    "PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON;";
+/// - WAL mode lets readers run concurrently with a single writer.
+/// - 5-second busy timeout retries on transient lock contention.
+/// - `synchronous = NORMAL` is the recommended pairing with WAL: fsyncs are
+///   batched at checkpoint time instead of every commit, which dramatically
+///   shortens how long the global writer lock is held under concurrent
+///   sandbox creates. Crash-safe (no corruption on process/OS crash); the
+///   only risk is losing the most recently committed transactions on a
+///   power loss, which is acceptable for sandbox lifecycle and image
+///   catalog state.
+/// - Foreign key enforcement is off by default in SQLite.
+pub const SQLITE_PRAGMAS: &str = "PRAGMA journal_mode = WAL; \
+    PRAGMA synchronous = NORMAL; \
+    PRAGMA busy_timeout = 5000; \
+    PRAGMA foreign_keys = ON;";
 
 /// Global configuration filename.
 pub const CONFIG_FILENAME: &str = "config.json";


### PR DESCRIPTION
The biggest change in this PR is to add a fast path for the Image upserts that happen on sandbox creation. If a image is reused and already cached there should be no need to upsert all image layers.  Currently the upserts happen everytime a sandbox is created. This PR checks if the Image already exists and if the manifest digest matches. If the manifest digest matches there is no point to upsert all rows and instead does a single update last_used_at column statement. For cached images it removes 25~30 statements  for each upsert.

I also added the PRAGMA synchronous = NORMAL to the sqlite connection. This makes it so it only fsyncs on WAL checkpoints. This is recommended in WAL mode and should speed up global write lock. 