### PR TITLE
refactor(db): typed read and write connection types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,8 +2617,11 @@ dependencies = [
 name = "microsandbox-db"
 version = "0.4.3"
 dependencies = [
+ "async-trait",
  "sea-orm",
  "sqlx",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -12,5 +12,8 @@ name = "microsandbox_db"
 path = "lib/lib.rs"
 
 [dependencies]
+async-trait = "0.1"
 sea-orm.workspace = true
 sqlx.workspace = true
+tokio.workspace = true
+tracing.workspace = true

--- a/crates/db/lib/connection.rs
+++ b/crates/db/lib/connection.rs
@@ -1,0 +1,185 @@
+//! Typed wrappers around `sea_orm::DatabaseConnection`.
+//!
+//! Splits a connection into [`DbReadConnection`] and [`DbWriteConnection`]
+//! so the type system enforces which pool a given operation hits. SQLite is
+//! single-writer system-wide; routing every write through a dedicated
+//! single-connection write pool turns intra-process contention into an
+//! in-process queue rather than `SQLITE_BUSY` retries.
+//!
+//! Both types implement [`sea_orm::ConnectionTrait`], so existing query
+//! builders (`Entity::find().all(db)`, `Entity::insert(...).exec(db)`, etc.)
+//! work without source changes — callers just pick the right type for the
+//! operation.
+
+use std::{future::Future, path::Path, time::Duration};
+
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, DbErr, ExecResult,
+    QueryResult, Statement, TransactionTrait,
+};
+
+use crate::{pool, retry, retry::IsSqliteBusy};
+
+/// Read pool. Multi-connection; concurrent reads enabled by WAL mode.
+///
+/// `ConnectionTrait` is implemented so SELECTs work transparently. Writes
+/// also technically execute (sea-orm has no read-only enforcement at the
+/// trait level), but doing so via this type defeats the purpose — write
+/// paths must take a [`DbWriteConnection`] argument.
+///
+/// `Clone` is cheap: the inner `DatabaseConnection` holds an `Arc` over
+/// the underlying sqlx pool, so clones share connection state.
+#[derive(Debug, Clone)]
+pub struct DbReadConnection(DatabaseConnection);
+
+/// Write pool. Single connection; serialises in-process writes so the
+/// SQLite writer lock is never contested from within one process.
+///
+/// Cross-process contention with other writers (e.g. the in-VM runtime)
+/// still exists and is absorbed by the `busy_timeout` PRAGMA + the
+/// retry-on-busy transaction helpers (added in a follow-up step).
+///
+/// `Clone` is cheap: the inner `DatabaseConnection` holds an `Arc` over
+/// the underlying sqlx pool, so clones share the same single connection.
+#[derive(Debug, Clone)]
+pub struct DbWriteConnection(DatabaseConnection);
+
+impl DbReadConnection {
+    /// Wrap a sea-orm connection as a read pool.
+    pub fn new(inner: DatabaseConnection) -> Self {
+        Self(inner)
+    }
+
+    /// Open a stand-alone read pool at `db_path` with shared PRAGMAs.
+    pub async fn open(
+        db_path: &Path,
+        max_connections: u32,
+        connect_timeout: Duration,
+        busy_timeout: Duration,
+    ) -> Result<Self, sqlx::Error> {
+        let conn =
+            pool::build_pool(db_path, max_connections, connect_timeout, busy_timeout).await?;
+        Ok(Self(conn))
+    }
+
+    /// Borrow the underlying sea-orm connection.
+    pub fn inner(&self) -> &DatabaseConnection {
+        &self.0
+    }
+}
+
+impl DbWriteConnection {
+    /// Wrap a sea-orm connection as a write pool.
+    pub fn new(inner: DatabaseConnection) -> Self {
+        Self(inner)
+    }
+
+    /// Open a stand-alone single-connection write pool at `db_path`.
+    ///
+    /// Used by callers that don't need a paired read pool (e.g. the in-VM
+    /// runtime, which only writes run records).
+    pub async fn open(
+        db_path: &Path,
+        connect_timeout: Duration,
+        busy_timeout: Duration,
+    ) -> Result<Self, sqlx::Error> {
+        let conn = pool::build_pool(db_path, 1, connect_timeout, busy_timeout).await?;
+        Ok(Self(conn))
+    }
+
+    /// Borrow the underlying sea-orm connection.
+    pub fn inner(&self) -> &DatabaseConnection {
+        &self.0
+    }
+
+    /// Run a write transaction with automatic retry on `SQLITE_BUSY` and
+    /// `SQLITE_BUSY_SNAPSHOT`. Prefer this over bare `Entity::insert(...)
+    /// .exec(self)` for any DB write so retry policy stays centralised.
+    ///
+    /// `f` is invoked once per attempt with a freshly opened transaction.
+    /// Return `Ok((txn, value))` to commit, or any `Err` to roll back (the
+    /// helper drops the transaction on failure, which sea-orm rolls back).
+    /// The closure must be callable multiple times: clone owned data inside
+    /// the body so retries see fresh values.
+    ///
+    /// Generic over the closure's error type `E` so callers can return
+    /// app-level errors directly (e.g. `MicrosandboxError`) provided
+    /// `E: From<DbErr> + IsSqliteBusy`.
+    pub async fn transaction<F, Fut, T, E>(&self, name: &'static str, f: F) -> Result<T, E>
+    where
+        F: Fn(DatabaseTransaction) -> Fut,
+        Fut: Future<Output = Result<(DatabaseTransaction, T), E>> + Send,
+        T: Send,
+        E: From<DbErr> + IsSqliteBusy,
+    {
+        retry::retry_on_busy(name, || async {
+            let txn = self.0.begin().await?;
+            let (txn, value) = f(txn).await?;
+            txn.commit().await?;
+            Ok(value)
+        })
+        .await
+    }
+}
+
+#[async_trait::async_trait]
+impl ConnectionTrait for DbReadConnection {
+    fn get_database_backend(&self) -> DbBackend {
+        self.0.get_database_backend()
+    }
+
+    async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
+        self.0.execute(stmt).await
+    }
+
+    async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
+        self.0.execute_unprepared(sql).await
+    }
+
+    async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
+        self.0.query_one(stmt).await
+    }
+
+    async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
+        self.0.query_all(stmt).await
+    }
+
+    fn support_returning(&self) -> bool {
+        self.0.support_returning()
+    }
+
+    fn is_mock_connection(&self) -> bool {
+        self.0.is_mock_connection()
+    }
+}
+
+#[async_trait::async_trait]
+impl ConnectionTrait for DbWriteConnection {
+    fn get_database_backend(&self) -> DbBackend {
+        self.0.get_database_backend()
+    }
+
+    async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
+        self.0.execute(stmt).await
+    }
+
+    async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
+        self.0.execute_unprepared(sql).await
+    }
+
+    async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
+        self.0.query_one(stmt).await
+    }
+
+    async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
+        self.0.query_all(stmt).await
+    }
+
+    fn support_returning(&self) -> bool {
+        self.0.support_returning()
+    }
+
+    fn is_mock_connection(&self) -> bool {
+        self.0.is_mock_connection()
+    }
+}

--- a/crates/db/lib/lib.rs
+++ b/crates/db/lib/lib.rs
@@ -11,7 +11,10 @@
 // Exports
 //--------------------------------------------------------------------------------------------------
 
+pub mod connection;
 #[allow(missing_docs)]
 pub mod entity;
 pub mod pool;
 pub mod retry;
+
+pub use connection::{DbReadConnection, DbWriteConnection};

