### PR TITLE
docs(recipes): add systemd services recipe

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -151,7 +151,7 @@
         "tab": "Recipes",
         "groups": [
           {
-            "group": "Container Integration",
+            "group": "Docker",
             "icon": "docker",
             "pages": [
               "recipes/docker",
@@ -159,8 +159,8 @@
             ]
           },
           {
-            "group": "Guest Setup",
-            "icon": "gear",
+            "group": "Guest",
+            "icon": "server",
             "pages": [
               "recipes/systemd-services"
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -157,6 +157,13 @@
               "recipes/docker",
               "recipes/local-images"
             ]
+          },
+          {
+            "group": "Guest Setup",
+            "icon": "gear",
+            "pages": [
+              "recipes/systemd-services"
+            ]
           }
         ]
       }

--- a/docs/recipes/docker.mdx
+++ b/docs/recipes/docker.mdx
@@ -1,7 +1,7 @@
 ---
 title: Running in Docker
 description: Deploy microsandbox as a Docker container on Linux
-icon: "docker"
+icon: "box"
 ---
 
 <Tip>

--- a/docs/recipes/local-images.mdx
+++ b/docs/recipes/local-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using Local Docker Images
 description: Use locally built Docker images with microsandbox via a local registry
-icon: "docker"
+icon: "boxes-stacked"
 ---
 
 microsandbox pulls images from OCI-compatible registries. If you build an image locally with `docker build`, microsandbox can't access it directly from Docker's local store. The workaround is to run a local registry and push your image there.

--- a/docs/recipes/systemd-services.mdx
+++ b/docs/recipes/systemd-services.mdx
@@ -11,13 +11,13 @@ By default the microsandbox agent is PID 1. That's enough for one-shot processes
 ## Step 1: Boot
 
 ```bash
-msb run oowy/systemd:debian-bookworm \
+msb run ghcr.io/superradcompany/debian-systemd:12 \
   --memory 1G --cpus 2 \
   --init auto \
   -- bash
 ```
 
