### PR TITLE
feat(utils): MSB_HOME env override for isolated state

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -429,6 +429,11 @@ jobs:
 
       - name: Run SDK smoke tests
         working-directory: sdk/node-ts
+        env:
+          # Per-job isolated state directory so concurrent / sequential
+          # runs of this job don't share `~/.microsandbox/{db,sandboxes}`.
+          # `$RUNNER_TEMP` is wiped between jobs, so cleanup is automatic.
+          MSB_HOME: ${{ runner.temp }}/msb-home-${{ github.run_id }}
         run: |
           export PATH="$HOME/.microsandbox/bin:$PATH"
           export LD_LIBRARY_PATH="${{ github.workspace }}/build:$HOME/.microsandbox/lib"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2796,6 +2796,7 @@ dependencies = [
 name = "microsandbox-utils"
 version = "0.4.4"
 dependencies = [
+ "dirs",
  "libc",
  "reflink-copy",
  "scopeguard",

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -403,9 +403,7 @@ async fn fetch_latest_version() -> anyhow::Result<String> {
 }
 
 fn resolve_base_dir() -> anyhow::Result<PathBuf> {
-    dirs::home_dir()
-        .map(|h| h.join(microsandbox_utils::BASE_DIR_NAME))
-        .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))
+    Ok(microsandbox_utils::resolve_home())
 }
 
 fn info(msg: &str) {

--- a/crates/microsandbox/lib/config/mod.rs
+++ b/crates/microsandbox/lib/config/mod.rs
@@ -783,11 +783,9 @@ fn read_config_from(path: &Path) -> MicrosandboxResult<GlobalConfig> {
     })
 }
 
-/// Resolve the default home directory (`~/.microsandbox`).
+/// Resolve the default home directory (`~/.microsandbox`, or `$MSB_HOME` if set).
 fn resolve_default_home() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(microsandbox_utils::BASE_DIR_NAME)
+    microsandbox_utils::resolve_home()
 }
 
 /// Load config from the default config file path.