--- a/crates/db/lib/pool.rs
+++ b/crates/db/lib/pool.rs
@@ -71,7 +71,7 @@ impl DbPools {
 /// lock before returning `SQLITE_BUSY`. It interacts with the
 /// application-level retry policy: a longer busy timeout reduces retry
 /// volume at the cost of higher tail latency on contention.
-pub async fn build_pool(
+pub(crate) async fn build_pool(
     db_path: &Path,
     max_connections: u32,
     connect_timeout: Duration,

--- a/crates/db/lib/pool.rs
+++ b/crates/db/lib/pool.rs
@@ -10,10 +10,57 @@ use std::{path::Path, time::Duration};
 use sea_orm::{DatabaseConnection, SqlxSqliteConnector};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 
+use crate::connection::{DbReadConnection, DbWriteConnection};
+
 /// Default `busy_timeout` PRAGMA value used when a caller has no
 /// user-facing knob to plumb (e.g. the in-VM runtime, where the host
 /// owns DB-tuning policy and the runtime is not user-configurable).
 pub const DEFAULT_BUSY_TIMEOUT_SECS: u64 = 5;
+
+/// Read pool + dedicated single-connection write pool for the same SQLite
+/// file. SQLite is single-writer system-wide, so a multi-connection pool
+/// fighting for the writer lock just generates `SQLITE_BUSY` and (under
+/// deferred transactions) `SQLITE_BUSY_SNAPSHOT`. Funnelling all writes
+/// from one process through a single connection turns within-process
+/// contention into an in-process queue (deterministic) instead of
+/// SQLite-level lock contention (probabilistic, retry-required). Reads
+/// keep the wider pool — WAL mode lets readers run concurrently.
+#[derive(Debug)]
+pub struct DbPools {
+    read: DbReadConnection,
+    write: DbWriteConnection,
+}
+
+impl DbPools {
+    /// Open both pools for the SQLite file at `db_path` with shared PRAGMAs.
+    ///
+    /// The write pool connects first so WAL mode (persisted in the database
+    /// header) is set before the read pool opens. `max_read_connections`
+    /// sizes only the read pool; the write pool is always single-connection
+    /// by design.
+    pub async fn open(
+        db_path: &Path,
+        max_read_connections: u32,
+        connect_timeout: Duration,
+        busy_timeout: Duration,
+    ) -> Result<Self, sqlx::Error> {
+        let write = DbWriteConnection::open(db_path, connect_timeout, busy_timeout).await?;
+        let read =
+            DbReadConnection::open(db_path, max_read_connections, connect_timeout, busy_timeout)
+                .await?;
+        Ok(Self { read, write })
+    }
+
+    /// Borrow the read pool (multi-connection).
+    pub fn read(&self) -> &DbReadConnection {
+        &self.read
+    }
+
+    /// Borrow the write pool (single-connection, retries handled inside).
+    pub fn write(&self) -> &DbWriteConnection {
+        &self.write
+    }
+}
 
 /// Open a sqlx-backed SQLite pool wrapped as a sea-orm `DatabaseConnection`.
 ///

--- a/crates/db/lib/retry.rs
+++ b/crates/db/lib/retry.rs
@@ -1,8 +1,10 @@
-//! SQLite-specific error classification used by retry layers.
+//! SQLite-specific error classification and retry loop used by write paths.
 //!
 //! Lives in this crate (rather than the host) because it pattern-matches
 //! on `sqlx::Error` directly — sqlx is already a dep here, and we don't
 //! want to re-add it to `microsandbox` just for an error sniff.
+
+use std::{future::Future, time::Duration};
 
 use sea_orm::{DbErr, RuntimeErr};
 
@@ -13,6 +15,10 @@ use sea_orm::{DbErr, RuntimeErr};
 /// into exponential backoff.
 const SQLITE_BUSY: &str = "5";
 const SQLITE_BUSY_SNAPSHOT: &str = "517";
+
+const MAX_BUSY_RETRY_ATTEMPTS: u32 = 8;
+const INITIAL_DELAY: Duration = Duration::from_millis(10);
+const MAX_DELAY: Duration = Duration::from_millis(500);
 
 /// Returns `true` if `err` is a SQLite `BUSY` / `BUSY_SNAPSHOT` error
 /// from any of the sea-orm variants that wrap a sqlx database error.
@@ -28,4 +34,61 @@ pub fn is_sqlite_busy(err: &DbErr) -> bool {
         db_err.code().as_deref(),
         Some(SQLITE_BUSY) | Some(SQLITE_BUSY_SNAPSHOT)
     )
+}
+
+/// Trait for application error types so the retry layer can recognise
+/// SQLite-busy failures wrapped inside larger error enums.
+///
+/// Implemented for [`DbErr`] out of the box. Host crates that wrap
+/// `DbErr` in their own error type (e.g. `MicrosandboxError`,
+/// `RuntimeError`) should implement this trait by delegating to
+/// [`is_sqlite_busy`] on the wrapped `DbErr` — otherwise the retry
+/// layer cannot tell which errors are transient.
+pub trait IsSqliteBusy {
+    /// Whether this error represents a transient SQLite busy/lock state.
+    fn is_sqlite_busy(&self) -> bool;
+}
+
+impl IsSqliteBusy for DbErr {
+    fn is_sqlite_busy(&self) -> bool {
+        is_sqlite_busy(self)
+    }
+}
+
+/// Retry a database operation on SQLite `BUSY` / `BUSY_SNAPSHOT` with
+/// exponential backoff, capped at a small fixed number of attempts.
+///
+/// `name` is used purely for tracing. `f` is invoked once per attempt and
+/// must produce a fresh future each call (so it can be retried with a
+/// clean transaction or query). `E` must implement [`IsSqliteBusy`] so the
+/// loop can distinguish transient busy errors from permanent failures.
+pub async fn retry_on_busy<F, Fut, T, E>(name: &'static str, mut f: F) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: IsSqliteBusy,
+{
+    let mut delay = INITIAL_DELAY;
+    for attempt in 1..=MAX_BUSY_RETRY_ATTEMPTS {
+        match f().await {
+            Ok(value) => {
+                if attempt > 1 {
+                    tracing::debug!(operation = name, attempt, "db busy retry succeeded");
+                }
+                return Ok(value);
+            }
+            Err(err) if err.is_sqlite_busy() && attempt < MAX_BUSY_RETRY_ATTEMPTS => {
+                tracing::debug!(
+                    operation = name,
+                    attempt,
+                    delay_ms = delay.as_millis() as u64,
+                    "db busy, retrying"
+                );
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(MAX_DELAY);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    unreachable!("loop returns or errors before exhausting attempts")
 }

--- a/crates/microsandbox/lib/db/mod.rs
+++ b/crates/microsandbox/lib/db/mod.rs
@@ -1,23 +1,17 @@
-//! Database connection pool init and accessors.
+//! Global database connection pool init and accessor.
 //!
-//! Provides dual-pool access for global (`~/.microsandbox/db/msb.db`) and
-//! project-local (`.microsandbox/db/msb.db`) databases. Migrations are
-//! automatically applied on first connection.
-//!
-//! Init functions return [`DbPools`] from `microsandbox-db`; callers pick
-//! `pools.read()` (a [`DbReadConnection`]) or `pools.write()` (a
-//! [`DbWriteConnection`]) based on the operation. The type system blocks
-//! accidental writes against the read pool.
+//! Opens both pools (read + write) for `~/.microsandbox/db/msb.db` and
+//! runs migrations on the writer. Returns [`DbPools`] from
+//! `microsandbox-db`; callers pick `pools.read()` (a [`DbReadConnection`])
+//! or `pools.write()` (a [`DbWriteConnection`]) based on the operation.
+//! The type system blocks accidental writes against the read pool.
 //!
 //! [`DbReadConnection`]: microsandbox_db::DbReadConnection
 //! [`DbWriteConnection`]: microsandbox_db::DbWriteConnection
 
 pub use microsandbox_db::entity;
 
-use std::{
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::{path::Path, time::Duration};
 
 use microsandbox_db::pool::DbPools;
 use microsandbox_migration::{Migrator, MigratorTrait};
@@ -30,7 +24,6 @@ use crate::{MicrosandboxError, MicrosandboxResult};
 //--------------------------------------------------------------------------------------------------
 
 static GLOBAL_POOL: OnceCell<DbPools> = OnceCell::const_new();
-static PROJECT_POOL: OnceCell<(PathBuf, DbPools)> = OnceCell::const_new();
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -57,45 +50,9 @@ pub async fn init_global() -> MicrosandboxResult<&'static DbPools> {
         .await
 }
 
-/// Initialize the project-local database pools at `<project>/.microsandbox/db/msb.db`.
-///
-/// Migrations are applied automatically. Idempotent — repeat calls
-/// return the existing pools. Errors if called with a different
-/// project directory than the first call. Tuning is read from the
-/// global config.
-pub async fn init_project(project_dir: impl AsRef<Path>) -> MicrosandboxResult<&'static DbPools> {
-    let requested = project_dir.as_ref().to_path_buf();
-
-    let pair = PROJECT_POOL
-        .get_or_try_init(|| async {
-            let db_dir = requested
-                .join(microsandbox_utils::BASE_DIR_NAME)
-                .join(microsandbox_utils::DB_SUBDIR);
-
-            let pools = connect_and_migrate(&db_dir).await?;
-            Ok::<_, MicrosandboxError>((requested.clone(), pools))
-        })
-        .await?;
-
-    if pair.0 != requested {
-        return Err(MicrosandboxError::Custom(format!(
-            "project pool already initialized for '{}', cannot reinitialize for '{}'",
-            pair.0.display(),
-            requested.display(),
-        )));
-    }
-
-    Ok(&pair.1)
-}
-
 /// Get the global pools, or `None` if [`init_global`] has not run.
 pub fn global() -> Option<&'static DbPools> {
     GLOBAL_POOL.get()
-}
-
-/// Get the project-local pools, or `None` if [`init_project`] has not run.
-pub fn project() -> Option<&'static DbPools> {
-    PROJECT_POOL.get().map(|(_, p)| p)
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/crates/microsandbox/lib/db/mod.rs
+++ b/crates/microsandbox/lib/db/mod.rs
@@ -1,39 +1,33 @@
-//! Database connection pool and entity definitions.
+//! Database connection pool init and accessors.
 //!
 //! Provides dual-pool access for global (`~/.microsandbox/db/msb.db`) and
 //! project-local (`.microsandbox/db/msb.db`) databases. Migrations are
 //! automatically applied on first connection.
+//!
+//! Init functions return [`DbPools`] from `microsandbox-db`; callers pick
+//! `pools.read()` (a [`DbReadConnection`]) or `pools.write()` (a
+//! [`DbWriteConnection`]) based on the operation. The type system blocks
+//! accidental writes against the read pool.
+//!
+//! [`DbReadConnection`]: microsandbox_db::DbReadConnection
+//! [`DbWriteConnection`]: microsandbox_db::DbWriteConnection
 
 pub use microsandbox_db::entity;
 
 use std::{
-    future::Future,
     path::{Path, PathBuf},
     time::Duration,
 };
 
+use microsandbox_db::pool::DbPools;
 use microsandbox_migration::{Migrator, MigratorTrait};
-use sea_orm::{DatabaseConnection, DatabaseTransaction, TransactionTrait};
 use tokio::sync::OnceCell;
 
 use crate::{MicrosandboxError, MicrosandboxResult};
 
 //--------------------------------------------------------------------------------------------------
-// Types
+// Statics
 //--------------------------------------------------------------------------------------------------
-
-/// Read pool + dedicated single-connection write pool for the same SQLite
-/// file. SQLite is single-writer system-wide, so a multi-connection pool
-/// fighting for the writer lock just generates `SQLITE_BUSY` and (under
-/// deferred transactions) `SQLITE_BUSY_SNAPSHOT`. Funnelling all writes
-/// from one process through a single connection turns within-process
-/// contention into an in-process queue (deterministic) instead of
-/// SQLite-level lock contention (probabilistic, retry-required). Reads
-/// keep the wider pool — WAL mode lets readers run concurrently.
-struct DbPools {
-    read: DatabaseConnection,
-    write: DatabaseConnection,
-}
 
 static GLOBAL_POOL: OnceCell<DbPools> = OnceCell::const_new();
 static PROJECT_POOL: OnceCell<(PathBuf, DbPools)> = OnceCell::const_new();
@@ -42,49 +36,34 @@ static PROJECT_POOL: OnceCell<(PathBuf, DbPools)> = OnceCell::const_new();
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Initialize the global database connection pool at `~/.microsandbox/db/msb.db`.
+/// Initialize the global database pools at `~/.microsandbox/db/msb.db`.
 ///
-/// Migrations are applied automatically. This is idempotent — calling it
-/// multiple times returns the existing pool. Returns the **read** pool;
-/// writes go through a separate dedicated connection accessed via
-/// [`with_retry_transaction`].
-pub async fn init_global(
-    max_connections: Option<u32>,
-) -> MicrosandboxResult<&'static DatabaseConnection> {
-    let pools = GLOBAL_POOL
+/// Migrations are applied automatically. Idempotent — repeat calls
+/// return the existing pools. All tuning (max_connections,
+/// connect_timeout, busy_timeout) is read from `~/.microsandbox/config.json`.
+pub async fn init_global() -> MicrosandboxResult<&'static DbPools> {
+    GLOBAL_POOL
         .get_or_try_init(|| async {
             let base = dirs::home_dir().ok_or_else(|| {
-                crate::MicrosandboxError::Custom("cannot determine home directory".into())
+                MicrosandboxError::Custom("cannot determine home directory".into())
             })?;
 
             let db_dir = base
                 .join(microsandbox_utils::BASE_DIR_NAME)
                 .join(microsandbox_utils::DB_SUBDIR);
 
-            let database = &crate::config::config().database;
-            connect_and_migrate_pools(
-                &db_dir,
-                max_connections.unwrap_or(crate::config::DEFAULT_MAX_CONNECTIONS),
-                database.connect_timeout_secs,
-                database.busy_timeout_secs,
-            )
-            .await
+            connect_and_migrate(&db_dir).await
         })
-        .await?;
-    Ok(&pools.read)
+        .await
 }
 
-/// Initialize a project-local database connection pool at `<project>/.microsandbox/db/msb.db`.
+/// Initialize the project-local database pools at `<project>/.microsandbox/db/msb.db`.
 ///
-/// Migrations are applied automatically. This is idempotent — calling it
-/// multiple times returns the existing pool. Returns an error if called
-/// with a different project directory than the first call. Returns the
-/// **read** pool; writes go through a separate dedicated connection
-/// accessed via [`with_retry_transaction`].
-pub async fn init_project(
-    project_dir: impl AsRef<Path>,
-    max_connections: Option<u32>,
-) -> MicrosandboxResult<&'static DatabaseConnection> {
+/// Migrations are applied automatically. Idempotent — repeat calls
+/// return the existing pools. Errors if called with a different
+/// project directory than the first call. Tuning is read from the
+/// global config.
+pub async fn init_project(project_dir: impl AsRef<Path>) -> MicrosandboxResult<&'static DbPools> {
     let requested = project_dir.as_ref().to_path_buf();
 
     let pair = PROJECT_POOL
@@ -93,196 +72,58 @@ pub async fn init_project(
                 .join(microsandbox_utils::BASE_DIR_NAME)
                 .join(microsandbox_utils::DB_SUBDIR);
 
-            let database = &crate::config::config().database;
-            let pools = connect_and_migrate_pools(
-                &db_dir,
-                max_connections.unwrap_or(crate::config::DEFAULT_MAX_CONNECTIONS),
-                database.connect_timeout_secs,
-                database.busy_timeout_secs,
-            )
-            .await?;
-            Ok::<_, crate::MicrosandboxError>((requested.clone(), pools))
+            let pools = connect_and_migrate(&db_dir).await?;
+            Ok::<_, MicrosandboxError>((requested.clone(), pools))
         })
         .await?;
 
-    // Verify the requested project matches the initialized one.
     if pair.0 != requested {
-        return Err(crate::MicrosandboxError::Custom(format!(
+        return Err(MicrosandboxError::Custom(format!(
             "project pool already initialized for '{}', cannot reinitialize for '{}'",
             pair.0.display(),
             requested.display(),
         )));
     }
 
-    Ok(&pair.1.read)
+    Ok(&pair.1)
 }
 
-/// Get the global read pool.
-///
-/// Returns `None` if [`init_global`] has not been called yet.
-pub fn global() -> Option<&'static DatabaseConnection> {
-    GLOBAL_POOL.get().map(|p| &p.read)
+/// Get the global pools, or `None` if [`init_global`] has not run.
+pub fn global() -> Option<&'static DbPools> {
+    GLOBAL_POOL.get()
 }
 
-/// Get the project-local read pool.
-///
-/// Returns `None` if [`init_project`] has not been called yet.
-pub fn project() -> Option<&'static DatabaseConnection> {
-    PROJECT_POOL.get().map(|(_, p)| &p.read)
-}
-
-/// Look up the write pool that pairs with a given read-pool reference.
-///
-/// `with_retry_transaction` accepts the read pool that callers already
-/// have a reference to (since that's what `init_global`/`init_project`
-/// return) and routes the actual write through the matching dedicated
-/// single-connection write pool. Pointer equality on the read pool
-/// reference is the cheapest way to disambiguate global vs project
-/// without changing every call site to thread a different handle.
-///
-/// Falls back to the input reference when the caller's pool isn't one
-/// of ours (e.g. ad-hoc test connections).
-fn write_pool_for(read_db: &DatabaseConnection) -> &DatabaseConnection {
-    if let Some(pools) = GLOBAL_POOL.get()
-        && std::ptr::eq(&pools.read, read_db)
-    {
-        return &pools.write;
-    }
-    if let Some((_, pools)) = PROJECT_POOL.get()
-        && std::ptr::eq(&pools.read, read_db)
-    {
-        return &pools.write;
-    }
-    read_db
-}
-
-/// Run a write transaction with automatic retry on `SQLITE_BUSY` and
-/// `SQLITE_BUSY_SNAPSHOT`. Prefer this over `db.transaction(...)` or raw
-/// `Entity::insert(...).exec(db)` for any DB write so retry policy stays
-/// centralised.
-///
-/// `f` is invoked once per attempt with a freshly opened transaction.
-/// Return `Ok((txn, value))` to commit, or any `Err` to roll back (the
-/// helper drops the transaction on failure, which sea-orm rolls back).
-/// The closure must be callable multiple times: clone owned data inside
-/// the body so retries see fresh values.
-pub async fn with_retry_transaction<F, Fut, T>(
-    db: &DatabaseConnection,
-    name: &'static str,
-    f: F,
-) -> MicrosandboxResult<T>
-where
-    F: Fn(DatabaseTransaction) -> Fut,
-    Fut: Future<Output = MicrosandboxResult<(DatabaseTransaction, T)>> + Send,
-    T: Send,
-{
-    let write_db = write_pool_for(db);
-    retry_on_busy(name, || async {
-        let txn = write_db.begin().await?;
-        let (txn, value) = f(txn).await?;
-        txn.commit().await?;
-        Ok(value)
-    })
-    .await
-}
-
-/// Retry an arbitrary DB-only operation on `SQLITE_BUSY` (5) and
-/// `SQLITE_BUSY_SNAPSHOT` (517). Backs off exponentially up to
-/// `MAX_BUSY_RETRY_ATTEMPTS` total tries. Prefer [`with_retry_transaction`]
-/// for normal write operations; this lower-level helper is for cases that
-/// don't fit the transaction shape.
-pub async fn retry_on_busy<F, Fut, T>(name: &'static str, mut f: F) -> MicrosandboxResult<T>
-where
-    F: FnMut() -> Fut,
-    Fut: std::future::Future<Output = MicrosandboxResult<T>>,
-{
-    const MAX_BUSY_RETRY_ATTEMPTS: u32 = 8;
-    const INITIAL_DELAY: Duration = Duration::from_millis(10);
-    const MAX_DELAY: Duration = Duration::from_millis(500);
-
-    let mut delay = INITIAL_DELAY;
-    for attempt in 1..=MAX_BUSY_RETRY_ATTEMPTS {
-        match f().await {
-            Ok(value) => {
-                if attempt > 1 {
-                    tracing::debug!(operation = name, attempt, "db busy retry succeeded");
-                }
-                return Ok(value);
-            }
-            Err(err) if is_sqlite_busy(&err) && attempt < MAX_BUSY_RETRY_ATTEMPTS => {
-                tracing::debug!(
-                    operation = name,
-                    attempt,
-                    delay_ms = delay.as_millis() as u64,
-                    "db busy, retrying"
-                );
-                tokio::time::sleep(delay).await;
-                delay = (delay * 2).min(MAX_DELAY);
-            }
-            Err(err) => return Err(err),
-        }
-    }
-    unreachable!("loop returns or errors before exhausting attempts")
-}
-
-fn is_sqlite_busy(err: &crate::MicrosandboxError) -> bool {
-    matches!(
-        err,
-        MicrosandboxError::Database(db_err)
-            if microsandbox_db::retry::is_sqlite_busy(db_err)
-    )
+/// Get the project-local pools, or `None` if [`init_project`] has not run.
+pub fn project() -> Option<&'static DbPools> {
+    PROJECT_POOL.get().map(|(_, p)| p)
 }
 
 //--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
-/// Open both pools (read + dedicated single-connection writer) for the
-/// SQLite file at `db_dir/msb.db` and run migrations on the writer.
-async fn connect_and_migrate_pools(
-    db_dir: &Path,
-    max_connections: u32,
-    connect_timeout_secs: u64,
-    busy_timeout_secs: u64,
-) -> MicrosandboxResult<DbPools> {
+/// Open both pools for `db_dir/msb.db` and run migrations on the writer.
+///
+/// The write pool connects first so WAL mode (persisted in the database
+/// header) is set before the read pool opens. Tuning is read from the
+/// global config.
+async fn connect_and_migrate(db_dir: &Path) -> MicrosandboxResult<DbPools> {
     tokio::fs::create_dir_all(db_dir).await?;
 
+    let database = &crate::config::config().database;
     let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
-
-    // Open the writer first and run migrations on it. WAL mode and
-    // foreign-key enforcement are persisted in the database header /
-    // session state, so once this connects every subsequent connection
-    // (including the read pool) sees the right configuration.
-    let write = build_pool(&db_path, 1, connect_timeout_secs, busy_timeout_secs).await?;
-    Migrator::up(&write, None).await?;
-
-    // Read pool: sized for concurrent readers. WAL allows readers to run
-    // while a write is in progress.
-    let read = build_pool(
+    let pools = DbPools::open(
         &db_path,
-        max_connections,
-        connect_timeout_secs,
-        busy_timeout_secs,
-    )
-    .await?;
-
-    Ok(DbPools { read, write })
-}
-
-async fn build_pool(
-    db_path: &Path,
-    max_connections: u32,
-    connect_timeout_secs: u64,
-    busy_timeout_secs: u64,
-) -> MicrosandboxResult<DatabaseConnection> {
-    microsandbox_db::pool::build_pool(
-        db_path,
-        max_connections,
-        Duration::from_secs(connect_timeout_secs),
-        Duration::from_secs(busy_timeout_secs),
+        database.max_connections,
+        Duration::from_secs(database.connect_timeout_secs),
+        Duration::from_secs(database.busy_timeout_secs),
     )
     .await
-    .map_err(|e| MicrosandboxError::Custom(format!("connect to {}: {e}", db_path.display())))
+    .map_err(|e| MicrosandboxError::Custom(format!("connect to {}: {e}", db_path.display())))?;
+
+    Migrator::up(pools.write().inner(), None).await?;
+
+    Ok(pools)
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -300,10 +141,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db_dir = tmp.path().join("db");
 
-        let conn = connect_and_migrate_pools(&db_dir, 1, 1, 5)
-            .await
-            .unwrap()
-            .read;
+        let pools = connect_and_migrate(&db_dir).await.unwrap();
+        let conn = pools.read();
 
         // DB file should exist on disk.
         assert!(db_dir.join(microsandbox_utils::DB_FILENAME).exists());
@@ -344,13 +183,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db_dir = tmp.path().join("db");
 
-        let conn1 = connect_and_migrate_pools(&db_dir, 1, 1, 5)
-            .await
-            .unwrap()
-            .read;
+        let pools = connect_and_migrate(&db_dir).await.unwrap();
 
         // Running migrations again on the same DB should succeed.
-        Migrator::up(&conn1, None).await.unwrap();
+        Migrator::up(pools.write().inner(), None).await.unwrap();
     }
 
     #[tokio::test]
@@ -427,12 +263,10 @@ mod tests {
 
         drop(conn);
 
-        let recovered = connect_and_migrate_pools(&db_dir, 1, 1, 5)
-            .await
-            .unwrap()
-            .read;
+        let recovered = connect_and_migrate(&db_dir).await.unwrap();
 
         let migration_row_count = recovered
+            .read()
             .query_one(Statement::from_string(
                 DatabaseBackend::Sqlite,
                 "SELECT COUNT(*) FROM seaql_migrations WHERE version = 'm20260305_000003_create_storage_tables'",
@@ -445,6 +279,7 @@ mod tests {
         assert_eq!(migration_row_count, 1);
 
         let index_count = recovered
+            .read()
             .query_one(Statement::from_string(
                 DatabaseBackend::Sqlite,
                 "SELECT COUNT(*) FROM sqlite_master

--- a/crates/microsandbox/lib/error.rs
+++ b/crates/microsandbox/lib/error.rs
@@ -102,3 +102,9 @@ pub enum MicrosandboxError {
     #[error("{0}")]
     Custom(String),
 }
+
+impl microsandbox_db::retry::IsSqliteBusy for MicrosandboxError {
+    fn is_sqlite_busy(&self) -> bool {
+        matches!(self, MicrosandboxError::Database(db_err) if microsandbox_db::retry::is_sqlite_busy(db_err))
+    }
+}

--- a/crates/microsandbox/lib/image/mod.rs
+++ b/crates/microsandbox/lib/image/mod.rs
@@ -6,7 +6,7 @@
 
 use sea_orm::{
     ColumnTrait, ConnectionTrait, EntityTrait, JoinType, PaginatorTrait, QueryFilter, QueryOrder,
-    QuerySelect, RelationTrait, Set, TransactionTrait, sea_query::OnConflict,
+    QuerySelect, RelationTrait, Set, sea_query::OnConflict,
 };
 
 use microsandbox_image::{
@@ -15,10 +15,13 @@ use microsandbox_image::{
 
 use crate::{
     MicrosandboxError, MicrosandboxResult,
-    db::entity::{
-        config as config_entity, image_ref as image_ref_entity, layer as layer_entity,
-        manifest as manifest_entity, manifest_layer as manifest_layer_entity,
-        sandbox_rootfs as sandbox_rootfs_entity,
+    db::{
+        self,
+        entity::{
+            config as config_entity, image_ref as image_ref_entity, layer as layer_entity,
+            manifest as manifest_entity, manifest_layer as manifest_layer_entity,
+            sandbox_rootfs as sandbox_rootfs_entity,
+        },
     },
 };
 
@@ -155,13 +158,14 @@ impl Image {
         reference: &str,
         metadata: CachedImageMetadata,
     ) -> MicrosandboxResult<i32> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
-
+        let pools = db::init_global().await?;
+        let db = pools.write();
         let reference = reference.to_string();
 
-        db.transaction::<_, i32, MicrosandboxError>(|txn| {
-            Box::pin(async move {
+        db.transaction("cache_image", |txn| {
+            let reference = reference.clone();
+            let metadata = metadata.clone();
+            async move {
                 let total_size: i64 = metadata
                     .layers
                     .iter()
@@ -173,7 +177,7 @@ impl Image {
 
                 // 1. Upsert manifest record.
                 let manifest_id = upsert_manifest_record(
-                    txn,
+                    &txn,
                     &metadata.manifest_digest,
                     &metadata.config_digest,
                     &platform,
@@ -183,19 +187,19 @@ impl Image {
                 .await?;
 
                 // 2. Upsert config record.
-                upsert_config_record(txn, manifest_id, &metadata.config_digest, &metadata.config)
+                upsert_config_record(&txn, manifest_id, &metadata.config_digest, &metadata.config)
                     .await?;
 
                 // 3. Clear old manifest_layer entries.
                 manifest_layer_entity::Entity::delete_many()
                     .filter(manifest_layer_entity::Column::ManifestId.eq(manifest_id))
-                    .exec(txn)
+                    .exec(&txn)
                     .await?;
 
                 // 4. Upsert layers and insert junction records.
                 let mut manifest_layers = Vec::with_capacity(metadata.layers.len());
                 for (position, layer_meta) in metadata.layers.iter().enumerate() {
-                    let layer_id = upsert_layer_record(txn, layer_meta).await?;
+                    let layer_id = upsert_layer_record(&txn, layer_meta).await?;
                     manifest_layers.push(manifest_layer_entity::ActiveModel {
                         manifest_id: Set(manifest_id),
                         layer_id: Set(layer_id),
@@ -205,27 +209,22 @@ impl Image {
                 }
                 if !manifest_layers.is_empty() {
                     manifest_layer_entity::Entity::insert_many(manifest_layers)
-                        .exec(txn)
+                        .exec(&txn)
                         .await?;
                 }
 
                 // 5. Upsert image_ref record.
-                let image_ref_id = upsert_image_ref_record(txn, &reference, manifest_id).await?;
+                let image_ref_id = upsert_image_ref_record(&txn, &reference, manifest_id).await?;
 
-                Ok(image_ref_id)
-            })
+                Ok((txn, image_ref_id))
+            }
         })
         .await
-        .map_err(|err| match err {
-            sea_orm::TransactionError::Connection(db_err) => db_err.into(),
-            sea_orm::TransactionError::Transaction(err) => err,
-        })
     }
 
     /// Get an image handle by reference.
     pub async fn get(reference: &str) -> MicrosandboxResult<ImageHandle> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = db::init_global().await?.read();
 
         let (image_ref_model, manifest) = image_ref_entity::Entity::find()
             .filter(image_ref_entity::Column::Reference.eq(reference))
@@ -243,8 +242,7 @@ impl Image {
 
     /// List all cached images, ordered by creation time (newest first).
     pub async fn list() -> MicrosandboxResult<Vec<ImageHandle>> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = db::init_global().await?.read();
 
         let models = image_ref_entity::Entity::find()
             .order_by_desc(image_ref_entity::Column::CreatedAt)
@@ -261,8 +259,7 @@ impl Image {
 
     /// Get full detail for an image (config + layers).
     pub async fn inspect(reference: &str) -> MicrosandboxResult<ImageDetail> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = db::init_global().await?.read();
 
         let image_ref_model = image_ref_entity::Entity::find()
             .filter(image_ref_entity::Column::Reference.eq(reference))
@@ -356,12 +353,12 @@ impl Image {
     /// If `force` is false and the image is referenced by any sandbox, returns
     /// [`MicrosandboxError::ImageInUse`].
     pub async fn remove(reference: &str, force: bool) -> MicrosandboxResult<()> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let pools = db::init_global().await?;
+        let db = pools.write();
 
         let image_ref_model = image_ref_entity::Entity::find()
             .filter(image_ref_entity::Column::Reference.eq(reference))
-            .one(db)
+            .one(pools.read())
             .await?
             .ok_or_else(|| MicrosandboxError::ImageNotFound(reference.into()))?;
 
@@ -369,88 +366,82 @@ impl Image {
         let image_ref_id = image_ref_model.id;
 
         let (layer_diff_ids, flat_manifest_digest) = db
-            .transaction::<_, (Vec<String>, Option<String>), MicrosandboxError>(|txn| {
-                Box::pin(async move {
-                    // Check sandbox references inside transaction to avoid TOCTOU.
-                    if !force {
-                        let refs = sandbox_rootfs_entity::Entity::find()
-                            .filter(sandbox_rootfs_entity::Column::ManifestId.eq(manifest_id))
-                            .all(txn)
-                            .await?;
-                        if !refs.is_empty() {
-                            let sandbox_ids: Vec<String> =
-                                refs.iter().map(|r| r.sandbox_id.to_string()).collect();
-                            return Err(MicrosandboxError::ImageInUse(sandbox_ids.join(", ")));
-                        }
+            .transaction("remove_image", |txn| async move {
+                // Check sandbox references inside transaction to avoid TOCTOU.
+                if !force {
+                    let refs = sandbox_rootfs_entity::Entity::find()
+                        .filter(sandbox_rootfs_entity::Column::ManifestId.eq(manifest_id))
+                        .all(&txn)
+                        .await?;
+                    if !refs.is_empty() {
+                        let sandbox_ids: Vec<String> =
+                            refs.iter().map(|r| r.sandbox_id.to_string()).collect();
+                        return Err(MicrosandboxError::ImageInUse(sandbox_ids.join(", ")));
                     }
+                }
 
-                    let manifest_digest = manifest_entity::Entity::find_by_id(manifest_id)
-                        .one(txn)
-                        .await?
-                        .map(|manifest| manifest.digest);
+                let manifest_digest = manifest_entity::Entity::find_by_id(manifest_id)
+                    .one(&txn)
+                    .await?
+                    .map(|manifest| manifest.digest);
 
-                    // Collect layer diff_ids before cascade delete removes junction rows.
-                    let layer_diff_ids: Vec<String> = layer_entity::Entity::find()
-                        .join(
-                            JoinType::InnerJoin,
-                            layer_entity::Relation::ManifestLayer.def(),
-                        )
-                        .filter(manifest_layer_entity::Column::ManifestId.eq(manifest_id))
-                        .all(txn)
-                        .await?
-                        .into_iter()
-                        .map(|l| l.diff_id)
-                        .collect();
+                // Collect layer diff_ids before cascade delete removes junction rows.
+                let layer_diff_ids: Vec<String> = layer_entity::Entity::find()
+                    .join(
+                        JoinType::InnerJoin,
+                        layer_entity::Relation::ManifestLayer.def(),
+                    )
+                    .filter(manifest_layer_entity::Column::ManifestId.eq(manifest_id))
+                    .all(&txn)
+                    .await?
+                    .into_iter()
+                    .map(|l| l.diff_id)
+                    .collect();
 
-                    // Delete the image_ref.
-                    image_ref_entity::Entity::delete_by_id(image_ref_id)
-                        .exec(txn)
+                // Delete the image_ref.
+                image_ref_entity::Entity::delete_by_id(image_ref_id)
+                    .exec(&txn)
+                    .await?;
+
+                // Check if any other image_refs still point to this manifest.
+                let remaining_refs = image_ref_entity::Entity::find()
+                    .filter(image_ref_entity::Column::ManifestId.eq(manifest_id))
+                    .count(&txn)
+                    .await?;
+
+                if remaining_refs == 0 {
+                    // No more references — delete manifest (cascades to config, manifest_layers).
+                    manifest_entity::Entity::delete_by_id(manifest_id)
+                        .exec(&txn)
                         .await?;
 
-                    // Check if any other image_refs still point to this manifest.
-                    let remaining_refs = image_ref_entity::Entity::find()
-                        .filter(image_ref_entity::Column::ManifestId.eq(manifest_id))
-                        .count(txn)
-                        .await?;
-
-                    if remaining_refs == 0 {
-                        // No more references — delete manifest (cascades to config, manifest_layers).
-                        manifest_entity::Entity::delete_by_id(manifest_id)
-                            .exec(txn)
+                    // Clean up orphaned layers with zero remaining manifest refs.
+                    let mut orphaned = Vec::new();
+                    for diff_id in &layer_diff_ids {
+                        let refs = manifest_layer_entity::Entity::find()
+                            .join(
+                                JoinType::InnerJoin,
+                                manifest_layer_entity::Relation::Layer.def(),
+                            )
+                            .filter(layer_entity::Column::DiffId.eq(diff_id.as_str()))
+                            .count(&txn)
                             .await?;
 
-                        // Clean up orphaned layers with zero remaining manifest refs.
-                        let mut orphaned = Vec::new();
-                        for diff_id in &layer_diff_ids {
-                            let refs = manifest_layer_entity::Entity::find()
-                                .join(
-                                    JoinType::InnerJoin,
-                                    manifest_layer_entity::Relation::Layer.def(),
-                                )
+                        if refs == 0 {
+                            layer_entity::Entity::delete_many()
                                 .filter(layer_entity::Column::DiffId.eq(diff_id.as_str()))
-                                .count(txn)
+                                .exec(&txn)
                                 .await?;
-
-                            if refs == 0 {
-                                layer_entity::Entity::delete_many()
-                                    .filter(layer_entity::Column::DiffId.eq(diff_id.as_str()))
-                                    .exec(txn)
-                                    .await?;
-                                orphaned.push(diff_id.clone());
-                            }
+                            orphaned.push(diff_id.clone());
                         }
-
-                        return Ok((orphaned, manifest_digest));
                     }
 
-                    Ok((Vec::new(), None))
-                })
+                    return Ok((txn, (orphaned, manifest_digest)));
+                }
+
+                Ok((txn, (Vec::new(), None)))
             })
-            .await
-            .map_err(|err| match err {
-                sea_orm::TransactionError::Connection(db_err) => db_err.into(),
-                sea_orm::TransactionError::Transaction(err) => err,
-            })?;
+            .await?;
 
         // Best-effort on-disk cleanup (outside transaction).
         let cache_dir = crate::config::config().cache_dir();
@@ -484,14 +475,13 @@ impl Image {
     ///
     /// Returns the number of layers removed.
     pub async fn gc_layers() -> MicrosandboxResult<u32> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let pools = db::init_global().await?;
 
         // Find layers with zero manifest_layer references.
         let orphans: Vec<layer_entity::Model> = layer_entity::Entity::find()
             .left_join(manifest_layer_entity::Entity)
             .filter(manifest_layer_entity::Column::Id.is_null())
-            .all(db)
+            .all(pools.read())
             .await?;
 
         let cache_dir = crate::config::config().cache_dir();
@@ -500,7 +490,7 @@ impl Image {
 
         for orphan in &orphans {
             layer_entity::Entity::delete_by_id(orphan.id)
-                .exec(db)
+                .exec(pools.write())
                 .await?;
 
             // Best-effort on-disk cleanup.

--- a/crates/microsandbox/lib/sandbox/handle.rs
+++ b/crates/microsandbox/lib/sandbox/handle.rs
@@ -94,8 +94,7 @@ impl SandboxHandle {
             )));
         }
 
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?.read();
         super::metrics::metrics_for_sandbox(
             db,
             self.db_id,
@@ -179,8 +178,7 @@ impl SandboxHandle {
         let all_dead = pids.is_empty() || pids.iter().all(|pid| !super::pid_is_alive(*pid));
 
         if all_dead {
-            let db = crate::db::init_global(Some(crate::config::config().database.max_connections))
-                .await?;
+            let db = crate::db::init_global().await?.write();
             if let Err(e) =
                 super::update_sandbox_status(db, self.db_id, SandboxStatus::Stopped).await
             {
@@ -204,12 +202,11 @@ impl SandboxHandle {
             )));
         }
 
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let pools = crate::db::init_global().await?;
 
         super::remove_dir_if_exists(&crate::config::config().sandboxes_dir().join(&self.name))?;
         sandbox_entity::Entity::delete_by_id(self.db_id)
-            .exec(db)
+            .exec(pools.write())
             .await?;
 
         Ok(())

--- a/crates/microsandbox/lib/sandbox/metrics.rs
+++ b/crates/microsandbox/lib/sandbox/metrics.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use futures::stream;
+use microsandbox_db::DbReadConnection;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
 
 use crate::{
@@ -47,8 +48,7 @@ pub struct SandboxMetrics {
 impl Sandbox {
     /// Get the latest metrics snapshot for this running sandbox.
     pub async fn metrics(&self) -> MicrosandboxResult<SandboxMetrics> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?.read();
         metrics_for_sandbox(db, self.db_id, memory_limit_bytes(&self.config)).await
     }
 
@@ -69,11 +69,9 @@ impl Sandbox {
             tokio::time::interval(interval),
             move |mut ticker| async move {
                 ticker.tick().await;
-                let db =
-                    crate::db::init_global(Some(crate::config::config().database.max_connections))
-                        .await;
-                let item = match db {
-                    Ok(db) => metrics_for_sandbox(db, db_id, memory_limit_bytes).await,
+                let pools = crate::db::init_global().await;
+                let item = match pools {
+                    Ok(pools) => metrics_for_sandbox(pools.read(), db_id, memory_limit_bytes).await,
                     Err(err) => Err(err),
                 };
                 Some((item, ticker))
@@ -88,7 +86,8 @@ impl Sandbox {
 
 /// Get the latest metrics snapshot for every running sandbox.
 pub async fn all_sandbox_metrics() -> MicrosandboxResult<HashMap<String, SandboxMetrics>> {
-    let db = crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+    let pools = crate::db::init_global().await?;
+    let db = pools.read();
     let sandboxes = sandbox_entity::Entity::find()
         .filter(
             sandbox_entity::Column::Status.is_in([SandboxStatus::Running, SandboxStatus::Draining]),
@@ -99,7 +98,7 @@ pub async fn all_sandbox_metrics() -> MicrosandboxResult<HashMap<String, Sandbox
 
     let mut metrics = HashMap::with_capacity(sandboxes.len());
     for sandbox in sandboxes {
-        let sandbox = super::reconcile_sandbox_runtime_state(db, sandbox).await?;
+        let sandbox = super::reconcile_sandbox_runtime_state(pools, sandbox).await?;
         if !matches!(
             sandbox.status,
             SandboxStatus::Running | SandboxStatus::Draining
@@ -116,7 +115,7 @@ pub async fn all_sandbox_metrics() -> MicrosandboxResult<HashMap<String, Sandbox
 }
 
 pub(super) async fn metrics_for_sandbox(
-    db: &sea_orm::DatabaseConnection,
+    db: &DbReadConnection,
     sandbox_id: i32,
     memory_limit_bytes: u64,
 ) -> MicrosandboxResult<SandboxMetrics> {
@@ -176,7 +175,7 @@ pub(super) async fn metrics_for_sandbox(
 }
 
 async fn latest_metric(
-    db: &sea_orm::DatabaseConnection,
+    db: &DbReadConnection,
     sandbox_id: i32,
 ) -> MicrosandboxResult<Option<sandbox_metric_entity::Model>> {
     sandbox_metric_entity::Entity::find()

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -18,14 +18,15 @@ mod types;
 use std::{collections::HashMap, path::Path, process::ExitStatus, sync::Arc};
 
 use bytes::Bytes;
+use microsandbox_db::pool::DbPools;
+use microsandbox_db::{DbReadConnection, DbWriteConnection};
 use microsandbox_image::Registry;
 use microsandbox_protocol::{
     exec::{ExecExited, ExecRequest, ExecRlimit, ExecStarted, ExecStderr, ExecStdin, ExecStdout},
     message::{Message, MessageType},
 };
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
-    sea_query::Expr,
+    ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set, sea_query::Expr,
 };
 use tokio::sync::{Mutex, mpsc};
 
@@ -199,7 +200,7 @@ impl Sandbox {
 
         // Initialize the database before any expensive image pull so we can
         // fail fast on conflicting persisted sandbox state.
-        let db = db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = db::init_global().await?;
         let sandbox_dir = crate::config::config().sandboxes_dir().join(&config.name);
         prepare_create_target(db, &config, &sandbox_dir).await?;
 
@@ -280,7 +281,8 @@ impl Sandbox {
         }
 
         // Insert the sandbox record and keep its stable database ID.
-        let sandbox_id = insert_sandbox_record(db, &config).await?;
+        let write_db = db.write();
+        let sandbox_id = insert_sandbox_record(write_db, &config).await?;
         tracing::debug!(sandbox_id, sandbox = %config.name, "create_with_mode: db record inserted");
 
         // Spawn the sandbox process and create the bridge. On failure, mark the sandbox
@@ -288,7 +290,7 @@ impl Sandbox {
         let sandbox = match Self::create_inner(config, sandbox_id, mode).await {
             Ok(sandbox) => sandbox,
             Err(e) => {
-                let _ = update_sandbox_status(db, sandbox_id, SandboxStatus::Stopped).await;
+                let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
                 return Err(e);
             }
         };
@@ -296,10 +298,10 @@ impl Sandbox {
         if let (Some(_reference), Some(manifest_digest)) = (
             pinned_reference.as_deref(),
             pinned_manifest_digest.as_deref(),
-        ) && let Err(err) = persist_oci_manifest_pin(db, sandbox_id, manifest_digest).await
+        ) && let Err(err) = persist_oci_manifest_pin(write_db, sandbox_id, manifest_digest).await
         {
             let _ = sandbox.stop().await;
-            let _ = update_sandbox_status(db, sandbox_id, SandboxStatus::Stopped).await;
+            let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
             return Err(err);
         }
 
@@ -308,7 +310,7 @@ impl Sandbox {
             && !sandbox.fs().exists(workdir).await.unwrap_or(false)
         {
             let _ = sandbox.stop().await;
-            let _ = update_sandbox_status(db, sandbox_id, SandboxStatus::Stopped).await;
+            let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
             return Err(crate::MicrosandboxError::InvalidConfig(format!(
                 "workdir does not exist in guest: {workdir}"
             )));
@@ -319,8 +321,9 @@ impl Sandbox {
 
     pub(super) async fn start_with_mode(name: &str, mode: SpawnMode) -> MicrosandboxResult<Self> {
         tracing::debug!(sandbox = name, ?mode, "start_with_mode: loading record");
-        let db = db::init_global(Some(crate::config::config().database.max_connections)).await?;
-        let model = load_sandbox_record_reconciled(db, name).await?;
+        let pools = db::init_global().await?;
+        let write_db = pools.write();
+        let model = load_sandbox_record_reconciled(pools, name).await?;
         tracing::debug!(sandbox = name, status = ?model.status, "start_with_mode: current status");
 
         if model.status == SandboxStatus::Running || model.status == SandboxStatus::Draining {
@@ -340,12 +343,12 @@ impl Sandbox {
         config.apply_runtime_defaults();
         validate_rootfs_source(&config.image)?;
         validate_start_state(&config, &crate::config::config().sandboxes_dir().join(name))?;
-        update_sandbox_status(db, model.id, SandboxStatus::Running).await?;
+        update_sandbox_status(write_db, model.id, SandboxStatus::Running).await?;
 
         match Self::create_inner(config, model.id, mode).await {
             Ok(sandbox) => Ok(sandbox),
             Err(err) => {
-                let _ = update_sandbox_status(db, model.id, SandboxStatus::Stopped).await;
+                let _ = update_sandbox_status(write_db, model.id, SandboxStatus::Stopped).await;
                 Err(err)
             }
         }
@@ -379,35 +382,35 @@ impl Sandbox {
 
     /// Get a sandbox handle by name from the database.
     pub async fn get(name: &str) -> MicrosandboxResult<SandboxHandle> {
-        let db = db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let pools = db::init_global().await?;
 
         let model = sandbox_entity::Entity::find()
             .filter(sandbox_entity::Column::Name.eq(name))
-            .one(db)
+            .one(pools.read())
             .await?
             .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(name.into()))?;
 
-        let model = reconcile_sandbox_runtime_state(db, model).await?;
-        build_handle(db, model).await
+        let model = reconcile_sandbox_runtime_state(pools, model).await?;
+        build_handle(pools.read(), model).await
     }
 
     /// List all sandboxes from the database.
     pub async fn list() -> MicrosandboxResult<Vec<SandboxHandle>> {
-        let db = db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let pools = db::init_global().await?;
 
         let sandboxes = sandbox_entity::Entity::find()
             .order_by_desc(sandbox_entity::Column::CreatedAt)
-            .all(db)
+            .all(pools.read())
             .await?;
 
         let mut reconciled = Vec::with_capacity(sandboxes.len());
         for sandbox in sandboxes {
-            let model = reconcile_sandbox_runtime_state(db, sandbox).await?;
+            let model = reconcile_sandbox_runtime_state(pools, sandbox).await?;
             reconciled.push(model);
         }
 
         let sandbox_ids: Vec<i32> = reconciled.iter().map(|sandbox| sandbox.id).collect();
-        let active_pids = load_active_pids(db, &sandbox_ids).await?;
+        let active_pids = load_active_pids(pools.read(), &sandbox_ids).await?;
         let mut handles = Vec::with_capacity(reconciled.len());
         for sandbox in reconciled {
             handles.push(build_handle_with_pid(
@@ -434,7 +437,7 @@ impl Sandbox {
 impl Sandbox {
     /// Remove this sandbox's persisted state after it has fully stopped.
     pub async fn remove_persisted(self) -> MicrosandboxResult<()> {
-        let db = db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let pools = db::init_global().await?;
 
         remove_dir_if_exists(
             &crate::config::config()
@@ -442,7 +445,7 @@ impl Sandbox {
                 .join(&self.config.name),
         )?;
         sandbox_entity::Entity::delete_by_id(self.db_id)
-            .exec(db)
+            .exec(pools.write())
             .await?;
 
         Ok(())
@@ -1054,7 +1057,7 @@ async fn wait_for_relay(
 
 /// Build a [`SandboxHandle`] by eagerly loading the microVM PID.
 async fn build_handle(
-    db: &sea_orm::DatabaseConnection,
+    db: &DbReadConnection,
     model: sandbox_entity::Model,
 ) -> MicrosandboxResult<SandboxHandle> {
     let run = load_active_run(db, model.id).await?;
@@ -1208,11 +1211,11 @@ async fn event_mapper_task(
 
 /// Update the sandbox status in the database.
 pub(super) async fn update_sandbox_status(
-    db: &sea_orm::DatabaseConnection,
+    db: &DbWriteConnection,
     sandbox_id: i32,
     status: SandboxStatus,
 ) -> MicrosandboxResult<()> {
-    db::with_retry_transaction(db, "update_sandbox_status", |txn| async move {
+    db.transaction("update_sandbox_status", |txn| async move {
         sandbox_entity::Entity::update_many()
             .col_expr(sandbox_entity::Column::Status, Expr::value(status))
             .col_expr(
@@ -1242,19 +1245,19 @@ pub(super) async fn update_sandbox_status(
 /// from updating the database on exit are cleaned up without blocking the
 /// main path.
 pub async fn reap_stale_sandboxes() -> MicrosandboxResult<()> {
-    let db = db::init_global(Some(crate::config::config().database.max_connections)).await?;
+    let pools = db::init_global().await?;
 
     let stale = sandbox_entity::Entity::find()
         .filter(
             sandbox_entity::Column::Status.is_in([SandboxStatus::Running, SandboxStatus::Draining]),
         )
-        .all(db)
+        .all(pools.read())
         .await?;
 
     for sandbox in stale {
         // Best-effort: ignore per-sandbox errors so one bad record does not
         // prevent the rest from being reaped.
-        let _ = reconcile_sandbox_runtime_state(db, sandbox).await;
+        let _ = reconcile_sandbox_runtime_state(pools, sandbox).await;
     }
 
     Ok(())
@@ -1289,15 +1292,15 @@ pub fn spawn_reaper() {
 //--------------------------------------------------------------------------------------------------
 
 pub(super) async fn load_sandbox_record_reconciled(
-    db: &sea_orm::DatabaseConnection,
+    pools: &DbPools,
     name: &str,
 ) -> MicrosandboxResult<sandbox_entity::Model> {
-    let sandbox = load_sandbox_record(db, name).await?;
-    reconcile_sandbox_runtime_state(db, sandbox).await
+    let sandbox = load_sandbox_record(pools.read(), name).await?;
+    reconcile_sandbox_runtime_state(pools, sandbox).await
 }
 
 pub(super) async fn reconcile_sandbox_runtime_state(
-    db: &sea_orm::DatabaseConnection,
+    pools: &DbPools,
     sandbox: sandbox_entity::Model,
 ) -> MicrosandboxResult<sandbox_entity::Model> {
     if !matches!(
@@ -1307,7 +1310,7 @@ pub(super) async fn reconcile_sandbox_runtime_state(
         return Ok(sandbox);
     }
 
-    let run = load_active_run(db, sandbox.id).await?;
+    let run = load_active_run(pools.read(), sandbox.id).await?;
 
     // No run record yet — the sandbox is still starting up (the child
     // process has not inserted its PID). Skip reconciliation to avoid
@@ -1320,16 +1323,16 @@ pub(super) async fn reconcile_sandbox_runtime_state(
         return Ok(sandbox);
     }
 
-    mark_sandbox_runtime_stale(db, sandbox.id, Some(run.id)).await?;
+    mark_sandbox_runtime_stale(pools.write(), sandbox.id, Some(run.id)).await?;
 
     sandbox_entity::Entity::find_by_id(sandbox.id)
-        .one(db)
+        .one(pools.read())
         .await?
         .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(sandbox.name))
 }
 
 pub(super) async fn load_active_run(
-    db: &sea_orm::DatabaseConnection,
+    db: &DbReadConnection,
     sandbox_id: i32,
 ) -> MicrosandboxResult<Option<run_entity::Model>> {
     run_entity::Entity::find()
@@ -1342,7 +1345,7 @@ pub(super) async fn load_active_run(
 }
 
 async fn load_active_pids(
-    db: &sea_orm::DatabaseConnection,
+    db: &DbReadConnection,
     sandbox_ids: &[i32],
 ) -> MicrosandboxResult<HashMap<i32, i32>> {
     if sandbox_ids.is_empty() {
@@ -1379,46 +1382,48 @@ fn pid_from_run(run: Option<&run_entity::Model>) -> Option<i32> {
 }
 
 async fn mark_sandbox_runtime_stale(
-    db: &sea_orm::DatabaseConnection,
+    db: &DbWriteConnection,
     sandbox_id: i32,
     run_id: Option<i32>,
 ) -> MicrosandboxResult<()> {
-    let txn = db.begin().await?;
-    let now = chrono::Utc::now().naive_utc();
+    db.transaction("mark_sandbox_runtime_stale", |txn| async move {
+        let now = chrono::Utc::now().naive_utc();
 
-    if let Some(run_id) = run_id {
-        run_entity::Entity::update_many()
+        if let Some(run_id) = run_id {
+            run_entity::Entity::update_many()
+                .col_expr(
+                    run_entity::Column::Status,
+                    Expr::value(run_entity::RunStatus::Terminated),
+                )
+                .col_expr(
+                    run_entity::Column::TerminationReason,
+                    Expr::value(run_entity::TerminationReason::InternalError),
+                )
+                .col_expr(run_entity::Column::TerminatedAt, Expr::value(now))
+                .filter(run_entity::Column::Id.eq(run_id))
+                .exec(&txn)
+                .await?;
+        }
+
+        // Only mark Crashed if the sandbox is still Running or Draining. This
+        // prevents a concurrent start() from having its Running status overwritten.
+        sandbox_entity::Entity::update_many()
             .col_expr(
-                run_entity::Column::Status,
-                Expr::value(run_entity::RunStatus::Terminated),
+                sandbox_entity::Column::Status,
+                Expr::value(SandboxStatus::Crashed),
             )
-            .col_expr(
-                run_entity::Column::TerminationReason,
-                Expr::value(run_entity::TerminationReason::InternalError),
+            .col_expr(sandbox_entity::Column::UpdatedAt, Expr::value(now))
+            .filter(sandbox_entity::Column::Id.eq(sandbox_id))
+            .filter(
+                sandbox_entity::Column::Status
+                    .is_in([SandboxStatus::Running, SandboxStatus::Draining]),
             )
-            .col_expr(run_entity::Column::TerminatedAt, Expr::value(now))
-            .filter(run_entity::Column::Id.eq(run_id))
             .exec(&txn)
             .await?;
-    }
 
-    // Only mark Crashed if the sandbox is still Running or Draining. This
-    // prevents a concurrent start() from having its Running status overwritten.
-    sandbox_entity::Entity::update_many()
-        .col_expr(
-            sandbox_entity::Column::Status,
-            Expr::value(SandboxStatus::Crashed),
-        )
-        .col_expr(sandbox_entity::Column::UpdatedAt, Expr::value(now))
-        .filter(sandbox_entity::Column::Id.eq(sandbox_id))
-        .filter(
-            sandbox_entity::Column::Status.is_in([SandboxStatus::Running, SandboxStatus::Draining]),
-        )
-        .exec(&txn)
-        .await?;
-
-    txn.commit().await?;
-    Ok(())
+        Ok((txn, ()))
+    })
+    .await
 }
 
 pub(super) fn pid_is_alive(pid: i32) -> bool {
@@ -1570,7 +1575,7 @@ pub(super) fn remove_dir_if_exists(path: &Path) -> MicrosandboxResult<()> {
 
 /// Load a sandbox row by name.
 pub(super) async fn load_sandbox_record(
-    db: &sea_orm::DatabaseConnection,
+    db: &DbReadConnection,
     name: &str,
 ) -> MicrosandboxResult<sandbox_entity::Model> {
     sandbox_entity::Entity::find()
@@ -1581,13 +1586,13 @@ pub(super) async fn load_sandbox_record(
 }
 
 async fn prepare_create_target(
-    db: &sea_orm::DatabaseConnection,
+    pools: &DbPools,
     config: &SandboxConfig,
     sandbox_dir: &Path,
 ) -> MicrosandboxResult<()> {
     let existing = sandbox_entity::Entity::find()
         .filter(sandbox_entity::Column::Name.eq(&config.name))
-        .one(db)
+        .one(pools.read())
         .await?;
 
     let dir_exists = sandbox_dir.exists();
@@ -1604,16 +1609,16 @@ async fn prepare_create_target(
     }
 
     if let Some(model) = existing {
-        let model = reconcile_sandbox_runtime_state(db, model).await?;
+        let model = reconcile_sandbox_runtime_state(pools, model).await?;
         if matches!(
             model.status,
             SandboxStatus::Running | SandboxStatus::Draining | SandboxStatus::Paused
         ) {
-            stop_sandbox_for_replacement(db, &model).await?;
+            stop_sandbox_for_replacement(pools, &model).await?;
         }
 
         sandbox_entity::Entity::delete_by_id(model.id)
-            .exec(db)
+            .exec(pools.write())
             .await?;
     }
 
@@ -1622,10 +1627,10 @@ async fn prepare_create_target(
 }
 
 async fn stop_sandbox_for_replacement(
-    db: &sea_orm::DatabaseConnection,
+    pools: &DbPools,
     sandbox: &sandbox_entity::Model,
 ) -> MicrosandboxResult<()> {
-    let run = load_active_run(db, sandbox.id).await?;
+    let run = load_active_run(pools.read(), sandbox.id).await?;
     let pids: Vec<i32> = run
         .as_ref()
         .and_then(|model| model.pid)
@@ -1649,45 +1654,51 @@ async fn stop_sandbox_for_replacement(
         )));
     }
 
-    mark_sandbox_stopped_for_replacement(db, sandbox.id, run.as_ref().map(|model| model.id)).await
+    mark_sandbox_stopped_for_replacement(
+        pools.write(),
+        sandbox.id,
+        run.as_ref().map(|model| model.id),
+    )
+    .await
 }
 
 async fn mark_sandbox_stopped_for_replacement(
-    db: &sea_orm::DatabaseConnection,
+    db: &DbWriteConnection,
     sandbox_id: i32,
     run_id: Option<i32>,
 ) -> MicrosandboxResult<()> {
-    let txn = db.begin().await?;
-    let now = chrono::Utc::now().naive_utc();
+    db.transaction("mark_sandbox_stopped_for_replacement", |txn| async move {
+        let now = chrono::Utc::now().naive_utc();
 
-    if let Some(run_id) = run_id {
-        run_entity::Entity::update_many()
+        if let Some(run_id) = run_id {
+            run_entity::Entity::update_many()
+                .col_expr(
+                    run_entity::Column::Status,
+                    Expr::value(run_entity::RunStatus::Terminated),
+                )
+                .col_expr(
+                    run_entity::Column::TerminationReason,
+                    Expr::value(run_entity::TerminationReason::Signal),
+                )
+                .col_expr(run_entity::Column::TerminatedAt, Expr::value(now))
+                .filter(run_entity::Column::Id.eq(run_id))
+                .exec(&txn)
+                .await?;
+        }
+
+        sandbox_entity::Entity::update_many()
             .col_expr(
-                run_entity::Column::Status,
-                Expr::value(run_entity::RunStatus::Terminated),
+                sandbox_entity::Column::Status,
+                Expr::value(SandboxStatus::Stopped),
             )
-            .col_expr(
-                run_entity::Column::TerminationReason,
-                Expr::value(run_entity::TerminationReason::Signal),
-            )
-            .col_expr(run_entity::Column::TerminatedAt, Expr::value(now))
-            .filter(run_entity::Column::Id.eq(run_id))
+            .col_expr(sandbox_entity::Column::UpdatedAt, Expr::value(now))
+            .filter(sandbox_entity::Column::Id.eq(sandbox_id))
             .exec(&txn)
             .await?;
-    }
 
-    sandbox_entity::Entity::update_many()
-        .col_expr(
-            sandbox_entity::Column::Status,
-            Expr::value(SandboxStatus::Stopped),
-        )
-        .col_expr(sandbox_entity::Column::UpdatedAt, Expr::value(now))
-        .filter(sandbox_entity::Column::Id.eq(sandbox_id))
-        .exec(&txn)
-        .await?;
-
-    txn.commit().await?;
-    Ok(())
+        Ok((txn, ()))
+    })
+    .await
 }
 
 async fn wait_for_pids_to_exit(pids: &[i32], timeout: std::time::Duration) {
@@ -1739,12 +1750,12 @@ fn validate_start_state(config: &SandboxConfig, sandbox_dir: &Path) -> Microsand
 
 /// Insert the sandbox record in the database and return its ID.
 async fn insert_sandbox_record(
-    db: &sea_orm::DatabaseConnection,
+    db: &DbWriteConnection,
     config: &SandboxConfig,
 ) -> MicrosandboxResult<i32> {
     let config_json = serde_json::to_string(config)?;
 
-    db::with_retry_transaction(db, "insert_sandbox_record", |txn| {
+    db.transaction("insert_sandbox_record", |txn| {
         let config_json = config_json.clone();
         async move {
             let now = chrono::Utc::now().naive_utc();
@@ -1764,11 +1775,11 @@ async fn insert_sandbox_record(
 }
 
 async fn persist_oci_manifest_pin(
-    db: &sea_orm::DatabaseConnection,
+    db: &DbWriteConnection,
     sandbox_id: i32,
     manifest_digest: &str,
 ) -> MicrosandboxResult<()> {
-    db::with_retry_transaction(db, "persist_oci_manifest_pin", |txn| async move {
+    db.transaction("persist_oci_manifest_pin", |txn| async move {
         replace_oci_manifest_pin(&txn, sandbox_id, manifest_digest).await?;
         Ok((txn, ()))
     })
@@ -1870,8 +1881,9 @@ mod tests {
     };
 
     use microsandbox_db::entity::{run as run_entity, sandbox_rootfs as sandbox_rootfs_entity};
+    use microsandbox_db::pool::DbPools;
     use microsandbox_migration::{Migrator, MigratorTrait};
-    use sea_orm::{ColumnTrait, ConnectOptions, Database, EntityTrait, QueryFilter, Set};
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
     use tempfile::tempdir;
 
     use super::{
@@ -1879,6 +1891,20 @@ mod tests {
         persist_oci_manifest_pin, prepare_create_target, reconcile_sandbox_runtime_state,
         remove_dir_if_exists, validate_rootfs_source,
     };
+
+    /// Open both pools at `db_path` for tests, with migrations applied.
+    async fn open_test_pools(db_path: &std::path::Path) -> DbPools {
+        let pools = DbPools::open(
+            db_path,
+            1,
+            std::time::Duration::from_secs(1),
+            std::time::Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        Migrator::up(pools.write().inner(), None).await.unwrap();
+        pools
+    }
 
     fn unique_temp_path(suffix: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -2032,11 +2058,7 @@ mod tests {
     async fn test_persist_oci_manifest_pin_upserts_rootfs_record() {
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let conn = Database::connect(ConnectOptions::new(&db_url))
-            .await
-            .unwrap();
-        Migrator::up(&conn, None).await.unwrap();
+        let pools = open_test_pools(&db_path).await;
 
         let mut config = SandboxConfig {
             name: "pinned".into(),
@@ -2044,11 +2066,11 @@ mod tests {
             ..Default::default()
         };
         config.manifest_digest = Some("sha256:aaaa".into());
-        let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
 
         // First pin (no matching manifest in DB, so manifest_id will be None).
         persist_oci_manifest_pin(
-            &conn,
+            pools.write(),
             sandbox_id,
             "sha256:1111111111111111111111111111111111111111111111111111111111111111",
         )
@@ -2057,7 +2079,7 @@ mod tests {
 
         // Second pin replaces the first.
         persist_oci_manifest_pin(
-            &conn,
+            pools.write(),
             sandbox_id,
             "sha256:2222222222222222222222222222222222222222222222222222222222222222",
         )
@@ -2065,7 +2087,7 @@ mod tests {
         .unwrap();
 
         let pins = sandbox_rootfs_entity::Entity::find()
-            .all(&conn)
+            .all(pools.write())
             .await
             .unwrap();
         assert_eq!(pins.len(), 1);
@@ -2078,11 +2100,7 @@ mod tests {
     async fn test_persist_oci_manifest_pin_replaces_stale_pin_for_different_digest() {
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let conn = Database::connect(ConnectOptions::new(&db_url))
-            .await
-            .unwrap();
-        Migrator::up(&conn, None).await.unwrap();
+        let pools = open_test_pools(&db_path).await;
 
         let mut config = SandboxConfig {
             name: "recreated".into(),
@@ -2090,10 +2108,10 @@ mod tests {
             ..Default::default()
         };
         config.manifest_digest = Some("sha256:aaaa".into());
-        let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
 
         persist_oci_manifest_pin(
-            &conn,
+            pools.write(),
             sandbox_id,
             "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         )
@@ -2102,7 +2120,7 @@ mod tests {
 
         // Replacing with a different digest should delete the old pin.
         persist_oci_manifest_pin(
-            &conn,
+            pools.write(),
             sandbox_id,
             "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         )
@@ -2110,7 +2128,7 @@ mod tests {
         .unwrap();
 
         let pins = sandbox_rootfs_entity::Entity::find()
-            .all(&conn)
+            .all(pools.write())
             .await
             .unwrap();
         assert_eq!(pins.len(), 1);
@@ -2123,11 +2141,7 @@ mod tests {
     async fn test_insert_sandbox_record_persists_manifest_digest_in_config_json() {
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let conn = Database::connect(ConnectOptions::new(&db_url))
-            .await
-            .unwrap();
-        Migrator::up(&conn, None).await.unwrap();
+        let pools = open_test_pools(&db_path).await;
 
         let mut config = SandboxConfig {
             name: "persisted-digest".into(),
@@ -2136,9 +2150,9 @@ mod tests {
         };
         config.manifest_digest = Some("sha256:abc123".into());
 
-        let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
         let row = super::sandbox_entity::Entity::find_by_id(sandbox_id)
-            .one(&conn)
+            .one(pools.write())
             .await
             .unwrap()
             .unwrap();
@@ -2151,11 +2165,7 @@ mod tests {
     async fn test_prepare_create_target_rejects_existing_state_without_force() {
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let conn = Database::connect(ConnectOptions::new(&db_url))
-            .await
-            .unwrap();
-        Migrator::up(&conn, None).await.unwrap();
+        let pools = open_test_pools(&db_path).await;
 
         let sandbox_dir = temp.path().join("sandboxes").join("existing");
         fs::create_dir_all(&sandbox_dir).unwrap();
@@ -2165,7 +2175,7 @@ mod tests {
             ..Default::default()
         };
 
-        let err = prepare_create_target(&conn, &config, &sandbox_dir)
+        let err = prepare_create_target(&pools, &config, &sandbox_dir)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("already exists"));
@@ -2175,11 +2185,7 @@ mod tests {
     async fn test_prepare_create_target_force_replaces_stopped_sandbox_state() {
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let conn = Database::connect(ConnectOptions::new(&db_url))
-            .await
-            .unwrap();
-        Migrator::up(&conn, None).await.unwrap();
+        let pools = open_test_pools(&db_path).await;
 
         let sandbox_dir = temp.path().join("sandboxes").join("replaceable");
         fs::create_dir_all(sandbox_dir.join("rw")).unwrap();
@@ -2187,8 +2193,8 @@ mod tests {
             name: "replaceable".into(),
             ..Default::default()
         };
-        let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
-        super::update_sandbox_status(&conn, sandbox_id, super::SandboxStatus::Stopped)
+        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
+        super::update_sandbox_status(pools.write(), sandbox_id, super::SandboxStatus::Stopped)
             .await
             .unwrap();
 
@@ -2198,14 +2204,14 @@ mod tests {
         };
         forced.replace_existing = true;
 
-        prepare_create_target(&conn, &forced, &sandbox_dir)
+        prepare_create_target(&pools, &forced, &sandbox_dir)
             .await
             .unwrap();
 
         assert!(!sandbox_dir.exists());
         assert!(
             super::sandbox_entity::Entity::find_by_id(sandbox_id)
-                .one(&conn)
+                .one(pools.write())
                 .await
                 .unwrap()
                 .is_none()
@@ -2216,17 +2222,13 @@ mod tests {
     async fn test_reconcile_sandbox_runtime_state_marks_dead_processes_crashed() {
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let conn = Database::connect(ConnectOptions::new(&db_url))
-            .await
-            .unwrap();
-        Migrator::up(&conn, None).await.unwrap();
+        let pools = open_test_pools(&db_path).await;
 
         let config = SandboxConfig {
             name: "stale".into(),
             ..Default::default()
         };
-        let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
         let dead_run_pid = dead_pid();
 
         let run = run_entity::ActiveModel {
@@ -2236,23 +2238,23 @@ mod tests {
             ..Default::default()
         };
         let run_id = run_entity::Entity::insert(run)
-            .exec(&conn)
+            .exec(pools.write())
             .await
             .unwrap()
             .last_insert_id;
 
         let sandbox = super::sandbox_entity::Entity::find_by_id(sandbox_id)
-            .one(&conn)
+            .one(pools.write())
             .await
             .unwrap()
             .unwrap();
-        let reconciled = reconcile_sandbox_runtime_state(&conn, sandbox)
+        let reconciled = reconcile_sandbox_runtime_state(&pools, sandbox)
             .await
             .unwrap();
         assert_eq!(reconciled.status, SandboxStatus::Crashed);
 
         let run = run_entity::Entity::find_by_id(run_id)
-            .one(&conn)
+            .one(pools.write())
             .await
             .unwrap()
             .unwrap();
@@ -2268,11 +2270,7 @@ mod tests {
     async fn test_prepare_create_target_force_replaces_stale_running_sandbox_state() {
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let conn = Database::connect(ConnectOptions::new(&db_url))
-            .await
-            .unwrap();
-        Migrator::up(&conn, None).await.unwrap();
+        let pools = open_test_pools(&db_path).await;
 
         let sandbox_dir = temp.path().join("sandboxes").join("stale-running");
         fs::create_dir_all(sandbox_dir.join("rw")).unwrap();
@@ -2280,7 +2278,7 @@ mod tests {
             name: "stale-running".into(),
             ..Default::default()
         };
-        let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
 
         let run = run_entity::ActiveModel {
             sandbox_id: Set(sandbox_id),
@@ -2288,7 +2286,10 @@ mod tests {
             status: Set(run_entity::RunStatus::Running),
             ..Default::default()
         };
-        run_entity::Entity::insert(run).exec(&conn).await.unwrap();
+        run_entity::Entity::insert(run)
+            .exec(pools.write())
+            .await
+            .unwrap();
 
         let mut forced = SandboxConfig {
             name: "stale-running".into(),
@@ -2296,14 +2297,14 @@ mod tests {
         };
         forced.replace_existing = true;
 
-        prepare_create_target(&conn, &forced, &sandbox_dir)
+        prepare_create_target(&pools, &forced, &sandbox_dir)
             .await
             .unwrap();
 
         assert!(!sandbox_dir.exists());
         assert!(
             super::sandbox_entity::Entity::find_by_id(sandbox_id)
-                .one(&conn)
+                .one(pools.write())
                 .await
                 .unwrap()
                 .is_none()
@@ -2314,11 +2315,7 @@ mod tests {
     async fn test_prepare_create_target_force_replaces_running_sandbox() {
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let conn = Database::connect(ConnectOptions::new(&db_url))
-            .await
-            .unwrap();
-        Migrator::up(&conn, None).await.unwrap();
+        let pools = open_test_pools(&db_path).await;
 
         let sandbox_dir = temp.path().join("sandboxes").join("running");
         fs::create_dir_all(&sandbox_dir).unwrap();
@@ -2326,7 +2323,7 @@ mod tests {
             name: "running".into(),
             ..Default::default()
         };
-        let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
 
         let child = Command::new("sleep").arg("30").spawn().unwrap();
         let live_pid = child.id() as i32;
@@ -2340,7 +2337,10 @@ mod tests {
             status: Set(run_entity::RunStatus::Running),
             ..Default::default()
         };
-        run_entity::Entity::insert(run).exec(&conn).await.unwrap();
+        run_entity::Entity::insert(run)
+            .exec(pools.write())
+            .await
+            .unwrap();
 
         let mut forced = SandboxConfig {
             name: "running".into(),
@@ -2348,7 +2348,7 @@ mod tests {
         };
         forced.replace_existing = true;
 
-        prepare_create_target(&conn, &forced, &sandbox_dir)
+        prepare_create_target(&pools, &forced, &sandbox_dir)
             .await
             .unwrap();
 
@@ -2358,7 +2358,7 @@ mod tests {
         assert!(!sandbox_dir.exists());
         assert!(
             super::sandbox_entity::Entity::find_by_id(sandbox_id)
-                .one(&conn)
+                .one(pools.write())
                 .await
                 .unwrap()
                 .is_none()
@@ -2406,11 +2406,7 @@ mod tests {
     async fn test_reap_marks_only_dead_running_and_draining_sandboxes() {
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let conn = Database::connect(ConnectOptions::new(&db_url))
-            .await
-            .unwrap();
-        Migrator::up(&conn, None).await.unwrap();
+        let pools = open_test_pools(&db_path).await;
 
         let dead = dead_pid();
 
@@ -2419,14 +2415,14 @@ mod tests {
             name: "running-dead".into(),
             ..Default::default()
         };
-        let id_a = insert_sandbox_record(&conn, &cfg_a).await.unwrap();
+        let id_a = insert_sandbox_record(pools.write(), &cfg_a).await.unwrap();
         run_entity::Entity::insert(run_entity::ActiveModel {
             sandbox_id: Set(id_a),
             pid: Set(Some(dead)),
             status: Set(run_entity::RunStatus::Running),
             ..Default::default()
         })
-        .exec(&conn)
+        .exec(pools.write())
         .await
         .unwrap();
 
@@ -2442,14 +2438,14 @@ mod tests {
             name: "running-alive".into(),
             ..Default::default()
         };
-        let id_b = insert_sandbox_record(&conn, &cfg_b).await.unwrap();
+        let id_b = insert_sandbox_record(pools.write(), &cfg_b).await.unwrap();
         run_entity::Entity::insert(run_entity::ActiveModel {
             sandbox_id: Set(id_b),
             pid: Set(Some(live_pid)),
             status: Set(run_entity::RunStatus::Running),
             ..Default::default()
         })
-        .exec(&conn)
+        .exec(pools.write())
         .await
         .unwrap();
 
@@ -2458,8 +2454,8 @@ mod tests {
             name: "draining-dead".into(),
             ..Default::default()
         };
-        let id_c = insert_sandbox_record(&conn, &cfg_c).await.unwrap();
-        super::update_sandbox_status(&conn, id_c, SandboxStatus::Draining)
+        let id_c = insert_sandbox_record(pools.write(), &cfg_c).await.unwrap();
+        super::update_sandbox_status(pools.write(), id_c, SandboxStatus::Draining)
             .await
             .unwrap();
         run_entity::Entity::insert(run_entity::ActiveModel {
@@ -2468,7 +2464,7 @@ mod tests {
             status: Set(run_entity::RunStatus::Running),
             ..Default::default()
         })
-        .exec(&conn)
+        .exec(pools.write())
         .await
         .unwrap();
 
@@ -2477,8 +2473,8 @@ mod tests {
             name: "stopped".into(),
             ..Default::default()
         };
-        let id_d = insert_sandbox_record(&conn, &cfg_d).await.unwrap();
-        super::update_sandbox_status(&conn, id_d, SandboxStatus::Stopped)
+        let id_d = insert_sandbox_record(pools.write(), &cfg_d).await.unwrap();
+        super::update_sandbox_status(pools.write(), id_d, SandboxStatus::Stopped)
             .await
             .unwrap();
 
@@ -2487,7 +2483,7 @@ mod tests {
             name: "starting".into(),
             ..Default::default()
         };
-        let id_e = insert_sandbox_record(&conn, &cfg_e).await.unwrap();
+        let id_e = insert_sandbox_record(pools.write(), &cfg_e).await.unwrap();
 
         // --- Reap: query all Running/Draining, reconcile each ---
         let stale = super::sandbox_entity::Entity::find()
@@ -2495,20 +2491,20 @@ mod tests {
                 super::sandbox_entity::Column::Status
                     .is_in([SandboxStatus::Running, SandboxStatus::Draining]),
             )
-            .all(&conn)
+            .all(pools.write())
             .await
             .unwrap();
 
         for sandbox in stale {
-            let _ = reconcile_sandbox_runtime_state(&conn, sandbox).await;
+            let _ = reconcile_sandbox_runtime_state(&pools, sandbox).await;
         }
 
         // --- Assertions ---
         let load = |id| {
-            let conn = &conn;
+            let read_db = pools.read();
             async move {
                 super::sandbox_entity::Entity::find_by_id(id)
-                    .one(conn)
+                    .one(read_db)
                     .await
                     .unwrap()
                     .unwrap()

--- a/crates/microsandbox/lib/volume/mod.rs
+++ b/crates/microsandbox/lib/volume/mod.rs
@@ -123,12 +123,11 @@ impl VolumeHandle {
     /// Deletes the DB record first, then the directory. An orphaned directory
     /// is easier to detect and clean up than an orphaned DB record.
     pub async fn remove(&self) -> MicrosandboxResult<()> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let pools = crate::db::init_global().await?;
 
         // Delete the DB record first.
         volume_entity::Entity::delete_by_id(self.db_id)
-            .exec(db)
+            .exec(pools.write())
             .await?;
 
         // Then delete the directory.
@@ -159,13 +158,12 @@ impl Volume {
         tracing::debug!(name = %config.name, quota_mib = ?config.quota_mib, "Volume::create");
         validate_volume_name(&config.name)?;
 
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let pools = crate::db::init_global().await?;
 
         // Check for existing volume.
         let existing = volume_entity::Entity::find()
             .filter(volume_entity::Column::Name.eq(&config.name))
-            .one(db)
+            .one(pools.read())
             .await?;
         if existing.is_some() {
             return Err(MicrosandboxError::VolumeAlreadyExists(config.name));
@@ -191,7 +189,9 @@ impl Volume {
             ..Default::default()
         };
 
-        volume_entity::Entity::insert(model).exec(db).await?;
+        volume_entity::Entity::insert(model)
+            .exec(pools.write())
+            .await?;
 
         // Create the volume directory. If this fails, clean up the DB record.
         let volumes_dir = crate::config::config().volumes_dir();
@@ -200,7 +200,7 @@ impl Volume {
         if let Err(e) = tokio::fs::create_dir_all(&path).await {
             let _ = volume_entity::Entity::delete_many()
                 .filter(volume_entity::Column::Name.eq(&config.name))
-                .exec(db)
+                .exec(pools.write())
                 .await;
             return Err(e.into());
         }
@@ -215,8 +215,7 @@ impl Volume {
     ///
     /// Returns a lightweight handle for metadata and management operations.
     pub async fn get(name: &str) -> MicrosandboxResult<VolumeHandle> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?.read();
 
         let model = volume_entity::Entity::find()
             .filter(volume_entity::Column::Name.eq(name))
@@ -229,8 +228,7 @@ impl Volume {
 
     /// List all volumes, ordered by creation time (newest first).
     pub async fn list() -> MicrosandboxResult<Vec<VolumeHandle>> {
-        let db =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let db = crate::db::init_global().await?.read();
 
         let models = volume_entity::Entity::find()
             .order_by_desc(volume_entity::Column::CreatedAt)

--- a/crates/runtime/lib/error.rs
+++ b/crates/runtime/lib/error.rs
@@ -32,3 +32,9 @@ pub enum RuntimeError {
     #[error("{0}")]
     Custom(String),
 }
+
+impl microsandbox_db::retry::IsSqliteBusy for RuntimeError {
+    fn is_sqlite_busy(&self) -> bool {
+        matches!(self, RuntimeError::Database(db_err) if microsandbox_db::retry::is_sqlite_busy(db_err))
+    }
+}

--- a/crates/runtime/lib/metrics.rs
+++ b/crates/runtime/lib/metrics.rs
@@ -2,8 +2,9 @@
 
 use std::time::{Duration, Instant};
 
+use microsandbox_db::DbWriteConnection;
 use microsandbox_db::entity::sandbox_metric as sandbox_metric_entity;
-use sea_orm::{ActiveModelTrait, DatabaseConnection, Set};
+use sea_orm::{ActiveModelTrait, Set};
 
 use crate::{RuntimeError, RuntimeResult};
 
@@ -63,7 +64,7 @@ struct ProcessSample {
 
 /// Run the background metrics sampler until the sandbox process exits.
 pub async fn run_metrics_sampler(
-    db: DatabaseConnection,
+    db: DbWriteConnection,
     sandbox_id: i32,
     pid: u32,
     network_metrics: Option<Box<dyn NetworkMetrics>>,
@@ -125,7 +126,7 @@ pub async fn run_metrics_sampler(
 }
 
 async fn persist_sample(
-    db: &DatabaseConnection,
+    db: &DbWriteConnection,
     sandbox_id: i32,
     cpu_percent: f32,
     process: ProcessSample,

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -11,10 +11,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use microsandbox_db::DbWriteConnection;
 use microsandbox_db::entity::run as run_entity;
 use microsandbox_filesystem::{DynFileSystem, PassthroughConfig, PassthroughFs};
 use msb_krun::VmBuilder;
-use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, Set};
+use sea_orm::{ColumnTrait, EntityTrait, Set};
 use serde::Serialize;
 
 use crate::console::{AgentConsoleBackend, ConsoleSharedState};
@@ -741,10 +742,9 @@ fn write_startup_info(json: &str) -> RuntimeResult<()> {
 async fn connect_db(
     db_path: &std::path::Path,
     connect_timeout_secs: u64,
-) -> RuntimeResult<DatabaseConnection> {
-    microsandbox_db::pool::build_pool(
+) -> RuntimeResult<DbWriteConnection> {
+    DbWriteConnection::open(
         db_path,
-        1,
         Duration::from_secs(connect_timeout_secs),
         Duration::from_secs(microsandbox_db::pool::DEFAULT_BUSY_TIMEOUT_SECS),
     )
@@ -753,7 +753,7 @@ async fn connect_db(
 }
 
 /// Insert a run record into the database.
-async fn insert_run(db: &DatabaseConnection, sandbox_id: i32, pid: u32) -> RuntimeResult<i32> {
+async fn insert_run(db: &DbWriteConnection, sandbox_id: i32, pid: u32) -> RuntimeResult<i32> {
     let now = chrono::Utc::now().naive_utc();
     let record = run_entity::ActiveModel {
         sandbox_id: Set(sandbox_id),
@@ -770,7 +770,7 @@ async fn insert_run(db: &DatabaseConnection, sandbox_id: i32, pid: u32) -> Runti
 }
 
 /// Mark a run record as failed (Terminated + InternalError) on startup error.
-async fn mark_run_failed(db: &DatabaseConnection, run_id: i32) -> RuntimeResult<()> {
+async fn mark_run_failed(db: &DbWriteConnection, run_id: i32) -> RuntimeResult<()> {
     use sea_orm::QueryFilter;
     use sea_orm::sea_query::Expr;
 


### PR DESCRIPTION
stacks on #666.

## summary

we already split each database into a read pool and a write pool, but both were just `sea_orm::DatabaseConnection`. nothing in the type system stopped a write from sneaking onto the read pool, and the retry-on-busy logic had to look up the right pool dynamically. this pr makes the read/write split a property of the type.

`DbReadConnection` and `DbWriteConnection` are newtypes over the underlying connection. both implement `ConnectionTrait` so existing query builders work unchanged, but write transactions are only available on `DbWriteConnection`. every host call site now declares its intent in its signature: read helpers take `&DbReadConnection`, write helpers take `&DbWriteConnection`, and the few that do both take `&DbPools`.

with the typed handles in place, the dynamic write-pool lookup and the per-call max-connections override are gone, and two writes that were managing their own transactions pick up retry-on-busy for free.

a 200-concurrent-boot benchmark shows a ~18% throughput improvement over the previous design (21.3 sandboxes/sec vs 18.2), with median wall time falling from ~6992 ms to ~5950 ms. zero `SQLITE_BUSY` errors observed in either run.

## test plan

- [x] cargo test -p microsandbox --lib
- [x] cargo check --workspace --all-targets