### PR TITLE
feat(packaging): publish official guest images

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,8 @@ jobs:
           filters: |
             code:
               - '!docs/**'
+              - '!packaging/guest-images/**'
+              - '!.github/workflows/guest-images.yml'
 
   # ---------------------------------------------------------------------------
   # Build kernel.c on Linux for macOS libkrunfw linking

--- a/.github/workflows/guest-images.yml
+++ b/.github/workflows/guest-images.yml
@@ -151,6 +151,8 @@ jobs:
             aliases: [latest]
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Compute date stamp
         id: date
         run: echo "stamp=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
@@ -162,29 +164,42 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build multi-arch manifest (primary tag)
+      - name: Build multi-arch manifest (primary + dated tags)
         run: |
+          set -euo pipefail
           IMG="${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}"
           PRIMARY="${{ matrix.image.primary_tag }}"
           DATE="${{ steps.date.outputs.stamp }}"
+          README="packaging/guest-images/${{ matrix.image.name }}/README.md"
+
+          # Pull the per-image README into a shell var so we can pass it as a
+          # multi-line annotation. ghcr renders this as the package's
+          # "About this package" markdown block.
+          DESC="$(cat "$README")"
 
           docker buildx imagetools create \
+            --annotation "index,manifest,manifest-descriptor:org.opencontainers.image.description=$DESC" \
             -t "$IMG:$PRIMARY" \
             "$IMG:$PRIMARY-amd64" \
             "$IMG:$PRIMARY-arm64"
 
           docker buildx imagetools create \
+            --annotation "index,manifest,manifest-descriptor:org.opencontainers.image.description=$DESC" \
             -t "$IMG:$PRIMARY-$DATE" \
             "$IMG:$PRIMARY-$DATE-amd64" \
             "$IMG:$PRIMARY-$DATE-arm64"
 
       - name: Build multi-arch manifest (aliases)
         run: |
+          set -euo pipefail
           IMG="${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}"
           PRIMARY="${{ matrix.image.primary_tag }}"
+          README="packaging/guest-images/${{ matrix.image.name }}/README.md"
+          DESC="$(cat "$README")"
 
           for alias in ${{ join(matrix.image.aliases, ' ') }}; do
             docker buildx imagetools create \
+              --annotation "index,manifest,manifest-descriptor:org.opencontainers.image.description=$DESC" \
               -t "$IMG:$alias" \
               "$IMG:$PRIMARY-amd64" \
               "$IMG:$PRIMARY-arm64"