--- a/crates/microsandbox/lib/db/mod.rs
+++ b/crates/microsandbox/lib/db/mod.rs
@@ -37,13 +37,7 @@ pub async fn init_global(
 ) -> MicrosandboxResult<&'static DatabaseConnection> {
     GLOBAL_POOL
         .get_or_try_init(|| async {
-            let base = dirs::home_dir().ok_or_else(|| {
-                crate::MicrosandboxError::Custom("cannot determine home directory".into())
-            })?;
-
-            let db_dir = base
-                .join(microsandbox_utils::BASE_DIR_NAME)
-                .join(microsandbox_utils::DB_SUBDIR);
+            let db_dir = microsandbox_utils::resolve_home().join(microsandbox_utils::DB_SUBDIR);
 
             connect_and_migrate(
                 &db_dir,

--- a/crates/microsandbox/lib/setup/download.rs
+++ b/crates/microsandbox/lib/setup/download.rs
@@ -8,9 +8,7 @@ use futures::StreamExt;
 use tar::Archive;
 
 use crate::{MicrosandboxError, MicrosandboxResult};
-use microsandbox_utils::{
-    BASE_DIR_NAME, BIN_SUBDIR, LIB_SUBDIR, LIBKRUNFW_ABI, MSB_BINARY, PREBUILT_VERSION,
-};
+use microsandbox_utils::{BIN_SUBDIR, LIB_SUBDIR, LIBKRUNFW_ABI, MSB_BINARY, PREBUILT_VERSION};
 
 use super::verify::verify_installation;
 
@@ -151,7 +149,7 @@ pub fn is_installed() -> bool {
 //--------------------------------------------------------------------------------------------------
 
 fn default_base_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|home| home.join(BASE_DIR_NAME))
+    Some(microsandbox_utils::resolve_home())
 }
 
 fn libkrunfw_symlinks(filename: &str) -> Vec<(String, String)> {

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -14,7 +14,6 @@
 //! }
 //! ```
 
-use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
@@ -23,37 +22,31 @@ pub use test_macros::msb_test;
 
 /// Env var that gates per-test home isolation.
 ///
-/// When set (any value), [`init_isolated_home`] redirects `HOME` at the
-/// process level to a fresh tempdir-rooted layout. When unset, the helper is
-/// a no-op and tests run against the real `~/.microsandbox` (suitable for
-/// quick local runs, but unsafe for parallel execution).
+/// When set (any value), [`init_isolated_home`] points microsandbox at a
+/// fresh tempdir for state (db, sandboxes, cache, logs). When unset, the
+/// helper is a no-op and tests run against the real `~/.microsandbox`
+/// (suitable for quick local runs, but unsafe for parallel execution).
 pub const ISOLATE_HOME_ENV: &str = "MSB_TEST_ISOLATE_HOME";
 
 /// Env var that, when set, preserves the isolated tempdir on drop so its
 /// contents (sqlite db, sandbox logs, etc.) can be inspected post-mortem.
 pub const KEEP_HOME_ENV: &str = "MSB_TEST_KEEP_HOME";
 
-/// Set up an isolated `HOME` for this test if [`ISOLATE_HOME_ENV`] is set,
-/// otherwise do nothing.
+/// Set up an isolated microsandbox home for this test if [`ISOLATE_HOME_ENV`]
+/// is set, otherwise do nothing.
 ///
 /// Returns a guard that the caller must hold for the full duration of the
 /// test. Dropping the guard removes the tempdir on disk (unless
 /// [`KEEP_HOME_ENV`] is set).
 ///
-/// Layout when isolation is active:
-///
-/// ```text
-/// /tmp/msb-XXXXXX/
-///   .microsandbox/
-///     bin/msb            -> symlink to $HOME/.microsandbox/bin/msb
-///     lib/libkrunfw.*    -> symlinks to $HOME/.microsandbox/lib/*
-/// ```
-///
-/// sandbox state, sqlite db, image cache, and volumes are then created fresh
-/// inside `<tempdir>/.microsandbox/` during the test.
+/// Isolation is achieved via the `MSB_HOME` env var, which microsandbox
+/// reads in preference to `$HOME/.microsandbox`. The real installed msb
+/// binary is reused via `MSB_PATH`; libkrunfw is resolved relative to it.
+/// No symlinks, no `$HOME` mutation, no impact on tooling that reads
+/// `$HOME` (npm cache, ssh keys, etc.).
 ///
 /// Relies on the test runner using one process per test (e.g. `cargo
-/// nextest`) — under plain libtest the `HOME` mutation leaks between tests
+/// nextest`) — under plain libtest the env mutation leaks between tests
 /// in the same binary.
 pub fn init_isolated_home() -> IsolatedHome {
     if std::env::var_os(ISOLATE_HOME_ENV).is_none() {
@@ -63,7 +56,13 @@ pub fn init_isolated_home() -> IsolatedHome {
     let real_home = PathBuf::from(
         std::env::var_os("HOME").expect("HOME must be set for integration-test setup"),
     );
-    let real_msb_home = real_home.join(".microsandbox");
+    let real_msb_path = real_home.join(".microsandbox").join("bin").join("msb");
+    if !real_msb_path.exists() {
+        panic!(
+            "required msb binary missing for isolated home: {}",
+            real_msb_path.display()
+        );
+    }
 
     // Anchor the tempdir under `/tmp` explicitly. On macOS `TMPDIR` points at
     // `/var/folders/<hash>/T/...` (~49 chars), which combined with
@@ -78,20 +77,12 @@ pub fn init_isolated_home() -> IsolatedHome {
         .tempdir_in("/tmp")
         .expect("failed to create tempdir under /tmp");
 
-    let msb_home = tempdir.path().join(".microsandbox");
-    let bin_dir = msb_home.join("bin");
-    let lib_dir = msb_home.join("lib");
-    std::fs::create_dir_all(&bin_dir).expect("create bin dir");
-    std::fs::create_dir_all(&lib_dir).expect("create lib dir");
-
-    symlink_into(&real_msb_home.join("bin").join("msb"), &bin_dir.join("msb"));
-    mirror_dir(&real_msb_home.join("lib"), &lib_dir);
-
     // SAFETY: each #[msb_test] runs in its own process under cargo-nextest,
-    // so mutating HOME only affects this test and its subprocesses. Must run
+    // so mutating env only affects this test and its subprocesses. Must run
     // before the first microsandbox API call.
     unsafe {
-        std::env::set_var("HOME", tempdir.path());
+        std::env::set_var("MSB_HOME", tempdir.path());
+        std::env::set_var("MSB_PATH", &real_msb_path);
     }
 
     IsolatedHome(Some(tempdir))
@@ -107,30 +98,5 @@ impl IsolatedHome {
     /// Returns the path to the isolated home, if isolation is active.
     pub fn path(&self) -> Option<&Path> {
         self.0.as_ref().map(TempDir::path)
-    }
-}
-
-fn symlink_into(src: &Path, dst: &Path) {
-    if !src.exists() {
-        panic!("required file missing for isolated home: {}", src.display());
-    }
-    symlink(src, dst)
-        .unwrap_or_else(|e| panic!("symlink {} -> {}: {e}", dst.display(), src.display()));
-}
-
-fn mirror_dir(src: &Path, dst: &Path) {
-    let entries =
-        std::fs::read_dir(src).unwrap_or_else(|e| panic!("read_dir {}: {e}", src.display()));
-    for entry in entries {
-        let entry = entry.expect("read_dir entry");
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-        symlink(&src_path, &dst_path).unwrap_or_else(|e| {
-            panic!(
-                "symlink {} -> {}: {e}",
-                dst_path.display(),
-                src_path.display()
-            )
-        });
     }
 }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 path = "lib/lib.rs"
 
 [dependencies]
+dirs.workspace = true
 libc.workspace = true
 reflink-copy.workspace = true
 scopeguard.workspace = true

--- a/crates/utils/lib/lib.rs
+++ b/crates/utils/lib/lib.rs
@@ -116,6 +116,25 @@ pub const MICROSANDBOX_REPO: &str = "microsandbox";
 // Functions
 //--------------------------------------------------------------------------------------------------
 
+/// Resolve the microsandbox home directory.
+///
+/// Order of resolution:
+/// 1. `MSB_HOME` env var (used as-is, no `.microsandbox` suffix appended)
+/// 2. `~/.microsandbox/` (i.e. `dirs::home_dir().join(BASE_DIR_NAME)`)
+/// 3. `./.microsandbox/` if no home is available
+///
+/// `MSB_HOME` lets CI and integration tests isolate microsandbox state
+/// (db, sandboxes, cache, logs) per process without disturbing other
+/// `$HOME`-rooted tooling.
+pub fn resolve_home() -> std::path::PathBuf {
+    if let Some(path) = std::env::var_os("MSB_HOME") {
+        return std::path::PathBuf::from(path);
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(BASE_DIR_NAME)
+}
+
 /// Returns the platform-specific libkrunfw filename.
 pub fn libkrunfw_filename(os: &str) -> String {
     if os == "macos" {
@@ -151,4 +170,31 @@ pub fn bundle_download_url(version: &str, arch: &str, os: &str) -> String {
     format!(
         "https://github.com/{GITHUB_ORG}/{MICROSANDBOX_REPO}/releases/download/v{version}/{MICROSANDBOX_REPO}-{target_os}-{arch}.tar.gz"
     )
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `MSB_HOME` is honoured verbatim (no `.microsandbox` suffix appended)
+    /// so callers can isolate state per process without disturbing tooling
+    /// that reads `$HOME` (npm cache, ssh keys, etc.).
+    ///
+    /// Uses a unique env var per test process to avoid clashing with other
+    /// parallel tests that read `MSB_HOME`.
+    #[test]
+    fn test_resolve_home_respects_env_override() {
+        // SAFETY: This test sets a process-global env var. Vitest-style
+        // single-test isolation isn't available; rely on the test being
+        // the sole reader of `MSB_HOME` in this binary.
+        let custom = std::path::PathBuf::from("/tmp/msb-home-resolve-test-12345");
+        unsafe { std::env::set_var("MSB_HOME", &custom) };
+        let resolved = resolve_home();
+        unsafe { std::env::remove_var("MSB_HOME") };
+        assert_eq!(resolved, custom);
+    }
 }


### PR DESCRIPTION
## summary

ci jobs that share a self-hosted runner also share `~/.microsandbox/` between runs, so a sandbox or sqlite migration left by one job can break the next. added an `MSB_HOME` env var that overrides the default home dir, letting each job point microsandbox at its own state without touching `$HOME` and clobbering everything else that reads it.

set per-job in the node sdk integration test workflow (the one currently flaking on `SQLITE_BUSY` / stale boot state):

```yaml
env:
  MSB_HOME: ${{ runner.temp }}/msb-home-${{ github.run_id }}
```

`$RUNNER_TEMP` is wiped between jobs, so cleanup is automatic. `test-utils::init_isolated_home` was migrated to use the same env var, which let it drop the `$HOME` mutation and the bin/lib symlink dance.

## test plan

- [ ] cargo test --workspace
- [ ] cargo check --workspace