### PR TITLE
fix(agent): bound relay handshake reads and prefer boot-error.json on timeout

### DIFF
--- a/crates/microsandbox/lib/agent/client.rs
+++ b/crates/microsandbox/lib/agent/client.rs
@@ -57,7 +57,14 @@ impl AgentClient {
     ///
     /// Performs the relay handshake to receive the assigned ID offset and
     /// the cached `core.ready` payload, then spawns a background reader task.
-    pub async fn connect(sock_path: &Path) -> MicrosandboxResult<Self> {
+    ///
+    /// `deadline` bounds both handshake reads. Without it, an accepted
+    /// connection that stalls (e.g. a sandbox alive but wedged before
+    /// writing the handshake bytes) would block this call indefinitely.
+    pub async fn connect(
+        sock_path: &Path,
+        deadline: tokio::time::Instant,
+    ) -> MicrosandboxResult<Self> {
         let stream = UnixStream::connect(sock_path).await.map_err(|e| {
             crate::MicrosandboxError::Runtime(format!(
                 "failed to connect to agent relay at {}: {e}",
@@ -69,15 +76,29 @@ impl AgentClient {
 
         // Read the handshake: [id_offset: u32 BE][ready_frame_bytes...]
         let mut offset_buf = [0u8; 4];
-        reader.read_exact(&mut offset_buf).await.map_err(|e| {
-            crate::MicrosandboxError::Runtime(format!("handshake read id_offset: {e}"))
-        })?;
+        tokio::time::timeout_at(deadline, reader.read_exact(&mut offset_buf))
+            .await
+            .map_err(|_| {
+                crate::MicrosandboxError::Runtime(
+                    "handshake read id_offset: timed out before relay sent bytes".into(),
+                )
+            })?
+            .map_err(|e| {
+                crate::MicrosandboxError::Runtime(format!("handshake read id_offset: {e}"))
+            })?;
         let id_offset = u32::from_be_bytes(offset_buf);
 
         // Read the ready frame using the protocol codec directly.
-        let ready_msg = codec::read_message(&mut reader).await.map_err(|e| {
-            crate::MicrosandboxError::Runtime(format!("handshake read ready frame: {e}"))
-        })?;
+        let ready_msg = tokio::time::timeout_at(deadline, codec::read_message(&mut reader))
+            .await
+            .map_err(|_| {
+                crate::MicrosandboxError::Runtime(
+                    "handshake read ready frame: timed out before relay sent frame".into(),
+                )
+            })?
+            .map_err(|e| {
+                crate::MicrosandboxError::Runtime(format!("handshake read ready frame: {e}"))
+            })?;
 
         let ready: Ready = ready_msg
             .payload()

--- a/crates/microsandbox/lib/sandbox/handle.rs
+++ b/crates/microsandbox/lib/sandbox/handle.rs
@@ -151,7 +151,12 @@ impl SandboxHandle {
             .join("runtime")
             .join("agent.sock");
 
-        let client = AgentClient::connect(&sock_path).await?;
+        // Bound the handshake reads. The relay is supposed to be running
+        // already for a sandbox in Running/Draining state; if it doesn't
+        // respond within 10s, something is wedged and the caller should
+        // see a timeout instead of hanging forever.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        let client = AgentClient::connect(&sock_path, deadline).await?;
         let config: SandboxConfig = serde_json::from_str(&self.config_json)?;
 
         Ok(Sandbox {

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -1077,7 +1077,7 @@ async fn wait_for_relay(
 
     loop {
         attempts += 1;
-        match AgentClient::connect(sock_path).await {
+        match AgentClient::connect(sock_path, deadline).await {
             Ok(client) => {
                 tracing::debug!(attempts, "wait_for_relay: connected");
                 // The relay is up — clear any stale boot-error.json from
@@ -1096,10 +1096,7 @@ async fn wait_for_relay(
 
                     // Prefer the structured boot-error record if the
                     // sandbox got far enough to write one.
-                    if let Some(ref dir) = log_dir
-                        && let Ok(Some(boot_err)) =
-                            microsandbox_runtime::boot_error::BootError::read(dir)
-                    {
+                    if let Some(boot_err) = read_boot_error(log_dir.as_deref()) {
                         return Err(crate::MicrosandboxError::BootStart {
                             name: sandbox_name.to_string(),
                             err: boot_err,
@@ -1137,10 +1134,36 @@ async fn wait_for_relay(
                     error = %e,
                     "wait_for_relay: timed out"
                 );
+                // Even when the process is still running, the sandbox
+                // may have written a structured boot-error before
+                // stalling (e.g. agentd reported a recoverable failure
+                // and never produced the handshake bytes). Prefer that
+                // typed record over the raw IO/timeout error so the CLI
+                // can render the styled boot-error block.
+                if let Some(boot_err) = read_boot_error(log_dir.as_deref()) {
+                    return Err(crate::MicrosandboxError::BootStart {
+                        name: sandbox_name.to_string(),
+                        err: boot_err,
+                    });
+                }
                 return Err(e);
             }
         }
     }
+}
+
+/// Read `boot-error.json` from `log_dir` if present and parseable.
+///
+/// Returns `None` when the directory is unknown, the file is missing, or
+/// the contents cannot be deserialized — callers fall back to a raw
+/// error in those cases.
+fn read_boot_error(
+    log_dir: Option<&std::path::Path>,
+) -> Option<microsandbox_runtime::boot_error::BootError> {
+    let dir = log_dir?;
+    microsandbox_runtime::boot_error::BootError::read(dir)
+        .ok()
+        .flatten()
 }
 
 /// Build a [`SandboxHandle`] by eagerly loading the microVM PID.


### PR DESCRIPTION
## Summary

two related fixes on the `AgentClient::connect` → `wait_for_relay` path:

- **the 30s deadline now actually means 30s wall-clock.** today the deadline in `wait_for_relay` is only checked *between* `AgentClient::connect` attempts; if a sandbox accepts the unix socket but stalls before writing the handshake bytes, the in-flight `read_exact` blocks forever and the deadline check is never reached. the fix threads the same deadline into `AgentClient::connect` so both handshake reads (`id_offset`, ready frame) are bounded by `timeout_at`. no new timeout, just the existing one applied where it can do its job.

- **prefer boot-error.json on the deadline-exceeded branch.** `wait_for_relay`'s timeout branch now consults `boot-error.json` before returning the raw IO error, matching what the existing process-exited branch already did. if the sandbox stalled after recording a structured boot failure, the CLI surfaces the typed boot-error block instead of an opaque IO message.

callers of `AgentClient::connect`:
- `wait_for_relay` shares its 30s outer deadline.
- `SandboxHandle::connect` (reconnect to a running sandbox) uses a 10s deadline; the relay should already be up for a sandbox in `Running`/`Draining`, so a stall there means something is wedged.

a small `read_boot_error` helper keeps the lookup logic in one place between the process-exited and deadline-exceeded branches.

## Test plan

- [x] `cargo check -p microsandbox` clean
- [x] `cargo clippy -p microsandbox --no-deps` clean
- [x] `cargo test -p microsandbox --lib` (164 passed, 0 failed locally)
- [x] manual: kill a sandbox between `UnixStream::connect` and the handshake write to confirm `connect` no longer hangs
- [x] manual: induce a relay-side stall after writing `boot-error.json` to confirm the typed block is rendered instead of a raw IO error