--- a/.github/workflows/guest-images.yml
+++ b/.github/workflows/guest-images.yml
@@ -1,0 +1,188 @@
+name: Guest Images
+
+on:
+  # Weekly rebuild to pick up upstream base-image security patches.
+  schedule:
+    - cron: '0 6 * * MON'
+  # Manual trigger for re-publishing on demand.
+  workflow_dispatch:
+  # Build (no push) on PRs that touch the image definitions or this workflow,
+  # so contributors get the smoke-test verdict before merge.
+  pull_request:
+    paths:
+      - 'packaging/guest-images/**'
+      - '.github/workflows/guest-images.yml'
+  # Build + push on tag releases too, so versioned image rebuilds align with
+  # microsandbox releases.
+  push:
+    tags: ['v*']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: superradcompany
+
+jobs:
+  build:
+    name: Build ${{ matrix.image.name }}:${{ matrix.image.primary_tag }} (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+        image:
+          - name: debian-systemd
+            context: packaging/guest-images/debian-systemd
+            build_arg_name: DEBIAN_VERSION
+            build_arg_value: bookworm
+            primary_tag: '12'
+            aliases: [bookworm, latest]
+          - name: ubuntu-systemd
+            context: packaging/guest-images/ubuntu-systemd
+            build_arg_name: UBUNTU_VERSION
+            build_arg_value: '24.04'
+            primary_tag: '24.04'
+            aliases: [noble, latest]
+          - name: fedora-systemd
+            context: packaging/guest-images/fedora-systemd
+            build_arg_name: FEDORA_VERSION
+            build_arg_value: '40'
+            primary_tag: '40'
+            aliases: [latest]
+          - name: alpine-openrc
+            context: packaging/guest-images/alpine-openrc
+            build_arg_name: ALPINE_VERSION
+            build_arg_value: '3.20'
+            primary_tag: '3.20'
+            aliases: [latest]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Compute date stamp
+        id: date
+        run: echo "stamp=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute platform suffix
+        id: platform
+        run: |
+          # linux/amd64 -> amd64, linux/arm64 -> arm64
+          suffix="${{ matrix.platform }}"
+          suffix="${suffix#linux/}"
+          echo "suffix=$suffix" >> "$GITHUB_OUTPUT"
+
+      - name: Build (load locally for smoke test)
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image.context }}
+          platforms: ${{ matrix.platform }}
+          load: true
+          push: false
+          build-args: |
+            ${{ matrix.image.build_arg_name }}=${{ matrix.image.build_arg_value }}
+          tags: |
+            ${{ matrix.image.name }}:smoke-${{ steps.platform.outputs.suffix }}
+
+      - name: Smoke test (init binary present)
+        run: |
+          docker run --rm --platform ${{ matrix.platform }} \
+            ${{ matrix.image.name }}:smoke-${{ steps.platform.outputs.suffix }} \
+            sh -c 'for p in /sbin/init /lib/systemd/systemd /usr/lib/systemd/systemd; do [ -x "$p" ] && echo "found init at $p" && exit 0; done; echo "no init binary found"; exit 1'
+
+      - name: Log in to ghcr.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (per-platform)
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image.context }}
+          platforms: ${{ matrix.platform }}
+          push: true
+          provenance: false
+          build-args: |
+            ${{ matrix.image.build_arg_name }}=${{ matrix.image.build_arg_value }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}:${{ matrix.image.primary_tag }}-${{ steps.platform.outputs.suffix }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}:${{ matrix.image.primary_tag }}-${{ steps.date.outputs.stamp }}-${{ steps.platform.outputs.suffix }}
+
+  manifest:
+    name: Publish multi-arch manifest for ${{ matrix.image.name }}
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: debian-systemd
+            primary_tag: '12'
+            aliases: [bookworm, latest]
+          - name: ubuntu-systemd
+            primary_tag: '24.04'
+            aliases: [noble, latest]
+          - name: fedora-systemd
+            primary_tag: '40'
+            aliases: [latest]
+          - name: alpine-openrc
+            primary_tag: '3.20'
+            aliases: [latest]
+
+    steps:
+      - name: Compute date stamp
+        id: date
+        run: echo "stamp=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build multi-arch manifest (primary tag)
+        run: |
+          IMG="${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}"
+          PRIMARY="${{ matrix.image.primary_tag }}"
+          DATE="${{ steps.date.outputs.stamp }}"
+
+          docker buildx imagetools create \
+            -t "$IMG:$PRIMARY" \
+            "$IMG:$PRIMARY-amd64" \
+            "$IMG:$PRIMARY-arm64"
+
+          docker buildx imagetools create \
+            -t "$IMG:$PRIMARY-$DATE" \
+            "$IMG:$PRIMARY-$DATE-amd64" \
+            "$IMG:$PRIMARY-$DATE-arm64"
+
+      - name: Build multi-arch manifest (aliases)
+        run: |
+          IMG="${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}"
+          PRIMARY="${{ matrix.image.primary_tag }}"
+
+          for alias in ${{ join(matrix.image.aliases, ' ') }}; do
+            docker buildx imagetools create \
+              -t "$IMG:$alias" \
+              "$IMG:$PRIMARY-amd64" \
+              "$IMG:$PRIMARY-arm64"
+          done

--- a/.github/workflows/guest-images.yml
+++ b/.github/workflows/guest-images.yml
@@ -16,6 +16,9 @@ on:
   # microsandbox releases.
   push:
     tags: ['v*']
+    # TEMP: push trigger on the PR branch so we can validate the publish path
+    # end-to-end before merge. Remove this `branches:` entry before merging.
+    branches: [feat/guest-images]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
           filters: |
             code:
               - '!docs/**'
+              - '!packaging/guest-images/**'
+              - '!.github/workflows/guest-images.yml'
 
   # ---------------------------------------------------------------------------
   # Build kernel.c on Linux for macOS libkrunfw linking