-`--init auto` probes a small set of well-known paths and picks the first that exists. See [Custom init system](/sandboxes/customize#custom-init-system) for the full list and for pinning to an exact path.
+`debian-systemd` is one of the [official guest images](https://github.com/superradcompany/guest-images) we publish. `--init auto` probes a small set of well-known paths and picks the first that exists. See [Custom init system](/sandboxes/customize#custom-init-system) for the full list and for pinning to an exact path.
 
 ## Step 2: Confirm systemd is PID 1
 

--- a/docs/recipes/systemd-services.mdx
+++ b/docs/recipes/systemd-services.mdx
@@ -17,7 +17,7 @@ msb run ghcr.io/superradcompany/debian-systemd:12 \
   -- bash
 ```
 
-`debian-systemd` is one of the [official guest images](https://github.com/superradcompany/guest-images) we publish. `--init auto` probes a small set of well-known paths and picks the first that exists. See [Custom init system](/sandboxes/customize#custom-init-system) for the full list and for pinning to an exact path.
+`debian-systemd` is one of the optional bases we maintain in [guest-images](https://github.com/superradcompany/guest-images) for cases like this. `--init auto` probes a small set of well-known paths and picks the first that exists. See [Custom init system](/sandboxes/customize#custom-init-system) for the full list and for pinning to an exact path.
 
 ## Step 2: Confirm systemd is PID 1
 

--- a/docs/recipes/systemd-services.mdx
+++ b/docs/recipes/systemd-services.mdx
@@ -1,0 +1,92 @@
+---
+title: Running systemd services
+description: Boot a sandbox under systemd so services like Cloudflare WARP can run as regular units
+icon: "gear"
+---
+
+By default the microsandbox agent is PID 1 in the guest. That's enough for one-shot processes, but it doesn't replace a real init: anything that calls into `systemctl`, `loginctl`, or expects a session bus will fail.
+
+Hand PID 1 over to systemd with `--init` and the rest of the guest behaves like a normal Linux box. This recipe walks through booting under systemd and installing Cloudflare WARP as a worked example, but the same shape works for any service that ships a `.service` unit.
+
+## Prerequisites
+
+- An image that ships a systemd init binary at one of `/sbin/init`, `/lib/systemd/systemd`, or `/usr/lib/systemd/systemd`. `oowy/systemd:debian-bookworm` and `jrei/systemd-debian:12` both work.
+- 1 GiB of memory or so. systemd plus the WARP daemon is heavier than the agent-only default.
+
+## Step 1: Boot under systemd
+
+```bash
+msb run oowy/systemd:debian-bookworm \
+  --memory 1G --cpus 2 \
+  --init auto \
+  -- bash
+```
+
+`--init auto` probes the well-known paths and picks the first that exists. Pass an absolute path (`--init /lib/systemd/systemd`) instead if you need pinning.
+
+Confirm systemd is actually PID 1:
+
+```bash
+root@msb-19bc4106:/# systemctl status
+● msb-19bc4106
+    State: running
+    Units: 113 loaded (incl. loaded aliases)
+  systemd: 252.39-1~deb12u1
+```
+
+## Step 2: Install the service
+
+WARP isn't in the Debian repos, so add Cloudflare's:
+
+```bash
+apt update && apt install -y curl gnupg lsb-release
+
+curl -fsSL https://pkg.cloudflareclient.com/pubkey.gpg \
+  | gpg --yes --dearmor \
+        --output /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg
+
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] \
+https://pkg.cloudflareclient.com/ $(lsb_release -cs) main" \
+  > /etc/apt/sources.list.d/cloudflare-client.list
+
+apt update && apt install -y cloudflare-warp
+```
+
+`lsb_release` has to be installed *before* the `echo` because the codename expansion (`bookworm`) comes from it. Skipping it produces a malformed source line and a follow-up `apt update` fails.
+
+## Step 3: Start the unit
+
+The package install enables the unit but doesn't start it (microsandbox is detected as a container, so policy-rc.d defers it):
+
+```bash
+systemctl enable --now warp-svc
+systemctl status warp-svc
+```
+
+You should see `Active: active (running)` and a real PID under `Main PID:`.
+
+## Step 4: Use the service
+
+Register the device, accept the EULA on first run, and connect:
+
+```bash
+warp-cli registration new
+warp-cli connect
+warp-cli status
+# Status update: Connected
+# Network: healthy
+```
+
+Verify egress is actually going through WARP:
+
+```bash
+curl https://1.1.1.1/cdn-cgi/trace
+```
+
+Look for `warp=on` in the response. That's the sandbox routing through Cloudflare's network instead of your host's NAT.
+
+## Notes
+
+- **Image choice matters.** Distroless / minimal images like `python:3.13-slim` don't ship an init binary; `--init auto` will fail and `kernel.log` will list every path it tried. Use a systemd-equipped base or layer one in.
+- **Memory budget.** systemd's idle footprint is ~50 MiB; daemons add more. Bump `--memory` if your service is hungry.
+- **Other inits work too.** `--init` accepts any absolute path. s6, OpenRC, runit, or a hand-rolled `/sbin/init` shell script are all fine — `auto` just covers the systemd-on-Debian/Ubuntu case.

--- a/docs/recipes/systemd-services.mdx
+++ b/docs/recipes/systemd-services.mdx
@@ -1,5 +1,5 @@
 ---
-title: Booting under systemd
+title: Booting Under systemd
 description: Hand PID 1 to systemd inside the guest so services run under a real init
 icon: "gear"
 ---

--- a/docs/recipes/systemd-services.mdx
+++ b/docs/recipes/systemd-services.mdx
@@ -17,7 +17,7 @@ msb run oowy/systemd:debian-bookworm \
   -- bash
 ```
 
-`--init auto` probes a few well-known paths (`/sbin/init`, `/lib/systemd/systemd`, `/usr/lib/systemd/systemd`) and picks the first that exists. Pass an absolute path instead if you want pinning.
+`--init auto` probes a small set of well-known paths and picks the first that exists. See [Custom init system](/sandboxes/customize#custom-init-system) for the full list and for pinning to an exact path.
 
 ## Step 2: Confirm systemd is PID 1
 

--- a/docs/recipes/systemd-services.mdx
+++ b/docs/recipes/systemd-services.mdx
@@ -1,19 +1,14 @@
 ---
-title: Running systemd services
-description: Boot a sandbox under systemd so services like Cloudflare WARP can run as regular units
+title: Booting under systemd
+description: Hand PID 1 to systemd inside the guest so services run under a real init
 icon: "gear"
 ---
 
-By default the microsandbox agent is PID 1 in the guest. That's enough for one-shot processes, but it doesn't replace a real init: anything that calls into `systemctl`, `loginctl`, or expects a session bus will fail.
+By default the microsandbox agent is PID 1. That's enough for one-shot processes, but anything that calls into `systemctl`, `loginctl`, or expects a session bus will fail.
 
-Hand PID 1 over to systemd with `--init` and the rest of the guest behaves like a normal Linux box. This recipe walks through booting under systemd and installing Cloudflare WARP as a worked example, but the same shape works for any service that ships a `.service` unit.
+`--init auto` hands PID 1 over to systemd. The rest of the guest then behaves like a normal Linux box.
 
-## Prerequisites
-
-- An image that ships a systemd init binary at one of `/sbin/init`, `/lib/systemd/systemd`, or `/usr/lib/systemd/systemd`. `oowy/systemd:debian-bookworm` and `jrei/systemd-debian:12` both work.
-- 1 GiB of memory or so. systemd plus the WARP daemon is heavier than the agent-only default.
-
-## Step 1: Boot under systemd
+## Step 1: Boot
 
 ```bash
 msb run oowy/systemd:debian-bookworm \
@@ -22,71 +17,49 @@ msb run oowy/systemd:debian-bookworm \
   -- bash
 ```
 
-`--init auto` probes the well-known paths and picks the first that exists. Pass an absolute path (`--init /lib/systemd/systemd`) instead if you need pinning.
+`--init auto` probes a few well-known paths (`/sbin/init`, `/lib/systemd/systemd`, `/usr/lib/systemd/systemd`) and picks the first that exists. Pass an absolute path instead if you want pinning.
 
-Confirm systemd is actually PID 1:
+## Step 2: Confirm systemd is PID 1
 
 ```bash
-root@msb-19bc4106:/# systemctl status
-● msb-19bc4106
+root@msb:/# systemctl status
+● msb
     State: running
     Units: 113 loaded (incl. loaded aliases)
   systemd: 252.39-1~deb12u1
 ```
 
-## Step 2: Install the service
-
-WARP isn't in the Debian repos, so add Cloudflare's:
+Or check directly:
 
 ```bash
-apt update && apt install -y curl gnupg lsb-release
-
-curl -fsSL https://pkg.cloudflareclient.com/pubkey.gpg \
-  | gpg --yes --dearmor \
-        --output /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg
-
-echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] \
-https://pkg.cloudflareclient.com/ $(lsb_release -cs) main" \
-  > /etc/apt/sources.list.d/cloudflare-client.list
-
-apt update && apt install -y cloudflare-warp
+root@msb:/# cat /proc/1/comm
+systemd
 ```
 
-`lsb_release` has to be installed *before* the `echo` because the codename expansion (`bookworm`) comes from it. Skipping it produces a malformed source line and a follow-up `apt update` fails.
+## Step 3: Manage units
 
-## Step 3: Start the unit
-
-The package install enables the unit but doesn't start it (microsandbox is detected as a container, so policy-rc.d defers it):
+`systemctl` works as it does on bare metal. Inspect a unit shipped with the image:
 
 ```bash
-systemctl enable --now warp-svc
-systemctl status warp-svc
+root@msb:/# systemctl status systemd-journald
+● systemd-journald.service - Journal Service
+     Loaded: loaded (/lib/systemd/system/systemd-journald.service; static)
+     Active: active (running)
 ```
 
-You should see `Active: active (running)` and a real PID under `Main PID:`.
-
-## Step 4: Use the service
-
-Register the device, accept the EULA on first run, and connect:
+Install your own and start it:
 
 ```bash
-warp-cli registration new
-warp-cli connect
-warp-cli status
-# Status update: Connected
-# Network: healthy
+root@msb:/# apt update && apt install -y nginx
+root@msb:/# systemctl enable --now nginx
+root@msb:/# curl -s localhost | head -1
+<!DOCTYPE html>
 ```
 
-Verify egress is actually going through WARP:
-
-```bash
-curl https://1.1.1.1/cdn-cgi/trace
-```
-
-Look for `warp=on` in the response. That's the sandbox routing through Cloudflare's network instead of your host's NAT.
+Microsandbox is detected as a container, so packages with `policy-rc.d` deferral install but don't auto-start. `systemctl enable --now <unit>` starts them in one step.
 
 ## Notes
 
-- **Image choice matters.** Distroless / minimal images like `python:3.13-slim` don't ship an init binary; `--init auto` will fail and `kernel.log` will list every path it tried. Use a systemd-equipped base or layer one in.
+- **Image choice matters.** Distroless / minimal images (`python:3.13-slim`, `alpine`) don't ship a systemd init binary; `--init auto` will fail and `kernel.log` will list every path it tried. Use a systemd-equipped base or layer one in.
 - **Memory budget.** systemd's idle footprint is ~50 MiB; daemons add more. Bump `--memory` if your service is hungry.
-- **Other inits work too.** `--init` accepts any absolute path. s6, OpenRC, runit, or a hand-rolled `/sbin/init` shell script are all fine — `auto` just covers the systemd-on-Debian/Ubuntu case.
+- **Other inits work.** `--init` accepts any absolute path. s6, OpenRC, runit, or a hand-rolled `/sbin/init` shell script are all fine; `auto` just covers the systemd-on-Debian/Ubuntu case.

--- a/docs/sandboxes/customize.mdx
+++ b/docs/sandboxes/customize.mdx
@@ -311,7 +311,7 @@ msb run alpine:3.20 --init /sbin/init -- sh -c "cat /proc/1/comm"
 
 ### Shutdown semantics
 
-Without `--init`, microsandbox shuts the guest down by remounting root read-only and calling `reboot(RB_POWER_OFF)`. Typically <100 ms.
+Without `--init`, microsandbox shuts the guest down by remounting root read-only and calling `reboot(RB_POWER_OFF)`. Typically &lt;100 ms.
 
 With `--init`, the agent isn't PID 1 anymore, so it asks your init to shut down:
 
@@ -322,7 +322,7 @@ Your init then runs its own teardown (stop services, unmount, halt), which is sl
 
 | Init | Typical shutdown |
 |------|------------------|
-| BusyBox / s6 / runit | <100 ms |
+| BusyBox / s6 / runit | &lt;100 ms |
 | OpenRC | 50-500 ms |
 | systemd | 1-5 s |
 

--- a/docs/sandboxes/customize.mdx
+++ b/docs/sandboxes/customize.mdx
@@ -280,11 +280,11 @@ sb = await Sandbox.create(
 
 Most slim Docker base images (`debian:bookworm-slim`, `ubuntu:24.04`, `python:3.12-slim`) are stripped of init binaries; they're built for "one process per container" and don't ship systemd at all. If you point `--init` at a path the image doesn't contain, the agent's pre-flight check fails boot with a clear error in the kernel log (no kernel panic).
 
-Three ways to get an image with an init, in order of how often you'd reach for them:
+Three ways to get an image with an init:
 
 <AccordionGroup>
-  <Accordion title="Use an official microsandbox image (recommended)">
-    We publish [`guest-images`](https://github.com/superradcompany/guest-images) on GHCR. The current set:
+  <Accordion title="Use an image from `guest-images`">
+    We maintain a small collection at [`superradcompany/guest-images`](https://github.com/superradcompany/guest-images) for the cases where you specifically need a real init. Current set:
 
     | Image | Pull |
     |-------|------|
@@ -293,7 +293,7 @@ Three ways to get an image with an init, in order of how often you'd reach for t
     | Fedora + systemd | `ghcr.io/superradcompany/fedora-systemd:40` |
     | Alpine + OpenRC | `ghcr.io/superradcompany/alpine-openrc:3.20` |
 
-    Multi-arch (`linux/amd64` + `linux/arm64`), rebuilt weekly to pick up upstream security patches, smoke-tested on every rebuild. Each image's GHCR page documents its specific tag aliases and contents.
+    Multi-arch (`linux/amd64` + `linux/arm64`), rebuilt weekly so they pick up upstream security patches, smoke-tested on every rebuild. Each image's GHCR page documents its specific tag aliases and contents.
   </Accordion>
   <Accordion title="Build a small custom image">
     ```dockerfile

--- a/docs/sandboxes/customize.mdx
+++ b/docs/sandboxes/customize.mdx
@@ -147,7 +147,16 @@ The patch builder is invoked through `SandboxBuilder.patch(p => ...)`. Each meth
 
 ## Custom init system
 
-By default the microsandbox agent runs as PID 1 inside the guest — small, fast, and minimal. For workloads that expect a real init (systemd, OpenRC, s6, runit) — long-lived daemons, system service tests, dbus-using tools — you can hand PID 1 over to the init binary of your choice. The agent does the boot-time setup (mount filesystems, configure network, prepare runtime dirs), then forks. The parent execs your init and becomes PID 1; the agent continues as a normal child process serving host requests over the same channel.
+By default the microsandbox agent runs as PID 1 inside the guest: small, fast, minimal. For workloads that expect a real init (systemd, OpenRC, s6, runit, etc.), `--init` hands PID 1 over to the init binary of your choice.
+
+The handoff sequence:
+
+- Agent does the boot-time setup: mount filesystems, configure network, prepare runtime dirs.
+- Agent forks.
+- Parent execs your init and becomes PID 1.
+- Child agent continues serving host requests over the same channel.
+
+Common reasons to opt in: long-lived daemons, system service tests, anything that talks to dbus or expects `systemctl` to work.
 
 The simplest entry point is `auto`, which probes a small list of well-known paths inside the guest rootfs and picks the first one that exists:
 
@@ -155,7 +164,7 @@ The simplest entry point is `auto`, which probes a small list of well-known path
 - `/lib/systemd/systemd`
 - `/usr/lib/systemd/systemd`
 
-If you need an exact path (e.g. for reproducible CI), pass an absolute path instead.
+Pass an absolute path instead when you need pinning (e.g. for reproducible CI).
 
 <CodeGroup>
 ```rust Rust
@@ -201,7 +210,7 @@ msb run jrei/systemd-debian:12 \
 ```
 </CodeGroup>
 
-To verify the handoff worked, check `/proc/1/comm` inside the sandbox — it should print the init's name (`systemd`, `init`, etc.):
+To verify the handoff worked, check `/proc/1/comm` inside the sandbox. It should print the init's name (`systemd`, `init`, etc.):
 
 ```bash
 $ msb run jrei/systemd-debian:12 --init auto -- cat /proc/1/comm
@@ -212,7 +221,13 @@ If `--init=auto` can't find anything in its candidate list, agentd fails boot wi
 
 ### Argv and env
 
-Pass extra argv to the init via `init_with` (Rust/TypeScript) or by giving `init=` an `InitConfig` (Python). On the CLI, repeat `--init-arg` once per entry and `--init-env KEY=VAL` for env vars. Argv defaults to `[<cmd>]` when no `--init-arg` is given; env is merged on top of the inherited environment.
+Pass extra argv and env to the init:
+
+- **Rust / TypeScript**: `init_with(...)` / `initWith(...)`.
+- **Python**: pass an `InitConfig` to `init=`.
+- **CLI**: repeat `--init-arg` once per entry, and `--init-env KEY=VAL` once per env var.
+
+Argv defaults to `[<cmd>]` when none is given; env is merged on top of the inherited environment.
 
 <CodeGroup>
 ```bash CLI
@@ -259,7 +274,7 @@ sb = await Sandbox.create(
 
 ### Picking an image
 
-Most slim Docker base images (`debian:bookworm-slim`, `ubuntu:24.04`, `python:3.12-slim`) are stripped of init binaries — they're built for "one process per container" and don't ship systemd at all. If you point `--init` at a path the image doesn't contain, the agent's pre-flight check fails boot with a clear error in the kernel log, no kernel panic.
+Most slim Docker base images (`debian:bookworm-slim`, `ubuntu:24.04`, `python:3.12-slim`) are stripped of init binaries; they're built for "one process per container" and don't ship systemd at all. If you point `--init` at a path the image doesn't contain, the agent's pre-flight check fails boot with a clear error in the kernel log (no kernel panic).
 
 Two ways to get an image with an init:
 
@@ -278,7 +293,7 @@ docker buildx build -t local-systemd:debian -f Dockerfile.systemd .
 msb run local-systemd:debian --init /lib/systemd/systemd -- bash
 ```
 
-**Use a community-built systemd image** (e.g. `jrei/systemd-debian:12`, `jrei/systemd-ubuntu:22.04`). These work out of the box but are published by community maintainers, not the distros themselves — vet them like any other third-party image before running real workloads.
+**Use a community-built systemd image** (e.g. `jrei/systemd-debian:12`, `jrei/systemd-ubuntu:22.04`). These work out of the box but are published by community maintainers, not the distros themselves. Vet them like any other third-party image before running real workloads.
 
 For a sanity check that doesn't need systemd, `alpine:3.20` ships BusyBox at `/sbin/init`, which is enough to exercise the handoff mechanics:
 
@@ -289,16 +304,28 @@ msb run alpine:3.20 --init /sbin/init -- sh -c "cat /proc/1/comm"
 
 ### Shutdown semantics
 
-In default (no-handoff) mode, microsandbox shuts the guest down by remounting root read-only and calling `reboot(RB_POWER_OFF)` — typically &lt;100 ms. With handoff, the agent isn't PID 1 anymore, so it asks your init to shut down via `SIGRTMIN+4` (systemd's poweroff signal) with a `SIGTERM` fallback. Your init then runs its own teardown — stop services, unmount, halt — which is **slower**:
+Without `--init`, microsandbox shuts the guest down by remounting root read-only and calling `reboot(RB_POWER_OFF)`. Typically <100 ms.
+
+With `--init`, the agent isn't PID 1 anymore, so it asks your init to shut down:
+
+- `SIGRTMIN+4` first (systemd's poweroff signal).
+- `SIGTERM` fallback for inits that don't speak it.
+
+Your init then runs its own teardown (stop services, unmount, halt), which is slower:
 
 | Init | Typical shutdown |
 |------|------------------|
-| BusyBox / s6 / runit | &lt;100 ms |
-| OpenRC | 50–500 ms |
-| systemd | 1–5 s |
+| BusyBox / s6 / runit | <100 ms |
+| OpenRC | 50-500 ms |
+| systemd | 1-5 s |
 
 This is the price of a real init. If your test harness measures end-to-end sandbox lifecycle and you're comparing to a no-handoff baseline, account for this.
 
 ### Init and entrypoint
 
-`--init` and `--entrypoint` are orthogonal. `--init` controls **PID 1** — what runs the system. `--entrypoint` (and the trailing `-- cmd`) controls **what your workload runs**. They can be combined: boot systemd as PID 1 and have microsandbox `exec` calls land your shell, scripts, or app inside the systemd-managed environment.
+`--init` and `--entrypoint` are orthogonal:
+
+- `--init` controls **PID 1**: what runs the system.
+- `--entrypoint` (and the trailing `-- cmd`) controls **what your workload runs**.
+
+They can be combined. Boot systemd as PID 1 and have microsandbox `exec` calls land your shell, scripts, or app inside the systemd-managed environment.

--- a/docs/sandboxes/customize.mdx
+++ b/docs/sandboxes/customize.mdx
@@ -175,7 +175,7 @@ Pass an absolute path instead when you need pinning (e.g. for reproducible CI).
 use microsandbox::Sandbox;
 
 let sb = Sandbox::builder("worker")
-    .image("jrei/systemd-debian:12")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
     .memory(1024)
     .cpus(2)
     .init("auto")
@@ -187,7 +187,7 @@ let sb = Sandbox::builder("worker")
 import { MiB, Sandbox } from "microsandbox";
 
 await using sb = await Sandbox.builder("worker")
-    .image("jrei/systemd-debian:12")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
     .memory(MiB(1024))
     .cpus(2)
     .init("auto")
@@ -199,7 +199,7 @@ from microsandbox import Sandbox
 
 sb = await Sandbox.create(
     "worker",
-    image="jrei/systemd-debian:12",
+    image="ghcr.io/superradcompany/debian-systemd:12",
     memory=1024,
     cpus=2,
     init="auto",
@@ -207,7 +207,7 @@ sb = await Sandbox.create(
 ```
 
 ```bash CLI
-msb run jrei/systemd-debian:12 \
+msb run ghcr.io/superradcompany/debian-systemd:12 \
   -m 1G -c 2 \
   --init auto \
   -- bash
@@ -217,7 +217,7 @@ msb run jrei/systemd-debian:12 \
 To verify the handoff worked, check `/proc/1/comm` inside the sandbox. It should print the init's name (`systemd`, `init`, etc.):
 
 ```bash
-$ msb run jrei/systemd-debian:12 --init auto -- cat /proc/1/comm
+$ msb run ghcr.io/superradcompany/debian-systemd:12 --init auto -- cat /proc/1/comm
 systemd
 ```
 
@@ -235,7 +235,7 @@ Argv defaults to `[<cmd>]` when none is given; env is merged on top of the inher
 
 <CodeGroup>
 ```bash CLI
-msb run jrei/systemd-debian:12 \
+msb run ghcr.io/superradcompany/debian-systemd:12 \
   --init /lib/systemd/systemd \
   --init-arg --unit=multi-user.target \
   --init-env container=microsandbox \
@@ -244,7 +244,7 @@ msb run jrei/systemd-debian:12 \
 
 ```rust Rust
 let sb = Sandbox::builder("worker")
-    .image("jrei/systemd-debian:12")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
     .init_with("/lib/systemd/systemd", |i| i
         .args(["--unit=multi-user.target"])
         .env("container", "microsandbox"))
@@ -254,7 +254,7 @@ let sb = Sandbox::builder("worker")
 
 ```typescript TypeScript
 await using sb = await Sandbox.builder("worker")
-    .image("jrei/systemd-debian:12")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
     .initWith("/lib/systemd/systemd", (i) => i
         .args(["--unit=multi-user.target"])
         .env("container", "microsandbox"))
@@ -266,7 +266,7 @@ from microsandbox import InitConfig, Sandbox
 
 sb = await Sandbox.create(
     "worker",
-    image="jrei/systemd-debian:12",
+    image="ghcr.io/superradcompany/debian-systemd:12",
     init=InitConfig(
         cmd="/lib/systemd/systemd",
         args=("--unit=multi-user.target",),
@@ -280,9 +280,21 @@ sb = await Sandbox.create(
 
 Most slim Docker base images (`debian:bookworm-slim`, `ubuntu:24.04`, `python:3.12-slim`) are stripped of init binaries; they're built for "one process per container" and don't ship systemd at all. If you point `--init` at a path the image doesn't contain, the agent's pre-flight check fails boot with a clear error in the kernel log (no kernel panic).
 
-Two ways to get an image with an init:
+Three ways to get an image with an init, in order of how often you'd reach for them:
 
 <AccordionGroup>
+  <Accordion title="Use an official microsandbox image (recommended)">
+    We publish [`guest-images`](https://github.com/superradcompany/guest-images) on GHCR. The current set:
+
+    | Image | Pull |
+    |-------|------|
+    | Debian + systemd | `ghcr.io/superradcompany/debian-systemd:12` |
+    | Ubuntu + systemd | `ghcr.io/superradcompany/ubuntu-systemd:24.04` |
+    | Fedora + systemd | `ghcr.io/superradcompany/fedora-systemd:40` |
+    | Alpine + OpenRC | `ghcr.io/superradcompany/alpine-openrc:3.20` |
+
+    Multi-arch (`linux/amd64` + `linux/arm64`), rebuilt weekly to pick up upstream security patches, smoke-tested on every rebuild. Each image's GHCR page documents its specific tag aliases and contents.
+  </Accordion>
   <Accordion title="Build a small custom image">
     ```dockerfile
     # Dockerfile.systemd

--- a/docs/sandboxes/customize.mdx
+++ b/docs/sandboxes/customize.mdx
@@ -132,21 +132,22 @@ sb = await Sandbox.create(
 
 The patch builder is invoked through `SandboxBuilder.patch(p => ...)`. Each method appends an operation; calls are chainable.
 
-| Method | Description | `opts` |
-|--------|-------------|--------|
-| `text(path, content, opts?)` | Write text content to a file | `mode`, `replace` |
-| `file(path, bytes, opts?)` | Write raw bytes to a file | `mode`, `replace` |
-| `mkdir(path, opts?)` | Create a directory (idempotent) | `mode` |
-| `append(path, content)` | Append content to an existing file | |
-| `copyFile(src, dst, opts?)` | Copy a file from the host into the rootfs | `mode`, `replace` |
-| `copyDir(src, dst, opts?)` | Recursively copy a directory from the host | `replace` |
-| `symlink(target, link, opts?)` | Create a symlink | `replace` |
-| `remove(path)` | Delete a file or directory (idempotent) | |
+| Method | Description |
+|--------|-------------|
+| `text(path, content, opts?)` | Write text content to a file |
+| `file(path, bytes, opts?)` | Write raw bytes to a file |
+| `mkdir(path, opts?)` | Create a directory (idempotent) |
+| `append(path, content)` | Append content to an existing file |
+| `copyFile(src, dst, opts?)` | Copy a file from the host into the rootfs |
+| `copyDir(src, dst, opts?)` | Recursively copy a directory from the host |
+| `symlink(target, link, opts?)` | Create a symlink |
+| `remove(path)` | Delete a file or directory (idempotent) |
 
-Both `opts` keys are optional:
+`opts` is per-method and always optional:
 
-- `mode`: numeric file mode, e.g. `0o644`.
-- `replace`: when `true`, overwrite a path that already exists in the image. Defaults to `false`, which errors on collision.
+- `mode` (numeric file mode, e.g. `0o644`) and `replace` (overwrite if the path already exists): `text`, `file`, `copyFile`.
+- `replace` only: `copyDir`, `symlink`.
+- `mode` only: `mkdir`.
 
 ## Custom init system
 

--- a/docs/sandboxes/customize.mdx
+++ b/docs/sandboxes/customize.mdx
@@ -283,7 +283,7 @@ Most slim Docker base images (`debian:bookworm-slim`, `ubuntu:24.04`, `python:3.
 Three ways to get an image with an init:
 
 <AccordionGroup>
-  <Accordion title="Use an image from `guest-images`">
+  <Accordion title="Use one of our published guest images">
     We maintain a small collection at [`superradcompany/guest-images`](https://github.com/superradcompany/guest-images) for the cases where you specifically need a real init. Current set:
 
     | Image | Pull |

--- a/docs/sandboxes/customize.mdx
+++ b/docs/sandboxes/customize.mdx
@@ -132,18 +132,21 @@ sb = await Sandbox.create(
 
 The patch builder is invoked through `SandboxBuilder.patch(p => ...)`. Each method appends an operation; calls are chainable.
 
-| Method | Description |
-|--------|-------------|
-| `text(path, content, opts?)` | Write text content to a file |
-| `file(path, bytes, opts?)` | Write raw bytes to a file |
-| `mkdir(path, opts?)` | Create a directory (idempotent) |
-| `append(path, content)` | Append content to an existing file |
-| `copyFile(src, dst, opts?)` | Copy a file from the host into the rootfs |
-| `copyDir(src, dst, opts?)` | Recursively copy a directory from the host |
-| `symlink(target, link, opts?)` | Create a symlink |
-| `remove(path)` | Delete a file or directory (idempotent) |
+| Method | Description | `opts` |
+|--------|-------------|--------|
+| `text(path, content, opts?)` | Write text content to a file | `mode`, `replace` |
+| `file(path, bytes, opts?)` | Write raw bytes to a file | `mode`, `replace` |
+| `mkdir(path, opts?)` | Create a directory (idempotent) | `mode` |
+| `append(path, content)` | Append content to an existing file | |
+| `copyFile(src, dst, opts?)` | Copy a file from the host into the rootfs | `mode`, `replace` |
+| `copyDir(src, dst, opts?)` | Recursively copy a directory from the host | `replace` |
+| `symlink(target, link, opts?)` | Create a symlink | `replace` |
+| `remove(path)` | Delete a file or directory (idempotent) | |
 
-`opts` accepts `{ mode?: number; replace?: boolean }` for `text` / `file` / `copyFile`, `{ replace?: boolean }` for `copyDir` / `symlink`, and `{ mode?: number }` for `mkdir`.
+Both `opts` keys are optional:
+
+- `mode`: numeric file mode, e.g. `0o644`.
+- `replace`: when `true`, overwrite a path that already exists in the image. Defaults to `false`, which errors on collision.
 
 ## Custom init system
 
@@ -278,22 +281,25 @@ Most slim Docker base images (`debian:bookworm-slim`, `ubuntu:24.04`, `python:3.
 
 Two ways to get an image with an init:
 
-**Build a small custom image:**
+<AccordionGroup>
+  <Accordion title="Build a small custom image">
+    ```dockerfile
+    # Dockerfile.systemd
+    FROM debian:bookworm
+    RUN apt-get update \
+        && apt-get install -y --no-install-recommends systemd \
+        && rm -rf /var/lib/apt/lists/*
+    ```
 
-```dockerfile
-# Dockerfile.systemd
-FROM debian:bookworm
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends systemd \
-    && rm -rf /var/lib/apt/lists/*
-```
-
-```bash
-docker buildx build -t local-systemd:debian -f Dockerfile.systemd .
-msb run local-systemd:debian --init /lib/systemd/systemd -- bash
-```
-
-**Use a community-built systemd image** (e.g. `jrei/systemd-debian:12`, `jrei/systemd-ubuntu:22.04`). These work out of the box but are published by community maintainers, not the distros themselves. Vet them like any other third-party image before running real workloads.
+    ```bash
+    docker buildx build -t local-systemd:debian -f Dockerfile.systemd .
+    msb run local-systemd:debian --init /lib/systemd/systemd -- bash
+    ```
+  </Accordion>
+  <Accordion title="Use a community-built systemd image">
+    Examples: `jrei/systemd-debian:12`, `jrei/systemd-ubuntu:22.04`. These work out of the box but are published by community maintainers, not the distros themselves. Vet them like any other third-party image before running real workloads.
+  </Accordion>
+</AccordionGroup>
 
 For a sanity check that doesn't need systemd, `alpine:3.20` ships BusyBox at `/sbin/init`, which is enough to exercise the handoff mechanics:
 


### PR DESCRIPTION
adds docs/recipes/systemd-services.mdx walking through booting a sandbox under systemd via --init auto and installing cloudflare warp end-to-end (apt setup, gpg keyring, systemctl enable --now, warp-cli registration + connect, verification via 1.1.1.1/cdn-cgi/trace).

new "Guest Setup" recipes group so the page sits next to Container Integration instead of nested under it.