### PR TITLE
docs(sdk): document PatchBuilder / Patch in each sdk reference

### DIFF
--- a/docs/sandboxes/customize.mdx
+++ b/docs/sandboxes/customize.mdx
@@ -130,20 +130,13 @@ sb = await Sandbox.create(
 
 ### Available operations
 
-The patch builder is invoked through `SandboxBuilder.patch(p => ...)`. Each method appends an operation; calls are chainable.
+The patch builder appends operations in the order you call them; calls are chainable. Available operations across SDKs: `text`, `file`, `mkdir`, `append`, `copyFile` / `copy_file`, `copyDir` / `copy_dir`, `symlink`, `remove`.
 
-| Method | Description |
-|--------|-------------|
-| `text(path, content, opts?)` | Write text content to a file |
-| `file(path, bytes, opts?)` | Write raw bytes to a file |
-| `mkdir(path, opts?)` | Create a directory (idempotent) |
-| `append(path, content)` | Append content to an existing file |
-| `copyFile(src, dst, opts?)` | Copy a file from the host into the rootfs |
-| `copyDir(src, dst, opts?)` | Recursively copy a directory from the host |
-| `symlink(target, link, opts?)` | Create a symlink |
-| `remove(path)` | Delete a file or directory (idempotent) |
+Full per-language signatures, parameters, and option shapes are documented in the SDK references:
 
-`opts` accepts `{ mode?: number; replace?: boolean }` for `text` / `file` / `copyFile`, `{ replace?: boolean }` for `copyDir` / `symlink`, and `{ mode?: number }` for `mkdir`.
+- Rust: [`PatchBuilder`](/sdk/rust/sandbox#patchbuilder)
+- TypeScript: [`PatchBuilder`](/sdk/typescript/sandbox#patchbuilder)
+- Python: [`Patch`](/sdk/python/sandbox#patch) (factory) and [`PatchConfig`](/sdk/python/sandbox#patchconfig) (the value type)
 
 ## Custom init system
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -54,6 +54,15 @@ Create and boot a sandbox. The first argument is either a name (`str`) or a full
 |------|-------------|
 | [`Sandbox`](#instance-methods) | Running sandbox |
 
+The returned `Sandbox` is an async context manager. Use `async with` to guarantee cleanup; on exit the sandbox is killed and its persisted state removed:
+
+```python
+async with await Sandbox.create("my-sandbox", image="alpine") as sb:
+    output = await sb.shell("echo hello")
+    print(output.stdout_text)
+# sandbox is automatically killed and removed on exit
+```
+
 ---
 
 #### Sandbox.create_with_progress()
@@ -523,19 +532,6 @@ Block until the sandbox exits on its own.
 | Type | Description |
 |------|-------------|
 | `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
-
----
-
-## Context manager
-
-```python
-async with await Sandbox.create("my-sandbox", image="alpine") as sb:
-    output = await sb.shell("echo hello")
-    print(output.stdout_text)
-# sandbox is automatically killed and removed on exit
-```
-
-Use `Sandbox` as an async context manager to ensure cleanup. On exit, the sandbox is killed and its persisted state is removed.
 
 ---
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -539,6 +539,157 @@ Use `Sandbox` as an async context manager to ensure cleanup. On exit, the sandbo
 
 ---
 
+## Patch
+
+Factory class for rootfs patches passed to `Sandbox.create(..., patches=[...])`. Each static method returns a [`PatchConfig`](#patchconfig). By default a patch that targets a path already present in the image errors at boot; pass `replace=True` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### Patch.append()
+
+```python
+@staticmethod
+def append(path: str, content: str) -> PatchConfig
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| content | `str` | Text to append |
+
+---
+
+#### Patch.copy_dir()
+
+```python
+@staticmethod
+def copy_dir(src: str, dst: str, *, replace: bool = False) -> PatchConfig
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Host source directory |
+| dst | `str` | Absolute destination path inside the guest |
+| replace | `bool` | When `True`, overwrite an existing path at `dst` |
+
+---
+
+#### Patch.copy_file()
+
+```python
+@staticmethod
+def copy_file(
+    src: str,
+    dst: str,
+    *,
+    mode: int | None = None,
+    replace: bool = False,
+) -> PatchConfig
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Host source file |
+| dst | `str` | Absolute destination path inside the guest |
+| mode | `int \| None` | File mode, e.g. `0o644`. `None` keeps the source mode |
+| replace | `bool` | When `True`, overwrite an existing path at `dst` |
+
+---
+
+#### Patch.mkdir()
+
+```python
+@staticmethod
+def mkdir(path: str, *, mode: int | None = None) -> PatchConfig
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| mode | `int \| None` | Directory mode, e.g. `0o755` |
+
+---
+
+#### Patch.remove()
+
+```python
+@staticmethod
+def remove(path: str) -> PatchConfig
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+---
+
+#### Patch.symlink()
+
+```python
+@staticmethod
+def symlink(target: str, link: str, *, replace: bool = False) -> PatchConfig
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `str` | What the symlink points to (literal symlink target text) |
+| link | `str` | Absolute path of the symlink itself |
+| replace | `bool` | When `True`, overwrite an existing path at `link` |
+
+---
+
+#### Patch.text()
+
+```python
+@staticmethod
+def text(
+    path: str,
+    content: str,
+    *,
+    mode: int | None = None,
+    replace: bool = False,
+) -> PatchConfig
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| content | `str` | Text content |
+| mode | `int \| None` | File mode, e.g. `0o644` |
+| replace | `bool` | When `True`, overwrite an existing path |
+
+---
+
 ## Types
 
 ### LogLevel
@@ -586,6 +737,22 @@ Async stream for receiving periodic metrics snapshots.
 |--------|---------|-------------|
 | `__aiter__` | `AsyncIterator[`[`SandboxMetrics`](#sandboxmetrics)`]` | Use with `async for` |
 | `recv()` | [`SandboxMetrics`](#sandboxmetrics) `\| None` | Receive next snapshot. Returns `None` when the stream ends. |
+
+### PatchConfig
+
+A single rootfs patch. Produced by the [`Patch`](#patch) factory; you'd normally not construct one directly. Frozen dataclass.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | `str` | One of `"text"`, `"file"`, `"copy_file"`, `"copy_dir"`, `"symlink"`, `"mkdir"`, `"remove"`, `"append"` |
+| path | `str \| None` | Absolute guest path (used by text / file / mkdir / remove / append) |
+| content | `str \| None` | Text content (text / append) |
+| src | `str \| None` | Host source path (copy_file / copy_dir) |
+| dst | `str \| None` | Guest destination path (copy_file / copy_dir) |
+| target | `str \| None` | Symlink target |
+| link | `str \| None` | Symlink path |
+| mode | `int \| None` | File / directory mode (e.g. `0o644`) |
+| replace | `bool` | When `True`, overwrite an existing path at the destination. Defaults to `False` |
 
 ### PullPolicy
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -876,6 +876,175 @@ Set the default working directory for all commands.
 
 ---
 
+## PatchBuilder
+
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder::patch(|p| p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `replace = true` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### append()
+
+```rust
+fn append(self, path: impl Into<String>, content: impl Into<String>) -> Self
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<String>` | Text to append |
+
+---
+
+#### copy_dir()
+
+```rust
+fn copy_dir(self, src: impl Into<PathBuf>, dst: impl Into<String>, replace: bool) -> Self
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<PathBuf>` | Host source directory |
+| dst | `impl Into<String>` | Absolute destination path inside the guest |
+| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### copy_file()
+
+```rust
+fn copy_file(
+    self,
+    src: impl Into<PathBuf>,
+    dst: impl Into<String>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<PathBuf>` | Host source file |
+| dst | `impl Into<String>` | Absolute destination path inside the guest |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)`. `None` keeps the source mode |
+| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### file()
+
+```rust
+fn file(
+    self,
+    path: impl Into<String>,
+    content: impl Into<Vec<u8>>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Write raw bytes at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<Vec<u8>>` | Raw byte content |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
+| replace | `bool` | When `true`, overwrite an existing path |
+
+---
+
+#### mkdir()
+
+```rust
+fn mkdir(self, path: impl Into<String>, mode: Option<u32>) -> Self
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| mode | `Option<u32>` | Directory mode, e.g. `Some(0o755)` |
+
+---
+
+#### remove()
+
+```rust
+fn remove(self, path: impl Into<String>) -> Self
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+
+---
+
+#### symlink()
+
+```rust
+fn symlink(self, target: impl Into<String>, link: impl Into<String>, replace: bool) -> Self
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `impl Into<String>` | What the symlink points to (literal symlink target text) |
+| link | `impl Into<String>` | Absolute path of the symlink itself |
+| replace | `bool` | When `true`, overwrite an existing path at `link` |
+
+---
+
+#### text()
+
+```rust
+fn text(
+    self,
+    path: impl Into<String>,
+    content: impl Into<String>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<String>` | Text content |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
+| replace | `bool` | When `true`, overwrite an existing path |
+
+---
+
 ## Types
 
 ### LogEntry

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -378,6 +378,169 @@ Implements `AsyncDisposable` so the sandbox can be used with `await using`. When
 
 ---
 
+## PatchBuilder
+
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder.patch(p => p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `{ replace: true }` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### append()
+
+```typescript
+append(path: string, content: string): this
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `string` | Text to append |
+
+---
+
+#### copyDir()
+
+```typescript
+copyDir(src: string, dst: string, opts?: { replace?: boolean }): this
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `string` | Host source directory |
+| dst | `string` | Absolute destination path inside the guest |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### copyFile()
+
+```typescript
+copyFile(
+  src: string,
+  dst: string,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `string` | Host source file |
+| dst | `string` | Absolute destination path inside the guest |
+| opts.mode | `number` | File mode, e.g. `0o644`. Omit to keep the source mode |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### file()
+
+```typescript
+file(
+  path: string,
+  content: Buffer,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Write raw bytes at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `Buffer` | Raw byte content |
+| opts.mode | `number` | File mode, e.g. `0o644` |
+| opts.replace | `boolean` | When `true`, overwrite an existing path |
+
+---
+
+#### mkdir()
+
+```typescript
+mkdir(path: string, opts?: { mode?: number }): this
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| opts.mode | `number` | Directory mode, e.g. `0o755` |
+
+---
+
+#### remove()
+
+```typescript
+remove(path: string): this
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+---
+
+#### symlink()
+
+```typescript
+symlink(target: string, link: string, opts?: { replace?: boolean }): this
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `string` | What the symlink points to (literal symlink target text) |
+| link | `string` | Absolute path of the symlink itself |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `link` |
+
+---
+
+#### text()
+
+```typescript
+text(
+  path: string,
+  content: string,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `string` | Text content |
+| opts.mode | `number` | File mode, e.g. `0o644` |
+| opts.replace | `boolean` | When `true`, overwrite an existing path |
+
+---
+
 ## Types
 
 ### SandboxBuilder


### PR DESCRIPTION
## Summary

every other builder we ship (`NetworkBuilder`, `RuleBuilder`, `DnsBuilder`, `TlsBuilder`, etc.) is documented per-method on the relevant sdk page. `PatchBuilder` was the asymmetric one: its operations were listed only on `docs/sandboxes/customize.mdx` as a small concept-page table. closed the gap.

## Changes

- `docs/sdk/rust/sandbox.mdx`: new `## PatchBuilder` with `append`, `copy_dir`, `copy_file`, `file`, `mkdir`, `remove`, `symlink`, `text`.
- `docs/sdk/typescript/sandbox.mdx`: new `## PatchBuilder` with `append`, `copyDir`, `copyFile`, `file`, `mkdir`, `remove`, `symlink`, `text`. opts shapes inlined in each signature.
- `docs/sdk/python/sandbox.mdx`: new `## Patch` factory section with `Patch.append`, `Patch.copy_dir`, `Patch.copy_file`, `Patch.mkdir`, `Patch.remove`, `Patch.symlink`, `Patch.text`. plus `### PatchConfig` in types.
- `docs/sandboxes/customize.mdx`: "Available operations" subsection replaced with a one-line summary of the op names plus three "see also" links to the sdk references.

## Test plan

- [ ] preview each sdk page; confirm the new `PatchBuilder` / `Patch` sections render and the inline anchor links from `customize.mdx` resolve.
- [ ] check methods are alphabetized within the section and match the existing builder documentation pattern.