--- a/packaging/guest-images/README.md
+++ b/packaging/guest-images/README.md
@@ -1,0 +1,38 @@
+# Guest images
+
+Base images we publish for use as the *guest* rootfs inside microsandbox VMs. Each one ships a real init binary so `--init auto` (or an explicit `--init <path>`) works out of the box.
+
+| Image | Base | Init | Primary tag |
+|-------|------|------|-------------|
+| `debian-systemd` | `debian:bookworm` | systemd | `:12`, `:bookworm` |
+| `ubuntu-systemd` | `ubuntu:24.04` | systemd | `:24.04`, `:noble` |
+| `fedora-systemd` | `fedora:40` | systemd | `:40` |
+| `alpine-openrc` | `alpine:3.20` | OpenRC + BusyBox init | `:3.20` |
+
+All images are published to `ghcr.io/superradcompany/<name>:<tag>` for both `linux/amd64` and `linux/arm64`.
+
+## Tags
+
+Each image carries three kinds of tags:
+
+- **Primary** (`:<distro-version>`, e.g. `debian-systemd:12`): the canonical pin most callers use. Mutable: rebuilt weekly to pick up upstream security patches.
+- **Distro alias** (`:<codename>`, e.g. `debian-systemd:bookworm`): mirror of the primary, friendlier for humans.
+- **Latest** (`:latest`): the newest supported distro version. Mutable.
+- **Dated** (`:<distro-version>-YYYY-MM-DD`, e.g. `debian-systemd:12-2026-05-12`): immutable digest pin for reproducible builds.
+
+For reproducible CI, prefer a dated tag or pin by digest (`@sha256:…`).
+
+## Rebuild cadence
+
+Two triggers:
+
+- Weekly cron (Monday 06:00 UTC), to pick up upstream base-image updates without us having to do anything.
+- Manual via the `Guest Images` workflow's `workflow_dispatch`.
+
+The same Dockerfiles are used for both. Each rebuild is gated by a smoke test that runs the produced image and verifies an init binary exists at one of the paths `--init auto` checks.
+
+## Adding a new image
+
+1. Add a directory `packaging/guest-images/<name>/` with `Dockerfile` and `README.md`.
+2. Add an entry to the `matrix` block in `.github/workflows/guest-images.yml`.
+3. Open a PR. The smoke test runs on every PR build.

--- a/packaging/guest-images/README.md
+++ b/packaging/guest-images/README.md
@@ -9,7 +9,7 @@ Base images we publish for use as the *guest* rootfs inside microsandbox VMs. Ea
 | `fedora-systemd` | `fedora:40` | systemd | `:40` |
 | `alpine-openrc` | `alpine:3.20` | OpenRC + BusyBox init | `:3.20` |
 
-All images are published to `ghcr.io/superradcompany/<name>:<tag>` for both `linux/amd64` and `linux/arm64`.
+All images are published to `ghcr.io/superradcompany/<name>:<tag>` for both `linux/amd64` and `linux/arm64` by the `Guest Images` workflow.
 
 ## Tags
 

--- a/packaging/guest-images/alpine-openrc/Dockerfile
+++ b/packaging/guest-images/alpine-openrc/Dockerfile
@@ -1,0 +1,17 @@
+ARG ALPINE_VERSION=3.20
+FROM alpine:${ALPINE_VERSION}
+
+LABEL org.opencontainers.image.source="https://github.com/superradcompany/microsandbox"
+LABEL org.opencontainers.image.description="Alpine with OpenRC + BusyBox init, an alternative to systemd for microsandbox --init"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+# Alpine's /sbin/init is BusyBox init reading /etc/inittab; OpenRC drives
+# the runlevels via that. busybox-openrc registers OpenRC compatible
+# init scripts; openrc itself provides rc-service / rc-update.
+RUN apk add --no-cache \
+        openrc \
+        busybox-openrc \
+        dbus \
+        ca-certificates
+
+CMD ["/sbin/init"]

