### PR TITLE
fix(ci): make rm in mcp-publish idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -469,7 +469,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: mcp
         run: |
-          rm package-lock.json
+          rm -f package-lock.json
           npm install
           npm run build
           npm publish --access public

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -2011,10 +2011,13 @@ mod tests {
 
     /// Open both pools at `db_path` for tests, with migrations applied.
     async fn open_test_pools(db_path: &std::path::Path) -> DbPools {
+        // Connect timeout matches the production default (30s). 1s was too
+        // tight on cold ci runners and surfaced as `PoolTimedOut` flakes
+        // before the test body had a chance to run.
         let pools = DbPools::open(
             db_path,
             1,
-            std::time::Duration::from_secs(1),
+            std::time::Duration::from_secs(30),
             std::time::Duration::from_secs(5),
         )
         .await


### PR DESCRIPTION
the mcp submodule doesn't ship a `package-lock.json`, so `rm package-lock.json` in the `mcp-publish` job was failing every release with `No such file or directory` and `bash -e` was killing the job before `npm install` / `npm publish` could run.

`rm -f` silently no-ops when the file is absent, so the step works whether or not a lock file ends up checked in upstream.

unblocks the current release.