--- a/packaging/guest-images/alpine-openrc/README.md
+++ b/packaging/guest-images/alpine-openrc/README.md
@@ -1,0 +1,42 @@
+# `alpine-openrc`
+
+Alpine with OpenRC and BusyBox init. This is the *non-systemd* path: same handoff mechanic, smaller footprint, faster shutdown.
+
+## Use
+
+```bash
+msb run ghcr.io/superradcompany/alpine-openrc:3.20 \
+  --memory 256M --cpus 2 \
+  --init /sbin/init \
+  -- sh
+```
+
+`/sbin/init` is BusyBox init, which reads `/etc/inittab` and hands off to OpenRC for runlevels. `--init auto` also works since `/sbin/init` is the first path it probes.
+
+## What's inside
+
+`alpine:3.20` plus:
+
+- `openrc`: provides `rc-service`, `rc-update`, runlevel management.
+- `busybox-openrc`: BusyBox-compatible OpenRC init scripts.
+- `dbus`: optional, but most "real service" workloads expect it.
+- `ca-certificates`: TLS works out of the box.
+
+apk cache is not retained.
+
+## Tags
+
+| Tag | Description |
+|-----|-------------|
+| `:3.20` | Alpine 3.20, mutable, rebuilt weekly |
+| `:3.20-YYYY-MM-DD` | Immutable date pin |
+| `:latest` | Alias for `:3.20` |
+
+For reproducible builds, pin to a dated tag or a digest (`@sha256:…`).
+
+## Why ship this alongside systemd images
+
+Two reasons:
+
+1. **Memory budget.** OpenRC's resident set is in the single-digit MiB; systemd is ~50 MiB idle. If your workload doesn't need systemd specifically, you can run far smaller sandboxes.
+2. **Reference for "any init works".** microsandbox's `--init` handoff is just `execve(2)`; it isn't tied to systemd. Shipping an OpenRC image alongside the systemd ones makes that visible in the catalog, not just claimed in the docs.

--- a/packaging/guest-images/debian-systemd/Dockerfile
+++ b/packaging/guest-images/debian-systemd/Dockerfile
@@ -1,0 +1,21 @@
+ARG DEBIAN_VERSION=bookworm
+FROM debian:${DEBIAN_VERSION}
+
+LABEL org.opencontainers.image.source="https://github.com/superradcompany/microsandbox"
+LABEL org.opencontainers.image.description="Debian with systemd, ready for microsandbox --init auto"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        systemd \
+        systemd-sysv \
+        dbus \
+        ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# `systemd-sysv` already symlinks /sbin/init -> /lib/systemd/systemd, but be
+# explicit so `--init auto` and `--init /sbin/init` both resolve.
+CMD ["/lib/systemd/systemd"]

--- a/packaging/guest-images/debian-systemd/README.md
+++ b/packaging/guest-images/debian-systemd/README.md
@@ -1,0 +1,33 @@
+# `debian-systemd`
+
+Debian with systemd installed and ready for microsandbox's `--init auto` handoff.
+
+## Use
+
+```bash
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  --memory 1G --cpus 2 \
+  --init auto \
+  -- bash
+```
+
+## What's inside
+
+`debian:bookworm` plus:
+
+- `systemd`: the init binary at `/lib/systemd/systemd`.
+- `systemd-sysv`: provides the `/sbin/init` symlink so `--init auto` finds it on the first probe.
+- `dbus`: most systemd-aware services need it.
+- `ca-certificates`: TLS works out of the box.
+
+apt lists are cleaned to keep the image small.
+
+## Tags
+
+| Tag | Description |
+|-----|-------------|
+| `:12`, `:bookworm` | Debian 12, mutable, rebuilt weekly |
+| `:12-YYYY-MM-DD` | Immutable date pin |
+| `:latest` | Alias for `:bookworm` |
+
+For reproducible builds, pin to a dated tag or a digest (`@sha256:…`).

--- a/packaging/guest-images/fedora-systemd/Dockerfile
+++ b/packaging/guest-images/fedora-systemd/Dockerfile
@@ -1,0 +1,15 @@
+ARG FEDORA_VERSION=40
+FROM fedora:${FEDORA_VERSION}
+
+LABEL org.opencontainers.image.source="https://github.com/superradcompany/microsandbox"
+LABEL org.opencontainers.image.description="Fedora with systemd, ready for microsandbox --init auto"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+# Fedora ships systemd by default; ensure dbus and ca-certificates are present
+# and bring the package set up to date.
+RUN dnf install -y systemd dbus ca-certificates \
+    && dnf upgrade --refresh -y \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf/*
+
+CMD ["/usr/lib/systemd/systemd"]

--- a/packaging/guest-images/fedora-systemd/README.md
+++ b/packaging/guest-images/fedora-systemd/README.md
@@ -1,0 +1,32 @@
+# `fedora-systemd`
+
+Fedora with systemd installed and ready for microsandbox's `--init auto` handoff.
+
+## Use
+
+```bash
+msb run ghcr.io/superradcompany/fedora-systemd:40 \
+  --memory 1G --cpus 2 \
+  --init auto \
+  -- bash
+```
+
+## What's inside
+
+`fedora:40` (which already ships systemd) plus:
+
+- `dbus`: required by most systemd-aware services.
+- `ca-certificates`: TLS works out of the box.
+- `dnf upgrade`: latest security fixes layered on top of the base.
+
+dnf cache is cleared after install.
+
+## Tags
+
+| Tag | Description |
+|-----|-------------|
+| `:40` | Fedora 40, mutable, rebuilt weekly |
+| `:40-YYYY-MM-DD` | Immutable date pin |
+| `:latest` | Alias for `:40` |
+
+For reproducible builds, pin to a dated tag or a digest (`@sha256:…`).

--- a/packaging/guest-images/ubuntu-systemd/Dockerfile
+++ b/packaging/guest-images/ubuntu-systemd/Dockerfile
@@ -1,0 +1,19 @@
+ARG UBUNTU_VERSION=24.04
+FROM ubuntu:${UBUNTU_VERSION}
+
+LABEL org.opencontainers.image.source="https://github.com/superradcompany/microsandbox"
+LABEL org.opencontainers.image.description="Ubuntu with systemd, ready for microsandbox --init auto"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        systemd \
+        systemd-sysv \
+        dbus \
+        ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+CMD ["/lib/systemd/systemd"]

--- a/packaging/guest-images/ubuntu-systemd/README.md
+++ b/packaging/guest-images/ubuntu-systemd/README.md
@@ -1,0 +1,33 @@
+# `ubuntu-systemd`
+
+Ubuntu with systemd installed and ready for microsandbox's `--init auto` handoff.
+
+## Use
+
+```bash
+msb run ghcr.io/superradcompany/ubuntu-systemd:24.04 \
+  --memory 1G --cpus 2 \
+  --init auto \
+  -- bash
+```
+
+## What's inside
+
+`ubuntu:24.04` plus:
+
+- `systemd`: the init binary at `/lib/systemd/systemd`.
+- `systemd-sysv`: provides `/sbin/init` so `--init auto` finds it.
+- `dbus`: most systemd-aware services need it.
+- `ca-certificates`: TLS works out of the box.
+
+apt lists are cleaned to keep the image small.
+
+## Tags
+
+| Tag | Description |
+|-----|-------------|
+| `:24.04`, `:noble` | Ubuntu 24.04 LTS, mutable, rebuilt weekly |
+| `:24.04-YYYY-MM-DD` | Immutable date pin |
+| `:latest` | Alias for `:24.04` |
+
+For reproducible builds, pin to a dated tag or a digest (`@sha256:…`).


### PR DESCRIPTION
## Summary

ship a small set of microsandbox-published guest base images so callers don't have to reach for third-party `*-systemd` forks. each image is a thin layer on top of the upstream distro, ensuring an init binary is at one of the paths `--init auto` checks.

| Image | Base | Init | Primary tag |
|-------|------|------|-------------|
| `debian-systemd` | `debian:bookworm` | systemd | `:12`, `:bookworm` |
| `ubuntu-systemd` | `ubuntu:24.04` | systemd | `:24.04`, `:noble` |
| `fedora-systemd` | `fedora:40` | systemd | `:40` |
| `alpine-openrc` | `alpine:3.20` | OpenRC + BusyBox | `:3.20` |

published to `ghcr.io/superradcompany/<name>:<tag>` for both `linux/amd64` and `linux/arm64`.

## Publishing model

`.github/workflows/guest-images.yml` triggers on:

- **schedule** `0 6 * * MON`: weekly rebuild to pick up upstream base-image security patches.
- **workflow_dispatch**: manual rebuild on demand.
- **push tags v***: rebuild aligned with microsandbox releases.
- **pull_request** (when image dirs change): build + smoke-test, no push.

each rebuild matrix-builds amd64 + arm64 with buildx, smoke-tests by running the image and verifying an init binary at one of the auto-probe paths, then assembles a multi-arch manifest at the primary, dated, and alias tags. the smoke test gates every push so a broken rebuild leaves the previous `:latest` digest in place.

## Tags published per image

- `<primary>` (mutable, e.g. `debian-systemd:12`)
- `<primary>-YYYY-MM-DD` (immutable date pin, for reproducible builds)
- aliases (e.g. `:bookworm`, `:latest`)

## Test plan

- [ ] cron firing creates a fresh build on monday morning.
- [ ] manual `workflow_dispatch` produces multi-arch tags on ghcr.
- [ ] each image boots under `msb run <image> --init auto -- bash` and `systemctl status` (or `rc-status` for alpine-openrc) reports `running`.
- [ ] dated tags are immutable across reruns of the same day.