### PR TITLE
docs(i18n): scaffold spanish, french, german, japanese translations

### DIFF
--- a/docs/de/cli/image-commands.mdx
+++ b/docs/de/cli/image-commands.mdx
@@ -1,0 +1,112 @@
+---
+title: Image Commands
+description: Pull and manage OCI images from the CLI
+icon: "layer-group"
+---
+
+## msb pull
+
+Pre-pull an image to the local cache. Layers are fetched in parallel with per-layer progress bars. Once cached, layers are content-addressable and deduplicated, so shared layers across images are only stored once.
+
+```bash
+msb pull python
+msb pull alpine
+msb pull ghcr.io/my-org/my-image:v1
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Force re-download even if cached |
+| `-q`, `--quiet` | Suppress progress output |
+| `--insecure` | Connect over plain HTTP instead of HTTPS |
+| `--ca-certs <PATH>` | Path to a PEM file with additional CA root certificates |
+
+<Tip>
+  Pre-pulling is useful when you want sandbox creation to be instant. Without a pre-pull, the first `Sandbox.create` with a new image will block on the download.
+</Tip>
+
+## msb image ls
+
+List images in the local cache.
+
+```bash
+msb image ls
+msb image ls --format json
+msb image ls -q               # References only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only image references |
+
+<Tip>
+  `msb images` is a shorthand alias for `msb image ls`.
+</Tip>
+
+## msb image inspect
+
+Show detailed metadata for a cached image (manifest, layers, config).
+
+```bash
+msb image inspect python
+msb image inspect python --format json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb image rm
+
+Remove one or more cached images and their layers (layers shared with other images are kept).
+
+```bash
+msb image rm python
+msb image rm alpine ubuntu   # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Remove even if the image is used by existing sandboxes |
+| `-q`, `--quiet` | Suppress output |
+
+<Tip>
+  `msb rmi` is a shorthand alias for `msb image rm`.
+</Tip>
+
+## msb registry
+
+Manage registry authentication.
+
+```bash
+msb registry login ghcr.io --username octocat
+printf '%s\n' "$GHCR_TOKEN" | msb registry login ghcr.io --username octocat --password-stdin
+msb registry logout ghcr.io
+msb registry ls
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `login` | Store credentials for a registry in the OS credential store |
+| `logout` | Remove stored credentials for a registry |
+| `list` (alias: `ls`) | List configured registries without printing secrets |
+
+**`msb registry login` flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--username` | Registry username |
+| `--password-stdin` | Read password from stdin |
+
+`msb registry login` stores the secret in the OS credential store (for example Keychain, Credential Manager, or Secret Service) and writes only metadata to `~/.microsandbox/config.json`.
+
+For CI or other headless environments, configure `registries.auth` in `~/.microsandbox/config.json` with `password_env`. Advanced host setups can also use `secret_name` to point at a file-backed secret under `~/.microsandbox/secrets/registries/`.
+
+When pulling from a registry, microsandbox resolves auth in this order:
+
+1. Explicit SDK auth (`.registry_auth(...)`)
+2. OS credential store
+3. `registries.auth` config
+4. Docker credential store/config
+5. Anonymous

--- a/docs/de/cli/overview.mdx
+++ b/docs/de/cli/overview.mdx
@@ -1,0 +1,97 @@
+---
+title: CLI Overview
+description: Manage sandboxes from the terminal
+icon: "book"
+---
+
+The `msb` CLI lets you create, manage, and interact with sandboxes from the terminal. It auto-detects TTY and interactivity, so no `-it` flags are needed. If your terminal is interactive, `msb` acts accordingly.
+
+## Install
+
+```bash
+curl -fsSL https://install.microsandbox.dev | sh
+```
+
+<Note>
+  microsandbox requires Linux with KVM enabled, or macOS with Apple Silicon (M-series chip). Both use hardware virtualization.
+</Note>
+
+## Quick reference
+
+```bash
+# Run a one-off command (ephemeral, auto-removed)
+msb run python -- python -c "print('Hello!')"
+
+# Interactive shell (auto-detects TTY)
+msb run alpine -- sh
+
+# Create a persistent sandbox
+msb run --name devbox ubuntu -- bash
+
+# Resume later
+msb start devbox
+
+# Execute in a running sandbox
+msb exec devbox -- sh -c "apt update && apt install -y cowsay && /usr/games/cowsay \"Hello from devbox\""
+
+# Manage
+msb ls                   # List all sandboxes
+msb ps                   # Running sandboxes only
+msb metrics              # Live CPU/memory/network stats
+msb inspect devbox       # Detailed info
+msb logs devbox          # Captured stdout/stderr (works on stopped sandboxes too)
+msb logs devbox -f       # Follow live
+msb stop devbox          # Graceful shutdown
+msb rm devbox            # Remove stopped sandbox
+
+# Images
+msb pull python     # Pre-pull to cache
+msb image ls             # List cached images
+msb image rm python # Remove a cached image
+
+# Volumes
+msb volume create data --size 10G
+msb volume ls
+msb volume rm data
+
+# Install as a system command
+msb install ubuntu       # Install as 'ubuntu' command
+msb uninstall ubuntu     # Remove installed command
+
+# Self-management
+msb self update          # Update msb to latest
+msb self uninstall       # Remove msb
+```
+
+<Tip>
+  Unnamed sandboxes (no `--name` flag) are ephemeral. They're automatically removed when the command finishes. Named sandboxes persist and can be stopped, restarted, and inspected later.
+</Tip>
+
+## Global options
+
+| Flag | Description |
+|------|-------------|
+| `--tree` | Display the complete command tree with descriptions |
+| `--error` | Show only errors |
+| `--warn` | Show warnings and errors |
+| `--info` | Show info, warnings, and errors |
+| `--debug` | Show debug output |
+| `--trace` | Show all output including trace |
+
+## Command tree
+
+Use `--tree` as an alternative to `--help` to see every command, subcommand, and flag at once:
+
+```bash
+msb --tree
+```
+
+You can scope it to a specific subcommand:
+
+```bash
+msb image --tree    # Show only image commands
+msb volume --tree   # Show only volume commands
+msb run --tree      # Show all flags for run
+```
+
+For detailed command reference, see [Sandbox Commands](/cli/sandbox-commands), [Volume Commands](/cli/volume-commands), and [Image Commands](/cli/image-commands).

--- a/docs/de/cli/sandbox-commands.mdx
+++ b/docs/de/cli/sandbox-commands.mdx
@@ -1,0 +1,328 @@
+---
+title: Sandbox Commands
+description: Create, run, and interact with sandboxes from the CLI
+icon: "cube"
+---
+
+## msb run
+
+Create a sandbox and optionally run a command. Without `--name`, the sandbox is ephemeral and removed when the command finishes. With `--name`, it persists for later use.
+
+```bash
+# Ephemeral: runs and cleans up
+msb run python -- python -c "print('hello')"
+
+# Named: persists after exit
+msb run --name devbox ubuntu -- bash
+
+# With volumes, ports, and environment
+msb run --name api \
+  -v ./src:/app \
+  -v pydata:/data \
+  -p 8000:8000 \
+  -e DEBUG=true \
+  -w /app \
+  python
+
+# Detached (runs in background)
+msb run -d --name worker python -- python worker.py
+```
+
+| Flag | Description |
+|------|-------------|
+| `-n`, `--name` | Sandbox name (if omitted, sandbox is ephemeral) |
+| `-c`, `--cpus` | Number of virtual CPUs to allocate |
+| `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
+| `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST`) |
+| `-p`, `--port` | Forward a host port to the sandbox (`HOST:GUEST` or `HOST:GUEST/udp`) |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-w`, `--workdir` | Working directory inside the sandbox |
+| `--shell` | Default shell for interactive sessions |
+| `-t`, `--tty` | Allocate a pseudo-terminal (enables colors, line editing) |
+| `-d`, `--detach` | Run in background and print the sandbox name |
+| `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`). Per-command; the sandbox stays alive |
+| `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`, `as=1073741824`) |
+| `--detach-keys` | Key sequence to detach from interactive session (default: `ctrl-]`) |
+| `--replace` | Replace an existing sandbox with the same name |
+| `-q`, `--quiet` | Suppress progress output |
+| `--entrypoint` | Override the image's default entrypoint command |
+| `--init` | Hand off PID 1 to this init binary (absolute path) inside the guest after agentd's setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| `--init-arg` | Argv entry appended to the handoff init. Repeatable. Defaults to `[<--init>]` when empty |
+| `--init-env` | Env var passed to the handoff init only (`KEY=VALUE`). Repeatable; merged on top of the inherited env |
+| `-H`, `--hostname` | Set the guest hostname (defaults to sandbox name) |
+| `-u`, `--user` | Run commands as the specified user (e.g. `nobody`, `1000`, `1000:1000`) |
+| `--pull` | When to pull the image: `always`, `if-missing` (default), `never` |
+| `--log-level` | Log verbosity for the sandbox runtime (`error`, `warn`, `info`, `debug`, `trace`) |
+| `--tmpfs` | Mount a temporary in-memory filesystem (`PATH` or `PATH:SIZE`) |
+| `--script` | Register an inline script (`NAME=BODY`). Available at `/.msb/scripts/<name>` and on `PATH` |
+| `--script-path` | Register a script from a host file (`NAME:PATH`). Same destination as `--script` |
+| `--max-duration` | Kill the entire sandbox after this duration (e.g. `30s`, `5m`, `1h`). Sandbox-level lifetime limit |
+| `--idle-timeout` | Stop the sandbox after this period of inactivity (e.g. `30s`, `5m`, `1h`) |
+| `--no-network` | Disable all network access |
+| `--network-policy` | Control which destinations are reachable from the sandbox. Accepted values: `none` (no network), `public-only` (default — public internet only), `nonlocal` (public + private/LAN; blocks loopback, link-local, and metadata), `allow-all` (unrestricted) |
+| `--deny-domain` | Deny egress to a domain. Repeatable. Adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback) |
+| `--deny-domain-suffix` | Deny egress to all subdomains of a suffix (e.g. `.ads.com`). Repeatable. Adds a `deny DomainSuffix("...")` policy rule |
+| `--no-dns-rebind-protection` | Allow DNS responses pointing to private/internal IP addresses |
+| `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
+| `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |
+| `--max-connections` | Limit the number of concurrent network connections |
+| `--trust-host-cas` | Ship the host's trusted root CAs into the guest so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, etc.) whose gateway CA is installed on the host but unknown to the guest's stock bundle. Opt-in; by default the guest validates against its stock Mozilla bundle only |
+| `--secret` | Inject a secret that is only sent to an allowed host (`ENV=VALUE@HOST`) |
+| `--on-secret-violation` | Action when a secret is sent to a disallowed host (`block`, `block-and-log`, `block-and-terminate`) |
+| `--tls-intercept` | Intercept and inspect HTTPS traffic via a built-in TLS proxy |
+| `--tls-intercept-port` | TCP port to apply TLS interception on (default: 443) |
+| `--tls-bypass` | Skip TLS interception for a domain (e.g. `*.internal.com`) |
+| `--no-block-quic` | Allow QUIC/HTTP3 traffic (blocked by default when TLS interception is on) |
+| `--tls-intercept-ca-cert` | Use a custom CA certificate for TLS interception (PEM file) |
+| `--tls-intercept-ca-key` | Use a custom CA private key for TLS interception (PEM file) |
+| `--tls-upstream-ca-cert` | Trust an additional CA certificate for upstream server verification (PEM file). Can be specified multiple times |
+
+When no `--` command is given, the image's `entrypoint` and `cmd` are used as the default process. If the image has neither, an interactive shell is started. When a command is given via `--`, it replaces the image `cmd` but the `entrypoint` is preserved. See [Image config inheritance](/images/overview#image-config-inheritance) for details.
+
+## msb create
+
+Create and boot a sandbox without running a command. Takes the same flags as `msb run` (except `--detach`).
+
+```bash
+msb create python --name worker -c 2 -m 1G
+msb create --replace python --name worker   # Replace existing
+```
+
+## msb start
+
+Resume a stopped sandbox.
+
+```bash
+msb start devbox
+```
+
+| Flag | Description |
+|------|-------------|
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb stop
+
+```bash
+msb stop devbox                # Graceful shutdown
+msb stop --force devbox        # Force kill immediately
+msb stop -t 10 devbox          # Wait 10s then force kill
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Immediately kill the sandbox without graceful shutdown |
+| `-t`, `--timeout` | Seconds to wait for graceful shutdown before force-killing |
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb exec
+
+Execute a command inside a running sandbox.
+
+```bash
+msb exec devbox -- python -c "print('hello')"
+msb exec devbox -- ls -la /app
+```
+
+| Flag | Description |
+|------|-------------|
+| `-t`, `--tty` | Allocate a pseudo-terminal (enables colors, line editing) |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-w`, `--workdir` | Override working directory |
+| `-u`, `--user` | Run the command as the specified guest user |
+| `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`) |
+| `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`) |
+| `-q`, `--quiet` | Suppress progress output |
+
+<Tip>
+  The CLI auto-detects whether stdin is a terminal. When interactive, `msb exec` uses `attach` mode (TTY, line editing). When piped, it captures output. No `-i` flag is needed.
+</Tip>
+
+## msb logs
+
+Read captured output from a sandbox. Each sandbox stores its captured stdio under `<sandbox-dir>/logs/exec.log` as JSON Lines, plus runtime/kernel diagnostics in `runtime.log`/`kernel.log`. The command works on running and stopped sandboxes alike — there is no protocol traffic, just a file read.
+
+```bash
+# Captured user-program output (default sources: stdout + stderr + output)
+msb logs devbox
+
+# Tail and follow
+msb logs devbox --tail 100
+msb logs devbox -f --grep ERROR
+
+# Time-bounded
+msb logs devbox --since 5m
+msb logs devbox --since 2026-04-30T20:00:00Z --until 5m
+
+# JSON Lines passthrough — feed to jq, vector, etc.
+msb logs devbox --json | jq 'select(.s == "stderr")'
+
+# Multi-session view: prefix each line with [id:N] so you can tell sessions apart
+msb logs devbox --show-id
+
+# Color each session's output a distinct color (implies --show-id)
+msb logs devbox --color-sessions
+
+# Include runtime/kernel diagnostics
+msb logs devbox --source system
+msb logs devbox --source all                # everything, chronologically merged
+```
+
+| Flag | Description |
+|------|-------------|
+| `--tail` | Show only the last N entries |
+| `--since` | Show entries at or after this time (RFC 3339 or relative `5m`/`2h`/`1d`) |
+| `--until` | Show entries strictly before this time (same formats) |
+| `-f`, `--follow` | Follow in real time (200 ms polling, rotation-aware) |
+| `--timestamps` | Prefix each line with the entry timestamp |
+| `--source` | Sources to include: `stdout`, `stderr`, `output`, `system`, `all`. Repeat or comma-separate. Default: `stdout,stderr,output` |
+| `--grep` | Client-side regex filter on the entry body |
+| `--json` | Emit raw JSON Lines without decoding (one entry per line) |
+| `--raw` | Opt into base64 encoding for non-UTF-8 bytes |
+| `--show-id` | Prefix each line with `[id:N]` (the session correlation id) |
+| `--color-sessions` | Color each session's lines a distinct color (implies `--show-id`) |
+| `--color` | ANSI handling: `auto` (default), `always`, `never` |
+| `--no-color` | Alias for `--color=never` |
+
+**Source tags** (the `s` field in `--json` output):
+
+- `stdout` / `stderr` — captured from the session's pipes when running in **pipe mode** (streams stay separated end to end).
+- `output` — captured from the session in **pty mode**. pty allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `output` rather than mislabelled as `stdout`.
+- `system` — synthetic lifecycle markers (`--- sandbox started ---` / `--- sandbox stopped ---`) plus diagnostic lines from `runtime.log`/`kernel.log` when `--source system` is requested.
+
+<Tip>
+  If a sandbox failed to start, `msb logs` prepends a styled error block reconstructed from `boot-error.json`. The block tells you the failure stage, errno, and a hint — even though no user-program output was ever captured.
+</Tip>
+
+## msb ls
+
+List all stored sandboxes.
+
+```bash
+msb ls                    # All sandboxes (running and stopped)
+msb ls --running          # Running sandboxes only
+msb ls --stopped          # Stopped sandboxes only
+msb ls --format json      # JSON output
+msb ls -q                 # Names only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--running` | Show only running sandboxes |
+| `--stopped` | Show only stopped sandboxes |
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only sandbox names |
+
+## msb status / ps
+
+Show sandbox status with process details.
+
+```bash
+msb ps                    # Running sandboxes
+msb ps my-app             # Single sandbox
+msb ps -a                 # All sandboxes (including stopped)
+msb ps --format json      # JSON output
+```
+
+| Flag | Description |
+|------|-------------|
+| `-a`, `--all` | Show all sandboxes, not just running ones |
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only sandbox names |
+
+## msb metrics
+
+Show live CPU, memory, disk, and network metrics for running sandboxes.
+
+```bash
+msb metrics               # All running sandboxes
+msb metrics my-app        # Single sandbox
+msb metrics --format json # JSON output
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb inspect
+
+Show detailed configuration and status.
+
+```bash
+msb inspect devbox
+msb inspect devbox --format json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb rm
+
+Remove one or more sandboxes and their associated state.
+
+```bash
+msb rm devbox
+msb rm --force devbox     # Stop and remove in one step
+msb rm worker-1 worker-2  # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Stop the sandbox if running, then remove it |
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb install
+
+Install a sandbox as a system command. Creates an executable in `~/.microsandbox/bin/` that launches `msb run` with the specified image and options.
+
+```bash
+msb install ubuntu                   # Install as 'ubuntu' command
+msb install --name nodebox node      # Custom command name
+msb install --tmp alpine             # Fresh sandbox every invocation
+msb install -c 2 -m 1G python  # With resource limits
+msb install --list                   # List installed commands
+```
+
+| Flag | Description |
+|------|-------------|
+| `-n`, `--name` | Command name for the alias (defaults to image name) |
+| `-c`, `--cpus` | Number of virtual CPUs to allocate |
+| `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
+| `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST`) |
+| `-w`, `--workdir` | Working directory inside the sandbox |
+| `--shell` | Shell for interactive sessions |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-f`, `--force` | Overwrite an existing alias with the same name |
+| `--no-pull` | Don't pull the image before installing |
+| `--tmp` | Create a fresh sandbox on every invocation (no persistent state) |
+| `-l`, `--list` | List all installed sandbox commands |
+
+## msb uninstall
+
+Remove an installed sandbox command.
+
+```bash
+msb uninstall nodebox
+msb uninstall ubuntu alpine   # Remove multiple
+```
+
+## msb self
+
+Manage the msb installation itself.
+
+```bash
+msb self update               # Update msb and libkrunfw to latest
+msb self update --force       # Re-download even if up to date
+msb self uninstall            # Remove msb (with confirmation prompt)
+msb self uninstall --yes      # Skip confirmation
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `update` (alias: `upgrade`) | Update msb and libkrunfw to the latest release |
+| `uninstall` | Remove msb, libkrunfw, and shell configuration |
+
+| Flag | Subcommand | Description |
+|------|------------|-------------|
+| `-f`, `--force` | `update` | Re-download even if already on the latest version |
+| `-y`, `--yes` | `uninstall` | Skip confirmation prompt |

--- a/docs/de/cli/volume-commands.mdx
+++ b/docs/de/cli/volume-commands.mdx
@@ -1,0 +1,67 @@
+---
+title: Volume Commands
+description: Create and manage named volumes from the CLI
+icon: "hard-drive"
+---
+
+Named volumes persist independently of sandboxes and are stored at `~/.microsandbox/volumes/`.
+
+## msb volume create
+
+```bash
+msb volume create my-data
+msb volume create my-data --size 10G
+```
+
+| Flag | Description |
+|------|-------------|
+| `--size` | Storage quota (e.g. `100M`, `1G`, `10G`) |
+| `-q`, `--quiet` | Suppress output (only print the volume name) |
+
+## msb volume ls
+
+```bash
+msb volume ls
+msb volume ls --format json
+msb volume ls -q               # Names only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only volume names |
+
+## msb volume inspect
+
+```bash
+msb volume inspect my-data
+```
+
+## msb volume rm
+
+```bash
+msb volume rm my-data
+msb volume rm cache-1 cache-2   # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-q`, `--quiet` | Suppress output |
+
+## Using volumes with sandboxes
+
+Mount a named volume when creating or running a sandbox. The volume name goes before the colon, the guest path after.
+
+```bash
+# Create a volume, then mount it
+msb volume create app-data --size 5G
+msb run --name worker -v app-data:/data python
+
+# Share between sandboxes
+msb run --name writer -v shared:/data alpine -- sh -c "echo hello > /data/msg.txt"
+msb run --name reader -v shared:/data alpine -- cat /data/msg.txt
+```
+
+<Tip>
+  The CLI distinguishes bind mounts from named volumes by looking for a `/` or `.` prefix. `./src:/app` is a bind mount (host path). `myvolume:/data` is a named volume. This matches Docker's convention.
+</Tip>

--- a/docs/de/configuration.mdx
+++ b/docs/de/configuration.mdx
@@ -1,0 +1,140 @@
+---
+title: config.json
+description: Global config.json reference
+icon: "gear"
+---
+
+microsandbox reads its global configuration from `~/.microsandbox/config.json`. All fields are optional. A missing file or empty JSON object is equivalent to using the defaults.
+
+<Accordion title="Full example">
+```json
+{
+  "home": "/custom/path/.microsandbox",
+  "log_level": "info",
+  "database": {
+    "url": "sqlite:///tmp/msb.db",
+    "max_connections": 10,
+    "connect_timeout_secs": 30
+  },
+  "paths": {
+    "msb": "/usr/local/bin/msb",
+    "libkrunfw": "/usr/local/lib/libkrunfw.so",
+    "cache": "/mnt/fast/msb-cache",
+    "sandboxes": null,
+    "volumes": null,
+    "logs": null,
+    "secrets": null
+  },
+  "sandbox_defaults": {
+    "cpus": 2,
+    "memory_mib": 1024,
+    "shell": "/bin/bash",
+    "workdir": "/app"
+  },
+  "registries": {
+    "auth": {
+      "ghcr.io": {
+        "username": "octocat",
+        "store": "keyring"
+      },
+      "registry.example.com": {
+        "username": "deploy",
+        "password_env": "REGISTRY_TOKEN"
+      },
+      "docker.io": {
+        "username": "user",
+        "secret_name": "dockerhub-token"
+      }
+    }
+  }
+}
+```
+</Accordion>
+
+## Top-level fields
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `home` | `~/.microsandbox` | Root directory for all microsandbox data |
+| `log_level` | `null` (silent) | Log level for sandbox processes: `error`, `warn`, `info`, `debug`, `trace` |
+| `database` | [reference](#database) | Database connection settings |
+| `paths` | [reference](#paths) | Path overrides for binaries and directories |
+| `sandbox_defaults` | [reference](#sandbox_defaults) | Defaults applied to every sandbox |
+| `registries` | [reference](#registries) | Container registry authentication |
+
+## `database`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `url` | `null` | Database URL. Uses SQLite under `home` when null |
+| `max_connections` | `5` | Maximum connection pool size |
+| `connect_timeout_secs` | `30` | Timeout when acquiring a database connection from the pool |
+
+## `paths`
+
+All path fields are optional. When `null`, they resolve relative to `home`.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `msb` | `{home}/bin/msb` | `msb` binary. Resolved via: `MSB_PATH` env, this field, default path, `PATH` |
+| `libkrunfw` | `{home}/lib/libkrunfw` | Path to a custom VM kernel (`.so` on Linux, `.dylib` on macOS) |
+| `cache` | `{home}/cache` | Image layer cache |
+| `sandboxes` | `{home}/sandboxes` | Per-sandbox state |
+| `volumes` | `{home}/volumes` | Named volumes |
+| `logs` | `{home}/logs` | Sandbox logs |
+| `secrets` | `{home}/secrets` | Secrets. Registry secrets live under `secrets/registries/` |
+
+## `sandbox_defaults`
+
+Defaults applied to every sandbox unless overridden per-sandbox.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `cpus` | `1` | Number of vCPUs |
+| `memory_mib` | `512` | Guest memory in MiB |
+| `shell` | `"/bin/sh"` | Shell for interactive sessions and scripts |
+| `workdir` | `null` | Working directory inside the sandbox |
+| `metrics_sample_interval_ms` | `1000` | Runtime metrics sampling interval in milliseconds. Set to `0` to disable sampling. |
+| `disable_metrics_sample` | `false` | Force-disable metrics sampling regardless of `metrics_sample_interval_ms`. |
+
+## `registries`
+
+### `registries.auth`
+
+A map of registry hostnames to authentication entries. Each entry specifies a username and exactly **one** credential source.
+
+```json
+{
+  "registries": {
+    "auth": {
+      "ghcr.io": {
+        "username": "octocat",
+        "store": "keyring"
+      }
+    }
+  }
+}
+```
+
+#### Auth entry fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `username` | Yes | Registry username |
+| `store` | No | Credential store. Only `"keyring"` is supported (macOS Keychain, Windows Credential Manager, Linux Secret Service) |
+| `password_env` | No | Environment variable containing the password or token |
+| `secret_name` | No | Filename under `{home}/secrets/registries/` containing the password or token |
+
+<Note>
+  Exactly one of `store`, `password_env`, or `secret_name` must be set per entry. Setting none or more than one is an error.
+</Note>
+
+### Auth resolution order
+
+When pulling from a registry, credentials are resolved in this order:
+
+1. **Explicit SDK auth** via `.registry_auth()` on the sandbox builder
+2. **OS keyring** entries created by `msb registry login`
+3. **Config file** `registries.auth` entries in `config.json`
+4. **Docker config** `~/.docker/config.json` credential helpers
+5. **Anonymous** (no authentication)

--- a/docs/de/getting-started/agents.mdx
+++ b/docs/de/getting-started/agents.mdx
@@ -1,0 +1,108 @@
+---
+title: AI Agents
+description: Give AI agents the ability to create and manage their own sandboxes
+icon: "robot"
+---
+
+microsandbox is built for AI agents. The SDK and CLI give you full programmatic control, but there are two additional ways to connect agents directly: **Agent Skills** for coding assistants and an **MCP server** for any MCP-compatible client.
+
+## Agent Skills
+
+[Agent Skills](https://github.com/superradcompany/skills) teach AI coding agents how to use microsandbox without any custom integration code. Once installed, the agent can create sandboxes, run commands, manage files, and control the full sandbox lifecycle through natural language.
+
+Works with Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, and other agents that support the skills format.
+
+```bash
+npx skills add superradcompany/skills
+```
+
+This installs a set of skill files into your project that the agent reads as context. No server process, no configuration, just files that describe how to use microsandbox.
+
+## MCP Server
+
+The [microsandbox MCP server](https://github.com/superradcompany/microsandbox-mcp) exposes microsandbox as a set of structured tool calls over the [Model Context Protocol](https://modelcontextprotocol.io). Any MCP-compatible client can use it to manage sandbox lifecycle, execute commands, access the filesystem, work with volumes, and monitor sandbox state.
+
+<CodeGroup>
+
+```bash Claude Code
+claude mcp add --transport stdio microsandbox -- npx -y microsandbox-mcp
+```
+
+```json Cursor
+// ~/.cursor/mcp.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json VS Code
+// .vscode/mcp.json
+{
+  "servers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Claude Desktop
+// ~/Library/Application Support/Claude/claude_desktop_config.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Windsurf
+// ~/.codeium/windsurf/mcp_config.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Open Code
+// .opencode.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Zed
+// Zed settings
+{
+  "context_servers": {
+    "microsandbox": {
+      "command": {
+        "path": "npx",
+        "args": ["-y", "microsandbox-mcp"]
+      }
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+Once connected, the agent gets access to tools for creating sandboxes, running commands inside them, reading and writing files, and managing the sandbox lifecycle, all through the MCP protocol.

--- a/docs/de/getting-started/introduction.mdx
+++ b/docs/de/getting-started/introduction.mdx
@@ -1,0 +1,370 @@
+---
+title: "Introduction"
+description: "Every agent deserves its own computer"
+icon: "house"
+---
+
+AI agents run with whatever privileges you give them, and most of the time that's too many. They can see API keys sitting in the environment, reach the network freely (including cloud metadata at `169.254.169.254`), and nothing stops a prompt injection from running `rm -rf /` on the host filesystem. Containers help with some of this, but they share the host kernel, and namespace escapes are a well-documented class of vulnerability.
+
+microsandbox takes a different approach: every sandbox is a real VM with its own Linux kernel. It provides security primitives for preventing exploits like secret exfiltration. And it **runs locally** on your machine.
+
+<CodeGroup>
+
+```rust Rust
+use microsandbox::{Sandbox, NetworkPolicy};
+
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .secret(|s| s
+        .env("OPENAI_API_KEY")
+        .value(std::env::var("OPENAI_API_KEY")?)
+        .allow_host("api.openai.com")
+    )
+    .network(|n| n.policy(NetworkPolicy::public_only()))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { NetworkPolicy, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .secret((s) =>
+        s.env("OPENAI_API_KEY")
+            .value(process.env.OPENAI_API_KEY!)
+            .allowHost("api.openai.com"),
+    )
+    .network((n) => n.policy(NetworkPolicy.publicOnly()))
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import Network, Sandbox, Secret
+
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    memory=512,
+    cpus=2,
+    secrets=[
+        Secret.env("OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+    network=Network.public_only(),
+)
+```
+
+</CodeGroup>
+
+<Callout icon="bolt" color="#7C3AED">
+  microsandbox spins up lightweight VMs in **under a second**, right from your code on your machine. **No servers, no daemons**, no infrastructure to manage.
+</Callout>
+
+## The basics
+
+- **Under 100ms boot.** Sandboxes boot in under 100 milliseconds.
+- **No daemon.** The runtime spawns directly as a child process of whatever application creates the sandbox. No root, no server, no background service.
+- **Any OCI image.** Docker Hub, GHCR, ECR, GCR, or any OCI-compatible registry. Shared layers are deduplicated and only stored once.
+- **Cross-platform.** Native on macOS (Apple Silicon) and Linux (KVM). Same CLI, same SDKs.
+- **Multi-language SDKs.** Rust, TypeScript, and Python, all with consistent APIs.
+- **Programmable.** Network policies, filesystem hooks, secret bindings, and TLS interception are all configured from the host side through the SDK.
+
+## What makes it different
+
+### Secrets that can't leak
+
+Most sandboxes protect secrets by restricting what the guest can do. microsandbox goes further: **the guest never has the secret at all**.
+
+Instead of injecting real credentials into the sandbox, microsandbox generates random placeholders. The actual value never enters the VM. The only way it reaches the outside world is when a request goes to an allowed host, at which point microsandbox swaps the placeholder for the real value. Everywhere else, the placeholder is just a meaningless string.
+
+So even with full code execution inside the sandbox, there's nothing to exfiltrate. The credential was never there. DNS rebinding protection and cloud metadata blocking kick in automatically when secrets are configured, closing the remaining side channels.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .secret_env("OPENAI_API_KEY", api_key, "api.openai.com")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    secrets=[
+        Secret.env("OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+)
+```
+
+</CodeGroup>
+
+### Programmable network layer <sup><sup>coming soon</sup></sup>
+
+Every packet leaving a sandbox passes through a networking stack controlled entirely from the host side, where policy is enforced at the IP, DNS, or HTTP level. From inside the sandbox it looks like a normal network interface, but on the host side you decide what gets through.
+
+There's no underlying host network to bridge to, no rules to circumvent, and no way for the guest to reach around the filter.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .network(|n| n
+        .policy(NetworkPolicy::allowlist(["api.openai.com", "pypi.org"]))
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Destination, NetworkPolicy, Rule, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .network((n) => n.policy({
+        defaultEgress: "deny",
+        defaultIngress: "allow",
+        rules: [
+            Rule.allowEgress(Destination.domain("api.openai.com")),
+            Rule.allowEgress(Destination.domain("pypi.org")),
+        ],
+    }))
+    .create();
+```
+
+```python Python
+from microsandbox import Network, NetworkPolicy, Rule, Sandbox
+
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    network=Network(
+        policy=NetworkPolicy(rules=(
+            Rule.allow(destination="api.openai.com"),
+            Rule.allow(destination="pypi.org"),
+        )),
+    ),
+)
+```
+
+</CodeGroup>
+
+### Extensible filesystem backends <sup><sup>coming soon</sup></sup>
+
+The host controls what the guest sees at the filesystem level. Mount host directories, use managed volumes, or attach custom filesystem backends entirely. Hooks let you intercept reads and writes to do things like encrypt everything going to disk or proxy to remote storage, and the guest never knows the difference.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("encrypted")
+    .image("python")
+    .volume("/secrets", |v| v
+        .bind("/data/secrets")
+        .on_read(move |_path, data| decrypt(data, &key))
+        .on_write(move |_path, data| encrypt(data, &key))
+    )
+    .create().await?;
+```
+
+```typescript TypeScript
+// Filesystem hooks (onRead / onWrite) are coming soon for Node. For now,
+// you can mount the host directory directly:
+await using sb = await Sandbox.builder("encrypted")
+    .image("python")
+    .volume("/secrets", (m) => m.bind("/data/secrets"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+key = get_encryption_key()
+sb = await Sandbox.create(
+    "encrypted",
+    image="python",
+    volumes={
+        "/secrets": Volume.bind("/data/secrets",
+            on_read=lambda path, data: decrypt(data, key),
+            on_write=lambda path, data: encrypt(data, key),
+        ),
+    },
+)
+```
+
+</CodeGroup>
+
+### Snapshot and reuse setup state
+
+Capture a stopped sandbox's writable upper layer as a portable artifact, then boot fresh sandboxes from it. Install dependencies once, snapshot, and `msb run --snapshot ...` workers that skip the setup phase. The artifact is a directory you can `scp` between machines or bundle into a `.tar.zst`. Snapshots today are disk-only and stopped-only; live VM-state snapshots are tracked as future work.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("baseline")
+    .image("python")
+    .create()
+    .await?;
+
+sb.exec("pip", ["install", "-r", "requirements.txt"]).await?;
+sb.stop_and_wait().await?;
+
+// Snapshot the stopped sandbox under a bare name
+let h = Sandbox::get("baseline").await?;
+let _snap = h.snapshot("after-pip-install").await?;
+
+// Boot 10 workers from the same snapshot (each gets its own upper layer)
+let workers: Vec<Sandbox> = futures::future::try_join_all(
+    (0..10).map(|i| async move {
+        Sandbox::builder(format!("worker-{i}"))
+            .from_snapshot("after-pip-install")
+            .create()
+            .await
+    })
+).await?;
+```
+
+```bash CLI
+msb run --name baseline --detach python -- sleep 3600
+msb exec baseline -- pip install -r requirements.txt
+msb stop baseline
+
+msb snapshot create after-pip-install --from baseline
+
+# Boot 10 workers from the snapshot
+for i in $(seq 1 10); do
+    msb run --name worker-$i --detach --snapshot after-pip-install -- sleep 3600
+done
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.builder("baseline").image("python").create();
+await sb.exec("pip", ["install", "-r", "requirements.txt"]);
+await sb.stopAndWait();
+
+const h = await Sandbox.get("baseline");
+await h.snapshot("after-pip-install");
+
+// Boot 10 workers from the same snapshot
+const workers = await Promise.all(
+    Array.from({ length: 10 }, (_, i) =>
+        Sandbox.builder(`worker-${i}`).fromSnapshot("after-pip-install").create(),
+    ),
+);
+```
+
+```python Python
+import asyncio
+from microsandbox import Sandbox
+
+sb = await Sandbox.create("baseline", image="python")
+await sb.exec("pip", ["install", "-r", "requirements.txt"])
+await sb.stop_and_wait()
+
+h = await Sandbox.get("baseline")
+await h.snapshot("after-pip-install")
+
+# Boot 10 workers from the same snapshot
+workers = await asyncio.gather(
+    *(Sandbox.create(f"worker-{i}", snapshot="after-pip-install") for i in range(10))
+)
+```
+
+</CodeGroup>
+
+### Spawn sandboxes from sandboxes <sup><sup>coming soon</sup></sup>
+
+Code running inside a sandbox can spawn peer sandboxes alongside itself. This is designed for multi-agent systems where agents need to create sub-environments. Peer sandboxes inherit nothing by default (their own network, filesystem, secrets), and the orchestrator coordinates via the SDK, not shared state. If the code isn't running inside a microsandbox, the spawn call fails safely.
+
+### Composable plugin system <sup><sup>coming soon</sup></sup>
+
+Extend microsandbox with in-process Rust plugins or out-of-process plugins in any language. Plugins hook into lifecycle events, exec calls, filesystem operations, or network traffic. They compose naturally, so you can stack an audit logger, a rate limiter, and a network monitor without them knowing about each other.
+
+### Bidirectional events <sup><sup>coming soon</sup></sup>
+
+Guest processes can emit typed events to the host, and the host can send events back. No special libraries required in the guest since any language can write JSON to a socket. This enables structured communication beyond stdin/stdout, like progress reporting, task completion signals, or custom RPC.
+
+<CodeGroup>
+
+```rust Rust
+// Receive events from guest
+let _sub = sb.on_event("task.progress", |event: EventData| {
+    if let Ok(p) = event.data.unwrap().deserialized::<Progress>() {
+        println!("[{}%] {}", p.percent, p.message);
+    }
+});
+
+// Send events to guest
+sb.emit("task.start", TaskConfig {
+    input_file: "/data/input.txt".into(),
+    output_dir: "/data/output".into(),
+}).await?;
+```
+
+```typescript TypeScript
+// Receive events from guest
+const sub = sb.onEvent("task.progress", (event: EventData) => {
+    const { percent, message } = event.data as { percent: number; message: string }
+    console.log(`[${percent}%] ${message}`)
+})
+
+// Send events to guest
+await sb.emit("task.start", { inputFile: "/data/input.txt", options: ["--verbose"] })
+```
+
+```python Python
+# Receive events from guest
+sub = sb.on_event("task.progress", lambda event: (
+    print(f"[{event.data['percent']}%] {event.data['message']}")
+))
+
+# Send events to guest
+await sb.emit("task.start", {
+    "input_file": "/data/input.txt",
+    "output_dir": "/data/output",
+})
+```
+
+</CodeGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="bolt" href="/getting-started/quickstart">
+    Get a sandbox running in under 5 minutes
+  </Card>
+
+  <Card title="Sandbox overview" icon="box" href="/sandboxes/overview">
+    Configuration, rootfs sources, and lifecycle
+  </Card>
+
+  <Card title="CLI reference" icon="square-terminal" href="/cli/overview">
+    Manage sandboxes from the terminal
+  </Card>
+
+  <Card title="SDK reference" icon="code" href="/sdk/rust">
+    Full API documentation for all SDKs
+  </Card>
+</CardGroup>

--- a/docs/de/getting-started/quickstart.mdx
+++ b/docs/de/getting-started/quickstart.mdx
@@ -1,0 +1,125 @@
+---
+title: Quickstart
+description: Get a sandbox running in under 5 minutes
+icon: "bolt"
+---
+
+<Note>
+  microsandbox requires **Linux with KVM** enabled, or **macOS with Apple Silicon** (M-series chip). Both use hardware virtualization.
+</Note>
+
+<Tip>
+  Boot a microVM in one command.
+
+  ```bash
+  npx microsandbox run debian
+  ```
+</Tip>
+
+<Steps>
+  <Step title="Install microsandbox">
+    The SDK **embeds the runtime directly**, so no separate server process is needed. Only install the `msb` CLI if you want to manage images, volumes, and sandboxes from the terminal.
+
+    <CodeGroup>
+    ```bash Rust
+    cargo add microsandbox
+    ```
+
+    ```bash TypeScript
+    npm install microsandbox
+    ```
+
+    ```bash Python
+    pip install microsandbox
+    ```
+
+    ```bash CLI
+    curl -fsSL https://install.microsandbox.dev | sh
+    ```
+
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run code in a sandbox">
+    Create a sandbox, execute code inside it, and get the result back.
+
+    <CodeGroup>
+    ```rust Rust
+    use microsandbox::Sandbox;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let sb = Sandbox::builder("hello")
+            .image("python")
+            .memory(512)
+            .create()
+            .await?;
+
+        let output = sb.exec("python", ["-c", "print('Hello from a microVM!')"]).await?;
+        println!("{}", output.stdout()?); // Hello from a microVM!
+
+        sb.stop().await?;
+        Ok(())
+    }
+    ```
+
+    ```typescript TypeScript
+    import { Sandbox } from "microsandbox";
+
+    await using sb = await Sandbox.builder("hello")
+        .image("python")
+        .memory(512)
+        .create();
+
+    const output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"]);
+    console.log(output.stdout()); // Hello from a microVM!
+    ```
+
+    ```python Python
+    import asyncio
+    from microsandbox import Sandbox
+
+    async def main():
+        sb = await Sandbox.create(
+            "hello",
+            image="python",
+            memory=512,
+        )
+
+        output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"])
+        print(output.stdout_text)  # Hello from a microVM!
+
+        await sb.stop()
+
+    asyncio.run(main())
+    ```
+
+    ```bash CLI
+    msb run python -- python3 -c "print('Hello from a microVM!')"
+    ```
+
+    </CodeGroup>
+  </Step>
+</Steps>
+
+## What just happened?
+
+Here's what actually happened behind that `Sandbox.builder(...).create()` call:
+
+1. **Pulled the image** from Docker Hub (or skipped this if it was already cached, since shared layers are deduplicated).
+2. **Assembled the filesystem** by stacking the image layers into a copy-on-write filesystem, so nothing you do inside the sandbox modifies the base image.
+3. **Booted a microVM** as a child process. The 512 MiB you specified is a limit, not a reservation, so the VM only uses what it actually needs.
+4. **Started the guest agent** inside the VM, which set up the environment and opened a communication channel back to the host.
+
+The `exec` call sent a message to that guest agent, which spawned `python` inside the VM, streamed stdout back, and returned the exit code. No SSH involved, no network overhead. The command channel is completely separate from the sandbox's network stack.
+
+<Tip>
+  Because exec doesn't go through the network, it works even when a sandbox has networking disabled via `.disable_network()` and no network interfaces at all.
+</Tip>
+
+## Next steps
+
+- [Understand sandbox configuration](/sandboxes/overview): how the VM, filesystem, and networking fit together
+- [Run commands and stream output](/sandboxes/commands): `exec`, `shell`, `attach`, and streaming
+- [Control network access](/networking/overview): policies, DNS interception, and secret protection
+- [Manage sandboxes with the CLI](/cli/overview): create, inspect, and manage sandboxes from the terminal

--- a/docs/de/images/disk-images.mdx
+++ b/docs/de/images/disk-images.mdx
@@ -1,0 +1,82 @@
+---
+title: Disk Images
+description: Boot from QCOW2, Raw, or VMDK disk images
+icon: "compact-disc"
+---
+
+In addition to OCI container images, microsandbox can boot a sandbox directly from a disk image file. The guest gets raw block device access, and its kernel mounts the filesystem from the device directly.
+
+This is a fundamentally different path from OCI images. With OCI, microsandbox stacks image layers as a copy-on-write filesystem. With disk images, the guest owns the block device. No overlay, no copy-on-write between sandboxes.
+
+Use disk images when you need a pre-built VM template, a custom kernel configuration, or an OS that isn't available as a container image.
+
+## Supported formats
+
+| Format | Description |
+|--------|-------------|
+| **QCOW2** | QEMU Copy-On-Write v2. Supports thin provisioning and backing files. The most common format. |
+| **Raw** | Uncompressed raw disk image. No overhead, but no thin provisioning. |
+| **VMDK** | VMware virtual disk format. |
+
+## Usage
+
+When you pass a file path ending in `.qcow2`, `.raw`, or `.vmdk`, microsandbox auto-detects the format. For ambiguous cases, specify the format and filesystem type explicitly.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::size::SizeExt;
+
+// Auto-detect
+let sb = Sandbox::builder("custom-vm")
+    .image("./ubuntu-22.04.qcow2")
+    .cpus(2)
+    .memory(2.gib())
+    .create()
+    .await?;
+
+// Explicit
+let sb2 = Sandbox::builder("custom-vm")
+    .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
+    .cpus(1)
+    .memory(512)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+// Auto-detect format from the file extension
+await using sb = await Sandbox.builder("custom-vm")
+    .image("./ubuntu-22.04.qcow2")
+    .cpus(2)
+    .memory(2048)
+    .create();
+
+// Explicit format / fstype via a RootfsSource literal
+await using sb2 = await Sandbox.builder("custom-vm")
+    .image({
+        kind: "disk",
+        path: "./alpine.raw",
+        format: "raw",
+        fstype: "ext4",
+    })
+    .cpus(1)
+    .memory(512)
+    .create();
+```
+
+```python Python
+from microsandbox import Image, Sandbox
+
+# Auto-detect format from file extension
+sb = await Sandbox.create("custom-vm", image="./ubuntu-22.04.qcow2", cpus=2, memory=2048)
+
+# Explicit filesystem type
+sb2 = await Sandbox.create("custom-vm", image=Image.disk("./alpine.raw", fstype="ext4"), cpus=1, memory=512)
+```
+</CodeGroup>
+
+<Note>
+  The filesystem type (`ext4`, `xfs`, etc.) must match what's actually on the disk image. The guest kernel mounts it using the specified filesystem driver.
+</Note>

--- a/docs/de/images/overview.mdx
+++ b/docs/de/images/overview.mdx
@@ -1,0 +1,177 @@
+---
+title: OCI Images
+description: Use standard container images from any registry
+icon: "layer-group"
+---
+
+microsandbox uses standard OCI container images as root filesystems. Docker Hub, GHCR, ECR, GCR, any OCI-compatible registry works. Existing images run as-is.
+
+When you specify an image like `python`, microsandbox pulls the manifest, downloads the layers in parallel, and stacks them as a copy-on-write filesystem. Changes inside the sandbox don't modify the base image. Two sandboxes using the same image share the same cached layers on disk.
+
+## Pull policies
+
+By default, microsandbox pulls an image only if it isn't already cached. You can change this behavior.
+
+| Policy | Behavior |
+|--------|----------|
+| `"if-missing"` | Pull only if not cached (default) |
+| `"always"` | Always check the registry for updates |
+| `"never"` | Use local cache only, fail if missing |
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+from microsandbox import PullPolicy, Sandbox
+
+sb = await Sandbox.create("worker", image="python", pull_policy=PullPolicy.ALWAYS)
+```
+</CodeGroup>
+
+<Tip>
+  Once an image reference is resolved, microsandbox pins the exact layers. `python` is resolved to a specific set of immutable layers at first pull. Subsequent `start()` calls use the pinned layers without re-resolving the mutable tag, so your sandbox is reproducible even if the upstream tag moves.
+</Tip>
+
+## Private registries
+
+Authenticate to private registries by passing credentials.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry(|r| r.auth(RegistryAuth::Basic {
+        username: "deploy".into(),
+        password: std::env::var("REGISTRY_PASSWORD")?,
+    }))
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry((r) => r.auth({
+        kind: "basic",
+        username: "deploy",
+        password: process.env.REGISTRY_TOKEN!,
+    }))
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import PullPolicy, RegistryAuth, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="registry.corp.io/team/app:latest",
+    registry_auth=RegistryAuth.basic("deploy", os.environ["REGISTRY_PASSWORD"]),
+    pull_policy=PullPolicy.ALWAYS,
+)
+```
+</CodeGroup>
+
+## Registry TLS
+
+By default, microsandbox connects to registries over HTTPS using system CA roots. You can customize this per-registry in `~/.microsandbox/config.json`.
+
+### Plain HTTP registries
+
+Local registries often run without TLS. Mark them as insecure to connect over plain HTTP:
+
+```json
+{
+  "registries": {
+    "hosts": {
+      "localhost:5050": {
+        "insecure": true
+      }
+    }
+  }
+}
+```
+
+### Custom CA certificates
+
+For registries using self-signed or internal CA certificates, point `ca_certs` to a PEM file. This applies globally to all registry connections:
+
+```json
+{
+  "registries": {
+    "ca_certs": "/path/to/ca-bundle.pem"
+  }
+}
+```
+
+The certificates are added to the default system roots — public registries continue to work normally.
+
+### Combined configuration
+
+```json
+{
+  "registries": {
+    "ca_certs": "/path/to/corporate-ca.pem",
+    "hosts": {
+      "localhost:5050": {
+        "insecure": true,
+        "auth": { "username": "deploy", "password_env": "REGISTRY_TOKEN" }
+      },
+      "ghcr.io": {
+        "auth": { "username": "user", "store": "keyring" }
+      }
+    }
+  }
+}
+```
+
+These settings can also be set per-sandbox via the SDK, overriding global config:
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("localhost:5050/my-app:latest")
+    .registry(|r| r.insecure())
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("localhost:5050/my-app:latest")
+    .registry((r) => r.insecure())
+    .create();
+```
+</CodeGroup>
+
+## Image storage
+
+Images are cached in the global microsandbox home directory:
+
+| Path | Description |
+|------|-------------|
+| `~/.microsandbox/cache/layers/` | Downloaded and extracted image layers |
+| `~/.microsandbox/db/` | Database tracking image metadata and digests |
+
+Layers are content-addressable and deduplicated. If `python` and `python` share a base layer, it's stored once.
+
+<Tip>
+  Use `msb pull` from the CLI to pre-pull images before creating sandboxes. This avoids blocking on a download during `Sandbox.create`.
+</Tip>

--- a/docs/de/networking/dns.mdx
+++ b/docs/de/networking/dns.mdx
@@ -1,0 +1,169 @@
+---
+title: DNS
+description: How the sandbox resolves DNS queries
+icon: "magnifying-glass"
+---
+
+DNS queries from the sandbox are intercepted on the host. Rather than letting the guest talk to a resolver directly, microsandbox proxies each query, which lets you:
+
+- block lookups by domain or suffix,
+- pin which upstream resolvers get used,
+- tune the query timeout,
+- power domain-based policy rules (by mapping responses back to IPs).
+
+The knobs below cover the day-to-day controls. For the rebinding and TOCTOU protections that also ride on the interceptor, see the [security model](/networking/security-model).
+
+## Blocking domains
+
+Domain blocking lives in the network policy as `deny Domain(...)` / `deny DomainSuffix(...)` rules. The interceptor enforces them at three layers:
+
+1. **DNS resolution** — denied names get a local `REFUSED` response; the upstream resolver never sees them.
+2. **TLS first-flight** — when a guest hardcodes an IP and opens a TLS connection, the SNI is checked against the same rules.
+3. **TCP egress (cache fallback)** — for non-TLS traffic, the resolved-hostname cache disambiguates by IP.
+
+The bulk-deny shortcuts in each SDK are convenience for `deny Domain` / `deny DomainSuffix` rules; they prepend onto whatever policy is set so the deny takes precedence over later allow rules.
+
+<CodeGroup>
+```rust Rust
+let policy = NetworkPolicy::builder()
+    .default_allow()
+    .egress(|e| e
+        .deny_domains(["malware.example.com"])
+        .deny_domain_suffixes([".tracking.com"]))
+    .build()?;
+
+let sb = Sandbox::builder("safe-agent")
+    .image("python")
+    .network(|n| n.policy(policy))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("safe-agent")
+    .image("python")
+    .network({
+        denyDomains: ["malware.example.com"],
+        denyDomainSuffixes: [".tracking.com"],
+    })
+    .create();
+```
+
+```python Python
+from microsandbox import Network, Sandbox
+
+sb = await Sandbox.create(
+    "safe-agent",
+    image="python",
+    network=Network(
+        deny_domains=("malware.example.com",),
+        deny_domain_suffixes=(".tracking.com",),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name safe-agent \
+  --deny-domain malware.example.com \
+  --deny-domain-suffix .tracking.com
+```
+
+</CodeGroup>
+
+
+## Pinning nameservers
+
+By default the sandbox picks up the host's resolver list automatically:
+
+- **macOS**: reads `State:/Network/Global/DNS` from the system configuration store, with `/etc/resolv.conf` as a fallback when the store isn't available.
+- **Linux**: reads `/etc/resolv.conf` directly.
+
+You can override this by setting `nameservers` to pin the exact resolvers you want (e.g. `1.1.1.1`, `dns.google`), which is useful when auto-discovery picks the wrong ones.
+
+Values can be plain IPs, `IP:PORT`, hostnames, or `HOST:PORT`. Hostnames are resolved once at sandbox startup using the host's OS resolver.
+
+<CodeGroup>
+```rust Rust
+use microsandbox_network::dns::Nameserver;
+
+let sb = Sandbox::builder("safe-agent")
+    .image("python")
+    .network(|n| n
+        .dns(|d| d
+            .nameservers([
+                "1.1.1.1".parse::<Nameserver>()?,
+                "1.0.0.1".parse::<Nameserver>()?,
+            ])
+            .query_timeout_ms(3000)
+        )
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("safe-agent")
+    .image("python")
+    .network((n) => n.dns((d) =>
+        d.nameservers(["1.1.1.1", "1.0.0.1"])
+            .queryTimeoutMs(3000),
+    ))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "safe-agent",
+    image="python",
+    network=Network(
+        dns=DnsConfig(
+            nameservers=("1.1.1.1", "1.0.0.1"),
+            query_timeout_ms=3000,
+        ),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name safe-agent \
+  --dns-nameserver 1.1.1.1 \
+  --dns-nameserver 1.0.0.1 \
+  --dns-query-timeout-ms 3000
+```
+
+</CodeGroup>
+
+If the guest aims a query at a specific resolver (`dig @1.1.1.1`, an `/etc/resolv.conf` entry inside the guest, or a library call that takes a resolver IP), the interceptor forwards it to that resolver directly. The pinned defaults aren't used in this case. The network policy still applies: the query only goes through if the destination IP is allowed.
+
+## DNS over alternative transports
+
+The block list and rebind protection only apply to queries the gateway can see. A guest that routes DNS through an encrypted or non-DNS protocol bypasses both unless the gateway intercepts or refuses it.
+
+**Intercepted** (block list and rebind protection apply):
+- DNS over UDP (UDP/53)
+- DNS over TCP (TCP/53)
+- DNS over TLS (DoT, TCP/853): requires [TLS interception](/networking/tls)
+
+**Refused** (guest's stub falls back to plain DNS):
+- DNS over QUIC (DoQ, UDP/853)
+- mDNS (UDP/5353), LLMNR (UDP/5355), NetBIOS-NS (UDP/137)
+
+**Not distinguishable from regular traffic** (you must filter via network policy):
+- DNS over HTTPS (DoH, TCP/443)
+
+For strict DNS integrity, combine DoT interception with a network policy denying egress `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway.
+
+## Domain-based policy rules
+
+Network policy rules can match a destination by exact domain or by suffix. The interceptor watches DNS responses as they flow back to the guest and keeps track of which IP addresses belong to which domain.
+
+A connection to `93.184.216.34` is only allowed by a rule targeting `example.com` if that IP actually came back as an answer to a lookup for `example.com` from this sandbox.
+
+Because of that, domain rules only take effect on connections that are preceded by a DNS lookup from inside the sandbox. An application that connects to a hard-coded IP it didn't resolve through the interceptor won't match any domain rule.
+
+## See also
+
+- [Security model](/networking/security-model): rebinding protection and DNS-to-IP binding (TOCTOU defense)
+- [TLS interception](/networking/tls): domains that get intercepted also go through TLS inspection

--- a/docs/de/networking/overview.mdx
+++ b/docs/de/networking/overview.mdx
@@ -1,0 +1,232 @@
+---
+title: Overview
+description: Control network access and isolation
+icon: "network-wired"
+---
+
+All network traffic from a sandbox flows through a host-controlled networking stack. From inside, the sandbox sees a normal network interface, but on the host side every packet is subject to policy before it goes anywhere. The sandbox's only path to the outside world is through this stack, so blocked traffic never leaves the VM.
+
+## Defaults
+
+Without any policy flags, sandboxes get **public-internet egress only**: routable destinations work, but private (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`), loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), and the cloud metadata endpoint (`169.254.169.254`) are denied. Inbound traffic on published ports is unfiltered until you add an explicit ingress rule.
+
+To turn off networking entirely:
+
+```bash
+msb create python --name isolated --no-net
+```
+
+```rust
+let sb = Sandbox::builder("isolated")
+    .image("python")
+    .network(|n| n.enabled(false))
+    .create()
+    .await?;
+```
+
+## Custom policies
+
+A policy is a list of rules plus two direction-specific defaults:
+
+```text
+default_egress  : Allow | Deny     (action when no egress rule matches)
+default_ingress : Allow | Deny     (action when no ingress rule matches)
+rules           : [Rule, ...]      (first match wins)
+```
+
+Each rule carries its own direction (`Egress`, `Ingress`, or `Any`), a destination, an optional protocol set, an optional port set, and an action.
+
+### CLI
+
+`--net-rule` takes a comma-separated list of tokens shaped as
+`<action>[:<direction>]@<target>[:<proto>[:<ports>]]`. Direction defaults to `egress` when omitted. Repeating the flag concatenates tokens in argv order; first match wins.
+
+```bash
+# Public internet plus the host machine, deny everything else by default
+msb create python --name agent \
+    --net-rule "allow@public,allow@host"
+
+# Allow public internet plus a specific private host on tcp/443
+msb create alpine --name secure-agent \
+    --net-rule "allow@10.0.5.10:tcp:443,allow@public" \
+    --net-default-egress deny
+
+# Block tcp/445 to private IPs while keeping everything else open
+msb create alpine --name smb-blocked \
+    --net-default-egress allow \
+    --net-rule "deny@private:tcp:445"
+
+# Publish a port and only accept ingress from RFC1918 sources
+msb create python --name api \
+    --port 8080:8080 \
+    --net-rule "allow:ingress@private"
+```
+
+`<target>` accepts `any`, a group keyword (`public`, `private`, `loopback`, `link-local`, `meta`, `multicast`, `host`), an IP, a CIDR, a domain (with at least one dot), `domain=<name>` for single-label hostnames, or `suffix=<domain>` for subdomain matches.
+
+### Rust
+
+```rust
+use microsandbox::{NetworkPolicy, Sandbox};
+
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e
+        .tcp().port(443).allow_public()
+        .udp().port(53).allow_public())
+    .build()?;
+
+let sb = Sandbox::builder("secure-agent")
+    .image("alpine")
+    .network(|n| n.policy(policy))
+    .create()
+    .await?;
+```
+
+The builder accepts string inputs (`.ip("10.0.0.5")`, `.cidr("10.0.0.0/24")`, `.domain("api.example.com")`, etc.) and parses them at `.build()` time, so the chain stays clean. See the [Rust reference](/sdk/rust/networking) for the full surface (per-category shortcuts, the explicit-rule sub-builder, shadow-rule warnings).
+
+### TypeScript / Python
+
+Both SDKs accept policies as plain config objects matching the wire format. Direction strings are `"egress"`, `"ingress"`, or `"any"`. Group keywords match the CLI grammar.
+
+```typescript
+import { Destination, PortRange, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("secure-agent")
+    .image("alpine")
+    .network((n) => n.policy({
+        defaultEgress: "deny",
+        defaultIngress: "allow",
+        rules: [
+            {
+                direction: "egress",
+                destination: Destination.any(),
+                protocols: ["tcp"],
+                ports: [PortRange.single(443)],
+                action: "allow",
+            },
+            {
+                direction: "egress",
+                destination: Destination.any(),
+                protocols: ["udp"],
+                ports: [PortRange.single(53)],
+                action: "allow",
+            },
+        ],
+    }))
+    .create();
+```
+
+```python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "secure-agent",
+    image="alpine",
+    network={
+        "policy": {
+            "default_egress": "deny",
+            "default_ingress": "allow",
+            "rules": [
+                {"action": "allow", "direction": "egress", "protocol": "tcp", "port": "443"},
+                {"action": "allow", "direction": "egress", "protocol": "udp", "port": "53"},
+            ],
+        },
+    },
+)
+```
+
+Domain rules match flows where the guest resolved the name through the sandbox's DNS interceptor. See [DNS](/networking/dns) for how the resolved-hostname cache works.
+
+## Port mapping
+
+Expose ports from the sandbox to the host so services running inside the VM are reachable from your machine.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("api")
+    .image("python")
+    .port(8080, 80)
+    .port_udp(5353, 5353)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("api")
+    .image("python")
+    .port(8080, 80)
+    .portUdp(5353, 5353)
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "api",
+    image="python",
+    ports={8080: 80},
+)
+```
+
+```bash CLI
+msb create python --name api -p 8080:80
+```
+
+</CodeGroup>
+
+## Reaching the host
+
+From inside the sandbox, `host.microsandbox.internal` resolves to the host machine, same idea as Docker's `host.docker.internal`. Use it to call a dev server, database, or other process running on your machine without hard-coding an IP.
+
+```bash
+# Inside the sandbox:
+curl http://host.microsandbox.internal:8080
+```
+
+The name is wired through `/etc/hosts` and the DNS interceptor, so both standard resolvers and tools that bypass `/etc/hosts` (like `dig`) find it.
+
+The default policy denies host access — the sandbox gateway sits in a private range, same as any other local destination. Add the `host` group to open it:
+
+```bash
+msb create python --name dev-agent \
+    --net-rule "allow@public,allow@host"
+```
+
+```rust
+NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.allow_public().allow_host())
+    .build()?
+```
+
+### Loopback vs host: a common trap
+
+`Group::Loopback` (`127.0.0.0/8`, `::1`) and `Group::Host` (the per-sandbox gateway IPs) are different things. The two-word summary:
+
+- **`loopback`** = the guest's own loopback interface. Services running inside the same VM.
+- **`host`** = the host machine, reached through `host.microsandbox.internal`.
+
+If you're coming from Docker and reach for `.allow_loopback()` to "let the sandbox talk to my host's localhost," that's the trap — you want `.allow_host()` instead. `.allow_loopback()` only fires for traffic *inside* the guest, which doesn't reach the policy gate under normal kernel routing anyway.
+
+`.deny_loopback()` does have a real use case. In `--net-default-egress allow` configurations, a process inside the guest could craft a packet bound to `eth0` with `dst=127.0.0.1`, route it past the guest kernel, and have smoltcp on the host land it on the host's loopback. `.deny_loopback()` blocks that vector. Default policies (with the implicit deny on egress) already cover this.
+
+If you want "everything near the sandbox" — guest loopback, link-local, and the host machine — `.allow_local()` is sugar for that triple. `Metadata` is deliberately excluded so cloud-IMDS isn't quietly exposed; opt in via `.allow_meta()` if you need it.
+
+## Protocol support
+
+For most sandboxed workloads, networking behaves the way you'd expect:
+
+- Normal egress **TCP** and **UDP** traffic works, including common tools and libraries like `curl`, `wget`, package managers, HTTP clients, database drivers, and DNS lookups.
+- **DNS** queries are intercepted on the host side. See [DNS](/networking/dns) for blocking, pinned resolvers, and query timeouts.
+- **ICMP echo** is supported: pinging external hosts works on systems that support unprivileged ICMP echo sockets.
+- **Ingress** on published ports is gated by the same policy. Denied connections drop with TCP RST so the peer sees `ECONNRESET`.
+
+<Note>
+**Raw sockets** and **full ICMP forwarding** are not supported because they require elevated privileges on the host. Tools that depend on richer ICMP behavior, such as `traceroute`, are outside the current scope.
+</Note>
+
+## Next
+
+- [DNS](/networking/dns): domain blocking, pinned nameservers, query timeouts
+- [TLS interception](/networking/tls): HTTPS inspection with an auto-generated CA
+- [Security model](/networking/security-model): how the stack defends against SSRF, rebinding, and metadata exfiltration

--- a/docs/de/networking/security-model.mdx
+++ b/docs/de/networking/security-model.mdx
@@ -1,0 +1,90 @@
+---
+title: Security Model
+description: What the networking stack defends against
+icon: "shield-halved"
+---
+
+microsandbox's networking defaults are shaped around giving an AI agent, a scraper, or some other untrusted workload access to the internet without letting it pivot into your internal infrastructure. This page walks through the specific threats the stack is designed to handle and where each defense lives.
+
+## Private IPs and the host's local network
+
+The largest class of real damage comes from workloads reaching things that live *inside* your network: the host machine itself, a local database, another VM on the same subnet. The default policy addresses this by denying egress to anything outside `Group::Public` (the complement of the named local categories), which covers:
+
+- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10` (RFC1918 + CGN private ranges)
+- `127.0.0.0/8`, `::1` (loopback)
+- `169.254.0.0/16`, `fe80::/10` (link-local)
+- `169.254.169.254` (cloud metadata, takes precedence over link-local)
+- the per-sandbox gateway IPs (`Group::Host`)
+
+If an agent runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Override the default with `--net-default-egress allow` only when the workload genuinely needs broad reach, or use `--no-net` when it doesn't need network at all.
+
+## Cloud metadata endpoints
+
+On AWS, GCP, Azure, and similar platforms, `169.254.169.254` is the instance metadata service, a well-known SSRF target because it hands out temporary credentials to anything that can connect. The default policy blocks it via the `Group::Public` complement. For custom policies that flip `default_egress` to `Allow`, `Group::Metadata` lets you deny it explicitly:
+
+```bash
+msb create python --name agent \
+    --net-default-egress allow \
+    --net-rule "deny@meta"
+```
+
+```rust
+NetworkPolicy::builder()
+    .default_allow()
+    .rule(|r| r.egress().deny_meta())
+    .build()?
+```
+
+## DNS rebinding
+
+An attacker who controls a domain can set up records that resolve to a public IP during the initial allowlist check and then flip to a private IP on a subsequent lookup. The guest ends up making a request that *looked* like it was going to `evil.example.com` and actually lands on `192.168.1.10`.
+
+Rebind protection catches this at the response level: when the DNS interceptor sees an answer resolving a domain to a private, loopback, or link-local IP, the response is rewritten to `REFUSED` and the connection never gets made. This is on by default. You can turn it off when you genuinely need domains to resolve to internal hosts (local development, split-horizon DNS):
+
+<CodeGroup>
+```rust Rust
+.network(|n| n.dns(|d| d.rebind_protection(false)))
+```
+
+```typescript TypeScript
+.network((n) => n.dns((d) => d.rebindProtection(false)))
+```
+
+```python Python
+network=Network(dns=DnsConfig(rebind_protection=False))
+```
+
+```bash CLI
+msb create python --name dev --no-dns-rebind-protection
+```
+
+</CodeGroup>
+
+## DNS-to-IP binding (TOCTOU)
+
+Even without rebinding tricks, a classic time-of-check/time-of-use race exists. An allowlisted domain resolves to an allowed IP when the policy is checked. The guest then looks it up again at connect time and reaches a different IP.
+
+Domain-based policy rules close this by maintaining a pin set of observed DNS answers. A connection only matches a domain rule if its destination IP was actually returned as an answer to a DNS query for that domain from this sandbox. A guest that hard-codes an IP it didn't resolve through the interceptor can't slip past a domain-based allowlist.
+
+The same mechanism gates host-scoped secret injection. When a `SecretEntry` is restricted via `allowed_hosts`, the secret is only injected into outbound requests whose destination IP the interceptor tied to one of those hosts. An exfiltration attempt that POSTs the secret to an arbitrary IP won't receive the injection in the first place.
+
+## DNS bypass surface
+
+DNS-based defenses (block list, rebind protection, domain pinning) only work on queries the interceptor sees. The gateway intercepts UDP/53 and TCP/53 directly, and DoT (TCP/853) when TLS interception is enabled. Alternative transports are either refused at the port layer (DoQ, mDNS, LLMNR, NetBIOS-NS) or indistinguishable from regular traffic (DoH on TCP/443). Tunneled DNS (VPN, SOCKS5 hostname mode, HTTP `CONNECT`) is carried inside the outer encrypted flow and never reaches the forwarder.
+
+For workloads where DNS integrity matters, pair DoT interception with a network policy that denies egress `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway. Tunneled DNS is a network-layer concern: close it by restricting egress to an allowlist that excludes tunnel destinations. See [DNS](/networking/dns) for the transport-by-transport breakdown.
+
+## Out of scope
+
+The networking stack doesn't try to defend against:
+
+- **Kernel exploits inside the guest.** The microVM boundary is what keeps a compromised guest contained.
+- **Raw packet crafting from outside the sandbox.** Host-side privileged processes aren't in this threat model.
+- **Host tampering.** If a workload can modify host-side config, it's already past this layer.
+- **Deep ICMP behavior.** Supported ICMP is limited to unprivileged echo; `traceroute`-style flows are not proxied.
+- **Host trust store integrity.** When [`trust_host_cas`](/sdk/rust/networking#trust_host_cas) is opted into, an attacker who can plant a CA on the host has that trust inside every sandbox. Off by default for exactly this reason.
+
+## See also
+
+- [DNS](/networking/dns): the controls that ride on the DNS interceptor
+- [TLS interception](/networking/tls): plaintext visibility for per-host policy and secret injection

--- a/docs/de/networking/tls.mdx
+++ b/docs/de/networking/tls.mdx
@@ -1,0 +1,134 @@
+---
+title: TLS Interception
+description: HTTPS inspection with an auto-generated CA
+icon: "lock"
+---
+
+Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server, which is how features like per-host secret injection and URL-level policy checks are able to see inside what would otherwise be an opaque stream.
+
+## How it works
+
+When you enable TLS interception:
+
+1. A CA key and certificate are generated for the sandbox at creation time. The CA is scoped to that sandbox: it's not shared across sandboxes or with the host.
+2. The guest's trust store is updated to trust this CA.
+3. When the guest opens an HTTPS connection, the host-side proxy intercepts the handshake, generates a leaf certificate for the target domain on the fly, and signs it with the per-sandbox CA.
+4. The proxy opens its own TLS connection to the upstream server and bridges the two.
+
+Because the CA lives only for the sandbox's lifetime, nothing signed by it is trusted anywhere else.
+
+## Enabling interception
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("agent")
+    .image("python")
+    .network(|n| n
+        .tls(|t| t
+            .bypass("pinned-api.example.com")
+            .bypass("*.gov")
+        )
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("agent")
+    .image("python")
+    .network((n) => n.tls((t) =>
+        t.bypass("pinned-api.example.com").bypass("*.gov"),
+    ))
+    .create();
+```
+
+```python Python
+from microsandbox import Network, Sandbox, TlsConfig
+
+sb = await Sandbox.create(
+    "agent",
+    image="python",
+    network=Network(
+        tls=TlsConfig(bypass=("pinned-api.example.com", "*.gov")),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name agent \
+  --tls-intercept \
+  --tls-bypass "pinned-api.example.com" \
+  --tls-bypass "*.gov"
+```
+
+</CodeGroup>
+
+## Bypass patterns
+
+Some domains don't play well with interception, typically ones whose clients pin a specific certificate or public key instead of trusting the system CA store. Software update channels (browser autoupdate, macOS `softwareupdate`, package-manager mirrors that ship a pinned signing CA) and vendor SDKs that bundle their own pinned CA are the usual suspects. Add them to the bypass list and their traffic flows through as-is, encrypted end-to-end between the guest and the upstream server.
+
+Bypass patterns accept exact matches (`api.example.com`) and wildcards (`*.gov`, `*.apple.com`).
+
+## Limits
+
+- **Pinned clients bypass the trust store.** Any client that pins the server's certificate or public key (rather than trusting the system CA) will fail TLS interception and needs to be bypassed explicitly.
+- **Bypassed traffic is opaque.** Policy checks that depend on inspecting request content (URL-based rules, secret injection with `require_tls_identity`) don't apply on bypassed domains.
+- **Client certificates are not proxied.** mTLS flows where the guest is the one presenting a client certificate aren't supported through interception; add those hosts to the bypass list.
+
+## Trusting host CAs
+
+Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, ...) terminate outbound HTTPS at the host and re-sign it with a gateway CA. That CA is installed in your macOS Keychain or Linux trust store as part of the corporate rollout, so HTTPS works silently on the host. Inside a sandbox it doesn't: the guest's stock Mozilla bundle has never seen the gateway CA, so `apk update`, `pip install`, `curl`, and any SDK fetch fail with `server certificate not trusted`.
+
+By default the sandbox does not extend host trust into the guest, so the guest validates TLS strictly against its stock Mozilla bundle. Opt in when you need the guest to trust whatever the host trusts: at sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle.
+
+<Note>
+**Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox.
+
+It matches the existing threat model (a host-access attacker already owns the sandbox), but worth knowing before enabling on a host with an unfamiliar trust store.
+</Note>
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("agent")
+    .image("alpine")
+    .network(|n| n.trust_host_cas(true))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("agent")
+    .image("alpine")
+    .network((n) => n.trustHostCAs(true))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "agent",
+    image="alpine",
+    network=Network(trust_host_cas=True),
+)
+```
+
+```bash CLI
+msb run alpine --trust-host-cas -- apk update
+```
+
+</CodeGroup>
+
+### Interaction with TLS interception
+
+TLS interception also covers the corporate-proxy case, but only on the ports it's configured for (default `[443]`), and only for non-bypassed domains. It doesn't touch QUIC / HTTP/3 flows. Everything outside that scope (gRPC, Postgres / Redis / Mongo TLS, custom 8443, non-intercepted ports, bypassed domains) goes over raw TLS from the guest, where host-CA trust is what makes certificate validation succeed.
+
+The two features compose. Turn on [`trust_host_cas`](/sdk/rust/networking#trust_host_cas) alongside TLS interception when you need both: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Leave it off to keep the guest's TLS stack validating strictly against its stock Mozilla bundle.
+
+## See also
+
+- [DNS](/networking/dns): the DNS interceptor is what makes per-host rules possible, and DoT interception reuses this TLS path
+- [Security model](/networking/security-model): how TLS interception interacts with secret injection and SSRF defenses

--- a/docs/de/recipes/docker.mdx
+++ b/docs/de/recipes/docker.mdx
@@ -1,0 +1,57 @@
+---
+title: Running in Docker
+description: Deploy microsandbox as a Docker container on Linux
+icon: "box"
+---
+
+<Tip>
+  For production use, we recommend [installing microsandbox natively](/getting-started/quickstart).
+</Tip>
+
+microsandbox publishes multi-arch Docker images (amd64/arm64) to GitHub Container Registry. This is an interim solution for environments that require containerized deployment, pending microsandbox implementing the [OCI runtime spec](https://github.com/opencontainers/runtime-spec).
+
+## Prerequisites
+
+- A **Linux** host with KVM support (`/dev/kvm` must be available)
+- Docker installed
+
+## Pull the image
+
+```bash
+docker pull ghcr.io/superradcompany/microsandbox:latest
+```
+
+Or pin to a specific version:
+
+```bash
+docker pull ghcr.io/superradcompany/microsandbox:0.4.0
+```
+
+## Run a sandbox
+
+The container requires `--privileged` and `/dev/kvm` access to run microVMs:
+
+```bash
+docker run --privileged --device /dev/kvm \
+  ghcr.io/superradcompany/microsandbox:latest \
+  run python --name my-sandbox --replace
+```
+
+## Persistent data
+
+By default, sandbox data (images, cache, databases) is stored inside the container and lost when it stops. Mount a volume to persist data across restarts:
+
+```bash
+docker run --privileged --device /dev/kvm \
+  -v microsandbox_data:/root/.microsandbox \
+  ghcr.io/superradcompany/microsandbox:latest \
+  run python --name my-sandbox --replace
+```
+
+## Available tags
+
+| Tag | Description |
+|-----|-------------|
+| `latest` | Latest release |
+| `x.y.z` (e.g. `0.4.0`) | Specific version |
+| `x.y` (e.g. `0.4`) | Latest patch of a minor version |

--- a/docs/de/recipes/local-images.mdx
+++ b/docs/de/recipes/local-images.mdx
@@ -1,0 +1,72 @@
+---
+title: Using Local Docker Images
+description: Use locally built Docker images with microsandbox via a local registry
+icon: "boxes-stacked"
+---
+
+microsandbox pulls images from OCI-compatible registries. If you build an image locally with `docker build`, microsandbox can't access it directly from Docker's local store. The workaround is to run a local registry and push your image there.
+
+## Step 1: Start a local registry
+
+Run a local OCI registry on port 5050:
+
+```bash
+docker run -d -p 5050:5000 --name registry registry:2
+```
+
+<Tip>
+  Port 5000 is used by AirPlay on macOS. This guide uses port 5050 to avoid conflicts.
+</Tip>
+
+## Step 2: Build, tag, and push your image
+
+Build your Docker image and tag it for the local registry:
+
+```bash
+docker build -t localhost:5050/my-image:latest .
+```
+
+If you already have an existing image, re-tag it:
+
+```bash
+docker tag my-image:latest localhost:5050/my-image:latest
+```
+
+Push to the local registry:
+
+```bash
+docker push localhost:5050/my-image:latest
+```
+
+## Step 3: Pull with microsandbox
+
+Since the local registry runs over plain HTTP, use the `--insecure` flag:
+
+```bash
+msb pull localhost:5050/my-image:latest --insecure
+```
+
+## Step 4: Use it in microsandbox
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("localhost:5050/my-image:latest")
+    .registry(|r| r.insecure())
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("localhost:5050/my-image:latest")
+    .registry((r) => r.insecure())
+    .create();
+```
+</CodeGroup>
+
+<Tip>
+  For persistent configuration that applies to all CLI and SDK operations, add the registry to `~/.microsandbox/config.json` instead. See [Registry TLS](/images/overview#registry-tls).
+</Tip>

--- a/docs/de/recipes/systemd-services.mdx
+++ b/docs/de/recipes/systemd-services.mdx
@@ -1,0 +1,65 @@
+---
+title: Booting Under systemd
+description: Hand PID 1 to systemd inside the guest so services run under a real init
+icon: "gear"
+---
+
+By default the microsandbox agent is PID 1. That's enough for one-shot processes, but anything that calls into `systemctl`, `loginctl`, or expects a session bus will fail.
+
+`--init auto` hands PID 1 over to systemd. The rest of the guest then behaves like a normal Linux box.
+
+## Step 1: Boot
+
+```bash
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  --memory 1G --cpus 2 \
+  --init auto \
+  -- bash
+```
+
+`debian-systemd` is one of the optional bases we maintain in [guest-images](https://github.com/superradcompany/guest-images) for cases like this. `--init auto` probes a small set of well-known paths and picks the first that exists. See [Custom init system](/sandboxes/customize#custom-init-system) for the full list and for pinning to an exact path.
+
+## Step 2: Confirm systemd is PID 1
+
+```bash
+root@msb:/# systemctl status
+● msb
+    State: running
+    Units: 113 loaded (incl. loaded aliases)
+  systemd: 252.39-1~deb12u1
+```
+
+Or check directly:
+
+```bash
+root@msb:/# cat /proc/1/comm
+systemd
+```
+
+## Step 3: Manage units
+
+`systemctl` works as it does on bare metal. Inspect a unit shipped with the image:
+
+```bash
+root@msb:/# systemctl status systemd-journald
+● systemd-journald.service - Journal Service
+     Loaded: loaded (/lib/systemd/system/systemd-journald.service; static)
+     Active: active (running)
+```
+
+Install your own and start it:
+
+```bash
+root@msb:/# apt update && apt install -y nginx
+root@msb:/# systemctl enable --now nginx
+root@msb:/# curl -s localhost | head -1
+<!DOCTYPE html>
+```
+
+Microsandbox is detected as a container, so packages with `policy-rc.d` deferral install but don't auto-start. `systemctl enable --now <unit>` starts them in one step.
+
+## Notes
+
+- **Image choice matters.** Distroless / minimal images (`python:3.13-slim`, `alpine`) don't ship a systemd init binary; `--init auto` will fail and `kernel.log` will list every path it tried. Use a systemd-equipped base or layer one in.
+- **Memory budget.** systemd's idle footprint is ~50 MiB; daemons add more. Bump `--memory` if your service is hungry.
+- **Other inits work.** `--init` accepts any absolute path. s6, OpenRC, runit, or a hand-rolled `/sbin/init` shell script are all fine; `auto` just covers the systemd-on-Debian/Ubuntu case.

--- a/docs/de/sandboxes/commands.mdx
+++ b/docs/de/sandboxes/commands.mdx
@@ -1,0 +1,284 @@
+---
+title: Commands
+description: Execute commands, stream output, and interact with sandboxes
+icon: "terminal"
+---
+
+Command execution doesn't use SSH or the network. There's a dedicated channel between the host and a guest agent running inside the VM, completely separate from the sandbox's network stack. The agent spawns processes, streams output back, and reports exit codes.
+
+One nice consequence: `exec` works even when a sandbox has networking fully disabled.
+
+## Execute a command
+
+Run a command and wait for it to complete. You get back the exit code, stdout, and stderr.
+
+<CodeGroup>
+```rust Rust
+let output = sb.exec("python", ["-c", "print('hello')"]).await?;
+println!("{}", output.stdout()?);     // "hello\n"
+println!("{}", output.status().code); // 0
+```
+
+```typescript TypeScript
+const output = await sb.exec("python", ["-c", "print('hello')"]);
+console.log(output.stdout()); // "hello\n"
+console.log(output.success);  // true
+console.log(output.code);     // 0
+```
+
+```python Python
+output = await sb.exec("python", ["-c", "print('hello')"])
+print(output.stdout_text)     # "hello\n"
+print(output.success)         # True
+print(output.exit_code)       # 0
+```
+
+```bash CLI
+msb exec worker -- python -c "print('hello')"
+```
+
+</CodeGroup>
+
+## Execution options
+
+These options apply to a single execution and don't change the sandbox's defaults.
+
+<CodeGroup>
+```rust Rust
+let output = sb.exec_with("python", |e| e
+    .args(["compute.py"])
+    .cwd("/app")
+    .env("PYTHONPATH", "/app/lib")
+    .timeout(Duration::from_secs(30))
+    .rlimit(RlimitResource::Nofile, 1024)
+).await?;
+```
+
+```typescript TypeScript
+const output = await sb.execWith("python", (e) =>
+    e.args(["compute.py"])
+        .cwd("/app")
+        .env("PYTHONPATH", "/app/lib")
+        .timeout(30_000)
+        .rlimit("nofile", 1024),
+);
+```
+
+```python Python
+from microsandbox import ExecOptions, Rlimit
+
+output = await sb.exec("python", ExecOptions(
+    args=("compute.py",),
+    cwd="/app",
+    env={"PYTHONPATH": "/app/lib"},
+    timeout=30.0,
+    rlimits=(Rlimit.nofile(1024),),
+))
+```
+
+```bash CLI
+msb exec worker \
+  -w /app \
+  -e PYTHONPATH=/app/lib \
+  --timeout 30s \
+  --rlimit nofile=1024 \
+  -- python compute.py
+```
+
+</CodeGroup>
+
+## Shell commands
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Useful for pipelines, redirects, and other shell syntax that `exec` doesn't interpret.
+
+<CodeGroup>
+```rust Rust
+let output = sb.shell("ls -la /app && echo done").await?;
+```
+
+```typescript TypeScript
+const output = await sb.shell("ls -la /app && echo done")
+```
+
+```python Python
+output = await sb.shell("ls -la /app && echo done")
+```
+
+```bash CLI
+msb exec worker -- sh -c "ls -la /app && echo done"
+```
+
+</CodeGroup>
+
+## Stream output
+
+For long-running processes or large output, streaming gives you stdout, stderr, and exit events as they happen instead of buffering everything until the command finishes.
+
+<CodeGroup>
+```rust Rust
+let mut handle = sb.exec_stream("tail", ["-f", "/var/log/app.log"]).await?;
+
+while let Some(event) = handle.recv().await {
+    match event {
+        ExecEvent::Stdout(data) => print!("{}", String::from_utf8_lossy(&data)),
+        ExecEvent::Stderr(data) => eprint!("{}", String::from_utf8_lossy(&data)),
+        ExecEvent::Exited { code } => break,
+        _ => {}
+    }
+}
+```
+
+```typescript TypeScript
+const handle = await sb.execStream("tail", ["-f", "/var/log/app.log"]);
+
+for await (const event of handle) {
+    switch (event.kind) {
+        case "stdout": process.stdout.write(event.data); break;
+        case "stderr": process.stderr.write(event.data); break;
+        case "exited": console.log(`Exited: ${event.code}`); break;
+    }
+}
+```
+
+```python Python
+handle = await sb.exec_stream("tail", ["-f", "/var/log/app.log"])
+
+async for event in handle:
+    match event.event_type:
+        case "stdout": print(event.data.decode(), end="")
+        case "stderr": print(event.data.decode(), end="", file=sys.stderr)
+        case "exited": print(f"Exited: {event.code}")
+```
+
+</CodeGroup>
+
+## Interactive attach
+
+Bridges your terminal directly to a process inside the sandbox for a fully interactive PTY session. Useful for debugging, running REPLs, or anything that expects a real terminal.
+
+<CodeGroup>
+```rust Rust
+let exit_code = sb.attach_shell().await?;
+
+let exit_code = sb.attach_with("python", |a| a
+    .env("DEBUG", "1")
+    .cwd("/app")
+    .detach_keys("ctrl-q")
+).await?;
+```
+
+```typescript TypeScript
+// Attach to the default shell
+const exitCode = await sb.attachShell();
+
+// Attach to a specific command with custom detach keys
+await sb.attachWith("bash", (a) =>
+    a.env("DEBUG", "1").cwd("/app").detachKeys("ctrl-q"),
+);
+```
+
+```python Python
+from microsandbox import AttachOptions
+
+# Attach to the default shell
+exit_code = await sb.attach_shell()
+
+# Attach to a specific command with custom detach keys
+exit_code = await sb.attach("python", AttachOptions(
+    env={"DEBUG": "1"},
+    cwd="/app",
+    detach_keys="ctrl-q",
+))
+```
+
+```bash CLI
+# Attach to the default shell
+msb exec -t worker
+
+# Attach to a specific command
+msb exec -t worker -e DEBUG=1 -w /app -- python
+```
+
+</CodeGroup>
+
+<Tip>
+  Press `Ctrl+]` (or your configured detach keys) to detach from the session without stopping the process. The process keeps running inside the VM and you can reattach later via its session ID.
+</Tip>
+
+## Write stdin
+
+Streaming handles can also accept stdin. Enable `stdin_pipe` and write bytes to it. Combined with `tty: true`, this lets you drive interactive processes programmatically.
+
+<CodeGroup>
+```rust Rust
+let mut handle = sb.exec_stream_with("python", |e| e.stdin_pipe().tty(true)).await?;
+let stdin = handle.take_stdin().unwrap();
+stdin.write(b"print('hello')\n").await?;
+stdin.write(b"exit()\n").await?;
+handle.wait().await?;
+```
+
+```typescript TypeScript
+const handle = await sb.execStreamWith("python", (e) => e.stdinPipe().tty(true));
+const stdin = await handle.takeStdin();
+await stdin!.write("print('hello')\n");
+await stdin!.write("exit()\n");
+await stdin!.close();
+await handle.wait();
+```
+
+```python Python
+from microsandbox import ExecOptions, Stdin
+
+handle = await sb.exec_stream("python", ExecOptions(stdin=Stdin.pipe(), tty=True))
+stdin = handle.take_stdin()
+await stdin.write(b"print('hello')\n")
+await stdin.write(b"exit()\n")
+await stdin.close()
+await handle.wait()
+```
+
+</CodeGroup>
+
+## Sessions <sup><sup>coming soon</sup></sup>
+
+Each streaming exec or attach creates a session. You can list active sessions and reattach to them by ID. Up to 16 simultaneous client connections are supported, so multiple sessions can run concurrently without interfering with each other.
+
+<CodeGroup>
+```rust Rust
+// Start a background process and capture its session ID
+let handle = sb.exec_stream("python", ["server.py"]).await?;
+let session_id = handle.id().to_string();
+
+// List active sessions
+let sessions = sb.sessions().await?;
+
+// Reattach to a session by ID
+let mut handle = sb.session(&session_id).await?;
+```
+
+```typescript TypeScript
+// Start a background process and capture its session ID
+const handle = await sb.execStream("python", ["server.py"])
+const sessionId = handle.id
+
+// List active sessions
+const sessions = await sb.sessions()
+
+// Reattach to a session by ID
+const reattached = await sb.session(sessionId)
+```
+
+```python Python
+# Start a background process and capture its session ID
+handle = await sb.exec_stream("python", ["server.py"])
+session_id = handle.id
+
+# List active sessions
+sessions = await sb.sessions()
+
+# Reattach to a session by ID
+reattached = await sb.session(session_id)
+```
+
+</CodeGroup>

--- a/docs/de/sandboxes/customize.mdx
+++ b/docs/de/sandboxes/customize.mdx
@@ -1,0 +1,339 @@
+---
+title: Customize
+description: Inject scripts, modify the rootfs, and choose your own init
+icon: "wand-magic-sparkles"
+---
+
+Before a sandbox starts doing real work, you can prepare it three ways. **Scripts** bundle reusable commands. **Patches** modify the rootfs before the VM boots. A **custom init system** (systemd, OpenRC, s6) can run as PID 1 instead of microsandbox's minimal agent. All three are defined at creation time and keep the base image untouched.
+
+## Scripts
+
+Scripts are files mounted at `/.msb/scripts/` inside the sandbox. The directory is on `PATH`, so each script is callable by name through `exec()` or `shell()`.
+
+It provides a clean way to bundle setup procedures or entry points with a sandbox without baking them into the image.
+
+<CodeGroup>
+```rust Rust
+use indoc::indoc;
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("ubuntu")
+    .script("setup", indoc! {"
+        #!/bin/bash
+        apt-get update && apt-get install -y python3 curl
+    "})
+    .script("start", indoc! {"
+        #!/bin/bash
+        exec python3 /app/main.py
+    "})
+    .create()
+    .await?;
+
+sb.shell("setup").await?;
+let output = sb.shell("start").await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("ubuntu")
+    .script("setup", "#!/bin/bash\napt-get update && apt-get install -y python3 curl")
+    .script("run",   "#!/bin/bash\nexec python3 /app/main.py")
+    .create();
+
+await sb.shell("setup");
+const output = await sb.shell("run");
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ubuntu",
+    scripts={
+        "setup": "#!/bin/bash\napt-get update && apt-get install -y python3 curl",
+        "start": "#!/bin/bash\nexec python3 /app/main.py",
+    },
+)
+
+await sb.shell("setup")
+output = await sb.shell("start")
+```
+
+</CodeGroup>
+
+## Patches
+
+Patches modify the rootfs **before the VM boots**. Write config files, copy directories from the host, create symlinks, append to existing files, remove things you don't need. The base image stays untouched since patches are written to the writable layer on top.
+
+Patches are applied in order and work with OCI images and bind-mounted rootfs. They're not supported with disk image roots (QCOW2, Raw).
+
+<Tip>
+  By default, patching a path that already exists in the image will error. Pass `replace: true` on the operation to allow it. `Mkdir` and `Remove` are idempotent and won't error either way.
+</Tip>
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("alpine")
+    .patch(|p| p
+        .text("/etc/greeting.txt", "Hello from a patched rootfs!\n", None, false)
+        .text("/etc/motd", "Custom message of the day.\n", None, true) // replace existing
+        .mkdir("/app", Some(0o755))
+        .text("/app/config.json", r#"{"debug": true}"#, Some(0o644), false)
+        .copy_file("./cert.pem", "/etc/ssl/cert.pem", None, false)
+        .append("/etc/hosts", "127.0.0.1 myapp.local\n")
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("alpine")
+    .patch((p) => p
+        .text("/etc/greeting.txt", "Hello from a patched rootfs!\n")
+        .text("/etc/motd", "Custom message of the day.\n", { replace: true })
+        .mkdir("/app", { mode: 0o755 })
+        .text("/app/config.json", '{"debug": true}', { mode: 0o644 })
+        .copyFile("./cert.pem", "/etc/ssl/cert.pem")
+        .append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+    )
+    .create();
+```
+
+```python Python
+from microsandbox import Patch, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="alpine",
+    patches=[
+        Patch.text("/etc/greeting.txt", "Hello from a patched rootfs!\n"),
+        Patch.text("/etc/motd", "Custom message of the day.\n", replace=True),
+        Patch.mkdir("/app", mode=0o755),
+        Patch.text("/app/config.json", '{"debug": true}', mode=0o644),
+        Patch.copy_file("./cert.pem", "/etc/ssl/cert.pem"),
+        Patch.append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+    ],
+)
+```
+
+</CodeGroup>
+
+### Available operations
+
+The patch builder appends operations in the order you call them; calls are chainable. Available operations across SDKs: `text`, `file`, `mkdir`, `append`, `copyFile` / `copy_file`, `copyDir` / `copy_dir`, `symlink`, `remove`.
+
+Full per-language signatures, parameters, and option shapes are documented in the SDK references:
+
+- Rust: [`PatchBuilder`](/sdk/rust/sandbox#patchbuilder)
+- TypeScript: [`PatchBuilder`](/sdk/typescript/sandbox#patchbuilder)
+- Python: [`Patch`](/sdk/python/sandbox#patch) (factory) and [`PatchConfig`](/sdk/python/sandbox#patchconfig) (the value type)
+
+## Custom init system
+
+By default the microsandbox agent runs as PID 1 inside the guest: small, fast, minimal. For workloads that expect a real init (systemd, OpenRC, s6, runit, etc.), `--init` hands PID 1 over to the init binary of your choice.
+
+The handoff sequence:
+
+- Agent does the boot-time setup: mount filesystems, configure network, prepare runtime dirs.
+- Agent forks.
+- Parent execs your init and becomes PID 1.
+- Child agent continues serving host requests over the same channel.
+
+Common reasons to opt in: long-lived daemons, system service tests, anything that talks to dbus or expects `systemctl` to work.
+
+The simplest entry point is `auto`, which probes a small list of well-known paths inside the guest rootfs and picks the first one that exists:
+
+- `/sbin/init`
+- `/lib/systemd/systemd`
+- `/usr/lib/systemd/systemd`
+
+Pass an absolute path instead when you need pinning (e.g. for reproducible CI).
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .memory(1024)
+    .cpus(2)
+    .init("auto")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { MiB, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .memory(MiB(1024))
+    .cpus(2)
+    .init("auto")
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ghcr.io/superradcompany/debian-systemd:12",
+    memory=1024,
+    cpus=2,
+    init="auto",
+)
+```
+
+```bash CLI
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  -m 1G -c 2 \
+  --init auto \
+  -- bash
+```
+</CodeGroup>
+
+To verify the handoff worked, check `/proc/1/comm` inside the sandbox. It should print the init's name (`systemd`, `init`, etc.):
+
+```bash
+$ msb run ghcr.io/superradcompany/debian-systemd:12 --init auto -- cat /proc/1/comm
+systemd
+```
+
+If `--init=auto` can't find anything in its candidate list, agentd fails boot with a clear error in `kernel.log` listing every path it checked. Switch to an explicit path (`--init=/lib/systemd/systemd`) when you know exactly where the init lives, or follow the image-picking guidance below to choose an image that actually ships one.
+
+### Argv and env
+
+Pass extra argv and env to the init:
+
+- **Rust / TypeScript**: `init_with(...)` / `initWith(...)`.
+- **Python**: pass an `InitConfig` to `init=`.
+- **CLI**: repeat `--init-arg` once per entry, and `--init-env KEY=VAL` once per env var.
+
+Argv defaults to `[<cmd>]` when none is given; env is merged on top of the inherited environment.
+
+<CodeGroup>
+```bash CLI
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  --init /lib/systemd/systemd \
+  --init-arg --unit=multi-user.target \
+  --init-env container=microsandbox \
+  -- bash
+```
+
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .init_with("/lib/systemd/systemd", |i| i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .initWith("/lib/systemd/systemd", (i) => i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create();
+```
+
+```python Python
+from microsandbox import InitConfig, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ghcr.io/superradcompany/debian-systemd:12",
+    init=InitConfig(
+        cmd="/lib/systemd/systemd",
+        args=("--unit=multi-user.target",),
+        env={"container": "microsandbox"},
+    ),
+)
+```
+</CodeGroup>
+
+### Picking an image
+
+Most slim Docker base images (`debian:bookworm-slim`, `ubuntu:24.04`, `python:3.12-slim`) are stripped of init binaries; they're built for "one process per container" and don't ship systemd at all. If you point `--init` at a path the image doesn't contain, the agent's pre-flight check fails boot with a clear error in the kernel log (no kernel panic).
+
+Three ways to get an image with an init:
+
+<AccordionGroup>
+  <Accordion title="Use one of our published guest images">
+    We maintain a small collection at [`superradcompany/guest-images`](https://github.com/superradcompany/guest-images) for the cases where you specifically need a real init. Current set:
+
+    | Image | Pull |
+    |-------|------|
+    | Debian + systemd | `ghcr.io/superradcompany/debian-systemd:12` |
+    | Ubuntu + systemd | `ghcr.io/superradcompany/ubuntu-systemd:24.04` |
+    | Fedora + systemd | `ghcr.io/superradcompany/fedora-systemd:40` |
+    | Alpine + OpenRC | `ghcr.io/superradcompany/alpine-openrc:3.20` |
+
+    Multi-arch (`linux/amd64` + `linux/arm64`), rebuilt weekly so they pick up upstream security patches, smoke-tested on every rebuild. Each image's GHCR page documents its specific tag aliases and contents.
+  </Accordion>
+  <Accordion title="Build a small custom image">
+    ```dockerfile
+    # Dockerfile.systemd
+    FROM debian:bookworm
+    RUN apt-get update \
+        && apt-get install -y --no-install-recommends systemd \
+        && rm -rf /var/lib/apt/lists/*
+    ```
+
+    ```bash
+    docker buildx build -t local-systemd:debian -f Dockerfile.systemd .
+    msb run local-systemd:debian --init /lib/systemd/systemd -- bash
+    ```
+  </Accordion>
+  <Accordion title="Use a community-built systemd image">
+    Examples: `jrei/systemd-debian:12`, `jrei/systemd-ubuntu:22.04`. These work out of the box but are published by community maintainers, not the distros themselves. Vet them like any other third-party image before running real workloads.
+  </Accordion>
+</AccordionGroup>
+
+For a sanity check that doesn't need systemd, `alpine:3.20` ships BusyBox at `/sbin/init`, which is enough to exercise the handoff mechanics:
+
+```bash
+msb run alpine:3.20 --init /sbin/init -- sh -c "cat /proc/1/comm"
+# busybox
+```
+
+### Shutdown semantics
+
+Without `--init`, microsandbox shuts the guest down by remounting root read-only and calling `reboot(RB_POWER_OFF)`. Typically &lt;100 ms.
+
+With `--init`, the agent isn't PID 1 anymore, so it asks your init to shut down:
+
+- `SIGRTMIN+4` first (systemd's poweroff signal).
+- `SIGTERM` fallback for inits that don't speak it.
+
+Your init then runs its own teardown (stop services, unmount, halt), which is slower:
+
+| Init | Typical shutdown |
+|------|------------------|
+| BusyBox / s6 / runit | &lt;100 ms |
+| OpenRC | 50-500 ms |
+| systemd | 1-5 s |
+
+This is the price of a real init. If your test harness measures end-to-end sandbox lifecycle and you're comparing to a no-handoff baseline, account for this.
+
+### Init and entrypoint
+
+`--init` and `--entrypoint` are orthogonal:
+
+- `--init` controls **PID 1**: what runs the system.
+- `--entrypoint` (and the trailing `-- cmd`) controls **what your workload runs**.
+
+They can be combined. Boot systemd as PID 1 and have microsandbox `exec` calls land your shell, scripts, or app inside the systemd-managed environment.

--- a/docs/de/sandboxes/events.mdx
+++ b/docs/de/sandboxes/events.mdx
@@ -1,0 +1,110 @@
+---
+title: Events
+description: Bidirectional host-guest communication
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+The events API is for structured communication between host and guest beyond stdin/stdout. The host can subscribe to named events from the guest and emit events back, all through the same channel used by `exec`.
+
+On the guest side, processes just write JSON to `/run/agent.sock`, which is a standard Unix domain socket. No special library needed. Any language that can open a socket and write a newline-delimited JSON message will work.
+
+## Basic example
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, EventData};
+use serde::Deserialize;
+
+let sb = Sandbox::get("worker").await?.start().await?;
+
+let _sub = sb.on_event("task.progress", |event: EventData| {
+    #[derive(Deserialize)]
+    struct Progress { percent: u32, message: String }
+
+    if let Some(data) = event.data {
+        if let Ok(p) = data.deserialized::<Progress>() {
+            println!("[{}%] {}", p.percent, p.message);
+        }
+    }
+});
+```
+
+```typescript TypeScript
+import { Sandbox, EventData } from 'microsandbox'
+
+const sb = await Sandbox.get("worker")
+
+const sub = sb.onEvent("task.progress", (event: EventData) => {
+    const { percent, message } = event.data as { percent: number; message: string }
+    console.log(`[${percent}%] ${message}`)
+})
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await (await Sandbox.get("worker")).start()
+
+sub = sb.on_event("task.progress", lambda event: (
+    print(f"[{event.data['percent']}%] {event.data['message']}")
+))
+```
+
+</CodeGroup>
+
+## Send events to guest
+
+Emit a named event with typed data into the guest. Any process listening on the agent socket receives it.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct TaskConfig { input_file: String, output_dir: String }
+
+sb.emit("task.start", TaskConfig {
+    input_file: "/data/input.txt".into(),
+    output_dir: "/data/output".into(),
+}).await?;
+```
+
+```typescript TypeScript
+await sb.emit("task.start", {
+    inputFile: "/data/input.txt",
+    options: ["--verbose"],
+})
+```
+
+```python Python
+await sb.emit("task.start", {
+    "input_file": "/data/input.txt",
+    "output_dir": "/data/output",
+})
+```
+
+</CodeGroup>
+
+## Guest-side emitting
+
+Inside the guest, any process can emit events by writing JSON to the Unix domain socket at `/run/agent.sock`. No SDK required.
+
+```python
+# Inside the guest, plain Python, no SDK
+import json, socket
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect("/run/agent.sock")
+sock.sendall(json.dumps({
+    "event": "task.progress",
+    "data": {"percent": 50, "message": "Halfway done"},
+}).encode() + b"\n")
+sock.close()
+```
+
+The host subscription registered with `on_event("task.progress", ...)` receives this message automatically.

--- a/docs/de/sandboxes/filesystem.mdx
+++ b/docs/de/sandboxes/filesystem.mdx
@@ -1,0 +1,240 @@
+---
+title: Filesystem
+description: Read and write files inside a running sandbox
+icon: "folder-open"
+---
+
+The filesystem API lets you read, write, and manage files inside a sandbox without mounting volumes or SSH. It uses the same channel as command execution, so it doesn't touch the sandbox's network.
+
+Handy for pushing generated code into a sandbox, pulling back results, or inspecting logs without having to pre-mount a shared directory.
+
+## Write a file
+
+<CodeGroup>
+```rust Rust
+sb.fs().write("/app/config.json", r#"{"debug": true}"#).await?;
+```
+
+```typescript TypeScript
+await sb.fs().write("/app/config.json", '{"debug": true}');
+```
+
+```python Python
+await sb.fs.write("/app/config.json", b'{"debug": true}')
+```
+
+</CodeGroup>
+
+## Read a file
+
+<CodeGroup>
+```rust Rust
+let content = sb.fs().read_to_string("/app/config.json").await?;
+```
+
+```typescript TypeScript
+const content = await sb.fs().readToString("/app/config.json");
+```
+
+```python Python
+content = await sb.fs.read_text("/app/config.json")
+```
+
+</CodeGroup>
+
+## List a directory
+
+<CodeGroup>
+```rust Rust
+let entries = sb.fs().list("/app").await?;
+for entry in entries {
+    println!("{}: {:?}", entry.path, entry.kind);
+}
+```
+
+```typescript TypeScript
+const entries = await sb.fs().list("/app");
+for (const entry of entries) {
+    console.log(`${entry.path}: ${entry.kind}`);
+}
+```
+
+```python Python
+entries = await sb.fs.list("/app")
+for entry in entries:
+    print(f"{entry.path}: {entry.kind}")
+```
+
+</CodeGroup>
+
+## Stream large files
+
+For files too large to fit in memory, use streaming. Data is transferred in chunks of approximately 3 MiB each.
+
+<CodeGroup>
+```rust Rust
+let mut stream = sb.fs().read_stream("/app/data.bin").await?;
+while let Some(chunk) = stream.recv().await? {
+    process(&chunk);
+}
+```
+
+```typescript TypeScript
+const stream = await sb.fs().readStream("/app/data.bin");
+for await (const chunk of stream) {
+    processChunk(chunk); // chunk is a Uint8Array
+}
+```
+
+```python Python
+stream = await sb.fs.read_stream("/app/data.bin")
+async for chunk in stream:
+    process(chunk)
+```
+
+</CodeGroup>
+
+## Copy from host
+
+Copy a file from the host machine into the sandbox in a single call.
+
+<CodeGroup>
+```rust Rust
+sb.fs().copy_from_host("./local-file.txt", "/app/remote-file.txt").await?;
+```
+
+```typescript TypeScript
+await sb.fs().copyFromHost("./local-file.txt", "/app/remote-file.txt");
+```
+
+```python Python
+await sb.fs.copy_from_host("./local-file.txt", "/app/remote-file.txt")
+```
+
+</CodeGroup>
+
+<Tip>
+  If you need to transfer many files at once, consider using a [bind-mounted volume](/sandboxes/volumes) instead. Volumes give the guest direct filesystem access, whereas the filesystem API transfers each file individually. For bulk operations, volumes are significantly faster.
+</Tip>
+
+## Extensible backends
+
+The default filesystem backends handle most use cases. For advanced scenarios, you can attach hooks to intercept operations on a volume, or implement a full custom backend.
+
+### Hooks <sup><sup>coming soon</sup></sup>
+
+Intercept file reads and writes on a volume without replacing the entire backend. Hooks receive the path and data, and return transformed data. The underlying filesystem handles everything else (permissions, directories, metadata).
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let key = get_encryption_key();
+let sb = Sandbox::builder("encrypted")
+    .image("python")
+    .volume("/secrets", |v| v
+        .bind("/data/secrets")
+        .on_read(move |_path, data| decrypt(data, &key))
+        .on_write(move |_path, data| encrypt(data, &key))
+    )
+    .create().await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+// Hooks are coming soon. The planned shape will sit alongside the regular
+// mount methods on the volume builder, e.g.:
+//
+//   .volume("/secrets", (m) => m
+//       .bind("/data/secrets")
+//       .onRead((path, data) => decrypt(data, key))
+//       .onWrite((path, data) => encrypt(data, key)),
+//   )
+//
+// For now the closest equivalent is a plain bind:
+await using sb = await Sandbox.builder("encrypted")
+    .image("python")
+    .volume("/secrets", (m) => m.bind("/data/secrets"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+key = get_encryption_key()
+sb = await Sandbox.create(
+    "encrypted",
+    image="python",
+    volumes={
+        "/secrets": Volume.bind("/data/secrets",
+            on_read=lambda path, data: decrypt(data, key),
+            on_write=lambda path, data: encrypt(data, key),
+        ),
+    },
+)
+```
+
+</CodeGroup>
+
+### Custom backend <sup><sup>coming soon</sup></sup>
+
+For full control, implement the `FsBackend` trait (Rust) or class (TypeScript). This gives you access to every POSIX operation: `read`, `write`, `lookup`, `getattr`, `readdir`, etc. You can delegate to a built-in backend (like `PassthroughFs`) for operations you don't need to customize.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{FsBackend, PassthroughFs};
+use std::io;
+
+struct EncryptedFs { key: [u8; 32], inner: PassthroughFs }
+
+impl FsBackend for EncryptedFs {
+    fn read(&self, ctx: Context, inode: u64, handle: u64,
+            buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        let n = self.inner.read(ctx, inode, handle, buf, offset)?;
+        self.decrypt_in_place(&mut buf[..n]);
+        Ok(n)
+    }
+    fn write(&self, ctx: Context, inode: u64, handle: u64,
+             buf: &[u8], offset: u64) -> io::Result<usize> {
+        let encrypted = self.encrypt(buf);
+        self.inner.write(ctx, inode, handle, &encrypted, offset)
+    }
+    // ... remaining methods delegate to self.inner
+}
+
+let sb = Sandbox::builder("custom")
+    .volume("/secrets", |v| v.backend(EncryptedFs::new(key, "/data")?))
+    .create().await?;
+```
+
+```typescript TypeScript
+// FsBackend is coming soon. The planned API will let you plug a custom
+// backend into a volume:
+//
+//   class EncryptedFs implements FsBackend {
+//     // ... implement read, write, and other required methods
+//   }
+//
+//   const sb = await Sandbox.builder("custom")
+//     .volume("/secrets", (m) => m.backend(new EncryptedFs(key, "/data")))
+//     .create();
+```
+
+```python Python
+from microsandbox import FsBackend, Sandbox, Volume
+
+# Implement the FsBackend interface
+class EncryptedFs(FsBackend):
+    # ... implement read, write, and other required methods
+    pass
+
+sb = await Sandbox.create(
+    "custom",
+    volumes={
+        "/secrets": Volume.backend(EncryptedFs(key, "/data")),
+    },
+)
+```
+
+</CodeGroup>

--- a/docs/de/sandboxes/lifecycle.mdx
+++ b/docs/de/sandboxes/lifecycle.mdx
@@ -1,0 +1,401 @@
+---
+title: Lifecycle
+description: Create, start, stop, and manage sandbox state
+icon: "rotate"
+---
+
+Each sandbox runs as a child process of whatever application creates it. `Sandbox.builder(...).create()` boots a microVM, starts the guest agent inside it, and establishes a communication channel back to the host.
+
+Understanding the lifecycle is useful once you start managing long-running sandboxes, graceful shutdown, or resilient agent workflows.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Creating: create()
+    Creating --> Running: boot complete
+    Running --> Paused: pause()
+    Paused --> Running: resume()
+    Running --> Draining: drain()
+    Running --> Stopped: stop()
+    Running --> Crashed: unexpected exit
+    Draining --> Stopped: drain complete
+    Stopped --> Running: start()
+    Stopped --> [*]: remove()
+    Crashed --> [*]: remove()
+```
+
+## States
+
+| Status | Description |
+|--------|-------------|
+| **Creating** | The VM is booting. The kernel is loaded, the filesystem is mounted, and the guest agent is initializing (configuring network, setting up the environment). |
+| **Running** | The guest agent is ready. You can call `exec`, `shell`, `fs`, and `emit`. |
+| **Paused** | All guest processes are frozen. No CPU cycles consumed. Resume is instant with no re-boot or re-init. |
+| **Draining** | Graceful shutdown in progress. Existing commands run to completion, but new `exec` calls are rejected. Transitions to Stopped when all commands finish. |
+| **Stopped** | The VM has shut down. Sandbox configuration and state are persisted to the database and can be restarted. |
+| **Crashed** | The VM exited unexpectedly (e.g., kernel panic, OOM kill). |
+
+## Create a sandbox
+
+Creating a sandbox boots the microVM, mounts the filesystem, initializes the guest agent, and waits until it's ready to accept commands.
+
+<CodeGroup>
+```rust Rust
+// Attached: sandbox stops when your process exits
+let sb = Sandbox::builder("worker").image("python").create().await?;
+
+// Detached: sandbox survives after your process exits
+let sb = Sandbox::builder("worker").image("python").create_detached().await?;
+```
+
+```typescript TypeScript
+// Attached: sandbox stops when your process exits
+await using sb = await Sandbox.builder("worker").image("python").create();
+
+// Detached: sandbox survives after your process exits
+const detached = await Sandbox.builder("worker").image("python").createDetached();
+```
+
+```python Python
+# Attached: sandbox stops when your process exits
+sb = await Sandbox.create("worker", image="python")
+
+# Detached: sandbox survives after your process exits
+sb = await Sandbox.create("worker", image="python", detached=True)
+```
+
+```bash CLI
+# Attached
+msb create python --name worker
+
+# Detached
+msb run -d python --name worker
+```
+
+</CodeGroup>
+
+## Stop and restart
+
+Stopping gracefully terminates guest processes and shuts down the VM. The sandbox moves to `Stopped` and can be restarted later with all its configuration preserved.
+
+<CodeGroup>
+```rust Rust
+sb.stop().await?;
+
+let sb = Sandbox::start("worker").await?;
+```
+
+```typescript TypeScript
+await sb.stop()
+
+// Later, resume where you left off
+const sb = await Sandbox.start("worker")
+```
+
+```python Python
+await sb.stop()
+
+# Later, resume where you left off
+sb = await Sandbox.start("worker")
+```
+
+```bash CLI
+msb stop worker
+
+# Later, resume where you left off
+msb start worker
+```
+
+</CodeGroup>
+
+## Kill immediately
+
+If a sandbox is unresponsive (e.g., stuck in a tight loop or a panic), force-kill it. The sandbox is terminated immediately with no graceful shutdown.
+
+<CodeGroup>
+```rust Rust
+sb.kill().await?;
+```
+
+```typescript TypeScript
+await sb.kill()
+```
+
+```python Python
+await sb.kill()
+```
+
+```bash CLI
+msb stop --force worker
+```
+
+</CodeGroup>
+
+## Pause and resume <sup><sup>coming soon</sup></sup>
+
+Freeze all guest processes without shutting down. The VM uses zero CPU while paused, and resume is instant. The guest continues exactly where it left off with no boot time and no re-init.
+
+<CodeGroup>
+```rust Rust
+sb.pause().await?;
+sb.resume().await?;
+```
+
+```typescript TypeScript
+await sb.pause()
+await sb.resume()
+```
+
+```python Python
+await sb.pause()
+await sb.resume()
+```
+
+</CodeGroup>
+
+## Detach
+
+Keeps a sandbox running after the parent process exits. It becomes a background process that you can reconnect to later with `Sandbox::get("worker")`.
+
+<CodeGroup>
+```rust Rust
+sb.detach().await;
+```
+
+```typescript TypeScript
+await sb.detach()
+```
+
+```python Python
+await sb.detach()
+```
+
+</CodeGroup>
+
+<Tip>
+  Detached sandboxes are tracked at `~/.microsandbox/db/`. A background reaper periodically checks for stale sandboxes that have exited unexpectedly and cleans up their records.
+</Tip>
+
+## Drain
+
+Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and transitions to `Stopped` when all in-flight commands complete. This is useful for zero-downtime rotation of worker sandboxes.
+
+<CodeGroup>
+```rust Rust
+sb.drain().await?;
+```
+
+```typescript TypeScript
+await sb.drain()
+```
+
+```python Python
+await sb.drain()
+```
+
+</CodeGroup>
+
+## Wait
+
+Block until the sandbox exits on its own, without triggering a stop.
+
+<CodeGroup>
+```rust Rust
+let exit_status = sb.wait().await?;
+```
+
+```typescript TypeScript
+const exitStatus = await sb.wait()
+```
+
+```python Python
+code, success = await sb.wait()
+```
+
+</CodeGroup>
+
+## Remove
+
+Delete a stopped sandbox and its associated state from disk.
+
+<CodeGroup>
+```rust Rust
+Sandbox::remove("worker").await?;
+```
+
+```typescript TypeScript
+await Sandbox.remove("worker")
+```
+
+```python Python
+await Sandbox.remove("worker")
+```
+
+```bash CLI
+msb rm worker
+```
+
+</CodeGroup>
+
+## List and inspect
+
+<CodeGroup>
+```rust Rust
+for handle in Sandbox::list().await? {
+    println!("{}: {:?}", handle.name(), handle.status());
+}
+```
+
+```typescript TypeScript
+const sandboxes = await Sandbox.list();
+for (const handle of sandboxes) {
+    console.log(`${handle.name}: ${handle.status}`);
+}
+
+const handle = await Sandbox.get("worker");
+console.log(handle.status); // "running" | "stopped" | ...
+```
+
+```python Python
+for handle in await Sandbox.list():
+    print(f"{handle.name}: {handle.status}")
+
+handle = await Sandbox.get("worker")
+print(handle.status)  # "running" | "stopped" | ...
+```
+
+```bash CLI
+msb ls
+msb ps worker
+```
+
+</CodeGroup>
+
+## Runtime process architecture
+
+Here's what's running and how the pieces talk to each other.
+
+```mermaid
+graph TD
+    subgraph Host["Host"]
+        A["Your Application<br/><small>microsandbox SDK</small>"]
+        B["Sandbox Process<br/><small>VM + networking + lifecycle</small>"]
+    end
+
+    subgraph Guest["Guest VM"]
+        F["agentd<br/><small>exec, fs, events</small>"]
+    end
+
+    A -- "spawn" --> B
+    B -- "boot" --> F
+    A -. "commands & responses" .-> F
+
+    style Host fill:#f5f0ff,stroke:#a770ef,color:#333
+    style Guest fill:#fef4e8,stroke:#e8a838,color:#333
+    style A fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
+    style B fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
+    style F fill:#fdd49e,stroke:#d97706,color:#1a1a1a
+```
+
+There are two layers here. The **sandbox process** runs the VM and the networking stack on the host side, and relays messages between the application and the **guest agent** inside the VM. Up to 16 clients can connect to the same sandbox simultaneously.
+
+The sandbox process also handles:
+
+- Graceful stop and drain signals
+- Cleanup when the sandbox exits
+- Idle detection (auto-drain after a configurable timeout)
+- Maximum sandbox lifetime enforcement
+
+The sandbox process does not execute guest commands itself. It only relays traffic between your application and the guest agent.
+
+## Logs and diagnostics
+
+Each sandbox keeps four files under `<sandbox-dir>/logs/`:
+
+| File | Producer | Contents |
+|------|----------|----------|
+| `exec.log` | Host relay (tap on guest frames) | User-program stdout/stderr/output as JSON Lines |
+| `runtime.log` | Sandbox process (host) | Runtime tracing — relay setup, lifecycle, network |
+| `kernel.log` | Guest VM virtio-console | Kernel boot messages and `agentd` console |
+| `boot-error.json` | Sandbox process | Present only when the most recent start failed before the agent came up |
+
+The user-facing surface for these is [`msb logs`](/cli/sandbox-commands#msb-logs) and the SDK [`logs()`](/sandboxes/logs) method — both work on running and stopped sandboxes alike. See the [Logs](/sandboxes/logs) page for the capture model, source semantics, and diagnostic flows.
+
+When a sandbox is in the **Crashed** state, its log directory is left in place so you can read what happened. Use `msb logs --source system <name>` to see the runtime/kernel diagnostic merge.
+
+## Graceful shutdown with timeout fallback
+
+Attempt a graceful stop, then force-kill if the sandbox doesn't shut down in time.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+use std::time::Duration;
+
+let mut handle = Sandbox::get("worker").await?;
+match tokio::time::timeout(Duration::from_secs(30), handle.stop()).await {
+    Ok(Ok(())) => println!("Stopped"),
+    Ok(Err(e)) => eprintln!("Error: {e}"),
+    Err(_) => handle.kill().await?,
+}
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.get("worker");
+try {
+    await Promise.race([
+        sb.stop(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 30_000)),
+    ]);
+} catch {
+    await sb.kill();
+}
+```
+
+```python Python
+import asyncio
+from microsandbox import Sandbox
+
+handle = await Sandbox.get("worker")
+sb = await handle.connect()
+try:
+    await asyncio.wait_for(sb.stop(), timeout=30)
+except asyncio.TimeoutError:
+    await sb.kill()
+```
+
+</CodeGroup>
+
+## Sandbox process policies
+
+For production workloads, configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .max_duration(3600)
+    .idle_timeout(300)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .maxDuration(3600)   // maximum sandbox lifetime in seconds
+    .idleTimeout(300)    // auto-drain after 5 minutes of inactivity
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    max_duration=3600,
+    idle_timeout=300,
+)
+```
+
+</CodeGroup>

--- a/docs/de/sandboxes/logs.mdx
+++ b/docs/de/sandboxes/logs.mdx
@@ -1,0 +1,288 @@
+---
+title: Logs
+description: Capture, read, and diagnose sandbox output
+icon: "scroll"
+---
+
+Every sandbox records its captured output to disk so you can read it later — even after the sandbox stops or crashes. The CLI surface is `msb logs <name>`; the SDK surface is `logs()` on `Sandbox` and `SandboxHandle`. Both work on running and stopped sandboxes alike, with no protocol traffic — just a file read.
+
+## What's captured
+
+When a sandbox is running, the host-side **relay tap** intercepts the protocol frames flowing from the guest agent (`agentd`) and writes a copy of every exec session's stdout/stderr to `exec.log` as JSON Lines. Every session is captured, tagged with its own monotonic id so readers can group or filter by session.
+
+```jsonl
+{"t":"2026-04-30T20:32:59.688Z","s":"system","d":"--- sandbox started ---\n"}
+{"t":"2026-04-30T20:32:59.689Z","s":"stdout","d":"Listening on :8080\n","id":1}
+{"t":"2026-04-30T20:32:59.690Z","s":"stderr","d":"warn: no TLS\n","id":1}
+{"t":"2026-04-30T20:33:01.112Z","s":"stdout","d":"got request\n","id":2}
+{"t":"2026-04-30T20:33:05.220Z","s":"system","d":"--- sandbox stopped ---\n"}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `t` | RFC 3339 timestamp at the moment the chunk was captured |
+| `s` | Source tag — see [Sources](#sources) |
+| `d` | The chunk's bytes, UTF-8 lossy decoded by default |
+| `id` | Relay-monotonic session id (starts at 1, +1 per `exec`); absent on `system` entries |
+
+## Sources
+
+The `s` field tells you where each chunk came from. Four values:
+
+| Source | When emitted |
+|--------|--------------|
+| `stdout` | Captured from a session's stdout, **pipe mode** — streams stayed separated end to end. |
+| `stderr` | Captured from a session's stderr, **pipe mode**. |
+| `output` | Captured from a session running in **PTY mode**. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream. We tag them `output` rather than mislabel as `stdout` so a reader doing `jq 'select(.s == "stderr")'` doesn't accidentally pick up merged PTY bytes. |
+| `system` | Synthetic entries: lifecycle markers (`--- sandbox started ---` / `--- sandbox stopped ---`) plus runtime/kernel diagnostic lines from `runtime.log` / `kernel.log` merged in at read time when `--source system` is requested. |
+
+The default `msb logs <name>` and SDK `logs()` show `stdout` + `stderr` + `output` — all user-program output, regardless of pipe vs PTY. Add `system` explicitly when you want the diagnostics merge.
+
+<Tip>
+  **Pipe vs PTY modes.** Non-interactive `msb run` (with stdin piped or redirected) and `Sandbox.exec()` use pipe mode — streams stay separate. Interactive `msb run` from a real terminal, `msb attach`, and explicit `--tty` use PTY mode — streams are merged in the kernel. Choose pipe mode when you want clean per-stream filtering in your logs.
+</Tip>
+
+## Reading logs
+
+### From the CLI
+
+```bash
+# Default — user-program output (stdout + stderr + output)
+msb logs devbox
+
+# Tail the most recent entries
+msb logs devbox --tail 100
+
+# Follow live
+msb logs devbox -f
+
+# Filter by source
+msb logs devbox --source stderr           # just stderr (pipe-mode only)
+msb logs devbox --source output           # just PTY-merged
+msb logs devbox --source system           # runtime + kernel diagnostics
+msb logs devbox --source all              # everything, chronologically merged
+
+# Time-bounded
+msb logs devbox --since 5m                # last 5 minutes
+msb logs devbox --since 2026-04-30T20:00:00Z
+
+# Grep
+msb logs devbox --grep ERROR
+
+# Multi-session view: prefix each line with [id:N]
+msb logs devbox --show-id
+
+# Color each session distinctly (implies --show-id)
+msb logs devbox --color-sessions
+
+# Programmatic: raw JSON Lines
+msb logs devbox --json | jq 'select(.s == "stderr")'
+```
+
+See [`msb logs` reference](/cli/sandbox-commands#msb-logs) for the full flag list.
+
+### From the SDK
+
+<CodeGroup>
+```rust Rust
+use microsandbox::sandbox::{LogOptions, LogSource, Sandbox};
+
+let handle = Sandbox::get("web").await?;
+
+let entries = handle.logs(&LogOptions::default())?;
+
+for e in entries {
+    let source = match e.source {
+        LogSource::Stdout => "OUT",
+        LogSource::Stderr => "ERR",
+        LogSource::Output => "PTY",
+        LogSource::System => "SYS",
+    };
+    println!(
+        "[{}] {} {:?}: {}",
+        e.timestamp.to_rfc3339(),
+        source,
+        e.session_id,
+        String::from_utf8_lossy(&e.data).trim_end()
+    );
+}
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const handle = await Sandbox.get("web");
+
+const entries = await handle.logs();
+
+for (const e of entries) {
+    const source =
+        e.source === "stdout" ? "OUT" :
+        e.source === "stderr" ? "ERR" :
+        e.source === "output" ? "PTY" :
+        "SYS";
+
+    console.log(
+        `[${e.timestamp.toISOString()}] ${source} ${e.sessionId}: ${e.text().trimEnd()}`
+    );
+}
+```
+
+```python Python
+import asyncio
+import microsandbox
+
+async def main():
+    handle = await microsandbox.Sandbox.get("web")
+
+    entries = await handle.logs()
+
+    for e in entries:
+        source = {
+            "stdout": "OUT",
+            "stderr": "ERR",
+            "output": "PTY",
+            "system": "SYS",
+        }[e.source]
+
+        print(
+            f"[{e.timestamp_ms / 1000:.3f}] "
+            f"{source} {e.session_id}: {e.text().rstrip()}"
+        )
+
+asyncio.run(main())
+```
+</CodeGroup>
+
+### Filtering at read time
+
+All filters are client-side. The on-disk file is bounded (10 MiB rotated × 3 = 30 MiB ceiling per sandbox), so a linear scan is always cheap.
+
+<CodeGroup>
+```rust Rust
+use chrono::{Duration, Utc};
+use microsandbox::sandbox::{LogOptions, LogSource};
+
+let recent = handle.logs(&LogOptions {
+    tail: Some(50),
+    since: Some(Utc::now() - Duration::hours(1)),
+    sources: vec![
+        LogSource::Stdout,
+        LogSource::Stderr,
+        LogSource::Output,
+        LogSource::System,
+    ],
+    ..Default::default()
+})?;
+```
+
+```typescript TypeScript
+const recent = await handle.logs({
+    tail: 50,
+    since: new Date(Date.now() - 60 * 60 * 1000),
+    sources: ["stdout", "stderr", "output", "system"],
+});
+```
+
+```python Python
+import time
+
+recent = await handle.logs(
+    tail=50,
+    since_ms=(time.time() - 3600) * 1000,
+    sources=["stdout", "stderr", "output", "system"],
+)
+```
+</CodeGroup>
+
+## On-disk layout
+
+Each sandbox has its own log directory under `<sandbox-dir>/logs/`:
+
+| File | Producer | Format | Bounded? |
+|------|----------|--------|----------|
+| `exec.log` | Host relay tap | JSON Lines (one entry per chunk) | Yes — `RotatingLog`, 10 MiB × 3 |
+| `runtime.log` | Sandbox process tracing | Plain text (RFC 3339 prefix) | Yes — `RotatingLog`, 10 MiB × 3 |
+| `kernel.log` | Guest VM virtio-console | Plain text (kernel + `agentd`) | Append-only |
+| `boot-error.json` | Sandbox process (failed start only) | JSON object | Single file, atomically replaced |
+
+Lifecycle: the directory is created on `msb create`. `exec.log` gets `--- sandbox started ---` injected when the agent reports `core.ready`, and `--- sandbox stopped ---` when the sandbox process exits (the latter from the VMM's `on_exit` observer, so it fires reliably even on crashes). On `msb remove`, the entire directory is deleted.
+
+## Boot errors
+
+When a sandbox process exits before the agent relay is ready — typically a mount error, missing rootfs, or network setup failure — there's no `exec.log` content yet. The runtime writes a small structured `boot-error.json` instead:
+
+```json
+{
+  "t": "2026-04-30T20:32:59.690Z",
+  "stage": "mount",
+  "errno": 2,
+  "message": "mount tmp_x_…: No such file or directory (os error 2)"
+}
+```
+
+The CLI prepends a styled error block reconstructed from this file before any captured log content:
+
+```
+error: failed to start "dind"
+  → mount: mount tmp_x_…: No such file or directory (os error 2)
+  → the host path for one of the mounts does not exist
+  → run `msb logs --source system dind` for full diagnostics
+```
+
+`stage` values: `mount`, `build_vm`, `config`, `network`, `image`, `other`. The CLI's stage-to-hint mapper turns `(stage, errno)` into the actionable hint line.
+
+SDK callers see this as a typed [`BootStart` error](/sdk/errors#sandbox-start-failures) — match on it to recover or report cleanly.
+
+## Common diagnostic flows
+
+**"My sandbox crashed — what happened?"**
+
+```bash
+msb ls                              # confirm Crashed state
+msb logs <name>                     # what was the program doing right before?
+msb logs <name> --source system     # runtime + kernel diagnostics
+```
+
+**"My sandbox won't start."**
+
+```bash
+msb create --name nope ...          # observe the styled error block
+cat ~/.microsandbox/sandboxes/nope/logs/boot-error.json
+msb logs nope --source system       # full diagnostics from runtime.log/kernel.log
+```
+
+**"My program isn't logging."**
+
+If `exec.log` only has `--- sandbox started ---` and nothing else, no exec session ever opened. Check that you actually ran something — `msb create` alone doesn't run any user program.
+
+**"My program is logging but I can't tell which session."**
+
+```bash
+msb logs <name> --show-id           # prefix every line with the session id
+msb logs <name> --color-sessions    # one color per session
+```
+
+**"I want to feed logs to my own pipeline."**
+
+```bash
+# JSON Lines — schema in this page's "What's captured" section
+msb logs <name> --json | jq -c 'select(.s == "stderr")'
+
+# Or programmatic via the SDK — same data, typed.
+```
+
+## Capture model in detail
+
+A sandbox can host many concurrent exec sessions: an `msb run` at creation, plus arbitrary `msb exec` calls, plus SDK-driven sessions. **Every session is captured** to `exec.log`, tagged with its own monotonic `id` field so readers can group or filter without losing data.
+
+The id is minted by the relay (`next_session_id: AtomicU64`, starts at 1, +1 per observed `ExecRequest`). It's distinct from the protocol correlation id — the latter is per-client and gets reused across slot recycling, which would make sequential `msb exec` calls indistinguishable. The relay-minted id never repeats within a sandbox lifetime.
+
+System entries (`--- sandbox started ---`, `--- sandbox stopped ---`) have no `id` field — they aren't tied to a specific session.
+
+## Troubleshooting log capture
+
+- **`exec.log` is empty.** No exec session ever opened. `msb create` alone doesn't run anything; you need `msb run` or `msb exec` to produce output.
+- **Stderr appears as `stdout`.** The session is in PTY mode (interactive). PTY merges streams in the kernel — by the time bytes leave the guest, they're indistinguishable. Use `< /dev/null` or non-interactive invocation to take the pipe path. PTY-mode bytes are tagged `output`, not `stdout` — make sure your filters cover both.
+- **`runtime.log` has weird `[2m...` characters.** Older sandboxes may still have ANSI color codes from `tracing`. Newly-created sandboxes don't (we disable ANSI at the source for the sandbox subprocess).
+- **`msb logs -f` exits immediately.** The sandbox is stopped. Follow mode against a stopped sandbox dumps the existing contents and exits — it doesn't block waiting for it to start.

--- a/docs/de/sandboxes/metrics.mdx
+++ b/docs/de/sandboxes/metrics.mdx
@@ -1,0 +1,83 @@
+---
+title: Metrics
+description: Monitor sandbox resource usage
+icon: "chart-line"
+---
+
+Query resource usage for a running sandbox: CPU, memory, and more. Get a single point-in-time snapshot, or open a streaming subscription that delivers updates at a fixed interval.
+
+## Point-in-time
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let metrics = sb.metrics().await?;
+println!("CPU: {:.1}%, Mem: {} MB", metrics.cpu_percent, metrics.memory_bytes / 1024 / 1024);
+```
+
+```typescript TypeScript
+const metrics = await sb.metrics();
+console.log(`CPU: ${metrics.cpuPercent.toFixed(1)}%, Mem: ${Math.floor(metrics.memoryBytes / 1024 / 1024)} MB`);
+```
+
+```python Python
+m = await sb.metrics()
+print(f"CPU: {m.cpu_percent:.1f}%, Mem: {m.memory_bytes // 1024 // 1024} MB")
+```
+
+</CodeGroup>
+
+## Streaming
+
+Subscribe to metric updates at a regular interval. Each update arrives as a separate event.
+
+<CodeGroup>
+```rust Rust
+use std::time::Duration;
+use futures::StreamExt;
+
+let mut stream = sb.metrics_stream(Duration::from_secs(1));
+while let Some(m) = stream.next().await {
+    let m = m?;
+    println!("CPU: {:.1}%, Mem: {} MB", m.cpu_percent, m.memory_bytes / 1024 / 1024);
+}
+```
+
+```typescript TypeScript
+for await (const m of await sb.metricsStream(1000)) {
+    console.log(`[${m.timestamp.toISOString()}] CPU: ${m.cpuPercent.toFixed(1)}%`);
+}
+```
+
+```python Python
+async for m in await sb.metrics_stream(interval=1.0):
+    print(f"[{m.timestamp_ms}] CPU: {m.cpu_percent:.1f}%")
+```
+
+</CodeGroup>
+
+## Fleet-wide metrics
+
+Get metrics for all running sandboxes at once. Useful for dashboards or capacity planning.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::all_sandbox_metrics;
+
+let all = all_sandbox_metrics().await?;
+```
+
+```typescript TypeScript
+import { allSandboxMetrics } from "microsandbox";
+
+const all = await allSandboxMetrics();
+```
+
+```python Python
+from microsandbox import all_sandbox_metrics
+
+all_metrics = await all_sandbox_metrics()
+```
+
+</CodeGroup>

--- a/docs/de/sandboxes/overview.mdx
+++ b/docs/de/sandboxes/overview.mdx
@@ -1,0 +1,355 @@
+---
+title: Overview
+description: What sandboxes are and how to configure them
+icon: "circle-info"
+---
+
+A sandbox is a microVM: a real virtual machine with its own Linux kernel, filesystem, and network stack, running as a child process of whatever application creates it.
+
+The security boundary here is hardware virtualization, not Linux namespaces. Container escapes are a well-documented class of vulnerability; breaking out of a microVM requires exploiting the hypervisor itself, which is a fundamentally harder problem.
+
+## Creating a sandbox
+
+At minimum, a sandbox needs a name and an image. Everything else has sensible defaults: 1 vCPU, 512 MiB memory, public-only networking, `/bin/sh` as the shell.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create("worker", image="python")
+```
+
+```bash CLI
+msb create python --name worker
+```
+
+</CodeGroup>
+
+## Configuration options
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .memory(1024)
+    .cpus(2)
+    .env("DEBUG", "true")
+    .env("API_PORT", "8000")
+    .volume("/app/src", |v| v.bind("./src").readonly())
+    .volume("/data", |v| v.named("my-data"))
+    .volume("/tmp/scratch", |v| v.tmpfs().size(100))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .memory(1024)
+    .cpus(2)
+    .env("DEBUG", "true")
+    .env("API_PORT", "8000")
+    .volume("/app/src",     (m) => m.bind("./src").readonly())
+    .volume("/data",        (m) => m.named("my-data"))
+    .volume("/tmp/scratch", (m) => m.tmpfs().size(100))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    memory=1024,
+    cpus=2,
+
+    env={"DEBUG": "true", "API_PORT": "8000"},
+    volumes={
+        "/app/src": Volume.bind("./src", readonly=True),
+        "/data": Volume.named("my-data"),
+        "/tmp/scratch": Volume.tmpfs(size_mib=100),
+    },
+)
+```
+
+```bash CLI
+msb create python --name worker \
+  -c 2 \
+  -m 1G \
+  -e DEBUG=true \
+  -e API_PORT=8000 \
+  -v ./src:/app/src:ro \
+  -v my-data:/data \
+  --tmpfs /tmp/scratch:100
+```
+
+</CodeGroup>
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `image` | — | OCI image, local path, or disk image |
+| `cpus` | `1` | Number of virtual CPUs |
+| `memory` | `512` | Guest memory in MiB |
+| `workdir` | — | Default working directory for commands |
+| `shell` | `/bin/sh` | Shell used by `shell()` calls |
+| `env` | `{}` | Environment variables |
+| `volumes` | `[]` | Volume mounts (bind, named, or tmpfs) |
+| `network` | `public` | Network policy and port mappings |
+| `scripts` | `{}` | Named scripts stored at `/.msb/scripts/` |
+
+<Tip>
+  `cpus` and `memory` are **limits, not reservations**. Setting `memory: 512` doesn't allocate 512 MiB upfront. Physical pages are only allocated as the guest actually touches them, so you can comfortably run many sandboxes on a single host without worrying about overcommitting.
+</Tip>
+
+## Rootfs sources
+
+microsandbox supports three ways to provide a root filesystem. The choice affects how the filesystem is assembled and what features are available.
+
+### OCI images
+
+The most common option. microsandbox pulls the image and stacks its layers as a copy-on-write filesystem. Changes inside the sandbox don't modify the base image. If two sandboxes use the same image, they share the same cached layers on disk.
+
+<CodeGroup>
+```rust Rust
+Sandbox::builder("worker").image("python").create().await?;
+```
+
+```typescript TypeScript
+await Sandbox.builder("worker").image("python").create();
+```
+
+```python Python
+await Sandbox.create("worker", image="python")
+```
+
+```bash CLI
+msb create python --name worker
+```
+
+</CodeGroup>
+
+### Bind mounts
+
+Use a local directory on the host as the root filesystem directly. The guest sees the directory contents as its `/`. This is useful for development when you have a pre-built rootfs, or for minimal environments where you've assembled the filesystem yourself.
+
+<CodeGroup>
+```rust Rust
+Sandbox::builder("worker").image("./my-rootfs").create().await?;
+```
+
+```typescript TypeScript
+await Sandbox.builder("worker").image("./my-rootfs").create();
+```
+
+```python Python
+await Sandbox.create("worker", image="./my-rootfs")
+```
+
+```bash CLI
+msb create ./my-rootfs --name worker
+```
+
+</CodeGroup>
+
+<Note>
+  The guest agent is automatically included in the rootfs during sandbox creation, regardless of rootfs source. You don't need to add anything to your image or directory.
+</Note>
+
+### Disk images
+
+Boot from a QCOW2, Raw, or VMDK disk image. Unlike OCI images (which use a copy-on-write overlay), disk images give the guest raw block device access. See [Disk Images](/images/disk-images) for details.
+
+<CodeGroup>
+```rust Rust
+// Auto-detect filesystem
+Sandbox::builder("worker")
+    .image("./ubuntu-22.04.qcow2")
+    .create()
+    .await?;
+
+// Explicit filesystem type
+Sandbox::builder("worker")
+    .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+// Auto-detect the disk image format from the file extension.
+await Sandbox.builder("worker")
+    .image("./alpine.qcow2")
+    .create();
+```
+
+```python Python
+from microsandbox import Image, Sandbox
+
+# Auto-detect filesystem
+await Sandbox.create("worker", image="./ubuntu-22.04.qcow2")
+
+# Explicit filesystem type
+await Sandbox.create("worker", image=Image.disk("./alpine.raw", fstype="ext4"))
+```
+
+```bash CLI
+msb create ./alpine.qcow2 --name worker
+```
+
+</CodeGroup>
+
+<Note>
+  With OCI images, microsandbox stacks layers and adds a copy-on-write overlay so sandboxes share the base. With disk images, the guest gets the block device directly, so there's no copy-on-write isolation between sandboxes using the same disk image. Each sandbox needs its own copy (or use QCOW2's built-in snapshot/backing file support).
+</Note>
+
+## Replace existing
+
+Replace a stopped sandbox with the same name instead of failing on conflict. This stops the old sandbox (if still running), removes it, and creates a fresh one.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .replace()
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .replace()
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create("worker", image="python", replace=True)
+```
+
+```bash CLI
+msb create --replace python --name worker
+```
+
+</CodeGroup>
+
+## Private registry
+
+Authenticate to private container registries and control when images are pulled.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, RegistryAuth, PullPolicy};
+
+let sb = Sandbox::builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry_auth(RegistryAuth::Basic {
+        username: "deploy".into(),
+        password: std::env::var("REGISTRY_PASSWORD")?,
+    })
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("private.registry.io/org/app:v1")
+    .registry((r) => r.auth({
+        kind: "basic",
+        username: "deploy",
+        password: process.env.REGISTRY_TOKEN!,
+    }))
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import PullPolicy, RegistryAuth, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="private.registry.io/org/app:v1",
+    registry_auth=RegistryAuth.basic("deploy", os.environ["REGISTRY_PASSWORD"]),
+    pull_policy=PullPolicy.ALWAYS,
+)
+```
+
+```bash CLI
+msb registry login private.registry.io -u deploy
+msb create private.registry.io/org/app:v1 \
+  --name worker --pull always
+```
+
+</CodeGroup>
+
+| Policy | Behavior |
+|--------|----------|
+| `"always"` | Pull the image every time, even if cached locally |
+| `"if-missing"` | Pull only if the image is not already cached (default) |
+| `"never"` | Never pull; fail if the image is not cached |
+
+<Tip>
+  Once an OCI image is resolved, microsandbox pins the exact layers. A `python` reference is resolved to an immutable set of layers at first pull. Subsequent `start()` calls use the pinned layers without re-resolving the mutable tag, so your sandbox is reproducible even if the upstream tag is updated.
+</Tip>
+
+## Config inspection <sup><sup>coming soon</sup></sup>
+
+Build a sandbox configuration without booting the VM. Useful for serializing, storing, validating, or modifying configs before creation.
+
+<CodeGroup>
+```rust Rust
+let config = Sandbox::builder("preview")
+    .image("python")
+    .memory(1024)
+    .build()?;
+
+println!("{}", serde_json::to_string_pretty(&config)?);
+let sb = Sandbox::create(config).await?;
+```
+
+```typescript TypeScript
+const builder = Sandbox.builder("preview").image("python").memory(1024);
+const config = builder.build();
+
+console.log(JSON.stringify(config, null, 2));
+const sb = await builder.create();
+```
+
+```python Python
+import json
+from microsandbox import Sandbox
+
+config = Sandbox.build_config(
+    "preview",
+    image="python",
+    memory=1024,
+)
+
+print(json.dumps(config, indent=2))
+sb = await Sandbox.create(config)
+```
+
+</CodeGroup>
+
+## Customizing the guest environment
+
+If you need to run setup logic, install packages, or inject files before a sandbox starts doing real work, there are two ways to do it without building a custom image:
+
+- **[Scripts](/sandboxes/customize#scripts)** are files mounted into the sandbox at `/.msb/scripts/` and added to `PATH`. Define them at creation time and call them by name with `exec()` or `shell()`. Good for multi-step setup procedures or named entry points.
+- **[Patches](/sandboxes/customize#patches)** modify the rootfs before the VM boots: write config files, copy directories from the host, create symlinks, append to existing files, etc. The base image stays untouched since patches go into the writable layer.

--- a/docs/de/sandboxes/secrets.mdx
+++ b/docs/de/sandboxes/secrets.mdx
@@ -1,0 +1,76 @@
+---
+title: Secrets
+description: Secure credential injection for sandboxes
+icon: "key"
+---
+
+Secrets use a **placeholder substitution** model. The guest VM never sees the real credential.
+
+When you bind a secret to an environment variable and one or more allowed hosts, microsandbox generates a random placeholder (e.g., `OPENAI_API_KEY=msb_ph_a8f3c2...`) and injects that into the guest instead. The real value never enters the VM. The only way it reaches the outside world is when a request goes to an allowed host, at which point microsandbox swaps the placeholder for the real value. Everywhere else, the placeholder is just a meaningless string.
+
+So even with full code execution inside the sandbox, there's nothing to steal. The credential was never there.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("agent")
+    .image("python")
+    .secret(|s| s
+        .env("GITHUB_TOKEN")
+        .value(std::env::var("GITHUB_TOKEN")?)
+        .allow_host("api.github.com")
+        .allow_host_pattern("*.githubusercontent.com")
+    )
+    .secret_env("OPENAI_API_KEY", api_key, "api.openai.com")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("agent")
+    .image("python")
+    .secret((s) =>
+        s.env("GITHUB_TOKEN")
+            .value(process.env.GITHUB_TOKEN!)
+            .allowHost("api.github.com")
+            .allowHostPattern("*.githubusercontent.com"),
+    )
+    .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import Sandbox, Secret
+
+sb = await Sandbox.create(
+    "agent",
+    image="python",
+    secrets=[
+        Secret.env(
+            "GITHUB_TOKEN",
+            value=os.environ["GITHUB_TOKEN"],
+            allow_hosts=["api.github.com"],
+            allow_host_patterns=["*.githubusercontent.com"],
+        ),
+        Secret.env(
+            "OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+)
+```
+
+```bash CLI
+msb create python --name agent \
+  --secret "GITHUB_TOKEN=$GITHUB_TOKEN@api.github.com" \
+  --secret "OPENAI_API_KEY=$OPENAI_API_KEY@api.openai.com"
+```
+
+</CodeGroup>
+
+See the SDK Reference for the full API: [Rust](/sdk/rust/secrets) | [TypeScript](/sdk/typescript/secrets) | [Python](/sdk/python/secrets).

--- a/docs/de/sandboxes/snapshots.mdx
+++ b/docs/de/sandboxes/snapshots.mdx
@@ -1,0 +1,338 @@
+---
+title: Snapshots
+description: Capture a stopped sandbox's writable layer as a portable artifact
+icon: "code-branch"
+---
+
+A snapshot is a portable, on-disk capture of a sandbox's writable filesystem. Move it with `scp`, archive it as `.tar.zst`, or boot fresh sandboxes from it.
+
+<Note>
+Snapshots are **disk-only and stopped-only**: the sandbox can't be running when you take one. Memory and CPU state, plus qcow2 backing chains, are future work.
+</Note>
+
+## What gets captured
+
+| Captured                                     | Not captured                      |
+| -------------------------------------------- | --------------------------------- |
+| `upper.ext4`, the sandbox's writable overlay | Memory contents                   |
+| Pinned image reference + manifest digest     | CPU registers / running processes |
+| `fstype`, `format`, optional labels          | Network state                     |
+| Optional content-integrity hash              | Open file handles                 |
+
+Booting from a snapshot is a cold boot of a fresh VM that reuses the captured upper layer as its starting filesystem. The image (lower layer) is re-resolved by digest from the local OCI cache, or re-pulled from the registry if missing.
+
+## Quick start
+
+You'll usually reach for the CLI first:
+
+```bash
+# 1. Run something, install state, then stop it
+msb run --name baseline --detach python:3.12 -- sleep 3600
+msb exec baseline -- pip install requests
+msb stop baseline
+
+# 2. Snapshot the stopped sandbox
+msb snapshot create after-pip-install --from baseline
+
+# 3. Boot a fresh sandbox from the snapshot
+msb run --name worker --snapshot after-pip-install \
+    -- python -c "import requests; print(requests.__version__)"
+```
+
+<Tip>
+The snapshot lives at `~/.microsandbox/snapshots/after-pip-install/`. That whole directory is the snapshot.
+</Tip>
+
+## Snapshot a stopped sandbox
+
+Snapshot under a bare name (resolved to `~/.microsandbox/snapshots/<name>/`) or to an explicit path:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let h = Sandbox::get("baseline").await?;
+
+// Bare name resolves under ~/.microsandbox/snapshots/<name>/
+let snap = h.snapshot("after-pip-install").await?;
+
+// Or write to an explicit path
+let snap = h.snapshot_to("/tmp/snaps/v1").await?;
+
+println!("{}", snap.digest()); // sha256:...
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const h = await Sandbox.get("baseline");
+
+// Bare name resolves under ~/.microsandbox/snapshots/<name>/
+const snap = await h.snapshot("after-pip-install");
+
+// Or write to an explicit path
+const snap2 = await h.snapshotTo("/tmp/snaps/v1");
+
+console.log(snap.digest); // sha256:...
+```
+
+```python Python
+from microsandbox import Sandbox
+
+h = await Sandbox.get("baseline")
+
+# Bare name resolves under ~/.microsandbox/snapshots/<name>/
+snap = await h.snapshot("after-pip-install")
+
+# Or write to an explicit path
+snap2 = await h.snapshot_to("/tmp/snaps/v1")
+
+print(snap.digest)  # sha256:...
+```
+
+```bash CLI
+msb snapshot create after-pip-install --from baseline
+msb snapshot create ./snaps/v1     --from baseline   # Explicit path
+msb snapshot create after-pip-install --from baseline --label stage=ready
+```
+
+</CodeGroup>
+
+The sandbox must be stopped or crashed; running sandboxes are rejected.
+
+## Boot from a snapshot
+
+A snapshot already pins its image, so booting from one is mutually exclusive with the image source:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .from_snapshot("after-pip-install")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.builder("worker")
+    .fromSnapshot("after-pip-install")
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox
+
+# `snapshot=` is a peer of `image=` and mutually exclusive with it
+sb = await Sandbox.create("worker", snapshot="after-pip-install")
+```
+
+```bash CLI
+msb run --name worker --snapshot after-pip-install -- python -V
+```
+
+</CodeGroup>
+
+Booting validates the snapshot's manifest, re-resolves the pinned image from the local OCI cache (re-pulling and verifying the digest if it's missing), and reflinks the captured `upper.ext4` into the new sandbox's directory. Reflinks use `clonefile` on macOS APFS, `FICLONE` on btrfs/XFS, with a sparse-aware fallback on ext4, so each new sandbox gets an independent COW copy without paying the bytes again.
+
+## List, inspect, and remove
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Snapshot;
+
+let all = Snapshot::list().await?; // Indexed snapshots
+let h = Snapshot::get("after-pip-install").await?; // By name, digest, or path
+println!("{} ({})", h.name().unwrap_or("-"), h.digest());
+
+Snapshot::remove("after-pip-install", false).await?;
+Snapshot::reindex("~/.microsandbox/snapshots").await?;
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+const all = await Snapshot.list();                       // Indexed snapshots
+const h = await Snapshot.get("after-pip-install");       // By name, digest, or path
+console.log(`${h.name ?? "-"} (${h.digest})`);
+
+await Snapshot.remove("after-pip-install");
+await Snapshot.reindex("~/.microsandbox/snapshots");
+```
+
+```python Python
+from microsandbox import Snapshot
+
+all = await Snapshot.list()                              # Indexed snapshots
+h = await Snapshot.get("after-pip-install")              # By name, digest, or path
+print(f"{h.name or '-'} ({h.digest})")
+
+await Snapshot.remove("after-pip-install")
+await Snapshot.reindex("~/.microsandbox/snapshots")
+```
+
+```bash CLI
+msb snapshot ls
+msb snapshot inspect after-pip-install
+msb snapshot rm after-pip-install
+
+# Also if it has indexed children
+msb snapshot rm after-pip-install --force
+
+# Rebuild the index from artifacts on disk
+msb snapshot reindex
+```
+
+</CodeGroup>
+
+Opening a snapshot is cheap: it validates the manifest and checks the upper file's size, but does **not** read the file's contents. The same path powers `inspect` and the boot flow; the load-bearing local operation has to stay fast.
+
+`list` and `get` are backed by a small local index DB. The index is just a cache for fast lookups, not a source of truth; if it ever gets out of sync (or you delete it), `reindex` rebuilds it from the artifacts on disk.
+
+## Move snapshots between machines
+
+The artifact is a directory containing `manifest.json` (canonical JSON; identity is the SHA-256 of these bytes) plus the captured `upper.ext4`. The directory **is** the snapshot; there's no hidden daemon state, so any of these three transports work:
+
+```bash
+# Copy the directory directly with scp (image must be cached or pullable on the target)
+scp -r ~/.microsandbox/snapshots/after-pip-install \
+    other-host:~/.microsandbox/snapshots/
+
+# Bundle into a .tar.zst, transport, then import
+msb snapshot export after-pip-install /tmp/snap.tar.zst
+scp /tmp/snap.tar.zst other-host:
+ssh other-host msb snapshot import /tmp/snap.tar.zst
+
+# Fully offline: include the OCI image cache so the target needs no network
+msb snapshot export after-pip-install /tmp/snap.tar.zst --with-image
+ssh other-host msb snapshot import /tmp/snap.tar.zst
+```
+
+Archives default to `.tar.zst` since zstd collapses sparse zero runs cheaply. Pass `--plain-tar` for a plain `.tar`; both are accepted on import via magic-byte detection.
+
+Or drive `export` and `import` from code:
+
+<CodeGroup>
+```rust Rust
+use std::path::Path;
+use microsandbox::Snapshot;
+use microsandbox::snapshot::ExportOpts;
+
+Snapshot::export(
+    "after-pip-install",
+    Path::new("/tmp/snap.tar.zst"),
+    ExportOpts { with_image: true, ..Default::default() },
+).await?;
+
+let snap = Snapshot::import(
+    Path::new("/tmp/snap.tar.zst"),
+    None,
+).await?;
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+await Snapshot.export("after-pip-install", "/tmp/snap.tar.zst", {
+  withImage: true,
+});
+
+const snap = await Snapshot.import("/tmp/snap.tar.zst");
+```
+
+```python Python
+from microsandbox import Snapshot
+
+await Snapshot.export(
+    "after-pip-install",
+    "/tmp/snap.tar.zst",
+    with_image=True,
+)
+
+snap = await Snapshot.import_("/tmp/snap.tar.zst")  # Trailing _ avoids the keyword
+```
+
+```bash CLI
+msb snapshot export after-pip-install /tmp/snap.tar.zst --with-image
+msb snapshot import /tmp/snap.tar.zst
+```
+
+</CodeGroup>
+
+## Integrity verification
+
+By default, snapshot creation does **not** hash the upper file. The artifact carries the upper's size and the pinned image's manifest digest, which together catch any corruption that would stop it from booting. Skipping the hash keeps `inspect` fast on multi-GB sparse upper layers, where the cost would otherwise dominate.
+
+Opt in to a content-integrity hash when crossing a trust boundary:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Snapshot;
+
+// Compute and record an integrity hash at create time
+let snap = Snapshot::builder("baseline")
+    .name("after-pip-install")
+    .record_integrity()
+    .create()
+    .await?;
+
+// Verify a snapshot's recorded integrity on demand
+let report = snap.verify().await?;
+
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+// Compute and record an integrity hash at create time
+const snap = await Snapshot.builder("baseline")
+  .name("after-pip-install")
+  .recordIntegrity()
+  .create();
+
+// Verify a snapshot's recorded integrity on demand
+const report = await snap.verify();
+```
+
+```python Python
+from microsandbox import Snapshot
+
+# Compute and record an integrity hash at create time
+snap = await Snapshot.create(
+    "baseline",
+    name="after-pip-install",
+    record_integrity=True,
+)
+
+# Verify a snapshot's recorded integrity on demand
+report = await snap.verify()
+```
+
+```bash CLI
+# Compute and record an integrity hash at create time
+msb snapshot create after-pip-install --from baseline --integrity
+
+# Verify a snapshot's recorded integrity on demand
+msb snapshot verify after-pip-install
+msb snapshot inspect after-pip-install --verify
+```
+
+</CodeGroup>
+
+`msb snapshot export` automatically populates the integrity hash before bundling, and `msb snapshot import` verifies it on the way in. The local index path stays fast; the cross-machine path stays trustworthy.
+
+## Use cases
+
+- **Reusable build state.** Install dependencies once, snapshot, then `msb run --snapshot ...` repeatedly without paying the install cost. Common pattern for CI, agent workloads, and reproducible dev environments.
+- **Portable scratch state.** Capture a sandbox after a long setup, hand the artifact to a teammate or push it to shared storage, and let them boot from the same starting point.
+- **Local fork-by-copy.** Multiple sandboxes from one snapshot are independent; each copy of the upper layer diverges on its own.
+- **Disaster recovery.** Snapshot a sandbox before a risky migration; if it goes wrong, `msb rm` the broken one and `msb run --snapshot` from the pre-migration artifact.
+
+## What's not yet supported
+
+- **Live (running) snapshots.** The sandbox must be stopped first. Live capture requires an in-guest filesystem freeze and memory checkpointing that's tracked as future work.
+- **qcow2 backing chains.** Snapshots always copy the upper layer today. The manifest's `format` and `parent` fields are reserved so qcow2 chains can land additively without a schema break.
+- **Push/pull from a registry.** The artifact format is registry-shaped on purpose, but transport tooling beyond `scp` and `tar.zst` is a separate piece of work.
+- **Snapshotting `DiskImage` volumes.** The same mechanism would apply (reflink the disk file), but is currently out of scope.

--- a/docs/de/sandboxes/volumes.mdx
+++ b/docs/de/sandboxes/volumes.mdx
@@ -1,0 +1,271 @@
+---
+title: Volumes
+description: Persist and share data across sandboxes
+icon: "hard-drive"
+---
+
+Volumes give a sandbox direct filesystem access to host-side directories. They're useful for persisting data across restarts, sharing data between sandboxes, or mounting host directories into the guest. They're also significantly faster than the [filesystem API](/sandboxes/filesystem) (which transfers files individually), so for anything beyond ad-hoc reads and writes, volumes are the way to go.
+
+microsandbox supports three types of mounts: bind mounts, named volumes, and tmpfs.
+
+## Bind mounts
+
+Mount a directory from the host directly into the sandbox. Changes inside the sandbox are reflected on the host, and vice versa.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("dev")
+    .image("python")
+    .volume("/app/src", |v| v.bind("./src").readonly())
+    .volume("/app/data", |v| v.bind("./data"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("dev")
+    .image("python")
+    .volume("/app/src",  (m) => m.bind("./src").readonly())
+    .volume("/app/data", (m) => m.bind("./data"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+sb = await Sandbox.create(
+    "dev",
+    image="python",
+    volumes={
+        "/app/src": Volume.bind("./src", readonly=True),
+        "/app/data": Volume.bind("./data"),
+    },
+)
+```
+
+```bash CLI
+msb create python --name dev \
+  -v ./src:/app/src:ro \
+  -v ./data:/app/data
+```
+
+</CodeGroup>
+
+## Named volumes
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox, so you can create a volume, populate it, and mount it into different sandboxes over time.
+
+### Create a volume
+
+<CodeGroup>
+```rust Rust
+let cache = Volume::builder("pip-cache")
+    .quota(1024)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Volume } from "microsandbox";
+
+const cache = await Volume.builder("pip-cache").quota(1024).create();
+```
+
+```python Python
+cache = await Volume.create("pip-cache", quota_mib=1024)
+```
+
+```bash CLI
+msb volume create pip-cache --size 1024
+```
+
+</CodeGroup>
+
+### Mount in a sandbox
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .volume("/root/.cache/pip", |v| v.named(cache.name()))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .volume("/root/.cache/pip", (m) => m.named(cache.name))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    volumes={
+        "/root/.cache/pip": Volume.named(cache.name),
+    },
+)
+```
+
+```bash CLI
+msb create python --name worker \
+  -v pip-cache:/root/.cache/pip
+```
+
+</CodeGroup>
+
+### Share between sandboxes
+
+Named volumes are the simplest way to share data between sandboxes. Mount the same volume into multiple sandboxes: one writes, another reads.
+
+<CodeGroup>
+```rust Rust
+// Writer
+let writer = Sandbox::builder("writer")
+    .image("alpine")
+    .volume("/data", |v| v.named("shared-data"))
+    .create()
+    .await?;
+writer.shell("echo 'hello' > /data/message.txt").await?;
+
+// Reader (read-only)
+let reader = Sandbox::builder("reader")
+    .image("alpine")
+    .volume("/data", |v| v.named("shared-data").readonly())
+    .create()
+    .await?;
+let output = reader.exec("cat", ["/data/message.txt"]).await?;
+// => "hello"
+```
+
+```typescript TypeScript
+// Writer
+await using writer = await Sandbox.builder("writer")
+    .image("alpine")
+    .volume("/data", (m) => m.named("shared-data"))
+    .create();
+await writer.shell("echo 'hello' > /data/message.txt");
+
+// Reader (read-only)
+await using reader = await Sandbox.builder("reader")
+    .image("alpine")
+    .volume("/data", (m) => m.named("shared-data").readonly())
+    .create();
+const output = await reader.exec("cat", ["/data/message.txt"]);
+// => "hello"
+```
+
+```python Python
+# Writer
+writer = await Sandbox.create(
+    "writer",
+    image="alpine",
+    volumes={"/data": Volume.named("shared-data")},
+)
+await writer.shell("echo 'hello' > /data/message.txt")
+
+# Reader (read-only)
+reader = await Sandbox.create(
+    "reader",
+    image="alpine",
+    volumes={"/data": Volume.named("shared-data", readonly=True)},
+)
+output = await reader.exec("cat", ["/data/message.txt"])
+# => "hello"
+```
+
+</CodeGroup>
+
+<Tip>
+  When sharing volumes between sandboxes, both sandboxes access the same underlying host directory. There's no built-in locking, so if two sandboxes write to the same file concurrently, you'll get the usual race conditions. Use the read-only flag on the reader side to make intent explicit.
+</Tip>
+
+### Host-side access
+
+Named volumes are accessible from the host even without a running sandbox, which is handy for pre-populating data before any sandbox mounts it.
+
+<CodeGroup>
+```rust Rust
+let vol = Volume::get("pip-cache").await?;
+vol.fs().write("/requirements.txt", "requests==2.28.0").await?;
+```
+
+```typescript TypeScript
+const vol = await Volume.get("pip-cache");
+await vol.fs().write("requirements.txt", "requests==2.28.0");
+```
+
+```python Python
+vol = await Volume.get("pip-cache")
+await vol.fs.write("/requirements.txt", b"requests==2.28.0")
+```
+
+</CodeGroup>
+
+### Manage volumes
+
+<CodeGroup>
+```rust Rust
+let volumes = Volume::list().await?;
+Volume::remove("old-cache").await?;
+```
+
+```typescript TypeScript
+const volumes = await Volume.list();
+await Volume.remove("old-cache");
+```
+
+```python Python
+volumes = await Volume.list()
+await Volume.remove("old-cache")
+```
+
+```bash CLI
+msb volume ls
+msb volume rm old-cache
+```
+
+</CodeGroup>
+
+## Tmpfs
+
+An in-memory filesystem that disappears when the sandbox stops. Useful for scratch space, build artifacts, or anything that doesn't need to outlive the sandbox.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("alpine")
+    .volume("/tmp/scratch", |v| v.tmpfs().size(100))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("alpine")
+    .volume("/tmp/scratch", (m) => m.tmpfs().size(100))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="alpine",
+    volumes={
+        "/tmp/scratch": Volume.tmpfs(size_mib=100),
+    },
+)
+```
+
+```bash CLI
+msb create alpine --name worker \
+  --tmpfs /tmp/scratch:100
+```
+
+</CodeGroup>

--- a/docs/de/sdk/errors.mdx
+++ b/docs/de/sdk/errors.mdx
@@ -1,0 +1,266 @@
+---
+title: Error Handling
+description: Typed errors and resource cleanup patterns
+icon: "triangle-exclamation"
+---
+
+All SDKs surface typed errors so you can match on specific failure modes instead of parsing strings. Rust has an `Error` enum, TypeScript exposes a dedicated subclass per variant (use `instanceof`), and Python provides dedicated exception classes.
+
+## Matching errors
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, Error};
+
+async fn get_or_create(name: &str) -> Result<Sandbox, Error> {
+    match Sandbox::get(name).await {
+        Ok(handle) => handle.start().await,
+        Err(Error::SandboxNotFound(_)) => {
+            Sandbox::builder(name).image("python").create().await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+match sb.exec("python", ["script.py"]).await {
+    Ok(output) if output.status().success => {
+        println!("{}", output.stdout()?);
+    }
+    Ok(output) => {
+        eprintln!("Exit {}: {}", output.status().code, output.stderr()?);
+    }
+    Err(Error::ExecTimeout) => eprintln!("Timed out"),
+    Err(Error::Runtime(msg)) => eprintln!("Runtime: {msg}"),
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import {
+    ExecTimeoutError,
+    RuntimeError,
+    Sandbox,
+    SandboxNotFoundError,
+} from "microsandbox";
+
+async function getOrCreate(name: string): Promise<Sandbox> {
+    try {
+        const handle = await Sandbox.get(name);
+        return await handle.start();
+    } catch (e) {
+        if (e instanceof SandboxNotFoundError) {
+            return Sandbox.builder(name).image("python").create();
+        }
+        throw e;
+    }
+}
+
+try {
+    const output = await sb.exec("python", ["script.py"]);
+    if (!output.success) {
+        console.error(`Failed (exit ${output.code}):`, output.stderr());
+    }
+} catch (e) {
+    if (e instanceof ExecTimeoutError) {
+        console.error(`Timed out after ${e.timeoutMs}ms`);
+    } else if (e instanceof RuntimeError) {
+        console.error("Runtime:", e.message);
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import (
+    ExecTimeoutError, Sandbox, SandboxNotFoundError
+)
+
+async def get_or_create(name: str):
+    try:
+        handle = await Sandbox.get(name)
+        return await handle.start()
+    except SandboxNotFoundError:
+        return await Sandbox.create(name, image="python")
+
+try:
+    output = await sb.exec("python", ["script.py"])
+    if not output.success:
+        print(f"Exit {output.exit_code}: {output.stderr_text}")
+except ExecTimeoutError:
+    print("Timed out")
+```
+
+</CodeGroup>
+
+## Spawn-time exec failures
+
+`exec()` distinguishes between:
+
+- **A program that ran and exited non-zero** — the call returns an `ExecOutput` with a non-zero `code`. This is *not* an error in the SDK sense; it's a normal result.
+- **A program that never started** — the binary doesn't exist, isn't executable, the working directory is unreachable, etc. This surfaces as a typed error variant: `ExecFailed` (Rust), `ExecFailedError` (TypeScript), `ExecFailedError` (Python).
+
+The typed error carries a classified `kind` plus the underlying `errno`, so callers can branch on the cause and react. Common kinds: `NotFound` (binary missing on PATH), `PermissionDenied`, `NotExecutable`, `BadCwd`, `BadArgs`, `ResourceLimit`, `UserSetupFailed`, `OutOfMemory`, `PtySetupFailed`, `Other`.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Error;
+use microsandbox_protocol::exec::ExecFailureKind;
+
+match sb.exec("nonexistent", []).await {
+    Ok(output) => { /* program ran, check output.status() */ }
+    Err(Error::ExecFailed(payload)) => {
+        match payload.kind {
+            ExecFailureKind::NotFound => {
+                eprintln!("Binary not found on PATH: {}", payload.message);
+            }
+            ExecFailureKind::PermissionDenied => {
+                eprintln!("Not executable (chmod +x?): {}", payload.message);
+            }
+            kind => {
+                eprintln!("Spawn failed ({:?}): {}", kind, payload.message);
+            }
+        }
+        // payload.errno, payload.errno_name, payload.stage are also available
+    }
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import { ExecFailedError, Sandbox } from "microsandbox";
+
+try {
+    const output = await sb.exec("nonexistent");
+    // program ran, check output.success / output.code
+} catch (e) {
+    if (e instanceof ExecFailedError) {
+        switch (e.kind) {
+            case "not_found":
+                console.error("Binary not on PATH:", e.message);
+                break;
+            case "permission_denied":
+                console.error("Not executable (chmod +x?):", e.message);
+                break;
+            default:
+                console.error(`Spawn failed (${e.kind}):`, e.message);
+        }
+        // e.errno, e.errnoName, e.stage are also available
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import ExecFailedError
+
+try:
+    output = await sb.exec("nonexistent")
+    # program ran, check output.success / output.exit_code
+except ExecFailedError as e:
+    if e.kind == "not_found":
+        print(f"Binary not on PATH: {e.message}")
+    elif e.kind == "permission_denied":
+        print(f"Not executable (chmod +x?): {e.message}")
+    else:
+        print(f"Spawn failed ({e.kind}): {e.message}")
+    # e.errno, e.errno_name, e.stage are also available
+```
+</CodeGroup>
+
+The CLI maps these kinds to POSIX-style exit codes: `127` for `NotFound`, `126` for `PermissionDenied` and `NotExecutable`, `1` otherwise. SDK callers reading the error directly don't need to think about exit codes — branch on `kind` instead.
+
+## Sandbox start failures
+
+When a sandbox process exits before the agent relay is ready (mount errors, missing rootfs, network setup failures), the SDK surfaces a typed `BootStart` / `BootStartError`. The payload carries the failure stage and errno so callers can recover or report cleanly.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Error;
+use microsandbox_runtime::boot_error::BootErrorStage;
+
+match Sandbox::builder("svc").image("alpine").create().await {
+    Ok(sb) => { /* ... */ }
+    Err(Error::BootStart { name, err }) => {
+        eprintln!("Sandbox {name:?} failed at stage {:?}: {}", err.stage, err.message);
+        if matches!(err.stage, BootErrorStage::Mount) {
+            eprintln!("Hint: a host volume path may not exist.");
+        }
+    }
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import { BootStartError } from "microsandbox";
+
+try {
+    const sb = await Sandbox.builder("svc").image("alpine").create();
+} catch (e) {
+    if (e instanceof BootStartError) {
+        console.error(`Sandbox "${e.name}" failed at stage ${e.stage}: ${e.message}`);
+        if (e.stage === "mount") {
+            console.error("Hint: a host volume path may not exist.");
+        }
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import BootStartError
+
+try:
+    sb = await Sandbox.create("svc", image="alpine")
+except BootStartError as e:
+    print(f"Sandbox {e.name!r} failed at stage {e.stage}: {e.message}")
+    if e.stage == "mount":
+        print("Hint: a host volume path may not exist.")
+```
+</CodeGroup>
+
+The CLI prepends the same payload as a styled `error:` block before any captured log output, so you see "what went wrong + a hint" inline. SDK callers get the structured payload to make their own decisions.
+
+## Resource cleanup
+
+Sandboxes hold compute resources, so release them when done. In Rust, `Drop` handles cleanup when the sandbox goes out of scope. In TypeScript, prefer `await using` (Node 22+) which calls `Sandbox.stop()` automatically when the binding leaves scope.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+// Sandbox implements Drop, so resources are released when `sb` goes out of scope.
+// For explicit control, call stop() or kill().
+{
+    let sb = Sandbox::builder("temp")
+        .image("python")
+        .create()
+        .await?;
+
+    let output = sb.exec("python", ["-c", "print('hello')"]).await?;
+} // sb is dropped here, resources are cleaned up
+```
+
+```typescript TypeScript
+async function runTemporary(): Promise<string> {
+    // `await using` calls Sandbox.stop() when the binding leaves scope.
+    await using sb = await Sandbox.builder("temp")
+        .image("python")
+        .replace()
+        .create();
+
+    const out = await sb.exec("python", ["-c", "print('hello')"]);
+    return out.stdout();
+}
+```
+
+```python Python
+# Use async context manager — auto-kills and removes on exit.
+async with await Sandbox.create("temp", image="python") as sb:
+    output = await sb.exec("python", ["-c", "print('hello')"])
+    print(output.stdout_text)
+```
+
+</CodeGroup>

--- a/docs/de/sdk/overview.mdx
+++ b/docs/de/sdk/overview.mdx
@@ -1,0 +1,96 @@
+---
+title: Overview
+description: Install the SDK and create your first sandbox
+icon: "play"
+---
+
+The SDK embeds the microsandbox runtime directly into whatever application uses it. `Sandbox.builder(name).create()` spawns the VM as a child process. No daemon to install, no server to connect to.
+
+## Installation
+
+<CodeGroup>
+```bash Rust
+cargo add microsandbox
+```
+
+```bash TypeScript
+npm install microsandbox
+```
+
+```bash Python
+pip install microsandbox
+```
+</CodeGroup>
+
+## Quick start
+
+Create a sandbox from a container image, run a command, print the output, and stop it.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, NetworkPolicy};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let sb = Sandbox::builder("my-sandbox")
+        .image("python")
+        .memory(512)
+        .cpus(2)
+        .env("PYTHONDONTWRITEBYTECODE", "1")
+        .volume("/app/src", |v| v.bind("./src").readonly())
+        .network(|n| n.policy(NetworkPolicy::public_only()))
+        .create()
+        .await?;
+
+    let output = sb.exec("python", ["-c", "print('Hello, World!')"]).await?;
+    println!("{}", output.stdout()?);
+
+    sb.stop().await?;
+    Ok(())
+}
+```
+
+```typescript TypeScript
+import { NetworkPolicy, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("my-sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .env("PYTHONDONTWRITEBYTECODE", "1")
+    .volume("/app/src", (m) => m.bind("./src").readonly())
+    .network((n) => n.policy(NetworkPolicy.publicOnly()))
+    .create();
+
+const output = await sb.exec("python", ["-c", "print('Hello, World!')"]);
+console.log("Output:", output.stdout());
+```
+
+```python Python
+import asyncio
+from microsandbox import Network, Sandbox, Volume
+
+async def main():
+    sb = await Sandbox.create(
+        "my-sandbox",
+        image="python",
+        memory=512,
+        cpus=2,
+        env={"PYTHONDONTWRITEBYTECODE": "1"},
+        volumes={
+            "/app/src": Volume.bind("./src", readonly=True),
+        },
+        network=Network.public_only(),
+    )
+
+    output = await sb.exec("python", ["-c", "print('Hello, World!')"])
+    print("Output:", output.stdout_text)
+
+    await sb.stop()
+
+asyncio.run(main())
+```
+
+</CodeGroup>
+
+The SDK reference is split by language - choose [Rust SDK](/sdk/rust/sandbox), [TypeScript SDK](/sdk/typescript/sandbox), or [Python SDK](/sdk/python/sandbox) for the full API. See also [error handling](/sdk/errors).

--- a/docs/de/sdk/python/events.mdx
+++ b/docs/de/sdk/python/events.mdx
@@ -1,0 +1,11 @@
+---
+title: Events
+description: Python SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for a preview of event concepts and planned API.

--- a/docs/de/sdk/python/execution.mdx
+++ b/docs/de/sdk/python/execution.mdx
@@ -1,0 +1,212 @@
+---
+title: Execution
+description: Python SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+## Types
+
+### ExecOutput
+
+The result of a completed command execution.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| exit_code | `int` | Exit code |
+| success | `bool` | `True` if exit_code is `0` |
+| stdout_text | `str` | Collected stdout decoded as UTF-8. Raises on invalid encoding. |
+| stderr_text | `str` | Collected stderr decoded as UTF-8 |
+| stdout_bytes | `bytes` | Raw stdout bytes |
+| stderr_bytes | `bytes` | Raw stderr bytes |
+
+---
+
+### ExecHandle
+
+A handle to a running streaming execution. Supports `async for event in handle:` to iterate over events until the stream ends.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| id | `str` | Correlation ID for this execution |
+| take_stdin() | [`ExecSink`](#execsink) ` \| None` | Take the stdin writer. Returns `None` after first call. |
+| recv() | `ExecEvent \| None` | *(async)* Receive the next event. Returns `None` when done. |
+| wait() | `tuple[int, bool]` | *(async)* Wait for the process to exit. Returns `(code, success)`. |
+| collect() | [`ExecOutput`](#execoutput) | *(async)* Wait and collect all remaining output |
+| signal(sig) | `None` | *(async)* Send a POSIX signal to the process |
+| kill() | `None` | *(async)* Send SIGKILL |
+
+---
+
+### ExecSink
+
+Writer for sending data to a running process's stdin.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| write() | `data: bytes` | *(async)* Write bytes to the process's stdin |
+| close() | - | *(async)* Close stdin. The process sees EOF. |
+
+---
+
+### ExecEvent
+
+Low-level event from PyO3 bindings.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| event_type | `str` | `"started"`, `"stdout"`, `"stderr"`, or `"exited"` |
+| pid | `int \| None` | Guest PID (on `"started"`) |
+| data | `bytes \| None` | Output data (on `"stdout"` / `"stderr"`) |
+| code | `int \| None` | Exit code (on `"exited"`) |
+
+Python dataclass variants are also available for pattern matching:
+
+| Class | Fields | Description |
+|-------|--------|-------------|
+| `StartedEvent` | `pid: int` | The process has started |
+| `StdoutEvent` | `data: bytes` | A chunk of stdout data |
+| `StderrEvent` | `data: bytes` | A chunk of stderr data |
+| `ExitedEvent` | `code: int` | The process has exited |
+
+The union type `ExecEvent = StartedEvent | StdoutEvent | StderrEvent | ExitedEvent` is available from `events.py`.
+
+---
+
+### ExecOptions
+
+```python
+ExecOptions(
+    args: tuple[str, ...] = (),
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] = {},
+    timeout: float | None = None,  # seconds
+    stdin: Stdin = Stdin.null(),
+    tty: bool = False,
+    rlimits: tuple[Rlimit, ...] = (),
+)
+```
+
+Frozen dataclass for per-execution overrides.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| args | `tuple[str, ...]` | `()` | Command arguments |
+| cwd | `str \| None` | `None` | Working directory |
+| user | `str \| None` | `None` | Guest user |
+| env | `Mapping[str, str]` | `{}` | Environment variables |
+| timeout | `float \| None` | `None` | Kill the process after this many seconds |
+| stdin | [`Stdin`](#stdin) | `Stdin.null()` | Stdin source |
+| tty | `bool` | `False` | Allocate a pseudo-terminal |
+| rlimits | `tuple[`[`Rlimit`](#rlimit)`, ...]` | `()` | Resource limits |
+
+---
+
+### AttachOptions
+
+```python
+AttachOptions(
+    args: tuple[str, ...] = (),
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] = {},
+    detach_keys: str | None = None,
+)
+```
+
+Frozen dataclass for interactive PTY attach configuration.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| args | `tuple[str, ...]` | `()` | Command arguments |
+| cwd | `str \| None` | `None` | Working directory |
+| user | `str \| None` | `None` | Guest user |
+| env | `Mapping[str, str]` | `{}` | Environment variables |
+| detach_keys | `str \| None` | `None` | Key sequence to detach without stopping |
+
+---
+
+### Stdin
+
+Frozen dataclass with factory methods for configuring process stdin.
+
+| Factory | Parameters | Description |
+|---------|-----------|-------------|
+| Stdin.null() | - | `/dev/null` (default) |
+| Stdin.pipe() | - | Piped stdin. Use [`take_stdin()`](#exechandle) on the handle to write. |
+| Stdin.bytes() | `data: bytes` | Inline data sent before the process starts |
+
+---
+
+### Rlimit
+
+Frozen dataclass with factory methods for POSIX resource limits.
+
+| Factory | Parameters | Description |
+|---------|-----------|-------------|
+| Rlimit.nofile(limit) | `limit: int` | Max open file descriptors |
+| Rlimit.cpu(secs) | `secs: int` | CPU time limit in seconds |
+| Rlimit.as_(*, soft, hard) | `soft: int, hard: int` | Virtual memory size |
+| Rlimit.nproc(limit) | `limit: int` | Max number of processes |
+| Rlimit.fsize(limit) | `limit: int` | Max file size |
+| Rlimit.memlock(limit) | `limit: int` | Max locked memory |
+| Rlimit.stack(limit) | `limit: int` | Max stack size |
+
+**Properties**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| resource | [`RlimitResource`](#rlimitresource) | Resource type |
+| soft | `int` | Soft limit |
+| hard | `int` | Hard limit |
+
+---
+
+### RlimitResource
+
+Enum of POSIX resource types.
+
+| Value | Description |
+|-------|-------------|
+| `cpu` | CPU time |
+| `fsize` | File size |
+| `data` | Data segment size |
+| `stack` | Stack size |
+| `core` | Core file size |
+| `rss` | Resident set size |
+| `nproc` | Number of processes |
+| `nofile` | Open file descriptors |
+| `memlock` | Locked memory |
+| `as` | Virtual memory |
+| `locks` | File locks |
+| `sigpending` | Pending signals |
+| `msgqueue` | Message queue size |
+| `nice` | Nice priority ceiling |
+| `rtprio` | Real-time priority ceiling |
+| `rttime` | Real-time CPU time |
+
+---
+
+### SandboxMetrics
+
+Metrics snapshot for a running sandbox.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| cpu_percent | `float` | CPU utilization percentage |
+| memory_bytes | `int` | Current memory usage in bytes |
+| memory_limit_bytes | `int` | Memory limit in bytes |
+| disk_read_bytes | `int` | Total bytes read from disk |
+| disk_write_bytes | `int` | Total bytes written to disk |
+| net_rx_bytes | `int` | Total bytes received over the network |
+| net_tx_bytes | `int` | Total bytes sent over the network |
+| uptime_ms | `int` | Sandbox uptime in milliseconds |
+| timestamp_ms | `float` | Timestamp of the snapshot in milliseconds |
+
+---
+
+### MetricsStream
+
+Async iterator yielding [`SandboxMetrics`](#sandboxmetrics). Use `async for metrics in stream:` to consume.

--- a/docs/de/sdk/python/filesystem.mdx
+++ b/docs/de/sdk/python/filesystem.mdx
@@ -1,0 +1,357 @@
+---
+title: Filesystem
+description: Python SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via the `sandbox.fs` property. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
+
+---
+
+#### copy()
+
+```python
+async def copy(src: str, dst: str) -> None
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Source path |
+| dst | `str` | Destination path |
+
+---
+
+#### copy_from_host()
+
+```python
+async def copy_from_host(host_path: str, guest_path: str) -> None
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `str` | Path on the host filesystem |
+| guest_path | `str` | Destination path inside the sandbox |
+
+---
+
+#### copy_to_host()
+
+```python
+async def copy_to_host(guest_path: str, host_path: str) -> None
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `str` | Path inside the sandbox |
+| host_path | `str` | Destination path on the host |
+
+---
+
+#### exists()
+
+```python
+async def exists(path: str) -> bool
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `True` if the path exists |
+
+---
+
+#### list()
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`FsEntry`](#fsentry)`]` | Directory entries |
+
+---
+
+#### mkdir()
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory and all parent directories.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path |
+
+---
+
+#### read()
+
+```python
+async def read(path: str) -> bytes
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bytes` | File contents as raw bytes |
+
+---
+
+#### read_stream()
+
+```python
+async def read_stream(path: str) -> FsReadStream
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsReadStream`](#fsreadstream) | Async iterator that yields chunks of file data |
+
+---
+
+#### read_text()
+
+```python
+async def read_text(path: str) -> str
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `str` | File contents as a string |
+
+---
+
+#### remove()
+
+```python
+async def remove(path: str) -> None
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute file path |
+
+---
+
+#### remove_dir()
+
+```python
+async def remove_dir(path: str) -> None
+```
+
+Remove a directory recursively.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path |
+
+---
+
+#### rename()
+
+```python
+async def rename(src: str, dst: str) -> None
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Current path |
+| dst | `str` | New path |
+
+---
+
+#### stat()
+
+```python
+async def stat(path: str) -> FsMetadata
+```
+
+Get detailed metadata for a file or directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsMetadata`](#fsmetadata) | File metadata |
+
+---
+
+#### write()
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| data | `bytes` | File content |
+
+---
+
+#### write_stream()
+
+```python
+async def write_stream(path: str) -> FsWriteSink
+```
+
+Open a streaming writer for a file. Use this for files too large to fit in memory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsWriteSink`](#fswritesink) | Async writer that accepts chunks of data |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
+| mode | `int` | Unix permission bits |
+| modified | `float \| None` | Last modified timestamp (ms since epoch) |
+| path | `str` | File path |
+| size | `int` | File size in bytes |
+
+### FsEntryKind
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) representing the type of a filesystem entry.
+
+| Value | Description |
+|-------|-------------|
+| `"directory"` | Directory |
+| `"file"` | Regular file |
+| `"other"` | Other entry type |
+| `"symlink"` | Symbolic link |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| created | `float \| None` | Creation timestamp (ms since epoch) |
+| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
+| mode | `int` | Unix permission bits |
+| modified | `float \| None` | Last modified timestamp (ms since epoch) |
+| readonly | `bool` | Whether the file is read-only |
+| size | `int` | File size in bytes |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`read_stream()`](#read_stream).
+
+| Method / Protocol | Returns | Description |
+|-------------------|---------|-------------|
+| `__aiter__` / `__anext__` | `bytes` | Async iterator - use with `async for chunk in stream:` |
+| `collect()` | `bytes` | Collect all remaining data into a single `bytes` object |
+
+### FsWriteSink
+
+Async writer for streaming data into a file. Obtained via [`write_stream()`](#write_stream). Supports the async context manager protocol (`async with`).
+
+| Method / Protocol | Returns | Description |
+|-------------------|---------|-------------|
+| `write(data)` | `None` | Write a chunk of `bytes` to the file |
+| `close()` | `None` | Send EOF and finalize the file |
+| `__aenter__` / `__aexit__` | `FsWriteSink` | Use with `async with` for automatic close on exit |

--- a/docs/de/sdk/python/networking.mdx
+++ b/docs/de/sdk/python/networking.mdx
@@ -1,0 +1,333 @@
+---
+title: Networking
+description: Python SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## Network
+
+Frozen dataclass for sandbox network configuration. Use a class-method preset for the common cases, or construct directly with custom options.
+
+```python
+Network(
+    policy: str | NetworkPolicy | None = None,
+    ports: Mapping[int, int] = {},
+    deny_domains: tuple[str, ...] = (),
+    deny_domain_suffixes: tuple[str, ...] = (),
+    dns: DnsConfig | None = None,
+    tls: TlsConfig | None = None,
+    max_connections: int | None = None,
+    trust_host_cas: bool | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| policy | `str \| NetworkPolicy \| None` | Preset name (`"none"`, `"public_only"`, `"allow_all"`) or custom [`NetworkPolicy`](#networkpolicy-1) |
+| ports | `Mapping[int, int]` | Port mappings from host to guest |
+| deny_domains | `tuple[str, ...]` | Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy so it takes precedence over later allow rules |
+| deny_domain_suffixes | `tuple[str, ...]` | Deny egress to all subdomains of these suffixes. Adds `deny DomainSuffix("...")` rules; same enforcement layers as `deny_domains` |
+| dns | [`DnsConfig`](#dnsconfig) ` \| None` | DNS interception configuration |
+| tls | [`TlsConfig`](#tlsconfig) ` \| None` | TLS interception configuration |
+| max_connections | `int \| None` | Maximum concurrent connections |
+| trust_host_cas | `bool \| None` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle. Opt-in |
+
+---
+
+#### Network.allow_all()
+
+```python
+@classmethod
+def allow_all() -> Network
+```
+
+Unrestricted network access, including to private addresses and the host machine.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Unrestricted network configuration |
+
+---
+
+#### Network.none()
+
+```python
+@classmethod
+def none() -> Network
+```
+
+Deny all traffic. No network interface is created; the guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Fully airgapped network configuration |
+
+---
+
+#### Network.public_only()
+
+```python
+@classmethod
+def public_only() -> Network
+```
+
+Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Public-only network configuration |
+
+---
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Pass to `Network(policy=...)` for custom policies:
+
+```python
+from microsandbox import NetworkPolicy, Rule, Action, Direction, Protocol
+
+policy = NetworkPolicy(
+    default_egress=Action.DENY,
+    default_ingress=Action.ALLOW,
+    rules=(
+        Rule.allow(protocol=Protocol.TCP, port=443, destination="public"),
+        Rule.deny(destination="198.51.100.5"),
+    ),
+)
+```
+
+The default policy denies egress except for an implicit `allow public`, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry.
+
+```python
+NetworkPolicy(
+    default_egress: Action = Action.DENY,
+    default_ingress: Action = Action.ALLOW,
+    rules: tuple[Rule, ...] = (),
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
+| rules | `tuple[`[`Rule`](#rule)`, ...]` | Rules evaluated first-match-wins per direction |
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```python
+policy = NetworkPolicy(
+    default_egress=Action.DENY,
+    default_ingress=Action.ALLOW,
+    rules=(
+        Rule.allow(destination="10.0.0.0/8"),     # matches everything in 10.x
+        Rule.deny(destination="10.0.0.5"),        # never reached
+    ),
+)
+```
+
+Put specific rules before general ones.
+
+---
+
+## Rule
+
+Frozen dataclass for a single network policy rule.
+
+```python
+Rule(
+    action: Action,
+    direction: Direction = Direction.EGRESS,
+    destination: str | None = None,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| action | [`Action`](#action) | What to do when this rule matches |
+| direction | [`Direction`](#direction) | Which evaluator considers this rule. `Direction.ANY` matches in either direction |
+| destination | `str \| None` | Target filter: a [`DestGroup`](#destgroup) value, domain, CIDR range, domain suffix (prefixed with `"."`), or `"*"` for any. Domain and suffix strings are validated at sandbox creation; invalid names raise `ValueError` |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Single port (`443`) or range (`"8000-9000"`) |
+
+Ingress rules carrying ICMP protocols are rejected at sandbox creation; the host has no inbound ICMP path. Use `Direction.EGRESS` for ICMP allow/deny.
+
+---
+
+#### Rule.allow()
+
+```python
+@classmethod
+def allow(
+    *,
+    direction: Direction = Direction.EGRESS,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+    destination: str | None = None,
+) -> Rule
+```
+
+Create a rule that permits matching traffic.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| direction | [`Direction`](#direction) | Traffic direction |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Port or port range |
+| destination | `str \| None` | Destination filter |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | An allow rule |
+
+---
+
+#### Rule.deny()
+
+```python
+@classmethod
+def deny(
+    *,
+    direction: Direction = Direction.EGRESS,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+    destination: str | None = None,
+) -> Rule
+```
+
+Create a rule that blocks matching traffic.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| direction | [`Direction`](#direction) | Traffic direction |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Port or port range |
+| destination | `str \| None` | Destination filter |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | A deny rule |
+
+---
+
+## DnsConfig
+
+Frozen dataclass for DNS interception settings.
+
+```python
+DnsConfig(
+    rebind_protection: bool = True,
+    nameservers: tuple[str, ...] = (),
+    query_timeout_ms: int | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| nameservers | `tuple[str, ...]` | Nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). Overrides the host's `/etc/resolv.conf` when set. Hostnames are resolved once at startup via the host's OS resolver |
+| query_timeout_ms | `int \| None` | Per-DNS-query timeout in milliseconds |
+| rebind_protection | `bool` | Block DNS responses resolving to private IPs |
+
+---
+
+## TlsConfig
+
+Frozen dataclass for TLS interception settings within [`Network`](#network).
+
+```python
+TlsConfig(
+    bypass: tuple[str, ...] = (),
+    verify_upstream: bool = True,
+    intercepted_ports: tuple[int, ...] = (443,),
+    block_quic: bool = False,
+    ca_cert: str | None = None,
+    ca_key: str | None = None,
+    ca_cn: str | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| block_quic | `bool` | Block QUIC/HTTP3 (UDP) on intercepted ports, forcing TCP/TLS fallback |
+| bypass | `tuple[str, ...]` | Domains to skip interception. Use for domains with certificate pinning |
+| ca_cert | `str \| None` | Path to a custom interception CA certificate PEM file |
+| ca_cn | `str \| None` | Common name for the generated interception CA |
+| ca_key | `str \| None` | Path to a custom interception CA private key PEM file |
+| intercepted_ports | `tuple[int, ...]` | TCP ports where TLS interception is active |
+| verify_upstream | `bool` | Verify upstream server certificates. Set to `False` only for self-signed servers |
+
+---
+
+## Types
+
+### Action
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) for policy actions.
+
+| Value | Description |
+|-------|-------------|
+| `"allow"` | Permit the traffic |
+| `"deny"` | Drop the traffic silently |
+
+### Direction
+
+String enum for traffic direction.
+
+| Value | Description |
+|-------|-------------|
+| `"egress"` | Traffic leaving the sandbox |
+| `"ingress"` | Traffic entering the sandbox (via published ports) |
+| `"any"` | Rule applies in either direction |
+
+### Protocol
+
+String enum for network protocols in policy rules.
+
+| Value | Description |
+|-------|-------------|
+| `"tcp"` | TCP traffic |
+| `"udp"` | UDP traffic |
+| `"icmpv4"` | ICMPv4 traffic |
+| `"icmpv6"` | ICMPv6 traffic |
+
+### PortProtocol
+
+String enum for port-level protocol selection.
+
+| Value | Description |
+|-------|-------------|
+| `"tcp"` | TCP port |
+| `"udp"` | UDP port |
+
+### DestGroup
+
+String enum for well-known destination groups used in [`Rule.destination`](#rule).
+
+| Value | Description |
+|-------|-------------|
+| `"public"` | Complement of the named categories: every address not in any other group |
+| `"private"` | Private/RFC 1918 addresses + ULA + CGN (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7`) |
+| `"loopback"` | Loopback addresses (`127.0.0.0/8`, `::1`); the **guest's own** loopback, not the host. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap) |
+| `"link-local"` | Link-local addresses (`169.254.0.0/16`, `fe80::/10`) excluding metadata |
+| `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
+| `"multicast"` | Multicast addresses (`224.0.0.0/4`, `ff00::/8`) |
+| `"host"` | The host machine, reached via `host.microsandbox.internal`. This is the right group for "let the sandbox reach my host's localhost", not `"loopback"` |

--- a/docs/de/sdk/python/sandbox.mdx
+++ b/docs/de/sdk/python/sandbox.mdx
@@ -1,0 +1,898 @@
+---
+title: Sandbox
+description: Python SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+## Static methods
+
+---
+
+#### Sandbox.create()
+
+```python
+@staticmethod
+async def create(name_or_config: str | dict, **kwargs) -> Sandbox
+```
+
+Create and boot a sandbox. The first argument is either a name (`str`) or a full config (`dict`). Keyword arguments provide individual config fields. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name_or_config | `str \| dict` | Sandbox name or full configuration dict |
+| image | `str \| ImageSource` | OCI image, local path, or disk image (required) |
+| cpus | `int` | Virtual CPUs (default `1`) |
+| memory | `int` | Guest memory in MiB (default `512`) |
+| workdir | `str` | Default working directory for commands |
+| shell | `str` | Shell for `shell()` calls (default `"/bin/sh"`) |
+| hostname | `str` | Guest hostname |
+| user | `str` | Default guest user |
+| entrypoint | `list[str]` | Override image entrypoint |
+| init | `str \| dict \|` [`InitConfig`](#initconfig) | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) and [`InitConfig`](#initconfig) for accepted shapes |
+| replace | `bool` | Replace existing sandbox with same name |
+| max_duration | `float` | Maximum sandbox lifetime in seconds |
+| idle_timeout | `float` | Idle timeout in seconds |
+| env | `dict[str, str]` | Environment variables visible to all commands |
+| scripts | `dict[str, str]` | Named scripts mounted at `/.msb/scripts/` |
+| pull_policy | `str \| PullPolicy` | Image pull behavior |
+| log_level | `str \| LogLevel` | Override log verbosity |
+| registry_auth | [`RegistryAuth`](#registryauth) | Private registry credentials |
+| volumes | `dict[str, dict]` | Volume mounts. See [Volumes](/sdk/python/volumes). |
+| patches | `list[PatchConfig]` | Rootfs modifications applied before boot |
+| ports | `dict[int, int]` | Port mappings (`host_port: guest_port`) |
+| network | [`Network`](/sdk/python/networking#network) | Network policy and configuration |
+| secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | Secret injection |
+| detached | `bool` | If `True`, sandbox survives after your process exits |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+The returned `Sandbox` is an async context manager. Use `async with` to guarantee cleanup; on exit the sandbox is killed and its persisted state removed:
+
+```python
+async with await Sandbox.create("my-sandbox", image="alpine") as sb:
+    output = await sb.shell("echo hello")
+    print(output.stdout_text)
+# sandbox is automatically killed and removed on exit
+```
+
+---
+
+#### Sandbox.create_with_progress()
+
+```python
+@staticmethod
+def create_with_progress(name_or_config: str | dict, **kwargs) -> PullSession
+```
+
+Same parameters as [`Sandbox.create()`](#sandboxcreate) but returns a [`PullSession`](#pullsession) that lets you track image pull progress before the sandbox is ready. This method is synchronous (not awaitable) -- the async work happens through the `PullSession`.
+
+**Parameters**
+
+Same as [`Sandbox.create()`](#sandboxcreate).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`PullSession`](#pullsession) | Session for tracking pull progress and obtaining the final sandbox |
+
+---
+
+#### Sandbox.start()
+
+```python
+@staticmethod
+async def start(name: str, *, detached: bool = False) -> Sandbox
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Name of a stopped sandbox |
+| detached | `bool` | If `True`, sandbox survives after your process exits (default `False`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox.get()
+
+```python
+@staticmethod
+async def get(name: str) -> SandboxHandle
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox.list()
+
+```python
+@staticmethod
+async def list() -> list[SandboxHandle]
+```
+
+List all sandboxes (running, stopped, and crashed).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`SandboxHandle`](#sandboxhandle)`]` | All sandboxes |
+
+---
+
+#### Sandbox.remove()
+
+```python
+@staticmethod
+async def remove(name: str) -> None
+```
+
+Delete a stopped sandbox and all its state from disk. Fails if the sandbox is still running.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Sandbox name |
+
+---
+
+## Instance properties
+
+---
+
+#### name
+
+```python
+@property
+async def name(self) -> str
+```
+
+Sandbox name. This is an async property -- use `await sb.name`.
+
+---
+
+#### owns_lifecycle
+
+```python
+@property
+async def owns_lifecycle(self) -> bool
+```
+
+Whether this handle owns the sandbox lifecycle. `True` in attached mode, `False` in detached mode. This is an async property -- use `await sb.owns_lifecycle`.
+
+---
+
+#### fs
+
+```python
+@property
+def fs(self) -> SandboxFs
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. This is a synchronous property -- use `sb.fs` (no `await`). See [Filesystem](/sdk/python/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/python/filesystem) | Filesystem handle |
+
+---
+
+## Instance methods
+
+---
+
+#### attach()
+
+```python
+async def attach(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> int
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to run |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or execution options |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `int` | Exit code of the process |
+
+---
+
+#### attach_shell()
+
+```python
+async def attach_shell() -> int
+```
+
+Attach to the sandbox's default shell.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `int` | Exit code |
+
+---
+
+#### detach()
+
+```python
+async def detach() -> None
+```
+
+Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```python
+async def drain() -> None
+```
+
+Start a graceful drain (SIGUSR1). Existing commands run to completion, new `exec` calls are rejected.
+
+---
+
+#### exec()
+
+```python
+async def exec(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecOutput
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments (e.g. `["-c", "print('hello')"]`) or [`ExecOptions`](/sdk/python/execution#execoptions) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### exec_stream()
+
+```python
+async def exec_stream(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecHandle
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to execute |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or [`ExecOptions`](/sdk/python/execution#execoptions) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### kill()
+
+```python
+async def kill() -> None
+```
+
+Force-terminate the sandbox immediately (SIGKILL). No graceful shutdown.
+
+---
+
+#### metrics()
+
+```python
+async def metrics() -> SandboxMetrics
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network metrics |
+
+---
+
+#### metrics_stream()
+
+```python
+async def metrics_stream(interval: float = 1.0) -> MetricsStream
+```
+
+Stream resource metrics at a regular interval. The returned stream supports both `recv()` and `async for`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| interval | `float` | Seconds between metric snapshots (default `1.0`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`MetricsStream`](#metricsstream) | Async stream of metrics |
+
+---
+
+#### logs()
+
+```python
+async def logs(
+    tail: int | None = None,
+    since_ms: float | None = None,
+    until_ms: float | None = None,
+    sources: list[str] | None = None,
+) -> list[LogEntry]
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```python
+import asyncio
+import microsandbox
+
+async def main():
+    handle = await microsandbox.Sandbox.get("web")
+
+    # Default — all user-program output, regardless of pipe/pty mode
+    entries = await handle.logs()
+
+    for e in entries:
+        source = {
+            "stdout": "OUT",
+            "stderr": "ERR",
+            "output": "PTY",
+            "system": "SYS",
+        }[e.source]
+        print(
+            f"[{e.timestamp_ms / 1000:.3f}] "
+            f"{source} {e.session_id}: {e.text().rstrip()}"
+        )
+
+    # Filtered: last 50 entries from the past hour, including system lines
+    import time
+    recent = await handle.logs(
+        tail=50,
+        since_ms=(time.time() - 3600) * 1000,
+        sources=["stdout", "stderr", "output", "system"],
+    )
+
+asyncio.run(main())
+```
+
+Timestamps are exposed as `float` ms since the Unix epoch (UTC) for parity with `SandboxMetrics.timestamp_ms`. Convert to `datetime` if needed:
+
+```python
+from datetime import datetime, timezone
+dt = datetime.fromtimestamp(e.timestamp_ms / 1000, timezone.utc)
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| tail | `int \| None` | Show only the last N entries after other filters apply |
+| since_ms | `float \| None` | Inclusive lower bound on entry timestamp (ms since epoch) |
+| until_ms | `float \| None` | Exclusive upper bound on entry timestamp (ms since epoch) |
+| sources | `list[str] \| None` | Sources to include. `None` = `["stdout", "stderr", "output"]`. Add `"system"` to merge runtime/kernel diagnostics. Use `"all"` as shorthand for all four. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`LogEntry`](#logentry)`]` | Matching entries in chronological order |
+
+---
+
+#### remove_persisted()
+
+```python
+async def remove_persisted() -> None
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### shell()
+
+```python
+async def shell(script: str) -> ExecOutput
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `str` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell_stream()
+
+```python
+async def shell_stream(script: str) -> ExecHandle
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `str` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle |
+
+---
+
+#### stop()
+
+```python
+async def stop() -> None
+```
+
+Gracefully shut down the sandbox (SIGTERM).
+
+---
+
+#### stop_and_wait()
+
+```python
+async def stop_and_wait() -> tuple[int, bool]
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
+
+---
+
+#### wait()
+
+```python
+async def wait() -> tuple[int, bool]
+```
+
+Block until the sandbox exits on its own.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
+
+---
+
+## Patch
+
+Factory class for rootfs patches passed to `Sandbox.create(..., patches=[...])`. Each static method returns a [`PatchConfig`](#patchconfig). By default a patch that targets a path already present in the image errors at boot; pass `replace=True` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### Patch.append()
+
+```python
+@staticmethod
+def append(path: str, content: str) -> PatchConfig
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| content | `str` | Text to append |
+
+---
+
+#### Patch.copy_dir()
+
+```python
+@staticmethod
+def copy_dir(src: str, dst: str, *, replace: bool = False) -> PatchConfig
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Host source directory |
+| dst | `str` | Absolute destination path inside the guest |
+| replace | `bool` | When `True`, overwrite an existing path at `dst` |
+
+---
+
+#### Patch.copy_file()
+
+```python
+@staticmethod
+def copy_file(
+    src: str,
+    dst: str,
+    *,
+    mode: int | None = None,
+    replace: bool = False,
+) -> PatchConfig
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Host source file |
+| dst | `str` | Absolute destination path inside the guest |
+| mode | `int \| None` | File mode, e.g. `0o644`. `None` keeps the source mode |
+| replace | `bool` | When `True`, overwrite an existing path at `dst` |
+
+---
+
+#### Patch.mkdir()
+
+```python
+@staticmethod
+def mkdir(path: str, *, mode: int | None = None) -> PatchConfig
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| mode | `int \| None` | Directory mode, e.g. `0o755` |
+
+---
+
+#### Patch.remove()
+
+```python
+@staticmethod
+def remove(path: str) -> PatchConfig
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+---
+
+#### Patch.symlink()
+
+```python
+@staticmethod
+def symlink(target: str, link: str, *, replace: bool = False) -> PatchConfig
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `str` | What the symlink points to (literal symlink target text) |
+| link | `str` | Absolute path of the symlink itself |
+| replace | `bool` | When `True`, overwrite an existing path at `link` |
+
+---
+
+#### Patch.text()
+
+```python
+@staticmethod
+def text(
+    path: str,
+    content: str,
+    *,
+    mode: int | None = None,
+    replace: bool = False,
+) -> PatchConfig
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| content | `str` | Text content |
+| mode | `int \| None` | File mode, e.g. `0o644` |
+| replace | `bool` | When `True`, overwrite an existing path |
+
+---
+
+## Types
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `"debug"` | Debug and higher |
+| `"error"` | Errors only |
+| `"info"` | Info and higher |
+| `"trace"` | Most verbose -- all diagnostic output |
+| `"warn"` | Warnings and errors only |
+
+### LogEntry
+
+A single captured log entry returned by [`logs()`](#logs).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| timestamp_ms | `float` | Wall-clock capture time (ms since Unix epoch, UTC) |
+| source | `str` | Where the chunk came from. See [LogSource](#logsource). |
+| session_id | `int \| None` | Relay-monotonic session id; `None` for `"system"` entries |
+| data | `bytes` | The chunk's bytes (UTF-8 lossy decoded by default) |
+| `text()` | `str` | Convenience: UTF-8 decode of `data` (lossy — invalid bytes are replaced) |
+
+### LogSource
+
+The string values that the `source` field on a [`LogEntry`](#logentry) can take, also accepted by `logs(sources=[...])`.
+
+| Value | Description |
+|-------|-------------|
+| `"stdout"` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `"stderr"` | Captured from a session's stderr (pipe mode) |
+| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `"output"` rather than mislabelled as `"stdout"`. |
+| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested. |
+
+In addition, `logs(sources=["all"])` is a shorthand for all four.
+
+### MetricsStream
+
+Async stream for receiving periodic metrics snapshots.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `__aiter__` | `AsyncIterator[`[`SandboxMetrics`](#sandboxmetrics)`]` | Use with `async for` |
+| `recv()` | [`SandboxMetrics`](#sandboxmetrics) `\| None` | Receive next snapshot. Returns `None` when the stream ends. |
+
+### PatchConfig
+
+A single rootfs patch. Produced by the [`Patch`](#patch) factory; you'd normally not construct one directly. Frozen dataclass.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | `str` | One of `"text"`, `"file"`, `"copy_file"`, `"copy_dir"`, `"symlink"`, `"mkdir"`, `"remove"`, `"append"` |
+| path | `str \| None` | Absolute guest path (used by text / file / mkdir / remove / append) |
+| content | `str \| None` | Text content (text / append) |
+| src | `str \| None` | Host source path (copy_file / copy_dir) |
+| dst | `str \| None` | Guest destination path (copy_file / copy_dir) |
+| target | `str \| None` | Symlink target |
+| link | `str \| None` | Symlink path |
+| mode | `int \| None` | File / directory mode (e.g. `0o644`) |
+| replace | `bool` | When `True`, overwrite an existing path at the destination. Defaults to `False` |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `"always"` | Pull the image every time, even if cached locally |
+| `"if-missing"` | Pull only if the image is not already cached. This is the default. |
+| `"never"` | Never pull; fail if the image is not cached locally |
+
+### PullSession
+
+Returned by [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress). Use as an async context manager to track image pull progress.
+
+```python
+session = Sandbox.create_with_progress("my-sandbox", image="ubuntu:latest")
+async with session:
+    async for event in session.progress:
+        print(event)
+    sb = await session.result()
+```
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| progress | `AsyncIterator[PullProgress]` | Async iterator of pull progress events |
+| result() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Await to get the final running sandbox |
+
+### RegistryAuth
+
+Private registry credentials.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| username | `str` | Registry username |
+| password | `str` | Registry password |
+
+### SandboxConfig
+
+The keyword arguments accepted by [`Sandbox.create()`](#sandboxcreate) and [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| image | `str \| ImageSource` | - | OCI image, local path, or disk image (required) |
+| cpus | `int` | `1` | Virtual CPUs |
+| memory | `int` | `512` | Guest memory in MiB. This is a limit, not a reservation. |
+| workdir | `str` | - | Default working directory for commands |
+| shell | `str` | `"/bin/sh"` | Shell for `shell()` calls |
+| hostname | `str` | - | Guest hostname |
+| user | `str` | - | Default guest user |
+| entrypoint | `list[str]` | - | Override image entrypoint |
+| init | `str \| dict \|` [`InitConfig`](#initconfig) | - | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| replace | `bool` | `False` | Replace existing sandbox with same name |
+| max_duration | `float` | - | Maximum sandbox lifetime in seconds |
+| idle_timeout | `float` | - | Idle timeout in seconds |
+| env | `dict[str, str]` | `{}` | Environment variables visible to all commands |
+| scripts | `dict[str, str]` | `{}` | Named scripts mounted at `/.msb/scripts/` |
+| pull_policy | `str \| PullPolicy` | `"if-missing"` | Image pull behavior |
+| log_level | `str \| LogLevel` | - | Override log verbosity |
+| registry_auth | [`RegistryAuth`](#registryauth) | - | Private registry credentials |
+| volumes | `dict[str, dict]` | `{}` | Volume mounts. See [Volumes](/sdk/python/volumes). |
+| patches | `list[PatchConfig]` | `[]` | Rootfs modifications applied before boot |
+| ports | `dict[int, int]` | `{}` | Port mappings (`host_port: guest_port`) |
+| network | [`Network`](/sdk/python/networking#network) | `public_only` | Network policy and configuration |
+| secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | `[]` | Secret injection |
+| detached | `bool` | `False` | If `True`, sandbox survives after your process exits |
+
+### InitConfig
+
+Custom init specification. Pass it (or one of the equivalent shorthand shapes) as the `init=` kwarg to [`Sandbox.create()`](#sandboxcreate) to hand PID 1 inside the guest off to your own init binary after agentd's setup. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks, shutdown semantics, and tradeoffs.
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True, slots=True)
+class InitConfig:
+    cmd: str
+    args: tuple[str, ...] = ()
+    env: Mapping[str, str] = {}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cmd | `str` | Absolute path or `"auto"` to the init binary inside the guest rootfs |
+| args | `tuple[str, ...]` | Supplemental argv (`argv[0]` is implicitly `cmd`) |
+| env | `dict[str, str]` | Extra env vars merged on top of the inherited env |
+
+The `init=` kwarg follows the same shape as other `Sandbox.create` kwargs that carry structured values (`image=`, `network=`, etc.): a bare scalar for the simple case, or a dataclass / dict for the rich case.
+
+| Form | Equivalent to |
+|------|---------------|
+| `init="auto"` or `init="/sbin/init"` | `InitConfig(cmd=...)` |
+| `init={"cmd": ..., "args": [...], "env": {...}}` | dict equivalent of `InitConfig` |
+| `init=InitConfig(cmd="/sbin/init", args=("--foo",))` | itself |
+
+```python
+from microsandbox import InitConfig, Sandbox
+
+# Common case: bare string.
+sb = await Sandbox.create("worker", image="jrei/systemd-debian:12", init="auto")
+
+# Argv / env: dataclass.
+sb = await Sandbox.create(
+    "worker",
+    image="jrei/systemd-debian:12",
+    init=InitConfig(
+        cmd="/lib/systemd/systemd",
+        args=("--unit=multi-user.target",),
+        env={"container": "microsandbox"},
+    ),
+)
+```
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandboxget) or [`Sandbox.list()`](#sandboxlist). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. Call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `str` | Sandbox name |
+| status | `str` | Current status (`"running"`, `"stopped"`, `"crashed"`, `"draining"`, `"paused"`) |
+| config_json | `str` | Raw JSON configuration |
+| created_at | `float \| None` | Creation timestamp (ms since epoch) |
+| updated_at | `float \| None` | Last update timestamp (ms since epoch) |
+| connect() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Connect to a running sandbox |
+| start(*, detached=False) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Start in attached or detached mode |
+| stop() | `Awaitable[None]` | Graceful shutdown |
+| kill() | `Awaitable[None]` | Force terminate |
+| remove() | `Awaitable[None]` | Delete sandbox and state |
+| metrics() | `Awaitable[`[`SandboxMetrics`](#sandboxmetrics)`]` | Point-in-time resource metrics |
+| logs() | `Awaitable[list[`[`LogEntry`](#logentry)`]]` | Read captured `exec.log` (works without starting) |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpu_percent | `float` | CPU usage as a percentage |
+| disk_read_bytes | `int` | Total bytes read from disk since boot |
+| disk_write_bytes | `int` | Total bytes written to disk since boot |
+| memory_bytes | `int` | Current memory usage in bytes |
+| memory_limit_bytes | `int` | Memory limit in bytes |
+| net_rx_bytes | `int` | Total bytes received over the network since boot |
+| net_tx_bytes | `int` | Total bytes sent over the network since boot |
+| timestamp_ms | `float` | When this measurement was taken (ms since epoch) |
+| uptime_ms | `int` | Time since the sandbox was created (ms) |

--- a/docs/de/sdk/python/secrets.mdx
+++ b/docs/de/sdk/python/secrets.mdx
@@ -1,0 +1,77 @@
+---
+title: Secrets
+description: Python SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## Secret
+
+Static factory for creating secret entries used in `SandboxConfig.secrets`.
+
+---
+
+#### Secret.env()
+
+```python
+@staticmethod
+def env(
+    env_var: str,
+    *,
+    value: str,
+    allow_hosts: Sequence[str] = (),
+    allow_host_patterns: Sequence[str] = (),
+    placeholder: str | None = None,
+    require_tls: bool = True,
+    on_violation: ViolationAction = ViolationAction.BLOCK_AND_LOG,
+) -> SecretEntry
+```
+
+Create a secret entry that maps an environment variable to a real value. The guest sees a placeholder - the real value is only substituted by the TLS proxy when traffic goes to an allowed host.
+
+**Parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| env_var | `str` | - | Environment variable name (e.g. `"OPENAI_API_KEY"`) |
+| value | `str` | - | The real secret value. Never enters the guest VM. **Required.** |
+| allow_hosts | `Sequence[str]` | `()` | Hosts allowed to receive the real value (exact match). The TLS proxy matches against the SNI. |
+| allow_host_patterns | `Sequence[str]` | `()` | Wildcard host patterns (e.g. `"*.googleapis.com"`) |
+| placeholder | `str \| None` | `None` | Custom placeholder string. Auto-generated as `$MSB_<env_var>` if not set. |
+| require_tls | `bool` | `True` | Only substitute on TLS-intercepted connections. Disable only if you know the traffic is safe. |
+| on_violation | [`ViolationAction`](#violationaction) | `BLOCK_AND_LOG` | Action when the placeholder is sent to a disallowed host |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SecretEntry`](#secretentry) | Secret entry for `SandboxConfig.secrets` |
+
+---
+
+## Types
+
+### SecretEntry
+
+Frozen dataclass returned by [`Secret.env()`](#secretenv) and used in `SandboxConfig.secrets`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| env_var | `str` | Environment variable name |
+| value | `str` | Secret value |
+| allow_hosts | `tuple[str, ...]` | Allowed hosts (exact match) |
+| allow_host_patterns | `tuple[str, ...]` | Wildcard patterns |
+| placeholder | `str \| None` | Placeholder string |
+| require_tls | `bool` | TLS requirement |
+| on_violation | [`ViolationAction`](#violationaction) | Violation action |
+
+### ViolationAction
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) defining the action taken when a secret placeholder is sent to a disallowed host.
+
+| Value | Description |
+|-------|-------------|
+| `"block"` | Silently drop the request. The guest sees a connection reset. |
+| `"block-and-log"` | Drop the request and emit a warning log on the host side. This is the default. |
+| `"block-and-terminate"` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/de/sdk/python/snapshots.mdx
+++ b/docs/de/sdk/python/snapshots.mdx
@@ -1,0 +1,270 @@
+---
+title: Snapshots
+description: Python SDK - Snapshot API reference
+icon: "code-branch"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Python SDK reference.
+
+```python
+from microsandbox import Sandbox, Snapshot, SnapshotHandle
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## Sandbox.create() — `snapshot=` kwarg
+
+```python
+@staticmethod
+async def create(name_or_config, *, snapshot: str | os.PathLike | None = None, **kwargs) -> Sandbox
+```
+
+Boot a fresh sandbox from a snapshot artifact by passing `snapshot=` as a peer of `image=`. The two are mutually exclusive — pass exactly one.
+
+```python
+# Boot from a snapshot
+sb = await Sandbox.create("worker", snapshot="after-pip-install")
+
+# Or from an image (existing flow, unchanged)
+sb = await Sandbox.create("worker", image="python:3.12")
+```
+
+**Errors**
+
+- `ValueError` — both `image=` and `snapshot=` were passed or neither, the snapshot artifact doesn't exist, or the artifact's manifest failed validation
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```python
+async def snapshot(self, name: str) -> Snapshot
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination, see [`snapshot_to()`](#snapshot-to).
+
+**Errors**
+
+- `SnapshotSandboxRunning` — the sandbox is not stopped
+- `SnapshotAlreadyExists` — destination exists (use `Snapshot.create(..., force=True)` to overwrite)
+
+---
+
+#### snapshot_to()
+
+```python
+async def snapshot_to(self, path: str | os.PathLike) -> Snapshot
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path.
+
+---
+
+## Snapshot (instance)
+
+Properties are read-only attributes (not async).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `path` | `str` | Path to the artifact directory |
+| `digest` | `str` | Canonical content digest (`sha256:hex`). The snapshot's identity. |
+| `size_bytes` | `int` | Apparent size of the captured upper layer in bytes (sparse on disk) |
+| `image_ref` | `str` | Image reference the snapshot was taken from |
+| `image_manifest_digest` | `str` | OCI manifest digest of the pinned image |
+| `format` | `str` | `"raw"` or `"qcow2"` (always `"raw"` today) |
+| `fstype` | `str` | Filesystem type inside the upper (e.g. `"ext4"`) |
+| `parent` | `str \| None` | Parent snapshot's digest, or `None` for a root |
+| `created_at` | `str` | RFC 3339 timestamp |
+| `labels` | `dict[str, str]` | User-supplied labels |
+| `source_sandbox` | `str \| None` | Best-effort source-sandbox name |
+
+---
+
+#### verify()
+
+```python
+async def verify(self) -> dict[str, Any]
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds.
+
+```python
+report = await snap.verify()
+if report["upper"]["kind"] == "verified":
+    print(f"hash matches: {report['upper']['digest']}")
+else:
+    print("no integrity hash recorded")
+```
+
+The report shape:
+
+```python
+{
+    "digest": "sha256:...",
+    "path": "/path/to/artifact",
+    "upper": {"kind": "not_recorded"}                            # no integrity recorded
+        | {"kind": "verified", "algorithm": "...", "digest": "sha256:..."},
+}
+```
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot.create()
+
+```python
+@staticmethod
+async def create(
+    source_sandbox: str,
+    *,
+    name: str | None = None,
+    path: str | os.PathLike | None = None,
+    labels: dict[str, str] | None = None,
+    force: bool = False,
+    record_integrity: bool = False,
+) -> Snapshot
+```
+
+Create a snapshot from a stopped sandbox. Exactly one of `name=` (resolved under the default snapshots directory) or `path=` (explicit filesystem destination) is required.
+
+```python
+snap = await Snapshot.create(
+    "baseline",
+    name="after-pip-install",
+    labels={"stage": "post-deps"},
+    record_integrity=True,
+)
+```
+
+---
+
+#### Snapshot.open()
+
+```python
+@staticmethod
+async def open(path_or_name: str) -> Snapshot
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot.get()
+
+```python
+@staticmethod
+async def get(name_or_digest: str) -> SnapshotHandle
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot.list()
+
+```python
+@staticmethod
+async def list() -> list[SnapshotHandle]
+```
+
+List indexed snapshots from the local DB cache.
+
+---
+
+#### Snapshot.list_dir()
+
+```python
+@staticmethod
+async def list_dir(dir: str | os.PathLike) -> list[Snapshot]
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot.remove()
+
+```python
+@staticmethod
+async def remove(path_or_name: str, *, force: bool = False) -> None
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force=True`.
+
+---
+
+#### Snapshot.reindex()
+
+```python
+@staticmethod
+async def reindex(dir: str | os.PathLike | None = None) -> int
+```
+
+Walk `dir` (default: configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot.export()
+
+```python
+@staticmethod
+async def export(
+    name_or_path: str,
+    out: str | os.PathLike,
+    *,
+    with_parents: bool = False,
+    with_image: bool = False,
+    plain_tar: bool = False,
+) -> None
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+---
+
+#### Snapshot.import_()
+
+```python
+@staticmethod
+async def import_(
+    archive: str | os.PathLike,
+    *,
+    dest: str | os.PathLike | None = None,
+) -> SnapshotHandle
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+The trailing underscore is intentional — `import` is a reserved Python keyword.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot.list()`](#snapshot-list) and [`Snapshot.get()`](#snapshot-get).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `digest` | `str` | Manifest digest — canonical identity |
+| `name` | `str \| None` | Convenience alias |
+| `parent_digest` | `str \| None` | Parent snapshot digest (`None` today; populated when chains land) |
+| `image_ref` | `str` | Image the snapshot was taken from |
+| `format` | `str` | `"raw"` or `"qcow2"` |
+| `size_bytes` | `int \| None` | Apparent upper size at index time |
+| `created_at` | `float` | ms since Unix epoch |
+| `path` | `str` | Local artifact directory path |
+
+```python
+h = await Snapshot.get("after-pip-install")
+snap = await h.open()                # metadata-validated
+await h.remove(force=False)          # refuse if has children
+```

--- a/docs/de/sdk/python/volumes.mdx
+++ b/docs/de/sdk/python/volumes.mdx
@@ -1,0 +1,375 @@
+---
+title: Volumes
+description: Python SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+## Static methods
+
+---
+
+#### Volume.create()
+
+```python
+async def Volume.create(
+    name: str,
+    *,
+    quota_mib: int | None = None,
+    labels: dict[str, str] | None = None,
+) -> Volume
+```
+
+Create a new named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name (required) |
+| quota_mib | `int \| None` | Maximum storage size in MiB |
+| labels | `dict[str, str] \| None` | Metadata labels |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Volume` | Created volume with `name` and `path` properties |
+
+---
+
+#### Volume.get()
+
+```python
+async def Volume.get(name: str) -> VolumeHandle
+```
+
+Get a handle to an existing named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeHandle`](#volumehandle) | Volume handle |
+
+---
+
+#### Volume.list()
+
+```python
+async def Volume.list() -> list[VolumeHandle]
+```
+
+List all named volumes.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`VolumeHandle`](#volumehandle)`]` | All volumes |
+
+---
+
+#### Volume.remove()
+
+```python
+async def Volume.remove(name: str) -> None
+```
+
+Delete a named volume and its contents. Fails if the volume is currently mounted.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+
+---
+
+## Volume instance properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| name | `str` | Volume name |
+| path | `str` | Host path to the volume directory |
+
+---
+
+## Mount config factories
+
+Static factory methods on `Volume` for creating mount configurations used in sandbox volume config.
+
+---
+
+#### Volume.bind()
+
+```python
+def Volume.bind(path: str, *, readonly: bool = False) -> dict
+```
+
+Mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Directory path on the host |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+#### Volume.named()
+
+```python
+def Volume.named(name: str, *, readonly: bool = False) -> dict
+```
+
+Mount a named volume. The volume must already exist (create it with [`Volume.create()`](#volumecreate)).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+#### Volume.tmpfs()
+
+```python
+def Volume.tmpfs(*, size_mib: int | None = None, readonly: bool = False) -> dict
+```
+
+Use an in-memory filesystem. Contents are discarded when the sandbox stops.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size_mib | `int \| None` | Maximum size in MiB |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+## VolumeHandle
+
+Handle to an existing named volume, returned by [`Volume.get()`](#volumeget) and [`Volume.list()`](#volumelist).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `str` | Volume name |
+| quota_mib | `int \| None` | Storage quota in MiB |
+| used_bytes | `int` | Current disk usage in bytes |
+| labels | `dict[str, str]` | Metadata labels |
+| created_at | `float \| None` | Creation timestamp (ms since epoch) |
+| fs | [`VolumeFs`](#volumefs) | Host-side filesystem handle |
+| remove() | *(async)* `None` | Delete this volume |
+
+---
+
+## VolumeFs
+
+Host-side filesystem operations on a named volume. Obtained via the `fs` property on [`VolumeHandle`](#volumehandle). These operations run directly on the host filesystem - no running sandbox is required.
+
+---
+
+#### read()
+
+```python
+async def read(path: str) -> bytes
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bytes` | File contents as raw bytes |
+
+---
+
+#### read_text()
+
+```python
+async def read_text(path: str) -> str
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `str` | File contents as a string |
+
+---
+
+#### write()
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+| data | `bytes` | File content |
+
+---
+
+#### list()
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`FsEntry`](/sdk/python/filesystem#fsentry)`]` | Directory entries |
+
+---
+
+#### mkdir()
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory and all parent directories.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+---
+
+#### remove_file()
+
+```python
+async def remove_file(path: str) -> None
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+---
+
+#### exists()
+
+```python
+async def exists(path: str) -> bool
+```
+
+Check whether a path exists within the volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `True` if the path exists |
+
+---
+
+## Types
+
+### MountConfig
+
+Frozen dataclass representing a mount configuration.
+
+```python
+MountConfig(
+    kind: MountKind,
+    bind: str | None = None,
+    named: str | None = None,
+    size_mib: int | None = None,
+    readonly: bool = False,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| kind | [`MountKind`](#mountkind) | - | Type of mount (required) |
+| bind | `str \| None` | `None` | Host path for bind mounts |
+| named | `str \| None` | `None` | Volume name for named mounts |
+| size_mib | `int \| None` | `None` | Size limit for tmpfs mounts |
+| readonly | `bool` | `False` | Whether the mount is read-only |
+
+### MountKind
+
+String enum representing the type of mount.
+
+| Value | Description |
+|-------|-------------|
+| `"bind"` | Host bind mount |
+| `"named"` | Named volume mount |
+| `"tmpfs"` | In-memory filesystem |

--- a/docs/de/sdk/rust/events.mdx
+++ b/docs/de/sdk/rust/events.mdx
@@ -1,0 +1,66 @@
+---
+title: Events
+description: Rust SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for usage examples and guest-side emitting.
+
+## Sandbox methods
+
+---
+
+#### emit()
+
+```rust
+async fn emit(&self, event_name: &str, data: impl Serialize) -> MicrosandboxResult<()>
+```
+
+Send a named event with a JSON-serializable payload into the guest. Any process listening on the agent socket (`/run/agent.sock`) receives it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| event_name | `&str` | Event name (e.g. `"task.start"`) |
+| data | `impl Serialize` | Event payload - must be serializable to JSON |
+
+---
+
+#### on_event()
+
+```rust
+fn on_event(&self, event_name: &str, callback: impl FnMut(EventData) + Send + 'static) -> Subscription
+```
+
+Subscribe to named events emitted by guest processes. The callback fires each time the guest sends a matching event through `/run/agent.sock`. Multiple subscriptions to the same event name are supported.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| event_name | `&str` | Event name to subscribe to (e.g. `"task.progress"`) |
+| callback | `impl FnMut(EventData) + Send + 'static` | Called with the event data each time |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Subscription` | Handle that unsubscribes when dropped |
+
+---
+
+## Types
+
+### EventData
+
+Data received from a guest event.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| data | `Option<serde_json::Value>` | Event payload as a JSON value. `None` if the event had no data. |
+| event | `String` | Event name |

--- a/docs/de/sdk/rust/execution.mdx
+++ b/docs/de/sdk/rust/execution.mdx
@@ -1,0 +1,306 @@
+---
+title: Execution
+description: Rust SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+---
+
+#### attach()
+
+```rust
+async fn attach(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<i32>
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Your terminal's stdin, stdout, and stderr are connected to the guest process. Press `Ctrl+]` (or configured detach keys) to disconnect without stopping the process - it keeps running and can be reattached via its session ID.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to run |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code of the process |
+
+---
+
+#### attach_shell()
+
+```rust
+async fn attach_shell(&self) -> MicrosandboxResult<i32>
+```
+
+Attach to the sandbox's default shell (configured via `SandboxBuilder::shell()`, defaults to `/bin/sh`).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code |
+
+---
+
+#### attach_with()
+
+```rust
+async fn attach_with(&self, cmd: impl Into<String>, f: impl FnOnce(AttachOptionsBuilder) -> AttachOptionsBuilder) -> MicrosandboxResult<i32>
+```
+
+Interactive PTY attach with options for environment variables, working directory, user, and custom detach keys.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to run |
+| f | `AttachOptionsBuilder` | Configure attach options (env, cwd, user, detach keys). |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code of the process |
+
+---
+
+#### exec()
+
+```rust
+async fn exec(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments (e.g. `["-c", "print('hello')"]`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### exec_stream()
+
+```rust
+async fn exec_stream(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<ExecHandle>
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything until the command finishes. Use this for long-running processes, large output, or when you need to process output incrementally.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### exec_stream_with()
+
+```rust
+async fn exec_stream_with(&self, cmd: impl Into<String>, f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder) -> MicrosandboxResult<ExecHandle>
+```
+
+Streaming execution with per-execution overrides. Enable `stdin_pipe()` to write to the process's stdin, and `tty(true)` to allocate a pseudo-terminal for interactive programs like shells, REPLs, or editors.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| f | [`ExecOptionsBuilder`](#execoptionsbuilder) | Configure execution options. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle |
+
+---
+
+#### exec_with()
+
+```rust
+async fn exec_with(&self, cmd: impl Into<String>, f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command with per-execution overrides. The closure receives an [`ExecOptionsBuilder`](#execoptionsbuilder) to configure working directory, environment variables, timeout, resource limits, stdin mode, and TTY allocation. These overrides apply only to this execution and don't change the sandbox's defaults.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| f | [`ExecOptionsBuilder`](#execoptionsbuilder) | Configure execution options. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell()
+
+```rust
+async fn shell(&self, script: impl Into<String>) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). The script is passed as `sh -c "<script>"`, so shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `impl Into<String>` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell_stream()
+
+```rust
+async fn shell_stream(&self, script: impl Into<String>) -> MicrosandboxResult<ExecHandle>
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `impl Into<String>` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle |
+
+---
+
+## Types
+
+### ExecEvent
+
+Events emitted by a streaming execution.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Exited` | `code: i32` | The process has exited. `code` is the exit code. |
+| `Started` | `pid: u32` | The process has started. `pid` is the guest-side PID. |
+| `Stderr` | `Bytes` | A chunk of stderr data. |
+| `Stdout` | `Bytes` | A chunk of stdout data. May arrive in arbitrary sizes. |
+
+### ExecHandle
+
+A handle to a running streaming execution. Receives events as the process produces output, and provides control over stdin and signals.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| collect() | [`ExecOutput`](#execoutput) | Wait for exit and collect all remaining stdout/stderr. |
+| id() | `String` | Session ID for this execution. Can be used to reattach later. |
+| kill() | `()` | Send SIGKILL to the process. |
+| recv() | `Option<`[`ExecEvent`](#execevent)`>` | Receive the next event. Returns `None` when the process has exited and all output has been delivered. |
+| signal(signal) | `()` | Send a POSIX signal to the process (e.g. `libc::SIGTERM`). |
+| take_stdin() | `Option<`[`ExecSink`](#execsink)`>` | Take the stdin writer. Only available if `stdin_pipe()` was enabled. Returns `None` after the first call. |
+| wait() | [`ExitStatus`](#exitstatus) | Wait for the process to exit, discarding any remaining output. |
+
+### ExecOptionsBuilder
+
+Builder for per-execution overrides. Does not change the sandbox's defaults.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| args() | `impl IntoIterator<Item = impl Into<String>>` | Append command-line arguments. |
+| cwd() | `impl Into<String>` | Override the working directory for this command. |
+| env() | - `key: impl Into<String>` <br/> - `value: impl Into<String>` | Set an environment variable. Merged on top of sandbox-level env vars. |
+| envs() | `impl IntoIterator<Item = (String, String)>` | Set multiple environment variables at once. |
+| rlimit() | - `resource:` [`RlimitResource`](#rlimitresource) <br/> - `limit: u64` | Set a POSIX resource limit (soft = hard). Applied via `setrlimit()` before exec. |
+| rlimit_range() | - `resource:` [`RlimitResource`](#rlimitresource) <br/> - `soft: u64` <br/> - `hard: u64` | Set a resource limit with different soft and hard values. |
+| stdin_bytes() | `impl Into<Vec<u8>>` | Provide fixed bytes as stdin. The process reads them and then sees EOF. |
+| stdin_null() | - | Stdin reads from `/dev/null`. This is the default. |
+| stdin_pipe() | - | Enable a stdin writer via [`ExecSink`](#execsink). Use with [`ExecHandle::take_stdin()`](#exechandle). |
+| timeout() | `Duration` | Kill the process with SIGKILL if it hasn't exited within this duration. |
+| tty() | `bool` | Allocate a pseudo-terminal. Enable for interactive programs (shells, editors, `top`); disable for scripts and batch jobs. Default: `false`. |
+| user() | `impl Into<String>` | Override the guest user for this command. |
+
+### ExecOutput
+
+The result of a completed command execution. Holds the exit status and all captured output.
+
+| Field / Method | Type | Description |
+|----------------|------|-------------|
+| status() | [`ExitStatus`](#exitstatus) | Exit code and success flag |
+| stderr() | `Result<String>` | Collected stderr decoded as UTF-8 |
+| stderr_bytes() | `&Bytes` | Raw stderr bytes without decoding |
+| stdout() | `Result<String>` | Collected stdout decoded as UTF-8. Returns `Err` if the output is not valid UTF-8. |
+| stdout_bytes() | `&Bytes` | Raw stdout bytes without decoding |
+
+### ExecSink
+
+A writer for sending data to a running process's stdin. Obtained via [`ExecHandle::take_stdin()`](#exechandle).
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| close() | - | Close stdin. The process sees EOF on its stdin. |
+| write() | `data: impl AsRef<[u8]>` | Write bytes to the process's stdin. |
+
+### ExitStatus
+
+The exit status of a completed process.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| code | `i32` | Exit code. `0` typically means success. |
+| success | `bool` | `true` if code is `0` |
+
+### RlimitResource
+
+POSIX resource limit identifiers. Maps to `RLIMIT_*` constants.
+
+| Value | Description |
+|-------|-------------|
+| `As` | Max address space size |
+| `Core` | Max core file size |
+| `Cpu` | Max CPU time in seconds |
+| `Data` | Max data segment size |
+| `Fsize` | Max file size in bytes |
+| `Locks` | Max file locks |
+| `Memlock` | Max locked memory |
+| `Msgqueue` | Max bytes in POSIX message queues |
+| `Nice` | Max nice priority |
+| `Nofile` | Max open file descriptors |
+| `Nproc` | Max number of processes |
+| `Rss` | Max resident set size |
+| `Rtprio` | Max real-time priority |
+| `Rttime` | Max real-time timeout |
+| `Sigpending` | Max pending signals |
+| `Stack` | Max stack size |

--- a/docs/de/sdk/rust/filesystem.mdx
+++ b/docs/de/sdk/rust/filesystem.mdx
@@ -1,0 +1,356 @@
+---
+title: Filesystem
+description: Rust SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead, which give the guest direct filesystem access.
+
+---
+
+#### copy()
+
+```rust
+async fn copy(&self, from: &str, to: &str) -> MicrosandboxResult<()>
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `&str` | Source path |
+| to | `&str` | Destination path |
+
+---
+
+#### copy_from_host()
+
+```rust
+async fn copy_from_host(&self, host_path: impl AsRef<Path>, guest_path: &str) -> MicrosandboxResult<()>
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `impl AsRef<Path>` | Path on the host filesystem |
+| guest_path | `&str` | Destination path inside the sandbox |
+
+---
+
+#### copy_to_host()
+
+```rust
+async fn copy_to_host(&self, guest_path: &str, host_path: impl AsRef<Path>) -> MicrosandboxResult<()>
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `&str` | Path inside the sandbox |
+| host_path | `impl AsRef<Path>` | Destination path on the host |
+
+---
+
+#### exists()
+
+```rust
+async fn exists(&self, path: &str) -> MicrosandboxResult<bool>
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `true` if the path exists |
+
+---
+
+#### list()
+
+```rust
+async fn list(&self, path: &str) -> MicrosandboxResult<Vec<FsEntry>>
+```
+
+List the entries in a directory. Returns metadata for each entry including name, type, size, and permissions.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`FsEntry`](#fsentry)`>` | Directory entries |
+
+---
+
+#### mkdir()
+
+```rust
+async fn mkdir(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Create a directory. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path |
+
+---
+
+#### read()
+
+```rust
+async fn read(&self, path: &str) -> MicrosandboxResult<Bytes>
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Bytes` | File contents as raw bytes |
+
+---
+
+#### read_stream()
+
+```rust
+async fn read_stream(&self, path: &str) -> MicrosandboxResult<FsReadStream>
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory, or when you want to process data incrementally.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsReadStream`](#fsreadstream) | Async stream that yields chunks of file data |
+
+---
+
+#### read_to_string()
+
+```rust
+async fn read_to_string(&self, path: &str) -> MicrosandboxResult<String>
+```
+
+Read the entire contents of a file and decode as UTF-8. Returns an error if the file contains invalid UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `String` | File contents as a UTF-8 string |
+
+---
+
+#### remove()
+
+```rust
+async fn remove(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute file path |
+
+---
+
+#### remove_dir()
+
+```rust
+async fn remove_dir(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Remove a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path |
+
+---
+
+#### rename()
+
+```rust
+async fn rename(&self, from: &str, to: &str) -> MicrosandboxResult<()>
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `&str` | Current path |
+| to | `&str` | New path |
+
+---
+
+#### stat()
+
+```rust
+async fn stat(&self, path: &str) -> MicrosandboxResult<FsMetadata>
+```
+
+Get detailed metadata for a file or directory, including type, size, permissions, and timestamps.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsMetadata`](#fsmetadata) | File metadata |
+
+---
+
+#### write()
+
+```rust
+async fn write(&self, path: &str, data: impl AsRef<[u8]>) -> MicrosandboxResult<()>
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+| data | `impl AsRef<[u8]>` | File content |
+
+---
+
+#### write_stream()
+
+```rust
+async fn write_stream(&self, path: &str) -> MicrosandboxResult<FsWriteSink>
+```
+
+Open a streaming writer for large files. Write chunks incrementally and close when done.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsWriteSink`](#fswritesink) | Async writer for sending chunks |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| mode | `u32` | Unix permission bits (e.g. `0o644`) |
+| modified | `Option<DateTime<Utc>>` | Last modified timestamp |
+| path | `String` | File path |
+| size | `u64` | File size in bytes |
+
+### FsEntryKind
+
+The type of a filesystem entry.
+
+| Value | Description |
+|-------|-------------|
+| `Directory` | Directory |
+| `File` | Regular file |
+| `Other` | Other entry type (device, socket, etc.) |
+| `Symlink` | Symbolic link |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| created | `Option<DateTime<Utc>>` | Creation timestamp (not available on all filesystems) |
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| mode | `u32` | Unix permission bits |
+| modified | `Option<DateTime<Utc>>` | Last modified timestamp |
+| readonly | `bool` | Whether the file is read-only |
+| size | `u64` | File size in bytes |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`read_stream()`](#read_stream).
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| collect() | `Bytes` | Collect all remaining chunks into a single `Bytes` buffer. |
+| recv() | `Option<Bytes>` | Receive the next chunk. Returns `None` when the file has been fully read. |
+
+### FsWriteSink
+
+Async writer for streaming data into a file. Obtained via [`write_stream()`](#write_stream).
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| close() | - | Finalize the write and close the stream. Must be called to ensure all data is flushed. |
+| write() | `data: impl AsRef<[u8]>` | Write a chunk of data to the file. |

--- a/docs/de/sdk/rust/networking.mdx
+++ b/docs/de/sdk/rust/networking.mdx
@@ -1,0 +1,916 @@
+---
+title: Networking
+description: Rust SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Build one with [`NetworkPolicy::builder()`](#networkpolicybuilder):
+
+```rust
+use microsandbox::NetworkPolicy;
+
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.tcp().port(443).allow_public().allow_private())
+    .rule(|r| r.any().deny().ip("198.51.100.5"))
+    .build()?;
+```
+
+The default policy denies egress except for an implicit `allow public`, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
+| rules | `Vec<`[`Rule`](#rule)`>` | Ordered list of rules; first match wins |
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```rust
+NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e
+        .allow().cidr("10.0.0.0/8")     // matches everything in 10.x
+        .deny().ip("10.0.0.5"))          // never reached
+    .build()?;
+```
+
+Put specific rules before general ones.
+
+### Shadow detection
+
+`.build()` walks the rules and warns (via `tracing::warn!`) when a rule is fully covered by an earlier one in the same direction. Only `Ip`, `Cidr`, and `Group` destinations are checked; domain coverage depends on runtime DNS and is skipped. Builds still succeed:
+
+```text
+WARN rule #1 (Egress Cidr(10.0.0.5/32) Deny) is shadowed by rule #0 (Egress Cidr(10.0.0.0/8) Allow); to narrow, place the more specific rule first
+```
+
+### State accumulation
+
+State setters (`.tcp()`, `.port()`, etc.) inside a closure carry into every rule-adder that follows. State is **not reset** between adders:
+
+```rust
+.rule(|r| r.egress()
+    .tcp().port(443).allow_public()    // rule 1: egress, TCP, 443, allow Public
+    .udp().allow_private())            // rule 2: egress, [TCP, UDP], 443, allow Private
+```
+
+Use separate closures for rules that need different state.
+
+---
+
+## NetworkPolicy::builder()
+
+The fluent builder is the primary construction path. String inputs (`.ip(&str)`, `.cidr(&str)`, `.domain(&str)`, `.domain_suffix(&str)`) are stored raw and parsed at `.build()` time, so the chain stays clean. The first parse / validation failure surfaces as [`BuildError`](#builderror).
+
+The closure signature for `.rule()` / `.egress()` / `.ingress()` / `.any()` is `FnOnce(&mut RuleBuilder) -> &mut RuleBuilder`. A chain ending in any rule-adder (`.allow_public()`, `.deny().ip(...)`, etc.) returns the builder reference and satisfies the bound. Multi-statement bodies end with an explicit `r` return.
+
+---
+
+#### any()
+
+```rust
+fn any<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Any`. Rules committed inside apply in both directions.
+
+---
+
+#### build()
+
+```rust
+fn build(self) -> Result<NetworkPolicy, BuildError>
+```
+
+Consume the builder and produce a [`NetworkPolicy`](#networkpolicy). Lazy-parses every `.ip()` / `.cidr()` / `.domain()` / `.domain_suffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a `tracing::warn!` for each shadowed rule pair detected.
+
+---
+
+#### default_allow()
+
+```rust
+fn default_allow(self) -> Self
+```
+
+Set both `default_egress` and `default_ingress` to `Allow`.
+
+---
+
+#### default_deny()
+
+```rust
+fn default_deny(self) -> Self
+```
+
+Set both `default_egress` and `default_ingress` to `Deny`.
+
+---
+
+#### default_egress()
+
+```rust
+fn default_egress(self, action: Action) -> Self
+```
+
+Per-direction override for the egress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`Action`](#action) | Default action for egress |
+
+---
+
+#### default_ingress()
+
+```rust
+fn default_ingress(self, action: Action) -> Self
+```
+
+Per-direction override for the ingress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`Action`](#action) | Default action for ingress |
+
+---
+
+#### egress()
+
+```rust
+fn egress<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Egress`.
+
+---
+
+#### ingress()
+
+```rust
+fn ingress<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Ingress`.
+
+---
+
+#### rule()
+
+```rust
+fn rule<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Open a multi-rule batch closure. Direction must be set inside via `.egress()`, `.ingress()`, or `.any()` before any rule-adder.
+
+---
+
+## RuleBuilder
+
+The closure passed to `.rule(...)` (or any of the direction sugar methods) gives you a `RuleBuilder`. State setters and rule-adders interleave freely. State accumulates eagerly across the closure (see [State accumulation](#state-accumulation)).
+
+### Direction setters
+
+Last-write-wins. ICMP rule-adders are egress-only at build time.
+
+---
+
+#### any()
+
+```rust
+fn any(&mut self) -> &mut Self
+```
+
+Set direction to `Any` for subsequent rule-adders. Rules committed after this apply in both directions.
+
+---
+
+#### egress()
+
+```rust
+fn egress(&mut self) -> &mut Self
+```
+
+Set direction to `Egress` for subsequent rule-adders.
+
+---
+
+#### ingress()
+
+```rust
+fn ingress(&mut self) -> &mut Self
+```
+
+Set direction to `Ingress` for subsequent rule-adders.
+
+---
+
+### Protocol setters
+
+Protocols accumulate as a set; duplicates dedupe.
+
+---
+
+#### icmpv4()
+
+```rust
+fn icmpv4(&mut self) -> &mut Self
+```
+
+Add `Icmpv4` to the protocols set. Egress-only; an ICMP rule on an `Ingress` or `Any` direction fails build with [`BuildError::IngressDoesNotSupportIcmp`](#builderror).
+
+---
+
+#### icmpv6()
+
+```rust
+fn icmpv6(&mut self) -> &mut Self
+```
+
+Add `Icmpv6` to the protocols set. Egress-only; same rules as [`icmpv4()`](#icmpv4).
+
+---
+
+#### tcp()
+
+```rust
+fn tcp(&mut self) -> &mut Self
+```
+
+Add `Tcp` to the protocols set.
+
+---
+
+#### udp()
+
+```rust
+fn udp(&mut self) -> &mut Self
+```
+
+Add `Udp` to the protocols set.
+
+---
+
+### Port setters
+
+Ports accumulate as a set; duplicates dedupe. Always guest-side (egress destination port / ingress listening port).
+
+---
+
+#### port()
+
+```rust
+fn port(&mut self, port: u16) -> &mut Self
+```
+
+Add a single port to the ports set.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `u16` | Port number |
+
+---
+
+#### port_range()
+
+```rust
+fn port_range(&mut self, lo: u16, hi: u16) -> &mut Self
+```
+
+Add an inclusive port range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| lo | `u16` | Lower bound (inclusive) |
+| hi | `u16` | Upper bound (inclusive). `lo > hi` records [`BuildError::InvalidPortRange`](#builderror) |
+
+---
+
+#### ports()
+
+```rust
+fn ports<I: IntoIterator<Item = u16>>(&mut self, ports: I) -> &mut Self
+```
+
+Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
+
+---
+
+### Group rule-adders
+
+Each adder commits one rule using the current state and the named destination group.
+
+---
+
+#### allow_host()
+
+```rust
+fn allow_host(&mut self) -> &mut Self
+```
+
+Allow the `Host` group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allow_loopback()`](#allow_loopback).
+
+---
+
+#### allow_link_local()
+
+```rust
+fn allow_link_local(&mut self) -> &mut Self
+```
+
+Allow the `LinkLocal` group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
+
+---
+
+#### allow_loopback()
+
+```rust
+fn allow_loopback(&mut self) -> &mut Self
+```
+
+Allow the `Loopback` group (`127.0.0.0/8`, `::1`). The **guest's own** loopback, not the host. To reach a service on the host's localhost, use [`allow_host()`](#allow_host) instead. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
+
+---
+
+#### allow_meta()
+
+```rust
+fn allow_meta(&mut self) -> &mut Self
+```
+
+Allow the `Metadata` group (`169.254.169.254`). **Dangerous on cloud hosts** (exposes IAM credentials).
+
+---
+
+#### allow_multicast()
+
+```rust
+fn allow_multicast(&mut self) -> &mut Self
+```
+
+Allow the `Multicast` group (`224.0.0.0/4`, `ff00::/8`).
+
+---
+
+#### allow_private()
+
+```rust
+fn allow_private(&mut self) -> &mut Self
+```
+
+Allow the `Private` group (RFC1918 + ULA + CGN).
+
+---
+
+#### allow_public()
+
+```rust
+fn allow_public(&mut self) -> &mut Self
+```
+
+Allow the `Public` group (complement of named categories: every IP not in any other group).
+
+---
+
+#### deny_host()
+
+```rust
+fn deny_host(&mut self) -> &mut Self
+```
+
+Deny the `Host` group.
+
+---
+
+#### deny_link_local()
+
+```rust
+fn deny_link_local(&mut self) -> &mut Self
+```
+
+Deny the `LinkLocal` group.
+
+---
+
+#### deny_loopback()
+
+```rust
+fn deny_loopback(&mut self) -> &mut Self
+```
+
+Deny the `Loopback` group.
+
+---
+
+#### deny_meta()
+
+```rust
+fn deny_meta(&mut self) -> &mut Self
+```
+
+Deny the `Metadata` group.
+
+---
+
+#### deny_multicast()
+
+```rust
+fn deny_multicast(&mut self) -> &mut Self
+```
+
+Deny the `Multicast` group.
+
+---
+
+#### deny_private()
+
+```rust
+fn deny_private(&mut self) -> &mut Self
+```
+
+Deny the `Private` group.
+
+---
+
+#### deny_public()
+
+```rust
+fn deny_public(&mut self) -> &mut Self
+```
+
+Deny the `Public` group.
+
+---
+
+### Bulk-domain rule-adders
+
+Each call adds one rule per name, inheriting the current direction / protocol / port state. Lazy-parse: invalid names surface as [`BuildError::InvalidDomain`](#builderror) from `.build()`.
+
+```rust
+NetworkPolicy::builder()
+    .default_allow()
+    .egress(|e| e
+        .deny_domains(["evil.com", "tracker.example"])
+        .deny_domain_suffixes([".ads.example", ".doubleclick.net"]))
+    .build()?
+```
+
+---
+
+#### allow_domain_suffixes()
+
+```rust
+fn allow_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::DomainSuffix` allow rule per suffix.
+
+---
+
+#### allow_domains()
+
+```rust
+fn allow_domains<I, S>(&mut self, names: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::Domain` allow rule per name.
+
+---
+
+#### deny_domain_suffixes()
+
+```rust
+fn deny_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::DomainSuffix` deny rule per suffix.
+
+---
+
+#### deny_domains()
+
+```rust
+fn deny_domains<I, S>(&mut self, names: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::Domain` deny rule per name.
+
+---
+
+### Composite rule-adders
+
+---
+
+#### allow_local()
+
+```rust
+fn allow_local(&mut self) -> &mut Self
+```
+
+Add three allow rules atomically: `Loopback + LinkLocal + Host`. Each uses the closure's current state. `Metadata` is intentionally not included; opt in via [`allow_meta()`](#allow_meta) separately.
+
+---
+
+#### deny_local()
+
+```rust
+fn deny_local(&mut self) -> &mut Self
+```
+
+Add three deny rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is intentionally not included.
+
+---
+
+### Explicit-destination rule-adders
+
+`.allow()` / `.deny()` open an [`ExplicitRuleBuilder`](#explicitrulebuilder) that requires a destination call to commit.
+
+```rust
+.rule(|r| r.egress().tcp().port(443).allow().domain("api.example.com"))
+.rule(|r| r.any().deny().cidr("198.51.100.0/24"))
+```
+
+Dropping without a destination call adds no rule (the type is `#[must_use]`).
+
+---
+
+#### allow()
+
+```rust
+fn allow(&mut self) -> ExplicitRuleBuilder<'_>
+```
+
+Begin an explicit-destination rule with action `Allow`.
+
+---
+
+#### deny()
+
+```rust
+fn deny(&mut self) -> ExplicitRuleBuilder<'_>
+```
+
+Begin an explicit-destination rule with action `Deny`.
+
+---
+
+## NetworkBuilder
+
+Builder for configuring the sandbox's network stack. Used in `SandboxBuilder::network(|n| n...)`. Errors accumulated by nested builders cascade up; the outermost `SandboxBuilder::build()` surfaces them as `MicrosandboxError::NetworkBuilder(BuildError)`.
+
+---
+
+#### dns()
+
+```rust
+fn dns(self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self
+```
+
+Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
+
+```rust
+.network(|n| n
+    .dns(|d| d
+        .nameservers(["1.1.1.1".parse::<Nameserver>()?])
+        .query_timeout_ms(3000)
+    )
+)
+```
+
+---
+
+#### max_connections()
+
+```rust
+fn max_connections(self, max: usize) -> Self
+```
+
+Limit the maximum number of concurrent network connections from the sandbox.
+
+---
+
+#### on_secret_violation()
+
+```rust
+fn on_secret_violation(self, action: ViolationAction) -> Self
+```
+
+Set the action taken when a secret placeholder is detected in traffic destined for a host not in the secret's allow list. See [`ViolationAction`](#violationaction).
+
+---
+
+#### policy()
+
+```rust
+fn policy(self, policy: NetworkPolicy) -> Self
+```
+
+Set the network access policy. Pass a builder-constructed [`NetworkPolicy`](#networkpolicy):
+
+```rust
+.network(|n| n.policy(NetworkPolicy::builder().default_deny().build()?))
+```
+
+---
+
+#### tls()
+
+```rust
+fn tls(self, f: impl FnOnce(TlsBuilder) -> TlsBuilder) -> Self
+```
+
+Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
+
+---
+
+#### trust_host_cas()
+
+```rust
+fn trust_host_cas(self, enabled: bool) -> Self
+```
+
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in when egress HTTPS inside the sandbox needs to work behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle.
+
+---
+
+## DnsBuilder
+
+Builder for DNS interception settings. Used in `NetworkBuilder::dns(|d| d...)`. Owns rebind protection, nameserver pinning, and the per-query timeout.
+
+---
+
+#### nameservers()
+
+```rust
+fn nameservers<I>(self, nameservers: I) -> Self
+where
+    I: IntoIterator,
+    I::Item: Into<Nameserver>
+```
+
+Set the upstream nameservers to forward DNS queries to. Replaces any previously-set nameservers. Each element is convertible into `Nameserver` (`SocketAddr`, `IpAddr`, or a parsed string via `"dns.google:53".parse::<Nameserver>()?`).
+
+---
+
+#### query_timeout_ms()
+
+```rust
+fn query_timeout_ms(self, ms: u64) -> Self
+```
+
+Set the per-DNS-query timeout in milliseconds. Default: `5000`.
+
+---
+
+#### rebind_protection()
+
+```rust
+fn rebind_protection(self, enabled: bool) -> Self
+```
+
+When enabled, DNS responses that resolve to private IP addresses are blocked. Prevents DNS rebinding attacks. Default: `true`.
+
+---
+
+## TlsBuilder
+
+Builder for TLS interception settings. Used in `NetworkBuilder::tls(|t| t...)`.
+
+---
+
+#### block_quic()
+
+```rust
+fn block_quic(self, block: bool) -> Self
+```
+
+Block QUIC/HTTP3 on intercepted ports, forcing TCP/TLS fallback. Default: `true`.
+
+---
+
+#### bypass()
+
+```rust
+fn bypass(self, pattern: impl Into<String>) -> Self
+```
+
+Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). Use for domains with certificate pinning.
+
+---
+
+#### intercept_ca_cert()
+
+```rust
+fn intercept_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file used as the intercepting CA's certificate. Pair with [`intercept_ca_key()`](#intercept_ca_key) to provide a stable CA across sandbox restarts.
+
+---
+
+#### intercept_ca_key()
+
+```rust
+fn intercept_ca_key(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file used as the intercepting CA's private key.
+
+---
+
+#### intercepted_ports()
+
+```rust
+fn intercepted_ports(self, ports: Vec<u16>) -> Self
+```
+
+TCP ports where TLS interception is active. Default: `[443]`.
+
+---
+
+#### upstream_ca_cert()
+
+```rust
+fn upstream_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file with extra root CAs the proxy should trust when verifying upstream servers.
+
+---
+
+#### verify_upstream()
+
+```rust
+fn verify_upstream(self, verify: bool) -> Self
+```
+
+Whether the proxy verifies upstream server certificates. Default: `true`. Set to `false` only for self-signed servers.
+
+---
+
+## Types
+
+### Action
+
+| Value | Wire format | Description |
+|-------|-------------|-------------|
+| `Allow` | `"allow"` | Permit the traffic |
+| `Deny` | `"deny"` | Drop the traffic silently |
+
+### Direction
+
+| Value | Wire format | Description |
+|-------|-------------|-------------|
+| `Egress` | `"egress"` | Traffic leaving the sandbox |
+| `Ingress` | `"ingress"` | Traffic entering the sandbox (via published ports) |
+| `Any` | `"any"` | Rule applies in either direction |
+
+### Destination
+
+| Variant | Description |
+|---------|-------------|
+| `Any` | Match any address |
+| `Cidr(IpNetwork)` | Match a CIDR range (e.g. `10.0.0.0/8`); single IPs are stored as `/32` or `/128` |
+| `Domain(`[`DomainName`](#domainname)`)` | Match an exact domain (e.g. `example.com`) |
+| `DomainSuffix(`[`DomainName`](#domainname)`)` | Match the apex domain and every subdomain (e.g. `example.com` and `api.example.com`) |
+| `Group(`[`DestinationGroup`](#destinationgroup)`)` | Match a predefined address group |
+
+### DestinationGroup
+
+| Value | Wire format | Matches |
+|-------|-------------|---------|
+| `Public` | `"public"` | Complement of the other categories: every address not in any other group |
+| `Private` | `"private"` | `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7` |
+| `Loopback` | `"loopback"` | `127.0.0.0/8`, `::1` (the **guest's own** loopback, not the host) |
+| `LinkLocal` | `"link_local"` | `169.254.0.0/16`, `fe80::/10` (excludes metadata) |
+| `Metadata` | `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
+| `Multicast` | `"multicast"` | `224.0.0.0/4`, `ff00::/8` |
+| `Host` | `"host"` | Per-sandbox gateway IPs that back `host.microsandbox.internal` |
+
+### DomainName
+
+A validated DNS name. Construction goes through `str::parse` (or `TryFrom<String>`), which delegates to `hickory_proto::rr::Name` and canonicalizes the input (lowercased ASCII, leading and trailing dots stripped) so rule matching is a byte-wise compare against the DNS cache. Invalid inputs return a `DomainNameError`.
+
+```rust
+use microsandbox_network::policy::{Destination, DomainName};
+
+let exact: DomainName = "PyPI.Org.".parse()?;     // -> "pypi.org"
+let suffix: DomainName = ".example.com".parse()?;  // -> "example.com"
+```
+
+Labels follow the permissive DNS grammar (RFC 2181 §11), so underscore-prefixed names like `_service._tcp.example.com` are accepted.
+
+The builder methods (`.domain(&str)`, `.domain_suffix(&str)`) take strings and parse them lazily at `.build()`; callers don't need to construct `DomainName` directly.
+
+### Protocol
+
+| Value | Wire format |
+|-------|-------------|
+| `Tcp` | `"tcp"` |
+| `Udp` | `"udp"` |
+| `Icmpv4` | `"icmpv4"` |
+| `Icmpv6` | `"icmpv6"` |
+
+ICMP protocols are egress-only. A rule with direction `Ingress` or `Any` carrying an ICMP protocol fails build with [`BuildError::IngressDoesNotSupportIcmp`](#builderror).
+
+### PortRange
+
+```rust
+struct PortRange {
+    start: u16,  // inclusive
+    end: u16,    // inclusive
+}
+```
+
+| Method | Description |
+|--------|-------------|
+| `PortRange::single(port)` | Match a single port |
+| `PortRange::range(start, end)` | Match an inclusive range |
+
+### Rule
+
+A single network policy rule.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| direction | [`Direction`](#direction) | Which evaluator considers this rule |
+| destination | [`Destination`](#destination) | Target filter (egress destination / ingress source) |
+| protocols | `Vec<`[`Protocol`](#protocol)`>` | Set semantics; empty = any protocol |
+| ports | `Vec<`[`PortRange`](#portrange)`>` | Set semantics; empty = any port. Always guest-side (egress destination port / ingress listening port) |
+| action | [`Action`](#action) | What to do on match |
+
+Convenience constructors:
+
+| Method | Description |
+|--------|-------------|
+| `Rule::allow_egress(destination)` | Allow rule, direction `Egress` |
+| `Rule::deny_egress(destination)` | Deny rule, direction `Egress` |
+| `Rule::allow_ingress(destination)` | Allow rule, direction `Ingress` |
+| `Rule::deny_ingress(destination)` | Deny rule, direction `Ingress` |
+| `Rule::allow_any(destination)` | Allow rule, direction `Any` |
+| `Rule::deny_any(destination)` | Deny rule, direction `Any` |
+
+### ExplicitRuleBuilder
+
+Returned by [`RuleBuilder`](#rulebuilder)`::allow()` / `::deny()`. Requires exactly one destination method call to commit the rule. The type is `#[must_use]`; dropping without a call adds no rule.
+
+| Method | Description |
+|--------|-------------|
+| `.ip(impl Into<String>)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
+| `.cidr(impl Into<String>)` | Commit with `Destination::Cidr` |
+| `.domain(impl Into<String>)` | Commit with `Destination::Domain` |
+| `.domain_suffix(impl Into<String>)` | Commit with `Destination::DomainSuffix` |
+| `.group(DestinationGroup)` | Commit with `Destination::Group` |
+| `.any()` | Commit with `Destination::Any` |
+
+### BuildError
+
+Errors surfaced by the builders' `.build()` methods. The same enum covers `NetworkPolicy::builder()`, `DnsBuilder`, and `NetworkBuilder` (the network and DNS builders accumulate errors lazily; the first failure surfaces from the outermost `.build()` in the chain).
+
+| Variant | Cause |
+|---------|-------|
+| `DirectionNotSet { rule_index }` | A rule was committed without `.egress() / .ingress() / .any()` |
+| `MissingDestination { rule_index }` | `.allow()` or `.deny()` was called but no destination method followed |
+| `InvalidIp { rule_index, raw }` | `.ip(&str)` got an unparseable value |
+| `InvalidCidr { rule_index, raw }` | `.cidr(&str)` got an unparseable value |
+| `InvalidDomain { rule_index, raw, source }` | `.domain` or `.domain_suffix` got a value that failed `DomainName` parse |
+| `InvalidPortRange { rule_index, lo, hi }` | `.port_range(lo, hi)` had `lo > hi` |
+| `IngressDoesNotSupportIcmp { rule_index }` | ICMP protocol on a non-egress rule |
+
+Inside `SandboxBuilder::build()`, `BuildError` is wrapped as `MicrosandboxError::NetworkBuilder(BuildError)`.
+
+### ViolationAction
+
+Action taken when a secret placeholder is sent to a disallowed host.
+
+| Value | Description |
+|-------|-------------|
+| `Block` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `BlockAndLog` | Drop the request and emit a warning log on the host side. |
+| `BlockAndTerminate` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/de/sdk/rust/sandbox.mdx
+++ b/docs/de/sdk/rust/sandbox.mdx
@@ -1,0 +1,1176 @@
+---
+title: Sandbox
+description: Rust SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+## Static methods
+
+---
+
+#### Sandbox::builder()
+
+```rust
+fn builder(name: impl Into<String>) -> SandboxBuilder
+```
+
+Create a builder for configuring a new sandbox. The builder lets you set the image, resources, volumes, networking, secrets, and other options before booting the VM. See [`SandboxBuilder`](#sandboxbuilder) for all available options.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Sandbox name - must be unique among running sandboxes |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxBuilder`](#sandboxbuilder) | Builder for configuring the sandbox |
+
+---
+
+#### Sandbox::get()
+
+```rust
+async fn get(name: &str) -> MicrosandboxResult<SandboxHandle>
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control without requiring a full connection to the guest agent.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<SandboxHandle>>
+```
+
+List all sandboxes (running, stopped, and crashed).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`SandboxHandle`](#sandboxhandle)`>` | All sandbox handles |
+
+---
+
+#### Sandbox::remove()
+
+```rust
+async fn remove(name: &str) -> MicrosandboxResult<()>
+```
+
+Delete a stopped sandbox and all its state from disk (configuration, logs, runtime directory). Fails if the sandbox is still running - stop it first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Sandbox name |
+
+---
+
+#### Sandbox::start()
+
+```rust
+async fn start(name: &str) -> MicrosandboxResult<Sandbox>
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration. The sandbox enters attached mode - it stops when your process exits.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox::start_detached()
+
+```rust
+async fn start_detached(name: &str) -> MicrosandboxResult<Sandbox>
+```
+
+Restart a stopped sandbox in detached mode. The sandbox survives after your process exits.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+## Instance methods
+
+---
+
+#### config()
+
+```rust
+fn config(&self) -> &SandboxConfig
+```
+
+Access the sandbox's full configuration.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`&SandboxConfig`](#sandboxconfig) | Sandbox configuration |
+
+---
+
+#### detach()
+
+```rust
+async fn detach(self)
+```
+
+Release the handle without stopping the sandbox. The sandbox continues running as a background process. Reconnect later with [`Sandbox::get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```rust
+async fn drain(&self) -> MicrosandboxResult<()>
+```
+
+Start a graceful drain. Existing commands run to completion, but new `exec` calls are rejected. The sandbox transitions to `Stopped` when all in-flight commands finish. Useful for zero-downtime rotation of worker sandboxes.
+
+---
+
+#### fs()
+
+```rust
+fn fs(&self) -> SandboxFs<'_>
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/rust/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/rust/filesystem) | Filesystem handle |
+
+---
+
+#### kill()
+
+```rust
+async fn kill(&self) -> MicrosandboxResult<()>
+```
+
+Force-terminate the sandbox immediately with SIGKILL. No graceful shutdown - use when the sandbox is unresponsive.
+
+---
+
+#### metrics()
+
+```rust
+async fn metrics(&self) -> MicrosandboxResult<SandboxMetrics>
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk I/O, network I/O, and uptime.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | Resource metrics |
+
+---
+
+#### metrics_stream()
+
+```rust
+fn metrics_stream(&self, interval: Duration) -> impl Stream<Item = MicrosandboxResult<SandboxMetrics>>
+```
+
+Stream resource metrics at a regular interval. Returns an async stream that yields a new snapshot every `interval` duration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| interval | `Duration` | Time between metric snapshots |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `impl Stream<Item = Result<`[`SandboxMetrics`](#sandboxmetrics)`>>` | Async stream of metrics |
+
+---
+
+#### logs()
+
+```rust
+fn logs(&self, opts: &LogOptions) -> MicrosandboxResult<Vec<LogEntry>>
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `Stdout`, `Stderr`, and `Output` (PTY-merged). Pass `LogSource::System` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```rust
+use microsandbox::sandbox::{LogOptions, LogSource, Sandbox};
+
+let handle = Sandbox::get("web").await?;
+
+// Default — all user-program output, regardless of pipe/pty mode
+let entries = handle.logs(&LogOptions::default())?;
+
+for e in entries {
+    let source = match e.source {
+        LogSource::Stdout => "OUT",
+        LogSource::Stderr => "ERR",
+        LogSource::Output => "PTY",
+        LogSource::System => "SYS",
+    };
+    println!(
+        "[{}] {} {:?}: {}",
+        e.timestamp.to_rfc3339(),
+        source,
+        e.session_id,
+        String::from_utf8_lossy(&e.data).trim_end()
+    );
+}
+
+// Filtered: last 50 entries from the past hour, including system lines
+let recent = handle.logs(&LogOptions {
+    tail: Some(50),
+    since: Some(chrono::Utc::now() - chrono::Duration::hours(1)),
+    sources: vec![
+        LogSource::Stdout,
+        LogSource::Stderr,
+        LogSource::Output,
+        LogSource::System,
+    ],
+    ..Default::default()
+})?;
+```
+
+`logs()` is **synchronous** because it's a pure file read.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| opts | `&`[`LogOptions`](#logoptions) | Filters: `tail`, `since`, `until`, `sources`. `LogOptions::default()` returns everything for the default sources. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`LogEntry`](#logentry)`>` | Matching entries in chronological order |
+
+---
+
+#### name()
+
+```rust
+fn name(&self) -> &str
+```
+
+Get the sandbox name.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `&str` | Sandbox name |
+
+---
+
+#### owns_lifecycle()
+
+```rust
+fn owns_lifecycle(&self) -> bool
+```
+
+Whether this handle owns the sandbox lifecycle. `true` in attached mode (sandbox stops when your process exits), `false` in detached mode.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `true` if attached |
+
+---
+
+#### remove_persisted()
+
+```rust
+async fn remove_persisted(self) -> MicrosandboxResult<()>
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### stop()
+
+```rust
+async fn stop(&self) -> MicrosandboxResult<()>
+```
+
+Gracefully shut down the sandbox. Sends SIGTERM to all guest processes and waits for the VM to exit.
+
+---
+
+#### stop_and_wait()
+
+```rust
+async fn stop_and_wait(&self) -> MicrosandboxResult<ExitStatus>
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### wait()
+
+```rust
+async fn wait(&self) -> MicrosandboxResult<ExitStatus>
+```
+
+Block until the sandbox exits on its own (without triggering a stop). Returns the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
+
+---
+
+## SandboxBuilder
+
+Builder for configuring a sandbox before creation. Obtained via [`Sandbox::builder(name)`](#sandboxbuilder-1).
+
+---
+
+#### cpus()
+
+```rust
+fn cpus(self, count: u8) -> Self
+```
+
+Set the number of virtual CPUs. This is a limit, not a reservation. Default: `1`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| count | `u8` | Number of vCPUs |
+
+---
+
+#### create()
+
+```rust
+async fn create(self) -> MicrosandboxResult<Sandbox>
+```
+
+Boot the sandbox in attached mode. The sandbox stops when your process exits.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### create_detached()
+
+```rust
+async fn create_detached(self) -> MicrosandboxResult<Sandbox>
+```
+
+Boot the sandbox in detached mode. The sandbox survives after your process exits.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### disable_network()
+
+```rust
+fn disable_network(self) -> Self
+```
+
+Fully disable networking. No network interface is created.
+
+---
+
+#### entrypoint()
+
+```rust
+fn entrypoint(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> Self
+```
+
+Override the OCI image's entrypoint.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl IntoIterator<Item = impl Into<String>>` | Entrypoint command and arguments |
+
+---
+
+#### env()
+
+```rust
+fn env(self, key: impl Into<String>, value: impl Into<String>) -> Self
+```
+
+Set an environment variable visible to all commands. Can be called multiple times. Per-command env vars (via `exec_with`) are merged on top.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| key | `impl Into<String>` | Variable name |
+| value | `impl Into<String>` | Variable value |
+
+---
+
+#### hostname()
+
+```rust
+fn hostname(self, hostname: impl Into<String>) -> Self
+```
+
+Set the guest hostname.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostname | `impl Into<String>` | Hostname |
+
+---
+
+#### idle_timeout()
+
+```rust
+fn idle_timeout(self, secs: u64) -> Self
+```
+
+Auto-drain the sandbox after this many seconds of inactivity (no active exec sessions). Enforced on the host side.
+
+---
+
+#### init()
+
+```rust
+fn init(self, cmd: impl Into<PathBuf>) -> Self
+```
+
+Hand off PID 1 inside the guest to `cmd` after agentd finishes its boot-time setup. The agent forks; the parent execs the init and becomes PID 1, the agent continues as a child process. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks, shutdown semantics, and tradeoffs.
+
+`cmd` is either an absolute path inside the guest rootfs or the literal `"auto"` (probes `/sbin/init`, `/lib/systemd/systemd`, `/usr/lib/systemd/systemd`). For init binaries that take argv or extra env (rare), use [`init_with`](#init_with).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<PathBuf>` | Absolute path inside the guest, or `"auto"` |
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("jrei/systemd-debian:12")
+    .init("auto")
+    .create()
+    .await?;
+```
+
+---
+
+#### init_with()
+
+```rust
+fn init_with(
+    self,
+    cmd: impl Into<PathBuf>,
+    f: impl FnOnce(InitOptionsBuilder) -> InitOptionsBuilder,
+) -> Self
+```
+
+Like [`init`](#init), but with a closure-builder for argv and env vars. Mirrors `exec_with` in shape.
+
+The builder exposes `arg`, `args`, `env`, and `envs`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<PathBuf>` | Absolute path to the init binary inside the guest |
+| f | `FnOnce(InitOptionsBuilder) -> InitOptionsBuilder` | Closure populating argv and env |
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("jrei/systemd-debian:12")
+    .init_with("/lib/systemd/systemd", |i| i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create()
+    .await?;
+```
+
+Calling `init` or `init_with` more than once overwrites — different from `env`, which appends. The init is one-shot pre-boot.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `u64` | Idle timeout in seconds |
+
+---
+
+#### image()
+
+```rust
+fn image(self, image: impl IntoImage) -> Self
+```
+
+Set the root filesystem source. Accepts OCI image names, local directory paths, or disk image paths. The format is auto-detected.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| image | `impl IntoImage` | OCI image name, local directory path, or disk image path |
+
+---
+
+#### image_with()
+
+```rust
+fn image_with(self, f: impl FnOnce(ImageBuilder) -> ImageBuilder) -> Self
+```
+
+Configure a disk image rootfs with explicit filesystem type. Use when the filesystem type can't be auto-detected.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | `ImageBuilder` | Configure the disk image rootfs. |
+
+---
+
+#### log_level()
+
+```rust
+fn log_level(self, level: LogLevel) -> Self
+```
+
+Override the sandbox process's log verbosity.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| level | [`LogLevel`](#loglevel) | Log level |
+
+---
+
+#### max_duration()
+
+```rust
+fn max_duration(self, secs: u64) -> Self
+```
+
+Set the maximum sandbox lifetime in seconds. When exceeded, the sandbox is drained and stopped. Enforced on the host side - the guest cannot override it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `u64` | Maximum lifetime in seconds |
+
+---
+
+#### memory()
+
+```rust
+fn memory(self, size: impl Into<Mebibytes>) -> Self
+```
+
+Set the guest memory size. Physical pages are only allocated as the guest touches them, so this is a limit, not an upfront reservation. Default: `512` MiB.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size | `impl Into<Mebibytes>` | Memory in MiB |
+
+---
+
+#### network()
+
+```rust
+fn network(self, f: impl FnOnce(NetworkBuilder) -> NetworkBuilder) -> Self
+```
+
+Configure networking. See [Networking](/sdk/rust/networking) for the full builder API.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`NetworkBuilder`](/sdk/rust/networking#networkbuilder) | Configure the network. |
+
+---
+
+#### patch()
+
+```rust
+fn patch(self, f: impl FnOnce(PatchBuilder) -> PatchBuilder) -> Self
+```
+
+Modify the rootfs before the VM boots. Patches go into the writable layer - the base image is untouched.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | `PatchBuilder` | Configure rootfs patches. |
+
+---
+
+#### port()
+
+```rust
+fn port(self, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a TCP port from the sandbox to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_port | `u16` | Port on the host |
+| guest_port | `u16` | Port inside the sandbox |
+
+---
+
+#### port_udp()
+
+```rust
+fn port_udp(self, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a UDP port.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_port | `u16` | Port on the host |
+| guest_port | `u16` | Port inside the sandbox |
+
+---
+
+#### pull_policy()
+
+```rust
+fn pull_policy(self, policy: PullPolicy) -> Self
+```
+
+Control when the OCI image is pulled from the registry.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| policy | [`PullPolicy`](#pullpolicy) | Pull behavior |
+
+---
+
+#### registry_auth()
+
+```rust
+fn registry_auth(self, auth: RegistryAuth) -> Self
+```
+
+Authenticate to a private container registry.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| auth | [`RegistryAuth`](#registryauth) | Registry credentials |
+
+---
+
+#### replace()
+
+```rust
+fn replace(self) -> Self
+```
+
+If a sandbox with the same name already exists, stop it, remove it, and create a fresh one. Without this, creation fails on name conflict.
+
+---
+
+#### script()
+
+```rust
+fn script(self, name: impl Into<String>, content: impl Into<String>) -> Self
+```
+
+Add a named script at `/.msb/scripts/` inside the guest. Scripts are added to `PATH` and can be called by name via `exec()` or `shell()`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Script name (becomes the filename) |
+| content | `impl Into<String>` | Script content |
+
+---
+
+#### secret()
+
+```rust
+fn secret(self, f: impl FnOnce(SecretBuilder) -> SecretBuilder) -> Self
+```
+
+Add a secret with full configuration. See [Secrets](/sdk/rust/secrets) for the builder API. Automatically enables TLS interception.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`SecretBuilder`](/sdk/rust/secrets#secretbuilder) | Configure the secret. |
+
+---
+
+#### secret_env()
+
+```rust
+fn secret_env(self, env_var: impl Into<String>, value: impl Into<String>, allowed_host: impl Into<String>) -> Self
+```
+
+Shorthand for adding a header-injected secret. Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| env_var | `impl Into<String>` | Environment variable name |
+| value | `impl Into<String>` | Secret value |
+| allowed_host | `impl Into<String>` | Allowed destination host |
+
+---
+
+#### shell()
+
+```rust
+fn shell(self, shell: impl Into<String>) -> Self
+```
+
+Set the shell used by [`Sandbox::shell()`](#shell). Default: `/bin/sh`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| shell | `impl Into<String>` | Shell path (e.g. `"/bin/bash"`) |
+
+---
+
+#### user()
+
+```rust
+fn user(self, user: impl Into<String>) -> Self
+```
+
+Set the default guest user for all commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| user | `impl Into<String>` | User name or UID |
+
+---
+
+#### volume()
+
+```rust
+fn volume(self, guest_path: impl Into<String>, f: impl FnOnce(MountBuilder) -> MountBuilder) -> Self
+```
+
+Add a volume mount. See [Volumes](/sdk/rust/volumes) for mount types.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `impl Into<String>` | Mount point inside the sandbox |
+| f | [`MountBuilder`](/sdk/rust/volumes#mountbuilder) | Configure the mount. |
+
+---
+
+#### workdir()
+
+```rust
+fn workdir(self, path: impl Into<String>) -> Self
+```
+
+Set the default working directory for all commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+
+---
+
+## PatchBuilder
+
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder::patch(|p| p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `replace = true` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### append()
+
+```rust
+fn append(self, path: impl Into<String>, content: impl Into<String>) -> Self
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<String>` | Text to append |
+
+---
+
+#### copy_dir()
+
+```rust
+fn copy_dir(self, src: impl Into<PathBuf>, dst: impl Into<String>, replace: bool) -> Self
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<PathBuf>` | Host source directory |
+| dst | `impl Into<String>` | Absolute destination path inside the guest |
+| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### copy_file()
+
+```rust
+fn copy_file(
+    self,
+    src: impl Into<PathBuf>,
+    dst: impl Into<String>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<PathBuf>` | Host source file |
+| dst | `impl Into<String>` | Absolute destination path inside the guest |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)`. `None` keeps the source mode |
+| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### file()
+
+```rust
+fn file(
+    self,
+    path: impl Into<String>,
+    content: impl Into<Vec<u8>>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Write raw bytes at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<Vec<u8>>` | Raw byte content |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
+| replace | `bool` | When `true`, overwrite an existing path |
+
+---
+
+#### mkdir()
+
+```rust
+fn mkdir(self, path: impl Into<String>, mode: Option<u32>) -> Self
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| mode | `Option<u32>` | Directory mode, e.g. `Some(0o755)` |
+
+---
+
+#### remove()
+
+```rust
+fn remove(self, path: impl Into<String>) -> Self
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+
+---
+
+#### symlink()
+
+```rust
+fn symlink(self, target: impl Into<String>, link: impl Into<String>, replace: bool) -> Self
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `impl Into<String>` | What the symlink points to (literal symlink target text) |
+| link | `impl Into<String>` | Absolute path of the symlink itself |
+| replace | `bool` | When `true`, overwrite an existing path at `link` |
+
+---
+
+#### text()
+
+```rust
+fn text(
+    self,
+    path: impl Into<String>,
+    content: impl Into<String>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<String>` | Text content |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
+| replace | `bool` | When `true`, overwrite an existing path |
+
+---
+
+## Types
+
+### LogEntry
+
+A single captured log entry returned by [`logs()`](#logs).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| timestamp | `DateTime<Utc>` | Wall-clock capture time on the host |
+| source | [`LogSource`](#logsource) | Where the chunk came from |
+| session_id | `Option<u64>` | Relay-monotonic session id; `None` for `System` entries |
+| data | `Bytes` | The chunk's bytes (UTF-8 lossy decoded by default; raw bytes if `--raw` mode was used) |
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `Error` | Errors only |
+| `Warn` | Warnings and errors only |
+| `Info` | Info and higher |
+| `Debug` | Debug and higher |
+| `Trace` | Most verbose - all diagnostic output |
+
+### LogOptions
+
+Filters passed to [`logs()`](#logs). All fields optional. `LogOptions::default()` returns everything for the default sources (`Stdout` + `Stderr` + `Output`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tail | `Option<usize>` | Show only the last N entries after other filters apply |
+| since | `Option<DateTime<Utc>>` | Inclusive lower bound on entry timestamp |
+| until | `Option<DateTime<Utc>>` | Exclusive upper bound on entry timestamp |
+| sources | `Vec<`[`LogSource`](#logsource)`>` | Sources to include. Empty = `[Stdout, Stderr, Output]` (the default user-program sources). Add `System` to merge runtime/kernel diagnostics. |
+
+### LogSource
+
+Tag indicating where a captured log entry came from.
+
+| Value | Description |
+|-------|-------------|
+| `Stdout` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `Stderr` | Captured from a session's stderr (pipe mode) |
+| `Output` | Captured from a session running in pty mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `Output` rather than mislabelled as `Stdout`. |
+| `System` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `System` is requested. |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `Always` | Pull the image every time, even if cached locally |
+| `IfMissing` | Pull only if the image is not already cached. This is the default. |
+| `Never` | Never pull; fail if the image is not cached locally |
+
+### RegistryAuth
+
+Credentials for authenticating to a private container registry.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Basic` | - `username: String` <br/> - `password: String` | Username and password authentication |
+
+### SandboxConfig
+
+The full configuration of a sandbox. Obtained via [`config()`](#config) or built via [`SandboxBuilder`](#sandboxbuilder). Contains all settings used to create the sandbox.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpus | `u8` | Number of virtual CPUs |
+| env | `Vec<(String, String)>` | Environment variables |
+| idle_timeout_secs | `Option<u64>` | Idle timeout |
+| image | `RootfsSource` | Root filesystem source (OCI, bind, or disk image) |
+| max_duration_secs | `Option<u64>` | Maximum lifetime |
+| memory_mib | `u32` | Guest memory in MiB |
+| name | `String` | Sandbox name |
+| patches | `Vec<Patch>` | Rootfs patches |
+| scripts | `Vec<(String, String)>` | Named scripts |
+| shell | `Option<String>` | Shell for `shell()` calls |
+| volumes | `Vec<VolumeMount>` | Volume mounts |
+| workdir | `Option<String>` | Default working directory |
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox::get()`](#sandboxget) or [`Sandbox::list()`](#sandboxlist). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. You cannot `exec` or `fs` on a handle - call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| config() | `Result<`[`SandboxConfig`](#sandboxconfig)`>` | Parsed configuration |
+| config_json() | `&str` | Raw JSON configuration |
+| connect() | `Result<`[`Sandbox`](#instance-methods)`>` | Connect to a running sandbox |
+| created_at() | `Option<DateTime<Utc>>` | Creation timestamp |
+| kill() | `Result<()>` | Force terminate |
+| logs() | `Result<Vec<`[`LogEntry`](#logentry)`>>` | Read captured `exec.log` (works without starting) |
+| metrics() | `Result<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
+| name() | `&str` | Sandbox name |
+| remove() | `Result<()>` | Delete sandbox and state |
+| start() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
+| start_detached() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |
+| status() | [`SandboxStatus`](#sandboxstatus) | Current status |
+| stop() | `Result<()>` | Graceful shutdown |
+| updated_at() | `Option<DateTime<Utc>>` | Last update timestamp |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpu_percent | `f32` | CPU usage as a percentage |
+| disk_read_bytes | `u64` | Total bytes read from disk since boot |
+| disk_write_bytes | `u64` | Total bytes written to disk since boot |
+| memory_bytes | `u64` | Current memory usage in bytes |
+| memory_limit_bytes | `u64` | Memory limit in bytes |
+| net_rx_bytes | `u64` | Total bytes received over the network since boot |
+| net_tx_bytes | `u64` | Total bytes sent over the network since boot |
+| timestamp | `DateTime<Utc>` | When this measurement was taken |
+| uptime | `Duration` | Time since the sandbox was created |
+
+### SandboxStatus
+
+| Value | Description |
+|-------|-------------|
+| `Crashed` | VM exited unexpectedly (kernel panic, OOM, etc.) |
+| `Draining` | Graceful shutdown in progress; existing commands finish, new ones rejected |
+| `Running` | Guest agent is ready; `exec`, `shell`, `fs` work |
+| `Stopped` | VM shut down; configuration persisted; can be restarted |

--- a/docs/de/sdk/rust/secrets.mdx
+++ b/docs/de/sdk/rust/secrets.mdx
@@ -1,0 +1,221 @@
+---
+title: Secrets
+description: Rust SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## SecretBuilder
+
+Builder for configuring a secret's placeholder, allowed hosts, and injection scopes. Obtained through `SandboxBuilder::secret(|s| s...)`. Each secret maps an environment variable to a real value that is only revealed when traffic goes to an allowed host via the TLS proxy.
+
+---
+
+#### allow_any_host_dangerous()
+
+```rust
+fn allow_any_host_dangerous(self, i_understand_the_risk: bool) -> Self
+```
+
+Allow substitution on **any** host. This means any server the guest connects to will receive the real secret - effectively disabling host-based protection. Only use this when the secret is not sensitive or the sandbox network is fully locked down.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| i_understand_the_risk | `bool` | Must be `true` to take effect |
+
+---
+
+#### allow_host()
+
+```rust
+fn allow_host(self, host: impl Into<String>) -> Self
+```
+
+Add a host that is allowed to receive the real secret value. The TLS proxy matches this against the SNI (Server Name Indication) in the TLS ClientHello. Can be called multiple times to allow multiple hosts.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `impl Into<String>` | Exact hostname (e.g. `"api.openai.com"`) |
+
+---
+
+#### allow_host_pattern()
+
+```rust
+fn allow_host_pattern(self, pattern: impl Into<String>) -> Self
+```
+
+Add a wildcard host pattern. The `*` matches any subdomain prefix.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pattern | `impl Into<String>` | Wildcard pattern (e.g. `"*.googleapis.com"`) |
+
+---
+
+#### env()
+
+```rust
+fn env(self, var: impl Into<String>) -> Self
+```
+
+Set the environment variable name that will hold the placeholder inside the guest. The guest sees `$MSB_<var>` (or a custom placeholder) - never the real value. **Required.**
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| var | `impl Into<String>` | Environment variable name (e.g. `"OPENAI_API_KEY"`) |
+
+---
+
+#### inject_basic_auth()
+
+```rust
+fn inject_basic_auth(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced specifically in `Authorization` header lines. When `inject_headers` is `true`, this has no additional effect since all headers are already covered.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### inject_body()
+
+```rust
+fn inject_body(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced in the HTTP request body. When enabled, the TLS proxy also updates the `Content-Length` header to match the new body size after substitution.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `false` |
+
+---
+
+#### inject_headers()
+
+```rust
+fn inject_headers(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced anywhere in HTTP headers. This is the most common injection scope - covers `Authorization: Bearer $MSB_...` and similar patterns.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### inject_query()
+
+```rust
+fn inject_query(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced in the URL query string (the `?key=value` portion of the request line).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `false` |
+
+---
+
+#### placeholder()
+
+```rust
+fn placeholder(self, placeholder: impl Into<String>) -> Self
+```
+
+Override the auto-generated placeholder string. By default, microsandbox generates `$MSB_<env_var>`. Use this when you need a specific format or when the placeholder must match a particular byte length.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| placeholder | `impl Into<String>` | Custom placeholder string |
+
+---
+
+#### require_tls_identity()
+
+```rust
+fn require_tls_identity(self, enabled: bool) -> Self
+```
+
+When `true`, the secret is only substituted on TLS-intercepted connections where the proxy has verified it is performing MITM. When `false`, substitution also happens on non-intercepted (bypass) connections. Disable only if you know the traffic is safe.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### value()
+
+```rust
+fn value(self, value: impl Into<String>) -> Self
+```
+
+Set the real secret value. This is the string that replaces the placeholder when a request reaches an allowed host. It never enters the guest VM. **Required.**
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| value | `impl Into<String>` | The actual credential or token |
+
+---
+
+## Shorthand
+
+#### secret_env()
+
+```rust
+fn secret_env(self, env_var: impl Into<String>, value: impl Into<String>, allowed_host: impl Into<String>) -> Self
+```
+
+Convenience method on `SandboxBuilder`. Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`. Uses default injection scopes (headers enabled, body disabled).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| env_var | `impl Into<String>` | Environment variable name |
+| value | `impl Into<String>` | Secret value |
+| allowed_host | `impl Into<String>` | Allowed destination host |
+
+---
+
+## Types
+
+### ViolationAction
+
+Configured via [`NetworkBuilder::on_secret_violation()`](/sdk/rust/networking#on_secret_violation). Determines what happens when the guest sends a request containing a secret placeholder to a host that is **not** in the secret's allow list.
+
+| Value | Description |
+|-------|-------------|
+| `Block` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `BlockAndLog` | Drop the request and emit a warning log on the host side. |
+| `BlockAndTerminate` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/de/sdk/rust/snapshots.mdx
+++ b/docs/de/sdk/rust/snapshots.mdx
@@ -1,0 +1,343 @@
+---
+title: Snapshots
+description: Rust SDK - Snapshot API reference
+icon: "camera"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Rust SDK reference.
+
+```rust
+use microsandbox::{Sandbox, Snapshot, SnapshotHandle, SnapshotFormat};
+use microsandbox::snapshot::ExportOpts;
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## SandboxBuilder
+
+---
+
+#### from_snapshot()
+
+```rust
+fn from_snapshot(self, src: impl Into<String>) -> Self
+```
+
+Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`image()`](/sdk/rust/sandbox#image) and [`image_with()`](/sdk/rust/sandbox#image-with) — the snapshot already pins the image.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<String>` | Bare name (resolved under `~/.microsandbox/snapshots/`) or filesystem path to an artifact directory |
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```rust
+async fn snapshot(&self, name: &str) -> MicrosandboxResult<Snapshot>
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination see [`snapshot_to()`](#snapshot-to).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Bare snapshot name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Snapshot` | The created artifact handle |
+
+**Errors**
+
+- `MicrosandboxError::SnapshotSandboxRunning` — the sandbox is not stopped
+- `MicrosandboxError::SnapshotAlreadyExists` — destination already exists (use the builder with `.force()` to overwrite)
+
+---
+
+#### snapshot_to()
+
+```rust
+async fn snapshot_to(&self, path: impl AsRef<Path>) -> MicrosandboxResult<Snapshot>
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path. For the common case of writing under the default snapshots directory see [`snapshot()`](#snapshot).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl AsRef<Path>` | Destination directory |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Snapshot` | The created artifact handle |
+
+---
+
+## Snapshot (instance)
+
+---
+
+#### path()
+
+```rust
+fn path(&self) -> &Path
+```
+
+Path to the artifact directory.
+
+---
+
+#### digest()
+
+```rust
+fn digest(&self) -> &str
+```
+
+Canonical content digest (`sha256:hex`) over the manifest bytes. The snapshot's identity.
+
+---
+
+#### manifest()
+
+```rust
+fn manifest(&self) -> &Manifest
+```
+
+Parsed manifest — image reference, image manifest digest, fstype, format, labels, upper-layer metadata, and optional integrity hash.
+
+---
+
+#### size_bytes()
+
+```rust
+fn size_bytes(&self) -> u64
+```
+
+Apparent size of the captured upper layer in bytes (the ext4 virtual size, sparse on disk).
+
+---
+
+#### verify()
+
+```rust
+async fn verify(&self) -> MicrosandboxResult<SnapshotVerifyReport>
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds. Returns `NotRecorded` when the manifest has no integrity hash.
+
+---
+
+## Snapshot::builder
+
+---
+
+#### Snapshot::builder()
+
+```rust
+fn builder(source_sandbox: impl Into<String>) -> SnapshotBuilder
+```
+
+Start configuring a new snapshot. The fluent builder is the API the CLI uses internally.
+
+```rust
+let snap = Snapshot::builder("baseline")
+    .name("after-pip-install")        // bare name in default dir
+    .label("stage", "post-deps")
+    .force()                           // overwrite if it exists
+    .record_integrity()                // hash the upper layer
+    .create()
+    .await?;
+```
+
+**Builder methods**
+
+| Method | Description |
+|--------|-------------|
+| `.destination(SnapshotDestination)` | Explicit destination variant |
+| `.name(&str)` | Convenience: bare name under the default snapshots directory |
+| `.path(PathBuf)` | Convenience: explicit filesystem path |
+| `.label(k, v)` | Add a `key=value` label (sorted in canonical form) |
+| `.force()` | Overwrite an existing artifact at the destination |
+| `.record_integrity()` | Compute and record a content-integrity hash at creation |
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot::create()
+
+```rust
+async fn create(config: SnapshotConfig) -> MicrosandboxResult<Snapshot>
+```
+
+Create a snapshot from a [`SnapshotConfig`](#snapshotconfig). Equivalent to using the builder.
+
+---
+
+#### Snapshot::open()
+
+```rust
+async fn open(path_or_name: impl AsRef<str>) -> MicrosandboxResult<Snapshot>
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot::get()
+
+```rust
+async fn get(name_or_digest: &str) -> MicrosandboxResult<SnapshotHandle>
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<SnapshotHandle>>
+```
+
+List indexed snapshots from the local DB cache. External-path artifacts opened via `Snapshot::open(/some/path)` may not appear here unless they live under the configured snapshots directory.
+
+---
+
+#### Snapshot::list_dir()
+
+```rust
+async fn list_dir(dir: impl AsRef<Path>) -> MicrosandboxResult<Vec<Snapshot>>
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index. Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot::remove()
+
+```rust
+async fn remove(path_or_name: &str, force: bool) -> MicrosandboxResult<()>
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force` is `true`.
+
+---
+
+#### Snapshot::reindex()
+
+```rust
+async fn reindex(dir: impl AsRef<Path>) -> MicrosandboxResult<usize>
+```
+
+Walk `dir`, upsert index rows for every artifact found, recompute parent-edge child counts. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot::export()
+
+```rust
+async fn export(name_or_path: &str, out: &Path, opts: ExportOpts) -> MicrosandboxResult<()>
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+**ExportOpts**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `with_parents` | `bool` | Walk the parent chain and include each ancestor (no-op today) |
+| `with_image` | `bool` | Bundle the OCI image cache (`cache/{layers,fsmeta,vmdk}`) for offline transport |
+| `plain_tar` | `bool` | Skip zstd compression and write a plain `.tar` |
+
+---
+
+#### Snapshot::import()
+
+```rust
+async fn import(archive: &Path, dest: Option<&Path>) -> MicrosandboxResult<SnapshotHandle>
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot::list()`](#snapshotlist) and [`Snapshot::get()`](#snapshotget).
+
+```rust
+let h = Snapshot::get("after-pip-install").await?;
+
+h.digest();           // &str — sha256:...
+h.name();             // Option<&str>
+h.parent_digest();    // Option<&str> — None today; populated when chains land
+h.image_ref();        // &str
+h.format();           // SnapshotFormat::Raw | Qcow2
+h.size_bytes();       // Option<u64>
+h.created_at();       // chrono::NaiveDateTime
+h.path();             // &Path
+
+let snap = h.open().await?;       // verify metadata, return Snapshot
+h.remove(false).await?;            // false = refuse if has children
+```
+
+---
+
+## Types
+
+#### SnapshotDestination
+
+```rust
+pub enum SnapshotDestination {
+    Name(String),
+    Path(PathBuf),
+}
+```
+
+Used by [`SnapshotBuilder::destination()`](#snapshotbuilder). The handle methods [`snapshot()`](#snapshot) and [`snapshot_to()`](#snapshot-to) construct this enum internally so callers don't need to import it.
+
+#### SnapshotFormat
+
+```rust
+pub enum SnapshotFormat {
+    Raw,
+    Qcow2,    // future
+}
+```
+
+Always emits `Raw` today. The `Qcow2` variant is reserved for backing-chain checkpoints.
+
+#### SnapshotVerifyReport
+
+```rust
+pub struct SnapshotVerifyReport {
+    pub digest: String,
+    pub path: PathBuf,
+    pub upper: UpperVerifyStatus,
+}
+
+pub enum UpperVerifyStatus {
+    NotRecorded,
+    Verified { algorithm: String, digest: String },
+}
+```
+
+Returned by [`Snapshot::verify()`](#verify).

--- a/docs/de/sdk/rust/volumes.mdx
+++ b/docs/de/sdk/rust/volumes.mdx
@@ -1,0 +1,213 @@
+---
+title: Volumes
+description: Rust SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+---
+
+#### Volume::builder()
+
+```rust
+fn builder(name: impl Into<String>) -> VolumeBuilder
+```
+
+Create a builder for a new named volume. Call `.quota()` to set a storage limit, then `.create()` to finalize.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Volume name (e.g. `"pip-cache"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeBuilder`](#volumebuilder) | Builder with `.quota()` and `.create()` |
+
+---
+
+#### Volume::get()
+
+```rust
+async fn get(name: &str) -> MicrosandboxResult<VolumeHandle>
+```
+
+Get a handle to an existing named volume. Use the handle to access the volume's filesystem from the host or to delete it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeHandle`](#volumehandle) | Handle for host-side operations |
+
+---
+
+#### Volume::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<VolumeHandle>>
+```
+
+List all named volumes.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`VolumeHandle`](#volumehandle)`>` | All volume handles |
+
+---
+
+#### Volume::remove()
+
+```rust
+async fn remove(name: &str) -> MicrosandboxResult<()>
+```
+
+Delete a named volume and its contents from disk. Fails if the volume is currently mounted by a running sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Volume name |
+
+---
+
+## VolumeBuilder
+
+Builder for creating a named volume.
+
+---
+
+#### create()
+
+```rust
+async fn create(self) -> MicrosandboxResult<Volume>
+```
+
+Create the volume on disk.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Volume` | The created volume |
+
+---
+
+#### quota()
+
+```rust
+fn quota(self, mib: u64) -> Self
+```
+
+Set the maximum storage size for this volume. The guest cannot write beyond this limit.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| mib | `u64` | Quota in MiB |
+
+---
+
+## MountBuilder
+
+Builder for configuring a volume mount. Used in `SandboxBuilder::volume(path, |v| v...)`.
+
+---
+
+#### bind()
+
+```rust
+fn bind(self, host_path: impl Into<PathBuf>) -> Self
+```
+
+Mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `impl Into<PathBuf>` | Directory path on the host |
+
+---
+
+#### named()
+
+```rust
+fn named(self, name: impl Into<String>) -> Self
+```
+
+Mount a named volume. The volume must already exist (create it with [`Volume::builder()`](#volumebuilder)).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Volume name |
+
+---
+
+#### readonly()
+
+```rust
+fn readonly(self) -> Self
+```
+
+Mount as read-only. The guest can read but not write.
+
+---
+
+#### size()
+
+```rust
+fn size(self, mib: impl Into<Mebibytes>) -> Self
+```
+
+Set the size limit for a tmpfs mount. Has no effect on bind or named mounts.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| mib | `impl Into<Mebibytes>` | Size limit in MiB |
+
+---
+
+#### tmpfs()
+
+```rust
+fn tmpfs(self) -> Self
+```
+
+Use an in-memory filesystem. Contents are discarded when the sandbox stops. Good for scratch space, temp files, and build artifacts.
+
+---
+
+## Types
+
+### VolumeHandle
+
+Handle for interacting with a named volume from the host side.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| fs() | `VolumeFsHandle` | Host-side filesystem access - read and write files without a running sandbox |
+| name() | `&str` | Volume name |
+| remove() | `()` | Delete this volume from disk |

--- a/docs/de/sdk/typescript/events.mdx
+++ b/docs/de/sdk/typescript/events.mdx
@@ -1,0 +1,66 @@
+---
+title: Events
+description: TypeScript SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for usage examples and guest-side emitting.
+
+## Sandbox methods
+
+---
+
+#### emit()
+
+```typescript
+emit(eventName: string, data: any): Promise<void>
+```
+
+Send a named event with a JSON-serializable payload into the guest. Any process listening on the agent socket (`/run/agent.sock`) receives it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| eventName | `string` | Event name (e.g. `"task.start"`) |
+| data | `any` | Event payload - must be JSON-serializable |
+
+---
+
+#### onEvent()
+
+```typescript
+onEvent(eventName: string, callback: (event: EventData) => void): Subscription
+```
+
+Subscribe to named events emitted by guest processes. The callback fires each time the guest sends a matching event through `/run/agent.sock`. Multiple subscriptions to the same event name are supported.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| eventName | `string` | Event name to subscribe to (e.g. `"task.progress"`) |
+| callback | `(event: EventData) => void` | Called with the event data each time |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Subscription` | Call `.unsubscribe()` to stop receiving events |
+
+---
+
+## Types
+
+### EventData
+
+Data received from a guest event.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| data | `any` | Event payload. `undefined` if the event had no data. |
+| event | `string` | Event name |

--- a/docs/de/sdk/typescript/execution.mdx
+++ b/docs/de/sdk/typescript/execution.mdx
@@ -1,0 +1,364 @@
+---
+title: Execution
+description: TypeScript SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+---
+
+#### attach()
+
+```typescript
+attach(cmd: string, args?: Iterable<string>): Promise<number>
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Press `Ctrl+]` (or configured detach keys) to disconnect without stopping the process.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to run |
+| args? | `Iterable<string>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code of the process |
+
+---
+
+#### attachShell()
+
+```typescript
+attachShell(): Promise<number>
+```
+
+Attach to the sandbox's default shell.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code |
+
+---
+
+#### attachWith()
+
+```typescript
+attachWith(
+  cmd: string,
+  configure: (b: AttachOptionsBuilder) => AttachOptionsBuilder,
+): Promise<number>
+```
+
+Interactive PTY attach with options for environment variables, working directory, user, and custom detach keys. Configure via the builder callback.
+
+```typescript
+const code = await sandbox.attachWith("bash", (a) =>
+  a.cwd("/app")
+    .env("EDITOR", "vim")
+    .detachKeys("ctrl-]"),
+);
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to run |
+| configure | `(b: AttachOptionsBuilder) => AttachOptionsBuilder` | Builder callback — see [`AttachOptionsBuilder`](#attachoptionsbuilder) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code |
+
+---
+
+#### exec()
+
+```typescript
+exec(cmd: string, args?: Iterable<string>): Promise<ExecOutput>
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`execStream()`](#execstream) instead.
+
+```typescript
+const result = await sandbox.exec("python3", ["-c", "print(1 + 1)"]);
+console.log(result.stdout()); // "2\n"
+console.log(result.code);     // 0
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args? | `Iterable<string>` | Command arguments (e.g. `["-c", "print('hello')"]`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### execStream()
+
+```typescript
+execStream(cmd: string, args?: Iterable<string>): Promise<ExecHandle>
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
+
+```typescript
+const handle = await sandbox.execStream("tail", ["-f", "/var/log/app.log"]);
+for await (const event of handle) {
+  if (event.kind === "stdout") process.stdout.write(event.data);
+  if (event.kind === "exited") break;
+}
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute |
+| args? | `Iterable<string>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecHandle`](#exechandle)`>` | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### execStreamWith()
+
+```typescript
+execStreamWith(
+  cmd: string,
+  configure: (b: ExecOptionsBuilder) => ExecOptionsBuilder,
+): Promise<ExecHandle>
+```
+
+Streaming variant of [`execWith()`](#execwith) — same configuration via [`ExecOptionsBuilder`](#execoptionsbuilder), but returns an [`ExecHandle`](#exechandle).
+
+---
+
+#### execWith()
+
+```typescript
+execWith(
+  cmd: string,
+  configure: (b: ExecOptionsBuilder) => ExecOptionsBuilder,
+): Promise<ExecOutput>
+```
+
+Run a command with per-execution overrides. Configure working directory, environment variables, timeout, stdin, TTY allocation, and rlimits via the builder callback. These overrides apply only to this execution and don't change the sandbox's defaults.
+
+```typescript
+const out = await sandbox.execWith("python3", (e) =>
+  e.args(["script.py"])
+    .cwd("/app")
+    .env("PYTHONPATH", "/app/lib")
+    .timeout(30_000),
+);
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute |
+| configure | `(b: ExecOptionsBuilder) => ExecOptionsBuilder` | Builder callback — see [`ExecOptionsBuilder`](#execoptionsbuilder) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell()
+
+```typescript
+shell(script: string): Promise<ExecOutput>
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `string` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### shellStream()
+
+```typescript
+shellStream(script: string): Promise<ExecHandle>
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `string` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecHandle`](#exechandle)`>` | Streaming handle |
+
+---
+
+## Types
+
+### AttachOptionsBuilder
+
+Fluent builder used inside `Sandbox.attachWith(cmd, b => ...)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `arg(s)` | Append a single argument |
+| `args(iter)` | Append many arguments |
+| `cwd(path)` | Working directory |
+| `user(user)` | Guest user |
+| `env(key, value)` | Add a single env var |
+| `envs(record \| iter)` | Add many env vars |
+| `detachKeys(spec)` | Detach key sequence (e.g. `"ctrl-]"` or `"ctrl-p,ctrl-q"`) |
+| `rlimit(resource, n)` | Set both soft and hard rlimit |
+| `rlimitRange(resource, soft, hard)` | Set distinct soft/hard rlimits |
+| `build()` | Produce an immutable [`AttachOptions`](#attachoptions) |
+
+### AttachOptions
+
+The immutable object produced by `AttachOptionsBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| args | `readonly string[]` | Command arguments |
+| cwd | `string \| null` | Working directory |
+| user | `string \| null` | Guest user |
+| env | `ReadonlyArray<readonly [string, string]>` | Environment variables |
+| detachKeys | `string \| null` | Detach key sequence |
+| rlimits | `readonly Rlimit[]` | rlimits for the process |
+
+### ExecOptionsBuilder
+
+Fluent builder used inside `Sandbox.execWith(cmd, b => ...)`.
+
+| Method | Description |
+|--------|-------------|
+| `arg(s)` / `args(iter)` | Append arguments |
+| `cwd(path)` | Working directory |
+| `user(user)` | Guest user |
+| `env(key, value)` / `envs(record \| iter)` | Environment variables |
+| `timeout(ms)` | Kill the process after this many milliseconds |
+| `stdinNull()` | Stdin connected to `/dev/null` (default) |
+| `stdinPipe()` | Open a writable stdin pipe — read it back with `ExecHandle.takeStdin()` |
+| `stdinBytes(data)` | Pre-supply stdin (`Uint8Array \| string`) |
+| `tty(enabled)` | Allocate a pseudo-terminal |
+| `rlimit(resource, n)` / `rlimitRange(resource, soft, hard)` | rlimits |
+| `build()` | Produce an immutable [`ExecOptions`](#execoptions) |
+
+### ExecOptions
+
+The immutable object produced by `ExecOptionsBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| args | `readonly string[]` | Command arguments |
+| cwd | `string \| null` | Working directory |
+| user | `string \| null` | Guest user |
+| env | `ReadonlyArray<readonly [string, string]>` | Environment variables |
+| timeoutMs | `number \| null` | Timeout in milliseconds |
+| stdin | `StdinMode` | `null`, `pipe`, or pre-supplied `bytes` |
+| tty | `boolean` | TTY allocation |
+| rlimits | `readonly Rlimit[]` | rlimits |
+
+### ExecEvent
+
+Discriminated union emitted by `ExecHandle`. The discriminator is `kind` (not `eventType`).
+
+```typescript
+type ExecEvent =
+  | { kind: "started"; pid: number }
+  | { kind: "stdout"; data: Uint8Array }
+  | { kind: "stderr"; data: Uint8Array }
+  | { kind: "exited"; code: number };
+```
+
+| `kind` | Payload | Description |
+|--------|---------|-------------|
+| `'started'` | `pid: number` | The process has started |
+| `'stdout'` | `data: Uint8Array` | A chunk of stdout data |
+| `'stderr'` | `data: Uint8Array` | A chunk of stderr data |
+| `'exited'` | `code: number` | The process has exited |
+
+### ExecHandle
+
+A handle to a running streaming execution. `AsyncIterable<ExecEvent>` and `AsyncDisposable`.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `recv()` | `Promise<`[`ExecEvent`](#execevent)` \| null>` | Receive the next event. Returns `null` when done. |
+| `takeStdin()` | `Promise<`[`ExecSink`](#execsink)` \| null>` | Take the stdin writer. Returns `null` after first call. |
+| `wait()` | `Promise<`[`ExitStatus`](#exitstatus)`>` | Wait for the process to exit |
+| `collect()` | `Promise<`[`ExecOutput`](#execoutput)`>` | Drain remaining output and wait |
+| `signal(n)` | `Promise<void>` | Send a POSIX signal |
+| `kill()` | `Promise<void>` | Send SIGKILL |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<`[`ExecEvent`](#execevent)`>` | Iterate events with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Best-effort kill on `await using` exit |
+
+### ExecOutput
+
+The result of a completed command execution.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `code` | `number` (getter) | Exit code |
+| `success` | `boolean` (getter) | `true` if code is `0` |
+| `status` | [`ExitStatus`](#exitstatus) (getter) | Exit status object |
+| `stdout()` | `string` | Collected stdout decoded as UTF-8 |
+| `stderr()` | `string` | Collected stderr decoded as UTF-8 |
+| `stdoutBytes()` | `Uint8Array` | Raw stdout bytes |
+| `stderrBytes()` | `Uint8Array` | Raw stderr bytes |
+
+### ExecSink
+
+Writer for sending data to a running process's stdin.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `write(data)` | `Uint8Array \| string` | Write bytes to the process's stdin |
+| `close()` | - | Close stdin. The process sees EOF. |
+| `[Symbol.asyncDispose]()` | - | Calls `close()` |
+
+### ExitStatus
+
+| Field | Type | Description |
+|-------|------|-------------|
+| code | `number` | Exit code. `0` typically means success. |
+| success | `boolean` | `true` if code is `0` |

--- a/docs/de/sdk/typescript/filesystem.mdx
+++ b/docs/de/sdk/typescript/filesystem.mdx
@@ -1,0 +1,379 @@
+---
+title: Filesystem
+description: TypeScript SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution — no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
+
+```typescript
+const fs = sandbox.fs();
+
+await fs.write("/tmp/config.json", '{"debug": true}');
+const content = await fs.readToString("/tmp/config.json");
+```
+
+---
+
+#### copy()
+
+```typescript
+copy(from: string, to: string): Promise<void>
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `string` | Source path |
+| to | `string` | Destination path |
+
+---
+
+#### copyFromHost()
+
+```typescript
+copyFromHost(hostPath: string, guestPath: string): Promise<void>
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostPath | `string` | Path on the host filesystem |
+| guestPath | `string` | Destination path inside the sandbox |
+
+---
+
+#### copyToHost()
+
+```typescript
+copyToHost(guestPath: string, hostPath: string): Promise<void>
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guestPath | `string` | Path inside the sandbox |
+| hostPath | `string` | Destination path on the host |
+
+---
+
+#### exists()
+
+```typescript
+exists(path: string): Promise<boolean>
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<boolean>` | `true` if the path exists |
+
+---
+
+#### list()
+
+```typescript
+list(path: string): Promise<FsEntry[]>
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsEntry`](#fsentry)`[]>` | Directory entries |
+
+---
+
+#### mkdir()
+
+```typescript
+mkdir(path: string): Promise<void>
+```
+
+Create a directory. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path |
+
+---
+
+#### read()
+
+```typescript
+read(path: string): Promise<Uint8Array>
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<Uint8Array>` | File contents as raw bytes |
+
+---
+
+#### readStream()
+
+```typescript
+readStream(path: string): Promise<FsReadStream>
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory.
+
+```typescript
+for await (const chunk of await fs.readStream("/var/log/syslog")) {
+  process.stdout.write(chunk); // chunk is a Uint8Array
+}
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsReadStream`](#fsreadstream)`>` | Async stream that yields chunks of file data |
+
+---
+
+#### readToString()
+
+```typescript
+readToString(path: string): Promise<string>
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<string>` | File contents as a string |
+
+---
+
+#### remove()
+
+```typescript
+remove(path: string): Promise<void>
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute file path |
+
+---
+
+#### removeDir()
+
+```typescript
+removeDir(path: string): Promise<void>
+```
+
+Remove a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path |
+
+---
+
+#### rename()
+
+```typescript
+rename(from: string, to: string): Promise<void>
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `string` | Current path |
+| to | `string` | New path |
+
+---
+
+#### stat()
+
+```typescript
+stat(path: string): Promise<FsMetadata>
+```
+
+Get detailed metadata for a file or directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsMetadata`](#fsmetadata)`>` | File metadata |
+
+---
+
+#### write()
+
+```typescript
+write(path: string, data: Uint8Array | string): Promise<void>
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does. Parent directories must already exist. `string` payloads are encoded as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| data | `Uint8Array \| string` | File content |
+
+---
+
+#### writeStream()
+
+```typescript
+writeStream(path: string): Promise<FsWriteSink>
+```
+
+Open a streaming writer for a file. Use for files too large to hold in memory; pair with `await using` so the sink closes itself.
+
+```typescript
+await using sink = await fs.writeStream("/tmp/big.bin");
+await sink.write(new Uint8Array(1 << 20));
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsWriteSink`](#fswritesink)`>` | Streaming writer |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| path | `string` | File path |
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| size | `number` | File size in bytes |
+| mode | `number` | Unix permission bits |
+| modified | `Date \| null` | Last modified timestamp |
+
+### FsEntryKind
+
+```typescript
+type FsEntryKind = "file" | "directory" | "symlink" | "other";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'file'` | Regular file |
+| `'directory'` | Directory |
+| `'symlink'` | Symbolic link |
+| `'other'` | Other entry type |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| size | `number` | File size in bytes |
+| mode | `number` | Unix permission bits |
+| readonly | `boolean` | Whether the file is read-only |
+| modified | `Date \| null` | Last modified timestamp |
+| created | `Date \| null` | Creation timestamp |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`readStream()`](#readstream). `AsyncIterable<Uint8Array>` and `AsyncDisposable`.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `recv()` | `Promise<Uint8Array \| null>` | Receive the next chunk. Returns `null` when the file has been fully read. |
+| `collect()` | `Promise<Uint8Array>` | Drain the stream into a single buffer |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<Uint8Array>` | Use with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop reading; safe to use with `await using` |
+
+### FsWriteSink
+
+Streaming writer returned by [`writeStream()`](#writestream). `AsyncDisposable`.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `write(data)` | `Uint8Array \| string` | Append a chunk |
+| `close()` | - | Flush and close. Idempotent. |
+| `[Symbol.asyncDispose]()` | - | Calls `close()` |

--- a/docs/de/sdk/typescript/networking.mdx
+++ b/docs/de/sdk/typescript/networking.mdx
@@ -1,0 +1,1361 @@
+---
+title: Networking
+description: TypeScript SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Use a static factory for a preset, build a literal, or chain through [`NetworkPolicy.builder()`](#networkpolicybuilder) for the fluent builder:
+
+```typescript
+import { NetworkPolicy, Rule, Destination } from "microsandbox";
+
+// Custom policy literal
+const custom = {
+  defaultEgress: "deny",
+  defaultIngress: "allow",
+  rules: [
+    Rule.allowEgress(Destination.domain("api.openai.com")),
+    Rule.denyEgress(Destination.group("metadata")),
+  ],
+};
+
+// Or via the builder
+const built = NetworkPolicy.builder()
+  .defaultDeny()
+  .egress((e) => e.tcp().port(443).allowPublic())
+  .build();
+```
+
+Pass any of these to `NetworkBuilder.policy(...)`.
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```typescript
+const policy = {
+  defaultEgress: "deny",
+  defaultIngress: "allow",
+  rules: [
+    Rule.allowEgress(Destination.cidr("10.0.0.0/8")),  // matches everything in 10.x
+    Rule.denyEgress(Destination.cidr("10.0.0.5/32")),  // never reached
+  ],
+};
+```
+
+Put specific rules before general ones.
+
+### Shadow detection
+
+[`NetworkPolicyBuilder.build()`](#networkpolicybuilder) walks the rules and warns when a rule is fully covered by an earlier one in the same direction. Only `ip`, `cidr`, and `group` destinations are checked; domain coverage depends on runtime DNS and is skipped. Builds still succeed; the warning surfaces as a host-side `tracing::warn!` from the rust core:
+
+```text
+WARN rule #1 (Egress Cidr(10.0.0.5/32) Deny) is shadowed by rule #0 (Egress Cidr(10.0.0.0/8) Allow); to narrow, place the more specific rule first
+```
+
+Policy literals constructed via `Rule.allowEgress(...)` etc. do not run through the builder and skip this check.
+
+### State accumulation
+
+State setters (`.tcp()`, `.port()`, etc.) inside a [`RuleBuilder`](#rulebuilder) callback carry into every rule-adder that follows. State is **not reset** between adders:
+
+```typescript
+NetworkPolicy.builder()
+  .egress((r) => r
+    .tcp().port(443).allowPublic()    // rule 1: egress, TCP, 443, allow Public
+    .udp().allowPrivate()             // rule 2: egress, [TCP, UDP], 443, allow Private
+  )
+  .build();
+```
+
+Use separate `.rule()` / `.egress()` callbacks for rules that need different state.
+
+---
+
+#### NetworkPolicy.allowAll()
+
+```typescript
+static allowAll(): NetworkPolicy
+```
+
+Unrestricted network access, including to private addresses and the host machine.
+
+---
+
+#### NetworkPolicy.builder()
+
+```typescript
+static builder(): NetworkPolicyBuilder
+```
+
+Start a fluent [`NetworkPolicyBuilder`](#networkpolicybuilder). Equivalent to `new NetworkPolicyBuilder()`.
+
+---
+
+#### NetworkPolicy.none()
+
+```typescript
+static none(): NetworkPolicy
+```
+
+Deny all traffic. The guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+
+---
+
+#### NetworkPolicy.nonLocal()
+
+```typescript
+static nonLocal(): NetworkPolicy
+```
+
+Allow egress to public + private (LAN) destinations; ingress allowed by default.
+
+---
+
+#### NetworkPolicy.publicOnly()
+
+```typescript
+static publicOnly(): NetworkPolicy
+```
+
+Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+
+---
+
+## NetworkPolicyBuilder
+
+Fluent builder for [`NetworkPolicy`](#networkpolicy). The closure passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` receives a [`RuleBuilder`](#rulebuilder); state setters and rule-adders chain freely. The first parse / validation failure surfaces from `.build()`.
+
+```typescript
+import { NetworkPolicy } from "microsandbox";
+
+const policy = NetworkPolicy.builder()
+  .defaultDeny()
+  .egress((e) => e.tcp().port(443).allowPublic().allowPrivate())
+  .rule((r) => r.any().deny((d) => d.ip("198.51.100.5")))
+  .build();
+```
+
+---
+
+#### any()
+
+```typescript
+any(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Any`. Rules committed inside apply in both directions.
+
+---
+
+#### build()
+
+```typescript
+build(): NetworkPolicy
+```
+
+Materialize the accumulated state into a [`NetworkPolicy`](#networkpolicy-1). Lazily parses every recorded `.ip()` / `.cidr()` / `.domain()` / `.domainSuffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a host-side warning for each shadowed rule pair.
+
+---
+
+#### defaultAllow()
+
+```typescript
+defaultAllow(): this
+```
+
+Set both `defaultEgress` and `defaultIngress` to `"allow"`.
+
+---
+
+#### defaultDeny()
+
+```typescript
+defaultDeny(): this
+```
+
+Set both `defaultEgress` and `defaultIngress` to `"deny"`.
+
+---
+
+#### defaultEgress()
+
+```typescript
+defaultEgress(action: "allow" | "deny"): this
+```
+
+Per-direction override for the egress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | `"allow" \| "deny"` | Default action for egress |
+
+---
+
+#### defaultIngress()
+
+```typescript
+defaultIngress(action: "allow" | "deny"): this
+```
+
+Per-direction override for the ingress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | `"allow" \| "deny"` | Default action for ingress |
+
+---
+
+#### egress()
+
+```typescript
+egress(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Egress`.
+
+---
+
+#### ingress()
+
+```typescript
+ingress(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Ingress`.
+
+---
+
+#### rule()
+
+```typescript
+rule(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Open a multi-rule batch closure. Direction must be set inside via `.egress()`, `.ingress()`, or `.any()` before any rule-adder.
+
+---
+
+## RuleBuilder
+
+Per-rule-batch builder. Lives only inside the callback passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` on a [`NetworkPolicyBuilder`](#networkpolicybuilder). State setters and rule-adders interleave freely; state accumulates eagerly across the callback (see [State accumulation](#state-accumulation)).
+
+### Direction setters
+
+Last-write-wins. ICMP rule-adders are egress-only at build time.
+
+---
+
+#### any()
+
+```typescript
+any(): this
+```
+
+Set direction to `Any` for subsequent rule-adders. Rules committed after this apply in both directions.
+
+---
+
+#### egress()
+
+```typescript
+egress(): this
+```
+
+Set direction to `Egress` for subsequent rule-adders.
+
+---
+
+#### ingress()
+
+```typescript
+ingress(): this
+```
+
+Set direction to `Ingress` for subsequent rule-adders.
+
+---
+
+### Protocol setters
+
+Protocols accumulate as a set; duplicates dedupe.
+
+---
+
+#### icmpv4()
+
+```typescript
+icmpv4(): this
+```
+
+Add `Icmpv4` to the protocols set. Egress-only; an ICMP rule on an `Ingress` or `Any` direction fails build.
+
+---
+
+#### icmpv6()
+
+```typescript
+icmpv6(): this
+```
+
+Add `Icmpv6` to the protocols set. Egress-only; same rules as [`icmpv4()`](#icmpv4).
+
+---
+
+#### tcp()
+
+```typescript
+tcp(): this
+```
+
+Add `Tcp` to the protocols set.
+
+---
+
+#### udp()
+
+```typescript
+udp(): this
+```
+
+Add `Udp` to the protocols set.
+
+---
+
+### Port setters
+
+Ports accumulate as a set; duplicates dedupe. Always guest-side (egress destination port / ingress listening port).
+
+---
+
+#### port()
+
+```typescript
+port(port: number): this
+```
+
+Add a single port to the ports set.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `number` | Port number `0..=65535` |
+
+---
+
+#### portRange()
+
+```typescript
+portRange(lo: number, hi: number): this
+```
+
+Add an inclusive port range. `lo > hi` records an error surfaced at `.build()` time.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| lo | `number` | Lower bound (inclusive) |
+| hi | `number` | Upper bound (inclusive) |
+
+---
+
+#### ports()
+
+```typescript
+ports(ports: number[]): this
+```
+
+Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
+
+---
+
+### Group rule-adders
+
+Each adder commits one rule using the current state and the named destination group.
+
+---
+
+#### allowHost()
+
+```typescript
+allowHost(): this
+```
+
+Allow the `Host` group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allowLoopback()`](#allowloopback).
+
+---
+
+#### allowLinkLocal()
+
+```typescript
+allowLinkLocal(): this
+```
+
+Allow the `LinkLocal` group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
+
+---
+
+#### allowLoopback()
+
+```typescript
+allowLoopback(): this
+```
+
+Allow the `Loopback` group (`127.0.0.0/8`, `::1`). The **guest's own** loopback, not the host. To reach a service on the host's localhost, use [`allowHost()`](#allowhost) instead. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
+
+---
+
+#### allowMeta()
+
+```typescript
+allowMeta(): this
+```
+
+Allow the `Metadata` group (`169.254.169.254`). **Dangerous on cloud hosts** (exposes IAM credentials).
+
+---
+
+#### allowMulticast()
+
+```typescript
+allowMulticast(): this
+```
+
+Allow the `Multicast` group (`224.0.0.0/4`, `ff00::/8`).
+
+---
+
+#### allowPrivate()
+
+```typescript
+allowPrivate(): this
+```
+
+Allow the `Private` group (RFC1918 + ULA + CGN).
+
+---
+
+#### allowPublic()
+
+```typescript
+allowPublic(): this
+```
+
+Allow the `Public` group (complement of named categories: every IP not in any other group).
+
+---
+
+#### denyHost()
+
+```typescript
+denyHost(): this
+```
+
+Deny the `Host` group.
+
+---
+
+#### denyLinkLocal()
+
+```typescript
+denyLinkLocal(): this
+```
+
+Deny the `LinkLocal` group.
+
+---
+
+#### denyLoopback()
+
+```typescript
+denyLoopback(): this
+```
+
+Deny the `Loopback` group.
+
+---
+
+#### denyMeta()
+
+```typescript
+denyMeta(): this
+```
+
+Deny the `Metadata` group.
+
+---
+
+#### denyMulticast()
+
+```typescript
+denyMulticast(): this
+```
+
+Deny the `Multicast` group.
+
+---
+
+#### denyPrivate()
+
+```typescript
+denyPrivate(): this
+```
+
+Deny the `Private` group.
+
+---
+
+#### denyPublic()
+
+```typescript
+denyPublic(): this
+```
+
+Deny the `Public` group.
+
+---
+
+### Domain rule-adders
+
+Singular forms add one rule; plural forms add one rule per element.
+
+---
+
+#### allowDomain()
+
+```typescript
+allowDomain(name: string): this
+```
+
+Add one `Destination::Domain` allow rule.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Fully qualified domain name |
+
+---
+
+#### allowDomainSuffix()
+
+```typescript
+allowDomainSuffix(suffix: string): this
+```
+
+Add one `Destination::DomainSuffix` allow rule. Matches the apex and any subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### allowDomainSuffixes()
+
+```typescript
+allowDomainSuffixes(suffixes: string[]): this
+```
+
+Add one `Destination::DomainSuffix` allow rule per suffix.
+
+---
+
+#### allowDomains()
+
+```typescript
+allowDomains(names: string[]): this
+```
+
+Add one `Destination::Domain` allow rule per name.
+
+---
+
+#### denyDomain()
+
+```typescript
+denyDomain(name: string): this
+```
+
+Add one `Destination::Domain` deny rule.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Fully qualified domain name |
+
+---
+
+#### denyDomainSuffix()
+
+```typescript
+denyDomainSuffix(suffix: string): this
+```
+
+Add one `Destination::DomainSuffix` deny rule. Matches the apex and any subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### denyDomainSuffixes()
+
+```typescript
+denyDomainSuffixes(suffixes: string[]): this
+```
+
+Add one `Destination::DomainSuffix` deny rule per suffix.
+
+---
+
+#### denyDomains()
+
+```typescript
+denyDomains(names: string[]): this
+```
+
+Add one `Destination::Domain` deny rule per name.
+
+---
+
+### Composite rule-adders
+
+---
+
+#### allowLocal()
+
+```typescript
+allowLocal(): this
+```
+
+Add three allow rules atomically: `Loopback + LinkLocal + Host`. Each uses the callback's current state. `Metadata` is intentionally not included; opt in via [`allowMeta()`](#allowmeta) separately.
+
+---
+
+#### denyLocal()
+
+```typescript
+denyLocal(): this
+```
+
+Add three deny rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is intentionally not included.
+
+---
+
+### Explicit-destination rule-adders
+
+`.allow()` / `.deny()` open a [`RuleDestinationBuilder`](#ruledestinationbuilder) callback. Exactly one destination call commits the rule.
+
+```typescript
+NetworkPolicy.builder()
+  .egress((r) => r
+    .tcp().port(443).allow((d) => d.domain("api.example.com"))
+    .deny((d) => d.cidr("198.51.100.0/24"))
+  )
+  .build();
+```
+
+---
+
+#### allow()
+
+```typescript
+allow(configure: (d: RuleDestinationBuilder) => RuleDestinationBuilder): this
+```
+
+Begin an explicit-destination rule with action `Allow`.
+
+---
+
+#### deny()
+
+```typescript
+deny(configure: (d: RuleDestinationBuilder) => RuleDestinationBuilder): this
+```
+
+Begin an explicit-destination rule with action `Deny`.
+
+---
+
+## Rule
+
+Factory for individual policy rules. Each method returns a single [`Rule`](#rule-1) value.
+
+---
+
+#### Rule.allowAny()
+
+```typescript
+static allowAny(destination: Destination): Rule
+```
+
+Allow rule with direction `any` (matches in either direction).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.allowEgress()
+
+```typescript
+static allowEgress(destination: Destination): Rule
+```
+
+Allow rule with direction `egress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.allowIngress()
+
+```typescript
+static allowIngress(destination: Destination): Rule
+```
+
+Allow rule with direction `ingress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyAny()
+
+```typescript
+static denyAny(destination: Destination): Rule
+```
+
+Deny rule with direction `any` (matches in either direction).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyEgress()
+
+```typescript
+static denyEgress(destination: Destination): Rule
+```
+
+Deny rule with direction `egress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyIngress()
+
+```typescript
+static denyIngress(destination: Destination): Rule
+```
+
+Deny rule with direction `ingress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+## Destination
+
+Factory for rule destinations.
+
+---
+
+#### Destination.any()
+
+```typescript
+static any(): Destination
+```
+
+Match any destination.
+
+---
+
+#### Destination.cidr()
+
+```typescript
+static cidr(cidr: string): Destination
+```
+
+Match an IP range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cidr | `string` | CIDR notation (e.g. `"10.0.0.0/8"`) |
+
+---
+
+#### Destination.domain()
+
+```typescript
+static domain(domain: string): Destination
+```
+
+Match an exact domain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| domain | `string` | Fully qualified domain name |
+
+---
+
+#### Destination.domainSuffix()
+
+```typescript
+static domainSuffix(suffix: string): Destination
+```
+
+Match the apex domain and every subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### Destination.group()
+
+```typescript
+static group(group: DestinationGroup): Destination
+```
+
+Match a predefined address group.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| group | [`DestinationGroup`](#destinationgroup) | Group keyword |
+
+---
+
+## PortRange
+
+Factory for port ranges.
+
+---
+
+#### PortRange.range()
+
+```typescript
+static range(start: number, end: number): PortRange
+```
+
+Match an inclusive port range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| start | `number` | Lower bound (inclusive) |
+| end | `number` | Upper bound (inclusive) |
+
+---
+
+#### PortRange.single()
+
+```typescript
+static single(port: number): PortRange
+```
+
+Match a single port. `start` and `end` are set to the same value.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `number` | Port number |
+
+---
+
+## NetworkBuilder
+
+Returned to the callback you pass to `SandboxBuilder.network(...)`. Every setter returns the same builder.
+
+---
+
+#### denyDomainSuffixes()
+
+```typescript
+denyDomainSuffixes(...suffixes: string[]): this
+```
+
+Deny egress to all subdomains of these suffixes. Same enforcement layers as [`denyDomains()`](#denydomains).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffixes | `string[]` | Domain suffixes |
+
+---
+
+#### denyDomains()
+
+```typescript
+denyDomains(...names: string[]): this
+```
+
+Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| names | `string[]` | Fully qualified domain names |
+
+---
+
+#### dns()
+
+```typescript
+dns(f: (d: DnsBuilder) => DnsBuilder): this
+```
+
+Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
+
+---
+
+#### enabled()
+
+```typescript
+enabled(b: boolean): this
+```
+
+Enable or disable networking entirely.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| b | `boolean` | When `false`, no network interface is created |
+
+---
+
+#### maxConnections()
+
+```typescript
+maxConnections(n: number): this
+```
+
+Limit the maximum number of concurrent network connections from the sandbox.
+
+---
+
+#### onSecretViolation()
+
+```typescript
+onSecretViolation(action: ViolationAction): this
+```
+
+Set the action taken when a secret reaches a disallowed host. See [`ViolationAction`](/sdk/typescript/secrets#violationaction).
+
+---
+
+#### policy()
+
+```typescript
+policy(policy: NetworkPolicy): this
+```
+
+Set the policy. Use a [`NetworkPolicy`](#networkpolicy) factory or a literal.
+
+---
+
+#### port()
+
+```typescript
+port(host: number, guest: number): this
+```
+
+Publish a TCP port from the guest to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `number` | Port on the host |
+| guest | `number` | Port inside the sandbox |
+
+---
+
+#### portUdp()
+
+```typescript
+portUdp(host: number, guest: number): this
+```
+
+Publish a UDP port from the guest to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `number` | Port on the host |
+| guest | `number` | Port inside the sandbox |
+
+---
+
+#### secret()
+
+```typescript
+secret(f: (s: SecretBuilder) => SecretBuilder): this
+```
+
+Add a secret. See [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder).
+
+---
+
+#### secretEnv()
+
+```typescript
+secretEnv(envVar: string, value: string, placeholder: string, allowedHost: string): this
+```
+
+Four-arg explicit-placeholder shorthand for adding a secret without opening a builder callback.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Real secret value |
+| placeholder | `string` | Placeholder string surfaced to the guest |
+| allowedHost | `string` | Single hostname allowed to receive the real value |
+
+---
+
+#### tls()
+
+```typescript
+tls(f: (t: TlsBuilder) => TlsBuilder): this
+```
+
+Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
+
+---
+
+#### trustHostCAs()
+
+```typescript
+trustHostCAs(enabled: boolean): this
+```
+
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in for corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle.
+
+---
+
+## DnsBuilder
+
+Builder for DNS interception settings. Used in `NetworkBuilder.dns(d => ...)`. Owns rebind protection, nameserver pinning, and the per-query timeout.
+
+---
+
+#### nameservers()
+
+```typescript
+nameservers(servers: string[]): this
+```
+
+Override upstream nameservers. Replaces any previously-set nameservers.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| servers | `string[]` | Each entry is `IP`, `IP:PORT`, `HOST`, or `HOST:PORT` |
+
+---
+
+#### queryTimeoutMs()
+
+```typescript
+queryTimeoutMs(ms: number): this
+```
+
+Per-DNS-query timeout in milliseconds.
+
+---
+
+#### rebindProtection()
+
+```typescript
+rebindProtection(enabled: boolean): this
+```
+
+Toggle DNS rebinding protection. When enabled, DNS responses resolving to private IPs are blocked.
+
+---
+
+## TlsBuilder
+
+Builder for TLS interception settings. Used in `NetworkBuilder.tls(t => ...)`.
+
+---
+
+#### blockQuic()
+
+```typescript
+blockQuic(block: boolean): this
+```
+
+Block QUIC on intercepted ports, forcing TCP/TLS fallback.
+
+---
+
+#### bypass()
+
+```typescript
+bypass(pattern: string): this
+```
+
+Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). Use for domains with certificate pinning.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pattern | `string` | Glob pattern |
+
+---
+
+#### interceptCaCert()
+
+```typescript
+interceptCaCert(path: string): this
+```
+
+Path to a PEM file used as the intercepting CA's certificate.
+
+---
+
+#### interceptCaKey()
+
+```typescript
+interceptCaKey(path: string): this
+```
+
+Path to a PEM file used as the intercepting CA's private key.
+
+---
+
+#### interceptedPorts()
+
+```typescript
+interceptedPorts(ports: number[]): this
+```
+
+TCP ports where interception is active. Default: `[443]`.
+
+---
+
+#### upstreamCaCert()
+
+```typescript
+upstreamCaCert(path: string): this
+```
+
+Path to a PEM file with extra root CAs the proxy should trust.
+
+---
+
+#### verifyUpstream()
+
+```typescript
+verifyUpstream(verify: boolean): this
+```
+
+Verify upstream server certificates. Default `true`. Set to `false` only for self-signed servers.
+
+---
+
+## Types
+
+### NetworkConfig
+
+Built network configuration produced by `NetworkBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| enabled | `boolean` | Master enable flag |
+| ports | `readonly PublishedPort[]` | Port publishings |
+| policy | [`NetworkPolicy`](#networkpolicy-1) ` \| null` | Active policy |
+| dns | [`DnsConfig`](#dnsconfig) ` \| null` | DNS interception |
+| tls | [`TlsConfig`](#tlsconfig) ` \| null` | TLS interception |
+| secrets | `readonly SecretEntry[]` | Secret entries |
+| secretViolation | [`ViolationAction`](/sdk/typescript/secrets#violationaction) ` \| null` | Action on disallowed secret use |
+| maxConnections | `number \| null` | Maximum concurrent connections |
+| trustHostCAs | `boolean` | Ship host CAs into the guest |
+
+### NetworkPolicy
+
+```typescript
+interface NetworkPolicy {
+  readonly defaultEgress: Action;
+  readonly defaultIngress: Action;
+  readonly rules: readonly Rule[];
+}
+```
+
+### Rule
+
+```typescript
+interface Rule {
+  readonly direction: Direction;
+  readonly destination: Destination;
+  readonly protocols: readonly Protocol[]; // empty = any
+  readonly ports: readonly PortRange[];    // empty = any
+  readonly action: Action;
+}
+```
+
+### Destination
+
+```typescript
+type Destination =
+  | { kind: "any" }
+  | { kind: "cidr"; cidr: string }
+  | { kind: "domain"; domain: string }
+  | { kind: "domainSuffix"; suffix: string }
+  | { kind: "group"; group: DestinationGroup };
+```
+
+### Action
+
+```typescript
+type Action = "allow" | "deny";
+```
+
+### Direction
+
+```typescript
+type Direction = "egress" | "ingress" | "any";
+```
+
+### Protocol
+
+```typescript
+type Protocol = "tcp" | "udp" | "icmpv4" | "icmpv6";
+```
+
+### DestinationGroup
+
+```typescript
+type DestinationGroup =
+  | "public"
+  | "loopback"
+  | "private"
+  | "link-local"
+  | "metadata"
+  | "multicast"
+  | "host";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'public'` | Public internet (everything not in another group) |
+| `'loopback'` | Guest's own `127.0.0.0/8` / `::1` |
+| `'private'` | RFC1918 LAN ranges |
+| `'link-local'` | `169.254.0.0/16` / `fe80::/10` |
+| `'metadata'` | Cloud metadata endpoints (`169.254.169.254`, `fd00:ec2::254`) |
+| `'multicast'` | Multicast addresses |
+| `'host'` | The host machine, reached via `host.microsandbox.internal` |
+
+### PortRange
+
+```typescript
+interface PortRange {
+  readonly start: number;
+  readonly end: number;
+}
+```
+
+### RuleDestinationBuilder
+
+Returned by [`RuleBuilder`](#rulebuilder)`.allow(d => ...)` / `.deny(d => ...)`. Exactly one destination call commits the rule; dropping without a destination call silently does nothing.
+
+| Method | Description |
+|--------|-------------|
+| `.ip(ip)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
+| `.cidr(cidr)` | Commit with `Destination::Cidr` |
+| `.domain(domain)` | Commit with `Destination::Domain` |
+| `.domainSuffix(suffix)` | Commit with `Destination::DomainSuffix` |
+| `.group(group)` | Commit with `Destination::Group`. `group` is a [`DestinationGroup`](#destinationgroup) string |
+| `.any()` | Commit with `Destination::Any` |
+
+### DnsConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| nameservers | `readonly string[]` | Upstream nameservers |
+| rebindProtection | `boolean \| null` | DNS rebinding protection toggle |
+| queryTimeoutMs | `number \| null` | Per-query timeout |
+
+### TlsConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| bypass | `readonly string[]` | Bypass globs (e.g. `"*.googleapis.com"`) |
+| verifyUpstream | `boolean \| null` | Verify upstream certs |
+| interceptedPorts | `readonly number[]` | Intercepted TCP ports |
+| blockQuic | `boolean \| null` | Block QUIC on intercepted ports |
+| upstreamCaCertPaths | `readonly string[]` | Extra trust roots for upstream verification |
+| interceptCaCertPath | `string \| null` | Custom intercept CA cert (PEM) |
+| interceptCaKeyPath | `string \| null` | Custom intercept CA key (PEM) |
+
+### PublishedPort
+
+```typescript
+interface PublishedPort {
+  readonly hostPort: number;
+  readonly guestPort: number;
+  readonly protocol: "tcp" | "udp";
+}
+```

--- a/docs/de/sdk/typescript/sandbox.mdx
+++ b/docs/de/sdk/typescript/sandbox.mdx
@@ -1,0 +1,736 @@
+---
+title: Sandbox
+description: TypeScript SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox from `Sandbox.builder(name)` and chain configuration calls before terminating with `.create()` or `.createDetached()`.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+await using sandbox = await Sandbox.builder("demo")
+  .image("alpine")
+  .cpus(1)
+  .memory(512)
+  .create();
+```
+
+## Static methods
+
+---
+
+#### Sandbox.builder()
+
+```typescript
+static builder(name: string): SandboxBuilder
+```
+
+Begin building a new sandbox. Configure it with chainable setters, then call `.create()` or `.createDetached()` to boot it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxBuilder`](#sandboxbuilder) | Fluent builder |
+
+---
+
+#### Sandbox.get()
+
+```typescript
+static get(name: string): Promise<SandboxHandle>
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox.list()
+
+```typescript
+static list(): Promise<SandboxHandle[]>
+```
+
+List all sandboxes (running, stopped, and crashed). Handles returned from `list()` are read-only — call `Sandbox.get(name)` to get a live handle for lifecycle calls.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle[]`](#sandboxhandle) | All sandboxes (read-only handles) |
+
+---
+
+#### Sandbox.remove()
+
+```typescript
+static remove(name: string): Promise<void>
+```
+
+Delete a stopped sandbox and all its state from disk. Fails if the sandbox is still running.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+---
+
+#### Sandbox.start()
+
+```typescript
+static start(name: string): Promise<Sandbox>
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox.startDetached()
+
+```typescript
+static startDetached(name: string): Promise<Sandbox>
+```
+
+Restart a stopped sandbox in detached mode.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+## Instance properties
+
+---
+
+#### name
+
+```typescript
+readonly name: string
+```
+
+Sandbox name.
+
+---
+
+#### config
+
+```typescript
+readonly config: Readonly<SandboxConfig>
+```
+
+The frozen configuration the sandbox was built with.
+
+---
+
+#### ownsLifecycle
+
+```typescript
+readonly ownsLifecycle: boolean
+```
+
+Whether this handle owns the sandbox lifecycle. `true` in attached mode (the auto-disposer will stop the sandbox), `false` in detached mode.
+
+---
+
+## Instance methods
+
+---
+
+#### detach()
+
+```typescript
+detach(): Promise<void>
+```
+
+Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```typescript
+drain(): Promise<void>
+```
+
+Start a graceful drain. Existing commands run to completion, new `exec` calls are rejected.
+
+---
+
+#### fs()
+
+```typescript
+fs(): SandboxFs
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/typescript/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/typescript/filesystem) | Filesystem handle |
+
+---
+
+#### kill()
+
+```typescript
+kill(): Promise<void>
+```
+
+Force-terminate the sandbox immediately. No graceful shutdown.
+
+---
+
+#### metrics()
+
+```typescript
+metrics(): Promise<SandboxMetrics>
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network metrics |
+
+---
+
+#### metricsStream()
+
+```typescript
+metricsStream(intervalMs: number): Promise<MetricsStream>
+```
+
+Stream resource metrics at a regular interval. The returned stream supports both `recv()` and `for await...of`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| intervalMs | `number` | Milliseconds between metric snapshots |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`MetricsStream`](#metricsstream) | Async stream of metrics |
+
+---
+
+#### logs()
+
+```typescript
+logs(opts?: LogReadOptions): Promise<LogEntry[]>
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+const handle = await Sandbox.get("web");
+
+// Default — all user-program output, regardless of pipe/pty mode
+const entries = await handle.logs();
+
+for (const e of entries) {
+  const source =
+    e.source === "stdout" ? "OUT" :
+    e.source === "stderr" ? "ERR" :
+    e.source === "output" ? "PTY" :
+    "SYS";
+
+  console.log(
+    `[${e.timestamp.toISOString()}] ${source} ${e.sessionId}: ${e.text().trimEnd()}`
+  );
+}
+
+// Filtered: last 50 entries from the past hour, including system lines
+const recent = await handle.logs({
+  tail: 50,
+  since: new Date(Date.now() - 60 * 60 * 1000),
+  sources: ["stdout", "stderr", "output", "system"],
+});
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| opts | [`LogReadOptions`](#logreadoptions) `?` | Filters: `tail`, `since`, `until`, `sources`. Omit for the default user-program sources. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`LogEntry`](#logentry)`[]>` | Matching entries in chronological order |
+
+---
+
+#### removePersisted()
+
+```typescript
+removePersisted(): Promise<void>
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### stop()
+
+```typescript
+stop(): Promise<void>
+```
+
+Gracefully shut down the sandbox.
+
+---
+
+#### stopAndWait()
+
+```typescript
+stopAndWait(): Promise<ExitStatus>
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/typescript/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### wait()
+
+```typescript
+wait(): Promise<ExitStatus>
+```
+
+Block until the sandbox exits on its own.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/typescript/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### \[Symbol.asyncDispose\]()
+
+```typescript
+[Symbol.asyncDispose](): Promise<void>
+```
+
+Implements `AsyncDisposable` so the sandbox can be used with `await using`. When the binding goes out of scope, the sandbox is stopped (best-effort) — but only if `ownsLifecycle` is `true`.
+
+---
+
+## PatchBuilder
+
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder.patch(p => p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `{ replace: true }` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### append()
+
+```typescript
+append(path: string, content: string): this
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `string` | Text to append |
+
+---
+
+#### copyDir()
+
+```typescript
+copyDir(src: string, dst: string, opts?: { replace?: boolean }): this
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `string` | Host source directory |
+| dst | `string` | Absolute destination path inside the guest |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### copyFile()
+
+```typescript
+copyFile(
+  src: string,
+  dst: string,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `string` | Host source file |
+| dst | `string` | Absolute destination path inside the guest |
+| opts.mode | `number` | File mode, e.g. `0o644`. Omit to keep the source mode |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### file()
+
+```typescript
+file(
+  path: string,
+  content: Buffer,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Write raw bytes at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `Buffer` | Raw byte content |
+| opts.mode | `number` | File mode, e.g. `0o644` |
+| opts.replace | `boolean` | When `true`, overwrite an existing path |
+
+---
+
+#### mkdir()
+
+```typescript
+mkdir(path: string, opts?: { mode?: number }): this
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| opts.mode | `number` | Directory mode, e.g. `0o755` |
+
+---
+
+#### remove()
+
+```typescript
+remove(path: string): this
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+---
+
+#### symlink()
+
+```typescript
+symlink(target: string, link: string, opts?: { replace?: boolean }): this
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `string` | What the symlink points to (literal symlink target text) |
+| link | `string` | Absolute path of the symlink itself |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `link` |
+
+---
+
+#### text()
+
+```typescript
+text(
+  path: string,
+  content: string,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `string` | Text content |
+| opts.mode | `number` | File mode, e.g. `0o644` |
+| opts.replace | `boolean` | When `true`, overwrite an existing path |
+
+---
+
+## Types
+
+### SandboxBuilder
+
+Fluent configuration builder returned by `Sandbox.builder(name)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `image(src)` | OCI image (`"alpine"`), local rootfs path, or a `RootfsSource`. **Required.** |
+| `cpus(n)` | Virtual CPUs |
+| `memory(mib)` | Guest memory in MiB |
+| `logLevel(level)` | Override log verbosity |
+| `quietLogs()` | Suppress log output |
+| `workdir(path)` | Default working directory for commands |
+| `shell(shell)` | Shell binary used by `sandbox.shell(...)` |
+| `entrypoint(iter)` | Override the image entrypoint |
+| `init(cmd, args?)` | Hand off PID 1 to `cmd` (absolute path or `"auto"`) after agentd setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| `initWith(cmd, i => ...)` | Like `init` but with a closure-builder for argv and env (`.arg`, `.args`, `.env`, `.envs`) |
+| `hostname(name)` | Guest hostname |
+| `user(user)` | Default guest user |
+| `pullPolicy(policy)` | Image pull behavior |
+| `libkrunfwPath(path)` | Override the bundled libkrunfw shared library |
+| `env(key, value)` | Add a single env var |
+| `envs(record \| iter)` | Add many env vars |
+| `script(name, content)` | Mount a script at `/.msb/scripts/<name>` |
+| `scripts(record \| iter)` | Mount many scripts |
+| `replace()` | Replace any existing sandbox with the same name |
+| `maxDuration(secs)` | Maximum sandbox lifetime |
+| `idleTimeout(secs)` | Stop the sandbox after this many idle seconds |
+| `volume(guestPath, m => ...)` | Mount a volume — see [Volumes](/sdk/typescript/volumes) |
+| `patch(p => ...)` | Modify the rootfs before boot — see [Snapshots](/sdk/typescript/snapshots) |
+| `addPatch(patch)` | Append a pre-built `Patch` |
+| `registry(r => r.auth(...).insecure().caCertsPath(...))` | Configure the OCI registry |
+| `port(host, guest)` | Publish a TCP port |
+| `portUdp(host, guest)` | Publish a UDP port |
+| `disableNetwork()` | Disable networking entirely |
+| `network(n => ...)` | Configure DNS / TLS / policy / secrets — see [Networking](/sdk/typescript/networking) |
+| `secret(s => ...)` | Add a secret via [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder) |
+| `secretEnv(envVar, value, allowedHost)` | Auto-placeholder shorthand. Generates `$MSB_<ENV_VAR>`. |
+| `build(): SandboxConfig` | Materialize without booting |
+| `create(): Promise<Sandbox>` | Build and boot in attached mode |
+| `createDetached(): Promise<Sandbox>` | Build and boot in detached mode |
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `'debug'` | Debug and higher |
+| `'error'` | Errors only |
+| `'info'` | Info and higher |
+| `'trace'` | Most verbose - all diagnostic output |
+| `'warn'` | Warnings and errors only |
+
+### LogEntry
+
+A class wrapping one captured log entry. Returned by [`logs()`](#logs).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| timestamp | `Date` | Wall-clock capture time on the host |
+| source | [`LogSource`](#logsource) | Where the chunk came from |
+| sessionId | `number \| null` | Relay-monotonic session id; `null` for `"system"` entries |
+| data | `Uint8Array` | The chunk's bytes (UTF-8 lossy decoded by default) |
+| `text()` | `string` | Convenience: UTF-8 decode of `data` (lossy — invalid bytes are replaced) |
+
+### LogReadOptions
+
+Filters passed to [`logs()`](#logs). All fields optional. Omit the argument entirely for the default sources (`stdout` + `stderr` + `output`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tail | `number?` | Show only the last N entries after other filters apply |
+| since | `Date?` | Inclusive lower bound on entry timestamp |
+| until | `Date?` | Exclusive upper bound on entry timestamp |
+| sources | [`LogSource`](#logsource)`[]?` | Sources to include. Omit = `["stdout", "stderr", "output"]`. Add `"system"` to merge runtime/kernel diagnostics. |
+
+### LogSource
+
+Tag indicating where a captured log entry came from. String literal type:
+
+```typescript
+type LogSource = "stdout" | "stderr" | "output" | "system";
+```
+
+| Value | Description |
+|-------|-------------|
+| `"stdout"` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `"stderr"` | Captured from a session's stderr (pipe mode) |
+| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `"output"` rather than mislabelled as `"stdout"`. |
+| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested. |
+
+### MetricsStream
+
+Async stream for receiving periodic metrics snapshots.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `[Symbol.asyncIterator]` | `AsyncIterator<`[`SandboxMetrics`](#sandboxmetrics)`>` | Use with `for await...of` |
+| `recv()` | `Promise<`[`SandboxMetrics`](#sandboxmetrics)` \| null>` | Receive next snapshot. Returns `null` when the stream ends. |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop iterating; safe to use with `await using`. |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `'always'` | Pull the image every time, even if cached locally |
+| `'if-missing'` | Pull only if the image is not already cached. This is the default. |
+| `'never'` | Never pull; fail if the image is not cached locally |
+
+### SandboxConfig
+
+Frozen configuration object — produced by `SandboxBuilder.build()` and exposed as the `config` property on a `Sandbox`. You generally should not construct this by hand; use the builder.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Sandbox name |
+| image | `RootfsSource` | OCI / bind / disk discriminated union |
+| cpus | `number \| null` | Virtual CPUs |
+| memoryMib | `number \| null` | Guest memory in MiB |
+| logLevel | `LogLevel \| null` | Log verbosity |
+| quietLogs | `boolean` | Suppress log output |
+| workdir | `string \| null` | Default working directory |
+| shell | `string \| null` | Shell binary |
+| entrypoint | `string[] \| null` | Override image entrypoint |
+| cmd | `string[] \| null` | Override image cmd |
+| hostname | `string \| null` | Guest hostname |
+| user | `string \| null` | Default guest user |
+| libkrunfwPath | `string \| null` | Custom libkrunfw path |
+| env | `Array<readonly [string, string]>` | Environment variables |
+| scripts | `Array<readonly [string, string]>` | Named scripts |
+| mounts | `VolumeMount[]` | Volume mounts |
+| patches | `Patch[]` | Rootfs modifications applied before boot |
+| pullPolicy | `PullPolicy \| null` | Image pull behavior |
+| replace | `boolean` | Replace existing sandbox with same name |
+| maxDurationSecs | `number \| null` | Maximum sandbox lifetime |
+| idleTimeoutSecs | `number \| null` | Stop after idle time |
+| portsTcp | `Array<readonly [number, number]>` | TCP host→guest mappings |
+| portsUdp | `Array<readonly [number, number]>` | UDP host→guest mappings |
+| registry | `RegistryConfig \| null` | Registry connection settings |
+| network | `NetworkConfig \| null` | Network configuration |
+| disableNetwork | `boolean` | Disable networking entirely |
+| secrets | `SecretEntry[]` | Secret entries (top-level) |
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandboxget) or [`Sandbox.list()`](#sandboxlist).
+
+Handles from `Sandbox.get(name)` are **live** — they expose lifecycle methods (`start`, `stop`, `kill`, `connect`, etc). Handles in the array returned by `Sandbox.list()` are **read-only**: calling lifecycle methods on them throws. Use `Sandbox.get(name)` to upgrade to a live handle.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `string` | Sandbox name |
+| status | [`SandboxStatus`](#sandboxstatus) | Current status |
+| configJson | `string` | Raw JSON configuration |
+| createdAt | `Date \| null` | Creation timestamp |
+| updatedAt | `Date \| null` | Last update timestamp |
+| metrics() | `Promise<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
+| logs() | `Promise<`[`LogEntry`](#logentry)`[]>` | Read captured `exec.log` (works without starting) |
+| start() | `Promise<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
+| startDetached() | `Promise<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |
+| connect() | `Promise<`[`Sandbox`](#instance-methods)`>` | Connect to a running sandbox without taking ownership |
+| stop() | `Promise<void>` | Graceful shutdown |
+| kill() | `Promise<void>` | Force terminate |
+| remove() | `Promise<void>` | Delete sandbox and state |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpuPercent | `number` | CPU usage as a percentage |
+| diskReadBytes | `number` | Total bytes read from disk since boot |
+| diskWriteBytes | `number` | Total bytes written to disk since boot |
+| memoryBytes | `number` | Current memory usage in bytes |
+| memoryLimitBytes | `number` | Memory limit in bytes |
+| netRxBytes | `number` | Total bytes received over the network since boot |
+| netTxBytes | `number` | Total bytes sent over the network since boot |
+| timestamp | `Date` | When this measurement was taken |
+| uptimeMs | `number` | Time since the sandbox was created (ms) |
+
+### SandboxStatus
+
+| Value | Description |
+|-------|-------------|
+| `'crashed'` | VM exited unexpectedly |
+| `'draining'` | Graceful shutdown in progress |
+| `'running'` | Guest agent is ready |
+| `'stopped'` | VM shut down; can be restarted |

--- a/docs/de/sdk/typescript/secrets.mdx
+++ b/docs/de/sdk/typescript/secrets.mdx
@@ -1,0 +1,126 @@
+---
+title: Secrets
+description: TypeScript SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## Adding secrets
+
+Secrets are configured on a sandbox via `SandboxBuilder.secret(s => ...)` (or its shorthand `secretEnv`). The guest only ever sees a placeholder — the real value is substituted by the TLS proxy when traffic reaches an allowed host.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+// Auto-placeholder shorthand: generates `$MSB_OPENAI_API_KEY`.
+await using sb = await Sandbox.builder("agent")
+  .image("python")
+  .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+  .create();
+
+// Full control via SecretBuilder.
+await using sb2 = await Sandbox.builder("agent2")
+  .image("python")
+  .secret((s) =>
+    s.env("STRIPE_KEY")
+      .value(process.env.STRIPE_KEY!)
+      .allowHost("api.stripe.com")
+      .allowHostPattern("*.stripe.com")
+      .injectHeaders(true)
+      .injectQuery(false),
+  )
+  .create();
+```
+
+The same `secret(...)` and `secretEnv(...)` methods are also available inside `SandboxBuilder.network(n => n.secret(...))` and on `NetworkBuilder.secretEnv(envVar, value, placeholder, allowedHost)` (4-arg explicit-placeholder shorthand).
+
+---
+
+## SecretBuilder
+
+Fluent builder used inside `SandboxBuilder.secret(s => ...)` or `NetworkBuilder.secret(s => ...)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `env(varName)` | Environment variable to expose the placeholder under. **Required.** |
+| `value(value)` | The real secret value (stays on the host). **Required.** |
+| `placeholder(placeholder)` | Custom placeholder. Auto-generated as `$MSB_<ENV_VAR>` when omitted. |
+| `allowHost(host)` | Allow substitution to a specific host (exact match). |
+| `allowHostPattern(pattern)` | Allow substitution to any host matching a wildcard. |
+| `allowAnyHostDangerous(true)` | Permit substitution to any host. Acknowledge the risk explicitly. |
+| `requireTlsIdentity(enabled)` | Require a verified TLS identity before substituting. Default `true`. |
+| `injectHeaders(enabled)` | Allow substitution in HTTP headers. Default `true`. |
+| `injectBasicAuth(enabled)` | Allow substitution in HTTP Basic Auth. Default `true`. |
+| `injectQuery(enabled)` | Allow substitution in URL query parameters. Default `false`. |
+| `injectBody(enabled)` | Allow substitution in the HTTP request body. Default `false`. |
+| `build()` | Produce a [`SecretEntry`](#secretentry). |
+
+---
+
+## Convenience helpers
+
+#### SandboxBuilder.secretEnv()
+
+```typescript
+secretEnv(envVar: string, value: string, allowedHost: string): this
+```
+
+Three-argument shorthand. Auto-generates the placeholder as `$MSB_<ENV_VAR>` and allows substitution only on `allowedHost`.
+
+#### NetworkBuilder.secretEnv()
+
+```typescript
+secretEnv(
+  envVar: string,
+  value: string,
+  placeholder: string,
+  allowedHost: string,
+): this
+```
+
+Four-argument shorthand. Same as the `SandboxBuilder` form but lets you provide the placeholder explicitly.
+
+---
+
+## Types
+
+### SecretEntry
+
+The object produced by `SecretBuilder.build()`. You normally construct one with the builder, but the shape is exposed for advanced cases.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Real secret value (stays on the host) |
+| placeholder | `string \| null` | Custom placeholder; defaults to `$MSB_<ENV_VAR>` when `null` |
+| allowedHosts | `readonly string[]` | Allowed hosts (exact match) |
+| allowedHostPatterns | `readonly string[]` | Wildcard host patterns |
+| allowAnyHost | `boolean` | Permit substitution to any host |
+| requireTlsIdentity | `boolean` | Require verified TLS identity |
+| injection | [`SecretInjection`](#secretinjection) | Where to substitute |
+
+### SecretInjection
+
+Controls where the TLS proxy substitutes the placeholder with the real value. Each field is optional; omitted fields use the default.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| headers? | `boolean` | `true` | Replace the placeholder anywhere in HTTP headers. |
+| basicAuth? | `boolean` | `true` | Replace the placeholder specifically in HTTP Basic Auth credentials. |
+| queryParams? | `boolean` | `false` | Replace the placeholder in URL query parameters. |
+| body? | `boolean` | `false` | Replace the placeholder in the HTTP request body. `Content-Length` is rewritten. |
+
+### ViolationAction
+
+Action taken when a secret placeholder is sent to a disallowed host. Set on the network builder via `NetworkBuilder.onSecretViolation(action)`.
+
+```typescript
+type ViolationAction = "block" | "block-and-log" | "block-and-terminate";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'block'` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `'block-and-log'` | Drop the request and emit a warning log on the host side. |
+| `'block-and-terminate'` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/de/sdk/typescript/snapshots.mdx
+++ b/docs/de/sdk/typescript/snapshots.mdx
@@ -1,0 +1,348 @@
+---
+title: Snapshots
+description: TypeScript SDK - Snapshot API reference
+icon: "camera"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the TypeScript SDK reference.
+
+```ts
+import { Sandbox, Snapshot, SnapshotHandle } from "microsandbox";
+import type { ExportOpts, SnapshotVerifyReport } from "microsandbox";
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## SandboxBuilder
+
+---
+
+#### fromSnapshot()
+
+```ts
+fromSnapshot(pathOrName: string): SandboxBuilder
+```
+
+Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`image()`](/sdk/typescript/sandbox#image) — the snapshot already pins the image.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pathOrName | `string` | Bare name (resolved under `~/.microsandbox/snapshots/`) or filesystem path to an artifact directory |
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```ts
+snapshot(name: string): Promise<Snapshot>
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination, see [`snapshotTo()`](#snapshotto).
+
+**Errors**
+
+- `SnapshotSandboxRunning` — the sandbox is not stopped
+- `SnapshotAlreadyExists` — destination exists (use the builder with `.force()` to overwrite)
+
+---
+
+#### snapshotTo()
+
+```ts
+snapshotTo(path: string): Promise<Snapshot>
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path.
+
+---
+
+## Snapshot (instance)
+
+---
+
+#### path
+
+```ts
+readonly path: string
+```
+
+Path to the artifact directory.
+
+---
+
+#### digest
+
+```ts
+readonly digest: string
+```
+
+Canonical content digest (`sha256:hex`) over the manifest bytes. The snapshot's identity.
+
+---
+
+#### sizeBytes
+
+```ts
+readonly sizeBytes: bigint
+```
+
+Apparent size of the captured upper layer in bytes (the ext4 virtual size, sparse on disk).
+
+---
+
+#### imageRef
+
+```ts
+readonly imageRef: string
+```
+
+Image reference the snapshot was taken from.
+
+---
+
+#### imageManifestDigest
+
+```ts
+readonly imageManifestDigest: string
+```
+
+OCI manifest digest of the pinned image.
+
+---
+
+#### format
+
+```ts
+readonly format: "raw" | "qcow2"
+```
+
+On-disk format of the upper layer. Always `"raw"` today.
+
+---
+
+#### fstype
+
+```ts
+readonly fstype: string
+```
+
+Filesystem type inside the upper (e.g. `"ext4"`).
+
+---
+
+#### parent
+
+```ts
+readonly parent: string | null
+```
+
+Manifest digest of the parent snapshot, or `null` for a root.
+
+---
+
+#### createdAt
+
+```ts
+readonly createdAt: string
+```
+
+RFC 3339 timestamp when the snapshot was created.
+
+---
+
+#### labels
+
+```ts
+readonly labels: ReadonlyArray<readonly [string, string]>
+```
+
+User-supplied labels (sorted by key in canonical form).
+
+---
+
+#### verify()
+
+```ts
+verify(): Promise<SnapshotVerifyReport>
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds.
+
+```ts
+const report = await snap.verify();
+if (report.upper.kind === "verified") {
+  console.log(`hash matches: ${report.upper.digest}`);
+} else {
+  console.log("no integrity hash recorded");
+}
+```
+
+---
+
+## Snapshot.builder()
+
+```ts
+static builder(sourceSandbox: string): SnapshotBuilder
+```
+
+Start configuring a new snapshot. The fluent builder is what powers the CLI internally.
+
+```ts
+const snap = await Snapshot.builder("baseline")
+  .name("after-pip-install")        // bare name in default dir
+  .label("stage", "post-deps")
+  .force()                           // overwrite if it exists
+  .recordIntegrity()                 // hash the upper layer
+  .create();
+```
+
+**Builder methods**
+
+| Method | Description |
+|--------|-------------|
+| `.name(string)` | Bare name under the default snapshots directory |
+| `.path(string)` | Explicit filesystem path |
+| `.label(key, value)` | Add a `key=value` label (may be repeated) |
+| `.force()` | Overwrite an existing artifact at the destination |
+| `.recordIntegrity()` | Compute and record a content-integrity hash at creation |
+| `.build()` | Snapshot the accumulated configuration |
+| `.create()` | Build and execute |
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot.open()
+
+```ts
+static open(pathOrName: string): Promise<Snapshot>
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot.get()
+
+```ts
+static get(nameOrDigest: string): Promise<SnapshotHandle>
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot.list()
+
+```ts
+static list(): Promise<SnapshotHandle[]>
+```
+
+List indexed snapshots from the local DB cache.
+
+---
+
+#### Snapshot.listDir()
+
+```ts
+static listDir(dir: string): Promise<Snapshot[]>
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot.remove()
+
+```ts
+static remove(pathOrName: string, opts?: { force?: boolean }): Promise<void>
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force: true`.
+
+---
+
+#### Snapshot.reindex()
+
+```ts
+static reindex(dir?: string): Promise<number>
+```
+
+Walk `dir` (default: configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot.export()
+
+```ts
+static export(nameOrPath: string, out: string, opts?: ExportOpts): Promise<void>
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+**ExportOpts**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `withParents` | `boolean` | Walk the parent chain (no-op today) |
+| `withImage` | `boolean` | Bundle the OCI image cache for offline transport |
+| `plainTar` | `boolean` | Skip zstd compression and write a plain `.tar` |
+
+---
+
+#### Snapshot.import()
+
+```ts
+static import(archive: string, dest?: string): Promise<SnapshotHandle>
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot.list()`](#snapshotlist) and [`Snapshot.get()`](#snapshotget).
+
+```ts
+const h = await Snapshot.get("after-pip-install");
+
+h.digest;          // string ("sha256:...")
+h.name;            // string | null
+h.parentDigest;    // string | null — null today
+h.imageRef;        // string
+h.format;          // "raw" | "qcow2"
+h.sizeBytes;       // bigint | null
+h.createdAt;       // Date
+h.path;            // string
+
+const snap = await h.open();              // metadata-validated
+await h.remove({ force: false });          // refuse if has children
+```
+
+---
+
+## Types
+
+```ts
+export interface ExportOpts {
+  withParents?: boolean;
+  withImage?: boolean;
+  plainTar?: boolean;
+}
+
+export type SnapshotVerifyReport =
+  | { digest: string; path: string; upper: { kind: "notRecorded" } }
+  | { digest: string; path: string;
+      upper: { kind: "verified"; algorithm: string; digest: string } };
+```

--- a/docs/de/sdk/typescript/volumes.mdx
+++ b/docs/de/sdk/typescript/volumes.mdx
@@ -1,0 +1,234 @@
+---
+title: Volumes
+description: TypeScript SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+```typescript
+import { Volume } from "microsandbox";
+
+const data = await Volume.builder("my-data")
+  .quota(100)
+  .label("env", "prod")
+  .create();
+```
+
+## Static methods
+
+---
+
+#### Volume.builder()
+
+```typescript
+static builder(name: string): VolumeBuilder
+```
+
+Begin building a named volume. Configure with `.quota(...)` and `.label(...)`, then call `.create()`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeBuilder`](#volumebuilder) | Fluent builder |
+
+---
+
+#### Volume.get()
+
+```typescript
+static get(name: string): Promise<VolumeHandle>
+```
+
+Get a handle to an existing named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`VolumeHandle`](#volumehandle)`>` | Volume handle |
+
+---
+
+#### Volume.list()
+
+```typescript
+static list(): Promise<VolumeHandle[]>
+```
+
+List all named volumes. Handles returned from `list()` are read-only — call `Volume.get(name)` to get a live handle for `.remove()` / `.fs()`.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`VolumeHandle`](#volumehandle)`[]>` | All volumes |
+
+---
+
+#### Volume.remove()
+
+```typescript
+static remove(name: string): Promise<void>
+```
+
+Delete a named volume and its contents. Fails if the volume is currently mounted.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+---
+
+## Instance properties
+
+#### name
+
+```typescript
+get name(): string
+```
+
+The volume's name.
+
+---
+
+#### path
+
+```typescript
+get path(): string
+```
+
+Absolute host path to the volume's directory.
+
+---
+
+#### fs()
+
+```typescript
+fs(): VolumeFs
+```
+
+Get a host-side filesystem handle for this volume — no sandbox required.
+
+```typescript
+const vfs = data.fs();
+await vfs.write("seed.txt", "hello");
+console.log(await vfs.list(""));
+```
+
+---
+
+## Mounts
+
+Volume mounts attach a host directory, named volume, tmpfs, or disk image to a guest path. Configure them via `SandboxBuilder.volume(guestPath, m => ...)`:
+
+```typescript
+await using sb = await Sandbox.builder("worker")
+  .image("alpine")
+  .volume("/host",    (m) => m.bind("/var/data"))
+  .volume("/data",    (m) => m.named("my-data"))
+  .volume("/scratch", (m) => m.tmpfs().size(128))
+  .volume("/img",     (m) => m.disk("./data.qcow2").fstype("ext4").readonly())
+  .create();
+```
+
+### MountBuilder
+
+Used inside `SandboxBuilder.volume(guestPath, m => ...)`. Pick exactly one mount kind, then chain modifiers.
+
+| Method | Description |
+|--------|-------------|
+| `bind(host)` | Mount a host directory into the guest. |
+| `named(name)` | Mount a named volume created via [`Volume.builder`](#volumebuilder). |
+| `tmpfs()` | Mount an in-memory filesystem. |
+| `disk(host)` | Mount a host disk image as a virtio-blk device. |
+| `format(fmt)` | Disk image format (`'qcow2' \| 'raw' \| 'vmdk'`). Defaults to the file extension. Disk only. |
+| `fstype(fs)` | Inner filesystem type (e.g. `"ext4"`). Disk only; omit to autodetect. |
+| `readonly()` | Mount read-only. |
+| `size(mib)` | Cap in MiB. Tmpfs only. |
+| `build()` | Internal — produce a `VolumeMount`. |
+
+### VolumeMount
+
+Discriminated union produced by `MountBuilder.build()`.
+
+```typescript
+type VolumeMount =
+  | { kind: "bind"; host: string; guest: string; readonly: boolean }
+  | { kind: "named"; name: string; guest: string; readonly: boolean }
+  | { kind: "tmpfs"; guest: string; sizeMib: number | null; readonly: boolean }
+  | {
+      kind: "disk";
+      host: string;
+      guest: string;
+      format: DiskImageFormat;
+      fstype: string | null;
+      readonly: boolean;
+    };
+```
+
+### DiskImageFormat
+
+```typescript
+type DiskImageFormat = "qcow2" | "raw" | "vmdk";
+```
+
+---
+
+## Types
+
+### VolumeBuilder
+
+| Method | Description |
+|--------|-------------|
+| `quota(mib)` | Maximum storage size in MiB |
+| `label(key, value)` | Add a metadata label |
+| `build()` | Materialize a [`VolumeConfig`](#volumeconfig) |
+| `create()` | Build and create the volume; returns a [`Volume`](#volume) |
+
+### VolumeConfig
+
+Frozen configuration produced by `VolumeBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Volume name |
+| quotaMib | `number \| null` | Maximum storage size in MiB |
+| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
+
+### VolumeHandle
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `string` | Volume name |
+| quotaMib | `number \| null` | Storage quota |
+| usedBytes | `number` | Current disk usage in bytes |
+| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
+| createdAt | `Date \| null` | Creation timestamp |
+| fs() | [`VolumeFs`](#volumefs) | Host-side filesystem on this volume (live handles only) |
+| remove() | `Promise<void>` | Delete this volume (live handles only) |
+
+Handles in the array returned by `Volume.list()` are read-only: calling `.fs()` or `.remove()` throws. Use `Volume.get(name)` to upgrade.
+
+### VolumeFs
+
+Host-side filesystem operations on a volume's directory. Same surface area as [`SandboxFs`](/sdk/typescript/filesystem) (read, readToString, readStream, write, writeStream, list, mkdir, removeDir, remove, copy, rename, stat, exists) — but operates directly on the host without booting a sandbox.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -20,149 +20,758 @@
     }
   },
   "navigation": {
-    "tabs": [
+    "languages": [
       {
-        "tab": "Documentation",
-        "groups": [
+        "language": "en",
+        "tabs": [
           {
-            "group": "Getting Started",
-            "icon": "rocket",
-            "pages": [
-              "getting-started/introduction",
-              "getting-started/quickstart",
-              "getting-started/agents"
+            "tab": "Documentation",
+            "groups": [
+              {
+                "group": "Getting Started",
+                "icon": "rocket",
+                "pages": [
+                  "getting-started/introduction",
+                  "getting-started/quickstart",
+                  "getting-started/agents"
+                ]
+              },
+              {
+                "group": "Sandboxes",
+                "icon": "box",
+                "pages": [
+                  "sandboxes/overview",
+                  "sandboxes/lifecycle",
+                  "sandboxes/commands",
+                  "sandboxes/filesystem",
+                  "sandboxes/volumes",
+                  "sandboxes/secrets",
+                  "sandboxes/customize",
+                  "sandboxes/snapshots",
+                  "sandboxes/logs",
+                  "sandboxes/metrics",
+                  "sandboxes/events"
+                ]
+              },
+              {
+                "group": "Networking",
+                "icon": "network-wired",
+                "pages": [
+                  "networking/overview",
+                  "networking/dns",
+                  "networking/tls",
+                  "networking/security-model"
+                ]
+              },
+              {
+                "group": "Images",
+                "icon": "layer-group",
+                "pages": [
+                  "images/overview",
+                  "images/disk-images"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "icon": "gear",
+                "pages": [
+                  "configuration"
+                ]
+              }
             ]
           },
           {
-            "group": "Sandboxes",
-            "icon": "box",
-            "pages": [
-              "sandboxes/overview",
-              "sandboxes/lifecycle",
-              "sandboxes/commands",
-              "sandboxes/filesystem",
-              "sandboxes/volumes",
-              "sandboxes/secrets",
-              "sandboxes/customize",
-              "sandboxes/snapshots",
-              "sandboxes/logs",
-              "sandboxes/metrics",
-              "sandboxes/events"
+            "tab": "SDK Reference",
+            "groups": [
+              {
+                "group": "Getting Started",
+                "icon": "flag",
+                "pages": [
+                  "sdk/overview",
+                  "sdk/errors"
+                ]
+              },
+              {
+                "group": "Rust SDK",
+                "icon": "rust",
+                "pages": [
+                  "sdk/rust/sandbox",
+                  "sdk/rust/execution",
+                  "sdk/rust/filesystem",
+                  "sdk/rust/volumes",
+                  "sdk/rust/networking",
+                  "sdk/rust/secrets",
+                  "sdk/rust/snapshots",
+                  "sdk/rust/events"
+                ]
+              },
+              {
+                "group": "TypeScript SDK",
+                "icon": "js",
+                "pages": [
+                  "sdk/typescript/sandbox",
+                  "sdk/typescript/execution",
+                  "sdk/typescript/filesystem",
+                  "sdk/typescript/volumes",
+                  "sdk/typescript/networking",
+                  "sdk/typescript/secrets",
+                  "sdk/typescript/snapshots",
+                  "sdk/typescript/events"
+                ]
+              },
+              {
+                "group": "Python SDK",
+                "icon": "python",
+                "pages": [
+                  "sdk/python/sandbox",
+                  "sdk/python/execution",
+                  "sdk/python/filesystem",
+                  "sdk/python/volumes",
+                  "sdk/python/networking",
+                  "sdk/python/secrets",
+                  "sdk/python/snapshots",
+                  "sdk/python/events"
+                ]
+              }
             ]
           },
           {
-            "group": "Networking",
-            "icon": "network-wired",
-            "pages": [
-              "networking/overview",
-              "networking/dns",
-              "networking/tls",
-              "networking/security-model"
+            "tab": "CLI Reference",
+            "groups": [
+              {
+                "group": "CLI",
+                "icon": "terminal",
+                "pages": [
+                  "cli/overview",
+                  "cli/sandbox-commands",
+                  "cli/volume-commands",
+                  "cli/image-commands"
+                ]
+              }
             ]
           },
           {
-            "group": "Images",
-            "icon": "layer-group",
-            "pages": [
-              "images/overview",
-              "images/disk-images"
-            ]
-          },
-          {
-            "group": "Configuration",
-            "icon": "gear",
-            "pages": [
-              "configuration"
+            "tab": "Recipes",
+            "groups": [
+              {
+                "group": "Docker",
+                "icon": "docker",
+                "pages": [
+                  "recipes/docker",
+                  "recipes/local-images"
+                ]
+              },
+              {
+                "group": "Guest",
+                "icon": "server",
+                "pages": [
+                  "recipes/systemd-services"
+                ]
+              }
             ]
           }
         ]
       },
       {
-        "tab": "SDK Reference",
-        "groups": [
+        "language": "es",
+        "tabs": [
           {
-            "group": "Getting Started",
-            "icon": "flag",
-            "pages": [
-              "sdk/overview",
-              "sdk/errors"
+            "tab": "Documentación",
+            "groups": [
+              {
+                "group": "Primeros pasos",
+                "icon": "rocket",
+                "pages": [
+                  "es/getting-started/introduction",
+                  "es/getting-started/quickstart",
+                  "es/getting-started/agents"
+                ]
+              },
+              {
+                "group": "Sandboxes",
+                "icon": "box",
+                "pages": [
+                  "es/sandboxes/overview",
+                  "es/sandboxes/lifecycle",
+                  "es/sandboxes/commands",
+                  "es/sandboxes/filesystem",
+                  "es/sandboxes/volumes",
+                  "es/sandboxes/secrets",
+                  "es/sandboxes/customize",
+                  "es/sandboxes/snapshots",
+                  "es/sandboxes/logs",
+                  "es/sandboxes/metrics",
+                  "es/sandboxes/events"
+                ]
+              },
+              {
+                "group": "Redes",
+                "icon": "network-wired",
+                "pages": [
+                  "es/networking/overview",
+                  "es/networking/dns",
+                  "es/networking/tls",
+                  "es/networking/security-model"
+                ]
+              },
+              {
+                "group": "Imágenes",
+                "icon": "layer-group",
+                "pages": [
+                  "es/images/overview",
+                  "es/images/disk-images"
+                ]
+              },
+              {
+                "group": "Configuración",
+                "icon": "gear",
+                "pages": [
+                  "es/configuration"
+                ]
+              }
             ]
           },
           {
-            "group": "Rust SDK",
-            "icon": "rust",
-            "pages": [
-              "sdk/rust/sandbox",
-              "sdk/rust/execution",
-              "sdk/rust/filesystem",
-              "sdk/rust/volumes",
-              "sdk/rust/networking",
-              "sdk/rust/secrets",
-              "sdk/rust/snapshots",
-              "sdk/rust/events"
+            "tab": "Referencia del SDK",
+            "groups": [
+              {
+                "group": "Primeros pasos",
+                "icon": "flag",
+                "pages": [
+                  "es/sdk/overview",
+                  "es/sdk/errors"
+                ]
+              },
+              {
+                "group": "SDK de Rust",
+                "icon": "rust",
+                "pages": [
+                  "es/sdk/rust/sandbox",
+                  "es/sdk/rust/execution",
+                  "es/sdk/rust/filesystem",
+                  "es/sdk/rust/volumes",
+                  "es/sdk/rust/networking",
+                  "es/sdk/rust/secrets",
+                  "es/sdk/rust/snapshots",
+                  "es/sdk/rust/events"
+                ]
+              },
+              {
+                "group": "SDK de TypeScript",
+                "icon": "js",
+                "pages": [
+                  "es/sdk/typescript/sandbox",
+                  "es/sdk/typescript/execution",
+                  "es/sdk/typescript/filesystem",
+                  "es/sdk/typescript/volumes",
+                  "es/sdk/typescript/networking",
+                  "es/sdk/typescript/secrets",
+                  "es/sdk/typescript/snapshots",
+                  "es/sdk/typescript/events"
+                ]
+              },
+              {
+                "group": "SDK de Python",
+                "icon": "python",
+                "pages": [
+                  "es/sdk/python/sandbox",
+                  "es/sdk/python/execution",
+                  "es/sdk/python/filesystem",
+                  "es/sdk/python/volumes",
+                  "es/sdk/python/networking",
+                  "es/sdk/python/secrets",
+                  "es/sdk/python/snapshots",
+                  "es/sdk/python/events"
+                ]
+              }
             ]
           },
           {
-            "group": "TypeScript SDK",
-            "icon": "js",
-            "pages": [
-              "sdk/typescript/sandbox",
-              "sdk/typescript/execution",
-              "sdk/typescript/filesystem",
-              "sdk/typescript/volumes",
-              "sdk/typescript/networking",
-              "sdk/typescript/secrets",
-              "sdk/typescript/snapshots",
-              "sdk/typescript/events"
+            "tab": "Referencia de CLI",
+            "groups": [
+              {
+                "group": "CLI",
+                "icon": "terminal",
+                "pages": [
+                  "es/cli/overview",
+                  "es/cli/sandbox-commands",
+                  "es/cli/volume-commands",
+                  "es/cli/image-commands"
+                ]
+              }
             ]
           },
           {
-            "group": "Python SDK",
-            "icon": "python",
-            "pages": [
-              "sdk/python/sandbox",
-              "sdk/python/execution",
-              "sdk/python/filesystem",
-              "sdk/python/volumes",
-              "sdk/python/networking",
-              "sdk/python/secrets",
-              "sdk/python/snapshots",
-              "sdk/python/events"
+            "tab": "Recetas",
+            "groups": [
+              {
+                "group": "Docker",
+                "icon": "docker",
+                "pages": [
+                  "es/recipes/docker",
+                  "es/recipes/local-images"
+                ]
+              },
+              {
+                "group": "Invitado",
+                "icon": "server",
+                "pages": [
+                  "es/recipes/systemd-services"
+                ]
+              }
             ]
           }
         ]
       },
       {
-        "tab": "CLI Reference",
-        "groups": [
+        "language": "fr",
+        "tabs": [
           {
-            "group": "CLI",
-            "icon": "terminal",
-            "pages": [
-              "cli/overview",
-              "cli/sandbox-commands",
-              "cli/volume-commands",
-              "cli/image-commands"
+            "tab": "Documentation",
+            "groups": [
+              {
+                "group": "Démarrage",
+                "icon": "rocket",
+                "pages": [
+                  "fr/getting-started/introduction",
+                  "fr/getting-started/quickstart",
+                  "fr/getting-started/agents"
+                ]
+              },
+              {
+                "group": "Sandboxes",
+                "icon": "box",
+                "pages": [
+                  "fr/sandboxes/overview",
+                  "fr/sandboxes/lifecycle",
+                  "fr/sandboxes/commands",
+                  "fr/sandboxes/filesystem",
+                  "fr/sandboxes/volumes",
+                  "fr/sandboxes/secrets",
+                  "fr/sandboxes/customize",
+                  "fr/sandboxes/snapshots",
+                  "fr/sandboxes/logs",
+                  "fr/sandboxes/metrics",
+                  "fr/sandboxes/events"
+                ]
+              },
+              {
+                "group": "Réseau",
+                "icon": "network-wired",
+                "pages": [
+                  "fr/networking/overview",
+                  "fr/networking/dns",
+                  "fr/networking/tls",
+                  "fr/networking/security-model"
+                ]
+              },
+              {
+                "group": "Images",
+                "icon": "layer-group",
+                "pages": [
+                  "fr/images/overview",
+                  "fr/images/disk-images"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "icon": "gear",
+                "pages": [
+                  "fr/configuration"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Référence du SDK",
+            "groups": [
+              {
+                "group": "Démarrage",
+                "icon": "flag",
+                "pages": [
+                  "fr/sdk/overview",
+                  "fr/sdk/errors"
+                ]
+              },
+              {
+                "group": "SDK Rust",
+                "icon": "rust",
+                "pages": [
+                  "fr/sdk/rust/sandbox",
+                  "fr/sdk/rust/execution",
+                  "fr/sdk/rust/filesystem",
+                  "fr/sdk/rust/volumes",
+                  "fr/sdk/rust/networking",
+                  "fr/sdk/rust/secrets",
+                  "fr/sdk/rust/snapshots",
+                  "fr/sdk/rust/events"
+                ]
+              },
+              {
+                "group": "SDK TypeScript",
+                "icon": "js",
+                "pages": [
+                  "fr/sdk/typescript/sandbox",
+                  "fr/sdk/typescript/execution",
+                  "fr/sdk/typescript/filesystem",
+                  "fr/sdk/typescript/volumes",
+                  "fr/sdk/typescript/networking",
+                  "fr/sdk/typescript/secrets",
+                  "fr/sdk/typescript/snapshots",
+                  "fr/sdk/typescript/events"
+                ]
+              },
+              {
+                "group": "SDK Python",
+                "icon": "python",
+                "pages": [
+                  "fr/sdk/python/sandbox",
+                  "fr/sdk/python/execution",
+                  "fr/sdk/python/filesystem",
+                  "fr/sdk/python/volumes",
+                  "fr/sdk/python/networking",
+                  "fr/sdk/python/secrets",
+                  "fr/sdk/python/snapshots",
+                  "fr/sdk/python/events"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Référence CLI",
+            "groups": [
+              {
+                "group": "CLI",
+                "icon": "terminal",
+                "pages": [
+                  "fr/cli/overview",
+                  "fr/cli/sandbox-commands",
+                  "fr/cli/volume-commands",
+                  "fr/cli/image-commands"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Recettes",
+            "groups": [
+              {
+                "group": "Docker",
+                "icon": "docker",
+                "pages": [
+                  "fr/recipes/docker",
+                  "fr/recipes/local-images"
+                ]
+              },
+              {
+                "group": "Invité",
+                "icon": "server",
+                "pages": [
+                  "fr/recipes/systemd-services"
+                ]
+              }
             ]
           }
         ]
       },
       {
-        "tab": "Recipes",
-        "groups": [
+        "language": "de",
+        "tabs": [
           {
-            "group": "Docker",
-            "icon": "docker",
-            "pages": [
-              "recipes/docker",
-              "recipes/local-images"
+            "tab": "Dokumentation",
+            "groups": [
+              {
+                "group": "Erste Schritte",
+                "icon": "rocket",
+                "pages": [
+                  "de/getting-started/introduction",
+                  "de/getting-started/quickstart",
+                  "de/getting-started/agents"
+                ]
+              },
+              {
+                "group": "Sandboxes",
+                "icon": "box",
+                "pages": [
+                  "de/sandboxes/overview",
+                  "de/sandboxes/lifecycle",
+                  "de/sandboxes/commands",
+                  "de/sandboxes/filesystem",
+                  "de/sandboxes/volumes",
+                  "de/sandboxes/secrets",
+                  "de/sandboxes/customize",
+                  "de/sandboxes/snapshots",
+                  "de/sandboxes/logs",
+                  "de/sandboxes/metrics",
+                  "de/sandboxes/events"
+                ]
+              },
+              {
+                "group": "Netzwerk",
+                "icon": "network-wired",
+                "pages": [
+                  "de/networking/overview",
+                  "de/networking/dns",
+                  "de/networking/tls",
+                  "de/networking/security-model"
+                ]
+              },
+              {
+                "group": "Images",
+                "icon": "layer-group",
+                "pages": [
+                  "de/images/overview",
+                  "de/images/disk-images"
+                ]
+              },
+              {
+                "group": "Konfiguration",
+                "icon": "gear",
+                "pages": [
+                  "de/configuration"
+                ]
+              }
             ]
           },
           {
-            "group": "Guest",
-            "icon": "server",
-            "pages": [
-              "recipes/systemd-services"
+            "tab": "SDK-Referenz",
+            "groups": [
+              {
+                "group": "Erste Schritte",
+                "icon": "flag",
+                "pages": [
+                  "de/sdk/overview",
+                  "de/sdk/errors"
+                ]
+              },
+              {
+                "group": "Rust-SDK",
+                "icon": "rust",
+                "pages": [
+                  "de/sdk/rust/sandbox",
+                  "de/sdk/rust/execution",
+                  "de/sdk/rust/filesystem",
+                  "de/sdk/rust/volumes",
+                  "de/sdk/rust/networking",
+                  "de/sdk/rust/secrets",
+                  "de/sdk/rust/snapshots",
+                  "de/sdk/rust/events"
+                ]
+              },
+              {
+                "group": "TypeScript-SDK",
+                "icon": "js",
+                "pages": [
+                  "de/sdk/typescript/sandbox",
+                  "de/sdk/typescript/execution",
+                  "de/sdk/typescript/filesystem",
+                  "de/sdk/typescript/volumes",
+                  "de/sdk/typescript/networking",
+                  "de/sdk/typescript/secrets",
+                  "de/sdk/typescript/snapshots",
+                  "de/sdk/typescript/events"
+                ]
+              },
+              {
+                "group": "Python-SDK",
+                "icon": "python",
+                "pages": [
+                  "de/sdk/python/sandbox",
+                  "de/sdk/python/execution",
+                  "de/sdk/python/filesystem",
+                  "de/sdk/python/volumes",
+                  "de/sdk/python/networking",
+                  "de/sdk/python/secrets",
+                  "de/sdk/python/snapshots",
+                  "de/sdk/python/events"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "CLI-Referenz",
+            "groups": [
+              {
+                "group": "CLI",
+                "icon": "terminal",
+                "pages": [
+                  "de/cli/overview",
+                  "de/cli/sandbox-commands",
+                  "de/cli/volume-commands",
+                  "de/cli/image-commands"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Rezepte",
+            "groups": [
+              {
+                "group": "Docker",
+                "icon": "docker",
+                "pages": [
+                  "de/recipes/docker",
+                  "de/recipes/local-images"
+                ]
+              },
+              {
+                "group": "Gast",
+                "icon": "server",
+                "pages": [
+                  "de/recipes/systemd-services"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "language": "ja",
+        "tabs": [
+          {
+            "tab": "ドキュメント",
+            "groups": [
+              {
+                "group": "はじめに",
+                "icon": "rocket",
+                "pages": [
+                  "ja/getting-started/introduction",
+                  "ja/getting-started/quickstart",
+                  "ja/getting-started/agents"
+                ]
+              },
+              {
+                "group": "サンドボックス",
+                "icon": "box",
+                "pages": [
+                  "ja/sandboxes/overview",
+                  "ja/sandboxes/lifecycle",
+                  "ja/sandboxes/commands",
+                  "ja/sandboxes/filesystem",
+                  "ja/sandboxes/volumes",
+                  "ja/sandboxes/secrets",
+                  "ja/sandboxes/customize",
+                  "ja/sandboxes/snapshots",
+                  "ja/sandboxes/logs",
+                  "ja/sandboxes/metrics",
+                  "ja/sandboxes/events"
+                ]
+              },
+              {
+                "group": "ネットワーク",
+                "icon": "network-wired",
+                "pages": [
+                  "ja/networking/overview",
+                  "ja/networking/dns",
+                  "ja/networking/tls",
+                  "ja/networking/security-model"
+                ]
+              },
+              {
+                "group": "イメージ",
+                "icon": "layer-group",
+                "pages": [
+                  "ja/images/overview",
+                  "ja/images/disk-images"
+                ]
+              },
+              {
+                "group": "設定",
+                "icon": "gear",
+                "pages": [
+                  "ja/configuration"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "SDK リファレンス",
+            "groups": [
+              {
+                "group": "はじめに",
+                "icon": "flag",
+                "pages": [
+                  "ja/sdk/overview",
+                  "ja/sdk/errors"
+                ]
+              },
+              {
+                "group": "Rust SDK",
+                "icon": "rust",
+                "pages": [
+                  "ja/sdk/rust/sandbox",
+                  "ja/sdk/rust/execution",
+                  "ja/sdk/rust/filesystem",
+                  "ja/sdk/rust/volumes",
+                  "ja/sdk/rust/networking",
+                  "ja/sdk/rust/secrets",
+                  "ja/sdk/rust/snapshots",
+                  "ja/sdk/rust/events"
+                ]
+              },
+              {
+                "group": "TypeScript SDK",
+                "icon": "js",
+                "pages": [
+                  "ja/sdk/typescript/sandbox",
+                  "ja/sdk/typescript/execution",
+                  "ja/sdk/typescript/filesystem",
+                  "ja/sdk/typescript/volumes",
+                  "ja/sdk/typescript/networking",
+                  "ja/sdk/typescript/secrets",
+                  "ja/sdk/typescript/snapshots",
+                  "ja/sdk/typescript/events"
+                ]
+              },
+              {
+                "group": "Python SDK",
+                "icon": "python",
+                "pages": [
+                  "ja/sdk/python/sandbox",
+                  "ja/sdk/python/execution",
+                  "ja/sdk/python/filesystem",
+                  "ja/sdk/python/volumes",
+                  "ja/sdk/python/networking",
+                  "ja/sdk/python/secrets",
+                  "ja/sdk/python/snapshots",
+                  "ja/sdk/python/events"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "CLI リファレンス",
+            "groups": [
+              {
+                "group": "CLI",
+                "icon": "terminal",
+                "pages": [
+                  "ja/cli/overview",
+                  "ja/cli/sandbox-commands",
+                  "ja/cli/volume-commands",
+                  "ja/cli/image-commands"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "レシピ",
+            "groups": [
+              {
+                "group": "Docker",
+                "icon": "docker",
+                "pages": [
+                  "ja/recipes/docker",
+                  "ja/recipes/local-images"
+                ]
+              },
+              {
+                "group": "ゲスト",
+                "icon": "server",
+                "pages": [
+                  "ja/recipes/systemd-services"
+                ]
+              }
             ]
           }
         ]

--- a/docs/es/cli/image-commands.mdx
+++ b/docs/es/cli/image-commands.mdx
@@ -1,0 +1,112 @@
+---
+title: Image Commands
+description: Pull and manage OCI images from the CLI
+icon: "layer-group"
+---
+
+## msb pull
+
+Pre-pull an image to the local cache. Layers are fetched in parallel with per-layer progress bars. Once cached, layers are content-addressable and deduplicated, so shared layers across images are only stored once.
+
+```bash
+msb pull python
+msb pull alpine
+msb pull ghcr.io/my-org/my-image:v1
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Force re-download even if cached |
+| `-q`, `--quiet` | Suppress progress output |
+| `--insecure` | Connect over plain HTTP instead of HTTPS |
+| `--ca-certs <PATH>` | Path to a PEM file with additional CA root certificates |
+
+<Tip>
+  Pre-pulling is useful when you want sandbox creation to be instant. Without a pre-pull, the first `Sandbox.create` with a new image will block on the download.
+</Tip>
+
+## msb image ls
+
+List images in the local cache.
+
+```bash
+msb image ls
+msb image ls --format json
+msb image ls -q               # References only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only image references |
+
+<Tip>
+  `msb images` is a shorthand alias for `msb image ls`.
+</Tip>
+
+## msb image inspect
+
+Show detailed metadata for a cached image (manifest, layers, config).
+
+```bash
+msb image inspect python
+msb image inspect python --format json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb image rm
+
+Remove one or more cached images and their layers (layers shared with other images are kept).
+
+```bash
+msb image rm python
+msb image rm alpine ubuntu   # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Remove even if the image is used by existing sandboxes |
+| `-q`, `--quiet` | Suppress output |
+
+<Tip>
+  `msb rmi` is a shorthand alias for `msb image rm`.
+</Tip>
+
+## msb registry
+
+Manage registry authentication.
+
+```bash
+msb registry login ghcr.io --username octocat
+printf '%s\n' "$GHCR_TOKEN" | msb registry login ghcr.io --username octocat --password-stdin
+msb registry logout ghcr.io
+msb registry ls
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `login` | Store credentials for a registry in the OS credential store |
+| `logout` | Remove stored credentials for a registry |
+| `list` (alias: `ls`) | List configured registries without printing secrets |
+
+**`msb registry login` flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--username` | Registry username |
+| `--password-stdin` | Read password from stdin |
+
+`msb registry login` stores the secret in the OS credential store (for example Keychain, Credential Manager, or Secret Service) and writes only metadata to `~/.microsandbox/config.json`.
+
+For CI or other headless environments, configure `registries.auth` in `~/.microsandbox/config.json` with `password_env`. Advanced host setups can also use `secret_name` to point at a file-backed secret under `~/.microsandbox/secrets/registries/`.
+
+When pulling from a registry, microsandbox resolves auth in this order:
+
+1. Explicit SDK auth (`.registry_auth(...)`)
+2. OS credential store
+3. `registries.auth` config
+4. Docker credential store/config
+5. Anonymous

--- a/docs/es/cli/overview.mdx
+++ b/docs/es/cli/overview.mdx
@@ -1,0 +1,97 @@
+---
+title: CLI Overview
+description: Manage sandboxes from the terminal
+icon: "book"
+---
+
+The `msb` CLI lets you create, manage, and interact with sandboxes from the terminal. It auto-detects TTY and interactivity, so no `-it` flags are needed. If your terminal is interactive, `msb` acts accordingly.
+
+## Install
+
+```bash
+curl -fsSL https://install.microsandbox.dev | sh
+```
+
+<Note>
+  microsandbox requires Linux with KVM enabled, or macOS with Apple Silicon (M-series chip). Both use hardware virtualization.
+</Note>
+
+## Quick reference
+
+```bash
+# Run a one-off command (ephemeral, auto-removed)
+msb run python -- python -c "print('Hello!')"
+
+# Interactive shell (auto-detects TTY)
+msb run alpine -- sh
+
+# Create a persistent sandbox
+msb run --name devbox ubuntu -- bash
+
+# Resume later
+msb start devbox
+
+# Execute in a running sandbox
+msb exec devbox -- sh -c "apt update && apt install -y cowsay && /usr/games/cowsay \"Hello from devbox\""
+
+# Manage
+msb ls                   # List all sandboxes
+msb ps                   # Running sandboxes only
+msb metrics              # Live CPU/memory/network stats
+msb inspect devbox       # Detailed info
+msb logs devbox          # Captured stdout/stderr (works on stopped sandboxes too)
+msb logs devbox -f       # Follow live
+msb stop devbox          # Graceful shutdown
+msb rm devbox            # Remove stopped sandbox
+
+# Images
+msb pull python     # Pre-pull to cache
+msb image ls             # List cached images
+msb image rm python # Remove a cached image
+
+# Volumes
+msb volume create data --size 10G
+msb volume ls
+msb volume rm data
+
+# Install as a system command
+msb install ubuntu       # Install as 'ubuntu' command
+msb uninstall ubuntu     # Remove installed command
+
+# Self-management
+msb self update          # Update msb to latest
+msb self uninstall       # Remove msb
+```
+
+<Tip>
+  Unnamed sandboxes (no `--name` flag) are ephemeral. They're automatically removed when the command finishes. Named sandboxes persist and can be stopped, restarted, and inspected later.
+</Tip>
+
+## Global options
+
+| Flag | Description |
+|------|-------------|
+| `--tree` | Display the complete command tree with descriptions |
+| `--error` | Show only errors |
+| `--warn` | Show warnings and errors |
+| `--info` | Show info, warnings, and errors |
+| `--debug` | Show debug output |
+| `--trace` | Show all output including trace |
+
+## Command tree
+
+Use `--tree` as an alternative to `--help` to see every command, subcommand, and flag at once:
+
+```bash
+msb --tree
+```
+
+You can scope it to a specific subcommand:
+
+```bash
+msb image --tree    # Show only image commands
+msb volume --tree   # Show only volume commands
+msb run --tree      # Show all flags for run
+```
+
+For detailed command reference, see [Sandbox Commands](/cli/sandbox-commands), [Volume Commands](/cli/volume-commands), and [Image Commands](/cli/image-commands).

--- a/docs/es/cli/sandbox-commands.mdx
+++ b/docs/es/cli/sandbox-commands.mdx
@@ -1,0 +1,328 @@
+---
+title: Sandbox Commands
+description: Create, run, and interact with sandboxes from the CLI
+icon: "cube"
+---
+
+## msb run
+
+Create a sandbox and optionally run a command. Without `--name`, the sandbox is ephemeral and removed when the command finishes. With `--name`, it persists for later use.
+
+```bash
+# Ephemeral: runs and cleans up
+msb run python -- python -c "print('hello')"
+
+# Named: persists after exit
+msb run --name devbox ubuntu -- bash
+
+# With volumes, ports, and environment
+msb run --name api \
+  -v ./src:/app \
+  -v pydata:/data \
+  -p 8000:8000 \
+  -e DEBUG=true \
+  -w /app \
+  python
+
+# Detached (runs in background)
+msb run -d --name worker python -- python worker.py
+```
+
+| Flag | Description |
+|------|-------------|
+| `-n`, `--name` | Sandbox name (if omitted, sandbox is ephemeral) |
+| `-c`, `--cpus` | Number of virtual CPUs to allocate |
+| `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
+| `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST`) |
+| `-p`, `--port` | Forward a host port to the sandbox (`HOST:GUEST` or `HOST:GUEST/udp`) |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-w`, `--workdir` | Working directory inside the sandbox |
+| `--shell` | Default shell for interactive sessions |
+| `-t`, `--tty` | Allocate a pseudo-terminal (enables colors, line editing) |
+| `-d`, `--detach` | Run in background and print the sandbox name |
+| `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`). Per-command; the sandbox stays alive |
+| `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`, `as=1073741824`) |
+| `--detach-keys` | Key sequence to detach from interactive session (default: `ctrl-]`) |
+| `--replace` | Replace an existing sandbox with the same name |
+| `-q`, `--quiet` | Suppress progress output |
+| `--entrypoint` | Override the image's default entrypoint command |
+| `--init` | Hand off PID 1 to this init binary (absolute path) inside the guest after agentd's setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| `--init-arg` | Argv entry appended to the handoff init. Repeatable. Defaults to `[<--init>]` when empty |
+| `--init-env` | Env var passed to the handoff init only (`KEY=VALUE`). Repeatable; merged on top of the inherited env |
+| `-H`, `--hostname` | Set the guest hostname (defaults to sandbox name) |
+| `-u`, `--user` | Run commands as the specified user (e.g. `nobody`, `1000`, `1000:1000`) |
+| `--pull` | When to pull the image: `always`, `if-missing` (default), `never` |
+| `--log-level` | Log verbosity for the sandbox runtime (`error`, `warn`, `info`, `debug`, `trace`) |
+| `--tmpfs` | Mount a temporary in-memory filesystem (`PATH` or `PATH:SIZE`) |
+| `--script` | Register an inline script (`NAME=BODY`). Available at `/.msb/scripts/<name>` and on `PATH` |
+| `--script-path` | Register a script from a host file (`NAME:PATH`). Same destination as `--script` |
+| `--max-duration` | Kill the entire sandbox after this duration (e.g. `30s`, `5m`, `1h`). Sandbox-level lifetime limit |
+| `--idle-timeout` | Stop the sandbox after this period of inactivity (e.g. `30s`, `5m`, `1h`) |
+| `--no-network` | Disable all network access |
+| `--network-policy` | Control which destinations are reachable from the sandbox. Accepted values: `none` (no network), `public-only` (default — public internet only), `nonlocal` (public + private/LAN; blocks loopback, link-local, and metadata), `allow-all` (unrestricted) |
+| `--deny-domain` | Deny egress to a domain. Repeatable. Adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback) |
+| `--deny-domain-suffix` | Deny egress to all subdomains of a suffix (e.g. `.ads.com`). Repeatable. Adds a `deny DomainSuffix("...")` policy rule |
+| `--no-dns-rebind-protection` | Allow DNS responses pointing to private/internal IP addresses |
+| `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
+| `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |
+| `--max-connections` | Limit the number of concurrent network connections |
+| `--trust-host-cas` | Ship the host's trusted root CAs into the guest so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, etc.) whose gateway CA is installed on the host but unknown to the guest's stock bundle. Opt-in; by default the guest validates against its stock Mozilla bundle only |
+| `--secret` | Inject a secret that is only sent to an allowed host (`ENV=VALUE@HOST`) |
+| `--on-secret-violation` | Action when a secret is sent to a disallowed host (`block`, `block-and-log`, `block-and-terminate`) |
+| `--tls-intercept` | Intercept and inspect HTTPS traffic via a built-in TLS proxy |
+| `--tls-intercept-port` | TCP port to apply TLS interception on (default: 443) |
+| `--tls-bypass` | Skip TLS interception for a domain (e.g. `*.internal.com`) |
+| `--no-block-quic` | Allow QUIC/HTTP3 traffic (blocked by default when TLS interception is on) |
+| `--tls-intercept-ca-cert` | Use a custom CA certificate for TLS interception (PEM file) |
+| `--tls-intercept-ca-key` | Use a custom CA private key for TLS interception (PEM file) |
+| `--tls-upstream-ca-cert` | Trust an additional CA certificate for upstream server verification (PEM file). Can be specified multiple times |
+
+When no `--` command is given, the image's `entrypoint` and `cmd` are used as the default process. If the image has neither, an interactive shell is started. When a command is given via `--`, it replaces the image `cmd` but the `entrypoint` is preserved. See [Image config inheritance](/images/overview#image-config-inheritance) for details.
+
+## msb create
+
+Create and boot a sandbox without running a command. Takes the same flags as `msb run` (except `--detach`).
+
+```bash
+msb create python --name worker -c 2 -m 1G
+msb create --replace python --name worker   # Replace existing
+```
+
+## msb start
+
+Resume a stopped sandbox.
+
+```bash
+msb start devbox
+```
+
+| Flag | Description |
+|------|-------------|
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb stop
+
+```bash
+msb stop devbox                # Graceful shutdown
+msb stop --force devbox        # Force kill immediately
+msb stop -t 10 devbox          # Wait 10s then force kill
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Immediately kill the sandbox without graceful shutdown |
+| `-t`, `--timeout` | Seconds to wait for graceful shutdown before force-killing |
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb exec
+
+Execute a command inside a running sandbox.
+
+```bash
+msb exec devbox -- python -c "print('hello')"
+msb exec devbox -- ls -la /app
+```
+
+| Flag | Description |
+|------|-------------|
+| `-t`, `--tty` | Allocate a pseudo-terminal (enables colors, line editing) |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-w`, `--workdir` | Override working directory |
+| `-u`, `--user` | Run the command as the specified guest user |
+| `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`) |
+| `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`) |
+| `-q`, `--quiet` | Suppress progress output |
+
+<Tip>
+  The CLI auto-detects whether stdin is a terminal. When interactive, `msb exec` uses `attach` mode (TTY, line editing). When piped, it captures output. No `-i` flag is needed.
+</Tip>
+
+## msb logs
+
+Read captured output from a sandbox. Each sandbox stores its captured stdio under `<sandbox-dir>/logs/exec.log` as JSON Lines, plus runtime/kernel diagnostics in `runtime.log`/`kernel.log`. The command works on running and stopped sandboxes alike — there is no protocol traffic, just a file read.
+
+```bash
+# Captured user-program output (default sources: stdout + stderr + output)
+msb logs devbox
+
+# Tail and follow
+msb logs devbox --tail 100
+msb logs devbox -f --grep ERROR
+
+# Time-bounded
+msb logs devbox --since 5m
+msb logs devbox --since 2026-04-30T20:00:00Z --until 5m
+
+# JSON Lines passthrough — feed to jq, vector, etc.
+msb logs devbox --json | jq 'select(.s == "stderr")'
+
+# Multi-session view: prefix each line with [id:N] so you can tell sessions apart
+msb logs devbox --show-id
+
+# Color each session's output a distinct color (implies --show-id)
+msb logs devbox --color-sessions
+
+# Include runtime/kernel diagnostics
+msb logs devbox --source system
+msb logs devbox --source all                # everything, chronologically merged
+```
+
+| Flag | Description |
+|------|-------------|
+| `--tail` | Show only the last N entries |
+| `--since` | Show entries at or after this time (RFC 3339 or relative `5m`/`2h`/`1d`) |
+| `--until` | Show entries strictly before this time (same formats) |
+| `-f`, `--follow` | Follow in real time (200 ms polling, rotation-aware) |
+| `--timestamps` | Prefix each line with the entry timestamp |
+| `--source` | Sources to include: `stdout`, `stderr`, `output`, `system`, `all`. Repeat or comma-separate. Default: `stdout,stderr,output` |
+| `--grep` | Client-side regex filter on the entry body |
+| `--json` | Emit raw JSON Lines without decoding (one entry per line) |
+| `--raw` | Opt into base64 encoding for non-UTF-8 bytes |
+| `--show-id` | Prefix each line with `[id:N]` (the session correlation id) |
+| `--color-sessions` | Color each session's lines a distinct color (implies `--show-id`) |
+| `--color` | ANSI handling: `auto` (default), `always`, `never` |
+| `--no-color` | Alias for `--color=never` |
+
+**Source tags** (the `s` field in `--json` output):
+
+- `stdout` / `stderr` — captured from the session's pipes when running in **pipe mode** (streams stay separated end to end).
+- `output` — captured from the session in **pty mode**. pty allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `output` rather than mislabelled as `stdout`.
+- `system` — synthetic lifecycle markers (`--- sandbox started ---` / `--- sandbox stopped ---`) plus diagnostic lines from `runtime.log`/`kernel.log` when `--source system` is requested.
+
+<Tip>
+  If a sandbox failed to start, `msb logs` prepends a styled error block reconstructed from `boot-error.json`. The block tells you the failure stage, errno, and a hint — even though no user-program output was ever captured.
+</Tip>
+
+## msb ls
+
+List all stored sandboxes.
+
+```bash
+msb ls                    # All sandboxes (running and stopped)
+msb ls --running          # Running sandboxes only
+msb ls --stopped          # Stopped sandboxes only
+msb ls --format json      # JSON output
+msb ls -q                 # Names only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--running` | Show only running sandboxes |
+| `--stopped` | Show only stopped sandboxes |
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only sandbox names |
+
+## msb status / ps
+
+Show sandbox status with process details.
+
+```bash
+msb ps                    # Running sandboxes
+msb ps my-app             # Single sandbox
+msb ps -a                 # All sandboxes (including stopped)
+msb ps --format json      # JSON output
+```
+
+| Flag | Description |
+|------|-------------|
+| `-a`, `--all` | Show all sandboxes, not just running ones |
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only sandbox names |
+
+## msb metrics
+
+Show live CPU, memory, disk, and network metrics for running sandboxes.
+
+```bash
+msb metrics               # All running sandboxes
+msb metrics my-app        # Single sandbox
+msb metrics --format json # JSON output
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb inspect
+
+Show detailed configuration and status.
+
+```bash
+msb inspect devbox
+msb inspect devbox --format json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb rm
+
+Remove one or more sandboxes and their associated state.
+
+```bash
+msb rm devbox
+msb rm --force devbox     # Stop and remove in one step
+msb rm worker-1 worker-2  # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Stop the sandbox if running, then remove it |
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb install
+
+Install a sandbox as a system command. Creates an executable in `~/.microsandbox/bin/` that launches `msb run` with the specified image and options.
+
+```bash
+msb install ubuntu                   # Install as 'ubuntu' command
+msb install --name nodebox node      # Custom command name
+msb install --tmp alpine             # Fresh sandbox every invocation
+msb install -c 2 -m 1G python  # With resource limits
+msb install --list                   # List installed commands
+```
+
+| Flag | Description |
+|------|-------------|
+| `-n`, `--name` | Command name for the alias (defaults to image name) |
+| `-c`, `--cpus` | Number of virtual CPUs to allocate |
+| `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
+| `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST`) |
+| `-w`, `--workdir` | Working directory inside the sandbox |
+| `--shell` | Shell for interactive sessions |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-f`, `--force` | Overwrite an existing alias with the same name |
+| `--no-pull` | Don't pull the image before installing |
+| `--tmp` | Create a fresh sandbox on every invocation (no persistent state) |
+| `-l`, `--list` | List all installed sandbox commands |
+
+## msb uninstall
+
+Remove an installed sandbox command.
+
+```bash
+msb uninstall nodebox
+msb uninstall ubuntu alpine   # Remove multiple
+```
+
+## msb self
+
+Manage the msb installation itself.
+
+```bash
+msb self update               # Update msb and libkrunfw to latest
+msb self update --force       # Re-download even if up to date
+msb self uninstall            # Remove msb (with confirmation prompt)
+msb self uninstall --yes      # Skip confirmation
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `update` (alias: `upgrade`) | Update msb and libkrunfw to the latest release |
+| `uninstall` | Remove msb, libkrunfw, and shell configuration |
+
+| Flag | Subcommand | Description |
+|------|------------|-------------|
+| `-f`, `--force` | `update` | Re-download even if already on the latest version |
+| `-y`, `--yes` | `uninstall` | Skip confirmation prompt |

--- a/docs/es/cli/volume-commands.mdx
+++ b/docs/es/cli/volume-commands.mdx
@@ -1,0 +1,67 @@
+---
+title: Volume Commands
+description: Create and manage named volumes from the CLI
+icon: "hard-drive"
+---
+
+Named volumes persist independently of sandboxes and are stored at `~/.microsandbox/volumes/`.
+
+## msb volume create
+
+```bash
+msb volume create my-data
+msb volume create my-data --size 10G
+```
+
+| Flag | Description |
+|------|-------------|
+| `--size` | Storage quota (e.g. `100M`, `1G`, `10G`) |
+| `-q`, `--quiet` | Suppress output (only print the volume name) |
+
+## msb volume ls
+
+```bash
+msb volume ls
+msb volume ls --format json
+msb volume ls -q               # Names only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only volume names |
+
+## msb volume inspect
+
+```bash
+msb volume inspect my-data
+```
+
+## msb volume rm
+
+```bash
+msb volume rm my-data
+msb volume rm cache-1 cache-2   # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-q`, `--quiet` | Suppress output |
+
+## Using volumes with sandboxes
+
+Mount a named volume when creating or running a sandbox. The volume name goes before the colon, the guest path after.
+
+```bash
+# Create a volume, then mount it
+msb volume create app-data --size 5G
+msb run --name worker -v app-data:/data python
+
+# Share between sandboxes
+msb run --name writer -v shared:/data alpine -- sh -c "echo hello > /data/msg.txt"
+msb run --name reader -v shared:/data alpine -- cat /data/msg.txt
+```
+
+<Tip>
+  The CLI distinguishes bind mounts from named volumes by looking for a `/` or `.` prefix. `./src:/app` is a bind mount (host path). `myvolume:/data` is a named volume. This matches Docker's convention.
+</Tip>

--- a/docs/es/configuration.mdx
+++ b/docs/es/configuration.mdx
@@ -1,0 +1,140 @@
+---
+title: config.json
+description: Global config.json reference
+icon: "gear"
+---
+
+microsandbox reads its global configuration from `~/.microsandbox/config.json`. All fields are optional. A missing file or empty JSON object is equivalent to using the defaults.
+
+<Accordion title="Full example">
+```json
+{
+  "home": "/custom/path/.microsandbox",
+  "log_level": "info",
+  "database": {
+    "url": "sqlite:///tmp/msb.db",
+    "max_connections": 10,
+    "connect_timeout_secs": 30
+  },
+  "paths": {
+    "msb": "/usr/local/bin/msb",
+    "libkrunfw": "/usr/local/lib/libkrunfw.so",
+    "cache": "/mnt/fast/msb-cache",
+    "sandboxes": null,
+    "volumes": null,
+    "logs": null,
+    "secrets": null
+  },
+  "sandbox_defaults": {
+    "cpus": 2,
+    "memory_mib": 1024,
+    "shell": "/bin/bash",
+    "workdir": "/app"
+  },
+  "registries": {
+    "auth": {
+      "ghcr.io": {
+        "username": "octocat",
+        "store": "keyring"
+      },
+      "registry.example.com": {
+        "username": "deploy",
+        "password_env": "REGISTRY_TOKEN"
+      },
+      "docker.io": {
+        "username": "user",
+        "secret_name": "dockerhub-token"
+      }
+    }
+  }
+}
+```
+</Accordion>
+
+## Top-level fields
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `home` | `~/.microsandbox` | Root directory for all microsandbox data |
+| `log_level` | `null` (silent) | Log level for sandbox processes: `error`, `warn`, `info`, `debug`, `trace` |
+| `database` | [reference](#database) | Database connection settings |
+| `paths` | [reference](#paths) | Path overrides for binaries and directories |
+| `sandbox_defaults` | [reference](#sandbox_defaults) | Defaults applied to every sandbox |
+| `registries` | [reference](#registries) | Container registry authentication |
+
+## `database`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `url` | `null` | Database URL. Uses SQLite under `home` when null |
+| `max_connections` | `5` | Maximum connection pool size |
+| `connect_timeout_secs` | `30` | Timeout when acquiring a database connection from the pool |
+
+## `paths`
+
+All path fields are optional. When `null`, they resolve relative to `home`.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `msb` | `{home}/bin/msb` | `msb` binary. Resolved via: `MSB_PATH` env, this field, default path, `PATH` |
+| `libkrunfw` | `{home}/lib/libkrunfw` | Path to a custom VM kernel (`.so` on Linux, `.dylib` on macOS) |
+| `cache` | `{home}/cache` | Image layer cache |
+| `sandboxes` | `{home}/sandboxes` | Per-sandbox state |
+| `volumes` | `{home}/volumes` | Named volumes |
+| `logs` | `{home}/logs` | Sandbox logs |
+| `secrets` | `{home}/secrets` | Secrets. Registry secrets live under `secrets/registries/` |
+
+## `sandbox_defaults`
+
+Defaults applied to every sandbox unless overridden per-sandbox.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `cpus` | `1` | Number of vCPUs |
+| `memory_mib` | `512` | Guest memory in MiB |
+| `shell` | `"/bin/sh"` | Shell for interactive sessions and scripts |
+| `workdir` | `null` | Working directory inside the sandbox |
+| `metrics_sample_interval_ms` | `1000` | Runtime metrics sampling interval in milliseconds. Set to `0` to disable sampling. |
+| `disable_metrics_sample` | `false` | Force-disable metrics sampling regardless of `metrics_sample_interval_ms`. |
+
+## `registries`
+
+### `registries.auth`
+
+A map of registry hostnames to authentication entries. Each entry specifies a username and exactly **one** credential source.
+
+```json
+{
+  "registries": {
+    "auth": {
+      "ghcr.io": {
+        "username": "octocat",
+        "store": "keyring"
+      }
+    }
+  }
+}
+```
+
+#### Auth entry fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `username` | Yes | Registry username |
+| `store` | No | Credential store. Only `"keyring"` is supported (macOS Keychain, Windows Credential Manager, Linux Secret Service) |
+| `password_env` | No | Environment variable containing the password or token |
+| `secret_name` | No | Filename under `{home}/secrets/registries/` containing the password or token |
+
+<Note>
+  Exactly one of `store`, `password_env`, or `secret_name` must be set per entry. Setting none or more than one is an error.
+</Note>
+
+### Auth resolution order
+
+When pulling from a registry, credentials are resolved in this order:
+
+1. **Explicit SDK auth** via `.registry_auth()` on the sandbox builder
+2. **OS keyring** entries created by `msb registry login`
+3. **Config file** `registries.auth` entries in `config.json`
+4. **Docker config** `~/.docker/config.json` credential helpers
+5. **Anonymous** (no authentication)

--- a/docs/es/getting-started/agents.mdx
+++ b/docs/es/getting-started/agents.mdx
@@ -1,0 +1,108 @@
+---
+title: AI Agents
+description: Give AI agents the ability to create and manage their own sandboxes
+icon: "robot"
+---
+
+microsandbox is built for AI agents. The SDK and CLI give you full programmatic control, but there are two additional ways to connect agents directly: **Agent Skills** for coding assistants and an **MCP server** for any MCP-compatible client.
+
+## Agent Skills
+
+[Agent Skills](https://github.com/superradcompany/skills) teach AI coding agents how to use microsandbox without any custom integration code. Once installed, the agent can create sandboxes, run commands, manage files, and control the full sandbox lifecycle through natural language.
+
+Works with Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, and other agents that support the skills format.
+
+```bash
+npx skills add superradcompany/skills
+```
+
+This installs a set of skill files into your project that the agent reads as context. No server process, no configuration, just files that describe how to use microsandbox.
+
+## MCP Server
+
+The [microsandbox MCP server](https://github.com/superradcompany/microsandbox-mcp) exposes microsandbox as a set of structured tool calls over the [Model Context Protocol](https://modelcontextprotocol.io). Any MCP-compatible client can use it to manage sandbox lifecycle, execute commands, access the filesystem, work with volumes, and monitor sandbox state.
+
+<CodeGroup>
+
+```bash Claude Code
+claude mcp add --transport stdio microsandbox -- npx -y microsandbox-mcp
+```
+
+```json Cursor
+// ~/.cursor/mcp.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json VS Code
+// .vscode/mcp.json
+{
+  "servers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Claude Desktop
+// ~/Library/Application Support/Claude/claude_desktop_config.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Windsurf
+// ~/.codeium/windsurf/mcp_config.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Open Code
+// .opencode.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Zed
+// Zed settings
+{
+  "context_servers": {
+    "microsandbox": {
+      "command": {
+        "path": "npx",
+        "args": ["-y", "microsandbox-mcp"]
+      }
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+Once connected, the agent gets access to tools for creating sandboxes, running commands inside them, reading and writing files, and managing the sandbox lifecycle, all through the MCP protocol.

--- a/docs/es/getting-started/introduction.mdx
+++ b/docs/es/getting-started/introduction.mdx
@@ -1,0 +1,370 @@
+---
+title: "Introduction"
+description: "Every agent deserves its own computer"
+icon: "house"
+---
+
+AI agents run with whatever privileges you give them, and most of the time that's too many. They can see API keys sitting in the environment, reach the network freely (including cloud metadata at `169.254.169.254`), and nothing stops a prompt injection from running `rm -rf /` on the host filesystem. Containers help with some of this, but they share the host kernel, and namespace escapes are a well-documented class of vulnerability.
+
+microsandbox takes a different approach: every sandbox is a real VM with its own Linux kernel. It provides security primitives for preventing exploits like secret exfiltration. And it **runs locally** on your machine.
+
+<CodeGroup>
+
+```rust Rust
+use microsandbox::{Sandbox, NetworkPolicy};
+
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .secret(|s| s
+        .env("OPENAI_API_KEY")
+        .value(std::env::var("OPENAI_API_KEY")?)
+        .allow_host("api.openai.com")
+    )
+    .network(|n| n.policy(NetworkPolicy::public_only()))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { NetworkPolicy, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .secret((s) =>
+        s.env("OPENAI_API_KEY")
+            .value(process.env.OPENAI_API_KEY!)
+            .allowHost("api.openai.com"),
+    )
+    .network((n) => n.policy(NetworkPolicy.publicOnly()))
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import Network, Sandbox, Secret
+
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    memory=512,
+    cpus=2,
+    secrets=[
+        Secret.env("OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+    network=Network.public_only(),
+)
+```
+
+</CodeGroup>
+
+<Callout icon="bolt" color="#7C3AED">
+  microsandbox spins up lightweight VMs in **under a second**, right from your code on your machine. **No servers, no daemons**, no infrastructure to manage.
+</Callout>
+
+## The basics
+
+- **Under 100ms boot.** Sandboxes boot in under 100 milliseconds.
+- **No daemon.** The runtime spawns directly as a child process of whatever application creates the sandbox. No root, no server, no background service.
+- **Any OCI image.** Docker Hub, GHCR, ECR, GCR, or any OCI-compatible registry. Shared layers are deduplicated and only stored once.
+- **Cross-platform.** Native on macOS (Apple Silicon) and Linux (KVM). Same CLI, same SDKs.
+- **Multi-language SDKs.** Rust, TypeScript, and Python, all with consistent APIs.
+- **Programmable.** Network policies, filesystem hooks, secret bindings, and TLS interception are all configured from the host side through the SDK.
+
+## What makes it different
+
+### Secrets that can't leak
+
+Most sandboxes protect secrets by restricting what the guest can do. microsandbox goes further: **the guest never has the secret at all**.
+
+Instead of injecting real credentials into the sandbox, microsandbox generates random placeholders. The actual value never enters the VM. The only way it reaches the outside world is when a request goes to an allowed host, at which point microsandbox swaps the placeholder for the real value. Everywhere else, the placeholder is just a meaningless string.
+
+So even with full code execution inside the sandbox, there's nothing to exfiltrate. The credential was never there. DNS rebinding protection and cloud metadata blocking kick in automatically when secrets are configured, closing the remaining side channels.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .secret_env("OPENAI_API_KEY", api_key, "api.openai.com")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    secrets=[
+        Secret.env("OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+)
+```
+
+</CodeGroup>
+
+### Programmable network layer <sup><sup>coming soon</sup></sup>
+
+Every packet leaving a sandbox passes through a networking stack controlled entirely from the host side, where policy is enforced at the IP, DNS, or HTTP level. From inside the sandbox it looks like a normal network interface, but on the host side you decide what gets through.
+
+There's no underlying host network to bridge to, no rules to circumvent, and no way for the guest to reach around the filter.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .network(|n| n
+        .policy(NetworkPolicy::allowlist(["api.openai.com", "pypi.org"]))
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Destination, NetworkPolicy, Rule, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .network((n) => n.policy({
+        defaultEgress: "deny",
+        defaultIngress: "allow",
+        rules: [
+            Rule.allowEgress(Destination.domain("api.openai.com")),
+            Rule.allowEgress(Destination.domain("pypi.org")),
+        ],
+    }))
+    .create();
+```
+
+```python Python
+from microsandbox import Network, NetworkPolicy, Rule, Sandbox
+
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    network=Network(
+        policy=NetworkPolicy(rules=(
+            Rule.allow(destination="api.openai.com"),
+            Rule.allow(destination="pypi.org"),
+        )),
+    ),
+)
+```
+
+</CodeGroup>
+
+### Extensible filesystem backends <sup><sup>coming soon</sup></sup>
+
+The host controls what the guest sees at the filesystem level. Mount host directories, use managed volumes, or attach custom filesystem backends entirely. Hooks let you intercept reads and writes to do things like encrypt everything going to disk or proxy to remote storage, and the guest never knows the difference.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("encrypted")
+    .image("python")
+    .volume("/secrets", |v| v
+        .bind("/data/secrets")
+        .on_read(move |_path, data| decrypt(data, &key))
+        .on_write(move |_path, data| encrypt(data, &key))
+    )
+    .create().await?;
+```
+
+```typescript TypeScript
+// Filesystem hooks (onRead / onWrite) are coming soon for Node. For now,
+// you can mount the host directory directly:
+await using sb = await Sandbox.builder("encrypted")
+    .image("python")
+    .volume("/secrets", (m) => m.bind("/data/secrets"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+key = get_encryption_key()
+sb = await Sandbox.create(
+    "encrypted",
+    image="python",
+    volumes={
+        "/secrets": Volume.bind("/data/secrets",
+            on_read=lambda path, data: decrypt(data, key),
+            on_write=lambda path, data: encrypt(data, key),
+        ),
+    },
+)
+```
+
+</CodeGroup>
+
+### Snapshot and reuse setup state
+
+Capture a stopped sandbox's writable upper layer as a portable artifact, then boot fresh sandboxes from it. Install dependencies once, snapshot, and `msb run --snapshot ...` workers that skip the setup phase. The artifact is a directory you can `scp` between machines or bundle into a `.tar.zst`. Snapshots today are disk-only and stopped-only; live VM-state snapshots are tracked as future work.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("baseline")
+    .image("python")
+    .create()
+    .await?;
+
+sb.exec("pip", ["install", "-r", "requirements.txt"]).await?;
+sb.stop_and_wait().await?;
+
+// Snapshot the stopped sandbox under a bare name
+let h = Sandbox::get("baseline").await?;
+let _snap = h.snapshot("after-pip-install").await?;
+
+// Boot 10 workers from the same snapshot (each gets its own upper layer)
+let workers: Vec<Sandbox> = futures::future::try_join_all(
+    (0..10).map(|i| async move {
+        Sandbox::builder(format!("worker-{i}"))
+            .from_snapshot("after-pip-install")
+            .create()
+            .await
+    })
+).await?;
+```
+
+```bash CLI
+msb run --name baseline --detach python -- sleep 3600
+msb exec baseline -- pip install -r requirements.txt
+msb stop baseline
+
+msb snapshot create after-pip-install --from baseline
+
+# Boot 10 workers from the snapshot
+for i in $(seq 1 10); do
+    msb run --name worker-$i --detach --snapshot after-pip-install -- sleep 3600
+done
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.builder("baseline").image("python").create();
+await sb.exec("pip", ["install", "-r", "requirements.txt"]);
+await sb.stopAndWait();
+
+const h = await Sandbox.get("baseline");
+await h.snapshot("after-pip-install");
+
+// Boot 10 workers from the same snapshot
+const workers = await Promise.all(
+    Array.from({ length: 10 }, (_, i) =>
+        Sandbox.builder(`worker-${i}`).fromSnapshot("after-pip-install").create(),
+    ),
+);
+```
+
+```python Python
+import asyncio
+from microsandbox import Sandbox
+
+sb = await Sandbox.create("baseline", image="python")
+await sb.exec("pip", ["install", "-r", "requirements.txt"])
+await sb.stop_and_wait()
+
+h = await Sandbox.get("baseline")
+await h.snapshot("after-pip-install")
+
+# Boot 10 workers from the same snapshot
+workers = await asyncio.gather(
+    *(Sandbox.create(f"worker-{i}", snapshot="after-pip-install") for i in range(10))
+)
+```
+
+</CodeGroup>
+
+### Spawn sandboxes from sandboxes <sup><sup>coming soon</sup></sup>
+
+Code running inside a sandbox can spawn peer sandboxes alongside itself. This is designed for multi-agent systems where agents need to create sub-environments. Peer sandboxes inherit nothing by default (their own network, filesystem, secrets), and the orchestrator coordinates via the SDK, not shared state. If the code isn't running inside a microsandbox, the spawn call fails safely.
+
+### Composable plugin system <sup><sup>coming soon</sup></sup>
+
+Extend microsandbox with in-process Rust plugins or out-of-process plugins in any language. Plugins hook into lifecycle events, exec calls, filesystem operations, or network traffic. They compose naturally, so you can stack an audit logger, a rate limiter, and a network monitor without them knowing about each other.
+
+### Bidirectional events <sup><sup>coming soon</sup></sup>
+
+Guest processes can emit typed events to the host, and the host can send events back. No special libraries required in the guest since any language can write JSON to a socket. This enables structured communication beyond stdin/stdout, like progress reporting, task completion signals, or custom RPC.
+
+<CodeGroup>
+
+```rust Rust
+// Receive events from guest
+let _sub = sb.on_event("task.progress", |event: EventData| {
+    if let Ok(p) = event.data.unwrap().deserialized::<Progress>() {
+        println!("[{}%] {}", p.percent, p.message);
+    }
+});
+
+// Send events to guest
+sb.emit("task.start", TaskConfig {
+    input_file: "/data/input.txt".into(),
+    output_dir: "/data/output".into(),
+}).await?;
+```
+
+```typescript TypeScript
+// Receive events from guest
+const sub = sb.onEvent("task.progress", (event: EventData) => {
+    const { percent, message } = event.data as { percent: number; message: string }
+    console.log(`[${percent}%] ${message}`)
+})
+
+// Send events to guest
+await sb.emit("task.start", { inputFile: "/data/input.txt", options: ["--verbose"] })
+```
+
+```python Python
+# Receive events from guest
+sub = sb.on_event("task.progress", lambda event: (
+    print(f"[{event.data['percent']}%] {event.data['message']}")
+))
+
+# Send events to guest
+await sb.emit("task.start", {
+    "input_file": "/data/input.txt",
+    "output_dir": "/data/output",
+})
+```
+
+</CodeGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="bolt" href="/getting-started/quickstart">
+    Get a sandbox running in under 5 minutes
+  </Card>
+
+  <Card title="Sandbox overview" icon="box" href="/sandboxes/overview">
+    Configuration, rootfs sources, and lifecycle
+  </Card>
+
+  <Card title="CLI reference" icon="square-terminal" href="/cli/overview">
+    Manage sandboxes from the terminal
+  </Card>
+
+  <Card title="SDK reference" icon="code" href="/sdk/rust">
+    Full API documentation for all SDKs
+  </Card>
+</CardGroup>

--- a/docs/es/getting-started/quickstart.mdx
+++ b/docs/es/getting-started/quickstart.mdx
@@ -1,0 +1,125 @@
+---
+title: Quickstart
+description: Get a sandbox running in under 5 minutes
+icon: "bolt"
+---
+
+<Note>
+  microsandbox requires **Linux with KVM** enabled, or **macOS with Apple Silicon** (M-series chip). Both use hardware virtualization.
+</Note>
+
+<Tip>
+  Boot a microVM in one command.
+
+  ```bash
+  npx microsandbox run debian
+  ```
+</Tip>
+
+<Steps>
+  <Step title="Install microsandbox">
+    The SDK **embeds the runtime directly**, so no separate server process is needed. Only install the `msb` CLI if you want to manage images, volumes, and sandboxes from the terminal.
+
+    <CodeGroup>
+    ```bash Rust
+    cargo add microsandbox
+    ```
+
+    ```bash TypeScript
+    npm install microsandbox
+    ```
+
+    ```bash Python
+    pip install microsandbox
+    ```
+
+    ```bash CLI
+    curl -fsSL https://install.microsandbox.dev | sh
+    ```
+
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run code in a sandbox">
+    Create a sandbox, execute code inside it, and get the result back.
+
+    <CodeGroup>
+    ```rust Rust
+    use microsandbox::Sandbox;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let sb = Sandbox::builder("hello")
+            .image("python")
+            .memory(512)
+            .create()
+            .await?;
+
+        let output = sb.exec("python", ["-c", "print('Hello from a microVM!')"]).await?;
+        println!("{}", output.stdout()?); // Hello from a microVM!
+
+        sb.stop().await?;
+        Ok(())
+    }
+    ```
+
+    ```typescript TypeScript
+    import { Sandbox } from "microsandbox";
+
+    await using sb = await Sandbox.builder("hello")
+        .image("python")
+        .memory(512)
+        .create();
+
+    const output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"]);
+    console.log(output.stdout()); // Hello from a microVM!
+    ```
+
+    ```python Python
+    import asyncio
+    from microsandbox import Sandbox
+
+    async def main():
+        sb = await Sandbox.create(
+            "hello",
+            image="python",
+            memory=512,
+        )
+
+        output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"])
+        print(output.stdout_text)  # Hello from a microVM!
+
+        await sb.stop()
+
+    asyncio.run(main())
+    ```
+
+    ```bash CLI
+    msb run python -- python3 -c "print('Hello from a microVM!')"
+    ```
+
+    </CodeGroup>
+  </Step>
+</Steps>
+
+## What just happened?
+
+Here's what actually happened behind that `Sandbox.builder(...).create()` call:
+
+1. **Pulled the image** from Docker Hub (or skipped this if it was already cached, since shared layers are deduplicated).
+2. **Assembled the filesystem** by stacking the image layers into a copy-on-write filesystem, so nothing you do inside the sandbox modifies the base image.
+3. **Booted a microVM** as a child process. The 512 MiB you specified is a limit, not a reservation, so the VM only uses what it actually needs.
+4. **Started the guest agent** inside the VM, which set up the environment and opened a communication channel back to the host.
+
+The `exec` call sent a message to that guest agent, which spawned `python` inside the VM, streamed stdout back, and returned the exit code. No SSH involved, no network overhead. The command channel is completely separate from the sandbox's network stack.
+
+<Tip>
+  Because exec doesn't go through the network, it works even when a sandbox has networking disabled via `.disable_network()` and no network interfaces at all.
+</Tip>
+
+## Next steps
+
+- [Understand sandbox configuration](/sandboxes/overview): how the VM, filesystem, and networking fit together
+- [Run commands and stream output](/sandboxes/commands): `exec`, `shell`, `attach`, and streaming
+- [Control network access](/networking/overview): policies, DNS interception, and secret protection
+- [Manage sandboxes with the CLI](/cli/overview): create, inspect, and manage sandboxes from the terminal

--- a/docs/es/images/disk-images.mdx
+++ b/docs/es/images/disk-images.mdx
@@ -1,0 +1,82 @@
+---
+title: Disk Images
+description: Boot from QCOW2, Raw, or VMDK disk images
+icon: "compact-disc"
+---
+
+In addition to OCI container images, microsandbox can boot a sandbox directly from a disk image file. The guest gets raw block device access, and its kernel mounts the filesystem from the device directly.
+
+This is a fundamentally different path from OCI images. With OCI, microsandbox stacks image layers as a copy-on-write filesystem. With disk images, the guest owns the block device. No overlay, no copy-on-write between sandboxes.
+
+Use disk images when you need a pre-built VM template, a custom kernel configuration, or an OS that isn't available as a container image.
+
+## Supported formats
+
+| Format | Description |
+|--------|-------------|
+| **QCOW2** | QEMU Copy-On-Write v2. Supports thin provisioning and backing files. The most common format. |
+| **Raw** | Uncompressed raw disk image. No overhead, but no thin provisioning. |
+| **VMDK** | VMware virtual disk format. |
+
+## Usage
+
+When you pass a file path ending in `.qcow2`, `.raw`, or `.vmdk`, microsandbox auto-detects the format. For ambiguous cases, specify the format and filesystem type explicitly.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::size::SizeExt;
+
+// Auto-detect
+let sb = Sandbox::builder("custom-vm")
+    .image("./ubuntu-22.04.qcow2")
+    .cpus(2)
+    .memory(2.gib())
+    .create()
+    .await?;
+
+// Explicit
+let sb2 = Sandbox::builder("custom-vm")
+    .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
+    .cpus(1)
+    .memory(512)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+// Auto-detect format from the file extension
+await using sb = await Sandbox.builder("custom-vm")
+    .image("./ubuntu-22.04.qcow2")
+    .cpus(2)
+    .memory(2048)
+    .create();
+
+// Explicit format / fstype via a RootfsSource literal
+await using sb2 = await Sandbox.builder("custom-vm")
+    .image({
+        kind: "disk",
+        path: "./alpine.raw",
+        format: "raw",
+        fstype: "ext4",
+    })
+    .cpus(1)
+    .memory(512)
+    .create();
+```
+
+```python Python
+from microsandbox import Image, Sandbox
+
+# Auto-detect format from file extension
+sb = await Sandbox.create("custom-vm", image="./ubuntu-22.04.qcow2", cpus=2, memory=2048)
+
+# Explicit filesystem type
+sb2 = await Sandbox.create("custom-vm", image=Image.disk("./alpine.raw", fstype="ext4"), cpus=1, memory=512)
+```
+</CodeGroup>
+
+<Note>
+  The filesystem type (`ext4`, `xfs`, etc.) must match what's actually on the disk image. The guest kernel mounts it using the specified filesystem driver.
+</Note>

--- a/docs/es/images/overview.mdx
+++ b/docs/es/images/overview.mdx
@@ -1,0 +1,177 @@
+---
+title: OCI Images
+description: Use standard container images from any registry
+icon: "layer-group"
+---
+
+microsandbox uses standard OCI container images as root filesystems. Docker Hub, GHCR, ECR, GCR, any OCI-compatible registry works. Existing images run as-is.
+
+When you specify an image like `python`, microsandbox pulls the manifest, downloads the layers in parallel, and stacks them as a copy-on-write filesystem. Changes inside the sandbox don't modify the base image. Two sandboxes using the same image share the same cached layers on disk.
+
+## Pull policies
+
+By default, microsandbox pulls an image only if it isn't already cached. You can change this behavior.
+
+| Policy | Behavior |
+|--------|----------|
+| `"if-missing"` | Pull only if not cached (default) |
+| `"always"` | Always check the registry for updates |
+| `"never"` | Use local cache only, fail if missing |
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+from microsandbox import PullPolicy, Sandbox
+
+sb = await Sandbox.create("worker", image="python", pull_policy=PullPolicy.ALWAYS)
+```
+</CodeGroup>
+
+<Tip>
+  Once an image reference is resolved, microsandbox pins the exact layers. `python` is resolved to a specific set of immutable layers at first pull. Subsequent `start()` calls use the pinned layers without re-resolving the mutable tag, so your sandbox is reproducible even if the upstream tag moves.
+</Tip>
+
+## Private registries
+
+Authenticate to private registries by passing credentials.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry(|r| r.auth(RegistryAuth::Basic {
+        username: "deploy".into(),
+        password: std::env::var("REGISTRY_PASSWORD")?,
+    }))
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry((r) => r.auth({
+        kind: "basic",
+        username: "deploy",
+        password: process.env.REGISTRY_TOKEN!,
+    }))
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import PullPolicy, RegistryAuth, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="registry.corp.io/team/app:latest",
+    registry_auth=RegistryAuth.basic("deploy", os.environ["REGISTRY_PASSWORD"]),
+    pull_policy=PullPolicy.ALWAYS,
+)
+```
+</CodeGroup>
+
+## Registry TLS
+
+By default, microsandbox connects to registries over HTTPS using system CA roots. You can customize this per-registry in `~/.microsandbox/config.json`.
+
+### Plain HTTP registries
+
+Local registries often run without TLS. Mark them as insecure to connect over plain HTTP:
+
+```json
+{
+  "registries": {
+    "hosts": {
+      "localhost:5050": {
+        "insecure": true
+      }
+    }
+  }
+}
+```
+
+### Custom CA certificates
+
+For registries using self-signed or internal CA certificates, point `ca_certs` to a PEM file. This applies globally to all registry connections:
+
+```json
+{
+  "registries": {
+    "ca_certs": "/path/to/ca-bundle.pem"
+  }
+}
+```
+
+The certificates are added to the default system roots — public registries continue to work normally.
+
+### Combined configuration
+
+```json
+{
+  "registries": {
+    "ca_certs": "/path/to/corporate-ca.pem",
+    "hosts": {
+      "localhost:5050": {
+        "insecure": true,
+        "auth": { "username": "deploy", "password_env": "REGISTRY_TOKEN" }
+      },
+      "ghcr.io": {
+        "auth": { "username": "user", "store": "keyring" }
+      }
+    }
+  }
+}
+```
+
+These settings can also be set per-sandbox via the SDK, overriding global config:
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("localhost:5050/my-app:latest")
+    .registry(|r| r.insecure())
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("localhost:5050/my-app:latest")
+    .registry((r) => r.insecure())
+    .create();
+```
+</CodeGroup>
+
+## Image storage
+
+Images are cached in the global microsandbox home directory:
+
+| Path | Description |
+|------|-------------|
+| `~/.microsandbox/cache/layers/` | Downloaded and extracted image layers |
+| `~/.microsandbox/db/` | Database tracking image metadata and digests |
+
+Layers are content-addressable and deduplicated. If `python` and `python` share a base layer, it's stored once.
+
+<Tip>
+  Use `msb pull` from the CLI to pre-pull images before creating sandboxes. This avoids blocking on a download during `Sandbox.create`.
+</Tip>

--- a/docs/es/networking/dns.mdx
+++ b/docs/es/networking/dns.mdx
@@ -1,0 +1,169 @@
+---
+title: DNS
+description: How the sandbox resolves DNS queries
+icon: "magnifying-glass"
+---
+
+DNS queries from the sandbox are intercepted on the host. Rather than letting the guest talk to a resolver directly, microsandbox proxies each query, which lets you:
+
+- block lookups by domain or suffix,
+- pin which upstream resolvers get used,
+- tune the query timeout,
+- power domain-based policy rules (by mapping responses back to IPs).
+
+The knobs below cover the day-to-day controls. For the rebinding and TOCTOU protections that also ride on the interceptor, see the [security model](/networking/security-model).
+
+## Blocking domains
+
+Domain blocking lives in the network policy as `deny Domain(...)` / `deny DomainSuffix(...)` rules. The interceptor enforces them at three layers:
+
+1. **DNS resolution** — denied names get a local `REFUSED` response; the upstream resolver never sees them.
+2. **TLS first-flight** — when a guest hardcodes an IP and opens a TLS connection, the SNI is checked against the same rules.
+3. **TCP egress (cache fallback)** — for non-TLS traffic, the resolved-hostname cache disambiguates by IP.
+
+The bulk-deny shortcuts in each SDK are convenience for `deny Domain` / `deny DomainSuffix` rules; they prepend onto whatever policy is set so the deny takes precedence over later allow rules.
+
+<CodeGroup>
+```rust Rust
+let policy = NetworkPolicy::builder()
+    .default_allow()
+    .egress(|e| e
+        .deny_domains(["malware.example.com"])
+        .deny_domain_suffixes([".tracking.com"]))
+    .build()?;
+
+let sb = Sandbox::builder("safe-agent")
+    .image("python")
+    .network(|n| n.policy(policy))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("safe-agent")
+    .image("python")
+    .network({
+        denyDomains: ["malware.example.com"],
+        denyDomainSuffixes: [".tracking.com"],
+    })
+    .create();
+```
+
+```python Python
+from microsandbox import Network, Sandbox
+
+sb = await Sandbox.create(
+    "safe-agent",
+    image="python",
+    network=Network(
+        deny_domains=("malware.example.com",),
+        deny_domain_suffixes=(".tracking.com",),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name safe-agent \
+  --deny-domain malware.example.com \
+  --deny-domain-suffix .tracking.com
+```
+
+</CodeGroup>
+
+
+## Pinning nameservers
+
+By default the sandbox picks up the host's resolver list automatically:
+
+- **macOS**: reads `State:/Network/Global/DNS` from the system configuration store, with `/etc/resolv.conf` as a fallback when the store isn't available.
+- **Linux**: reads `/etc/resolv.conf` directly.
+
+You can override this by setting `nameservers` to pin the exact resolvers you want (e.g. `1.1.1.1`, `dns.google`), which is useful when auto-discovery picks the wrong ones.
+
+Values can be plain IPs, `IP:PORT`, hostnames, or `HOST:PORT`. Hostnames are resolved once at sandbox startup using the host's OS resolver.
+
+<CodeGroup>
+```rust Rust
+use microsandbox_network::dns::Nameserver;
+
+let sb = Sandbox::builder("safe-agent")
+    .image("python")
+    .network(|n| n
+        .dns(|d| d
+            .nameservers([
+                "1.1.1.1".parse::<Nameserver>()?,
+                "1.0.0.1".parse::<Nameserver>()?,
+            ])
+            .query_timeout_ms(3000)
+        )
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("safe-agent")
+    .image("python")
+    .network((n) => n.dns((d) =>
+        d.nameservers(["1.1.1.1", "1.0.0.1"])
+            .queryTimeoutMs(3000),
+    ))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "safe-agent",
+    image="python",
+    network=Network(
+        dns=DnsConfig(
+            nameservers=("1.1.1.1", "1.0.0.1"),
+            query_timeout_ms=3000,
+        ),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name safe-agent \
+  --dns-nameserver 1.1.1.1 \
+  --dns-nameserver 1.0.0.1 \
+  --dns-query-timeout-ms 3000
+```
+
+</CodeGroup>
+
+If the guest aims a query at a specific resolver (`dig @1.1.1.1`, an `/etc/resolv.conf` entry inside the guest, or a library call that takes a resolver IP), the interceptor forwards it to that resolver directly. The pinned defaults aren't used in this case. The network policy still applies: the query only goes through if the destination IP is allowed.
+
+## DNS over alternative transports
+
+The block list and rebind protection only apply to queries the gateway can see. A guest that routes DNS through an encrypted or non-DNS protocol bypasses both unless the gateway intercepts or refuses it.
+
+**Intercepted** (block list and rebind protection apply):
+- DNS over UDP (UDP/53)
+- DNS over TCP (TCP/53)
+- DNS over TLS (DoT, TCP/853): requires [TLS interception](/networking/tls)
+
+**Refused** (guest's stub falls back to plain DNS):
+- DNS over QUIC (DoQ, UDP/853)
+- mDNS (UDP/5353), LLMNR (UDP/5355), NetBIOS-NS (UDP/137)
+
+**Not distinguishable from regular traffic** (you must filter via network policy):
+- DNS over HTTPS (DoH, TCP/443)
+
+For strict DNS integrity, combine DoT interception with a network policy denying egress `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway.
+
+## Domain-based policy rules
+
+Network policy rules can match a destination by exact domain or by suffix. The interceptor watches DNS responses as they flow back to the guest and keeps track of which IP addresses belong to which domain.
+
+A connection to `93.184.216.34` is only allowed by a rule targeting `example.com` if that IP actually came back as an answer to a lookup for `example.com` from this sandbox.
+
+Because of that, domain rules only take effect on connections that are preceded by a DNS lookup from inside the sandbox. An application that connects to a hard-coded IP it didn't resolve through the interceptor won't match any domain rule.
+
+## See also
+
+- [Security model](/networking/security-model): rebinding protection and DNS-to-IP binding (TOCTOU defense)
+- [TLS interception](/networking/tls): domains that get intercepted also go through TLS inspection

--- a/docs/es/networking/overview.mdx
+++ b/docs/es/networking/overview.mdx
@@ -1,0 +1,232 @@
+---
+title: Overview
+description: Control network access and isolation
+icon: "network-wired"
+---
+
+All network traffic from a sandbox flows through a host-controlled networking stack. From inside, the sandbox sees a normal network interface, but on the host side every packet is subject to policy before it goes anywhere. The sandbox's only path to the outside world is through this stack, so blocked traffic never leaves the VM.
+
+## Defaults
+
+Without any policy flags, sandboxes get **public-internet egress only**: routable destinations work, but private (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`), loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), and the cloud metadata endpoint (`169.254.169.254`) are denied. Inbound traffic on published ports is unfiltered until you add an explicit ingress rule.
+
+To turn off networking entirely:
+
+```bash
+msb create python --name isolated --no-net
+```
+
+```rust
+let sb = Sandbox::builder("isolated")
+    .image("python")
+    .network(|n| n.enabled(false))
+    .create()
+    .await?;
+```
+
+## Custom policies
+
+A policy is a list of rules plus two direction-specific defaults:
+
+```text
+default_egress  : Allow | Deny     (action when no egress rule matches)
+default_ingress : Allow | Deny     (action when no ingress rule matches)
+rules           : [Rule, ...]      (first match wins)
+```
+
+Each rule carries its own direction (`Egress`, `Ingress`, or `Any`), a destination, an optional protocol set, an optional port set, and an action.
+
+### CLI
+
+`--net-rule` takes a comma-separated list of tokens shaped as
+`<action>[:<direction>]@<target>[:<proto>[:<ports>]]`. Direction defaults to `egress` when omitted. Repeating the flag concatenates tokens in argv order; first match wins.
+
+```bash
+# Public internet plus the host machine, deny everything else by default
+msb create python --name agent \
+    --net-rule "allow@public,allow@host"
+
+# Allow public internet plus a specific private host on tcp/443
+msb create alpine --name secure-agent \
+    --net-rule "allow@10.0.5.10:tcp:443,allow@public" \
+    --net-default-egress deny
+
+# Block tcp/445 to private IPs while keeping everything else open
+msb create alpine --name smb-blocked \
+    --net-default-egress allow \
+    --net-rule "deny@private:tcp:445"
+
+# Publish a port and only accept ingress from RFC1918 sources
+msb create python --name api \
+    --port 8080:8080 \
+    --net-rule "allow:ingress@private"
+```
+
+`<target>` accepts `any`, a group keyword (`public`, `private`, `loopback`, `link-local`, `meta`, `multicast`, `host`), an IP, a CIDR, a domain (with at least one dot), `domain=<name>` for single-label hostnames, or `suffix=<domain>` for subdomain matches.
+
+### Rust
+
+```rust
+use microsandbox::{NetworkPolicy, Sandbox};
+
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e
+        .tcp().port(443).allow_public()
+        .udp().port(53).allow_public())
+    .build()?;
+
+let sb = Sandbox::builder("secure-agent")
+    .image("alpine")
+    .network(|n| n.policy(policy))
+    .create()
+    .await?;
+```
+
+The builder accepts string inputs (`.ip("10.0.0.5")`, `.cidr("10.0.0.0/24")`, `.domain("api.example.com")`, etc.) and parses them at `.build()` time, so the chain stays clean. See the [Rust reference](/sdk/rust/networking) for the full surface (per-category shortcuts, the explicit-rule sub-builder, shadow-rule warnings).
+
+### TypeScript / Python
+
+Both SDKs accept policies as plain config objects matching the wire format. Direction strings are `"egress"`, `"ingress"`, or `"any"`. Group keywords match the CLI grammar.
+
+```typescript
+import { Destination, PortRange, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("secure-agent")
+    .image("alpine")
+    .network((n) => n.policy({
+        defaultEgress: "deny",
+        defaultIngress: "allow",
+        rules: [
+            {
+                direction: "egress",
+                destination: Destination.any(),
+                protocols: ["tcp"],
+                ports: [PortRange.single(443)],
+                action: "allow",
+            },
+            {
+                direction: "egress",
+                destination: Destination.any(),
+                protocols: ["udp"],
+                ports: [PortRange.single(53)],
+                action: "allow",
+            },
+        ],
+    }))
+    .create();
+```
+
+```python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "secure-agent",
+    image="alpine",
+    network={
+        "policy": {
+            "default_egress": "deny",
+            "default_ingress": "allow",
+            "rules": [
+                {"action": "allow", "direction": "egress", "protocol": "tcp", "port": "443"},
+                {"action": "allow", "direction": "egress", "protocol": "udp", "port": "53"},
+            ],
+        },
+    },
+)
+```
+
+Domain rules match flows where the guest resolved the name through the sandbox's DNS interceptor. See [DNS](/networking/dns) for how the resolved-hostname cache works.
+
+## Port mapping
+
+Expose ports from the sandbox to the host so services running inside the VM are reachable from your machine.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("api")
+    .image("python")
+    .port(8080, 80)
+    .port_udp(5353, 5353)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("api")
+    .image("python")
+    .port(8080, 80)
+    .portUdp(5353, 5353)
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "api",
+    image="python",
+    ports={8080: 80},
+)
+```
+
+```bash CLI
+msb create python --name api -p 8080:80
+```
+
+</CodeGroup>
+
+## Reaching the host
+
+From inside the sandbox, `host.microsandbox.internal` resolves to the host machine, same idea as Docker's `host.docker.internal`. Use it to call a dev server, database, or other process running on your machine without hard-coding an IP.
+
+```bash
+# Inside the sandbox:
+curl http://host.microsandbox.internal:8080
+```
+
+The name is wired through `/etc/hosts` and the DNS interceptor, so both standard resolvers and tools that bypass `/etc/hosts` (like `dig`) find it.
+
+The default policy denies host access — the sandbox gateway sits in a private range, same as any other local destination. Add the `host` group to open it:
+
+```bash
+msb create python --name dev-agent \
+    --net-rule "allow@public,allow@host"
+```
+
+```rust
+NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.allow_public().allow_host())
+    .build()?
+```
+
+### Loopback vs host: a common trap
+
+`Group::Loopback` (`127.0.0.0/8`, `::1`) and `Group::Host` (the per-sandbox gateway IPs) are different things. The two-word summary:
+
+- **`loopback`** = the guest's own loopback interface. Services running inside the same VM.
+- **`host`** = the host machine, reached through `host.microsandbox.internal`.
+
+If you're coming from Docker and reach for `.allow_loopback()` to "let the sandbox talk to my host's localhost," that's the trap — you want `.allow_host()` instead. `.allow_loopback()` only fires for traffic *inside* the guest, which doesn't reach the policy gate under normal kernel routing anyway.
+
+`.deny_loopback()` does have a real use case. In `--net-default-egress allow` configurations, a process inside the guest could craft a packet bound to `eth0` with `dst=127.0.0.1`, route it past the guest kernel, and have smoltcp on the host land it on the host's loopback. `.deny_loopback()` blocks that vector. Default policies (with the implicit deny on egress) already cover this.
+
+If you want "everything near the sandbox" — guest loopback, link-local, and the host machine — `.allow_local()` is sugar for that triple. `Metadata` is deliberately excluded so cloud-IMDS isn't quietly exposed; opt in via `.allow_meta()` if you need it.
+
+## Protocol support
+
+For most sandboxed workloads, networking behaves the way you'd expect:
+
+- Normal egress **TCP** and **UDP** traffic works, including common tools and libraries like `curl`, `wget`, package managers, HTTP clients, database drivers, and DNS lookups.
+- **DNS** queries are intercepted on the host side. See [DNS](/networking/dns) for blocking, pinned resolvers, and query timeouts.
+- **ICMP echo** is supported: pinging external hosts works on systems that support unprivileged ICMP echo sockets.
+- **Ingress** on published ports is gated by the same policy. Denied connections drop with TCP RST so the peer sees `ECONNRESET`.
+
+<Note>
+**Raw sockets** and **full ICMP forwarding** are not supported because they require elevated privileges on the host. Tools that depend on richer ICMP behavior, such as `traceroute`, are outside the current scope.
+</Note>
+
+## Next
+
+- [DNS](/networking/dns): domain blocking, pinned nameservers, query timeouts
+- [TLS interception](/networking/tls): HTTPS inspection with an auto-generated CA
+- [Security model](/networking/security-model): how the stack defends against SSRF, rebinding, and metadata exfiltration

--- a/docs/es/networking/security-model.mdx
+++ b/docs/es/networking/security-model.mdx
@@ -1,0 +1,90 @@
+---
+title: Security Model
+description: What the networking stack defends against
+icon: "shield-halved"
+---
+
+microsandbox's networking defaults are shaped around giving an AI agent, a scraper, or some other untrusted workload access to the internet without letting it pivot into your internal infrastructure. This page walks through the specific threats the stack is designed to handle and where each defense lives.
+
+## Private IPs and the host's local network
+
+The largest class of real damage comes from workloads reaching things that live *inside* your network: the host machine itself, a local database, another VM on the same subnet. The default policy addresses this by denying egress to anything outside `Group::Public` (the complement of the named local categories), which covers:
+
+- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10` (RFC1918 + CGN private ranges)
+- `127.0.0.0/8`, `::1` (loopback)
+- `169.254.0.0/16`, `fe80::/10` (link-local)
+- `169.254.169.254` (cloud metadata, takes precedence over link-local)
+- the per-sandbox gateway IPs (`Group::Host`)
+
+If an agent runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Override the default with `--net-default-egress allow` only when the workload genuinely needs broad reach, or use `--no-net` when it doesn't need network at all.
+
+## Cloud metadata endpoints
+
+On AWS, GCP, Azure, and similar platforms, `169.254.169.254` is the instance metadata service, a well-known SSRF target because it hands out temporary credentials to anything that can connect. The default policy blocks it via the `Group::Public` complement. For custom policies that flip `default_egress` to `Allow`, `Group::Metadata` lets you deny it explicitly:
+
+```bash
+msb create python --name agent \
+    --net-default-egress allow \
+    --net-rule "deny@meta"
+```
+
+```rust
+NetworkPolicy::builder()
+    .default_allow()
+    .rule(|r| r.egress().deny_meta())
+    .build()?
+```
+
+## DNS rebinding
+
+An attacker who controls a domain can set up records that resolve to a public IP during the initial allowlist check and then flip to a private IP on a subsequent lookup. The guest ends up making a request that *looked* like it was going to `evil.example.com` and actually lands on `192.168.1.10`.
+
+Rebind protection catches this at the response level: when the DNS interceptor sees an answer resolving a domain to a private, loopback, or link-local IP, the response is rewritten to `REFUSED` and the connection never gets made. This is on by default. You can turn it off when you genuinely need domains to resolve to internal hosts (local development, split-horizon DNS):
+
+<CodeGroup>
+```rust Rust
+.network(|n| n.dns(|d| d.rebind_protection(false)))
+```
+
+```typescript TypeScript
+.network((n) => n.dns((d) => d.rebindProtection(false)))
+```
+
+```python Python
+network=Network(dns=DnsConfig(rebind_protection=False))
+```
+
+```bash CLI
+msb create python --name dev --no-dns-rebind-protection
+```
+
+</CodeGroup>
+
+## DNS-to-IP binding (TOCTOU)
+
+Even without rebinding tricks, a classic time-of-check/time-of-use race exists. An allowlisted domain resolves to an allowed IP when the policy is checked. The guest then looks it up again at connect time and reaches a different IP.
+
+Domain-based policy rules close this by maintaining a pin set of observed DNS answers. A connection only matches a domain rule if its destination IP was actually returned as an answer to a DNS query for that domain from this sandbox. A guest that hard-codes an IP it didn't resolve through the interceptor can't slip past a domain-based allowlist.
+
+The same mechanism gates host-scoped secret injection. When a `SecretEntry` is restricted via `allowed_hosts`, the secret is only injected into outbound requests whose destination IP the interceptor tied to one of those hosts. An exfiltration attempt that POSTs the secret to an arbitrary IP won't receive the injection in the first place.
+
+## DNS bypass surface
+
+DNS-based defenses (block list, rebind protection, domain pinning) only work on queries the interceptor sees. The gateway intercepts UDP/53 and TCP/53 directly, and DoT (TCP/853) when TLS interception is enabled. Alternative transports are either refused at the port layer (DoQ, mDNS, LLMNR, NetBIOS-NS) or indistinguishable from regular traffic (DoH on TCP/443). Tunneled DNS (VPN, SOCKS5 hostname mode, HTTP `CONNECT`) is carried inside the outer encrypted flow and never reaches the forwarder.
+
+For workloads where DNS integrity matters, pair DoT interception with a network policy that denies egress `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway. Tunneled DNS is a network-layer concern: close it by restricting egress to an allowlist that excludes tunnel destinations. See [DNS](/networking/dns) for the transport-by-transport breakdown.
+
+## Out of scope
+
+The networking stack doesn't try to defend against:
+
+- **Kernel exploits inside the guest.** The microVM boundary is what keeps a compromised guest contained.
+- **Raw packet crafting from outside the sandbox.** Host-side privileged processes aren't in this threat model.
+- **Host tampering.** If a workload can modify host-side config, it's already past this layer.
+- **Deep ICMP behavior.** Supported ICMP is limited to unprivileged echo; `traceroute`-style flows are not proxied.
+- **Host trust store integrity.** When [`trust_host_cas`](/sdk/rust/networking#trust_host_cas) is opted into, an attacker who can plant a CA on the host has that trust inside every sandbox. Off by default for exactly this reason.
+
+## See also
+
+- [DNS](/networking/dns): the controls that ride on the DNS interceptor
+- [TLS interception](/networking/tls): plaintext visibility for per-host policy and secret injection

--- a/docs/es/networking/tls.mdx
+++ b/docs/es/networking/tls.mdx
@@ -1,0 +1,134 @@
+---
+title: TLS Interception
+description: HTTPS inspection with an auto-generated CA
+icon: "lock"
+---
+
+Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server, which is how features like per-host secret injection and URL-level policy checks are able to see inside what would otherwise be an opaque stream.
+
+## How it works
+
+When you enable TLS interception:
+
+1. A CA key and certificate are generated for the sandbox at creation time. The CA is scoped to that sandbox: it's not shared across sandboxes or with the host.
+2. The guest's trust store is updated to trust this CA.
+3. When the guest opens an HTTPS connection, the host-side proxy intercepts the handshake, generates a leaf certificate for the target domain on the fly, and signs it with the per-sandbox CA.
+4. The proxy opens its own TLS connection to the upstream server and bridges the two.
+
+Because the CA lives only for the sandbox's lifetime, nothing signed by it is trusted anywhere else.
+
+## Enabling interception
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("agent")
+    .image("python")
+    .network(|n| n
+        .tls(|t| t
+            .bypass("pinned-api.example.com")
+            .bypass("*.gov")
+        )
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("agent")
+    .image("python")
+    .network((n) => n.tls((t) =>
+        t.bypass("pinned-api.example.com").bypass("*.gov"),
+    ))
+    .create();
+```
+
+```python Python
+from microsandbox import Network, Sandbox, TlsConfig
+
+sb = await Sandbox.create(
+    "agent",
+    image="python",
+    network=Network(
+        tls=TlsConfig(bypass=("pinned-api.example.com", "*.gov")),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name agent \
+  --tls-intercept \
+  --tls-bypass "pinned-api.example.com" \
+  --tls-bypass "*.gov"
+```
+
+</CodeGroup>
+
+## Bypass patterns
+
+Some domains don't play well with interception, typically ones whose clients pin a specific certificate or public key instead of trusting the system CA store. Software update channels (browser autoupdate, macOS `softwareupdate`, package-manager mirrors that ship a pinned signing CA) and vendor SDKs that bundle their own pinned CA are the usual suspects. Add them to the bypass list and their traffic flows through as-is, encrypted end-to-end between the guest and the upstream server.
+
+Bypass patterns accept exact matches (`api.example.com`) and wildcards (`*.gov`, `*.apple.com`).
+
+## Limits
+
+- **Pinned clients bypass the trust store.** Any client that pins the server's certificate or public key (rather than trusting the system CA) will fail TLS interception and needs to be bypassed explicitly.
+- **Bypassed traffic is opaque.** Policy checks that depend on inspecting request content (URL-based rules, secret injection with `require_tls_identity`) don't apply on bypassed domains.
+- **Client certificates are not proxied.** mTLS flows where the guest is the one presenting a client certificate aren't supported through interception; add those hosts to the bypass list.
+
+## Trusting host CAs
+
+Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, ...) terminate outbound HTTPS at the host and re-sign it with a gateway CA. That CA is installed in your macOS Keychain or Linux trust store as part of the corporate rollout, so HTTPS works silently on the host. Inside a sandbox it doesn't: the guest's stock Mozilla bundle has never seen the gateway CA, so `apk update`, `pip install`, `curl`, and any SDK fetch fail with `server certificate not trusted`.
+
+By default the sandbox does not extend host trust into the guest, so the guest validates TLS strictly against its stock Mozilla bundle. Opt in when you need the guest to trust whatever the host trusts: at sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle.
+
+<Note>
+**Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox.
+
+It matches the existing threat model (a host-access attacker already owns the sandbox), but worth knowing before enabling on a host with an unfamiliar trust store.
+</Note>
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("agent")
+    .image("alpine")
+    .network(|n| n.trust_host_cas(true))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("agent")
+    .image("alpine")
+    .network((n) => n.trustHostCAs(true))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "agent",
+    image="alpine",
+    network=Network(trust_host_cas=True),
+)
+```
+
+```bash CLI
+msb run alpine --trust-host-cas -- apk update
+```
+
+</CodeGroup>
+
+### Interaction with TLS interception
+
+TLS interception also covers the corporate-proxy case, but only on the ports it's configured for (default `[443]`), and only for non-bypassed domains. It doesn't touch QUIC / HTTP/3 flows. Everything outside that scope (gRPC, Postgres / Redis / Mongo TLS, custom 8443, non-intercepted ports, bypassed domains) goes over raw TLS from the guest, where host-CA trust is what makes certificate validation succeed.
+
+The two features compose. Turn on [`trust_host_cas`](/sdk/rust/networking#trust_host_cas) alongside TLS interception when you need both: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Leave it off to keep the guest's TLS stack validating strictly against its stock Mozilla bundle.
+
+## See also
+
+- [DNS](/networking/dns): the DNS interceptor is what makes per-host rules possible, and DoT interception reuses this TLS path
+- [Security model](/networking/security-model): how TLS interception interacts with secret injection and SSRF defenses

--- a/docs/es/recipes/docker.mdx
+++ b/docs/es/recipes/docker.mdx
@@ -1,0 +1,57 @@
+---
+title: Running in Docker
+description: Deploy microsandbox as a Docker container on Linux
+icon: "box"
+---
+
+<Tip>
+  For production use, we recommend [installing microsandbox natively](/getting-started/quickstart).
+</Tip>
+
+microsandbox publishes multi-arch Docker images (amd64/arm64) to GitHub Container Registry. This is an interim solution for environments that require containerized deployment, pending microsandbox implementing the [OCI runtime spec](https://github.com/opencontainers/runtime-spec).
+
+## Prerequisites
+
+- A **Linux** host with KVM support (`/dev/kvm` must be available)
+- Docker installed
+
+## Pull the image
+
+```bash
+docker pull ghcr.io/superradcompany/microsandbox:latest
+```
+
+Or pin to a specific version:
+
+```bash
+docker pull ghcr.io/superradcompany/microsandbox:0.4.0
+```
+
+## Run a sandbox
+
+The container requires `--privileged` and `/dev/kvm` access to run microVMs:
+
+```bash
+docker run --privileged --device /dev/kvm \
+  ghcr.io/superradcompany/microsandbox:latest \
+  run python --name my-sandbox --replace
+```
+
+## Persistent data
+
+By default, sandbox data (images, cache, databases) is stored inside the container and lost when it stops. Mount a volume to persist data across restarts:
+
+```bash
+docker run --privileged --device /dev/kvm \
+  -v microsandbox_data:/root/.microsandbox \
+  ghcr.io/superradcompany/microsandbox:latest \
+  run python --name my-sandbox --replace
+```
+
+## Available tags
+
+| Tag | Description |
+|-----|-------------|
+| `latest` | Latest release |
+| `x.y.z` (e.g. `0.4.0`) | Specific version |
+| `x.y` (e.g. `0.4`) | Latest patch of a minor version |

--- a/docs/es/recipes/local-images.mdx
+++ b/docs/es/recipes/local-images.mdx
@@ -1,0 +1,72 @@
+---
+title: Using Local Docker Images
+description: Use locally built Docker images with microsandbox via a local registry
+icon: "boxes-stacked"
+---
+
+microsandbox pulls images from OCI-compatible registries. If you build an image locally with `docker build`, microsandbox can't access it directly from Docker's local store. The workaround is to run a local registry and push your image there.
+
+## Step 1: Start a local registry
+
+Run a local OCI registry on port 5050:
+
+```bash
+docker run -d -p 5050:5000 --name registry registry:2
+```
+
+<Tip>
+  Port 5000 is used by AirPlay on macOS. This guide uses port 5050 to avoid conflicts.
+</Tip>
+
+## Step 2: Build, tag, and push your image
+
+Build your Docker image and tag it for the local registry:
+
+```bash
+docker build -t localhost:5050/my-image:latest .
+```
+
+If you already have an existing image, re-tag it:
+
+```bash
+docker tag my-image:latest localhost:5050/my-image:latest
+```
+
+Push to the local registry:
+
+```bash
+docker push localhost:5050/my-image:latest
+```
+
+## Step 3: Pull with microsandbox
+
+Since the local registry runs over plain HTTP, use the `--insecure` flag:
+
+```bash
+msb pull localhost:5050/my-image:latest --insecure
+```
+
+## Step 4: Use it in microsandbox
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("localhost:5050/my-image:latest")
+    .registry(|r| r.insecure())
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("localhost:5050/my-image:latest")
+    .registry((r) => r.insecure())
+    .create();
+```
+</CodeGroup>
+
+<Tip>
+  For persistent configuration that applies to all CLI and SDK operations, add the registry to `~/.microsandbox/config.json` instead. See [Registry TLS](/images/overview#registry-tls).
+</Tip>

--- a/docs/es/recipes/systemd-services.mdx
+++ b/docs/es/recipes/systemd-services.mdx
@@ -1,0 +1,65 @@
+---
+title: Booting Under systemd
+description: Hand PID 1 to systemd inside the guest so services run under a real init
+icon: "gear"
+---
+
+By default the microsandbox agent is PID 1. That's enough for one-shot processes, but anything that calls into `systemctl`, `loginctl`, or expects a session bus will fail.
+
+`--init auto` hands PID 1 over to systemd. The rest of the guest then behaves like a normal Linux box.
+
+## Step 1: Boot
+
+```bash
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  --memory 1G --cpus 2 \
+  --init auto \
+  -- bash
+```
+
+`debian-systemd` is one of the optional bases we maintain in [guest-images](https://github.com/superradcompany/guest-images) for cases like this. `--init auto` probes a small set of well-known paths and picks the first that exists. See [Custom init system](/sandboxes/customize#custom-init-system) for the full list and for pinning to an exact path.
+
+## Step 2: Confirm systemd is PID 1
+
+```bash
+root@msb:/# systemctl status
+● msb
+    State: running
+    Units: 113 loaded (incl. loaded aliases)
+  systemd: 252.39-1~deb12u1
+```
+
+Or check directly:
+
+```bash
+root@msb:/# cat /proc/1/comm
+systemd
+```
+
+## Step 3: Manage units
+
+`systemctl` works as it does on bare metal. Inspect a unit shipped with the image:
+
+```bash
+root@msb:/# systemctl status systemd-journald
+● systemd-journald.service - Journal Service
+     Loaded: loaded (/lib/systemd/system/systemd-journald.service; static)
+     Active: active (running)
+```
+
+Install your own and start it:
+
+```bash
+root@msb:/# apt update && apt install -y nginx
+root@msb:/# systemctl enable --now nginx
+root@msb:/# curl -s localhost | head -1
+<!DOCTYPE html>
+```
+
+Microsandbox is detected as a container, so packages with `policy-rc.d` deferral install but don't auto-start. `systemctl enable --now <unit>` starts them in one step.
+
+## Notes
+
+- **Image choice matters.** Distroless / minimal images (`python:3.13-slim`, `alpine`) don't ship a systemd init binary; `--init auto` will fail and `kernel.log` will list every path it tried. Use a systemd-equipped base or layer one in.
+- **Memory budget.** systemd's idle footprint is ~50 MiB; daemons add more. Bump `--memory` if your service is hungry.
+- **Other inits work.** `--init` accepts any absolute path. s6, OpenRC, runit, or a hand-rolled `/sbin/init` shell script are all fine; `auto` just covers the systemd-on-Debian/Ubuntu case.

--- a/docs/es/sandboxes/commands.mdx
+++ b/docs/es/sandboxes/commands.mdx
@@ -1,0 +1,284 @@
+---
+title: Commands
+description: Execute commands, stream output, and interact with sandboxes
+icon: "terminal"
+---
+
+Command execution doesn't use SSH or the network. There's a dedicated channel between the host and a guest agent running inside the VM, completely separate from the sandbox's network stack. The agent spawns processes, streams output back, and reports exit codes.
+
+One nice consequence: `exec` works even when a sandbox has networking fully disabled.
+
+## Execute a command
+
+Run a command and wait for it to complete. You get back the exit code, stdout, and stderr.
+
+<CodeGroup>
+```rust Rust
+let output = sb.exec("python", ["-c", "print('hello')"]).await?;
+println!("{}", output.stdout()?);     // "hello\n"
+println!("{}", output.status().code); // 0
+```
+
+```typescript TypeScript
+const output = await sb.exec("python", ["-c", "print('hello')"]);
+console.log(output.stdout()); // "hello\n"
+console.log(output.success);  // true
+console.log(output.code);     // 0
+```
+
+```python Python
+output = await sb.exec("python", ["-c", "print('hello')"])
+print(output.stdout_text)     # "hello\n"
+print(output.success)         # True
+print(output.exit_code)       # 0
+```
+
+```bash CLI
+msb exec worker -- python -c "print('hello')"
+```
+
+</CodeGroup>
+
+## Execution options
+
+These options apply to a single execution and don't change the sandbox's defaults.
+
+<CodeGroup>
+```rust Rust
+let output = sb.exec_with("python", |e| e
+    .args(["compute.py"])
+    .cwd("/app")
+    .env("PYTHONPATH", "/app/lib")
+    .timeout(Duration::from_secs(30))
+    .rlimit(RlimitResource::Nofile, 1024)
+).await?;
+```
+
+```typescript TypeScript
+const output = await sb.execWith("python", (e) =>
+    e.args(["compute.py"])
+        .cwd("/app")
+        .env("PYTHONPATH", "/app/lib")
+        .timeout(30_000)
+        .rlimit("nofile", 1024),
+);
+```
+
+```python Python
+from microsandbox import ExecOptions, Rlimit
+
+output = await sb.exec("python", ExecOptions(
+    args=("compute.py",),
+    cwd="/app",
+    env={"PYTHONPATH": "/app/lib"},
+    timeout=30.0,
+    rlimits=(Rlimit.nofile(1024),),
+))
+```
+
+```bash CLI
+msb exec worker \
+  -w /app \
+  -e PYTHONPATH=/app/lib \
+  --timeout 30s \
+  --rlimit nofile=1024 \
+  -- python compute.py
+```
+
+</CodeGroup>
+
+## Shell commands
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Useful for pipelines, redirects, and other shell syntax that `exec` doesn't interpret.
+
+<CodeGroup>
+```rust Rust
+let output = sb.shell("ls -la /app && echo done").await?;
+```
+
+```typescript TypeScript
+const output = await sb.shell("ls -la /app && echo done")
+```
+
+```python Python
+output = await sb.shell("ls -la /app && echo done")
+```
+
+```bash CLI
+msb exec worker -- sh -c "ls -la /app && echo done"
+```
+
+</CodeGroup>
+
+## Stream output
+
+For long-running processes or large output, streaming gives you stdout, stderr, and exit events as they happen instead of buffering everything until the command finishes.
+
+<CodeGroup>
+```rust Rust
+let mut handle = sb.exec_stream("tail", ["-f", "/var/log/app.log"]).await?;
+
+while let Some(event) = handle.recv().await {
+    match event {
+        ExecEvent::Stdout(data) => print!("{}", String::from_utf8_lossy(&data)),
+        ExecEvent::Stderr(data) => eprint!("{}", String::from_utf8_lossy(&data)),
+        ExecEvent::Exited { code } => break,
+        _ => {}
+    }
+}
+```
+
+```typescript TypeScript
+const handle = await sb.execStream("tail", ["-f", "/var/log/app.log"]);
+
+for await (const event of handle) {
+    switch (event.kind) {
+        case "stdout": process.stdout.write(event.data); break;
+        case "stderr": process.stderr.write(event.data); break;
+        case "exited": console.log(`Exited: ${event.code}`); break;
+    }
+}
+```
+
+```python Python
+handle = await sb.exec_stream("tail", ["-f", "/var/log/app.log"])
+
+async for event in handle:
+    match event.event_type:
+        case "stdout": print(event.data.decode(), end="")
+        case "stderr": print(event.data.decode(), end="", file=sys.stderr)
+        case "exited": print(f"Exited: {event.code}")
+```
+
+</CodeGroup>
+
+## Interactive attach
+
+Bridges your terminal directly to a process inside the sandbox for a fully interactive PTY session. Useful for debugging, running REPLs, or anything that expects a real terminal.
+
+<CodeGroup>
+```rust Rust
+let exit_code = sb.attach_shell().await?;
+
+let exit_code = sb.attach_with("python", |a| a
+    .env("DEBUG", "1")
+    .cwd("/app")
+    .detach_keys("ctrl-q")
+).await?;
+```
+
+```typescript TypeScript
+// Attach to the default shell
+const exitCode = await sb.attachShell();
+
+// Attach to a specific command with custom detach keys
+await sb.attachWith("bash", (a) =>
+    a.env("DEBUG", "1").cwd("/app").detachKeys("ctrl-q"),
+);
+```
+
+```python Python
+from microsandbox import AttachOptions
+
+# Attach to the default shell
+exit_code = await sb.attach_shell()
+
+# Attach to a specific command with custom detach keys
+exit_code = await sb.attach("python", AttachOptions(
+    env={"DEBUG": "1"},
+    cwd="/app",
+    detach_keys="ctrl-q",
+))
+```
+
+```bash CLI
+# Attach to the default shell
+msb exec -t worker
+
+# Attach to a specific command
+msb exec -t worker -e DEBUG=1 -w /app -- python
+```
+
+</CodeGroup>
+
+<Tip>
+  Press `Ctrl+]` (or your configured detach keys) to detach from the session without stopping the process. The process keeps running inside the VM and you can reattach later via its session ID.
+</Tip>
+
+## Write stdin
+
+Streaming handles can also accept stdin. Enable `stdin_pipe` and write bytes to it. Combined with `tty: true`, this lets you drive interactive processes programmatically.
+
+<CodeGroup>
+```rust Rust
+let mut handle = sb.exec_stream_with("python", |e| e.stdin_pipe().tty(true)).await?;
+let stdin = handle.take_stdin().unwrap();
+stdin.write(b"print('hello')\n").await?;
+stdin.write(b"exit()\n").await?;
+handle.wait().await?;
+```
+
+```typescript TypeScript
+const handle = await sb.execStreamWith("python", (e) => e.stdinPipe().tty(true));
+const stdin = await handle.takeStdin();
+await stdin!.write("print('hello')\n");
+await stdin!.write("exit()\n");
+await stdin!.close();
+await handle.wait();
+```
+
+```python Python
+from microsandbox import ExecOptions, Stdin
+
+handle = await sb.exec_stream("python", ExecOptions(stdin=Stdin.pipe(), tty=True))
+stdin = handle.take_stdin()
+await stdin.write(b"print('hello')\n")
+await stdin.write(b"exit()\n")
+await stdin.close()
+await handle.wait()
+```
+
+</CodeGroup>
+
+## Sessions <sup><sup>coming soon</sup></sup>
+
+Each streaming exec or attach creates a session. You can list active sessions and reattach to them by ID. Up to 16 simultaneous client connections are supported, so multiple sessions can run concurrently without interfering with each other.
+
+<CodeGroup>
+```rust Rust
+// Start a background process and capture its session ID
+let handle = sb.exec_stream("python", ["server.py"]).await?;
+let session_id = handle.id().to_string();
+
+// List active sessions
+let sessions = sb.sessions().await?;
+
+// Reattach to a session by ID
+let mut handle = sb.session(&session_id).await?;
+```
+
+```typescript TypeScript
+// Start a background process and capture its session ID
+const handle = await sb.execStream("python", ["server.py"])
+const sessionId = handle.id
+
+// List active sessions
+const sessions = await sb.sessions()
+
+// Reattach to a session by ID
+const reattached = await sb.session(sessionId)
+```
+
+```python Python
+# Start a background process and capture its session ID
+handle = await sb.exec_stream("python", ["server.py"])
+session_id = handle.id
+
+# List active sessions
+sessions = await sb.sessions()
+
+# Reattach to a session by ID
+reattached = await sb.session(session_id)
+```
+
+</CodeGroup>

--- a/docs/es/sandboxes/customize.mdx
+++ b/docs/es/sandboxes/customize.mdx
@@ -1,0 +1,339 @@
+---
+title: Customize
+description: Inject scripts, modify the rootfs, and choose your own init
+icon: "wand-magic-sparkles"
+---
+
+Before a sandbox starts doing real work, you can prepare it three ways. **Scripts** bundle reusable commands. **Patches** modify the rootfs before the VM boots. A **custom init system** (systemd, OpenRC, s6) can run as PID 1 instead of microsandbox's minimal agent. All three are defined at creation time and keep the base image untouched.
+
+## Scripts
+
+Scripts are files mounted at `/.msb/scripts/` inside the sandbox. The directory is on `PATH`, so each script is callable by name through `exec()` or `shell()`.
+
+It provides a clean way to bundle setup procedures or entry points with a sandbox without baking them into the image.
+
+<CodeGroup>
+```rust Rust
+use indoc::indoc;
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("ubuntu")
+    .script("setup", indoc! {"
+        #!/bin/bash
+        apt-get update && apt-get install -y python3 curl
+    "})
+    .script("start", indoc! {"
+        #!/bin/bash
+        exec python3 /app/main.py
+    "})
+    .create()
+    .await?;
+
+sb.shell("setup").await?;
+let output = sb.shell("start").await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("ubuntu")
+    .script("setup", "#!/bin/bash\napt-get update && apt-get install -y python3 curl")
+    .script("run",   "#!/bin/bash\nexec python3 /app/main.py")
+    .create();
+
+await sb.shell("setup");
+const output = await sb.shell("run");
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ubuntu",
+    scripts={
+        "setup": "#!/bin/bash\napt-get update && apt-get install -y python3 curl",
+        "start": "#!/bin/bash\nexec python3 /app/main.py",
+    },
+)
+
+await sb.shell("setup")
+output = await sb.shell("start")
+```
+
+</CodeGroup>
+
+## Patches
+
+Patches modify the rootfs **before the VM boots**. Write config files, copy directories from the host, create symlinks, append to existing files, remove things you don't need. The base image stays untouched since patches are written to the writable layer on top.
+
+Patches are applied in order and work with OCI images and bind-mounted rootfs. They're not supported with disk image roots (QCOW2, Raw).
+
+<Tip>
+  By default, patching a path that already exists in the image will error. Pass `replace: true` on the operation to allow it. `Mkdir` and `Remove` are idempotent and won't error either way.
+</Tip>
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("alpine")
+    .patch(|p| p
+        .text("/etc/greeting.txt", "Hello from a patched rootfs!\n", None, false)
+        .text("/etc/motd", "Custom message of the day.\n", None, true) // replace existing
+        .mkdir("/app", Some(0o755))
+        .text("/app/config.json", r#"{"debug": true}"#, Some(0o644), false)
+        .copy_file("./cert.pem", "/etc/ssl/cert.pem", None, false)
+        .append("/etc/hosts", "127.0.0.1 myapp.local\n")
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("alpine")
+    .patch((p) => p
+        .text("/etc/greeting.txt", "Hello from a patched rootfs!\n")
+        .text("/etc/motd", "Custom message of the day.\n", { replace: true })
+        .mkdir("/app", { mode: 0o755 })
+        .text("/app/config.json", '{"debug": true}', { mode: 0o644 })
+        .copyFile("./cert.pem", "/etc/ssl/cert.pem")
+        .append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+    )
+    .create();
+```
+
+```python Python
+from microsandbox import Patch, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="alpine",
+    patches=[
+        Patch.text("/etc/greeting.txt", "Hello from a patched rootfs!\n"),
+        Patch.text("/etc/motd", "Custom message of the day.\n", replace=True),
+        Patch.mkdir("/app", mode=0o755),
+        Patch.text("/app/config.json", '{"debug": true}', mode=0o644),
+        Patch.copy_file("./cert.pem", "/etc/ssl/cert.pem"),
+        Patch.append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+    ],
+)
+```
+
+</CodeGroup>
+
+### Available operations
+
+The patch builder appends operations in the order you call them; calls are chainable. Available operations across SDKs: `text`, `file`, `mkdir`, `append`, `copyFile` / `copy_file`, `copyDir` / `copy_dir`, `symlink`, `remove`.
+
+Full per-language signatures, parameters, and option shapes are documented in the SDK references:
+
+- Rust: [`PatchBuilder`](/sdk/rust/sandbox#patchbuilder)
+- TypeScript: [`PatchBuilder`](/sdk/typescript/sandbox#patchbuilder)
+- Python: [`Patch`](/sdk/python/sandbox#patch) (factory) and [`PatchConfig`](/sdk/python/sandbox#patchconfig) (the value type)
+
+## Custom init system
+
+By default the microsandbox agent runs as PID 1 inside the guest: small, fast, minimal. For workloads that expect a real init (systemd, OpenRC, s6, runit, etc.), `--init` hands PID 1 over to the init binary of your choice.
+
+The handoff sequence:
+
+- Agent does the boot-time setup: mount filesystems, configure network, prepare runtime dirs.
+- Agent forks.
+- Parent execs your init and becomes PID 1.
+- Child agent continues serving host requests over the same channel.
+
+Common reasons to opt in: long-lived daemons, system service tests, anything that talks to dbus or expects `systemctl` to work.
+
+The simplest entry point is `auto`, which probes a small list of well-known paths inside the guest rootfs and picks the first one that exists:
+
+- `/sbin/init`
+- `/lib/systemd/systemd`
+- `/usr/lib/systemd/systemd`
+
+Pass an absolute path instead when you need pinning (e.g. for reproducible CI).
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .memory(1024)
+    .cpus(2)
+    .init("auto")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { MiB, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .memory(MiB(1024))
+    .cpus(2)
+    .init("auto")
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ghcr.io/superradcompany/debian-systemd:12",
+    memory=1024,
+    cpus=2,
+    init="auto",
+)
+```
+
+```bash CLI
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  -m 1G -c 2 \
+  --init auto \
+  -- bash
+```
+</CodeGroup>
+
+To verify the handoff worked, check `/proc/1/comm` inside the sandbox. It should print the init's name (`systemd`, `init`, etc.):
+
+```bash
+$ msb run ghcr.io/superradcompany/debian-systemd:12 --init auto -- cat /proc/1/comm
+systemd
+```
+
+If `--init=auto` can't find anything in its candidate list, agentd fails boot with a clear error in `kernel.log` listing every path it checked. Switch to an explicit path (`--init=/lib/systemd/systemd`) when you know exactly where the init lives, or follow the image-picking guidance below to choose an image that actually ships one.
+
+### Argv and env
+
+Pass extra argv and env to the init:
+
+- **Rust / TypeScript**: `init_with(...)` / `initWith(...)`.
+- **Python**: pass an `InitConfig` to `init=`.
+- **CLI**: repeat `--init-arg` once per entry, and `--init-env KEY=VAL` once per env var.
+
+Argv defaults to `[<cmd>]` when none is given; env is merged on top of the inherited environment.
+
+<CodeGroup>
+```bash CLI
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  --init /lib/systemd/systemd \
+  --init-arg --unit=multi-user.target \
+  --init-env container=microsandbox \
+  -- bash
+```
+
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .init_with("/lib/systemd/systemd", |i| i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .initWith("/lib/systemd/systemd", (i) => i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create();
+```
+
+```python Python
+from microsandbox import InitConfig, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ghcr.io/superradcompany/debian-systemd:12",
+    init=InitConfig(
+        cmd="/lib/systemd/systemd",
+        args=("--unit=multi-user.target",),
+        env={"container": "microsandbox"},
+    ),
+)
+```
+</CodeGroup>
+
+### Picking an image
+
+Most slim Docker base images (`debian:bookworm-slim`, `ubuntu:24.04`, `python:3.12-slim`) are stripped of init binaries; they're built for "one process per container" and don't ship systemd at all. If you point `--init` at a path the image doesn't contain, the agent's pre-flight check fails boot with a clear error in the kernel log (no kernel panic).
+
+Three ways to get an image with an init:
+
+<AccordionGroup>
+  <Accordion title="Use one of our published guest images">
+    We maintain a small collection at [`superradcompany/guest-images`](https://github.com/superradcompany/guest-images) for the cases where you specifically need a real init. Current set:
+
+    | Image | Pull |
+    |-------|------|
+    | Debian + systemd | `ghcr.io/superradcompany/debian-systemd:12` |
+    | Ubuntu + systemd | `ghcr.io/superradcompany/ubuntu-systemd:24.04` |
+    | Fedora + systemd | `ghcr.io/superradcompany/fedora-systemd:40` |
+    | Alpine + OpenRC | `ghcr.io/superradcompany/alpine-openrc:3.20` |
+
+    Multi-arch (`linux/amd64` + `linux/arm64`), rebuilt weekly so they pick up upstream security patches, smoke-tested on every rebuild. Each image's GHCR page documents its specific tag aliases and contents.
+  </Accordion>
+  <Accordion title="Build a small custom image">
+    ```dockerfile
+    # Dockerfile.systemd
+    FROM debian:bookworm
+    RUN apt-get update \
+        && apt-get install -y --no-install-recommends systemd \
+        && rm -rf /var/lib/apt/lists/*
+    ```
+
+    ```bash
+    docker buildx build -t local-systemd:debian -f Dockerfile.systemd .
+    msb run local-systemd:debian --init /lib/systemd/systemd -- bash
+    ```
+  </Accordion>
+  <Accordion title="Use a community-built systemd image">
+    Examples: `jrei/systemd-debian:12`, `jrei/systemd-ubuntu:22.04`. These work out of the box but are published by community maintainers, not the distros themselves. Vet them like any other third-party image before running real workloads.
+  </Accordion>
+</AccordionGroup>
+
+For a sanity check that doesn't need systemd, `alpine:3.20` ships BusyBox at `/sbin/init`, which is enough to exercise the handoff mechanics:
+
+```bash
+msb run alpine:3.20 --init /sbin/init -- sh -c "cat /proc/1/comm"
+# busybox
+```
+
+### Shutdown semantics
+
+Without `--init`, microsandbox shuts the guest down by remounting root read-only and calling `reboot(RB_POWER_OFF)`. Typically &lt;100 ms.
+
+With `--init`, the agent isn't PID 1 anymore, so it asks your init to shut down:
+
+- `SIGRTMIN+4` first (systemd's poweroff signal).
+- `SIGTERM` fallback for inits that don't speak it.
+
+Your init then runs its own teardown (stop services, unmount, halt), which is slower:
+
+| Init | Typical shutdown |
+|------|------------------|
+| BusyBox / s6 / runit | &lt;100 ms |
+| OpenRC | 50-500 ms |
+| systemd | 1-5 s |
+
+This is the price of a real init. If your test harness measures end-to-end sandbox lifecycle and you're comparing to a no-handoff baseline, account for this.
+
+### Init and entrypoint
+
+`--init` and `--entrypoint` are orthogonal:
+
+- `--init` controls **PID 1**: what runs the system.
+- `--entrypoint` (and the trailing `-- cmd`) controls **what your workload runs**.
+
+They can be combined. Boot systemd as PID 1 and have microsandbox `exec` calls land your shell, scripts, or app inside the systemd-managed environment.

--- a/docs/es/sandboxes/events.mdx
+++ b/docs/es/sandboxes/events.mdx
@@ -1,0 +1,110 @@
+---
+title: Events
+description: Bidirectional host-guest communication
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+The events API is for structured communication between host and guest beyond stdin/stdout. The host can subscribe to named events from the guest and emit events back, all through the same channel used by `exec`.
+
+On the guest side, processes just write JSON to `/run/agent.sock`, which is a standard Unix domain socket. No special library needed. Any language that can open a socket and write a newline-delimited JSON message will work.
+
+## Basic example
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, EventData};
+use serde::Deserialize;
+
+let sb = Sandbox::get("worker").await?.start().await?;
+
+let _sub = sb.on_event("task.progress", |event: EventData| {
+    #[derive(Deserialize)]
+    struct Progress { percent: u32, message: String }
+
+    if let Some(data) = event.data {
+        if let Ok(p) = data.deserialized::<Progress>() {
+            println!("[{}%] {}", p.percent, p.message);
+        }
+    }
+});
+```
+
+```typescript TypeScript
+import { Sandbox, EventData } from 'microsandbox'
+
+const sb = await Sandbox.get("worker")
+
+const sub = sb.onEvent("task.progress", (event: EventData) => {
+    const { percent, message } = event.data as { percent: number; message: string }
+    console.log(`[${percent}%] ${message}`)
+})
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await (await Sandbox.get("worker")).start()
+
+sub = sb.on_event("task.progress", lambda event: (
+    print(f"[{event.data['percent']}%] {event.data['message']}")
+))
+```
+
+</CodeGroup>
+
+## Send events to guest
+
+Emit a named event with typed data into the guest. Any process listening on the agent socket receives it.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct TaskConfig { input_file: String, output_dir: String }
+
+sb.emit("task.start", TaskConfig {
+    input_file: "/data/input.txt".into(),
+    output_dir: "/data/output".into(),
+}).await?;
+```
+
+```typescript TypeScript
+await sb.emit("task.start", {
+    inputFile: "/data/input.txt",
+    options: ["--verbose"],
+})
+```
+
+```python Python
+await sb.emit("task.start", {
+    "input_file": "/data/input.txt",
+    "output_dir": "/data/output",
+})
+```
+
+</CodeGroup>
+
+## Guest-side emitting
+
+Inside the guest, any process can emit events by writing JSON to the Unix domain socket at `/run/agent.sock`. No SDK required.
+
+```python
+# Inside the guest, plain Python, no SDK
+import json, socket
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect("/run/agent.sock")
+sock.sendall(json.dumps({
+    "event": "task.progress",
+    "data": {"percent": 50, "message": "Halfway done"},
+}).encode() + b"\n")
+sock.close()
+```
+
+The host subscription registered with `on_event("task.progress", ...)` receives this message automatically.

--- a/docs/es/sandboxes/filesystem.mdx
+++ b/docs/es/sandboxes/filesystem.mdx
@@ -1,0 +1,240 @@
+---
+title: Filesystem
+description: Read and write files inside a running sandbox
+icon: "folder-open"
+---
+
+The filesystem API lets you read, write, and manage files inside a sandbox without mounting volumes or SSH. It uses the same channel as command execution, so it doesn't touch the sandbox's network.
+
+Handy for pushing generated code into a sandbox, pulling back results, or inspecting logs without having to pre-mount a shared directory.
+
+## Write a file
+
+<CodeGroup>
+```rust Rust
+sb.fs().write("/app/config.json", r#"{"debug": true}"#).await?;
+```
+
+```typescript TypeScript
+await sb.fs().write("/app/config.json", '{"debug": true}');
+```
+
+```python Python
+await sb.fs.write("/app/config.json", b'{"debug": true}')
+```
+
+</CodeGroup>
+
+## Read a file
+
+<CodeGroup>
+```rust Rust
+let content = sb.fs().read_to_string("/app/config.json").await?;
+```
+
+```typescript TypeScript
+const content = await sb.fs().readToString("/app/config.json");
+```
+
+```python Python
+content = await sb.fs.read_text("/app/config.json")
+```
+
+</CodeGroup>
+
+## List a directory
+
+<CodeGroup>
+```rust Rust
+let entries = sb.fs().list("/app").await?;
+for entry in entries {
+    println!("{}: {:?}", entry.path, entry.kind);
+}
+```
+
+```typescript TypeScript
+const entries = await sb.fs().list("/app");
+for (const entry of entries) {
+    console.log(`${entry.path}: ${entry.kind}`);
+}
+```
+
+```python Python
+entries = await sb.fs.list("/app")
+for entry in entries:
+    print(f"{entry.path}: {entry.kind}")
+```
+
+</CodeGroup>
+
+## Stream large files
+
+For files too large to fit in memory, use streaming. Data is transferred in chunks of approximately 3 MiB each.
+
+<CodeGroup>
+```rust Rust
+let mut stream = sb.fs().read_stream("/app/data.bin").await?;
+while let Some(chunk) = stream.recv().await? {
+    process(&chunk);
+}
+```
+
+```typescript TypeScript
+const stream = await sb.fs().readStream("/app/data.bin");
+for await (const chunk of stream) {
+    processChunk(chunk); // chunk is a Uint8Array
+}
+```
+
+```python Python
+stream = await sb.fs.read_stream("/app/data.bin")
+async for chunk in stream:
+    process(chunk)
+```
+
+</CodeGroup>
+
+## Copy from host
+
+Copy a file from the host machine into the sandbox in a single call.
+
+<CodeGroup>
+```rust Rust
+sb.fs().copy_from_host("./local-file.txt", "/app/remote-file.txt").await?;
+```
+
+```typescript TypeScript
+await sb.fs().copyFromHost("./local-file.txt", "/app/remote-file.txt");
+```
+
+```python Python
+await sb.fs.copy_from_host("./local-file.txt", "/app/remote-file.txt")
+```
+
+</CodeGroup>
+
+<Tip>
+  If you need to transfer many files at once, consider using a [bind-mounted volume](/sandboxes/volumes) instead. Volumes give the guest direct filesystem access, whereas the filesystem API transfers each file individually. For bulk operations, volumes are significantly faster.
+</Tip>
+
+## Extensible backends
+
+The default filesystem backends handle most use cases. For advanced scenarios, you can attach hooks to intercept operations on a volume, or implement a full custom backend.
+
+### Hooks <sup><sup>coming soon</sup></sup>
+
+Intercept file reads and writes on a volume without replacing the entire backend. Hooks receive the path and data, and return transformed data. The underlying filesystem handles everything else (permissions, directories, metadata).
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let key = get_encryption_key();
+let sb = Sandbox::builder("encrypted")
+    .image("python")
+    .volume("/secrets", |v| v
+        .bind("/data/secrets")
+        .on_read(move |_path, data| decrypt(data, &key))
+        .on_write(move |_path, data| encrypt(data, &key))
+    )
+    .create().await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+// Hooks are coming soon. The planned shape will sit alongside the regular
+// mount methods on the volume builder, e.g.:
+//
+//   .volume("/secrets", (m) => m
+//       .bind("/data/secrets")
+//       .onRead((path, data) => decrypt(data, key))
+//       .onWrite((path, data) => encrypt(data, key)),
+//   )
+//
+// For now the closest equivalent is a plain bind:
+await using sb = await Sandbox.builder("encrypted")
+    .image("python")
+    .volume("/secrets", (m) => m.bind("/data/secrets"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+key = get_encryption_key()
+sb = await Sandbox.create(
+    "encrypted",
+    image="python",
+    volumes={
+        "/secrets": Volume.bind("/data/secrets",
+            on_read=lambda path, data: decrypt(data, key),
+            on_write=lambda path, data: encrypt(data, key),
+        ),
+    },
+)
+```
+
+</CodeGroup>
+
+### Custom backend <sup><sup>coming soon</sup></sup>
+
+For full control, implement the `FsBackend` trait (Rust) or class (TypeScript). This gives you access to every POSIX operation: `read`, `write`, `lookup`, `getattr`, `readdir`, etc. You can delegate to a built-in backend (like `PassthroughFs`) for operations you don't need to customize.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{FsBackend, PassthroughFs};
+use std::io;
+
+struct EncryptedFs { key: [u8; 32], inner: PassthroughFs }
+
+impl FsBackend for EncryptedFs {
+    fn read(&self, ctx: Context, inode: u64, handle: u64,
+            buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        let n = self.inner.read(ctx, inode, handle, buf, offset)?;
+        self.decrypt_in_place(&mut buf[..n]);
+        Ok(n)
+    }
+    fn write(&self, ctx: Context, inode: u64, handle: u64,
+             buf: &[u8], offset: u64) -> io::Result<usize> {
+        let encrypted = self.encrypt(buf);
+        self.inner.write(ctx, inode, handle, &encrypted, offset)
+    }
+    // ... remaining methods delegate to self.inner
+}
+
+let sb = Sandbox::builder("custom")
+    .volume("/secrets", |v| v.backend(EncryptedFs::new(key, "/data")?))
+    .create().await?;
+```
+
+```typescript TypeScript
+// FsBackend is coming soon. The planned API will let you plug a custom
+// backend into a volume:
+//
+//   class EncryptedFs implements FsBackend {
+//     // ... implement read, write, and other required methods
+//   }
+//
+//   const sb = await Sandbox.builder("custom")
+//     .volume("/secrets", (m) => m.backend(new EncryptedFs(key, "/data")))
+//     .create();
+```
+
+```python Python
+from microsandbox import FsBackend, Sandbox, Volume
+
+# Implement the FsBackend interface
+class EncryptedFs(FsBackend):
+    # ... implement read, write, and other required methods
+    pass
+
+sb = await Sandbox.create(
+    "custom",
+    volumes={
+        "/secrets": Volume.backend(EncryptedFs(key, "/data")),
+    },
+)
+```
+
+</CodeGroup>

--- a/docs/es/sandboxes/lifecycle.mdx
+++ b/docs/es/sandboxes/lifecycle.mdx
@@ -1,0 +1,401 @@
+---
+title: Lifecycle
+description: Create, start, stop, and manage sandbox state
+icon: "rotate"
+---
+
+Each sandbox runs as a child process of whatever application creates it. `Sandbox.builder(...).create()` boots a microVM, starts the guest agent inside it, and establishes a communication channel back to the host.
+
+Understanding the lifecycle is useful once you start managing long-running sandboxes, graceful shutdown, or resilient agent workflows.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Creating: create()
+    Creating --> Running: boot complete
+    Running --> Paused: pause()
+    Paused --> Running: resume()
+    Running --> Draining: drain()
+    Running --> Stopped: stop()
+    Running --> Crashed: unexpected exit
+    Draining --> Stopped: drain complete
+    Stopped --> Running: start()
+    Stopped --> [*]: remove()
+    Crashed --> [*]: remove()
+```
+
+## States
+
+| Status | Description |
+|--------|-------------|
+| **Creating** | The VM is booting. The kernel is loaded, the filesystem is mounted, and the guest agent is initializing (configuring network, setting up the environment). |
+| **Running** | The guest agent is ready. You can call `exec`, `shell`, `fs`, and `emit`. |
+| **Paused** | All guest processes are frozen. No CPU cycles consumed. Resume is instant with no re-boot or re-init. |
+| **Draining** | Graceful shutdown in progress. Existing commands run to completion, but new `exec` calls are rejected. Transitions to Stopped when all commands finish. |
+| **Stopped** | The VM has shut down. Sandbox configuration and state are persisted to the database and can be restarted. |
+| **Crashed** | The VM exited unexpectedly (e.g., kernel panic, OOM kill). |
+
+## Create a sandbox
+
+Creating a sandbox boots the microVM, mounts the filesystem, initializes the guest agent, and waits until it's ready to accept commands.
+
+<CodeGroup>
+```rust Rust
+// Attached: sandbox stops when your process exits
+let sb = Sandbox::builder("worker").image("python").create().await?;
+
+// Detached: sandbox survives after your process exits
+let sb = Sandbox::builder("worker").image("python").create_detached().await?;
+```
+
+```typescript TypeScript
+// Attached: sandbox stops when your process exits
+await using sb = await Sandbox.builder("worker").image("python").create();
+
+// Detached: sandbox survives after your process exits
+const detached = await Sandbox.builder("worker").image("python").createDetached();
+```
+
+```python Python
+# Attached: sandbox stops when your process exits
+sb = await Sandbox.create("worker", image="python")
+
+# Detached: sandbox survives after your process exits
+sb = await Sandbox.create("worker", image="python", detached=True)
+```
+
+```bash CLI
+# Attached
+msb create python --name worker
+
+# Detached
+msb run -d python --name worker
+```
+
+</CodeGroup>
+
+## Stop and restart
+
+Stopping gracefully terminates guest processes and shuts down the VM. The sandbox moves to `Stopped` and can be restarted later with all its configuration preserved.
+
+<CodeGroup>
+```rust Rust
+sb.stop().await?;
+
+let sb = Sandbox::start("worker").await?;
+```
+
+```typescript TypeScript
+await sb.stop()
+
+// Later, resume where you left off
+const sb = await Sandbox.start("worker")
+```
+
+```python Python
+await sb.stop()
+
+# Later, resume where you left off
+sb = await Sandbox.start("worker")
+```
+
+```bash CLI
+msb stop worker
+
+# Later, resume where you left off
+msb start worker
+```
+
+</CodeGroup>
+
+## Kill immediately
+
+If a sandbox is unresponsive (e.g., stuck in a tight loop or a panic), force-kill it. The sandbox is terminated immediately with no graceful shutdown.
+
+<CodeGroup>
+```rust Rust
+sb.kill().await?;
+```
+
+```typescript TypeScript
+await sb.kill()
+```
+
+```python Python
+await sb.kill()
+```
+
+```bash CLI
+msb stop --force worker
+```
+
+</CodeGroup>
+
+## Pause and resume <sup><sup>coming soon</sup></sup>
+
+Freeze all guest processes without shutting down. The VM uses zero CPU while paused, and resume is instant. The guest continues exactly where it left off with no boot time and no re-init.
+
+<CodeGroup>
+```rust Rust
+sb.pause().await?;
+sb.resume().await?;
+```
+
+```typescript TypeScript
+await sb.pause()
+await sb.resume()
+```
+
+```python Python
+await sb.pause()
+await sb.resume()
+```
+
+</CodeGroup>
+
+## Detach
+
+Keeps a sandbox running after the parent process exits. It becomes a background process that you can reconnect to later with `Sandbox::get("worker")`.
+
+<CodeGroup>
+```rust Rust
+sb.detach().await;
+```
+
+```typescript TypeScript
+await sb.detach()
+```
+
+```python Python
+await sb.detach()
+```
+
+</CodeGroup>
+
+<Tip>
+  Detached sandboxes are tracked at `~/.microsandbox/db/`. A background reaper periodically checks for stale sandboxes that have exited unexpectedly and cleans up their records.
+</Tip>
+
+## Drain
+
+Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and transitions to `Stopped` when all in-flight commands complete. This is useful for zero-downtime rotation of worker sandboxes.
+
+<CodeGroup>
+```rust Rust
+sb.drain().await?;
+```
+
+```typescript TypeScript
+await sb.drain()
+```
+
+```python Python
+await sb.drain()
+```
+
+</CodeGroup>
+
+## Wait
+
+Block until the sandbox exits on its own, without triggering a stop.
+
+<CodeGroup>
+```rust Rust
+let exit_status = sb.wait().await?;
+```
+
+```typescript TypeScript
+const exitStatus = await sb.wait()
+```
+
+```python Python
+code, success = await sb.wait()
+```
+
+</CodeGroup>
+
+## Remove
+
+Delete a stopped sandbox and its associated state from disk.
+
+<CodeGroup>
+```rust Rust
+Sandbox::remove("worker").await?;
+```
+
+```typescript TypeScript
+await Sandbox.remove("worker")
+```
+
+```python Python
+await Sandbox.remove("worker")
+```
+
+```bash CLI
+msb rm worker
+```
+
+</CodeGroup>
+
+## List and inspect
+
+<CodeGroup>
+```rust Rust
+for handle in Sandbox::list().await? {
+    println!("{}: {:?}", handle.name(), handle.status());
+}
+```
+
+```typescript TypeScript
+const sandboxes = await Sandbox.list();
+for (const handle of sandboxes) {
+    console.log(`${handle.name}: ${handle.status}`);
+}
+
+const handle = await Sandbox.get("worker");
+console.log(handle.status); // "running" | "stopped" | ...
+```
+
+```python Python
+for handle in await Sandbox.list():
+    print(f"{handle.name}: {handle.status}")
+
+handle = await Sandbox.get("worker")
+print(handle.status)  # "running" | "stopped" | ...
+```
+
+```bash CLI
+msb ls
+msb ps worker
+```
+
+</CodeGroup>
+
+## Runtime process architecture
+
+Here's what's running and how the pieces talk to each other.
+
+```mermaid
+graph TD
+    subgraph Host["Host"]
+        A["Your Application<br/><small>microsandbox SDK</small>"]
+        B["Sandbox Process<br/><small>VM + networking + lifecycle</small>"]
+    end
+
+    subgraph Guest["Guest VM"]
+        F["agentd<br/><small>exec, fs, events</small>"]
+    end
+
+    A -- "spawn" --> B
+    B -- "boot" --> F
+    A -. "commands & responses" .-> F
+
+    style Host fill:#f5f0ff,stroke:#a770ef,color:#333
+    style Guest fill:#fef4e8,stroke:#e8a838,color:#333
+    style A fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
+    style B fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
+    style F fill:#fdd49e,stroke:#d97706,color:#1a1a1a
+```
+
+There are two layers here. The **sandbox process** runs the VM and the networking stack on the host side, and relays messages between the application and the **guest agent** inside the VM. Up to 16 clients can connect to the same sandbox simultaneously.
+
+The sandbox process also handles:
+
+- Graceful stop and drain signals
+- Cleanup when the sandbox exits
+- Idle detection (auto-drain after a configurable timeout)
+- Maximum sandbox lifetime enforcement
+
+The sandbox process does not execute guest commands itself. It only relays traffic between your application and the guest agent.
+
+## Logs and diagnostics
+
+Each sandbox keeps four files under `<sandbox-dir>/logs/`:
+
+| File | Producer | Contents |
+|------|----------|----------|
+| `exec.log` | Host relay (tap on guest frames) | User-program stdout/stderr/output as JSON Lines |
+| `runtime.log` | Sandbox process (host) | Runtime tracing — relay setup, lifecycle, network |
+| `kernel.log` | Guest VM virtio-console | Kernel boot messages and `agentd` console |
+| `boot-error.json` | Sandbox process | Present only when the most recent start failed before the agent came up |
+
+The user-facing surface for these is [`msb logs`](/cli/sandbox-commands#msb-logs) and the SDK [`logs()`](/sandboxes/logs) method — both work on running and stopped sandboxes alike. See the [Logs](/sandboxes/logs) page for the capture model, source semantics, and diagnostic flows.
+
+When a sandbox is in the **Crashed** state, its log directory is left in place so you can read what happened. Use `msb logs --source system <name>` to see the runtime/kernel diagnostic merge.
+
+## Graceful shutdown with timeout fallback
+
+Attempt a graceful stop, then force-kill if the sandbox doesn't shut down in time.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+use std::time::Duration;
+
+let mut handle = Sandbox::get("worker").await?;
+match tokio::time::timeout(Duration::from_secs(30), handle.stop()).await {
+    Ok(Ok(())) => println!("Stopped"),
+    Ok(Err(e)) => eprintln!("Error: {e}"),
+    Err(_) => handle.kill().await?,
+}
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.get("worker");
+try {
+    await Promise.race([
+        sb.stop(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 30_000)),
+    ]);
+} catch {
+    await sb.kill();
+}
+```
+
+```python Python
+import asyncio
+from microsandbox import Sandbox
+
+handle = await Sandbox.get("worker")
+sb = await handle.connect()
+try:
+    await asyncio.wait_for(sb.stop(), timeout=30)
+except asyncio.TimeoutError:
+    await sb.kill()
+```
+
+</CodeGroup>
+
+## Sandbox process policies
+
+For production workloads, configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .max_duration(3600)
+    .idle_timeout(300)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .maxDuration(3600)   // maximum sandbox lifetime in seconds
+    .idleTimeout(300)    // auto-drain after 5 minutes of inactivity
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    max_duration=3600,
+    idle_timeout=300,
+)
+```
+
+</CodeGroup>

--- a/docs/es/sandboxes/logs.mdx
+++ b/docs/es/sandboxes/logs.mdx
@@ -1,0 +1,288 @@
+---
+title: Logs
+description: Capture, read, and diagnose sandbox output
+icon: "scroll"
+---
+
+Every sandbox records its captured output to disk so you can read it later — even after the sandbox stops or crashes. The CLI surface is `msb logs <name>`; the SDK surface is `logs()` on `Sandbox` and `SandboxHandle`. Both work on running and stopped sandboxes alike, with no protocol traffic — just a file read.
+
+## What's captured
+
+When a sandbox is running, the host-side **relay tap** intercepts the protocol frames flowing from the guest agent (`agentd`) and writes a copy of every exec session's stdout/stderr to `exec.log` as JSON Lines. Every session is captured, tagged with its own monotonic id so readers can group or filter by session.
+
+```jsonl
+{"t":"2026-04-30T20:32:59.688Z","s":"system","d":"--- sandbox started ---\n"}
+{"t":"2026-04-30T20:32:59.689Z","s":"stdout","d":"Listening on :8080\n","id":1}
+{"t":"2026-04-30T20:32:59.690Z","s":"stderr","d":"warn: no TLS\n","id":1}
+{"t":"2026-04-30T20:33:01.112Z","s":"stdout","d":"got request\n","id":2}
+{"t":"2026-04-30T20:33:05.220Z","s":"system","d":"--- sandbox stopped ---\n"}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `t` | RFC 3339 timestamp at the moment the chunk was captured |
+| `s` | Source tag — see [Sources](#sources) |
+| `d` | The chunk's bytes, UTF-8 lossy decoded by default |
+| `id` | Relay-monotonic session id (starts at 1, +1 per `exec`); absent on `system` entries |
+
+## Sources
+
+The `s` field tells you where each chunk came from. Four values:
+
+| Source | When emitted |
+|--------|--------------|
+| `stdout` | Captured from a session's stdout, **pipe mode** — streams stayed separated end to end. |
+| `stderr` | Captured from a session's stderr, **pipe mode**. |
+| `output` | Captured from a session running in **PTY mode**. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream. We tag them `output` rather than mislabel as `stdout` so a reader doing `jq 'select(.s == "stderr")'` doesn't accidentally pick up merged PTY bytes. |
+| `system` | Synthetic entries: lifecycle markers (`--- sandbox started ---` / `--- sandbox stopped ---`) plus runtime/kernel diagnostic lines from `runtime.log` / `kernel.log` merged in at read time when `--source system` is requested. |
+
+The default `msb logs <name>` and SDK `logs()` show `stdout` + `stderr` + `output` — all user-program output, regardless of pipe vs PTY. Add `system` explicitly when you want the diagnostics merge.
+
+<Tip>
+  **Pipe vs PTY modes.** Non-interactive `msb run` (with stdin piped or redirected) and `Sandbox.exec()` use pipe mode — streams stay separate. Interactive `msb run` from a real terminal, `msb attach`, and explicit `--tty` use PTY mode — streams are merged in the kernel. Choose pipe mode when you want clean per-stream filtering in your logs.
+</Tip>
+
+## Reading logs
+
+### From the CLI
+
+```bash
+# Default — user-program output (stdout + stderr + output)
+msb logs devbox
+
+# Tail the most recent entries
+msb logs devbox --tail 100
+
+# Follow live
+msb logs devbox -f
+
+# Filter by source
+msb logs devbox --source stderr           # just stderr (pipe-mode only)
+msb logs devbox --source output           # just PTY-merged
+msb logs devbox --source system           # runtime + kernel diagnostics
+msb logs devbox --source all              # everything, chronologically merged
+
+# Time-bounded
+msb logs devbox --since 5m                # last 5 minutes
+msb logs devbox --since 2026-04-30T20:00:00Z
+
+# Grep
+msb logs devbox --grep ERROR
+
+# Multi-session view: prefix each line with [id:N]
+msb logs devbox --show-id
+
+# Color each session distinctly (implies --show-id)
+msb logs devbox --color-sessions
+
+# Programmatic: raw JSON Lines
+msb logs devbox --json | jq 'select(.s == "stderr")'
+```
+
+See [`msb logs` reference](/cli/sandbox-commands#msb-logs) for the full flag list.
+
+### From the SDK
+
+<CodeGroup>
+```rust Rust
+use microsandbox::sandbox::{LogOptions, LogSource, Sandbox};
+
+let handle = Sandbox::get("web").await?;
+
+let entries = handle.logs(&LogOptions::default())?;
+
+for e in entries {
+    let source = match e.source {
+        LogSource::Stdout => "OUT",
+        LogSource::Stderr => "ERR",
+        LogSource::Output => "PTY",
+        LogSource::System => "SYS",
+    };
+    println!(
+        "[{}] {} {:?}: {}",
+        e.timestamp.to_rfc3339(),
+        source,
+        e.session_id,
+        String::from_utf8_lossy(&e.data).trim_end()
+    );
+}
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const handle = await Sandbox.get("web");
+
+const entries = await handle.logs();
+
+for (const e of entries) {
+    const source =
+        e.source === "stdout" ? "OUT" :
+        e.source === "stderr" ? "ERR" :
+        e.source === "output" ? "PTY" :
+        "SYS";
+
+    console.log(
+        `[${e.timestamp.toISOString()}] ${source} ${e.sessionId}: ${e.text().trimEnd()}`
+    );
+}
+```
+
+```python Python
+import asyncio
+import microsandbox
+
+async def main():
+    handle = await microsandbox.Sandbox.get("web")
+
+    entries = await handle.logs()
+
+    for e in entries:
+        source = {
+            "stdout": "OUT",
+            "stderr": "ERR",
+            "output": "PTY",
+            "system": "SYS",
+        }[e.source]
+
+        print(
+            f"[{e.timestamp_ms / 1000:.3f}] "
+            f"{source} {e.session_id}: {e.text().rstrip()}"
+        )
+
+asyncio.run(main())
+```
+</CodeGroup>
+
+### Filtering at read time
+
+All filters are client-side. The on-disk file is bounded (10 MiB rotated × 3 = 30 MiB ceiling per sandbox), so a linear scan is always cheap.
+
+<CodeGroup>
+```rust Rust
+use chrono::{Duration, Utc};
+use microsandbox::sandbox::{LogOptions, LogSource};
+
+let recent = handle.logs(&LogOptions {
+    tail: Some(50),
+    since: Some(Utc::now() - Duration::hours(1)),
+    sources: vec![
+        LogSource::Stdout,
+        LogSource::Stderr,
+        LogSource::Output,
+        LogSource::System,
+    ],
+    ..Default::default()
+})?;
+```
+
+```typescript TypeScript
+const recent = await handle.logs({
+    tail: 50,
+    since: new Date(Date.now() - 60 * 60 * 1000),
+    sources: ["stdout", "stderr", "output", "system"],
+});
+```
+
+```python Python
+import time
+
+recent = await handle.logs(
+    tail=50,
+    since_ms=(time.time() - 3600) * 1000,
+    sources=["stdout", "stderr", "output", "system"],
+)
+```
+</CodeGroup>
+
+## On-disk layout
+
+Each sandbox has its own log directory under `<sandbox-dir>/logs/`:
+
+| File | Producer | Format | Bounded? |
+|------|----------|--------|----------|
+| `exec.log` | Host relay tap | JSON Lines (one entry per chunk) | Yes — `RotatingLog`, 10 MiB × 3 |
+| `runtime.log` | Sandbox process tracing | Plain text (RFC 3339 prefix) | Yes — `RotatingLog`, 10 MiB × 3 |
+| `kernel.log` | Guest VM virtio-console | Plain text (kernel + `agentd`) | Append-only |
+| `boot-error.json` | Sandbox process (failed start only) | JSON object | Single file, atomically replaced |
+
+Lifecycle: the directory is created on `msb create`. `exec.log` gets `--- sandbox started ---` injected when the agent reports `core.ready`, and `--- sandbox stopped ---` when the sandbox process exits (the latter from the VMM's `on_exit` observer, so it fires reliably even on crashes). On `msb remove`, the entire directory is deleted.
+
+## Boot errors
+
+When a sandbox process exits before the agent relay is ready — typically a mount error, missing rootfs, or network setup failure — there's no `exec.log` content yet. The runtime writes a small structured `boot-error.json` instead:
+
+```json
+{
+  "t": "2026-04-30T20:32:59.690Z",
+  "stage": "mount",
+  "errno": 2,
+  "message": "mount tmp_x_…: No such file or directory (os error 2)"
+}
+```
+
+The CLI prepends a styled error block reconstructed from this file before any captured log content:
+
+```
+error: failed to start "dind"
+  → mount: mount tmp_x_…: No such file or directory (os error 2)
+  → the host path for one of the mounts does not exist
+  → run `msb logs --source system dind` for full diagnostics
+```
+
+`stage` values: `mount`, `build_vm`, `config`, `network`, `image`, `other`. The CLI's stage-to-hint mapper turns `(stage, errno)` into the actionable hint line.
+
+SDK callers see this as a typed [`BootStart` error](/sdk/errors#sandbox-start-failures) — match on it to recover or report cleanly.
+
+## Common diagnostic flows
+
+**"My sandbox crashed — what happened?"**
+
+```bash
+msb ls                              # confirm Crashed state
+msb logs <name>                     # what was the program doing right before?
+msb logs <name> --source system     # runtime + kernel diagnostics
+```
+
+**"My sandbox won't start."**
+
+```bash
+msb create --name nope ...          # observe the styled error block
+cat ~/.microsandbox/sandboxes/nope/logs/boot-error.json
+msb logs nope --source system       # full diagnostics from runtime.log/kernel.log
+```
+
+**"My program isn't logging."**
+
+If `exec.log` only has `--- sandbox started ---` and nothing else, no exec session ever opened. Check that you actually ran something — `msb create` alone doesn't run any user program.
+
+**"My program is logging but I can't tell which session."**
+
+```bash
+msb logs <name> --show-id           # prefix every line with the session id
+msb logs <name> --color-sessions    # one color per session
+```
+
+**"I want to feed logs to my own pipeline."**
+
+```bash
+# JSON Lines — schema in this page's "What's captured" section
+msb logs <name> --json | jq -c 'select(.s == "stderr")'
+
+# Or programmatic via the SDK — same data, typed.
+```
+
+## Capture model in detail
+
+A sandbox can host many concurrent exec sessions: an `msb run` at creation, plus arbitrary `msb exec` calls, plus SDK-driven sessions. **Every session is captured** to `exec.log`, tagged with its own monotonic `id` field so readers can group or filter without losing data.
+
+The id is minted by the relay (`next_session_id: AtomicU64`, starts at 1, +1 per observed `ExecRequest`). It's distinct from the protocol correlation id — the latter is per-client and gets reused across slot recycling, which would make sequential `msb exec` calls indistinguishable. The relay-minted id never repeats within a sandbox lifetime.
+
+System entries (`--- sandbox started ---`, `--- sandbox stopped ---`) have no `id` field — they aren't tied to a specific session.
+
+## Troubleshooting log capture
+
+- **`exec.log` is empty.** No exec session ever opened. `msb create` alone doesn't run anything; you need `msb run` or `msb exec` to produce output.
+- **Stderr appears as `stdout`.** The session is in PTY mode (interactive). PTY merges streams in the kernel — by the time bytes leave the guest, they're indistinguishable. Use `< /dev/null` or non-interactive invocation to take the pipe path. PTY-mode bytes are tagged `output`, not `stdout` — make sure your filters cover both.
+- **`runtime.log` has weird `[2m...` characters.** Older sandboxes may still have ANSI color codes from `tracing`. Newly-created sandboxes don't (we disable ANSI at the source for the sandbox subprocess).
+- **`msb logs -f` exits immediately.** The sandbox is stopped. Follow mode against a stopped sandbox dumps the existing contents and exits — it doesn't block waiting for it to start.

--- a/docs/es/sandboxes/metrics.mdx
+++ b/docs/es/sandboxes/metrics.mdx
@@ -1,0 +1,83 @@
+---
+title: Metrics
+description: Monitor sandbox resource usage
+icon: "chart-line"
+---
+
+Query resource usage for a running sandbox: CPU, memory, and more. Get a single point-in-time snapshot, or open a streaming subscription that delivers updates at a fixed interval.
+
+## Point-in-time
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let metrics = sb.metrics().await?;
+println!("CPU: {:.1}%, Mem: {} MB", metrics.cpu_percent, metrics.memory_bytes / 1024 / 1024);
+```
+
+```typescript TypeScript
+const metrics = await sb.metrics();
+console.log(`CPU: ${metrics.cpuPercent.toFixed(1)}%, Mem: ${Math.floor(metrics.memoryBytes / 1024 / 1024)} MB`);
+```
+
+```python Python
+m = await sb.metrics()
+print(f"CPU: {m.cpu_percent:.1f}%, Mem: {m.memory_bytes // 1024 // 1024} MB")
+```
+
+</CodeGroup>
+
+## Streaming
+
+Subscribe to metric updates at a regular interval. Each update arrives as a separate event.
+
+<CodeGroup>
+```rust Rust
+use std::time::Duration;
+use futures::StreamExt;
+
+let mut stream = sb.metrics_stream(Duration::from_secs(1));
+while let Some(m) = stream.next().await {
+    let m = m?;
+    println!("CPU: {:.1}%, Mem: {} MB", m.cpu_percent, m.memory_bytes / 1024 / 1024);
+}
+```
+
+```typescript TypeScript
+for await (const m of await sb.metricsStream(1000)) {
+    console.log(`[${m.timestamp.toISOString()}] CPU: ${m.cpuPercent.toFixed(1)}%`);
+}
+```
+
+```python Python
+async for m in await sb.metrics_stream(interval=1.0):
+    print(f"[{m.timestamp_ms}] CPU: {m.cpu_percent:.1f}%")
+```
+
+</CodeGroup>
+
+## Fleet-wide metrics
+
+Get metrics for all running sandboxes at once. Useful for dashboards or capacity planning.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::all_sandbox_metrics;
+
+let all = all_sandbox_metrics().await?;
+```
+
+```typescript TypeScript
+import { allSandboxMetrics } from "microsandbox";
+
+const all = await allSandboxMetrics();
+```
+
+```python Python
+from microsandbox import all_sandbox_metrics
+
+all_metrics = await all_sandbox_metrics()
+```
+
+</CodeGroup>

--- a/docs/es/sandboxes/overview.mdx
+++ b/docs/es/sandboxes/overview.mdx
@@ -1,0 +1,355 @@
+---
+title: Overview
+description: What sandboxes are and how to configure them
+icon: "circle-info"
+---
+
+A sandbox is a microVM: a real virtual machine with its own Linux kernel, filesystem, and network stack, running as a child process of whatever application creates it.
+
+The security boundary here is hardware virtualization, not Linux namespaces. Container escapes are a well-documented class of vulnerability; breaking out of a microVM requires exploiting the hypervisor itself, which is a fundamentally harder problem.
+
+## Creating a sandbox
+
+At minimum, a sandbox needs a name and an image. Everything else has sensible defaults: 1 vCPU, 512 MiB memory, public-only networking, `/bin/sh` as the shell.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create("worker", image="python")
+```
+
+```bash CLI
+msb create python --name worker
+```
+
+</CodeGroup>
+
+## Configuration options
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .memory(1024)
+    .cpus(2)
+    .env("DEBUG", "true")
+    .env("API_PORT", "8000")
+    .volume("/app/src", |v| v.bind("./src").readonly())
+    .volume("/data", |v| v.named("my-data"))
+    .volume("/tmp/scratch", |v| v.tmpfs().size(100))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .memory(1024)
+    .cpus(2)
+    .env("DEBUG", "true")
+    .env("API_PORT", "8000")
+    .volume("/app/src",     (m) => m.bind("./src").readonly())
+    .volume("/data",        (m) => m.named("my-data"))
+    .volume("/tmp/scratch", (m) => m.tmpfs().size(100))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    memory=1024,
+    cpus=2,
+
+    env={"DEBUG": "true", "API_PORT": "8000"},
+    volumes={
+        "/app/src": Volume.bind("./src", readonly=True),
+        "/data": Volume.named("my-data"),
+        "/tmp/scratch": Volume.tmpfs(size_mib=100),
+    },
+)
+```
+
+```bash CLI
+msb create python --name worker \
+  -c 2 \
+  -m 1G \
+  -e DEBUG=true \
+  -e API_PORT=8000 \
+  -v ./src:/app/src:ro \
+  -v my-data:/data \
+  --tmpfs /tmp/scratch:100
+```
+
+</CodeGroup>
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `image` | — | OCI image, local path, or disk image |
+| `cpus` | `1` | Number of virtual CPUs |
+| `memory` | `512` | Guest memory in MiB |
+| `workdir` | — | Default working directory for commands |
+| `shell` | `/bin/sh` | Shell used by `shell()` calls |
+| `env` | `{}` | Environment variables |
+| `volumes` | `[]` | Volume mounts (bind, named, or tmpfs) |
+| `network` | `public` | Network policy and port mappings |
+| `scripts` | `{}` | Named scripts stored at `/.msb/scripts/` |
+
+<Tip>
+  `cpus` and `memory` are **limits, not reservations**. Setting `memory: 512` doesn't allocate 512 MiB upfront. Physical pages are only allocated as the guest actually touches them, so you can comfortably run many sandboxes on a single host without worrying about overcommitting.
+</Tip>
+
+## Rootfs sources
+
+microsandbox supports three ways to provide a root filesystem. The choice affects how the filesystem is assembled and what features are available.
+
+### OCI images
+
+The most common option. microsandbox pulls the image and stacks its layers as a copy-on-write filesystem. Changes inside the sandbox don't modify the base image. If two sandboxes use the same image, they share the same cached layers on disk.
+
+<CodeGroup>
+```rust Rust
+Sandbox::builder("worker").image("python").create().await?;
+```
+
+```typescript TypeScript
+await Sandbox.builder("worker").image("python").create();
+```
+
+```python Python
+await Sandbox.create("worker", image="python")
+```
+
+```bash CLI
+msb create python --name worker
+```
+
+</CodeGroup>
+
+### Bind mounts
+
+Use a local directory on the host as the root filesystem directly. The guest sees the directory contents as its `/`. This is useful for development when you have a pre-built rootfs, or for minimal environments where you've assembled the filesystem yourself.
+
+<CodeGroup>
+```rust Rust
+Sandbox::builder("worker").image("./my-rootfs").create().await?;
+```
+
+```typescript TypeScript
+await Sandbox.builder("worker").image("./my-rootfs").create();
+```
+
+```python Python
+await Sandbox.create("worker", image="./my-rootfs")
+```
+
+```bash CLI
+msb create ./my-rootfs --name worker
+```
+
+</CodeGroup>
+
+<Note>
+  The guest agent is automatically included in the rootfs during sandbox creation, regardless of rootfs source. You don't need to add anything to your image or directory.
+</Note>
+
+### Disk images
+
+Boot from a QCOW2, Raw, or VMDK disk image. Unlike OCI images (which use a copy-on-write overlay), disk images give the guest raw block device access. See [Disk Images](/images/disk-images) for details.
+
+<CodeGroup>
+```rust Rust
+// Auto-detect filesystem
+Sandbox::builder("worker")
+    .image("./ubuntu-22.04.qcow2")
+    .create()
+    .await?;
+
+// Explicit filesystem type
+Sandbox::builder("worker")
+    .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+// Auto-detect the disk image format from the file extension.
+await Sandbox.builder("worker")
+    .image("./alpine.qcow2")
+    .create();
+```
+
+```python Python
+from microsandbox import Image, Sandbox
+
+# Auto-detect filesystem
+await Sandbox.create("worker", image="./ubuntu-22.04.qcow2")
+
+# Explicit filesystem type
+await Sandbox.create("worker", image=Image.disk("./alpine.raw", fstype="ext4"))
+```
+
+```bash CLI
+msb create ./alpine.qcow2 --name worker
+```
+
+</CodeGroup>
+
+<Note>
+  With OCI images, microsandbox stacks layers and adds a copy-on-write overlay so sandboxes share the base. With disk images, the guest gets the block device directly, so there's no copy-on-write isolation between sandboxes using the same disk image. Each sandbox needs its own copy (or use QCOW2's built-in snapshot/backing file support).
+</Note>
+
+## Replace existing
+
+Replace a stopped sandbox with the same name instead of failing on conflict. This stops the old sandbox (if still running), removes it, and creates a fresh one.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .replace()
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .replace()
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create("worker", image="python", replace=True)
+```
+
+```bash CLI
+msb create --replace python --name worker
+```
+
+</CodeGroup>
+
+## Private registry
+
+Authenticate to private container registries and control when images are pulled.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, RegistryAuth, PullPolicy};
+
+let sb = Sandbox::builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry_auth(RegistryAuth::Basic {
+        username: "deploy".into(),
+        password: std::env::var("REGISTRY_PASSWORD")?,
+    })
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("private.registry.io/org/app:v1")
+    .registry((r) => r.auth({
+        kind: "basic",
+        username: "deploy",
+        password: process.env.REGISTRY_TOKEN!,
+    }))
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import PullPolicy, RegistryAuth, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="private.registry.io/org/app:v1",
+    registry_auth=RegistryAuth.basic("deploy", os.environ["REGISTRY_PASSWORD"]),
+    pull_policy=PullPolicy.ALWAYS,
+)
+```
+
+```bash CLI
+msb registry login private.registry.io -u deploy
+msb create private.registry.io/org/app:v1 \
+  --name worker --pull always
+```
+
+</CodeGroup>
+
+| Policy | Behavior |
+|--------|----------|
+| `"always"` | Pull the image every time, even if cached locally |
+| `"if-missing"` | Pull only if the image is not already cached (default) |
+| `"never"` | Never pull; fail if the image is not cached |
+
+<Tip>
+  Once an OCI image is resolved, microsandbox pins the exact layers. A `python` reference is resolved to an immutable set of layers at first pull. Subsequent `start()` calls use the pinned layers without re-resolving the mutable tag, so your sandbox is reproducible even if the upstream tag is updated.
+</Tip>
+
+## Config inspection <sup><sup>coming soon</sup></sup>
+
+Build a sandbox configuration without booting the VM. Useful for serializing, storing, validating, or modifying configs before creation.
+
+<CodeGroup>
+```rust Rust
+let config = Sandbox::builder("preview")
+    .image("python")
+    .memory(1024)
+    .build()?;
+
+println!("{}", serde_json::to_string_pretty(&config)?);
+let sb = Sandbox::create(config).await?;
+```
+
+```typescript TypeScript
+const builder = Sandbox.builder("preview").image("python").memory(1024);
+const config = builder.build();
+
+console.log(JSON.stringify(config, null, 2));
+const sb = await builder.create();
+```
+
+```python Python
+import json
+from microsandbox import Sandbox
+
+config = Sandbox.build_config(
+    "preview",
+    image="python",
+    memory=1024,
+)
+
+print(json.dumps(config, indent=2))
+sb = await Sandbox.create(config)
+```
+
+</CodeGroup>
+
+## Customizing the guest environment
+
+If you need to run setup logic, install packages, or inject files before a sandbox starts doing real work, there are two ways to do it without building a custom image:
+
+- **[Scripts](/sandboxes/customize#scripts)** are files mounted into the sandbox at `/.msb/scripts/` and added to `PATH`. Define them at creation time and call them by name with `exec()` or `shell()`. Good for multi-step setup procedures or named entry points.
+- **[Patches](/sandboxes/customize#patches)** modify the rootfs before the VM boots: write config files, copy directories from the host, create symlinks, append to existing files, etc. The base image stays untouched since patches go into the writable layer.

--- a/docs/es/sandboxes/secrets.mdx
+++ b/docs/es/sandboxes/secrets.mdx
@@ -1,0 +1,76 @@
+---
+title: Secrets
+description: Secure credential injection for sandboxes
+icon: "key"
+---
+
+Secrets use a **placeholder substitution** model. The guest VM never sees the real credential.
+
+When you bind a secret to an environment variable and one or more allowed hosts, microsandbox generates a random placeholder (e.g., `OPENAI_API_KEY=msb_ph_a8f3c2...`) and injects that into the guest instead. The real value never enters the VM. The only way it reaches the outside world is when a request goes to an allowed host, at which point microsandbox swaps the placeholder for the real value. Everywhere else, the placeholder is just a meaningless string.
+
+So even with full code execution inside the sandbox, there's nothing to steal. The credential was never there.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("agent")
+    .image("python")
+    .secret(|s| s
+        .env("GITHUB_TOKEN")
+        .value(std::env::var("GITHUB_TOKEN")?)
+        .allow_host("api.github.com")
+        .allow_host_pattern("*.githubusercontent.com")
+    )
+    .secret_env("OPENAI_API_KEY", api_key, "api.openai.com")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("agent")
+    .image("python")
+    .secret((s) =>
+        s.env("GITHUB_TOKEN")
+            .value(process.env.GITHUB_TOKEN!)
+            .allowHost("api.github.com")
+            .allowHostPattern("*.githubusercontent.com"),
+    )
+    .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import Sandbox, Secret
+
+sb = await Sandbox.create(
+    "agent",
+    image="python",
+    secrets=[
+        Secret.env(
+            "GITHUB_TOKEN",
+            value=os.environ["GITHUB_TOKEN"],
+            allow_hosts=["api.github.com"],
+            allow_host_patterns=["*.githubusercontent.com"],
+        ),
+        Secret.env(
+            "OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+)
+```
+
+```bash CLI
+msb create python --name agent \
+  --secret "GITHUB_TOKEN=$GITHUB_TOKEN@api.github.com" \
+  --secret "OPENAI_API_KEY=$OPENAI_API_KEY@api.openai.com"
+```
+
+</CodeGroup>
+
+See the SDK Reference for the full API: [Rust](/sdk/rust/secrets) | [TypeScript](/sdk/typescript/secrets) | [Python](/sdk/python/secrets).

--- a/docs/es/sandboxes/snapshots.mdx
+++ b/docs/es/sandboxes/snapshots.mdx
@@ -1,0 +1,338 @@
+---
+title: Snapshots
+description: Capture a stopped sandbox's writable layer as a portable artifact
+icon: "code-branch"
+---
+
+A snapshot is a portable, on-disk capture of a sandbox's writable filesystem. Move it with `scp`, archive it as `.tar.zst`, or boot fresh sandboxes from it.
+
+<Note>
+Snapshots are **disk-only and stopped-only**: the sandbox can't be running when you take one. Memory and CPU state, plus qcow2 backing chains, are future work.
+</Note>
+
+## What gets captured
+
+| Captured                                     | Not captured                      |
+| -------------------------------------------- | --------------------------------- |
+| `upper.ext4`, the sandbox's writable overlay | Memory contents                   |
+| Pinned image reference + manifest digest     | CPU registers / running processes |
+| `fstype`, `format`, optional labels          | Network state                     |
+| Optional content-integrity hash              | Open file handles                 |
+
+Booting from a snapshot is a cold boot of a fresh VM that reuses the captured upper layer as its starting filesystem. The image (lower layer) is re-resolved by digest from the local OCI cache, or re-pulled from the registry if missing.
+
+## Quick start
+
+You'll usually reach for the CLI first:
+
+```bash
+# 1. Run something, install state, then stop it
+msb run --name baseline --detach python:3.12 -- sleep 3600
+msb exec baseline -- pip install requests
+msb stop baseline
+
+# 2. Snapshot the stopped sandbox
+msb snapshot create after-pip-install --from baseline
+
+# 3. Boot a fresh sandbox from the snapshot
+msb run --name worker --snapshot after-pip-install \
+    -- python -c "import requests; print(requests.__version__)"
+```
+
+<Tip>
+The snapshot lives at `~/.microsandbox/snapshots/after-pip-install/`. That whole directory is the snapshot.
+</Tip>
+
+## Snapshot a stopped sandbox
+
+Snapshot under a bare name (resolved to `~/.microsandbox/snapshots/<name>/`) or to an explicit path:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let h = Sandbox::get("baseline").await?;
+
+// Bare name resolves under ~/.microsandbox/snapshots/<name>/
+let snap = h.snapshot("after-pip-install").await?;
+
+// Or write to an explicit path
+let snap = h.snapshot_to("/tmp/snaps/v1").await?;
+
+println!("{}", snap.digest()); // sha256:...
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const h = await Sandbox.get("baseline");
+
+// Bare name resolves under ~/.microsandbox/snapshots/<name>/
+const snap = await h.snapshot("after-pip-install");
+
+// Or write to an explicit path
+const snap2 = await h.snapshotTo("/tmp/snaps/v1");
+
+console.log(snap.digest); // sha256:...
+```
+
+```python Python
+from microsandbox import Sandbox
+
+h = await Sandbox.get("baseline")
+
+# Bare name resolves under ~/.microsandbox/snapshots/<name>/
+snap = await h.snapshot("after-pip-install")
+
+# Or write to an explicit path
+snap2 = await h.snapshot_to("/tmp/snaps/v1")
+
+print(snap.digest)  # sha256:...
+```
+
+```bash CLI
+msb snapshot create after-pip-install --from baseline
+msb snapshot create ./snaps/v1     --from baseline   # Explicit path
+msb snapshot create after-pip-install --from baseline --label stage=ready
+```
+
+</CodeGroup>
+
+The sandbox must be stopped or crashed; running sandboxes are rejected.
+
+## Boot from a snapshot
+
+A snapshot already pins its image, so booting from one is mutually exclusive with the image source:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .from_snapshot("after-pip-install")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.builder("worker")
+    .fromSnapshot("after-pip-install")
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox
+
+# `snapshot=` is a peer of `image=` and mutually exclusive with it
+sb = await Sandbox.create("worker", snapshot="after-pip-install")
+```
+
+```bash CLI
+msb run --name worker --snapshot after-pip-install -- python -V
+```
+
+</CodeGroup>
+
+Booting validates the snapshot's manifest, re-resolves the pinned image from the local OCI cache (re-pulling and verifying the digest if it's missing), and reflinks the captured `upper.ext4` into the new sandbox's directory. Reflinks use `clonefile` on macOS APFS, `FICLONE` on btrfs/XFS, with a sparse-aware fallback on ext4, so each new sandbox gets an independent COW copy without paying the bytes again.
+
+## List, inspect, and remove
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Snapshot;
+
+let all = Snapshot::list().await?; // Indexed snapshots
+let h = Snapshot::get("after-pip-install").await?; // By name, digest, or path
+println!("{} ({})", h.name().unwrap_or("-"), h.digest());
+
+Snapshot::remove("after-pip-install", false).await?;
+Snapshot::reindex("~/.microsandbox/snapshots").await?;
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+const all = await Snapshot.list();                       // Indexed snapshots
+const h = await Snapshot.get("after-pip-install");       // By name, digest, or path
+console.log(`${h.name ?? "-"} (${h.digest})`);
+
+await Snapshot.remove("after-pip-install");
+await Snapshot.reindex("~/.microsandbox/snapshots");
+```
+
+```python Python
+from microsandbox import Snapshot
+
+all = await Snapshot.list()                              # Indexed snapshots
+h = await Snapshot.get("after-pip-install")              # By name, digest, or path
+print(f"{h.name or '-'} ({h.digest})")
+
+await Snapshot.remove("after-pip-install")
+await Snapshot.reindex("~/.microsandbox/snapshots")
+```
+
+```bash CLI
+msb snapshot ls
+msb snapshot inspect after-pip-install
+msb snapshot rm after-pip-install
+
+# Also if it has indexed children
+msb snapshot rm after-pip-install --force
+
+# Rebuild the index from artifacts on disk
+msb snapshot reindex
+```
+
+</CodeGroup>
+
+Opening a snapshot is cheap: it validates the manifest and checks the upper file's size, but does **not** read the file's contents. The same path powers `inspect` and the boot flow; the load-bearing local operation has to stay fast.
+
+`list` and `get` are backed by a small local index DB. The index is just a cache for fast lookups, not a source of truth; if it ever gets out of sync (or you delete it), `reindex` rebuilds it from the artifacts on disk.
+
+## Move snapshots between machines
+
+The artifact is a directory containing `manifest.json` (canonical JSON; identity is the SHA-256 of these bytes) plus the captured `upper.ext4`. The directory **is** the snapshot; there's no hidden daemon state, so any of these three transports work:
+
+```bash
+# Copy the directory directly with scp (image must be cached or pullable on the target)
+scp -r ~/.microsandbox/snapshots/after-pip-install \
+    other-host:~/.microsandbox/snapshots/
+
+# Bundle into a .tar.zst, transport, then import
+msb snapshot export after-pip-install /tmp/snap.tar.zst
+scp /tmp/snap.tar.zst other-host:
+ssh other-host msb snapshot import /tmp/snap.tar.zst
+
+# Fully offline: include the OCI image cache so the target needs no network
+msb snapshot export after-pip-install /tmp/snap.tar.zst --with-image
+ssh other-host msb snapshot import /tmp/snap.tar.zst
+```
+
+Archives default to `.tar.zst` since zstd collapses sparse zero runs cheaply. Pass `--plain-tar` for a plain `.tar`; both are accepted on import via magic-byte detection.
+
+Or drive `export` and `import` from code:
+
+<CodeGroup>
+```rust Rust
+use std::path::Path;
+use microsandbox::Snapshot;
+use microsandbox::snapshot::ExportOpts;
+
+Snapshot::export(
+    "after-pip-install",
+    Path::new("/tmp/snap.tar.zst"),
+    ExportOpts { with_image: true, ..Default::default() },
+).await?;
+
+let snap = Snapshot::import(
+    Path::new("/tmp/snap.tar.zst"),
+    None,
+).await?;
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+await Snapshot.export("after-pip-install", "/tmp/snap.tar.zst", {
+  withImage: true,
+});
+
+const snap = await Snapshot.import("/tmp/snap.tar.zst");
+```
+
+```python Python
+from microsandbox import Snapshot
+
+await Snapshot.export(
+    "after-pip-install",
+    "/tmp/snap.tar.zst",
+    with_image=True,
+)
+
+snap = await Snapshot.import_("/tmp/snap.tar.zst")  # Trailing _ avoids the keyword
+```
+
+```bash CLI
+msb snapshot export after-pip-install /tmp/snap.tar.zst --with-image
+msb snapshot import /tmp/snap.tar.zst
+```
+
+</CodeGroup>
+
+## Integrity verification
+
+By default, snapshot creation does **not** hash the upper file. The artifact carries the upper's size and the pinned image's manifest digest, which together catch any corruption that would stop it from booting. Skipping the hash keeps `inspect` fast on multi-GB sparse upper layers, where the cost would otherwise dominate.
+
+Opt in to a content-integrity hash when crossing a trust boundary:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Snapshot;
+
+// Compute and record an integrity hash at create time
+let snap = Snapshot::builder("baseline")
+    .name("after-pip-install")
+    .record_integrity()
+    .create()
+    .await?;
+
+// Verify a snapshot's recorded integrity on demand
+let report = snap.verify().await?;
+
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+// Compute and record an integrity hash at create time
+const snap = await Snapshot.builder("baseline")
+  .name("after-pip-install")
+  .recordIntegrity()
+  .create();
+
+// Verify a snapshot's recorded integrity on demand
+const report = await snap.verify();
+```
+
+```python Python
+from microsandbox import Snapshot
+
+# Compute and record an integrity hash at create time
+snap = await Snapshot.create(
+    "baseline",
+    name="after-pip-install",
+    record_integrity=True,
+)
+
+# Verify a snapshot's recorded integrity on demand
+report = await snap.verify()
+```
+
+```bash CLI
+# Compute and record an integrity hash at create time
+msb snapshot create after-pip-install --from baseline --integrity
+
+# Verify a snapshot's recorded integrity on demand
+msb snapshot verify after-pip-install
+msb snapshot inspect after-pip-install --verify
+```
+
+</CodeGroup>
+
+`msb snapshot export` automatically populates the integrity hash before bundling, and `msb snapshot import` verifies it on the way in. The local index path stays fast; the cross-machine path stays trustworthy.
+
+## Use cases
+
+- **Reusable build state.** Install dependencies once, snapshot, then `msb run --snapshot ...` repeatedly without paying the install cost. Common pattern for CI, agent workloads, and reproducible dev environments.
+- **Portable scratch state.** Capture a sandbox after a long setup, hand the artifact to a teammate or push it to shared storage, and let them boot from the same starting point.
+- **Local fork-by-copy.** Multiple sandboxes from one snapshot are independent; each copy of the upper layer diverges on its own.
+- **Disaster recovery.** Snapshot a sandbox before a risky migration; if it goes wrong, `msb rm` the broken one and `msb run --snapshot` from the pre-migration artifact.
+
+## What's not yet supported
+
+- **Live (running) snapshots.** The sandbox must be stopped first. Live capture requires an in-guest filesystem freeze and memory checkpointing that's tracked as future work.
+- **qcow2 backing chains.** Snapshots always copy the upper layer today. The manifest's `format` and `parent` fields are reserved so qcow2 chains can land additively without a schema break.
+- **Push/pull from a registry.** The artifact format is registry-shaped on purpose, but transport tooling beyond `scp` and `tar.zst` is a separate piece of work.
+- **Snapshotting `DiskImage` volumes.** The same mechanism would apply (reflink the disk file), but is currently out of scope.

--- a/docs/es/sandboxes/volumes.mdx
+++ b/docs/es/sandboxes/volumes.mdx
@@ -1,0 +1,271 @@
+---
+title: Volumes
+description: Persist and share data across sandboxes
+icon: "hard-drive"
+---
+
+Volumes give a sandbox direct filesystem access to host-side directories. They're useful for persisting data across restarts, sharing data between sandboxes, or mounting host directories into the guest. They're also significantly faster than the [filesystem API](/sandboxes/filesystem) (which transfers files individually), so for anything beyond ad-hoc reads and writes, volumes are the way to go.
+
+microsandbox supports three types of mounts: bind mounts, named volumes, and tmpfs.
+
+## Bind mounts
+
+Mount a directory from the host directly into the sandbox. Changes inside the sandbox are reflected on the host, and vice versa.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("dev")
+    .image("python")
+    .volume("/app/src", |v| v.bind("./src").readonly())
+    .volume("/app/data", |v| v.bind("./data"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("dev")
+    .image("python")
+    .volume("/app/src",  (m) => m.bind("./src").readonly())
+    .volume("/app/data", (m) => m.bind("./data"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+sb = await Sandbox.create(
+    "dev",
+    image="python",
+    volumes={
+        "/app/src": Volume.bind("./src", readonly=True),
+        "/app/data": Volume.bind("./data"),
+    },
+)
+```
+
+```bash CLI
+msb create python --name dev \
+  -v ./src:/app/src:ro \
+  -v ./data:/app/data
+```
+
+</CodeGroup>
+
+## Named volumes
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox, so you can create a volume, populate it, and mount it into different sandboxes over time.
+
+### Create a volume
+
+<CodeGroup>
+```rust Rust
+let cache = Volume::builder("pip-cache")
+    .quota(1024)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Volume } from "microsandbox";
+
+const cache = await Volume.builder("pip-cache").quota(1024).create();
+```
+
+```python Python
+cache = await Volume.create("pip-cache", quota_mib=1024)
+```
+
+```bash CLI
+msb volume create pip-cache --size 1024
+```
+
+</CodeGroup>
+
+### Mount in a sandbox
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .volume("/root/.cache/pip", |v| v.named(cache.name()))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .volume("/root/.cache/pip", (m) => m.named(cache.name))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    volumes={
+        "/root/.cache/pip": Volume.named(cache.name),
+    },
+)
+```
+
+```bash CLI
+msb create python --name worker \
+  -v pip-cache:/root/.cache/pip
+```
+
+</CodeGroup>
+
+### Share between sandboxes
+
+Named volumes are the simplest way to share data between sandboxes. Mount the same volume into multiple sandboxes: one writes, another reads.
+
+<CodeGroup>
+```rust Rust
+// Writer
+let writer = Sandbox::builder("writer")
+    .image("alpine")
+    .volume("/data", |v| v.named("shared-data"))
+    .create()
+    .await?;
+writer.shell("echo 'hello' > /data/message.txt").await?;
+
+// Reader (read-only)
+let reader = Sandbox::builder("reader")
+    .image("alpine")
+    .volume("/data", |v| v.named("shared-data").readonly())
+    .create()
+    .await?;
+let output = reader.exec("cat", ["/data/message.txt"]).await?;
+// => "hello"
+```
+
+```typescript TypeScript
+// Writer
+await using writer = await Sandbox.builder("writer")
+    .image("alpine")
+    .volume("/data", (m) => m.named("shared-data"))
+    .create();
+await writer.shell("echo 'hello' > /data/message.txt");
+
+// Reader (read-only)
+await using reader = await Sandbox.builder("reader")
+    .image("alpine")
+    .volume("/data", (m) => m.named("shared-data").readonly())
+    .create();
+const output = await reader.exec("cat", ["/data/message.txt"]);
+// => "hello"
+```
+
+```python Python
+# Writer
+writer = await Sandbox.create(
+    "writer",
+    image="alpine",
+    volumes={"/data": Volume.named("shared-data")},
+)
+await writer.shell("echo 'hello' > /data/message.txt")
+
+# Reader (read-only)
+reader = await Sandbox.create(
+    "reader",
+    image="alpine",
+    volumes={"/data": Volume.named("shared-data", readonly=True)},
+)
+output = await reader.exec("cat", ["/data/message.txt"])
+# => "hello"
+```
+
+</CodeGroup>
+
+<Tip>
+  When sharing volumes between sandboxes, both sandboxes access the same underlying host directory. There's no built-in locking, so if two sandboxes write to the same file concurrently, you'll get the usual race conditions. Use the read-only flag on the reader side to make intent explicit.
+</Tip>
+
+### Host-side access
+
+Named volumes are accessible from the host even without a running sandbox, which is handy for pre-populating data before any sandbox mounts it.
+
+<CodeGroup>
+```rust Rust
+let vol = Volume::get("pip-cache").await?;
+vol.fs().write("/requirements.txt", "requests==2.28.0").await?;
+```
+
+```typescript TypeScript
+const vol = await Volume.get("pip-cache");
+await vol.fs().write("requirements.txt", "requests==2.28.0");
+```
+
+```python Python
+vol = await Volume.get("pip-cache")
+await vol.fs.write("/requirements.txt", b"requests==2.28.0")
+```
+
+</CodeGroup>
+
+### Manage volumes
+
+<CodeGroup>
+```rust Rust
+let volumes = Volume::list().await?;
+Volume::remove("old-cache").await?;
+```
+
+```typescript TypeScript
+const volumes = await Volume.list();
+await Volume.remove("old-cache");
+```
+
+```python Python
+volumes = await Volume.list()
+await Volume.remove("old-cache")
+```
+
+```bash CLI
+msb volume ls
+msb volume rm old-cache
+```
+
+</CodeGroup>
+
+## Tmpfs
+
+An in-memory filesystem that disappears when the sandbox stops. Useful for scratch space, build artifacts, or anything that doesn't need to outlive the sandbox.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("alpine")
+    .volume("/tmp/scratch", |v| v.tmpfs().size(100))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("alpine")
+    .volume("/tmp/scratch", (m) => m.tmpfs().size(100))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="alpine",
+    volumes={
+        "/tmp/scratch": Volume.tmpfs(size_mib=100),
+    },
+)
+```
+
+```bash CLI
+msb create alpine --name worker \
+  --tmpfs /tmp/scratch:100
+```
+
+</CodeGroup>

--- a/docs/es/sdk/errors.mdx
+++ b/docs/es/sdk/errors.mdx
@@ -1,0 +1,266 @@
+---
+title: Error Handling
+description: Typed errors and resource cleanup patterns
+icon: "triangle-exclamation"
+---
+
+All SDKs surface typed errors so you can match on specific failure modes instead of parsing strings. Rust has an `Error` enum, TypeScript exposes a dedicated subclass per variant (use `instanceof`), and Python provides dedicated exception classes.
+
+## Matching errors
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, Error};
+
+async fn get_or_create(name: &str) -> Result<Sandbox, Error> {
+    match Sandbox::get(name).await {
+        Ok(handle) => handle.start().await,
+        Err(Error::SandboxNotFound(_)) => {
+            Sandbox::builder(name).image("python").create().await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+match sb.exec("python", ["script.py"]).await {
+    Ok(output) if output.status().success => {
+        println!("{}", output.stdout()?);
+    }
+    Ok(output) => {
+        eprintln!("Exit {}: {}", output.status().code, output.stderr()?);
+    }
+    Err(Error::ExecTimeout) => eprintln!("Timed out"),
+    Err(Error::Runtime(msg)) => eprintln!("Runtime: {msg}"),
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import {
+    ExecTimeoutError,
+    RuntimeError,
+    Sandbox,
+    SandboxNotFoundError,
+} from "microsandbox";
+
+async function getOrCreate(name: string): Promise<Sandbox> {
+    try {
+        const handle = await Sandbox.get(name);
+        return await handle.start();
+    } catch (e) {
+        if (e instanceof SandboxNotFoundError) {
+            return Sandbox.builder(name).image("python").create();
+        }
+        throw e;
+    }
+}
+
+try {
+    const output = await sb.exec("python", ["script.py"]);
+    if (!output.success) {
+        console.error(`Failed (exit ${output.code}):`, output.stderr());
+    }
+} catch (e) {
+    if (e instanceof ExecTimeoutError) {
+        console.error(`Timed out after ${e.timeoutMs}ms`);
+    } else if (e instanceof RuntimeError) {
+        console.error("Runtime:", e.message);
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import (
+    ExecTimeoutError, Sandbox, SandboxNotFoundError
+)
+
+async def get_or_create(name: str):
+    try:
+        handle = await Sandbox.get(name)
+        return await handle.start()
+    except SandboxNotFoundError:
+        return await Sandbox.create(name, image="python")
+
+try:
+    output = await sb.exec("python", ["script.py"])
+    if not output.success:
+        print(f"Exit {output.exit_code}: {output.stderr_text}")
+except ExecTimeoutError:
+    print("Timed out")
+```
+
+</CodeGroup>
+
+## Spawn-time exec failures
+
+`exec()` distinguishes between:
+
+- **A program that ran and exited non-zero** — the call returns an `ExecOutput` with a non-zero `code`. This is *not* an error in the SDK sense; it's a normal result.
+- **A program that never started** — the binary doesn't exist, isn't executable, the working directory is unreachable, etc. This surfaces as a typed error variant: `ExecFailed` (Rust), `ExecFailedError` (TypeScript), `ExecFailedError` (Python).
+
+The typed error carries a classified `kind` plus the underlying `errno`, so callers can branch on the cause and react. Common kinds: `NotFound` (binary missing on PATH), `PermissionDenied`, `NotExecutable`, `BadCwd`, `BadArgs`, `ResourceLimit`, `UserSetupFailed`, `OutOfMemory`, `PtySetupFailed`, `Other`.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Error;
+use microsandbox_protocol::exec::ExecFailureKind;
+
+match sb.exec("nonexistent", []).await {
+    Ok(output) => { /* program ran, check output.status() */ }
+    Err(Error::ExecFailed(payload)) => {
+        match payload.kind {
+            ExecFailureKind::NotFound => {
+                eprintln!("Binary not found on PATH: {}", payload.message);
+            }
+            ExecFailureKind::PermissionDenied => {
+                eprintln!("Not executable (chmod +x?): {}", payload.message);
+            }
+            kind => {
+                eprintln!("Spawn failed ({:?}): {}", kind, payload.message);
+            }
+        }
+        // payload.errno, payload.errno_name, payload.stage are also available
+    }
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import { ExecFailedError, Sandbox } from "microsandbox";
+
+try {
+    const output = await sb.exec("nonexistent");
+    // program ran, check output.success / output.code
+} catch (e) {
+    if (e instanceof ExecFailedError) {
+        switch (e.kind) {
+            case "not_found":
+                console.error("Binary not on PATH:", e.message);
+                break;
+            case "permission_denied":
+                console.error("Not executable (chmod +x?):", e.message);
+                break;
+            default:
+                console.error(`Spawn failed (${e.kind}):`, e.message);
+        }
+        // e.errno, e.errnoName, e.stage are also available
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import ExecFailedError
+
+try:
+    output = await sb.exec("nonexistent")
+    # program ran, check output.success / output.exit_code
+except ExecFailedError as e:
+    if e.kind == "not_found":
+        print(f"Binary not on PATH: {e.message}")
+    elif e.kind == "permission_denied":
+        print(f"Not executable (chmod +x?): {e.message}")
+    else:
+        print(f"Spawn failed ({e.kind}): {e.message}")
+    # e.errno, e.errno_name, e.stage are also available
+```
+</CodeGroup>
+
+The CLI maps these kinds to POSIX-style exit codes: `127` for `NotFound`, `126` for `PermissionDenied` and `NotExecutable`, `1` otherwise. SDK callers reading the error directly don't need to think about exit codes — branch on `kind` instead.
+
+## Sandbox start failures
+
+When a sandbox process exits before the agent relay is ready (mount errors, missing rootfs, network setup failures), the SDK surfaces a typed `BootStart` / `BootStartError`. The payload carries the failure stage and errno so callers can recover or report cleanly.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Error;
+use microsandbox_runtime::boot_error::BootErrorStage;
+
+match Sandbox::builder("svc").image("alpine").create().await {
+    Ok(sb) => { /* ... */ }
+    Err(Error::BootStart { name, err }) => {
+        eprintln!("Sandbox {name:?} failed at stage {:?}: {}", err.stage, err.message);
+        if matches!(err.stage, BootErrorStage::Mount) {
+            eprintln!("Hint: a host volume path may not exist.");
+        }
+    }
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import { BootStartError } from "microsandbox";
+
+try {
+    const sb = await Sandbox.builder("svc").image("alpine").create();
+} catch (e) {
+    if (e instanceof BootStartError) {
+        console.error(`Sandbox "${e.name}" failed at stage ${e.stage}: ${e.message}`);
+        if (e.stage === "mount") {
+            console.error("Hint: a host volume path may not exist.");
+        }
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import BootStartError
+
+try:
+    sb = await Sandbox.create("svc", image="alpine")
+except BootStartError as e:
+    print(f"Sandbox {e.name!r} failed at stage {e.stage}: {e.message}")
+    if e.stage == "mount":
+        print("Hint: a host volume path may not exist.")
+```
+</CodeGroup>
+
+The CLI prepends the same payload as a styled `error:` block before any captured log output, so you see "what went wrong + a hint" inline. SDK callers get the structured payload to make their own decisions.
+
+## Resource cleanup
+
+Sandboxes hold compute resources, so release them when done. In Rust, `Drop` handles cleanup when the sandbox goes out of scope. In TypeScript, prefer `await using` (Node 22+) which calls `Sandbox.stop()` automatically when the binding leaves scope.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+// Sandbox implements Drop, so resources are released when `sb` goes out of scope.
+// For explicit control, call stop() or kill().
+{
+    let sb = Sandbox::builder("temp")
+        .image("python")
+        .create()
+        .await?;
+
+    let output = sb.exec("python", ["-c", "print('hello')"]).await?;
+} // sb is dropped here, resources are cleaned up
+```
+
+```typescript TypeScript
+async function runTemporary(): Promise<string> {
+    // `await using` calls Sandbox.stop() when the binding leaves scope.
+    await using sb = await Sandbox.builder("temp")
+        .image("python")
+        .replace()
+        .create();
+
+    const out = await sb.exec("python", ["-c", "print('hello')"]);
+    return out.stdout();
+}
+```
+
+```python Python
+# Use async context manager — auto-kills and removes on exit.
+async with await Sandbox.create("temp", image="python") as sb:
+    output = await sb.exec("python", ["-c", "print('hello')"])
+    print(output.stdout_text)
+```
+
+</CodeGroup>

--- a/docs/es/sdk/overview.mdx
+++ b/docs/es/sdk/overview.mdx
@@ -1,0 +1,96 @@
+---
+title: Overview
+description: Install the SDK and create your first sandbox
+icon: "play"
+---
+
+The SDK embeds the microsandbox runtime directly into whatever application uses it. `Sandbox.builder(name).create()` spawns the VM as a child process. No daemon to install, no server to connect to.
+
+## Installation
+
+<CodeGroup>
+```bash Rust
+cargo add microsandbox
+```
+
+```bash TypeScript
+npm install microsandbox
+```
+
+```bash Python
+pip install microsandbox
+```
+</CodeGroup>
+
+## Quick start
+
+Create a sandbox from a container image, run a command, print the output, and stop it.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, NetworkPolicy};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let sb = Sandbox::builder("my-sandbox")
+        .image("python")
+        .memory(512)
+        .cpus(2)
+        .env("PYTHONDONTWRITEBYTECODE", "1")
+        .volume("/app/src", |v| v.bind("./src").readonly())
+        .network(|n| n.policy(NetworkPolicy::public_only()))
+        .create()
+        .await?;
+
+    let output = sb.exec("python", ["-c", "print('Hello, World!')"]).await?;
+    println!("{}", output.stdout()?);
+
+    sb.stop().await?;
+    Ok(())
+}
+```
+
+```typescript TypeScript
+import { NetworkPolicy, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("my-sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .env("PYTHONDONTWRITEBYTECODE", "1")
+    .volume("/app/src", (m) => m.bind("./src").readonly())
+    .network((n) => n.policy(NetworkPolicy.publicOnly()))
+    .create();
+
+const output = await sb.exec("python", ["-c", "print('Hello, World!')"]);
+console.log("Output:", output.stdout());
+```
+
+```python Python
+import asyncio
+from microsandbox import Network, Sandbox, Volume
+
+async def main():
+    sb = await Sandbox.create(
+        "my-sandbox",
+        image="python",
+        memory=512,
+        cpus=2,
+        env={"PYTHONDONTWRITEBYTECODE": "1"},
+        volumes={
+            "/app/src": Volume.bind("./src", readonly=True),
+        },
+        network=Network.public_only(),
+    )
+
+    output = await sb.exec("python", ["-c", "print('Hello, World!')"])
+    print("Output:", output.stdout_text)
+
+    await sb.stop()
+
+asyncio.run(main())
+```
+
+</CodeGroup>
+
+The SDK reference is split by language - choose [Rust SDK](/sdk/rust/sandbox), [TypeScript SDK](/sdk/typescript/sandbox), or [Python SDK](/sdk/python/sandbox) for the full API. See also [error handling](/sdk/errors).

--- a/docs/es/sdk/python/events.mdx
+++ b/docs/es/sdk/python/events.mdx
@@ -1,0 +1,11 @@
+---
+title: Events
+description: Python SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for a preview of event concepts and planned API.

--- a/docs/es/sdk/python/execution.mdx
+++ b/docs/es/sdk/python/execution.mdx
@@ -1,0 +1,212 @@
+---
+title: Execution
+description: Python SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+## Types
+
+### ExecOutput
+
+The result of a completed command execution.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| exit_code | `int` | Exit code |
+| success | `bool` | `True` if exit_code is `0` |
+| stdout_text | `str` | Collected stdout decoded as UTF-8. Raises on invalid encoding. |
+| stderr_text | `str` | Collected stderr decoded as UTF-8 |
+| stdout_bytes | `bytes` | Raw stdout bytes |
+| stderr_bytes | `bytes` | Raw stderr bytes |
+
+---
+
+### ExecHandle
+
+A handle to a running streaming execution. Supports `async for event in handle:` to iterate over events until the stream ends.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| id | `str` | Correlation ID for this execution |
+| take_stdin() | [`ExecSink`](#execsink) ` \| None` | Take the stdin writer. Returns `None` after first call. |
+| recv() | `ExecEvent \| None` | *(async)* Receive the next event. Returns `None` when done. |
+| wait() | `tuple[int, bool]` | *(async)* Wait for the process to exit. Returns `(code, success)`. |
+| collect() | [`ExecOutput`](#execoutput) | *(async)* Wait and collect all remaining output |
+| signal(sig) | `None` | *(async)* Send a POSIX signal to the process |
+| kill() | `None` | *(async)* Send SIGKILL |
+
+---
+
+### ExecSink
+
+Writer for sending data to a running process's stdin.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| write() | `data: bytes` | *(async)* Write bytes to the process's stdin |
+| close() | - | *(async)* Close stdin. The process sees EOF. |
+
+---
+
+### ExecEvent
+
+Low-level event from PyO3 bindings.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| event_type | `str` | `"started"`, `"stdout"`, `"stderr"`, or `"exited"` |
+| pid | `int \| None` | Guest PID (on `"started"`) |
+| data | `bytes \| None` | Output data (on `"stdout"` / `"stderr"`) |
+| code | `int \| None` | Exit code (on `"exited"`) |
+
+Python dataclass variants are also available for pattern matching:
+
+| Class | Fields | Description |
+|-------|--------|-------------|
+| `StartedEvent` | `pid: int` | The process has started |
+| `StdoutEvent` | `data: bytes` | A chunk of stdout data |
+| `StderrEvent` | `data: bytes` | A chunk of stderr data |
+| `ExitedEvent` | `code: int` | The process has exited |
+
+The union type `ExecEvent = StartedEvent | StdoutEvent | StderrEvent | ExitedEvent` is available from `events.py`.
+
+---
+
+### ExecOptions
+
+```python
+ExecOptions(
+    args: tuple[str, ...] = (),
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] = {},
+    timeout: float | None = None,  # seconds
+    stdin: Stdin = Stdin.null(),
+    tty: bool = False,
+    rlimits: tuple[Rlimit, ...] = (),
+)
+```
+
+Frozen dataclass for per-execution overrides.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| args | `tuple[str, ...]` | `()` | Command arguments |
+| cwd | `str \| None` | `None` | Working directory |
+| user | `str \| None` | `None` | Guest user |
+| env | `Mapping[str, str]` | `{}` | Environment variables |
+| timeout | `float \| None` | `None` | Kill the process after this many seconds |
+| stdin | [`Stdin`](#stdin) | `Stdin.null()` | Stdin source |
+| tty | `bool` | `False` | Allocate a pseudo-terminal |
+| rlimits | `tuple[`[`Rlimit`](#rlimit)`, ...]` | `()` | Resource limits |
+
+---
+
+### AttachOptions
+
+```python
+AttachOptions(
+    args: tuple[str, ...] = (),
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] = {},
+    detach_keys: str | None = None,
+)
+```
+
+Frozen dataclass for interactive PTY attach configuration.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| args | `tuple[str, ...]` | `()` | Command arguments |
+| cwd | `str \| None` | `None` | Working directory |
+| user | `str \| None` | `None` | Guest user |
+| env | `Mapping[str, str]` | `{}` | Environment variables |
+| detach_keys | `str \| None` | `None` | Key sequence to detach without stopping |
+
+---
+
+### Stdin
+
+Frozen dataclass with factory methods for configuring process stdin.
+
+| Factory | Parameters | Description |
+|---------|-----------|-------------|
+| Stdin.null() | - | `/dev/null` (default) |
+| Stdin.pipe() | - | Piped stdin. Use [`take_stdin()`](#exechandle) on the handle to write. |
+| Stdin.bytes() | `data: bytes` | Inline data sent before the process starts |
+
+---
+
+### Rlimit
+
+Frozen dataclass with factory methods for POSIX resource limits.
+
+| Factory | Parameters | Description |
+|---------|-----------|-------------|
+| Rlimit.nofile(limit) | `limit: int` | Max open file descriptors |
+| Rlimit.cpu(secs) | `secs: int` | CPU time limit in seconds |
+| Rlimit.as_(*, soft, hard) | `soft: int, hard: int` | Virtual memory size |
+| Rlimit.nproc(limit) | `limit: int` | Max number of processes |
+| Rlimit.fsize(limit) | `limit: int` | Max file size |
+| Rlimit.memlock(limit) | `limit: int` | Max locked memory |
+| Rlimit.stack(limit) | `limit: int` | Max stack size |
+
+**Properties**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| resource | [`RlimitResource`](#rlimitresource) | Resource type |
+| soft | `int` | Soft limit |
+| hard | `int` | Hard limit |
+
+---
+
+### RlimitResource
+
+Enum of POSIX resource types.
+
+| Value | Description |
+|-------|-------------|
+| `cpu` | CPU time |
+| `fsize` | File size |
+| `data` | Data segment size |
+| `stack` | Stack size |
+| `core` | Core file size |
+| `rss` | Resident set size |
+| `nproc` | Number of processes |
+| `nofile` | Open file descriptors |
+| `memlock` | Locked memory |
+| `as` | Virtual memory |
+| `locks` | File locks |
+| `sigpending` | Pending signals |
+| `msgqueue` | Message queue size |
+| `nice` | Nice priority ceiling |
+| `rtprio` | Real-time priority ceiling |
+| `rttime` | Real-time CPU time |
+
+---
+
+### SandboxMetrics
+
+Metrics snapshot for a running sandbox.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| cpu_percent | `float` | CPU utilization percentage |
+| memory_bytes | `int` | Current memory usage in bytes |
+| memory_limit_bytes | `int` | Memory limit in bytes |
+| disk_read_bytes | `int` | Total bytes read from disk |
+| disk_write_bytes | `int` | Total bytes written to disk |
+| net_rx_bytes | `int` | Total bytes received over the network |
+| net_tx_bytes | `int` | Total bytes sent over the network |
+| uptime_ms | `int` | Sandbox uptime in milliseconds |
+| timestamp_ms | `float` | Timestamp of the snapshot in milliseconds |
+
+---
+
+### MetricsStream
+
+Async iterator yielding [`SandboxMetrics`](#sandboxmetrics). Use `async for metrics in stream:` to consume.

--- a/docs/es/sdk/python/filesystem.mdx
+++ b/docs/es/sdk/python/filesystem.mdx
@@ -1,0 +1,357 @@
+---
+title: Filesystem
+description: Python SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via the `sandbox.fs` property. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
+
+---
+
+#### copy()
+
+```python
+async def copy(src: str, dst: str) -> None
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Source path |
+| dst | `str` | Destination path |
+
+---
+
+#### copy_from_host()
+
+```python
+async def copy_from_host(host_path: str, guest_path: str) -> None
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `str` | Path on the host filesystem |
+| guest_path | `str` | Destination path inside the sandbox |
+
+---
+
+#### copy_to_host()
+
+```python
+async def copy_to_host(guest_path: str, host_path: str) -> None
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `str` | Path inside the sandbox |
+| host_path | `str` | Destination path on the host |
+
+---
+
+#### exists()
+
+```python
+async def exists(path: str) -> bool
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `True` if the path exists |
+
+---
+
+#### list()
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`FsEntry`](#fsentry)`]` | Directory entries |
+
+---
+
+#### mkdir()
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory and all parent directories.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path |
+
+---
+
+#### read()
+
+```python
+async def read(path: str) -> bytes
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bytes` | File contents as raw bytes |
+
+---
+
+#### read_stream()
+
+```python
+async def read_stream(path: str) -> FsReadStream
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsReadStream`](#fsreadstream) | Async iterator that yields chunks of file data |
+
+---
+
+#### read_text()
+
+```python
+async def read_text(path: str) -> str
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `str` | File contents as a string |
+
+---
+
+#### remove()
+
+```python
+async def remove(path: str) -> None
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute file path |
+
+---
+
+#### remove_dir()
+
+```python
+async def remove_dir(path: str) -> None
+```
+
+Remove a directory recursively.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path |
+
+---
+
+#### rename()
+
+```python
+async def rename(src: str, dst: str) -> None
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Current path |
+| dst | `str` | New path |
+
+---
+
+#### stat()
+
+```python
+async def stat(path: str) -> FsMetadata
+```
+
+Get detailed metadata for a file or directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsMetadata`](#fsmetadata) | File metadata |
+
+---
+
+#### write()
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| data | `bytes` | File content |
+
+---
+
+#### write_stream()
+
+```python
+async def write_stream(path: str) -> FsWriteSink
+```
+
+Open a streaming writer for a file. Use this for files too large to fit in memory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsWriteSink`](#fswritesink) | Async writer that accepts chunks of data |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
+| mode | `int` | Unix permission bits |
+| modified | `float \| None` | Last modified timestamp (ms since epoch) |
+| path | `str` | File path |
+| size | `int` | File size in bytes |
+
+### FsEntryKind
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) representing the type of a filesystem entry.
+
+| Value | Description |
+|-------|-------------|
+| `"directory"` | Directory |
+| `"file"` | Regular file |
+| `"other"` | Other entry type |
+| `"symlink"` | Symbolic link |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| created | `float \| None` | Creation timestamp (ms since epoch) |
+| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
+| mode | `int` | Unix permission bits |
+| modified | `float \| None` | Last modified timestamp (ms since epoch) |
+| readonly | `bool` | Whether the file is read-only |
+| size | `int` | File size in bytes |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`read_stream()`](#read_stream).
+
+| Method / Protocol | Returns | Description |
+|-------------------|---------|-------------|
+| `__aiter__` / `__anext__` | `bytes` | Async iterator - use with `async for chunk in stream:` |
+| `collect()` | `bytes` | Collect all remaining data into a single `bytes` object |
+
+### FsWriteSink
+
+Async writer for streaming data into a file. Obtained via [`write_stream()`](#write_stream). Supports the async context manager protocol (`async with`).
+
+| Method / Protocol | Returns | Description |
+|-------------------|---------|-------------|
+| `write(data)` | `None` | Write a chunk of `bytes` to the file |
+| `close()` | `None` | Send EOF and finalize the file |
+| `__aenter__` / `__aexit__` | `FsWriteSink` | Use with `async with` for automatic close on exit |

--- a/docs/es/sdk/python/networking.mdx
+++ b/docs/es/sdk/python/networking.mdx
@@ -1,0 +1,333 @@
+---
+title: Networking
+description: Python SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## Network
+
+Frozen dataclass for sandbox network configuration. Use a class-method preset for the common cases, or construct directly with custom options.
+
+```python
+Network(
+    policy: str | NetworkPolicy | None = None,
+    ports: Mapping[int, int] = {},
+    deny_domains: tuple[str, ...] = (),
+    deny_domain_suffixes: tuple[str, ...] = (),
+    dns: DnsConfig | None = None,
+    tls: TlsConfig | None = None,
+    max_connections: int | None = None,
+    trust_host_cas: bool | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| policy | `str \| NetworkPolicy \| None` | Preset name (`"none"`, `"public_only"`, `"allow_all"`) or custom [`NetworkPolicy`](#networkpolicy-1) |
+| ports | `Mapping[int, int]` | Port mappings from host to guest |
+| deny_domains | `tuple[str, ...]` | Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy so it takes precedence over later allow rules |
+| deny_domain_suffixes | `tuple[str, ...]` | Deny egress to all subdomains of these suffixes. Adds `deny DomainSuffix("...")` rules; same enforcement layers as `deny_domains` |
+| dns | [`DnsConfig`](#dnsconfig) ` \| None` | DNS interception configuration |
+| tls | [`TlsConfig`](#tlsconfig) ` \| None` | TLS interception configuration |
+| max_connections | `int \| None` | Maximum concurrent connections |
+| trust_host_cas | `bool \| None` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle. Opt-in |
+
+---
+
+#### Network.allow_all()
+
+```python
+@classmethod
+def allow_all() -> Network
+```
+
+Unrestricted network access, including to private addresses and the host machine.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Unrestricted network configuration |
+
+---
+
+#### Network.none()
+
+```python
+@classmethod
+def none() -> Network
+```
+
+Deny all traffic. No network interface is created; the guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Fully airgapped network configuration |
+
+---
+
+#### Network.public_only()
+
+```python
+@classmethod
+def public_only() -> Network
+```
+
+Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Public-only network configuration |
+
+---
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Pass to `Network(policy=...)` for custom policies:
+
+```python
+from microsandbox import NetworkPolicy, Rule, Action, Direction, Protocol
+
+policy = NetworkPolicy(
+    default_egress=Action.DENY,
+    default_ingress=Action.ALLOW,
+    rules=(
+        Rule.allow(protocol=Protocol.TCP, port=443, destination="public"),
+        Rule.deny(destination="198.51.100.5"),
+    ),
+)
+```
+
+The default policy denies egress except for an implicit `allow public`, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry.
+
+```python
+NetworkPolicy(
+    default_egress: Action = Action.DENY,
+    default_ingress: Action = Action.ALLOW,
+    rules: tuple[Rule, ...] = (),
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
+| rules | `tuple[`[`Rule`](#rule)`, ...]` | Rules evaluated first-match-wins per direction |
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```python
+policy = NetworkPolicy(
+    default_egress=Action.DENY,
+    default_ingress=Action.ALLOW,
+    rules=(
+        Rule.allow(destination="10.0.0.0/8"),     # matches everything in 10.x
+        Rule.deny(destination="10.0.0.5"),        # never reached
+    ),
+)
+```
+
+Put specific rules before general ones.
+
+---
+
+## Rule
+
+Frozen dataclass for a single network policy rule.
+
+```python
+Rule(
+    action: Action,
+    direction: Direction = Direction.EGRESS,
+    destination: str | None = None,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| action | [`Action`](#action) | What to do when this rule matches |
+| direction | [`Direction`](#direction) | Which evaluator considers this rule. `Direction.ANY` matches in either direction |
+| destination | `str \| None` | Target filter: a [`DestGroup`](#destgroup) value, domain, CIDR range, domain suffix (prefixed with `"."`), or `"*"` for any. Domain and suffix strings are validated at sandbox creation; invalid names raise `ValueError` |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Single port (`443`) or range (`"8000-9000"`) |
+
+Ingress rules carrying ICMP protocols are rejected at sandbox creation; the host has no inbound ICMP path. Use `Direction.EGRESS` for ICMP allow/deny.
+
+---
+
+#### Rule.allow()
+
+```python
+@classmethod
+def allow(
+    *,
+    direction: Direction = Direction.EGRESS,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+    destination: str | None = None,
+) -> Rule
+```
+
+Create a rule that permits matching traffic.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| direction | [`Direction`](#direction) | Traffic direction |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Port or port range |
+| destination | `str \| None` | Destination filter |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | An allow rule |
+
+---
+
+#### Rule.deny()
+
+```python
+@classmethod
+def deny(
+    *,
+    direction: Direction = Direction.EGRESS,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+    destination: str | None = None,
+) -> Rule
+```
+
+Create a rule that blocks matching traffic.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| direction | [`Direction`](#direction) | Traffic direction |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Port or port range |
+| destination | `str \| None` | Destination filter |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | A deny rule |
+
+---
+
+## DnsConfig
+
+Frozen dataclass for DNS interception settings.
+
+```python
+DnsConfig(
+    rebind_protection: bool = True,
+    nameservers: tuple[str, ...] = (),
+    query_timeout_ms: int | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| nameservers | `tuple[str, ...]` | Nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). Overrides the host's `/etc/resolv.conf` when set. Hostnames are resolved once at startup via the host's OS resolver |
+| query_timeout_ms | `int \| None` | Per-DNS-query timeout in milliseconds |
+| rebind_protection | `bool` | Block DNS responses resolving to private IPs |
+
+---
+
+## TlsConfig
+
+Frozen dataclass for TLS interception settings within [`Network`](#network).
+
+```python
+TlsConfig(
+    bypass: tuple[str, ...] = (),
+    verify_upstream: bool = True,
+    intercepted_ports: tuple[int, ...] = (443,),
+    block_quic: bool = False,
+    ca_cert: str | None = None,
+    ca_key: str | None = None,
+    ca_cn: str | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| block_quic | `bool` | Block QUIC/HTTP3 (UDP) on intercepted ports, forcing TCP/TLS fallback |
+| bypass | `tuple[str, ...]` | Domains to skip interception. Use for domains with certificate pinning |
+| ca_cert | `str \| None` | Path to a custom interception CA certificate PEM file |
+| ca_cn | `str \| None` | Common name for the generated interception CA |
+| ca_key | `str \| None` | Path to a custom interception CA private key PEM file |
+| intercepted_ports | `tuple[int, ...]` | TCP ports where TLS interception is active |
+| verify_upstream | `bool` | Verify upstream server certificates. Set to `False` only for self-signed servers |
+
+---
+
+## Types
+
+### Action
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) for policy actions.
+
+| Value | Description |
+|-------|-------------|
+| `"allow"` | Permit the traffic |
+| `"deny"` | Drop the traffic silently |
+
+### Direction
+
+String enum for traffic direction.
+
+| Value | Description |
+|-------|-------------|
+| `"egress"` | Traffic leaving the sandbox |
+| `"ingress"` | Traffic entering the sandbox (via published ports) |
+| `"any"` | Rule applies in either direction |
+
+### Protocol
+
+String enum for network protocols in policy rules.
+
+| Value | Description |
+|-------|-------------|
+| `"tcp"` | TCP traffic |
+| `"udp"` | UDP traffic |
+| `"icmpv4"` | ICMPv4 traffic |
+| `"icmpv6"` | ICMPv6 traffic |
+
+### PortProtocol
+
+String enum for port-level protocol selection.
+
+| Value | Description |
+|-------|-------------|
+| `"tcp"` | TCP port |
+| `"udp"` | UDP port |
+
+### DestGroup
+
+String enum for well-known destination groups used in [`Rule.destination`](#rule).
+
+| Value | Description |
+|-------|-------------|
+| `"public"` | Complement of the named categories: every address not in any other group |
+| `"private"` | Private/RFC 1918 addresses + ULA + CGN (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7`) |
+| `"loopback"` | Loopback addresses (`127.0.0.0/8`, `::1`); the **guest's own** loopback, not the host. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap) |
+| `"link-local"` | Link-local addresses (`169.254.0.0/16`, `fe80::/10`) excluding metadata |
+| `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
+| `"multicast"` | Multicast addresses (`224.0.0.0/4`, `ff00::/8`) |
+| `"host"` | The host machine, reached via `host.microsandbox.internal`. This is the right group for "let the sandbox reach my host's localhost", not `"loopback"` |

--- a/docs/es/sdk/python/sandbox.mdx
+++ b/docs/es/sdk/python/sandbox.mdx
@@ -1,0 +1,898 @@
+---
+title: Sandbox
+description: Python SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+## Static methods
+
+---
+
+#### Sandbox.create()
+
+```python
+@staticmethod
+async def create(name_or_config: str | dict, **kwargs) -> Sandbox
+```
+
+Create and boot a sandbox. The first argument is either a name (`str`) or a full config (`dict`). Keyword arguments provide individual config fields. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name_or_config | `str \| dict` | Sandbox name or full configuration dict |
+| image | `str \| ImageSource` | OCI image, local path, or disk image (required) |
+| cpus | `int` | Virtual CPUs (default `1`) |
+| memory | `int` | Guest memory in MiB (default `512`) |
+| workdir | `str` | Default working directory for commands |
+| shell | `str` | Shell for `shell()` calls (default `"/bin/sh"`) |
+| hostname | `str` | Guest hostname |
+| user | `str` | Default guest user |
+| entrypoint | `list[str]` | Override image entrypoint |
+| init | `str \| dict \|` [`InitConfig`](#initconfig) | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) and [`InitConfig`](#initconfig) for accepted shapes |
+| replace | `bool` | Replace existing sandbox with same name |
+| max_duration | `float` | Maximum sandbox lifetime in seconds |
+| idle_timeout | `float` | Idle timeout in seconds |
+| env | `dict[str, str]` | Environment variables visible to all commands |
+| scripts | `dict[str, str]` | Named scripts mounted at `/.msb/scripts/` |
+| pull_policy | `str \| PullPolicy` | Image pull behavior |
+| log_level | `str \| LogLevel` | Override log verbosity |
+| registry_auth | [`RegistryAuth`](#registryauth) | Private registry credentials |
+| volumes | `dict[str, dict]` | Volume mounts. See [Volumes](/sdk/python/volumes). |
+| patches | `list[PatchConfig]` | Rootfs modifications applied before boot |
+| ports | `dict[int, int]` | Port mappings (`host_port: guest_port`) |
+| network | [`Network`](/sdk/python/networking#network) | Network policy and configuration |
+| secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | Secret injection |
+| detached | `bool` | If `True`, sandbox survives after your process exits |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+The returned `Sandbox` is an async context manager. Use `async with` to guarantee cleanup; on exit the sandbox is killed and its persisted state removed:
+
+```python
+async with await Sandbox.create("my-sandbox", image="alpine") as sb:
+    output = await sb.shell("echo hello")
+    print(output.stdout_text)
+# sandbox is automatically killed and removed on exit
+```
+
+---
+
+#### Sandbox.create_with_progress()
+
+```python
+@staticmethod
+def create_with_progress(name_or_config: str | dict, **kwargs) -> PullSession
+```
+
+Same parameters as [`Sandbox.create()`](#sandboxcreate) but returns a [`PullSession`](#pullsession) that lets you track image pull progress before the sandbox is ready. This method is synchronous (not awaitable) -- the async work happens through the `PullSession`.
+
+**Parameters**
+
+Same as [`Sandbox.create()`](#sandboxcreate).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`PullSession`](#pullsession) | Session for tracking pull progress and obtaining the final sandbox |
+
+---
+
+#### Sandbox.start()
+
+```python
+@staticmethod
+async def start(name: str, *, detached: bool = False) -> Sandbox
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Name of a stopped sandbox |
+| detached | `bool` | If `True`, sandbox survives after your process exits (default `False`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox.get()
+
+```python
+@staticmethod
+async def get(name: str) -> SandboxHandle
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox.list()
+
+```python
+@staticmethod
+async def list() -> list[SandboxHandle]
+```
+
+List all sandboxes (running, stopped, and crashed).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`SandboxHandle`](#sandboxhandle)`]` | All sandboxes |
+
+---
+
+#### Sandbox.remove()
+
+```python
+@staticmethod
+async def remove(name: str) -> None
+```
+
+Delete a stopped sandbox and all its state from disk. Fails if the sandbox is still running.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Sandbox name |
+
+---
+
+## Instance properties
+
+---
+
+#### name
+
+```python
+@property
+async def name(self) -> str
+```
+
+Sandbox name. This is an async property -- use `await sb.name`.
+
+---
+
+#### owns_lifecycle
+
+```python
+@property
+async def owns_lifecycle(self) -> bool
+```
+
+Whether this handle owns the sandbox lifecycle. `True` in attached mode, `False` in detached mode. This is an async property -- use `await sb.owns_lifecycle`.
+
+---
+
+#### fs
+
+```python
+@property
+def fs(self) -> SandboxFs
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. This is a synchronous property -- use `sb.fs` (no `await`). See [Filesystem](/sdk/python/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/python/filesystem) | Filesystem handle |
+
+---
+
+## Instance methods
+
+---
+
+#### attach()
+
+```python
+async def attach(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> int
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to run |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or execution options |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `int` | Exit code of the process |
+
+---
+
+#### attach_shell()
+
+```python
+async def attach_shell() -> int
+```
+
+Attach to the sandbox's default shell.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `int` | Exit code |
+
+---
+
+#### detach()
+
+```python
+async def detach() -> None
+```
+
+Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```python
+async def drain() -> None
+```
+
+Start a graceful drain (SIGUSR1). Existing commands run to completion, new `exec` calls are rejected.
+
+---
+
+#### exec()
+
+```python
+async def exec(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecOutput
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments (e.g. `["-c", "print('hello')"]`) or [`ExecOptions`](/sdk/python/execution#execoptions) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### exec_stream()
+
+```python
+async def exec_stream(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecHandle
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to execute |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or [`ExecOptions`](/sdk/python/execution#execoptions) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### kill()
+
+```python
+async def kill() -> None
+```
+
+Force-terminate the sandbox immediately (SIGKILL). No graceful shutdown.
+
+---
+
+#### metrics()
+
+```python
+async def metrics() -> SandboxMetrics
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network metrics |
+
+---
+
+#### metrics_stream()
+
+```python
+async def metrics_stream(interval: float = 1.0) -> MetricsStream
+```
+
+Stream resource metrics at a regular interval. The returned stream supports both `recv()` and `async for`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| interval | `float` | Seconds between metric snapshots (default `1.0`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`MetricsStream`](#metricsstream) | Async stream of metrics |
+
+---
+
+#### logs()
+
+```python
+async def logs(
+    tail: int | None = None,
+    since_ms: float | None = None,
+    until_ms: float | None = None,
+    sources: list[str] | None = None,
+) -> list[LogEntry]
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```python
+import asyncio
+import microsandbox
+
+async def main():
+    handle = await microsandbox.Sandbox.get("web")
+
+    # Default — all user-program output, regardless of pipe/pty mode
+    entries = await handle.logs()
+
+    for e in entries:
+        source = {
+            "stdout": "OUT",
+            "stderr": "ERR",
+            "output": "PTY",
+            "system": "SYS",
+        }[e.source]
+        print(
+            f"[{e.timestamp_ms / 1000:.3f}] "
+            f"{source} {e.session_id}: {e.text().rstrip()}"
+        )
+
+    # Filtered: last 50 entries from the past hour, including system lines
+    import time
+    recent = await handle.logs(
+        tail=50,
+        since_ms=(time.time() - 3600) * 1000,
+        sources=["stdout", "stderr", "output", "system"],
+    )
+
+asyncio.run(main())
+```
+
+Timestamps are exposed as `float` ms since the Unix epoch (UTC) for parity with `SandboxMetrics.timestamp_ms`. Convert to `datetime` if needed:
+
+```python
+from datetime import datetime, timezone
+dt = datetime.fromtimestamp(e.timestamp_ms / 1000, timezone.utc)
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| tail | `int \| None` | Show only the last N entries after other filters apply |
+| since_ms | `float \| None` | Inclusive lower bound on entry timestamp (ms since epoch) |
+| until_ms | `float \| None` | Exclusive upper bound on entry timestamp (ms since epoch) |
+| sources | `list[str] \| None` | Sources to include. `None` = `["stdout", "stderr", "output"]`. Add `"system"` to merge runtime/kernel diagnostics. Use `"all"` as shorthand for all four. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`LogEntry`](#logentry)`]` | Matching entries in chronological order |
+
+---
+
+#### remove_persisted()
+
+```python
+async def remove_persisted() -> None
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### shell()
+
+```python
+async def shell(script: str) -> ExecOutput
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `str` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell_stream()
+
+```python
+async def shell_stream(script: str) -> ExecHandle
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `str` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle |
+
+---
+
+#### stop()
+
+```python
+async def stop() -> None
+```
+
+Gracefully shut down the sandbox (SIGTERM).
+
+---
+
+#### stop_and_wait()
+
+```python
+async def stop_and_wait() -> tuple[int, bool]
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
+
+---
+
+#### wait()
+
+```python
+async def wait() -> tuple[int, bool]
+```
+
+Block until the sandbox exits on its own.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
+
+---
+
+## Patch
+
+Factory class for rootfs patches passed to `Sandbox.create(..., patches=[...])`. Each static method returns a [`PatchConfig`](#patchconfig). By default a patch that targets a path already present in the image errors at boot; pass `replace=True` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### Patch.append()
+
+```python
+@staticmethod
+def append(path: str, content: str) -> PatchConfig
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| content | `str` | Text to append |
+
+---
+
+#### Patch.copy_dir()
+
+```python
+@staticmethod
+def copy_dir(src: str, dst: str, *, replace: bool = False) -> PatchConfig
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Host source directory |
+| dst | `str` | Absolute destination path inside the guest |
+| replace | `bool` | When `True`, overwrite an existing path at `dst` |
+
+---
+
+#### Patch.copy_file()
+
+```python
+@staticmethod
+def copy_file(
+    src: str,
+    dst: str,
+    *,
+    mode: int | None = None,
+    replace: bool = False,
+) -> PatchConfig
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Host source file |
+| dst | `str` | Absolute destination path inside the guest |
+| mode | `int \| None` | File mode, e.g. `0o644`. `None` keeps the source mode |
+| replace | `bool` | When `True`, overwrite an existing path at `dst` |
+
+---
+
+#### Patch.mkdir()
+
+```python
+@staticmethod
+def mkdir(path: str, *, mode: int | None = None) -> PatchConfig
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| mode | `int \| None` | Directory mode, e.g. `0o755` |
+
+---
+
+#### Patch.remove()
+
+```python
+@staticmethod
+def remove(path: str) -> PatchConfig
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+---
+
+#### Patch.symlink()
+
+```python
+@staticmethod
+def symlink(target: str, link: str, *, replace: bool = False) -> PatchConfig
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `str` | What the symlink points to (literal symlink target text) |
+| link | `str` | Absolute path of the symlink itself |
+| replace | `bool` | When `True`, overwrite an existing path at `link` |
+
+---
+
+#### Patch.text()
+
+```python
+@staticmethod
+def text(
+    path: str,
+    content: str,
+    *,
+    mode: int | None = None,
+    replace: bool = False,
+) -> PatchConfig
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| content | `str` | Text content |
+| mode | `int \| None` | File mode, e.g. `0o644` |
+| replace | `bool` | When `True`, overwrite an existing path |
+
+---
+
+## Types
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `"debug"` | Debug and higher |
+| `"error"` | Errors only |
+| `"info"` | Info and higher |
+| `"trace"` | Most verbose -- all diagnostic output |
+| `"warn"` | Warnings and errors only |
+
+### LogEntry
+
+A single captured log entry returned by [`logs()`](#logs).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| timestamp_ms | `float` | Wall-clock capture time (ms since Unix epoch, UTC) |
+| source | `str` | Where the chunk came from. See [LogSource](#logsource). |
+| session_id | `int \| None` | Relay-monotonic session id; `None` for `"system"` entries |
+| data | `bytes` | The chunk's bytes (UTF-8 lossy decoded by default) |
+| `text()` | `str` | Convenience: UTF-8 decode of `data` (lossy — invalid bytes are replaced) |
+
+### LogSource
+
+The string values that the `source` field on a [`LogEntry`](#logentry) can take, also accepted by `logs(sources=[...])`.
+
+| Value | Description |
+|-------|-------------|
+| `"stdout"` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `"stderr"` | Captured from a session's stderr (pipe mode) |
+| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `"output"` rather than mislabelled as `"stdout"`. |
+| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested. |
+
+In addition, `logs(sources=["all"])` is a shorthand for all four.
+
+### MetricsStream
+
+Async stream for receiving periodic metrics snapshots.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `__aiter__` | `AsyncIterator[`[`SandboxMetrics`](#sandboxmetrics)`]` | Use with `async for` |
+| `recv()` | [`SandboxMetrics`](#sandboxmetrics) `\| None` | Receive next snapshot. Returns `None` when the stream ends. |
+
+### PatchConfig
+
+A single rootfs patch. Produced by the [`Patch`](#patch) factory; you'd normally not construct one directly. Frozen dataclass.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | `str` | One of `"text"`, `"file"`, `"copy_file"`, `"copy_dir"`, `"symlink"`, `"mkdir"`, `"remove"`, `"append"` |
+| path | `str \| None` | Absolute guest path (used by text / file / mkdir / remove / append) |
+| content | `str \| None` | Text content (text / append) |
+| src | `str \| None` | Host source path (copy_file / copy_dir) |
+| dst | `str \| None` | Guest destination path (copy_file / copy_dir) |
+| target | `str \| None` | Symlink target |
+| link | `str \| None` | Symlink path |
+| mode | `int \| None` | File / directory mode (e.g. `0o644`) |
+| replace | `bool` | When `True`, overwrite an existing path at the destination. Defaults to `False` |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `"always"` | Pull the image every time, even if cached locally |
+| `"if-missing"` | Pull only if the image is not already cached. This is the default. |
+| `"never"` | Never pull; fail if the image is not cached locally |
+
+### PullSession
+
+Returned by [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress). Use as an async context manager to track image pull progress.
+
+```python
+session = Sandbox.create_with_progress("my-sandbox", image="ubuntu:latest")
+async with session:
+    async for event in session.progress:
+        print(event)
+    sb = await session.result()
+```
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| progress | `AsyncIterator[PullProgress]` | Async iterator of pull progress events |
+| result() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Await to get the final running sandbox |
+
+### RegistryAuth
+
+Private registry credentials.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| username | `str` | Registry username |
+| password | `str` | Registry password |
+
+### SandboxConfig
+
+The keyword arguments accepted by [`Sandbox.create()`](#sandboxcreate) and [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| image | `str \| ImageSource` | - | OCI image, local path, or disk image (required) |
+| cpus | `int` | `1` | Virtual CPUs |
+| memory | `int` | `512` | Guest memory in MiB. This is a limit, not a reservation. |
+| workdir | `str` | - | Default working directory for commands |
+| shell | `str` | `"/bin/sh"` | Shell for `shell()` calls |
+| hostname | `str` | - | Guest hostname |
+| user | `str` | - | Default guest user |
+| entrypoint | `list[str]` | - | Override image entrypoint |
+| init | `str \| dict \|` [`InitConfig`](#initconfig) | - | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| replace | `bool` | `False` | Replace existing sandbox with same name |
+| max_duration | `float` | - | Maximum sandbox lifetime in seconds |
+| idle_timeout | `float` | - | Idle timeout in seconds |
+| env | `dict[str, str]` | `{}` | Environment variables visible to all commands |
+| scripts | `dict[str, str]` | `{}` | Named scripts mounted at `/.msb/scripts/` |
+| pull_policy | `str \| PullPolicy` | `"if-missing"` | Image pull behavior |
+| log_level | `str \| LogLevel` | - | Override log verbosity |
+| registry_auth | [`RegistryAuth`](#registryauth) | - | Private registry credentials |
+| volumes | `dict[str, dict]` | `{}` | Volume mounts. See [Volumes](/sdk/python/volumes). |
+| patches | `list[PatchConfig]` | `[]` | Rootfs modifications applied before boot |
+| ports | `dict[int, int]` | `{}` | Port mappings (`host_port: guest_port`) |
+| network | [`Network`](/sdk/python/networking#network) | `public_only` | Network policy and configuration |
+| secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | `[]` | Secret injection |
+| detached | `bool` | `False` | If `True`, sandbox survives after your process exits |
+
+### InitConfig
+
+Custom init specification. Pass it (or one of the equivalent shorthand shapes) as the `init=` kwarg to [`Sandbox.create()`](#sandboxcreate) to hand PID 1 inside the guest off to your own init binary after agentd's setup. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks, shutdown semantics, and tradeoffs.
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True, slots=True)
+class InitConfig:
+    cmd: str
+    args: tuple[str, ...] = ()
+    env: Mapping[str, str] = {}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cmd | `str` | Absolute path or `"auto"` to the init binary inside the guest rootfs |
+| args | `tuple[str, ...]` | Supplemental argv (`argv[0]` is implicitly `cmd`) |
+| env | `dict[str, str]` | Extra env vars merged on top of the inherited env |
+
+The `init=` kwarg follows the same shape as other `Sandbox.create` kwargs that carry structured values (`image=`, `network=`, etc.): a bare scalar for the simple case, or a dataclass / dict for the rich case.
+
+| Form | Equivalent to |
+|------|---------------|
+| `init="auto"` or `init="/sbin/init"` | `InitConfig(cmd=...)` |
+| `init={"cmd": ..., "args": [...], "env": {...}}` | dict equivalent of `InitConfig` |
+| `init=InitConfig(cmd="/sbin/init", args=("--foo",))` | itself |
+
+```python
+from microsandbox import InitConfig, Sandbox
+
+# Common case: bare string.
+sb = await Sandbox.create("worker", image="jrei/systemd-debian:12", init="auto")
+
+# Argv / env: dataclass.
+sb = await Sandbox.create(
+    "worker",
+    image="jrei/systemd-debian:12",
+    init=InitConfig(
+        cmd="/lib/systemd/systemd",
+        args=("--unit=multi-user.target",),
+        env={"container": "microsandbox"},
+    ),
+)
+```
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandboxget) or [`Sandbox.list()`](#sandboxlist). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. Call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `str` | Sandbox name |
+| status | `str` | Current status (`"running"`, `"stopped"`, `"crashed"`, `"draining"`, `"paused"`) |
+| config_json | `str` | Raw JSON configuration |
+| created_at | `float \| None` | Creation timestamp (ms since epoch) |
+| updated_at | `float \| None` | Last update timestamp (ms since epoch) |
+| connect() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Connect to a running sandbox |
+| start(*, detached=False) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Start in attached or detached mode |
+| stop() | `Awaitable[None]` | Graceful shutdown |
+| kill() | `Awaitable[None]` | Force terminate |
+| remove() | `Awaitable[None]` | Delete sandbox and state |
+| metrics() | `Awaitable[`[`SandboxMetrics`](#sandboxmetrics)`]` | Point-in-time resource metrics |
+| logs() | `Awaitable[list[`[`LogEntry`](#logentry)`]]` | Read captured `exec.log` (works without starting) |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpu_percent | `float` | CPU usage as a percentage |
+| disk_read_bytes | `int` | Total bytes read from disk since boot |
+| disk_write_bytes | `int` | Total bytes written to disk since boot |
+| memory_bytes | `int` | Current memory usage in bytes |
+| memory_limit_bytes | `int` | Memory limit in bytes |
+| net_rx_bytes | `int` | Total bytes received over the network since boot |
+| net_tx_bytes | `int` | Total bytes sent over the network since boot |
+| timestamp_ms | `float` | When this measurement was taken (ms since epoch) |
+| uptime_ms | `int` | Time since the sandbox was created (ms) |

--- a/docs/es/sdk/python/secrets.mdx
+++ b/docs/es/sdk/python/secrets.mdx
@@ -1,0 +1,77 @@
+---
+title: Secrets
+description: Python SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## Secret
+
+Static factory for creating secret entries used in `SandboxConfig.secrets`.
+
+---
+
+#### Secret.env()
+
+```python
+@staticmethod
+def env(
+    env_var: str,
+    *,
+    value: str,
+    allow_hosts: Sequence[str] = (),
+    allow_host_patterns: Sequence[str] = (),
+    placeholder: str | None = None,
+    require_tls: bool = True,
+    on_violation: ViolationAction = ViolationAction.BLOCK_AND_LOG,
+) -> SecretEntry
+```
+
+Create a secret entry that maps an environment variable to a real value. The guest sees a placeholder - the real value is only substituted by the TLS proxy when traffic goes to an allowed host.
+
+**Parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| env_var | `str` | - | Environment variable name (e.g. `"OPENAI_API_KEY"`) |
+| value | `str` | - | The real secret value. Never enters the guest VM. **Required.** |
+| allow_hosts | `Sequence[str]` | `()` | Hosts allowed to receive the real value (exact match). The TLS proxy matches against the SNI. |
+| allow_host_patterns | `Sequence[str]` | `()` | Wildcard host patterns (e.g. `"*.googleapis.com"`) |
+| placeholder | `str \| None` | `None` | Custom placeholder string. Auto-generated as `$MSB_<env_var>` if not set. |
+| require_tls | `bool` | `True` | Only substitute on TLS-intercepted connections. Disable only if you know the traffic is safe. |
+| on_violation | [`ViolationAction`](#violationaction) | `BLOCK_AND_LOG` | Action when the placeholder is sent to a disallowed host |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SecretEntry`](#secretentry) | Secret entry for `SandboxConfig.secrets` |
+
+---
+
+## Types
+
+### SecretEntry
+
+Frozen dataclass returned by [`Secret.env()`](#secretenv) and used in `SandboxConfig.secrets`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| env_var | `str` | Environment variable name |
+| value | `str` | Secret value |
+| allow_hosts | `tuple[str, ...]` | Allowed hosts (exact match) |
+| allow_host_patterns | `tuple[str, ...]` | Wildcard patterns |
+| placeholder | `str \| None` | Placeholder string |
+| require_tls | `bool` | TLS requirement |
+| on_violation | [`ViolationAction`](#violationaction) | Violation action |
+
+### ViolationAction
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) defining the action taken when a secret placeholder is sent to a disallowed host.
+
+| Value | Description |
+|-------|-------------|
+| `"block"` | Silently drop the request. The guest sees a connection reset. |
+| `"block-and-log"` | Drop the request and emit a warning log on the host side. This is the default. |
+| `"block-and-terminate"` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/es/sdk/python/snapshots.mdx
+++ b/docs/es/sdk/python/snapshots.mdx
@@ -1,0 +1,270 @@
+---
+title: Snapshots
+description: Python SDK - Snapshot API reference
+icon: "code-branch"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Python SDK reference.
+
+```python
+from microsandbox import Sandbox, Snapshot, SnapshotHandle
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## Sandbox.create() — `snapshot=` kwarg
+
+```python
+@staticmethod
+async def create(name_or_config, *, snapshot: str | os.PathLike | None = None, **kwargs) -> Sandbox
+```
+
+Boot a fresh sandbox from a snapshot artifact by passing `snapshot=` as a peer of `image=`. The two are mutually exclusive — pass exactly one.
+
+```python
+# Boot from a snapshot
+sb = await Sandbox.create("worker", snapshot="after-pip-install")
+
+# Or from an image (existing flow, unchanged)
+sb = await Sandbox.create("worker", image="python:3.12")
+```
+
+**Errors**
+
+- `ValueError` — both `image=` and `snapshot=` were passed or neither, the snapshot artifact doesn't exist, or the artifact's manifest failed validation
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```python
+async def snapshot(self, name: str) -> Snapshot
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination, see [`snapshot_to()`](#snapshot-to).
+
+**Errors**
+
+- `SnapshotSandboxRunning` — the sandbox is not stopped
+- `SnapshotAlreadyExists` — destination exists (use `Snapshot.create(..., force=True)` to overwrite)
+
+---
+
+#### snapshot_to()
+
+```python
+async def snapshot_to(self, path: str | os.PathLike) -> Snapshot
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path.
+
+---
+
+## Snapshot (instance)
+
+Properties are read-only attributes (not async).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `path` | `str` | Path to the artifact directory |
+| `digest` | `str` | Canonical content digest (`sha256:hex`). The snapshot's identity. |
+| `size_bytes` | `int` | Apparent size of the captured upper layer in bytes (sparse on disk) |
+| `image_ref` | `str` | Image reference the snapshot was taken from |
+| `image_manifest_digest` | `str` | OCI manifest digest of the pinned image |
+| `format` | `str` | `"raw"` or `"qcow2"` (always `"raw"` today) |
+| `fstype` | `str` | Filesystem type inside the upper (e.g. `"ext4"`) |
+| `parent` | `str \| None` | Parent snapshot's digest, or `None` for a root |
+| `created_at` | `str` | RFC 3339 timestamp |
+| `labels` | `dict[str, str]` | User-supplied labels |
+| `source_sandbox` | `str \| None` | Best-effort source-sandbox name |
+
+---
+
+#### verify()
+
+```python
+async def verify(self) -> dict[str, Any]
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds.
+
+```python
+report = await snap.verify()
+if report["upper"]["kind"] == "verified":
+    print(f"hash matches: {report['upper']['digest']}")
+else:
+    print("no integrity hash recorded")
+```
+
+The report shape:
+
+```python
+{
+    "digest": "sha256:...",
+    "path": "/path/to/artifact",
+    "upper": {"kind": "not_recorded"}                            # no integrity recorded
+        | {"kind": "verified", "algorithm": "...", "digest": "sha256:..."},
+}
+```
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot.create()
+
+```python
+@staticmethod
+async def create(
+    source_sandbox: str,
+    *,
+    name: str | None = None,
+    path: str | os.PathLike | None = None,
+    labels: dict[str, str] | None = None,
+    force: bool = False,
+    record_integrity: bool = False,
+) -> Snapshot
+```
+
+Create a snapshot from a stopped sandbox. Exactly one of `name=` (resolved under the default snapshots directory) or `path=` (explicit filesystem destination) is required.
+
+```python
+snap = await Snapshot.create(
+    "baseline",
+    name="after-pip-install",
+    labels={"stage": "post-deps"},
+    record_integrity=True,
+)
+```
+
+---
+
+#### Snapshot.open()
+
+```python
+@staticmethod
+async def open(path_or_name: str) -> Snapshot
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot.get()
+
+```python
+@staticmethod
+async def get(name_or_digest: str) -> SnapshotHandle
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot.list()
+
+```python
+@staticmethod
+async def list() -> list[SnapshotHandle]
+```
+
+List indexed snapshots from the local DB cache.
+
+---
+
+#### Snapshot.list_dir()
+
+```python
+@staticmethod
+async def list_dir(dir: str | os.PathLike) -> list[Snapshot]
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot.remove()
+
+```python
+@staticmethod
+async def remove(path_or_name: str, *, force: bool = False) -> None
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force=True`.
+
+---
+
+#### Snapshot.reindex()
+
+```python
+@staticmethod
+async def reindex(dir: str | os.PathLike | None = None) -> int
+```
+
+Walk `dir` (default: configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot.export()
+
+```python
+@staticmethod
+async def export(
+    name_or_path: str,
+    out: str | os.PathLike,
+    *,
+    with_parents: bool = False,
+    with_image: bool = False,
+    plain_tar: bool = False,
+) -> None
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+---
+
+#### Snapshot.import_()
+
+```python
+@staticmethod
+async def import_(
+    archive: str | os.PathLike,
+    *,
+    dest: str | os.PathLike | None = None,
+) -> SnapshotHandle
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+The trailing underscore is intentional — `import` is a reserved Python keyword.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot.list()`](#snapshot-list) and [`Snapshot.get()`](#snapshot-get).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `digest` | `str` | Manifest digest — canonical identity |
+| `name` | `str \| None` | Convenience alias |
+| `parent_digest` | `str \| None` | Parent snapshot digest (`None` today; populated when chains land) |
+| `image_ref` | `str` | Image the snapshot was taken from |
+| `format` | `str` | `"raw"` or `"qcow2"` |
+| `size_bytes` | `int \| None` | Apparent upper size at index time |
+| `created_at` | `float` | ms since Unix epoch |
+| `path` | `str` | Local artifact directory path |
+
+```python
+h = await Snapshot.get("after-pip-install")
+snap = await h.open()                # metadata-validated
+await h.remove(force=False)          # refuse if has children
+```

--- a/docs/es/sdk/python/volumes.mdx
+++ b/docs/es/sdk/python/volumes.mdx
@@ -1,0 +1,375 @@
+---
+title: Volumes
+description: Python SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+## Static methods
+
+---
+
+#### Volume.create()
+
+```python
+async def Volume.create(
+    name: str,
+    *,
+    quota_mib: int | None = None,
+    labels: dict[str, str] | None = None,
+) -> Volume
+```
+
+Create a new named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name (required) |
+| quota_mib | `int \| None` | Maximum storage size in MiB |
+| labels | `dict[str, str] \| None` | Metadata labels |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Volume` | Created volume with `name` and `path` properties |
+
+---
+
+#### Volume.get()
+
+```python
+async def Volume.get(name: str) -> VolumeHandle
+```
+
+Get a handle to an existing named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeHandle`](#volumehandle) | Volume handle |
+
+---
+
+#### Volume.list()
+
+```python
+async def Volume.list() -> list[VolumeHandle]
+```
+
+List all named volumes.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`VolumeHandle`](#volumehandle)`]` | All volumes |
+
+---
+
+#### Volume.remove()
+
+```python
+async def Volume.remove(name: str) -> None
+```
+
+Delete a named volume and its contents. Fails if the volume is currently mounted.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+
+---
+
+## Volume instance properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| name | `str` | Volume name |
+| path | `str` | Host path to the volume directory |
+
+---
+
+## Mount config factories
+
+Static factory methods on `Volume` for creating mount configurations used in sandbox volume config.
+
+---
+
+#### Volume.bind()
+
+```python
+def Volume.bind(path: str, *, readonly: bool = False) -> dict
+```
+
+Mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Directory path on the host |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+#### Volume.named()
+
+```python
+def Volume.named(name: str, *, readonly: bool = False) -> dict
+```
+
+Mount a named volume. The volume must already exist (create it with [`Volume.create()`](#volumecreate)).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+#### Volume.tmpfs()
+
+```python
+def Volume.tmpfs(*, size_mib: int | None = None, readonly: bool = False) -> dict
+```
+
+Use an in-memory filesystem. Contents are discarded when the sandbox stops.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size_mib | `int \| None` | Maximum size in MiB |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+## VolumeHandle
+
+Handle to an existing named volume, returned by [`Volume.get()`](#volumeget) and [`Volume.list()`](#volumelist).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `str` | Volume name |
+| quota_mib | `int \| None` | Storage quota in MiB |
+| used_bytes | `int` | Current disk usage in bytes |
+| labels | `dict[str, str]` | Metadata labels |
+| created_at | `float \| None` | Creation timestamp (ms since epoch) |
+| fs | [`VolumeFs`](#volumefs) | Host-side filesystem handle |
+| remove() | *(async)* `None` | Delete this volume |
+
+---
+
+## VolumeFs
+
+Host-side filesystem operations on a named volume. Obtained via the `fs` property on [`VolumeHandle`](#volumehandle). These operations run directly on the host filesystem - no running sandbox is required.
+
+---
+
+#### read()
+
+```python
+async def read(path: str) -> bytes
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bytes` | File contents as raw bytes |
+
+---
+
+#### read_text()
+
+```python
+async def read_text(path: str) -> str
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `str` | File contents as a string |
+
+---
+
+#### write()
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+| data | `bytes` | File content |
+
+---
+
+#### list()
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`FsEntry`](/sdk/python/filesystem#fsentry)`]` | Directory entries |
+
+---
+
+#### mkdir()
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory and all parent directories.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+---
+
+#### remove_file()
+
+```python
+async def remove_file(path: str) -> None
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+---
+
+#### exists()
+
+```python
+async def exists(path: str) -> bool
+```
+
+Check whether a path exists within the volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `True` if the path exists |
+
+---
+
+## Types
+
+### MountConfig
+
+Frozen dataclass representing a mount configuration.
+
+```python
+MountConfig(
+    kind: MountKind,
+    bind: str | None = None,
+    named: str | None = None,
+    size_mib: int | None = None,
+    readonly: bool = False,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| kind | [`MountKind`](#mountkind) | - | Type of mount (required) |
+| bind | `str \| None` | `None` | Host path for bind mounts |
+| named | `str \| None` | `None` | Volume name for named mounts |
+| size_mib | `int \| None` | `None` | Size limit for tmpfs mounts |
+| readonly | `bool` | `False` | Whether the mount is read-only |
+
+### MountKind
+
+String enum representing the type of mount.
+
+| Value | Description |
+|-------|-------------|
+| `"bind"` | Host bind mount |
+| `"named"` | Named volume mount |
+| `"tmpfs"` | In-memory filesystem |

--- a/docs/es/sdk/rust/events.mdx
+++ b/docs/es/sdk/rust/events.mdx
@@ -1,0 +1,66 @@
+---
+title: Events
+description: Rust SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for usage examples and guest-side emitting.
+
+## Sandbox methods
+
+---
+
+#### emit()
+
+```rust
+async fn emit(&self, event_name: &str, data: impl Serialize) -> MicrosandboxResult<()>
+```
+
+Send a named event with a JSON-serializable payload into the guest. Any process listening on the agent socket (`/run/agent.sock`) receives it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| event_name | `&str` | Event name (e.g. `"task.start"`) |
+| data | `impl Serialize` | Event payload - must be serializable to JSON |
+
+---
+
+#### on_event()
+
+```rust
+fn on_event(&self, event_name: &str, callback: impl FnMut(EventData) + Send + 'static) -> Subscription
+```
+
+Subscribe to named events emitted by guest processes. The callback fires each time the guest sends a matching event through `/run/agent.sock`. Multiple subscriptions to the same event name are supported.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| event_name | `&str` | Event name to subscribe to (e.g. `"task.progress"`) |
+| callback | `impl FnMut(EventData) + Send + 'static` | Called with the event data each time |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Subscription` | Handle that unsubscribes when dropped |
+
+---
+
+## Types
+
+### EventData
+
+Data received from a guest event.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| data | `Option<serde_json::Value>` | Event payload as a JSON value. `None` if the event had no data. |
+| event | `String` | Event name |

--- a/docs/es/sdk/rust/execution.mdx
+++ b/docs/es/sdk/rust/execution.mdx
@@ -1,0 +1,306 @@
+---
+title: Execution
+description: Rust SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+---
+
+#### attach()
+
+```rust
+async fn attach(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<i32>
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Your terminal's stdin, stdout, and stderr are connected to the guest process. Press `Ctrl+]` (or configured detach keys) to disconnect without stopping the process - it keeps running and can be reattached via its session ID.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to run |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code of the process |
+
+---
+
+#### attach_shell()
+
+```rust
+async fn attach_shell(&self) -> MicrosandboxResult<i32>
+```
+
+Attach to the sandbox's default shell (configured via `SandboxBuilder::shell()`, defaults to `/bin/sh`).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code |
+
+---
+
+#### attach_with()
+
+```rust
+async fn attach_with(&self, cmd: impl Into<String>, f: impl FnOnce(AttachOptionsBuilder) -> AttachOptionsBuilder) -> MicrosandboxResult<i32>
+```
+
+Interactive PTY attach with options for environment variables, working directory, user, and custom detach keys.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to run |
+| f | `AttachOptionsBuilder` | Configure attach options (env, cwd, user, detach keys). |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code of the process |
+
+---
+
+#### exec()
+
+```rust
+async fn exec(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments (e.g. `["-c", "print('hello')"]`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### exec_stream()
+
+```rust
+async fn exec_stream(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<ExecHandle>
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything until the command finishes. Use this for long-running processes, large output, or when you need to process output incrementally.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### exec_stream_with()
+
+```rust
+async fn exec_stream_with(&self, cmd: impl Into<String>, f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder) -> MicrosandboxResult<ExecHandle>
+```
+
+Streaming execution with per-execution overrides. Enable `stdin_pipe()` to write to the process's stdin, and `tty(true)` to allocate a pseudo-terminal for interactive programs like shells, REPLs, or editors.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| f | [`ExecOptionsBuilder`](#execoptionsbuilder) | Configure execution options. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle |
+
+---
+
+#### exec_with()
+
+```rust
+async fn exec_with(&self, cmd: impl Into<String>, f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command with per-execution overrides. The closure receives an [`ExecOptionsBuilder`](#execoptionsbuilder) to configure working directory, environment variables, timeout, resource limits, stdin mode, and TTY allocation. These overrides apply only to this execution and don't change the sandbox's defaults.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| f | [`ExecOptionsBuilder`](#execoptionsbuilder) | Configure execution options. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell()
+
+```rust
+async fn shell(&self, script: impl Into<String>) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). The script is passed as `sh -c "<script>"`, so shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `impl Into<String>` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell_stream()
+
+```rust
+async fn shell_stream(&self, script: impl Into<String>) -> MicrosandboxResult<ExecHandle>
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `impl Into<String>` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle |
+
+---
+
+## Types
+
+### ExecEvent
+
+Events emitted by a streaming execution.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Exited` | `code: i32` | The process has exited. `code` is the exit code. |
+| `Started` | `pid: u32` | The process has started. `pid` is the guest-side PID. |
+| `Stderr` | `Bytes` | A chunk of stderr data. |
+| `Stdout` | `Bytes` | A chunk of stdout data. May arrive in arbitrary sizes. |
+
+### ExecHandle
+
+A handle to a running streaming execution. Receives events as the process produces output, and provides control over stdin and signals.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| collect() | [`ExecOutput`](#execoutput) | Wait for exit and collect all remaining stdout/stderr. |
+| id() | `String` | Session ID for this execution. Can be used to reattach later. |
+| kill() | `()` | Send SIGKILL to the process. |
+| recv() | `Option<`[`ExecEvent`](#execevent)`>` | Receive the next event. Returns `None` when the process has exited and all output has been delivered. |
+| signal(signal) | `()` | Send a POSIX signal to the process (e.g. `libc::SIGTERM`). |
+| take_stdin() | `Option<`[`ExecSink`](#execsink)`>` | Take the stdin writer. Only available if `stdin_pipe()` was enabled. Returns `None` after the first call. |
+| wait() | [`ExitStatus`](#exitstatus) | Wait for the process to exit, discarding any remaining output. |
+
+### ExecOptionsBuilder
+
+Builder for per-execution overrides. Does not change the sandbox's defaults.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| args() | `impl IntoIterator<Item = impl Into<String>>` | Append command-line arguments. |
+| cwd() | `impl Into<String>` | Override the working directory for this command. |
+| env() | - `key: impl Into<String>` <br/> - `value: impl Into<String>` | Set an environment variable. Merged on top of sandbox-level env vars. |
+| envs() | `impl IntoIterator<Item = (String, String)>` | Set multiple environment variables at once. |
+| rlimit() | - `resource:` [`RlimitResource`](#rlimitresource) <br/> - `limit: u64` | Set a POSIX resource limit (soft = hard). Applied via `setrlimit()` before exec. |
+| rlimit_range() | - `resource:` [`RlimitResource`](#rlimitresource) <br/> - `soft: u64` <br/> - `hard: u64` | Set a resource limit with different soft and hard values. |
+| stdin_bytes() | `impl Into<Vec<u8>>` | Provide fixed bytes as stdin. The process reads them and then sees EOF. |
+| stdin_null() | - | Stdin reads from `/dev/null`. This is the default. |
+| stdin_pipe() | - | Enable a stdin writer via [`ExecSink`](#execsink). Use with [`ExecHandle::take_stdin()`](#exechandle). |
+| timeout() | `Duration` | Kill the process with SIGKILL if it hasn't exited within this duration. |
+| tty() | `bool` | Allocate a pseudo-terminal. Enable for interactive programs (shells, editors, `top`); disable for scripts and batch jobs. Default: `false`. |
+| user() | `impl Into<String>` | Override the guest user for this command. |
+
+### ExecOutput
+
+The result of a completed command execution. Holds the exit status and all captured output.
+
+| Field / Method | Type | Description |
+|----------------|------|-------------|
+| status() | [`ExitStatus`](#exitstatus) | Exit code and success flag |
+| stderr() | `Result<String>` | Collected stderr decoded as UTF-8 |
+| stderr_bytes() | `&Bytes` | Raw stderr bytes without decoding |
+| stdout() | `Result<String>` | Collected stdout decoded as UTF-8. Returns `Err` if the output is not valid UTF-8. |
+| stdout_bytes() | `&Bytes` | Raw stdout bytes without decoding |
+
+### ExecSink
+
+A writer for sending data to a running process's stdin. Obtained via [`ExecHandle::take_stdin()`](#exechandle).
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| close() | - | Close stdin. The process sees EOF on its stdin. |
+| write() | `data: impl AsRef<[u8]>` | Write bytes to the process's stdin. |
+
+### ExitStatus
+
+The exit status of a completed process.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| code | `i32` | Exit code. `0` typically means success. |
+| success | `bool` | `true` if code is `0` |
+
+### RlimitResource
+
+POSIX resource limit identifiers. Maps to `RLIMIT_*` constants.
+
+| Value | Description |
+|-------|-------------|
+| `As` | Max address space size |
+| `Core` | Max core file size |
+| `Cpu` | Max CPU time in seconds |
+| `Data` | Max data segment size |
+| `Fsize` | Max file size in bytes |
+| `Locks` | Max file locks |
+| `Memlock` | Max locked memory |
+| `Msgqueue` | Max bytes in POSIX message queues |
+| `Nice` | Max nice priority |
+| `Nofile` | Max open file descriptors |
+| `Nproc` | Max number of processes |
+| `Rss` | Max resident set size |
+| `Rtprio` | Max real-time priority |
+| `Rttime` | Max real-time timeout |
+| `Sigpending` | Max pending signals |
+| `Stack` | Max stack size |

--- a/docs/es/sdk/rust/filesystem.mdx
+++ b/docs/es/sdk/rust/filesystem.mdx
@@ -1,0 +1,356 @@
+---
+title: Filesystem
+description: Rust SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead, which give the guest direct filesystem access.
+
+---
+
+#### copy()
+
+```rust
+async fn copy(&self, from: &str, to: &str) -> MicrosandboxResult<()>
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `&str` | Source path |
+| to | `&str` | Destination path |
+
+---
+
+#### copy_from_host()
+
+```rust
+async fn copy_from_host(&self, host_path: impl AsRef<Path>, guest_path: &str) -> MicrosandboxResult<()>
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `impl AsRef<Path>` | Path on the host filesystem |
+| guest_path | `&str` | Destination path inside the sandbox |
+
+---
+
+#### copy_to_host()
+
+```rust
+async fn copy_to_host(&self, guest_path: &str, host_path: impl AsRef<Path>) -> MicrosandboxResult<()>
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `&str` | Path inside the sandbox |
+| host_path | `impl AsRef<Path>` | Destination path on the host |
+
+---
+
+#### exists()
+
+```rust
+async fn exists(&self, path: &str) -> MicrosandboxResult<bool>
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `true` if the path exists |
+
+---
+
+#### list()
+
+```rust
+async fn list(&self, path: &str) -> MicrosandboxResult<Vec<FsEntry>>
+```
+
+List the entries in a directory. Returns metadata for each entry including name, type, size, and permissions.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`FsEntry`](#fsentry)`>` | Directory entries |
+
+---
+
+#### mkdir()
+
+```rust
+async fn mkdir(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Create a directory. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path |
+
+---
+
+#### read()
+
+```rust
+async fn read(&self, path: &str) -> MicrosandboxResult<Bytes>
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Bytes` | File contents as raw bytes |
+
+---
+
+#### read_stream()
+
+```rust
+async fn read_stream(&self, path: &str) -> MicrosandboxResult<FsReadStream>
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory, or when you want to process data incrementally.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsReadStream`](#fsreadstream) | Async stream that yields chunks of file data |
+
+---
+
+#### read_to_string()
+
+```rust
+async fn read_to_string(&self, path: &str) -> MicrosandboxResult<String>
+```
+
+Read the entire contents of a file and decode as UTF-8. Returns an error if the file contains invalid UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `String` | File contents as a UTF-8 string |
+
+---
+
+#### remove()
+
+```rust
+async fn remove(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute file path |
+
+---
+
+#### remove_dir()
+
+```rust
+async fn remove_dir(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Remove a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path |
+
+---
+
+#### rename()
+
+```rust
+async fn rename(&self, from: &str, to: &str) -> MicrosandboxResult<()>
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `&str` | Current path |
+| to | `&str` | New path |
+
+---
+
+#### stat()
+
+```rust
+async fn stat(&self, path: &str) -> MicrosandboxResult<FsMetadata>
+```
+
+Get detailed metadata for a file or directory, including type, size, permissions, and timestamps.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsMetadata`](#fsmetadata) | File metadata |
+
+---
+
+#### write()
+
+```rust
+async fn write(&self, path: &str, data: impl AsRef<[u8]>) -> MicrosandboxResult<()>
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+| data | `impl AsRef<[u8]>` | File content |
+
+---
+
+#### write_stream()
+
+```rust
+async fn write_stream(&self, path: &str) -> MicrosandboxResult<FsWriteSink>
+```
+
+Open a streaming writer for large files. Write chunks incrementally and close when done.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsWriteSink`](#fswritesink) | Async writer for sending chunks |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| mode | `u32` | Unix permission bits (e.g. `0o644`) |
+| modified | `Option<DateTime<Utc>>` | Last modified timestamp |
+| path | `String` | File path |
+| size | `u64` | File size in bytes |
+
+### FsEntryKind
+
+The type of a filesystem entry.
+
+| Value | Description |
+|-------|-------------|
+| `Directory` | Directory |
+| `File` | Regular file |
+| `Other` | Other entry type (device, socket, etc.) |
+| `Symlink` | Symbolic link |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| created | `Option<DateTime<Utc>>` | Creation timestamp (not available on all filesystems) |
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| mode | `u32` | Unix permission bits |
+| modified | `Option<DateTime<Utc>>` | Last modified timestamp |
+| readonly | `bool` | Whether the file is read-only |
+| size | `u64` | File size in bytes |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`read_stream()`](#read_stream).
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| collect() | `Bytes` | Collect all remaining chunks into a single `Bytes` buffer. |
+| recv() | `Option<Bytes>` | Receive the next chunk. Returns `None` when the file has been fully read. |
+
+### FsWriteSink
+
+Async writer for streaming data into a file. Obtained via [`write_stream()`](#write_stream).
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| close() | - | Finalize the write and close the stream. Must be called to ensure all data is flushed. |
+| write() | `data: impl AsRef<[u8]>` | Write a chunk of data to the file. |

--- a/docs/es/sdk/rust/networking.mdx
+++ b/docs/es/sdk/rust/networking.mdx
@@ -1,0 +1,916 @@
+---
+title: Networking
+description: Rust SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Build one with [`NetworkPolicy::builder()`](#networkpolicybuilder):
+
+```rust
+use microsandbox::NetworkPolicy;
+
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.tcp().port(443).allow_public().allow_private())
+    .rule(|r| r.any().deny().ip("198.51.100.5"))
+    .build()?;
+```
+
+The default policy denies egress except for an implicit `allow public`, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
+| rules | `Vec<`[`Rule`](#rule)`>` | Ordered list of rules; first match wins |
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```rust
+NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e
+        .allow().cidr("10.0.0.0/8")     // matches everything in 10.x
+        .deny().ip("10.0.0.5"))          // never reached
+    .build()?;
+```
+
+Put specific rules before general ones.
+
+### Shadow detection
+
+`.build()` walks the rules and warns (via `tracing::warn!`) when a rule is fully covered by an earlier one in the same direction. Only `Ip`, `Cidr`, and `Group` destinations are checked; domain coverage depends on runtime DNS and is skipped. Builds still succeed:
+
+```text
+WARN rule #1 (Egress Cidr(10.0.0.5/32) Deny) is shadowed by rule #0 (Egress Cidr(10.0.0.0/8) Allow); to narrow, place the more specific rule first
+```
+
+### State accumulation
+
+State setters (`.tcp()`, `.port()`, etc.) inside a closure carry into every rule-adder that follows. State is **not reset** between adders:
+
+```rust
+.rule(|r| r.egress()
+    .tcp().port(443).allow_public()    // rule 1: egress, TCP, 443, allow Public
+    .udp().allow_private())            // rule 2: egress, [TCP, UDP], 443, allow Private
+```
+
+Use separate closures for rules that need different state.
+
+---
+
+## NetworkPolicy::builder()
+
+The fluent builder is the primary construction path. String inputs (`.ip(&str)`, `.cidr(&str)`, `.domain(&str)`, `.domain_suffix(&str)`) are stored raw and parsed at `.build()` time, so the chain stays clean. The first parse / validation failure surfaces as [`BuildError`](#builderror).
+
+The closure signature for `.rule()` / `.egress()` / `.ingress()` / `.any()` is `FnOnce(&mut RuleBuilder) -> &mut RuleBuilder`. A chain ending in any rule-adder (`.allow_public()`, `.deny().ip(...)`, etc.) returns the builder reference and satisfies the bound. Multi-statement bodies end with an explicit `r` return.
+
+---
+
+#### any()
+
+```rust
+fn any<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Any`. Rules committed inside apply in both directions.
+
+---
+
+#### build()
+
+```rust
+fn build(self) -> Result<NetworkPolicy, BuildError>
+```
+
+Consume the builder and produce a [`NetworkPolicy`](#networkpolicy). Lazy-parses every `.ip()` / `.cidr()` / `.domain()` / `.domain_suffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a `tracing::warn!` for each shadowed rule pair detected.
+
+---
+
+#### default_allow()
+
+```rust
+fn default_allow(self) -> Self
+```
+
+Set both `default_egress` and `default_ingress` to `Allow`.
+
+---
+
+#### default_deny()
+
+```rust
+fn default_deny(self) -> Self
+```
+
+Set both `default_egress` and `default_ingress` to `Deny`.
+
+---
+
+#### default_egress()
+
+```rust
+fn default_egress(self, action: Action) -> Self
+```
+
+Per-direction override for the egress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`Action`](#action) | Default action for egress |
+
+---
+
+#### default_ingress()
+
+```rust
+fn default_ingress(self, action: Action) -> Self
+```
+
+Per-direction override for the ingress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`Action`](#action) | Default action for ingress |
+
+---
+
+#### egress()
+
+```rust
+fn egress<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Egress`.
+
+---
+
+#### ingress()
+
+```rust
+fn ingress<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Ingress`.
+
+---
+
+#### rule()
+
+```rust
+fn rule<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Open a multi-rule batch closure. Direction must be set inside via `.egress()`, `.ingress()`, or `.any()` before any rule-adder.
+
+---
+
+## RuleBuilder
+
+The closure passed to `.rule(...)` (or any of the direction sugar methods) gives you a `RuleBuilder`. State setters and rule-adders interleave freely. State accumulates eagerly across the closure (see [State accumulation](#state-accumulation)).
+
+### Direction setters
+
+Last-write-wins. ICMP rule-adders are egress-only at build time.
+
+---
+
+#### any()
+
+```rust
+fn any(&mut self) -> &mut Self
+```
+
+Set direction to `Any` for subsequent rule-adders. Rules committed after this apply in both directions.
+
+---
+
+#### egress()
+
+```rust
+fn egress(&mut self) -> &mut Self
+```
+
+Set direction to `Egress` for subsequent rule-adders.
+
+---
+
+#### ingress()
+
+```rust
+fn ingress(&mut self) -> &mut Self
+```
+
+Set direction to `Ingress` for subsequent rule-adders.
+
+---
+
+### Protocol setters
+
+Protocols accumulate as a set; duplicates dedupe.
+
+---
+
+#### icmpv4()
+
+```rust
+fn icmpv4(&mut self) -> &mut Self
+```
+
+Add `Icmpv4` to the protocols set. Egress-only; an ICMP rule on an `Ingress` or `Any` direction fails build with [`BuildError::IngressDoesNotSupportIcmp`](#builderror).
+
+---
+
+#### icmpv6()
+
+```rust
+fn icmpv6(&mut self) -> &mut Self
+```
+
+Add `Icmpv6` to the protocols set. Egress-only; same rules as [`icmpv4()`](#icmpv4).
+
+---
+
+#### tcp()
+
+```rust
+fn tcp(&mut self) -> &mut Self
+```
+
+Add `Tcp` to the protocols set.
+
+---
+
+#### udp()
+
+```rust
+fn udp(&mut self) -> &mut Self
+```
+
+Add `Udp` to the protocols set.
+
+---
+
+### Port setters
+
+Ports accumulate as a set; duplicates dedupe. Always guest-side (egress destination port / ingress listening port).
+
+---
+
+#### port()
+
+```rust
+fn port(&mut self, port: u16) -> &mut Self
+```
+
+Add a single port to the ports set.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `u16` | Port number |
+
+---
+
+#### port_range()
+
+```rust
+fn port_range(&mut self, lo: u16, hi: u16) -> &mut Self
+```
+
+Add an inclusive port range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| lo | `u16` | Lower bound (inclusive) |
+| hi | `u16` | Upper bound (inclusive). `lo > hi` records [`BuildError::InvalidPortRange`](#builderror) |
+
+---
+
+#### ports()
+
+```rust
+fn ports<I: IntoIterator<Item = u16>>(&mut self, ports: I) -> &mut Self
+```
+
+Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
+
+---
+
+### Group rule-adders
+
+Each adder commits one rule using the current state and the named destination group.
+
+---
+
+#### allow_host()
+
+```rust
+fn allow_host(&mut self) -> &mut Self
+```
+
+Allow the `Host` group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allow_loopback()`](#allow_loopback).
+
+---
+
+#### allow_link_local()
+
+```rust
+fn allow_link_local(&mut self) -> &mut Self
+```
+
+Allow the `LinkLocal` group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
+
+---
+
+#### allow_loopback()
+
+```rust
+fn allow_loopback(&mut self) -> &mut Self
+```
+
+Allow the `Loopback` group (`127.0.0.0/8`, `::1`). The **guest's own** loopback, not the host. To reach a service on the host's localhost, use [`allow_host()`](#allow_host) instead. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
+
+---
+
+#### allow_meta()
+
+```rust
+fn allow_meta(&mut self) -> &mut Self
+```
+
+Allow the `Metadata` group (`169.254.169.254`). **Dangerous on cloud hosts** (exposes IAM credentials).
+
+---
+
+#### allow_multicast()
+
+```rust
+fn allow_multicast(&mut self) -> &mut Self
+```
+
+Allow the `Multicast` group (`224.0.0.0/4`, `ff00::/8`).
+
+---
+
+#### allow_private()
+
+```rust
+fn allow_private(&mut self) -> &mut Self
+```
+
+Allow the `Private` group (RFC1918 + ULA + CGN).
+
+---
+
+#### allow_public()
+
+```rust
+fn allow_public(&mut self) -> &mut Self
+```
+
+Allow the `Public` group (complement of named categories: every IP not in any other group).
+
+---
+
+#### deny_host()
+
+```rust
+fn deny_host(&mut self) -> &mut Self
+```
+
+Deny the `Host` group.
+
+---
+
+#### deny_link_local()
+
+```rust
+fn deny_link_local(&mut self) -> &mut Self
+```
+
+Deny the `LinkLocal` group.
+
+---
+
+#### deny_loopback()
+
+```rust
+fn deny_loopback(&mut self) -> &mut Self
+```
+
+Deny the `Loopback` group.
+
+---
+
+#### deny_meta()
+
+```rust
+fn deny_meta(&mut self) -> &mut Self
+```
+
+Deny the `Metadata` group.
+
+---
+
+#### deny_multicast()
+
+```rust
+fn deny_multicast(&mut self) -> &mut Self
+```
+
+Deny the `Multicast` group.
+
+---
+
+#### deny_private()
+
+```rust
+fn deny_private(&mut self) -> &mut Self
+```
+
+Deny the `Private` group.
+
+---
+
+#### deny_public()
+
+```rust
+fn deny_public(&mut self) -> &mut Self
+```
+
+Deny the `Public` group.
+
+---
+
+### Bulk-domain rule-adders
+
+Each call adds one rule per name, inheriting the current direction / protocol / port state. Lazy-parse: invalid names surface as [`BuildError::InvalidDomain`](#builderror) from `.build()`.
+
+```rust
+NetworkPolicy::builder()
+    .default_allow()
+    .egress(|e| e
+        .deny_domains(["evil.com", "tracker.example"])
+        .deny_domain_suffixes([".ads.example", ".doubleclick.net"]))
+    .build()?
+```
+
+---
+
+#### allow_domain_suffixes()
+
+```rust
+fn allow_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::DomainSuffix` allow rule per suffix.
+
+---
+
+#### allow_domains()
+
+```rust
+fn allow_domains<I, S>(&mut self, names: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::Domain` allow rule per name.
+
+---
+
+#### deny_domain_suffixes()
+
+```rust
+fn deny_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::DomainSuffix` deny rule per suffix.
+
+---
+
+#### deny_domains()
+
+```rust
+fn deny_domains<I, S>(&mut self, names: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::Domain` deny rule per name.
+
+---
+
+### Composite rule-adders
+
+---
+
+#### allow_local()
+
+```rust
+fn allow_local(&mut self) -> &mut Self
+```
+
+Add three allow rules atomically: `Loopback + LinkLocal + Host`. Each uses the closure's current state. `Metadata` is intentionally not included; opt in via [`allow_meta()`](#allow_meta) separately.
+
+---
+
+#### deny_local()
+
+```rust
+fn deny_local(&mut self) -> &mut Self
+```
+
+Add three deny rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is intentionally not included.
+
+---
+
+### Explicit-destination rule-adders
+
+`.allow()` / `.deny()` open an [`ExplicitRuleBuilder`](#explicitrulebuilder) that requires a destination call to commit.
+
+```rust
+.rule(|r| r.egress().tcp().port(443).allow().domain("api.example.com"))
+.rule(|r| r.any().deny().cidr("198.51.100.0/24"))
+```
+
+Dropping without a destination call adds no rule (the type is `#[must_use]`).
+
+---
+
+#### allow()
+
+```rust
+fn allow(&mut self) -> ExplicitRuleBuilder<'_>
+```
+
+Begin an explicit-destination rule with action `Allow`.
+
+---
+
+#### deny()
+
+```rust
+fn deny(&mut self) -> ExplicitRuleBuilder<'_>
+```
+
+Begin an explicit-destination rule with action `Deny`.
+
+---
+
+## NetworkBuilder
+
+Builder for configuring the sandbox's network stack. Used in `SandboxBuilder::network(|n| n...)`. Errors accumulated by nested builders cascade up; the outermost `SandboxBuilder::build()` surfaces them as `MicrosandboxError::NetworkBuilder(BuildError)`.
+
+---
+
+#### dns()
+
+```rust
+fn dns(self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self
+```
+
+Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
+
+```rust
+.network(|n| n
+    .dns(|d| d
+        .nameservers(["1.1.1.1".parse::<Nameserver>()?])
+        .query_timeout_ms(3000)
+    )
+)
+```
+
+---
+
+#### max_connections()
+
+```rust
+fn max_connections(self, max: usize) -> Self
+```
+
+Limit the maximum number of concurrent network connections from the sandbox.
+
+---
+
+#### on_secret_violation()
+
+```rust
+fn on_secret_violation(self, action: ViolationAction) -> Self
+```
+
+Set the action taken when a secret placeholder is detected in traffic destined for a host not in the secret's allow list. See [`ViolationAction`](#violationaction).
+
+---
+
+#### policy()
+
+```rust
+fn policy(self, policy: NetworkPolicy) -> Self
+```
+
+Set the network access policy. Pass a builder-constructed [`NetworkPolicy`](#networkpolicy):
+
+```rust
+.network(|n| n.policy(NetworkPolicy::builder().default_deny().build()?))
+```
+
+---
+
+#### tls()
+
+```rust
+fn tls(self, f: impl FnOnce(TlsBuilder) -> TlsBuilder) -> Self
+```
+
+Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
+
+---
+
+#### trust_host_cas()
+
+```rust
+fn trust_host_cas(self, enabled: bool) -> Self
+```
+
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in when egress HTTPS inside the sandbox needs to work behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle.
+
+---
+
+## DnsBuilder
+
+Builder for DNS interception settings. Used in `NetworkBuilder::dns(|d| d...)`. Owns rebind protection, nameserver pinning, and the per-query timeout.
+
+---
+
+#### nameservers()
+
+```rust
+fn nameservers<I>(self, nameservers: I) -> Self
+where
+    I: IntoIterator,
+    I::Item: Into<Nameserver>
+```
+
+Set the upstream nameservers to forward DNS queries to. Replaces any previously-set nameservers. Each element is convertible into `Nameserver` (`SocketAddr`, `IpAddr`, or a parsed string via `"dns.google:53".parse::<Nameserver>()?`).
+
+---
+
+#### query_timeout_ms()
+
+```rust
+fn query_timeout_ms(self, ms: u64) -> Self
+```
+
+Set the per-DNS-query timeout in milliseconds. Default: `5000`.
+
+---
+
+#### rebind_protection()
+
+```rust
+fn rebind_protection(self, enabled: bool) -> Self
+```
+
+When enabled, DNS responses that resolve to private IP addresses are blocked. Prevents DNS rebinding attacks. Default: `true`.
+
+---
+
+## TlsBuilder
+
+Builder for TLS interception settings. Used in `NetworkBuilder::tls(|t| t...)`.
+
+---
+
+#### block_quic()
+
+```rust
+fn block_quic(self, block: bool) -> Self
+```
+
+Block QUIC/HTTP3 on intercepted ports, forcing TCP/TLS fallback. Default: `true`.
+
+---
+
+#### bypass()
+
+```rust
+fn bypass(self, pattern: impl Into<String>) -> Self
+```
+
+Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). Use for domains with certificate pinning.
+
+---
+
+#### intercept_ca_cert()
+
+```rust
+fn intercept_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file used as the intercepting CA's certificate. Pair with [`intercept_ca_key()`](#intercept_ca_key) to provide a stable CA across sandbox restarts.
+
+---
+
+#### intercept_ca_key()
+
+```rust
+fn intercept_ca_key(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file used as the intercepting CA's private key.
+
+---
+
+#### intercepted_ports()
+
+```rust
+fn intercepted_ports(self, ports: Vec<u16>) -> Self
+```
+
+TCP ports where TLS interception is active. Default: `[443]`.
+
+---
+
+#### upstream_ca_cert()
+
+```rust
+fn upstream_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file with extra root CAs the proxy should trust when verifying upstream servers.
+
+---
+
+#### verify_upstream()
+
+```rust
+fn verify_upstream(self, verify: bool) -> Self
+```
+
+Whether the proxy verifies upstream server certificates. Default: `true`. Set to `false` only for self-signed servers.
+
+---
+
+## Types
+
+### Action
+
+| Value | Wire format | Description |
+|-------|-------------|-------------|
+| `Allow` | `"allow"` | Permit the traffic |
+| `Deny` | `"deny"` | Drop the traffic silently |
+
+### Direction
+
+| Value | Wire format | Description |
+|-------|-------------|-------------|
+| `Egress` | `"egress"` | Traffic leaving the sandbox |
+| `Ingress` | `"ingress"` | Traffic entering the sandbox (via published ports) |
+| `Any` | `"any"` | Rule applies in either direction |
+
+### Destination
+
+| Variant | Description |
+|---------|-------------|
+| `Any` | Match any address |
+| `Cidr(IpNetwork)` | Match a CIDR range (e.g. `10.0.0.0/8`); single IPs are stored as `/32` or `/128` |
+| `Domain(`[`DomainName`](#domainname)`)` | Match an exact domain (e.g. `example.com`) |
+| `DomainSuffix(`[`DomainName`](#domainname)`)` | Match the apex domain and every subdomain (e.g. `example.com` and `api.example.com`) |
+| `Group(`[`DestinationGroup`](#destinationgroup)`)` | Match a predefined address group |
+
+### DestinationGroup
+
+| Value | Wire format | Matches |
+|-------|-------------|---------|
+| `Public` | `"public"` | Complement of the other categories: every address not in any other group |
+| `Private` | `"private"` | `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7` |
+| `Loopback` | `"loopback"` | `127.0.0.0/8`, `::1` (the **guest's own** loopback, not the host) |
+| `LinkLocal` | `"link_local"` | `169.254.0.0/16`, `fe80::/10` (excludes metadata) |
+| `Metadata` | `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
+| `Multicast` | `"multicast"` | `224.0.0.0/4`, `ff00::/8` |
+| `Host` | `"host"` | Per-sandbox gateway IPs that back `host.microsandbox.internal` |
+
+### DomainName
+
+A validated DNS name. Construction goes through `str::parse` (or `TryFrom<String>`), which delegates to `hickory_proto::rr::Name` and canonicalizes the input (lowercased ASCII, leading and trailing dots stripped) so rule matching is a byte-wise compare against the DNS cache. Invalid inputs return a `DomainNameError`.
+
+```rust
+use microsandbox_network::policy::{Destination, DomainName};
+
+let exact: DomainName = "PyPI.Org.".parse()?;     // -> "pypi.org"
+let suffix: DomainName = ".example.com".parse()?;  // -> "example.com"
+```
+
+Labels follow the permissive DNS grammar (RFC 2181 §11), so underscore-prefixed names like `_service._tcp.example.com` are accepted.
+
+The builder methods (`.domain(&str)`, `.domain_suffix(&str)`) take strings and parse them lazily at `.build()`; callers don't need to construct `DomainName` directly.
+
+### Protocol
+
+| Value | Wire format |
+|-------|-------------|
+| `Tcp` | `"tcp"` |
+| `Udp` | `"udp"` |
+| `Icmpv4` | `"icmpv4"` |
+| `Icmpv6` | `"icmpv6"` |
+
+ICMP protocols are egress-only. A rule with direction `Ingress` or `Any` carrying an ICMP protocol fails build with [`BuildError::IngressDoesNotSupportIcmp`](#builderror).
+
+### PortRange
+
+```rust
+struct PortRange {
+    start: u16,  // inclusive
+    end: u16,    // inclusive
+}
+```
+
+| Method | Description |
+|--------|-------------|
+| `PortRange::single(port)` | Match a single port |
+| `PortRange::range(start, end)` | Match an inclusive range |
+
+### Rule
+
+A single network policy rule.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| direction | [`Direction`](#direction) | Which evaluator considers this rule |
+| destination | [`Destination`](#destination) | Target filter (egress destination / ingress source) |
+| protocols | `Vec<`[`Protocol`](#protocol)`>` | Set semantics; empty = any protocol |
+| ports | `Vec<`[`PortRange`](#portrange)`>` | Set semantics; empty = any port. Always guest-side (egress destination port / ingress listening port) |
+| action | [`Action`](#action) | What to do on match |
+
+Convenience constructors:
+
+| Method | Description |
+|--------|-------------|
+| `Rule::allow_egress(destination)` | Allow rule, direction `Egress` |
+| `Rule::deny_egress(destination)` | Deny rule, direction `Egress` |
+| `Rule::allow_ingress(destination)` | Allow rule, direction `Ingress` |
+| `Rule::deny_ingress(destination)` | Deny rule, direction `Ingress` |
+| `Rule::allow_any(destination)` | Allow rule, direction `Any` |
+| `Rule::deny_any(destination)` | Deny rule, direction `Any` |
+
+### ExplicitRuleBuilder
+
+Returned by [`RuleBuilder`](#rulebuilder)`::allow()` / `::deny()`. Requires exactly one destination method call to commit the rule. The type is `#[must_use]`; dropping without a call adds no rule.
+
+| Method | Description |
+|--------|-------------|
+| `.ip(impl Into<String>)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
+| `.cidr(impl Into<String>)` | Commit with `Destination::Cidr` |
+| `.domain(impl Into<String>)` | Commit with `Destination::Domain` |
+| `.domain_suffix(impl Into<String>)` | Commit with `Destination::DomainSuffix` |
+| `.group(DestinationGroup)` | Commit with `Destination::Group` |
+| `.any()` | Commit with `Destination::Any` |
+
+### BuildError
+
+Errors surfaced by the builders' `.build()` methods. The same enum covers `NetworkPolicy::builder()`, `DnsBuilder`, and `NetworkBuilder` (the network and DNS builders accumulate errors lazily; the first failure surfaces from the outermost `.build()` in the chain).
+
+| Variant | Cause |
+|---------|-------|
+| `DirectionNotSet { rule_index }` | A rule was committed without `.egress() / .ingress() / .any()` |
+| `MissingDestination { rule_index }` | `.allow()` or `.deny()` was called but no destination method followed |
+| `InvalidIp { rule_index, raw }` | `.ip(&str)` got an unparseable value |
+| `InvalidCidr { rule_index, raw }` | `.cidr(&str)` got an unparseable value |
+| `InvalidDomain { rule_index, raw, source }` | `.domain` or `.domain_suffix` got a value that failed `DomainName` parse |
+| `InvalidPortRange { rule_index, lo, hi }` | `.port_range(lo, hi)` had `lo > hi` |
+| `IngressDoesNotSupportIcmp { rule_index }` | ICMP protocol on a non-egress rule |
+
+Inside `SandboxBuilder::build()`, `BuildError` is wrapped as `MicrosandboxError::NetworkBuilder(BuildError)`.
+
+### ViolationAction
+
+Action taken when a secret placeholder is sent to a disallowed host.
+
+| Value | Description |
+|-------|-------------|
+| `Block` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `BlockAndLog` | Drop the request and emit a warning log on the host side. |
+| `BlockAndTerminate` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/es/sdk/rust/sandbox.mdx
+++ b/docs/es/sdk/rust/sandbox.mdx
@@ -1,0 +1,1176 @@
+---
+title: Sandbox
+description: Rust SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+## Static methods
+
+---
+
+#### Sandbox::builder()
+
+```rust
+fn builder(name: impl Into<String>) -> SandboxBuilder
+```
+
+Create a builder for configuring a new sandbox. The builder lets you set the image, resources, volumes, networking, secrets, and other options before booting the VM. See [`SandboxBuilder`](#sandboxbuilder) for all available options.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Sandbox name - must be unique among running sandboxes |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxBuilder`](#sandboxbuilder) | Builder for configuring the sandbox |
+
+---
+
+#### Sandbox::get()
+
+```rust
+async fn get(name: &str) -> MicrosandboxResult<SandboxHandle>
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control without requiring a full connection to the guest agent.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<SandboxHandle>>
+```
+
+List all sandboxes (running, stopped, and crashed).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`SandboxHandle`](#sandboxhandle)`>` | All sandbox handles |
+
+---
+
+#### Sandbox::remove()
+
+```rust
+async fn remove(name: &str) -> MicrosandboxResult<()>
+```
+
+Delete a stopped sandbox and all its state from disk (configuration, logs, runtime directory). Fails if the sandbox is still running - stop it first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Sandbox name |
+
+---
+
+#### Sandbox::start()
+
+```rust
+async fn start(name: &str) -> MicrosandboxResult<Sandbox>
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration. The sandbox enters attached mode - it stops when your process exits.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox::start_detached()
+
+```rust
+async fn start_detached(name: &str) -> MicrosandboxResult<Sandbox>
+```
+
+Restart a stopped sandbox in detached mode. The sandbox survives after your process exits.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+## Instance methods
+
+---
+
+#### config()
+
+```rust
+fn config(&self) -> &SandboxConfig
+```
+
+Access the sandbox's full configuration.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`&SandboxConfig`](#sandboxconfig) | Sandbox configuration |
+
+---
+
+#### detach()
+
+```rust
+async fn detach(self)
+```
+
+Release the handle without stopping the sandbox. The sandbox continues running as a background process. Reconnect later with [`Sandbox::get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```rust
+async fn drain(&self) -> MicrosandboxResult<()>
+```
+
+Start a graceful drain. Existing commands run to completion, but new `exec` calls are rejected. The sandbox transitions to `Stopped` when all in-flight commands finish. Useful for zero-downtime rotation of worker sandboxes.
+
+---
+
+#### fs()
+
+```rust
+fn fs(&self) -> SandboxFs<'_>
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/rust/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/rust/filesystem) | Filesystem handle |
+
+---
+
+#### kill()
+
+```rust
+async fn kill(&self) -> MicrosandboxResult<()>
+```
+
+Force-terminate the sandbox immediately with SIGKILL. No graceful shutdown - use when the sandbox is unresponsive.
+
+---
+
+#### metrics()
+
+```rust
+async fn metrics(&self) -> MicrosandboxResult<SandboxMetrics>
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk I/O, network I/O, and uptime.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | Resource metrics |
+
+---
+
+#### metrics_stream()
+
+```rust
+fn metrics_stream(&self, interval: Duration) -> impl Stream<Item = MicrosandboxResult<SandboxMetrics>>
+```
+
+Stream resource metrics at a regular interval. Returns an async stream that yields a new snapshot every `interval` duration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| interval | `Duration` | Time between metric snapshots |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `impl Stream<Item = Result<`[`SandboxMetrics`](#sandboxmetrics)`>>` | Async stream of metrics |
+
+---
+
+#### logs()
+
+```rust
+fn logs(&self, opts: &LogOptions) -> MicrosandboxResult<Vec<LogEntry>>
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `Stdout`, `Stderr`, and `Output` (PTY-merged). Pass `LogSource::System` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```rust
+use microsandbox::sandbox::{LogOptions, LogSource, Sandbox};
+
+let handle = Sandbox::get("web").await?;
+
+// Default — all user-program output, regardless of pipe/pty mode
+let entries = handle.logs(&LogOptions::default())?;
+
+for e in entries {
+    let source = match e.source {
+        LogSource::Stdout => "OUT",
+        LogSource::Stderr => "ERR",
+        LogSource::Output => "PTY",
+        LogSource::System => "SYS",
+    };
+    println!(
+        "[{}] {} {:?}: {}",
+        e.timestamp.to_rfc3339(),
+        source,
+        e.session_id,
+        String::from_utf8_lossy(&e.data).trim_end()
+    );
+}
+
+// Filtered: last 50 entries from the past hour, including system lines
+let recent = handle.logs(&LogOptions {
+    tail: Some(50),
+    since: Some(chrono::Utc::now() - chrono::Duration::hours(1)),
+    sources: vec![
+        LogSource::Stdout,
+        LogSource::Stderr,
+        LogSource::Output,
+        LogSource::System,
+    ],
+    ..Default::default()
+})?;
+```
+
+`logs()` is **synchronous** because it's a pure file read.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| opts | `&`[`LogOptions`](#logoptions) | Filters: `tail`, `since`, `until`, `sources`. `LogOptions::default()` returns everything for the default sources. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`LogEntry`](#logentry)`>` | Matching entries in chronological order |
+
+---
+
+#### name()
+
+```rust
+fn name(&self) -> &str
+```
+
+Get the sandbox name.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `&str` | Sandbox name |
+
+---
+
+#### owns_lifecycle()
+
+```rust
+fn owns_lifecycle(&self) -> bool
+```
+
+Whether this handle owns the sandbox lifecycle. `true` in attached mode (sandbox stops when your process exits), `false` in detached mode.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `true` if attached |
+
+---
+
+#### remove_persisted()
+
+```rust
+async fn remove_persisted(self) -> MicrosandboxResult<()>
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### stop()
+
+```rust
+async fn stop(&self) -> MicrosandboxResult<()>
+```
+
+Gracefully shut down the sandbox. Sends SIGTERM to all guest processes and waits for the VM to exit.
+
+---
+
+#### stop_and_wait()
+
+```rust
+async fn stop_and_wait(&self) -> MicrosandboxResult<ExitStatus>
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### wait()
+
+```rust
+async fn wait(&self) -> MicrosandboxResult<ExitStatus>
+```
+
+Block until the sandbox exits on its own (without triggering a stop). Returns the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
+
+---
+
+## SandboxBuilder
+
+Builder for configuring a sandbox before creation. Obtained via [`Sandbox::builder(name)`](#sandboxbuilder-1).
+
+---
+
+#### cpus()
+
+```rust
+fn cpus(self, count: u8) -> Self
+```
+
+Set the number of virtual CPUs. This is a limit, not a reservation. Default: `1`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| count | `u8` | Number of vCPUs |
+
+---
+
+#### create()
+
+```rust
+async fn create(self) -> MicrosandboxResult<Sandbox>
+```
+
+Boot the sandbox in attached mode. The sandbox stops when your process exits.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### create_detached()
+
+```rust
+async fn create_detached(self) -> MicrosandboxResult<Sandbox>
+```
+
+Boot the sandbox in detached mode. The sandbox survives after your process exits.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### disable_network()
+
+```rust
+fn disable_network(self) -> Self
+```
+
+Fully disable networking. No network interface is created.
+
+---
+
+#### entrypoint()
+
+```rust
+fn entrypoint(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> Self
+```
+
+Override the OCI image's entrypoint.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl IntoIterator<Item = impl Into<String>>` | Entrypoint command and arguments |
+
+---
+
+#### env()
+
+```rust
+fn env(self, key: impl Into<String>, value: impl Into<String>) -> Self
+```
+
+Set an environment variable visible to all commands. Can be called multiple times. Per-command env vars (via `exec_with`) are merged on top.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| key | `impl Into<String>` | Variable name |
+| value | `impl Into<String>` | Variable value |
+
+---
+
+#### hostname()
+
+```rust
+fn hostname(self, hostname: impl Into<String>) -> Self
+```
+
+Set the guest hostname.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostname | `impl Into<String>` | Hostname |
+
+---
+
+#### idle_timeout()
+
+```rust
+fn idle_timeout(self, secs: u64) -> Self
+```
+
+Auto-drain the sandbox after this many seconds of inactivity (no active exec sessions). Enforced on the host side.
+
+---
+
+#### init()
+
+```rust
+fn init(self, cmd: impl Into<PathBuf>) -> Self
+```
+
+Hand off PID 1 inside the guest to `cmd` after agentd finishes its boot-time setup. The agent forks; the parent execs the init and becomes PID 1, the agent continues as a child process. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks, shutdown semantics, and tradeoffs.
+
+`cmd` is either an absolute path inside the guest rootfs or the literal `"auto"` (probes `/sbin/init`, `/lib/systemd/systemd`, `/usr/lib/systemd/systemd`). For init binaries that take argv or extra env (rare), use [`init_with`](#init_with).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<PathBuf>` | Absolute path inside the guest, or `"auto"` |
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("jrei/systemd-debian:12")
+    .init("auto")
+    .create()
+    .await?;
+```
+
+---
+
+#### init_with()
+
+```rust
+fn init_with(
+    self,
+    cmd: impl Into<PathBuf>,
+    f: impl FnOnce(InitOptionsBuilder) -> InitOptionsBuilder,
+) -> Self
+```
+
+Like [`init`](#init), but with a closure-builder for argv and env vars. Mirrors `exec_with` in shape.
+
+The builder exposes `arg`, `args`, `env`, and `envs`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<PathBuf>` | Absolute path to the init binary inside the guest |
+| f | `FnOnce(InitOptionsBuilder) -> InitOptionsBuilder` | Closure populating argv and env |
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("jrei/systemd-debian:12")
+    .init_with("/lib/systemd/systemd", |i| i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create()
+    .await?;
+```
+
+Calling `init` or `init_with` more than once overwrites — different from `env`, which appends. The init is one-shot pre-boot.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `u64` | Idle timeout in seconds |
+
+---
+
+#### image()
+
+```rust
+fn image(self, image: impl IntoImage) -> Self
+```
+
+Set the root filesystem source. Accepts OCI image names, local directory paths, or disk image paths. The format is auto-detected.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| image | `impl IntoImage` | OCI image name, local directory path, or disk image path |
+
+---
+
+#### image_with()
+
+```rust
+fn image_with(self, f: impl FnOnce(ImageBuilder) -> ImageBuilder) -> Self
+```
+
+Configure a disk image rootfs with explicit filesystem type. Use when the filesystem type can't be auto-detected.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | `ImageBuilder` | Configure the disk image rootfs. |
+
+---
+
+#### log_level()
+
+```rust
+fn log_level(self, level: LogLevel) -> Self
+```
+
+Override the sandbox process's log verbosity.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| level | [`LogLevel`](#loglevel) | Log level |
+
+---
+
+#### max_duration()
+
+```rust
+fn max_duration(self, secs: u64) -> Self
+```
+
+Set the maximum sandbox lifetime in seconds. When exceeded, the sandbox is drained and stopped. Enforced on the host side - the guest cannot override it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `u64` | Maximum lifetime in seconds |
+
+---
+
+#### memory()
+
+```rust
+fn memory(self, size: impl Into<Mebibytes>) -> Self
+```
+
+Set the guest memory size. Physical pages are only allocated as the guest touches them, so this is a limit, not an upfront reservation. Default: `512` MiB.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size | `impl Into<Mebibytes>` | Memory in MiB |
+
+---
+
+#### network()
+
+```rust
+fn network(self, f: impl FnOnce(NetworkBuilder) -> NetworkBuilder) -> Self
+```
+
+Configure networking. See [Networking](/sdk/rust/networking) for the full builder API.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`NetworkBuilder`](/sdk/rust/networking#networkbuilder) | Configure the network. |
+
+---
+
+#### patch()
+
+```rust
+fn patch(self, f: impl FnOnce(PatchBuilder) -> PatchBuilder) -> Self
+```
+
+Modify the rootfs before the VM boots. Patches go into the writable layer - the base image is untouched.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | `PatchBuilder` | Configure rootfs patches. |
+
+---
+
+#### port()
+
+```rust
+fn port(self, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a TCP port from the sandbox to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_port | `u16` | Port on the host |
+| guest_port | `u16` | Port inside the sandbox |
+
+---
+
+#### port_udp()
+
+```rust
+fn port_udp(self, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a UDP port.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_port | `u16` | Port on the host |
+| guest_port | `u16` | Port inside the sandbox |
+
+---
+
+#### pull_policy()
+
+```rust
+fn pull_policy(self, policy: PullPolicy) -> Self
+```
+
+Control when the OCI image is pulled from the registry.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| policy | [`PullPolicy`](#pullpolicy) | Pull behavior |
+
+---
+
+#### registry_auth()
+
+```rust
+fn registry_auth(self, auth: RegistryAuth) -> Self
+```
+
+Authenticate to a private container registry.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| auth | [`RegistryAuth`](#registryauth) | Registry credentials |
+
+---
+
+#### replace()
+
+```rust
+fn replace(self) -> Self
+```
+
+If a sandbox with the same name already exists, stop it, remove it, and create a fresh one. Without this, creation fails on name conflict.
+
+---
+
+#### script()
+
+```rust
+fn script(self, name: impl Into<String>, content: impl Into<String>) -> Self
+```
+
+Add a named script at `/.msb/scripts/` inside the guest. Scripts are added to `PATH` and can be called by name via `exec()` or `shell()`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Script name (becomes the filename) |
+| content | `impl Into<String>` | Script content |
+
+---
+
+#### secret()
+
+```rust
+fn secret(self, f: impl FnOnce(SecretBuilder) -> SecretBuilder) -> Self
+```
+
+Add a secret with full configuration. See [Secrets](/sdk/rust/secrets) for the builder API. Automatically enables TLS interception.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`SecretBuilder`](/sdk/rust/secrets#secretbuilder) | Configure the secret. |
+
+---
+
+#### secret_env()
+
+```rust
+fn secret_env(self, env_var: impl Into<String>, value: impl Into<String>, allowed_host: impl Into<String>) -> Self
+```
+
+Shorthand for adding a header-injected secret. Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| env_var | `impl Into<String>` | Environment variable name |
+| value | `impl Into<String>` | Secret value |
+| allowed_host | `impl Into<String>` | Allowed destination host |
+
+---
+
+#### shell()
+
+```rust
+fn shell(self, shell: impl Into<String>) -> Self
+```
+
+Set the shell used by [`Sandbox::shell()`](#shell). Default: `/bin/sh`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| shell | `impl Into<String>` | Shell path (e.g. `"/bin/bash"`) |
+
+---
+
+#### user()
+
+```rust
+fn user(self, user: impl Into<String>) -> Self
+```
+
+Set the default guest user for all commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| user | `impl Into<String>` | User name or UID |
+
+---
+
+#### volume()
+
+```rust
+fn volume(self, guest_path: impl Into<String>, f: impl FnOnce(MountBuilder) -> MountBuilder) -> Self
+```
+
+Add a volume mount. See [Volumes](/sdk/rust/volumes) for mount types.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `impl Into<String>` | Mount point inside the sandbox |
+| f | [`MountBuilder`](/sdk/rust/volumes#mountbuilder) | Configure the mount. |
+
+---
+
+#### workdir()
+
+```rust
+fn workdir(self, path: impl Into<String>) -> Self
+```
+
+Set the default working directory for all commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+
+---
+
+## PatchBuilder
+
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder::patch(|p| p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `replace = true` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### append()
+
+```rust
+fn append(self, path: impl Into<String>, content: impl Into<String>) -> Self
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<String>` | Text to append |
+
+---
+
+#### copy_dir()
+
+```rust
+fn copy_dir(self, src: impl Into<PathBuf>, dst: impl Into<String>, replace: bool) -> Self
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<PathBuf>` | Host source directory |
+| dst | `impl Into<String>` | Absolute destination path inside the guest |
+| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### copy_file()
+
+```rust
+fn copy_file(
+    self,
+    src: impl Into<PathBuf>,
+    dst: impl Into<String>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<PathBuf>` | Host source file |
+| dst | `impl Into<String>` | Absolute destination path inside the guest |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)`. `None` keeps the source mode |
+| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### file()
+
+```rust
+fn file(
+    self,
+    path: impl Into<String>,
+    content: impl Into<Vec<u8>>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Write raw bytes at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<Vec<u8>>` | Raw byte content |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
+| replace | `bool` | When `true`, overwrite an existing path |
+
+---
+
+#### mkdir()
+
+```rust
+fn mkdir(self, path: impl Into<String>, mode: Option<u32>) -> Self
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| mode | `Option<u32>` | Directory mode, e.g. `Some(0o755)` |
+
+---
+
+#### remove()
+
+```rust
+fn remove(self, path: impl Into<String>) -> Self
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+
+---
+
+#### symlink()
+
+```rust
+fn symlink(self, target: impl Into<String>, link: impl Into<String>, replace: bool) -> Self
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `impl Into<String>` | What the symlink points to (literal symlink target text) |
+| link | `impl Into<String>` | Absolute path of the symlink itself |
+| replace | `bool` | When `true`, overwrite an existing path at `link` |
+
+---
+
+#### text()
+
+```rust
+fn text(
+    self,
+    path: impl Into<String>,
+    content: impl Into<String>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<String>` | Text content |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
+| replace | `bool` | When `true`, overwrite an existing path |
+
+---
+
+## Types
+
+### LogEntry
+
+A single captured log entry returned by [`logs()`](#logs).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| timestamp | `DateTime<Utc>` | Wall-clock capture time on the host |
+| source | [`LogSource`](#logsource) | Where the chunk came from |
+| session_id | `Option<u64>` | Relay-monotonic session id; `None` for `System` entries |
+| data | `Bytes` | The chunk's bytes (UTF-8 lossy decoded by default; raw bytes if `--raw` mode was used) |
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `Error` | Errors only |
+| `Warn` | Warnings and errors only |
+| `Info` | Info and higher |
+| `Debug` | Debug and higher |
+| `Trace` | Most verbose - all diagnostic output |
+
+### LogOptions
+
+Filters passed to [`logs()`](#logs). All fields optional. `LogOptions::default()` returns everything for the default sources (`Stdout` + `Stderr` + `Output`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tail | `Option<usize>` | Show only the last N entries after other filters apply |
+| since | `Option<DateTime<Utc>>` | Inclusive lower bound on entry timestamp |
+| until | `Option<DateTime<Utc>>` | Exclusive upper bound on entry timestamp |
+| sources | `Vec<`[`LogSource`](#logsource)`>` | Sources to include. Empty = `[Stdout, Stderr, Output]` (the default user-program sources). Add `System` to merge runtime/kernel diagnostics. |
+
+### LogSource
+
+Tag indicating where a captured log entry came from.
+
+| Value | Description |
+|-------|-------------|
+| `Stdout` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `Stderr` | Captured from a session's stderr (pipe mode) |
+| `Output` | Captured from a session running in pty mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `Output` rather than mislabelled as `Stdout`. |
+| `System` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `System` is requested. |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `Always` | Pull the image every time, even if cached locally |
+| `IfMissing` | Pull only if the image is not already cached. This is the default. |
+| `Never` | Never pull; fail if the image is not cached locally |
+
+### RegistryAuth
+
+Credentials for authenticating to a private container registry.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Basic` | - `username: String` <br/> - `password: String` | Username and password authentication |
+
+### SandboxConfig
+
+The full configuration of a sandbox. Obtained via [`config()`](#config) or built via [`SandboxBuilder`](#sandboxbuilder). Contains all settings used to create the sandbox.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpus | `u8` | Number of virtual CPUs |
+| env | `Vec<(String, String)>` | Environment variables |
+| idle_timeout_secs | `Option<u64>` | Idle timeout |
+| image | `RootfsSource` | Root filesystem source (OCI, bind, or disk image) |
+| max_duration_secs | `Option<u64>` | Maximum lifetime |
+| memory_mib | `u32` | Guest memory in MiB |
+| name | `String` | Sandbox name |
+| patches | `Vec<Patch>` | Rootfs patches |
+| scripts | `Vec<(String, String)>` | Named scripts |
+| shell | `Option<String>` | Shell for `shell()` calls |
+| volumes | `Vec<VolumeMount>` | Volume mounts |
+| workdir | `Option<String>` | Default working directory |
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox::get()`](#sandboxget) or [`Sandbox::list()`](#sandboxlist). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. You cannot `exec` or `fs` on a handle - call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| config() | `Result<`[`SandboxConfig`](#sandboxconfig)`>` | Parsed configuration |
+| config_json() | `&str` | Raw JSON configuration |
+| connect() | `Result<`[`Sandbox`](#instance-methods)`>` | Connect to a running sandbox |
+| created_at() | `Option<DateTime<Utc>>` | Creation timestamp |
+| kill() | `Result<()>` | Force terminate |
+| logs() | `Result<Vec<`[`LogEntry`](#logentry)`>>` | Read captured `exec.log` (works without starting) |
+| metrics() | `Result<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
+| name() | `&str` | Sandbox name |
+| remove() | `Result<()>` | Delete sandbox and state |
+| start() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
+| start_detached() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |
+| status() | [`SandboxStatus`](#sandboxstatus) | Current status |
+| stop() | `Result<()>` | Graceful shutdown |
+| updated_at() | `Option<DateTime<Utc>>` | Last update timestamp |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpu_percent | `f32` | CPU usage as a percentage |
+| disk_read_bytes | `u64` | Total bytes read from disk since boot |
+| disk_write_bytes | `u64` | Total bytes written to disk since boot |
+| memory_bytes | `u64` | Current memory usage in bytes |
+| memory_limit_bytes | `u64` | Memory limit in bytes |
+| net_rx_bytes | `u64` | Total bytes received over the network since boot |
+| net_tx_bytes | `u64` | Total bytes sent over the network since boot |
+| timestamp | `DateTime<Utc>` | When this measurement was taken |
+| uptime | `Duration` | Time since the sandbox was created |
+
+### SandboxStatus
+
+| Value | Description |
+|-------|-------------|
+| `Crashed` | VM exited unexpectedly (kernel panic, OOM, etc.) |
+| `Draining` | Graceful shutdown in progress; existing commands finish, new ones rejected |
+| `Running` | Guest agent is ready; `exec`, `shell`, `fs` work |
+| `Stopped` | VM shut down; configuration persisted; can be restarted |

--- a/docs/es/sdk/rust/secrets.mdx
+++ b/docs/es/sdk/rust/secrets.mdx
@@ -1,0 +1,221 @@
+---
+title: Secrets
+description: Rust SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## SecretBuilder
+
+Builder for configuring a secret's placeholder, allowed hosts, and injection scopes. Obtained through `SandboxBuilder::secret(|s| s...)`. Each secret maps an environment variable to a real value that is only revealed when traffic goes to an allowed host via the TLS proxy.
+
+---
+
+#### allow_any_host_dangerous()
+
+```rust
+fn allow_any_host_dangerous(self, i_understand_the_risk: bool) -> Self
+```
+
+Allow substitution on **any** host. This means any server the guest connects to will receive the real secret - effectively disabling host-based protection. Only use this when the secret is not sensitive or the sandbox network is fully locked down.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| i_understand_the_risk | `bool` | Must be `true` to take effect |
+
+---
+
+#### allow_host()
+
+```rust
+fn allow_host(self, host: impl Into<String>) -> Self
+```
+
+Add a host that is allowed to receive the real secret value. The TLS proxy matches this against the SNI (Server Name Indication) in the TLS ClientHello. Can be called multiple times to allow multiple hosts.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `impl Into<String>` | Exact hostname (e.g. `"api.openai.com"`) |
+
+---
+
+#### allow_host_pattern()
+
+```rust
+fn allow_host_pattern(self, pattern: impl Into<String>) -> Self
+```
+
+Add a wildcard host pattern. The `*` matches any subdomain prefix.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pattern | `impl Into<String>` | Wildcard pattern (e.g. `"*.googleapis.com"`) |
+
+---
+
+#### env()
+
+```rust
+fn env(self, var: impl Into<String>) -> Self
+```
+
+Set the environment variable name that will hold the placeholder inside the guest. The guest sees `$MSB_<var>` (or a custom placeholder) - never the real value. **Required.**
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| var | `impl Into<String>` | Environment variable name (e.g. `"OPENAI_API_KEY"`) |
+
+---
+
+#### inject_basic_auth()
+
+```rust
+fn inject_basic_auth(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced specifically in `Authorization` header lines. When `inject_headers` is `true`, this has no additional effect since all headers are already covered.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### inject_body()
+
+```rust
+fn inject_body(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced in the HTTP request body. When enabled, the TLS proxy also updates the `Content-Length` header to match the new body size after substitution.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `false` |
+
+---
+
+#### inject_headers()
+
+```rust
+fn inject_headers(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced anywhere in HTTP headers. This is the most common injection scope - covers `Authorization: Bearer $MSB_...` and similar patterns.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### inject_query()
+
+```rust
+fn inject_query(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced in the URL query string (the `?key=value` portion of the request line).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `false` |
+
+---
+
+#### placeholder()
+
+```rust
+fn placeholder(self, placeholder: impl Into<String>) -> Self
+```
+
+Override the auto-generated placeholder string. By default, microsandbox generates `$MSB_<env_var>`. Use this when you need a specific format or when the placeholder must match a particular byte length.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| placeholder | `impl Into<String>` | Custom placeholder string |
+
+---
+
+#### require_tls_identity()
+
+```rust
+fn require_tls_identity(self, enabled: bool) -> Self
+```
+
+When `true`, the secret is only substituted on TLS-intercepted connections where the proxy has verified it is performing MITM. When `false`, substitution also happens on non-intercepted (bypass) connections. Disable only if you know the traffic is safe.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### value()
+
+```rust
+fn value(self, value: impl Into<String>) -> Self
+```
+
+Set the real secret value. This is the string that replaces the placeholder when a request reaches an allowed host. It never enters the guest VM. **Required.**
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| value | `impl Into<String>` | The actual credential or token |
+
+---
+
+## Shorthand
+
+#### secret_env()
+
+```rust
+fn secret_env(self, env_var: impl Into<String>, value: impl Into<String>, allowed_host: impl Into<String>) -> Self
+```
+
+Convenience method on `SandboxBuilder`. Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`. Uses default injection scopes (headers enabled, body disabled).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| env_var | `impl Into<String>` | Environment variable name |
+| value | `impl Into<String>` | Secret value |
+| allowed_host | `impl Into<String>` | Allowed destination host |
+
+---
+
+## Types
+
+### ViolationAction
+
+Configured via [`NetworkBuilder::on_secret_violation()`](/sdk/rust/networking#on_secret_violation). Determines what happens when the guest sends a request containing a secret placeholder to a host that is **not** in the secret's allow list.
+
+| Value | Description |
+|-------|-------------|
+| `Block` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `BlockAndLog` | Drop the request and emit a warning log on the host side. |
+| `BlockAndTerminate` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/es/sdk/rust/snapshots.mdx
+++ b/docs/es/sdk/rust/snapshots.mdx
@@ -1,0 +1,343 @@
+---
+title: Snapshots
+description: Rust SDK - Snapshot API reference
+icon: "camera"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Rust SDK reference.
+
+```rust
+use microsandbox::{Sandbox, Snapshot, SnapshotHandle, SnapshotFormat};
+use microsandbox::snapshot::ExportOpts;
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## SandboxBuilder
+
+---
+
+#### from_snapshot()
+
+```rust
+fn from_snapshot(self, src: impl Into<String>) -> Self
+```
+
+Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`image()`](/sdk/rust/sandbox#image) and [`image_with()`](/sdk/rust/sandbox#image-with) — the snapshot already pins the image.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<String>` | Bare name (resolved under `~/.microsandbox/snapshots/`) or filesystem path to an artifact directory |
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```rust
+async fn snapshot(&self, name: &str) -> MicrosandboxResult<Snapshot>
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination see [`snapshot_to()`](#snapshot-to).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Bare snapshot name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Snapshot` | The created artifact handle |
+
+**Errors**
+
+- `MicrosandboxError::SnapshotSandboxRunning` — the sandbox is not stopped
+- `MicrosandboxError::SnapshotAlreadyExists` — destination already exists (use the builder with `.force()` to overwrite)
+
+---
+
+#### snapshot_to()
+
+```rust
+async fn snapshot_to(&self, path: impl AsRef<Path>) -> MicrosandboxResult<Snapshot>
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path. For the common case of writing under the default snapshots directory see [`snapshot()`](#snapshot).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl AsRef<Path>` | Destination directory |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Snapshot` | The created artifact handle |
+
+---
+
+## Snapshot (instance)
+
+---
+
+#### path()
+
+```rust
+fn path(&self) -> &Path
+```
+
+Path to the artifact directory.
+
+---
+
+#### digest()
+
+```rust
+fn digest(&self) -> &str
+```
+
+Canonical content digest (`sha256:hex`) over the manifest bytes. The snapshot's identity.
+
+---
+
+#### manifest()
+
+```rust
+fn manifest(&self) -> &Manifest
+```
+
+Parsed manifest — image reference, image manifest digest, fstype, format, labels, upper-layer metadata, and optional integrity hash.
+
+---
+
+#### size_bytes()
+
+```rust
+fn size_bytes(&self) -> u64
+```
+
+Apparent size of the captured upper layer in bytes (the ext4 virtual size, sparse on disk).
+
+---
+
+#### verify()
+
+```rust
+async fn verify(&self) -> MicrosandboxResult<SnapshotVerifyReport>
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds. Returns `NotRecorded` when the manifest has no integrity hash.
+
+---
+
+## Snapshot::builder
+
+---
+
+#### Snapshot::builder()
+
+```rust
+fn builder(source_sandbox: impl Into<String>) -> SnapshotBuilder
+```
+
+Start configuring a new snapshot. The fluent builder is the API the CLI uses internally.
+
+```rust
+let snap = Snapshot::builder("baseline")
+    .name("after-pip-install")        // bare name in default dir
+    .label("stage", "post-deps")
+    .force()                           // overwrite if it exists
+    .record_integrity()                // hash the upper layer
+    .create()
+    .await?;
+```
+
+**Builder methods**
+
+| Method | Description |
+|--------|-------------|
+| `.destination(SnapshotDestination)` | Explicit destination variant |
+| `.name(&str)` | Convenience: bare name under the default snapshots directory |
+| `.path(PathBuf)` | Convenience: explicit filesystem path |
+| `.label(k, v)` | Add a `key=value` label (sorted in canonical form) |
+| `.force()` | Overwrite an existing artifact at the destination |
+| `.record_integrity()` | Compute and record a content-integrity hash at creation |
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot::create()
+
+```rust
+async fn create(config: SnapshotConfig) -> MicrosandboxResult<Snapshot>
+```
+
+Create a snapshot from a [`SnapshotConfig`](#snapshotconfig). Equivalent to using the builder.
+
+---
+
+#### Snapshot::open()
+
+```rust
+async fn open(path_or_name: impl AsRef<str>) -> MicrosandboxResult<Snapshot>
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot::get()
+
+```rust
+async fn get(name_or_digest: &str) -> MicrosandboxResult<SnapshotHandle>
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<SnapshotHandle>>
+```
+
+List indexed snapshots from the local DB cache. External-path artifacts opened via `Snapshot::open(/some/path)` may not appear here unless they live under the configured snapshots directory.
+
+---
+
+#### Snapshot::list_dir()
+
+```rust
+async fn list_dir(dir: impl AsRef<Path>) -> MicrosandboxResult<Vec<Snapshot>>
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index. Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot::remove()
+
+```rust
+async fn remove(path_or_name: &str, force: bool) -> MicrosandboxResult<()>
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force` is `true`.
+
+---
+
+#### Snapshot::reindex()
+
+```rust
+async fn reindex(dir: impl AsRef<Path>) -> MicrosandboxResult<usize>
+```
+
+Walk `dir`, upsert index rows for every artifact found, recompute parent-edge child counts. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot::export()
+
+```rust
+async fn export(name_or_path: &str, out: &Path, opts: ExportOpts) -> MicrosandboxResult<()>
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+**ExportOpts**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `with_parents` | `bool` | Walk the parent chain and include each ancestor (no-op today) |
+| `with_image` | `bool` | Bundle the OCI image cache (`cache/{layers,fsmeta,vmdk}`) for offline transport |
+| `plain_tar` | `bool` | Skip zstd compression and write a plain `.tar` |
+
+---
+
+#### Snapshot::import()
+
+```rust
+async fn import(archive: &Path, dest: Option<&Path>) -> MicrosandboxResult<SnapshotHandle>
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot::list()`](#snapshotlist) and [`Snapshot::get()`](#snapshotget).
+
+```rust
+let h = Snapshot::get("after-pip-install").await?;
+
+h.digest();           // &str — sha256:...
+h.name();             // Option<&str>
+h.parent_digest();    // Option<&str> — None today; populated when chains land
+h.image_ref();        // &str
+h.format();           // SnapshotFormat::Raw | Qcow2
+h.size_bytes();       // Option<u64>
+h.created_at();       // chrono::NaiveDateTime
+h.path();             // &Path
+
+let snap = h.open().await?;       // verify metadata, return Snapshot
+h.remove(false).await?;            // false = refuse if has children
+```
+
+---
+
+## Types
+
+#### SnapshotDestination
+
+```rust
+pub enum SnapshotDestination {
+    Name(String),
+    Path(PathBuf),
+}
+```
+
+Used by [`SnapshotBuilder::destination()`](#snapshotbuilder). The handle methods [`snapshot()`](#snapshot) and [`snapshot_to()`](#snapshot-to) construct this enum internally so callers don't need to import it.
+
+#### SnapshotFormat
+
+```rust
+pub enum SnapshotFormat {
+    Raw,
+    Qcow2,    // future
+}
+```
+
+Always emits `Raw` today. The `Qcow2` variant is reserved for backing-chain checkpoints.
+
+#### SnapshotVerifyReport
+
+```rust
+pub struct SnapshotVerifyReport {
+    pub digest: String,
+    pub path: PathBuf,
+    pub upper: UpperVerifyStatus,
+}
+
+pub enum UpperVerifyStatus {
+    NotRecorded,
+    Verified { algorithm: String, digest: String },
+}
+```
+
+Returned by [`Snapshot::verify()`](#verify).

--- a/docs/es/sdk/rust/volumes.mdx
+++ b/docs/es/sdk/rust/volumes.mdx
@@ -1,0 +1,213 @@
+---
+title: Volumes
+description: Rust SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+---
+
+#### Volume::builder()
+
+```rust
+fn builder(name: impl Into<String>) -> VolumeBuilder
+```
+
+Create a builder for a new named volume. Call `.quota()` to set a storage limit, then `.create()` to finalize.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Volume name (e.g. `"pip-cache"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeBuilder`](#volumebuilder) | Builder with `.quota()` and `.create()` |
+
+---
+
+#### Volume::get()
+
+```rust
+async fn get(name: &str) -> MicrosandboxResult<VolumeHandle>
+```
+
+Get a handle to an existing named volume. Use the handle to access the volume's filesystem from the host or to delete it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeHandle`](#volumehandle) | Handle for host-side operations |
+
+---
+
+#### Volume::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<VolumeHandle>>
+```
+
+List all named volumes.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`VolumeHandle`](#volumehandle)`>` | All volume handles |
+
+---
+
+#### Volume::remove()
+
+```rust
+async fn remove(name: &str) -> MicrosandboxResult<()>
+```
+
+Delete a named volume and its contents from disk. Fails if the volume is currently mounted by a running sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Volume name |
+
+---
+
+## VolumeBuilder
+
+Builder for creating a named volume.
+
+---
+
+#### create()
+
+```rust
+async fn create(self) -> MicrosandboxResult<Volume>
+```
+
+Create the volume on disk.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Volume` | The created volume |
+
+---
+
+#### quota()
+
+```rust
+fn quota(self, mib: u64) -> Self
+```
+
+Set the maximum storage size for this volume. The guest cannot write beyond this limit.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| mib | `u64` | Quota in MiB |
+
+---
+
+## MountBuilder
+
+Builder for configuring a volume mount. Used in `SandboxBuilder::volume(path, |v| v...)`.
+
+---
+
+#### bind()
+
+```rust
+fn bind(self, host_path: impl Into<PathBuf>) -> Self
+```
+
+Mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `impl Into<PathBuf>` | Directory path on the host |
+
+---
+
+#### named()
+
+```rust
+fn named(self, name: impl Into<String>) -> Self
+```
+
+Mount a named volume. The volume must already exist (create it with [`Volume::builder()`](#volumebuilder)).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Volume name |
+
+---
+
+#### readonly()
+
+```rust
+fn readonly(self) -> Self
+```
+
+Mount as read-only. The guest can read but not write.
+
+---
+
+#### size()
+
+```rust
+fn size(self, mib: impl Into<Mebibytes>) -> Self
+```
+
+Set the size limit for a tmpfs mount. Has no effect on bind or named mounts.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| mib | `impl Into<Mebibytes>` | Size limit in MiB |
+
+---
+
+#### tmpfs()
+
+```rust
+fn tmpfs(self) -> Self
+```
+
+Use an in-memory filesystem. Contents are discarded when the sandbox stops. Good for scratch space, temp files, and build artifacts.
+
+---
+
+## Types
+
+### VolumeHandle
+
+Handle for interacting with a named volume from the host side.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| fs() | `VolumeFsHandle` | Host-side filesystem access - read and write files without a running sandbox |
+| name() | `&str` | Volume name |
+| remove() | `()` | Delete this volume from disk |

--- a/docs/es/sdk/typescript/events.mdx
+++ b/docs/es/sdk/typescript/events.mdx
@@ -1,0 +1,66 @@
+---
+title: Events
+description: TypeScript SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for usage examples and guest-side emitting.
+
+## Sandbox methods
+
+---
+
+#### emit()
+
+```typescript
+emit(eventName: string, data: any): Promise<void>
+```
+
+Send a named event with a JSON-serializable payload into the guest. Any process listening on the agent socket (`/run/agent.sock`) receives it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| eventName | `string` | Event name (e.g. `"task.start"`) |
+| data | `any` | Event payload - must be JSON-serializable |
+
+---
+
+#### onEvent()
+
+```typescript
+onEvent(eventName: string, callback: (event: EventData) => void): Subscription
+```
+
+Subscribe to named events emitted by guest processes. The callback fires each time the guest sends a matching event through `/run/agent.sock`. Multiple subscriptions to the same event name are supported.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| eventName | `string` | Event name to subscribe to (e.g. `"task.progress"`) |
+| callback | `(event: EventData) => void` | Called with the event data each time |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Subscription` | Call `.unsubscribe()` to stop receiving events |
+
+---
+
+## Types
+
+### EventData
+
+Data received from a guest event.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| data | `any` | Event payload. `undefined` if the event had no data. |
+| event | `string` | Event name |

--- a/docs/es/sdk/typescript/execution.mdx
+++ b/docs/es/sdk/typescript/execution.mdx
@@ -1,0 +1,364 @@
+---
+title: Execution
+description: TypeScript SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+---
+
+#### attach()
+
+```typescript
+attach(cmd: string, args?: Iterable<string>): Promise<number>
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Press `Ctrl+]` (or configured detach keys) to disconnect without stopping the process.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to run |
+| args? | `Iterable<string>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code of the process |
+
+---
+
+#### attachShell()
+
+```typescript
+attachShell(): Promise<number>
+```
+
+Attach to the sandbox's default shell.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code |
+
+---
+
+#### attachWith()
+
+```typescript
+attachWith(
+  cmd: string,
+  configure: (b: AttachOptionsBuilder) => AttachOptionsBuilder,
+): Promise<number>
+```
+
+Interactive PTY attach with options for environment variables, working directory, user, and custom detach keys. Configure via the builder callback.
+
+```typescript
+const code = await sandbox.attachWith("bash", (a) =>
+  a.cwd("/app")
+    .env("EDITOR", "vim")
+    .detachKeys("ctrl-]"),
+);
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to run |
+| configure | `(b: AttachOptionsBuilder) => AttachOptionsBuilder` | Builder callback — see [`AttachOptionsBuilder`](#attachoptionsbuilder) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code |
+
+---
+
+#### exec()
+
+```typescript
+exec(cmd: string, args?: Iterable<string>): Promise<ExecOutput>
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`execStream()`](#execstream) instead.
+
+```typescript
+const result = await sandbox.exec("python3", ["-c", "print(1 + 1)"]);
+console.log(result.stdout()); // "2\n"
+console.log(result.code);     // 0
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args? | `Iterable<string>` | Command arguments (e.g. `["-c", "print('hello')"]`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### execStream()
+
+```typescript
+execStream(cmd: string, args?: Iterable<string>): Promise<ExecHandle>
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
+
+```typescript
+const handle = await sandbox.execStream("tail", ["-f", "/var/log/app.log"]);
+for await (const event of handle) {
+  if (event.kind === "stdout") process.stdout.write(event.data);
+  if (event.kind === "exited") break;
+}
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute |
+| args? | `Iterable<string>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecHandle`](#exechandle)`>` | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### execStreamWith()
+
+```typescript
+execStreamWith(
+  cmd: string,
+  configure: (b: ExecOptionsBuilder) => ExecOptionsBuilder,
+): Promise<ExecHandle>
+```
+
+Streaming variant of [`execWith()`](#execwith) — same configuration via [`ExecOptionsBuilder`](#execoptionsbuilder), but returns an [`ExecHandle`](#exechandle).
+
+---
+
+#### execWith()
+
+```typescript
+execWith(
+  cmd: string,
+  configure: (b: ExecOptionsBuilder) => ExecOptionsBuilder,
+): Promise<ExecOutput>
+```
+
+Run a command with per-execution overrides. Configure working directory, environment variables, timeout, stdin, TTY allocation, and rlimits via the builder callback. These overrides apply only to this execution and don't change the sandbox's defaults.
+
+```typescript
+const out = await sandbox.execWith("python3", (e) =>
+  e.args(["script.py"])
+    .cwd("/app")
+    .env("PYTHONPATH", "/app/lib")
+    .timeout(30_000),
+);
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute |
+| configure | `(b: ExecOptionsBuilder) => ExecOptionsBuilder` | Builder callback — see [`ExecOptionsBuilder`](#execoptionsbuilder) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell()
+
+```typescript
+shell(script: string): Promise<ExecOutput>
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `string` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### shellStream()
+
+```typescript
+shellStream(script: string): Promise<ExecHandle>
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `string` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecHandle`](#exechandle)`>` | Streaming handle |
+
+---
+
+## Types
+
+### AttachOptionsBuilder
+
+Fluent builder used inside `Sandbox.attachWith(cmd, b => ...)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `arg(s)` | Append a single argument |
+| `args(iter)` | Append many arguments |
+| `cwd(path)` | Working directory |
+| `user(user)` | Guest user |
+| `env(key, value)` | Add a single env var |
+| `envs(record \| iter)` | Add many env vars |
+| `detachKeys(spec)` | Detach key sequence (e.g. `"ctrl-]"` or `"ctrl-p,ctrl-q"`) |
+| `rlimit(resource, n)` | Set both soft and hard rlimit |
+| `rlimitRange(resource, soft, hard)` | Set distinct soft/hard rlimits |
+| `build()` | Produce an immutable [`AttachOptions`](#attachoptions) |
+
+### AttachOptions
+
+The immutable object produced by `AttachOptionsBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| args | `readonly string[]` | Command arguments |
+| cwd | `string \| null` | Working directory |
+| user | `string \| null` | Guest user |
+| env | `ReadonlyArray<readonly [string, string]>` | Environment variables |
+| detachKeys | `string \| null` | Detach key sequence |
+| rlimits | `readonly Rlimit[]` | rlimits for the process |
+
+### ExecOptionsBuilder
+
+Fluent builder used inside `Sandbox.execWith(cmd, b => ...)`.
+
+| Method | Description |
+|--------|-------------|
+| `arg(s)` / `args(iter)` | Append arguments |
+| `cwd(path)` | Working directory |
+| `user(user)` | Guest user |
+| `env(key, value)` / `envs(record \| iter)` | Environment variables |
+| `timeout(ms)` | Kill the process after this many milliseconds |
+| `stdinNull()` | Stdin connected to `/dev/null` (default) |
+| `stdinPipe()` | Open a writable stdin pipe — read it back with `ExecHandle.takeStdin()` |
+| `stdinBytes(data)` | Pre-supply stdin (`Uint8Array \| string`) |
+| `tty(enabled)` | Allocate a pseudo-terminal |
+| `rlimit(resource, n)` / `rlimitRange(resource, soft, hard)` | rlimits |
+| `build()` | Produce an immutable [`ExecOptions`](#execoptions) |
+
+### ExecOptions
+
+The immutable object produced by `ExecOptionsBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| args | `readonly string[]` | Command arguments |
+| cwd | `string \| null` | Working directory |
+| user | `string \| null` | Guest user |
+| env | `ReadonlyArray<readonly [string, string]>` | Environment variables |
+| timeoutMs | `number \| null` | Timeout in milliseconds |
+| stdin | `StdinMode` | `null`, `pipe`, or pre-supplied `bytes` |
+| tty | `boolean` | TTY allocation |
+| rlimits | `readonly Rlimit[]` | rlimits |
+
+### ExecEvent
+
+Discriminated union emitted by `ExecHandle`. The discriminator is `kind` (not `eventType`).
+
+```typescript
+type ExecEvent =
+  | { kind: "started"; pid: number }
+  | { kind: "stdout"; data: Uint8Array }
+  | { kind: "stderr"; data: Uint8Array }
+  | { kind: "exited"; code: number };
+```
+
+| `kind` | Payload | Description |
+|--------|---------|-------------|
+| `'started'` | `pid: number` | The process has started |
+| `'stdout'` | `data: Uint8Array` | A chunk of stdout data |
+| `'stderr'` | `data: Uint8Array` | A chunk of stderr data |
+| `'exited'` | `code: number` | The process has exited |
+
+### ExecHandle
+
+A handle to a running streaming execution. `AsyncIterable<ExecEvent>` and `AsyncDisposable`.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `recv()` | `Promise<`[`ExecEvent`](#execevent)` \| null>` | Receive the next event. Returns `null` when done. |
+| `takeStdin()` | `Promise<`[`ExecSink`](#execsink)` \| null>` | Take the stdin writer. Returns `null` after first call. |
+| `wait()` | `Promise<`[`ExitStatus`](#exitstatus)`>` | Wait for the process to exit |
+| `collect()` | `Promise<`[`ExecOutput`](#execoutput)`>` | Drain remaining output and wait |
+| `signal(n)` | `Promise<void>` | Send a POSIX signal |
+| `kill()` | `Promise<void>` | Send SIGKILL |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<`[`ExecEvent`](#execevent)`>` | Iterate events with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Best-effort kill on `await using` exit |
+
+### ExecOutput
+
+The result of a completed command execution.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `code` | `number` (getter) | Exit code |
+| `success` | `boolean` (getter) | `true` if code is `0` |
+| `status` | [`ExitStatus`](#exitstatus) (getter) | Exit status object |
+| `stdout()` | `string` | Collected stdout decoded as UTF-8 |
+| `stderr()` | `string` | Collected stderr decoded as UTF-8 |
+| `stdoutBytes()` | `Uint8Array` | Raw stdout bytes |
+| `stderrBytes()` | `Uint8Array` | Raw stderr bytes |
+
+### ExecSink
+
+Writer for sending data to a running process's stdin.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `write(data)` | `Uint8Array \| string` | Write bytes to the process's stdin |
+| `close()` | - | Close stdin. The process sees EOF. |
+| `[Symbol.asyncDispose]()` | - | Calls `close()` |
+
+### ExitStatus
+
+| Field | Type | Description |
+|-------|------|-------------|
+| code | `number` | Exit code. `0` typically means success. |
+| success | `boolean` | `true` if code is `0` |

--- a/docs/es/sdk/typescript/filesystem.mdx
+++ b/docs/es/sdk/typescript/filesystem.mdx
@@ -1,0 +1,379 @@
+---
+title: Filesystem
+description: TypeScript SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution — no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
+
+```typescript
+const fs = sandbox.fs();
+
+await fs.write("/tmp/config.json", '{"debug": true}');
+const content = await fs.readToString("/tmp/config.json");
+```
+
+---
+
+#### copy()
+
+```typescript
+copy(from: string, to: string): Promise<void>
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `string` | Source path |
+| to | `string` | Destination path |
+
+---
+
+#### copyFromHost()
+
+```typescript
+copyFromHost(hostPath: string, guestPath: string): Promise<void>
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostPath | `string` | Path on the host filesystem |
+| guestPath | `string` | Destination path inside the sandbox |
+
+---
+
+#### copyToHost()
+
+```typescript
+copyToHost(guestPath: string, hostPath: string): Promise<void>
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guestPath | `string` | Path inside the sandbox |
+| hostPath | `string` | Destination path on the host |
+
+---
+
+#### exists()
+
+```typescript
+exists(path: string): Promise<boolean>
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<boolean>` | `true` if the path exists |
+
+---
+
+#### list()
+
+```typescript
+list(path: string): Promise<FsEntry[]>
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsEntry`](#fsentry)`[]>` | Directory entries |
+
+---
+
+#### mkdir()
+
+```typescript
+mkdir(path: string): Promise<void>
+```
+
+Create a directory. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path |
+
+---
+
+#### read()
+
+```typescript
+read(path: string): Promise<Uint8Array>
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<Uint8Array>` | File contents as raw bytes |
+
+---
+
+#### readStream()
+
+```typescript
+readStream(path: string): Promise<FsReadStream>
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory.
+
+```typescript
+for await (const chunk of await fs.readStream("/var/log/syslog")) {
+  process.stdout.write(chunk); // chunk is a Uint8Array
+}
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsReadStream`](#fsreadstream)`>` | Async stream that yields chunks of file data |
+
+---
+
+#### readToString()
+
+```typescript
+readToString(path: string): Promise<string>
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<string>` | File contents as a string |
+
+---
+
+#### remove()
+
+```typescript
+remove(path: string): Promise<void>
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute file path |
+
+---
+
+#### removeDir()
+
+```typescript
+removeDir(path: string): Promise<void>
+```
+
+Remove a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path |
+
+---
+
+#### rename()
+
+```typescript
+rename(from: string, to: string): Promise<void>
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `string` | Current path |
+| to | `string` | New path |
+
+---
+
+#### stat()
+
+```typescript
+stat(path: string): Promise<FsMetadata>
+```
+
+Get detailed metadata for a file or directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsMetadata`](#fsmetadata)`>` | File metadata |
+
+---
+
+#### write()
+
+```typescript
+write(path: string, data: Uint8Array | string): Promise<void>
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does. Parent directories must already exist. `string` payloads are encoded as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| data | `Uint8Array \| string` | File content |
+
+---
+
+#### writeStream()
+
+```typescript
+writeStream(path: string): Promise<FsWriteSink>
+```
+
+Open a streaming writer for a file. Use for files too large to hold in memory; pair with `await using` so the sink closes itself.
+
+```typescript
+await using sink = await fs.writeStream("/tmp/big.bin");
+await sink.write(new Uint8Array(1 << 20));
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsWriteSink`](#fswritesink)`>` | Streaming writer |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| path | `string` | File path |
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| size | `number` | File size in bytes |
+| mode | `number` | Unix permission bits |
+| modified | `Date \| null` | Last modified timestamp |
+
+### FsEntryKind
+
+```typescript
+type FsEntryKind = "file" | "directory" | "symlink" | "other";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'file'` | Regular file |
+| `'directory'` | Directory |
+| `'symlink'` | Symbolic link |
+| `'other'` | Other entry type |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| size | `number` | File size in bytes |
+| mode | `number` | Unix permission bits |
+| readonly | `boolean` | Whether the file is read-only |
+| modified | `Date \| null` | Last modified timestamp |
+| created | `Date \| null` | Creation timestamp |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`readStream()`](#readstream). `AsyncIterable<Uint8Array>` and `AsyncDisposable`.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `recv()` | `Promise<Uint8Array \| null>` | Receive the next chunk. Returns `null` when the file has been fully read. |
+| `collect()` | `Promise<Uint8Array>` | Drain the stream into a single buffer |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<Uint8Array>` | Use with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop reading; safe to use with `await using` |
+
+### FsWriteSink
+
+Streaming writer returned by [`writeStream()`](#writestream). `AsyncDisposable`.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `write(data)` | `Uint8Array \| string` | Append a chunk |
+| `close()` | - | Flush and close. Idempotent. |
+| `[Symbol.asyncDispose]()` | - | Calls `close()` |

--- a/docs/es/sdk/typescript/networking.mdx
+++ b/docs/es/sdk/typescript/networking.mdx
@@ -1,0 +1,1361 @@
+---
+title: Networking
+description: TypeScript SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Use a static factory for a preset, build a literal, or chain through [`NetworkPolicy.builder()`](#networkpolicybuilder) for the fluent builder:
+
+```typescript
+import { NetworkPolicy, Rule, Destination } from "microsandbox";
+
+// Custom policy literal
+const custom = {
+  defaultEgress: "deny",
+  defaultIngress: "allow",
+  rules: [
+    Rule.allowEgress(Destination.domain("api.openai.com")),
+    Rule.denyEgress(Destination.group("metadata")),
+  ],
+};
+
+// Or via the builder
+const built = NetworkPolicy.builder()
+  .defaultDeny()
+  .egress((e) => e.tcp().port(443).allowPublic())
+  .build();
+```
+
+Pass any of these to `NetworkBuilder.policy(...)`.
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```typescript
+const policy = {
+  defaultEgress: "deny",
+  defaultIngress: "allow",
+  rules: [
+    Rule.allowEgress(Destination.cidr("10.0.0.0/8")),  // matches everything in 10.x
+    Rule.denyEgress(Destination.cidr("10.0.0.5/32")),  // never reached
+  ],
+};
+```
+
+Put specific rules before general ones.
+
+### Shadow detection
+
+[`NetworkPolicyBuilder.build()`](#networkpolicybuilder) walks the rules and warns when a rule is fully covered by an earlier one in the same direction. Only `ip`, `cidr`, and `group` destinations are checked; domain coverage depends on runtime DNS and is skipped. Builds still succeed; the warning surfaces as a host-side `tracing::warn!` from the rust core:
+
+```text
+WARN rule #1 (Egress Cidr(10.0.0.5/32) Deny) is shadowed by rule #0 (Egress Cidr(10.0.0.0/8) Allow); to narrow, place the more specific rule first
+```
+
+Policy literals constructed via `Rule.allowEgress(...)` etc. do not run through the builder and skip this check.
+
+### State accumulation
+
+State setters (`.tcp()`, `.port()`, etc.) inside a [`RuleBuilder`](#rulebuilder) callback carry into every rule-adder that follows. State is **not reset** between adders:
+
+```typescript
+NetworkPolicy.builder()
+  .egress((r) => r
+    .tcp().port(443).allowPublic()    // rule 1: egress, TCP, 443, allow Public
+    .udp().allowPrivate()             // rule 2: egress, [TCP, UDP], 443, allow Private
+  )
+  .build();
+```
+
+Use separate `.rule()` / `.egress()` callbacks for rules that need different state.
+
+---
+
+#### NetworkPolicy.allowAll()
+
+```typescript
+static allowAll(): NetworkPolicy
+```
+
+Unrestricted network access, including to private addresses and the host machine.
+
+---
+
+#### NetworkPolicy.builder()
+
+```typescript
+static builder(): NetworkPolicyBuilder
+```
+
+Start a fluent [`NetworkPolicyBuilder`](#networkpolicybuilder). Equivalent to `new NetworkPolicyBuilder()`.
+
+---
+
+#### NetworkPolicy.none()
+
+```typescript
+static none(): NetworkPolicy
+```
+
+Deny all traffic. The guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+
+---
+
+#### NetworkPolicy.nonLocal()
+
+```typescript
+static nonLocal(): NetworkPolicy
+```
+
+Allow egress to public + private (LAN) destinations; ingress allowed by default.
+
+---
+
+#### NetworkPolicy.publicOnly()
+
+```typescript
+static publicOnly(): NetworkPolicy
+```
+
+Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+
+---
+
+## NetworkPolicyBuilder
+
+Fluent builder for [`NetworkPolicy`](#networkpolicy). The closure passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` receives a [`RuleBuilder`](#rulebuilder); state setters and rule-adders chain freely. The first parse / validation failure surfaces from `.build()`.
+
+```typescript
+import { NetworkPolicy } from "microsandbox";
+
+const policy = NetworkPolicy.builder()
+  .defaultDeny()
+  .egress((e) => e.tcp().port(443).allowPublic().allowPrivate())
+  .rule((r) => r.any().deny((d) => d.ip("198.51.100.5")))
+  .build();
+```
+
+---
+
+#### any()
+
+```typescript
+any(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Any`. Rules committed inside apply in both directions.
+
+---
+
+#### build()
+
+```typescript
+build(): NetworkPolicy
+```
+
+Materialize the accumulated state into a [`NetworkPolicy`](#networkpolicy-1). Lazily parses every recorded `.ip()` / `.cidr()` / `.domain()` / `.domainSuffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a host-side warning for each shadowed rule pair.
+
+---
+
+#### defaultAllow()
+
+```typescript
+defaultAllow(): this
+```
+
+Set both `defaultEgress` and `defaultIngress` to `"allow"`.
+
+---
+
+#### defaultDeny()
+
+```typescript
+defaultDeny(): this
+```
+
+Set both `defaultEgress` and `defaultIngress` to `"deny"`.
+
+---
+
+#### defaultEgress()
+
+```typescript
+defaultEgress(action: "allow" | "deny"): this
+```
+
+Per-direction override for the egress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | `"allow" \| "deny"` | Default action for egress |
+
+---
+
+#### defaultIngress()
+
+```typescript
+defaultIngress(action: "allow" | "deny"): this
+```
+
+Per-direction override for the ingress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | `"allow" \| "deny"` | Default action for ingress |
+
+---
+
+#### egress()
+
+```typescript
+egress(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Egress`.
+
+---
+
+#### ingress()
+
+```typescript
+ingress(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Ingress`.
+
+---
+
+#### rule()
+
+```typescript
+rule(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Open a multi-rule batch closure. Direction must be set inside via `.egress()`, `.ingress()`, or `.any()` before any rule-adder.
+
+---
+
+## RuleBuilder
+
+Per-rule-batch builder. Lives only inside the callback passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` on a [`NetworkPolicyBuilder`](#networkpolicybuilder). State setters and rule-adders interleave freely; state accumulates eagerly across the callback (see [State accumulation](#state-accumulation)).
+
+### Direction setters
+
+Last-write-wins. ICMP rule-adders are egress-only at build time.
+
+---
+
+#### any()
+
+```typescript
+any(): this
+```
+
+Set direction to `Any` for subsequent rule-adders. Rules committed after this apply in both directions.
+
+---
+
+#### egress()
+
+```typescript
+egress(): this
+```
+
+Set direction to `Egress` for subsequent rule-adders.
+
+---
+
+#### ingress()
+
+```typescript
+ingress(): this
+```
+
+Set direction to `Ingress` for subsequent rule-adders.
+
+---
+
+### Protocol setters
+
+Protocols accumulate as a set; duplicates dedupe.
+
+---
+
+#### icmpv4()
+
+```typescript
+icmpv4(): this
+```
+
+Add `Icmpv4` to the protocols set. Egress-only; an ICMP rule on an `Ingress` or `Any` direction fails build.
+
+---
+
+#### icmpv6()
+
+```typescript
+icmpv6(): this
+```
+
+Add `Icmpv6` to the protocols set. Egress-only; same rules as [`icmpv4()`](#icmpv4).
+
+---
+
+#### tcp()
+
+```typescript
+tcp(): this
+```
+
+Add `Tcp` to the protocols set.
+
+---
+
+#### udp()
+
+```typescript
+udp(): this
+```
+
+Add `Udp` to the protocols set.
+
+---
+
+### Port setters
+
+Ports accumulate as a set; duplicates dedupe. Always guest-side (egress destination port / ingress listening port).
+
+---
+
+#### port()
+
+```typescript
+port(port: number): this
+```
+
+Add a single port to the ports set.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `number` | Port number `0..=65535` |
+
+---
+
+#### portRange()
+
+```typescript
+portRange(lo: number, hi: number): this
+```
+
+Add an inclusive port range. `lo > hi` records an error surfaced at `.build()` time.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| lo | `number` | Lower bound (inclusive) |
+| hi | `number` | Upper bound (inclusive) |
+
+---
+
+#### ports()
+
+```typescript
+ports(ports: number[]): this
+```
+
+Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
+
+---
+
+### Group rule-adders
+
+Each adder commits one rule using the current state and the named destination group.
+
+---
+
+#### allowHost()
+
+```typescript
+allowHost(): this
+```
+
+Allow the `Host` group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allowLoopback()`](#allowloopback).
+
+---
+
+#### allowLinkLocal()
+
+```typescript
+allowLinkLocal(): this
+```
+
+Allow the `LinkLocal` group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
+
+---
+
+#### allowLoopback()
+
+```typescript
+allowLoopback(): this
+```
+
+Allow the `Loopback` group (`127.0.0.0/8`, `::1`). The **guest's own** loopback, not the host. To reach a service on the host's localhost, use [`allowHost()`](#allowhost) instead. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
+
+---
+
+#### allowMeta()
+
+```typescript
+allowMeta(): this
+```
+
+Allow the `Metadata` group (`169.254.169.254`). **Dangerous on cloud hosts** (exposes IAM credentials).
+
+---
+
+#### allowMulticast()
+
+```typescript
+allowMulticast(): this
+```
+
+Allow the `Multicast` group (`224.0.0.0/4`, `ff00::/8`).
+
+---
+
+#### allowPrivate()
+
+```typescript
+allowPrivate(): this
+```
+
+Allow the `Private` group (RFC1918 + ULA + CGN).
+
+---
+
+#### allowPublic()
+
+```typescript
+allowPublic(): this
+```
+
+Allow the `Public` group (complement of named categories: every IP not in any other group).
+
+---
+
+#### denyHost()
+
+```typescript
+denyHost(): this
+```
+
+Deny the `Host` group.
+
+---
+
+#### denyLinkLocal()
+
+```typescript
+denyLinkLocal(): this
+```
+
+Deny the `LinkLocal` group.
+
+---
+
+#### denyLoopback()
+
+```typescript
+denyLoopback(): this
+```
+
+Deny the `Loopback` group.
+
+---
+
+#### denyMeta()
+
+```typescript
+denyMeta(): this
+```
+
+Deny the `Metadata` group.
+
+---
+
+#### denyMulticast()
+
+```typescript
+denyMulticast(): this
+```
+
+Deny the `Multicast` group.
+
+---
+
+#### denyPrivate()
+
+```typescript
+denyPrivate(): this
+```
+
+Deny the `Private` group.
+
+---
+
+#### denyPublic()
+
+```typescript
+denyPublic(): this
+```
+
+Deny the `Public` group.
+
+---
+
+### Domain rule-adders
+
+Singular forms add one rule; plural forms add one rule per element.
+
+---
+
+#### allowDomain()
+
+```typescript
+allowDomain(name: string): this
+```
+
+Add one `Destination::Domain` allow rule.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Fully qualified domain name |
+
+---
+
+#### allowDomainSuffix()
+
+```typescript
+allowDomainSuffix(suffix: string): this
+```
+
+Add one `Destination::DomainSuffix` allow rule. Matches the apex and any subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### allowDomainSuffixes()
+
+```typescript
+allowDomainSuffixes(suffixes: string[]): this
+```
+
+Add one `Destination::DomainSuffix` allow rule per suffix.
+
+---
+
+#### allowDomains()
+
+```typescript
+allowDomains(names: string[]): this
+```
+
+Add one `Destination::Domain` allow rule per name.
+
+---
+
+#### denyDomain()
+
+```typescript
+denyDomain(name: string): this
+```
+
+Add one `Destination::Domain` deny rule.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Fully qualified domain name |
+
+---
+
+#### denyDomainSuffix()
+
+```typescript
+denyDomainSuffix(suffix: string): this
+```
+
+Add one `Destination::DomainSuffix` deny rule. Matches the apex and any subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### denyDomainSuffixes()
+
+```typescript
+denyDomainSuffixes(suffixes: string[]): this
+```
+
+Add one `Destination::DomainSuffix` deny rule per suffix.
+
+---
+
+#### denyDomains()
+
+```typescript
+denyDomains(names: string[]): this
+```
+
+Add one `Destination::Domain` deny rule per name.
+
+---
+
+### Composite rule-adders
+
+---
+
+#### allowLocal()
+
+```typescript
+allowLocal(): this
+```
+
+Add three allow rules atomically: `Loopback + LinkLocal + Host`. Each uses the callback's current state. `Metadata` is intentionally not included; opt in via [`allowMeta()`](#allowmeta) separately.
+
+---
+
+#### denyLocal()
+
+```typescript
+denyLocal(): this
+```
+
+Add three deny rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is intentionally not included.
+
+---
+
+### Explicit-destination rule-adders
+
+`.allow()` / `.deny()` open a [`RuleDestinationBuilder`](#ruledestinationbuilder) callback. Exactly one destination call commits the rule.
+
+```typescript
+NetworkPolicy.builder()
+  .egress((r) => r
+    .tcp().port(443).allow((d) => d.domain("api.example.com"))
+    .deny((d) => d.cidr("198.51.100.0/24"))
+  )
+  .build();
+```
+
+---
+
+#### allow()
+
+```typescript
+allow(configure: (d: RuleDestinationBuilder) => RuleDestinationBuilder): this
+```
+
+Begin an explicit-destination rule with action `Allow`.
+
+---
+
+#### deny()
+
+```typescript
+deny(configure: (d: RuleDestinationBuilder) => RuleDestinationBuilder): this
+```
+
+Begin an explicit-destination rule with action `Deny`.
+
+---
+
+## Rule
+
+Factory for individual policy rules. Each method returns a single [`Rule`](#rule-1) value.
+
+---
+
+#### Rule.allowAny()
+
+```typescript
+static allowAny(destination: Destination): Rule
+```
+
+Allow rule with direction `any` (matches in either direction).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.allowEgress()
+
+```typescript
+static allowEgress(destination: Destination): Rule
+```
+
+Allow rule with direction `egress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.allowIngress()
+
+```typescript
+static allowIngress(destination: Destination): Rule
+```
+
+Allow rule with direction `ingress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyAny()
+
+```typescript
+static denyAny(destination: Destination): Rule
+```
+
+Deny rule with direction `any` (matches in either direction).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyEgress()
+
+```typescript
+static denyEgress(destination: Destination): Rule
+```
+
+Deny rule with direction `egress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyIngress()
+
+```typescript
+static denyIngress(destination: Destination): Rule
+```
+
+Deny rule with direction `ingress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+## Destination
+
+Factory for rule destinations.
+
+---
+
+#### Destination.any()
+
+```typescript
+static any(): Destination
+```
+
+Match any destination.
+
+---
+
+#### Destination.cidr()
+
+```typescript
+static cidr(cidr: string): Destination
+```
+
+Match an IP range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cidr | `string` | CIDR notation (e.g. `"10.0.0.0/8"`) |
+
+---
+
+#### Destination.domain()
+
+```typescript
+static domain(domain: string): Destination
+```
+
+Match an exact domain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| domain | `string` | Fully qualified domain name |
+
+---
+
+#### Destination.domainSuffix()
+
+```typescript
+static domainSuffix(suffix: string): Destination
+```
+
+Match the apex domain and every subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### Destination.group()
+
+```typescript
+static group(group: DestinationGroup): Destination
+```
+
+Match a predefined address group.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| group | [`DestinationGroup`](#destinationgroup) | Group keyword |
+
+---
+
+## PortRange
+
+Factory for port ranges.
+
+---
+
+#### PortRange.range()
+
+```typescript
+static range(start: number, end: number): PortRange
+```
+
+Match an inclusive port range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| start | `number` | Lower bound (inclusive) |
+| end | `number` | Upper bound (inclusive) |
+
+---
+
+#### PortRange.single()
+
+```typescript
+static single(port: number): PortRange
+```
+
+Match a single port. `start` and `end` are set to the same value.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `number` | Port number |
+
+---
+
+## NetworkBuilder
+
+Returned to the callback you pass to `SandboxBuilder.network(...)`. Every setter returns the same builder.
+
+---
+
+#### denyDomainSuffixes()
+
+```typescript
+denyDomainSuffixes(...suffixes: string[]): this
+```
+
+Deny egress to all subdomains of these suffixes. Same enforcement layers as [`denyDomains()`](#denydomains).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffixes | `string[]` | Domain suffixes |
+
+---
+
+#### denyDomains()
+
+```typescript
+denyDomains(...names: string[]): this
+```
+
+Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| names | `string[]` | Fully qualified domain names |
+
+---
+
+#### dns()
+
+```typescript
+dns(f: (d: DnsBuilder) => DnsBuilder): this
+```
+
+Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
+
+---
+
+#### enabled()
+
+```typescript
+enabled(b: boolean): this
+```
+
+Enable or disable networking entirely.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| b | `boolean` | When `false`, no network interface is created |
+
+---
+
+#### maxConnections()
+
+```typescript
+maxConnections(n: number): this
+```
+
+Limit the maximum number of concurrent network connections from the sandbox.
+
+---
+
+#### onSecretViolation()
+
+```typescript
+onSecretViolation(action: ViolationAction): this
+```
+
+Set the action taken when a secret reaches a disallowed host. See [`ViolationAction`](/sdk/typescript/secrets#violationaction).
+
+---
+
+#### policy()
+
+```typescript
+policy(policy: NetworkPolicy): this
+```
+
+Set the policy. Use a [`NetworkPolicy`](#networkpolicy) factory or a literal.
+
+---
+
+#### port()
+
+```typescript
+port(host: number, guest: number): this
+```
+
+Publish a TCP port from the guest to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `number` | Port on the host |
+| guest | `number` | Port inside the sandbox |
+
+---
+
+#### portUdp()
+
+```typescript
+portUdp(host: number, guest: number): this
+```
+
+Publish a UDP port from the guest to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `number` | Port on the host |
+| guest | `number` | Port inside the sandbox |
+
+---
+
+#### secret()
+
+```typescript
+secret(f: (s: SecretBuilder) => SecretBuilder): this
+```
+
+Add a secret. See [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder).
+
+---
+
+#### secretEnv()
+
+```typescript
+secretEnv(envVar: string, value: string, placeholder: string, allowedHost: string): this
+```
+
+Four-arg explicit-placeholder shorthand for adding a secret without opening a builder callback.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Real secret value |
+| placeholder | `string` | Placeholder string surfaced to the guest |
+| allowedHost | `string` | Single hostname allowed to receive the real value |
+
+---
+
+#### tls()
+
+```typescript
+tls(f: (t: TlsBuilder) => TlsBuilder): this
+```
+
+Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
+
+---
+
+#### trustHostCAs()
+
+```typescript
+trustHostCAs(enabled: boolean): this
+```
+
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in for corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle.
+
+---
+
+## DnsBuilder
+
+Builder for DNS interception settings. Used in `NetworkBuilder.dns(d => ...)`. Owns rebind protection, nameserver pinning, and the per-query timeout.
+
+---
+
+#### nameservers()
+
+```typescript
+nameservers(servers: string[]): this
+```
+
+Override upstream nameservers. Replaces any previously-set nameservers.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| servers | `string[]` | Each entry is `IP`, `IP:PORT`, `HOST`, or `HOST:PORT` |
+
+---
+
+#### queryTimeoutMs()
+
+```typescript
+queryTimeoutMs(ms: number): this
+```
+
+Per-DNS-query timeout in milliseconds.
+
+---
+
+#### rebindProtection()
+
+```typescript
+rebindProtection(enabled: boolean): this
+```
+
+Toggle DNS rebinding protection. When enabled, DNS responses resolving to private IPs are blocked.
+
+---
+
+## TlsBuilder
+
+Builder for TLS interception settings. Used in `NetworkBuilder.tls(t => ...)`.
+
+---
+
+#### blockQuic()
+
+```typescript
+blockQuic(block: boolean): this
+```
+
+Block QUIC on intercepted ports, forcing TCP/TLS fallback.
+
+---
+
+#### bypass()
+
+```typescript
+bypass(pattern: string): this
+```
+
+Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). Use for domains with certificate pinning.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pattern | `string` | Glob pattern |
+
+---
+
+#### interceptCaCert()
+
+```typescript
+interceptCaCert(path: string): this
+```
+
+Path to a PEM file used as the intercepting CA's certificate.
+
+---
+
+#### interceptCaKey()
+
+```typescript
+interceptCaKey(path: string): this
+```
+
+Path to a PEM file used as the intercepting CA's private key.
+
+---
+
+#### interceptedPorts()
+
+```typescript
+interceptedPorts(ports: number[]): this
+```
+
+TCP ports where interception is active. Default: `[443]`.
+
+---
+
+#### upstreamCaCert()
+
+```typescript
+upstreamCaCert(path: string): this
+```
+
+Path to a PEM file with extra root CAs the proxy should trust.
+
+---
+
+#### verifyUpstream()
+
+```typescript
+verifyUpstream(verify: boolean): this
+```
+
+Verify upstream server certificates. Default `true`. Set to `false` only for self-signed servers.
+
+---
+
+## Types
+
+### NetworkConfig
+
+Built network configuration produced by `NetworkBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| enabled | `boolean` | Master enable flag |
+| ports | `readonly PublishedPort[]` | Port publishings |
+| policy | [`NetworkPolicy`](#networkpolicy-1) ` \| null` | Active policy |
+| dns | [`DnsConfig`](#dnsconfig) ` \| null` | DNS interception |
+| tls | [`TlsConfig`](#tlsconfig) ` \| null` | TLS interception |
+| secrets | `readonly SecretEntry[]` | Secret entries |
+| secretViolation | [`ViolationAction`](/sdk/typescript/secrets#violationaction) ` \| null` | Action on disallowed secret use |
+| maxConnections | `number \| null` | Maximum concurrent connections |
+| trustHostCAs | `boolean` | Ship host CAs into the guest |
+
+### NetworkPolicy
+
+```typescript
+interface NetworkPolicy {
+  readonly defaultEgress: Action;
+  readonly defaultIngress: Action;
+  readonly rules: readonly Rule[];
+}
+```
+
+### Rule
+
+```typescript
+interface Rule {
+  readonly direction: Direction;
+  readonly destination: Destination;
+  readonly protocols: readonly Protocol[]; // empty = any
+  readonly ports: readonly PortRange[];    // empty = any
+  readonly action: Action;
+}
+```
+
+### Destination
+
+```typescript
+type Destination =
+  | { kind: "any" }
+  | { kind: "cidr"; cidr: string }
+  | { kind: "domain"; domain: string }
+  | { kind: "domainSuffix"; suffix: string }
+  | { kind: "group"; group: DestinationGroup };
+```
+
+### Action
+
+```typescript
+type Action = "allow" | "deny";
+```
+
+### Direction
+
+```typescript
+type Direction = "egress" | "ingress" | "any";
+```
+
+### Protocol
+
+```typescript
+type Protocol = "tcp" | "udp" | "icmpv4" | "icmpv6";
+```
+
+### DestinationGroup
+
+```typescript
+type DestinationGroup =
+  | "public"
+  | "loopback"
+  | "private"
+  | "link-local"
+  | "metadata"
+  | "multicast"
+  | "host";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'public'` | Public internet (everything not in another group) |
+| `'loopback'` | Guest's own `127.0.0.0/8` / `::1` |
+| `'private'` | RFC1918 LAN ranges |
+| `'link-local'` | `169.254.0.0/16` / `fe80::/10` |
+| `'metadata'` | Cloud metadata endpoints (`169.254.169.254`, `fd00:ec2::254`) |
+| `'multicast'` | Multicast addresses |
+| `'host'` | The host machine, reached via `host.microsandbox.internal` |
+
+### PortRange
+
+```typescript
+interface PortRange {
+  readonly start: number;
+  readonly end: number;
+}
+```
+
+### RuleDestinationBuilder
+
+Returned by [`RuleBuilder`](#rulebuilder)`.allow(d => ...)` / `.deny(d => ...)`. Exactly one destination call commits the rule; dropping without a destination call silently does nothing.
+
+| Method | Description |
+|--------|-------------|
+| `.ip(ip)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
+| `.cidr(cidr)` | Commit with `Destination::Cidr` |
+| `.domain(domain)` | Commit with `Destination::Domain` |
+| `.domainSuffix(suffix)` | Commit with `Destination::DomainSuffix` |
+| `.group(group)` | Commit with `Destination::Group`. `group` is a [`DestinationGroup`](#destinationgroup) string |
+| `.any()` | Commit with `Destination::Any` |
+
+### DnsConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| nameservers | `readonly string[]` | Upstream nameservers |
+| rebindProtection | `boolean \| null` | DNS rebinding protection toggle |
+| queryTimeoutMs | `number \| null` | Per-query timeout |
+
+### TlsConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| bypass | `readonly string[]` | Bypass globs (e.g. `"*.googleapis.com"`) |
+| verifyUpstream | `boolean \| null` | Verify upstream certs |
+| interceptedPorts | `readonly number[]` | Intercepted TCP ports |
+| blockQuic | `boolean \| null` | Block QUIC on intercepted ports |
+| upstreamCaCertPaths | `readonly string[]` | Extra trust roots for upstream verification |
+| interceptCaCertPath | `string \| null` | Custom intercept CA cert (PEM) |
+| interceptCaKeyPath | `string \| null` | Custom intercept CA key (PEM) |
+
+### PublishedPort
+
+```typescript
+interface PublishedPort {
+  readonly hostPort: number;
+  readonly guestPort: number;
+  readonly protocol: "tcp" | "udp";
+}
+```

--- a/docs/es/sdk/typescript/sandbox.mdx
+++ b/docs/es/sdk/typescript/sandbox.mdx
@@ -1,0 +1,736 @@
+---
+title: Sandbox
+description: TypeScript SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox from `Sandbox.builder(name)` and chain configuration calls before terminating with `.create()` or `.createDetached()`.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+await using sandbox = await Sandbox.builder("demo")
+  .image("alpine")
+  .cpus(1)
+  .memory(512)
+  .create();
+```
+
+## Static methods
+
+---
+
+#### Sandbox.builder()
+
+```typescript
+static builder(name: string): SandboxBuilder
+```
+
+Begin building a new sandbox. Configure it with chainable setters, then call `.create()` or `.createDetached()` to boot it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxBuilder`](#sandboxbuilder) | Fluent builder |
+
+---
+
+#### Sandbox.get()
+
+```typescript
+static get(name: string): Promise<SandboxHandle>
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox.list()
+
+```typescript
+static list(): Promise<SandboxHandle[]>
+```
+
+List all sandboxes (running, stopped, and crashed). Handles returned from `list()` are read-only — call `Sandbox.get(name)` to get a live handle for lifecycle calls.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle[]`](#sandboxhandle) | All sandboxes (read-only handles) |
+
+---
+
+#### Sandbox.remove()
+
+```typescript
+static remove(name: string): Promise<void>
+```
+
+Delete a stopped sandbox and all its state from disk. Fails if the sandbox is still running.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+---
+
+#### Sandbox.start()
+
+```typescript
+static start(name: string): Promise<Sandbox>
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox.startDetached()
+
+```typescript
+static startDetached(name: string): Promise<Sandbox>
+```
+
+Restart a stopped sandbox in detached mode.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+## Instance properties
+
+---
+
+#### name
+
+```typescript
+readonly name: string
+```
+
+Sandbox name.
+
+---
+
+#### config
+
+```typescript
+readonly config: Readonly<SandboxConfig>
+```
+
+The frozen configuration the sandbox was built with.
+
+---
+
+#### ownsLifecycle
+
+```typescript
+readonly ownsLifecycle: boolean
+```
+
+Whether this handle owns the sandbox lifecycle. `true` in attached mode (the auto-disposer will stop the sandbox), `false` in detached mode.
+
+---
+
+## Instance methods
+
+---
+
+#### detach()
+
+```typescript
+detach(): Promise<void>
+```
+
+Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```typescript
+drain(): Promise<void>
+```
+
+Start a graceful drain. Existing commands run to completion, new `exec` calls are rejected.
+
+---
+
+#### fs()
+
+```typescript
+fs(): SandboxFs
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/typescript/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/typescript/filesystem) | Filesystem handle |
+
+---
+
+#### kill()
+
+```typescript
+kill(): Promise<void>
+```
+
+Force-terminate the sandbox immediately. No graceful shutdown.
+
+---
+
+#### metrics()
+
+```typescript
+metrics(): Promise<SandboxMetrics>
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network metrics |
+
+---
+
+#### metricsStream()
+
+```typescript
+metricsStream(intervalMs: number): Promise<MetricsStream>
+```
+
+Stream resource metrics at a regular interval. The returned stream supports both `recv()` and `for await...of`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| intervalMs | `number` | Milliseconds between metric snapshots |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`MetricsStream`](#metricsstream) | Async stream of metrics |
+
+---
+
+#### logs()
+
+```typescript
+logs(opts?: LogReadOptions): Promise<LogEntry[]>
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+const handle = await Sandbox.get("web");
+
+// Default — all user-program output, regardless of pipe/pty mode
+const entries = await handle.logs();
+
+for (const e of entries) {
+  const source =
+    e.source === "stdout" ? "OUT" :
+    e.source === "stderr" ? "ERR" :
+    e.source === "output" ? "PTY" :
+    "SYS";
+
+  console.log(
+    `[${e.timestamp.toISOString()}] ${source} ${e.sessionId}: ${e.text().trimEnd()}`
+  );
+}
+
+// Filtered: last 50 entries from the past hour, including system lines
+const recent = await handle.logs({
+  tail: 50,
+  since: new Date(Date.now() - 60 * 60 * 1000),
+  sources: ["stdout", "stderr", "output", "system"],
+});
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| opts | [`LogReadOptions`](#logreadoptions) `?` | Filters: `tail`, `since`, `until`, `sources`. Omit for the default user-program sources. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`LogEntry`](#logentry)`[]>` | Matching entries in chronological order |
+
+---
+
+#### removePersisted()
+
+```typescript
+removePersisted(): Promise<void>
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### stop()
+
+```typescript
+stop(): Promise<void>
+```
+
+Gracefully shut down the sandbox.
+
+---
+
+#### stopAndWait()
+
+```typescript
+stopAndWait(): Promise<ExitStatus>
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/typescript/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### wait()
+
+```typescript
+wait(): Promise<ExitStatus>
+```
+
+Block until the sandbox exits on its own.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/typescript/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### \[Symbol.asyncDispose\]()
+
+```typescript
+[Symbol.asyncDispose](): Promise<void>
+```
+
+Implements `AsyncDisposable` so the sandbox can be used with `await using`. When the binding goes out of scope, the sandbox is stopped (best-effort) — but only if `ownsLifecycle` is `true`.
+
+---
+
+## PatchBuilder
+
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder.patch(p => p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `{ replace: true }` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### append()
+
+```typescript
+append(path: string, content: string): this
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `string` | Text to append |
+
+---
+
+#### copyDir()
+
+```typescript
+copyDir(src: string, dst: string, opts?: { replace?: boolean }): this
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `string` | Host source directory |
+| dst | `string` | Absolute destination path inside the guest |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### copyFile()
+
+```typescript
+copyFile(
+  src: string,
+  dst: string,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `string` | Host source file |
+| dst | `string` | Absolute destination path inside the guest |
+| opts.mode | `number` | File mode, e.g. `0o644`. Omit to keep the source mode |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### file()
+
+```typescript
+file(
+  path: string,
+  content: Buffer,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Write raw bytes at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `Buffer` | Raw byte content |
+| opts.mode | `number` | File mode, e.g. `0o644` |
+| opts.replace | `boolean` | When `true`, overwrite an existing path |
+
+---
+
+#### mkdir()
+
+```typescript
+mkdir(path: string, opts?: { mode?: number }): this
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| opts.mode | `number` | Directory mode, e.g. `0o755` |
+
+---
+
+#### remove()
+
+```typescript
+remove(path: string): this
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+---
+
+#### symlink()
+
+```typescript
+symlink(target: string, link: string, opts?: { replace?: boolean }): this
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `string` | What the symlink points to (literal symlink target text) |
+| link | `string` | Absolute path of the symlink itself |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `link` |
+
+---
+
+#### text()
+
+```typescript
+text(
+  path: string,
+  content: string,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `string` | Text content |
+| opts.mode | `number` | File mode, e.g. `0o644` |
+| opts.replace | `boolean` | When `true`, overwrite an existing path |
+
+---
+
+## Types
+
+### SandboxBuilder
+
+Fluent configuration builder returned by `Sandbox.builder(name)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `image(src)` | OCI image (`"alpine"`), local rootfs path, or a `RootfsSource`. **Required.** |
+| `cpus(n)` | Virtual CPUs |
+| `memory(mib)` | Guest memory in MiB |
+| `logLevel(level)` | Override log verbosity |
+| `quietLogs()` | Suppress log output |
+| `workdir(path)` | Default working directory for commands |
+| `shell(shell)` | Shell binary used by `sandbox.shell(...)` |
+| `entrypoint(iter)` | Override the image entrypoint |
+| `init(cmd, args?)` | Hand off PID 1 to `cmd` (absolute path or `"auto"`) after agentd setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| `initWith(cmd, i => ...)` | Like `init` but with a closure-builder for argv and env (`.arg`, `.args`, `.env`, `.envs`) |
+| `hostname(name)` | Guest hostname |
+| `user(user)` | Default guest user |
+| `pullPolicy(policy)` | Image pull behavior |
+| `libkrunfwPath(path)` | Override the bundled libkrunfw shared library |
+| `env(key, value)` | Add a single env var |
+| `envs(record \| iter)` | Add many env vars |
+| `script(name, content)` | Mount a script at `/.msb/scripts/<name>` |
+| `scripts(record \| iter)` | Mount many scripts |
+| `replace()` | Replace any existing sandbox with the same name |
+| `maxDuration(secs)` | Maximum sandbox lifetime |
+| `idleTimeout(secs)` | Stop the sandbox after this many idle seconds |
+| `volume(guestPath, m => ...)` | Mount a volume — see [Volumes](/sdk/typescript/volumes) |
+| `patch(p => ...)` | Modify the rootfs before boot — see [Snapshots](/sdk/typescript/snapshots) |
+| `addPatch(patch)` | Append a pre-built `Patch` |
+| `registry(r => r.auth(...).insecure().caCertsPath(...))` | Configure the OCI registry |
+| `port(host, guest)` | Publish a TCP port |
+| `portUdp(host, guest)` | Publish a UDP port |
+| `disableNetwork()` | Disable networking entirely |
+| `network(n => ...)` | Configure DNS / TLS / policy / secrets — see [Networking](/sdk/typescript/networking) |
+| `secret(s => ...)` | Add a secret via [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder) |
+| `secretEnv(envVar, value, allowedHost)` | Auto-placeholder shorthand. Generates `$MSB_<ENV_VAR>`. |
+| `build(): SandboxConfig` | Materialize without booting |
+| `create(): Promise<Sandbox>` | Build and boot in attached mode |
+| `createDetached(): Promise<Sandbox>` | Build and boot in detached mode |
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `'debug'` | Debug and higher |
+| `'error'` | Errors only |
+| `'info'` | Info and higher |
+| `'trace'` | Most verbose - all diagnostic output |
+| `'warn'` | Warnings and errors only |
+
+### LogEntry
+
+A class wrapping one captured log entry. Returned by [`logs()`](#logs).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| timestamp | `Date` | Wall-clock capture time on the host |
+| source | [`LogSource`](#logsource) | Where the chunk came from |
+| sessionId | `number \| null` | Relay-monotonic session id; `null` for `"system"` entries |
+| data | `Uint8Array` | The chunk's bytes (UTF-8 lossy decoded by default) |
+| `text()` | `string` | Convenience: UTF-8 decode of `data` (lossy — invalid bytes are replaced) |
+
+### LogReadOptions
+
+Filters passed to [`logs()`](#logs). All fields optional. Omit the argument entirely for the default sources (`stdout` + `stderr` + `output`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tail | `number?` | Show only the last N entries after other filters apply |
+| since | `Date?` | Inclusive lower bound on entry timestamp |
+| until | `Date?` | Exclusive upper bound on entry timestamp |
+| sources | [`LogSource`](#logsource)`[]?` | Sources to include. Omit = `["stdout", "stderr", "output"]`. Add `"system"` to merge runtime/kernel diagnostics. |
+
+### LogSource
+
+Tag indicating where a captured log entry came from. String literal type:
+
+```typescript
+type LogSource = "stdout" | "stderr" | "output" | "system";
+```
+
+| Value | Description |
+|-------|-------------|
+| `"stdout"` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `"stderr"` | Captured from a session's stderr (pipe mode) |
+| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `"output"` rather than mislabelled as `"stdout"`. |
+| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested. |
+
+### MetricsStream
+
+Async stream for receiving periodic metrics snapshots.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `[Symbol.asyncIterator]` | `AsyncIterator<`[`SandboxMetrics`](#sandboxmetrics)`>` | Use with `for await...of` |
+| `recv()` | `Promise<`[`SandboxMetrics`](#sandboxmetrics)` \| null>` | Receive next snapshot. Returns `null` when the stream ends. |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop iterating; safe to use with `await using`. |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `'always'` | Pull the image every time, even if cached locally |
+| `'if-missing'` | Pull only if the image is not already cached. This is the default. |
+| `'never'` | Never pull; fail if the image is not cached locally |
+
+### SandboxConfig
+
+Frozen configuration object — produced by `SandboxBuilder.build()` and exposed as the `config` property on a `Sandbox`. You generally should not construct this by hand; use the builder.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Sandbox name |
+| image | `RootfsSource` | OCI / bind / disk discriminated union |
+| cpus | `number \| null` | Virtual CPUs |
+| memoryMib | `number \| null` | Guest memory in MiB |
+| logLevel | `LogLevel \| null` | Log verbosity |
+| quietLogs | `boolean` | Suppress log output |
+| workdir | `string \| null` | Default working directory |
+| shell | `string \| null` | Shell binary |
+| entrypoint | `string[] \| null` | Override image entrypoint |
+| cmd | `string[] \| null` | Override image cmd |
+| hostname | `string \| null` | Guest hostname |
+| user | `string \| null` | Default guest user |
+| libkrunfwPath | `string \| null` | Custom libkrunfw path |
+| env | `Array<readonly [string, string]>` | Environment variables |
+| scripts | `Array<readonly [string, string]>` | Named scripts |
+| mounts | `VolumeMount[]` | Volume mounts |
+| patches | `Patch[]` | Rootfs modifications applied before boot |
+| pullPolicy | `PullPolicy \| null` | Image pull behavior |
+| replace | `boolean` | Replace existing sandbox with same name |
+| maxDurationSecs | `number \| null` | Maximum sandbox lifetime |
+| idleTimeoutSecs | `number \| null` | Stop after idle time |
+| portsTcp | `Array<readonly [number, number]>` | TCP host→guest mappings |
+| portsUdp | `Array<readonly [number, number]>` | UDP host→guest mappings |
+| registry | `RegistryConfig \| null` | Registry connection settings |
+| network | `NetworkConfig \| null` | Network configuration |
+| disableNetwork | `boolean` | Disable networking entirely |
+| secrets | `SecretEntry[]` | Secret entries (top-level) |
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandboxget) or [`Sandbox.list()`](#sandboxlist).
+
+Handles from `Sandbox.get(name)` are **live** — they expose lifecycle methods (`start`, `stop`, `kill`, `connect`, etc). Handles in the array returned by `Sandbox.list()` are **read-only**: calling lifecycle methods on them throws. Use `Sandbox.get(name)` to upgrade to a live handle.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `string` | Sandbox name |
+| status | [`SandboxStatus`](#sandboxstatus) | Current status |
+| configJson | `string` | Raw JSON configuration |
+| createdAt | `Date \| null` | Creation timestamp |
+| updatedAt | `Date \| null` | Last update timestamp |
+| metrics() | `Promise<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
+| logs() | `Promise<`[`LogEntry`](#logentry)`[]>` | Read captured `exec.log` (works without starting) |
+| start() | `Promise<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
+| startDetached() | `Promise<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |
+| connect() | `Promise<`[`Sandbox`](#instance-methods)`>` | Connect to a running sandbox without taking ownership |
+| stop() | `Promise<void>` | Graceful shutdown |
+| kill() | `Promise<void>` | Force terminate |
+| remove() | `Promise<void>` | Delete sandbox and state |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpuPercent | `number` | CPU usage as a percentage |
+| diskReadBytes | `number` | Total bytes read from disk since boot |
+| diskWriteBytes | `number` | Total bytes written to disk since boot |
+| memoryBytes | `number` | Current memory usage in bytes |
+| memoryLimitBytes | `number` | Memory limit in bytes |
+| netRxBytes | `number` | Total bytes received over the network since boot |
+| netTxBytes | `number` | Total bytes sent over the network since boot |
+| timestamp | `Date` | When this measurement was taken |
+| uptimeMs | `number` | Time since the sandbox was created (ms) |
+
+### SandboxStatus
+
+| Value | Description |
+|-------|-------------|
+| `'crashed'` | VM exited unexpectedly |
+| `'draining'` | Graceful shutdown in progress |
+| `'running'` | Guest agent is ready |
+| `'stopped'` | VM shut down; can be restarted |

--- a/docs/es/sdk/typescript/secrets.mdx
+++ b/docs/es/sdk/typescript/secrets.mdx
@@ -1,0 +1,126 @@
+---
+title: Secrets
+description: TypeScript SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## Adding secrets
+
+Secrets are configured on a sandbox via `SandboxBuilder.secret(s => ...)` (or its shorthand `secretEnv`). The guest only ever sees a placeholder — the real value is substituted by the TLS proxy when traffic reaches an allowed host.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+// Auto-placeholder shorthand: generates `$MSB_OPENAI_API_KEY`.
+await using sb = await Sandbox.builder("agent")
+  .image("python")
+  .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+  .create();
+
+// Full control via SecretBuilder.
+await using sb2 = await Sandbox.builder("agent2")
+  .image("python")
+  .secret((s) =>
+    s.env("STRIPE_KEY")
+      .value(process.env.STRIPE_KEY!)
+      .allowHost("api.stripe.com")
+      .allowHostPattern("*.stripe.com")
+      .injectHeaders(true)
+      .injectQuery(false),
+  )
+  .create();
+```
+
+The same `secret(...)` and `secretEnv(...)` methods are also available inside `SandboxBuilder.network(n => n.secret(...))` and on `NetworkBuilder.secretEnv(envVar, value, placeholder, allowedHost)` (4-arg explicit-placeholder shorthand).
+
+---
+
+## SecretBuilder
+
+Fluent builder used inside `SandboxBuilder.secret(s => ...)` or `NetworkBuilder.secret(s => ...)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `env(varName)` | Environment variable to expose the placeholder under. **Required.** |
+| `value(value)` | The real secret value (stays on the host). **Required.** |
+| `placeholder(placeholder)` | Custom placeholder. Auto-generated as `$MSB_<ENV_VAR>` when omitted. |
+| `allowHost(host)` | Allow substitution to a specific host (exact match). |
+| `allowHostPattern(pattern)` | Allow substitution to any host matching a wildcard. |
+| `allowAnyHostDangerous(true)` | Permit substitution to any host. Acknowledge the risk explicitly. |
+| `requireTlsIdentity(enabled)` | Require a verified TLS identity before substituting. Default `true`. |
+| `injectHeaders(enabled)` | Allow substitution in HTTP headers. Default `true`. |
+| `injectBasicAuth(enabled)` | Allow substitution in HTTP Basic Auth. Default `true`. |
+| `injectQuery(enabled)` | Allow substitution in URL query parameters. Default `false`. |
+| `injectBody(enabled)` | Allow substitution in the HTTP request body. Default `false`. |
+| `build()` | Produce a [`SecretEntry`](#secretentry). |
+
+---
+
+## Convenience helpers
+
+#### SandboxBuilder.secretEnv()
+
+```typescript
+secretEnv(envVar: string, value: string, allowedHost: string): this
+```
+
+Three-argument shorthand. Auto-generates the placeholder as `$MSB_<ENV_VAR>` and allows substitution only on `allowedHost`.
+
+#### NetworkBuilder.secretEnv()
+
+```typescript
+secretEnv(
+  envVar: string,
+  value: string,
+  placeholder: string,
+  allowedHost: string,
+): this
+```
+
+Four-argument shorthand. Same as the `SandboxBuilder` form but lets you provide the placeholder explicitly.
+
+---
+
+## Types
+
+### SecretEntry
+
+The object produced by `SecretBuilder.build()`. You normally construct one with the builder, but the shape is exposed for advanced cases.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Real secret value (stays on the host) |
+| placeholder | `string \| null` | Custom placeholder; defaults to `$MSB_<ENV_VAR>` when `null` |
+| allowedHosts | `readonly string[]` | Allowed hosts (exact match) |
+| allowedHostPatterns | `readonly string[]` | Wildcard host patterns |
+| allowAnyHost | `boolean` | Permit substitution to any host |
+| requireTlsIdentity | `boolean` | Require verified TLS identity |
+| injection | [`SecretInjection`](#secretinjection) | Where to substitute |
+
+### SecretInjection
+
+Controls where the TLS proxy substitutes the placeholder with the real value. Each field is optional; omitted fields use the default.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| headers? | `boolean` | `true` | Replace the placeholder anywhere in HTTP headers. |
+| basicAuth? | `boolean` | `true` | Replace the placeholder specifically in HTTP Basic Auth credentials. |
+| queryParams? | `boolean` | `false` | Replace the placeholder in URL query parameters. |
+| body? | `boolean` | `false` | Replace the placeholder in the HTTP request body. `Content-Length` is rewritten. |
+
+### ViolationAction
+
+Action taken when a secret placeholder is sent to a disallowed host. Set on the network builder via `NetworkBuilder.onSecretViolation(action)`.
+
+```typescript
+type ViolationAction = "block" | "block-and-log" | "block-and-terminate";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'block'` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `'block-and-log'` | Drop the request and emit a warning log on the host side. |
+| `'block-and-terminate'` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/es/sdk/typescript/snapshots.mdx
+++ b/docs/es/sdk/typescript/snapshots.mdx
@@ -1,0 +1,348 @@
+---
+title: Snapshots
+description: TypeScript SDK - Snapshot API reference
+icon: "camera"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the TypeScript SDK reference.
+
+```ts
+import { Sandbox, Snapshot, SnapshotHandle } from "microsandbox";
+import type { ExportOpts, SnapshotVerifyReport } from "microsandbox";
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## SandboxBuilder
+
+---
+
+#### fromSnapshot()
+
+```ts
+fromSnapshot(pathOrName: string): SandboxBuilder
+```
+
+Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`image()`](/sdk/typescript/sandbox#image) — the snapshot already pins the image.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pathOrName | `string` | Bare name (resolved under `~/.microsandbox/snapshots/`) or filesystem path to an artifact directory |
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```ts
+snapshot(name: string): Promise<Snapshot>
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination, see [`snapshotTo()`](#snapshotto).
+
+**Errors**
+
+- `SnapshotSandboxRunning` — the sandbox is not stopped
+- `SnapshotAlreadyExists` — destination exists (use the builder with `.force()` to overwrite)
+
+---
+
+#### snapshotTo()
+
+```ts
+snapshotTo(path: string): Promise<Snapshot>
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path.
+
+---
+
+## Snapshot (instance)
+
+---
+
+#### path
+
+```ts
+readonly path: string
+```
+
+Path to the artifact directory.
+
+---
+
+#### digest
+
+```ts
+readonly digest: string
+```
+
+Canonical content digest (`sha256:hex`) over the manifest bytes. The snapshot's identity.
+
+---
+
+#### sizeBytes
+
+```ts
+readonly sizeBytes: bigint
+```
+
+Apparent size of the captured upper layer in bytes (the ext4 virtual size, sparse on disk).
+
+---
+
+#### imageRef
+
+```ts
+readonly imageRef: string
+```
+
+Image reference the snapshot was taken from.
+
+---
+
+#### imageManifestDigest
+
+```ts
+readonly imageManifestDigest: string
+```
+
+OCI manifest digest of the pinned image.
+
+---
+
+#### format
+
+```ts
+readonly format: "raw" | "qcow2"
+```
+
+On-disk format of the upper layer. Always `"raw"` today.
+
+---
+
+#### fstype
+
+```ts
+readonly fstype: string
+```
+
+Filesystem type inside the upper (e.g. `"ext4"`).
+
+---
+
+#### parent
+
+```ts
+readonly parent: string | null
+```
+
+Manifest digest of the parent snapshot, or `null` for a root.
+
+---
+
+#### createdAt
+
+```ts
+readonly createdAt: string
+```
+
+RFC 3339 timestamp when the snapshot was created.
+
+---
+
+#### labels
+
+```ts
+readonly labels: ReadonlyArray<readonly [string, string]>
+```
+
+User-supplied labels (sorted by key in canonical form).
+
+---
+
+#### verify()
+
+```ts
+verify(): Promise<SnapshotVerifyReport>
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds.
+
+```ts
+const report = await snap.verify();
+if (report.upper.kind === "verified") {
+  console.log(`hash matches: ${report.upper.digest}`);
+} else {
+  console.log("no integrity hash recorded");
+}
+```
+
+---
+
+## Snapshot.builder()
+
+```ts
+static builder(sourceSandbox: string): SnapshotBuilder
+```
+
+Start configuring a new snapshot. The fluent builder is what powers the CLI internally.
+
+```ts
+const snap = await Snapshot.builder("baseline")
+  .name("after-pip-install")        // bare name in default dir
+  .label("stage", "post-deps")
+  .force()                           // overwrite if it exists
+  .recordIntegrity()                 // hash the upper layer
+  .create();
+```
+
+**Builder methods**
+
+| Method | Description |
+|--------|-------------|
+| `.name(string)` | Bare name under the default snapshots directory |
+| `.path(string)` | Explicit filesystem path |
+| `.label(key, value)` | Add a `key=value` label (may be repeated) |
+| `.force()` | Overwrite an existing artifact at the destination |
+| `.recordIntegrity()` | Compute and record a content-integrity hash at creation |
+| `.build()` | Snapshot the accumulated configuration |
+| `.create()` | Build and execute |
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot.open()
+
+```ts
+static open(pathOrName: string): Promise<Snapshot>
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot.get()
+
+```ts
+static get(nameOrDigest: string): Promise<SnapshotHandle>
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot.list()
+
+```ts
+static list(): Promise<SnapshotHandle[]>
+```
+
+List indexed snapshots from the local DB cache.
+
+---
+
+#### Snapshot.listDir()
+
+```ts
+static listDir(dir: string): Promise<Snapshot[]>
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot.remove()
+
+```ts
+static remove(pathOrName: string, opts?: { force?: boolean }): Promise<void>
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force: true`.
+
+---
+
+#### Snapshot.reindex()
+
+```ts
+static reindex(dir?: string): Promise<number>
+```
+
+Walk `dir` (default: configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot.export()
+
+```ts
+static export(nameOrPath: string, out: string, opts?: ExportOpts): Promise<void>
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+**ExportOpts**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `withParents` | `boolean` | Walk the parent chain (no-op today) |
+| `withImage` | `boolean` | Bundle the OCI image cache for offline transport |
+| `plainTar` | `boolean` | Skip zstd compression and write a plain `.tar` |
+
+---
+
+#### Snapshot.import()
+
+```ts
+static import(archive: string, dest?: string): Promise<SnapshotHandle>
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot.list()`](#snapshotlist) and [`Snapshot.get()`](#snapshotget).
+
+```ts
+const h = await Snapshot.get("after-pip-install");
+
+h.digest;          // string ("sha256:...")
+h.name;            // string | null
+h.parentDigest;    // string | null — null today
+h.imageRef;        // string
+h.format;          // "raw" | "qcow2"
+h.sizeBytes;       // bigint | null
+h.createdAt;       // Date
+h.path;            // string
+
+const snap = await h.open();              // metadata-validated
+await h.remove({ force: false });          // refuse if has children
+```
+
+---
+
+## Types
+
+```ts
+export interface ExportOpts {
+  withParents?: boolean;
+  withImage?: boolean;
+  plainTar?: boolean;
+}
+
+export type SnapshotVerifyReport =
+  | { digest: string; path: string; upper: { kind: "notRecorded" } }
+  | { digest: string; path: string;
+      upper: { kind: "verified"; algorithm: string; digest: string } };
+```

--- a/docs/es/sdk/typescript/volumes.mdx
+++ b/docs/es/sdk/typescript/volumes.mdx
@@ -1,0 +1,234 @@
+---
+title: Volumes
+description: TypeScript SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+```typescript
+import { Volume } from "microsandbox";
+
+const data = await Volume.builder("my-data")
+  .quota(100)
+  .label("env", "prod")
+  .create();
+```
+
+## Static methods
+
+---
+
+#### Volume.builder()
+
+```typescript
+static builder(name: string): VolumeBuilder
+```
+
+Begin building a named volume. Configure with `.quota(...)` and `.label(...)`, then call `.create()`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeBuilder`](#volumebuilder) | Fluent builder |
+
+---
+
+#### Volume.get()
+
+```typescript
+static get(name: string): Promise<VolumeHandle>
+```
+
+Get a handle to an existing named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`VolumeHandle`](#volumehandle)`>` | Volume handle |
+
+---
+
+#### Volume.list()
+
+```typescript
+static list(): Promise<VolumeHandle[]>
+```
+
+List all named volumes. Handles returned from `list()` are read-only — call `Volume.get(name)` to get a live handle for `.remove()` / `.fs()`.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`VolumeHandle`](#volumehandle)`[]>` | All volumes |
+
+---
+
+#### Volume.remove()
+
+```typescript
+static remove(name: string): Promise<void>
+```
+
+Delete a named volume and its contents. Fails if the volume is currently mounted.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+---
+
+## Instance properties
+
+#### name
+
+```typescript
+get name(): string
+```
+
+The volume's name.
+
+---
+
+#### path
+
+```typescript
+get path(): string
+```
+
+Absolute host path to the volume's directory.
+
+---
+
+#### fs()
+
+```typescript
+fs(): VolumeFs
+```
+
+Get a host-side filesystem handle for this volume — no sandbox required.
+
+```typescript
+const vfs = data.fs();
+await vfs.write("seed.txt", "hello");
+console.log(await vfs.list(""));
+```
+
+---
+
+## Mounts
+
+Volume mounts attach a host directory, named volume, tmpfs, or disk image to a guest path. Configure them via `SandboxBuilder.volume(guestPath, m => ...)`:
+
+```typescript
+await using sb = await Sandbox.builder("worker")
+  .image("alpine")
+  .volume("/host",    (m) => m.bind("/var/data"))
+  .volume("/data",    (m) => m.named("my-data"))
+  .volume("/scratch", (m) => m.tmpfs().size(128))
+  .volume("/img",     (m) => m.disk("./data.qcow2").fstype("ext4").readonly())
+  .create();
+```
+
+### MountBuilder
+
+Used inside `SandboxBuilder.volume(guestPath, m => ...)`. Pick exactly one mount kind, then chain modifiers.
+
+| Method | Description |
+|--------|-------------|
+| `bind(host)` | Mount a host directory into the guest. |
+| `named(name)` | Mount a named volume created via [`Volume.builder`](#volumebuilder). |
+| `tmpfs()` | Mount an in-memory filesystem. |
+| `disk(host)` | Mount a host disk image as a virtio-blk device. |
+| `format(fmt)` | Disk image format (`'qcow2' \| 'raw' \| 'vmdk'`). Defaults to the file extension. Disk only. |
+| `fstype(fs)` | Inner filesystem type (e.g. `"ext4"`). Disk only; omit to autodetect. |
+| `readonly()` | Mount read-only. |
+| `size(mib)` | Cap in MiB. Tmpfs only. |
+| `build()` | Internal — produce a `VolumeMount`. |
+
+### VolumeMount
+
+Discriminated union produced by `MountBuilder.build()`.
+
+```typescript
+type VolumeMount =
+  | { kind: "bind"; host: string; guest: string; readonly: boolean }
+  | { kind: "named"; name: string; guest: string; readonly: boolean }
+  | { kind: "tmpfs"; guest: string; sizeMib: number | null; readonly: boolean }
+  | {
+      kind: "disk";
+      host: string;
+      guest: string;
+      format: DiskImageFormat;
+      fstype: string | null;
+      readonly: boolean;
+    };
+```
+
+### DiskImageFormat
+
+```typescript
+type DiskImageFormat = "qcow2" | "raw" | "vmdk";
+```
+
+---
+
+## Types
+
+### VolumeBuilder
+
+| Method | Description |
+|--------|-------------|
+| `quota(mib)` | Maximum storage size in MiB |
+| `label(key, value)` | Add a metadata label |
+| `build()` | Materialize a [`VolumeConfig`](#volumeconfig) |
+| `create()` | Build and create the volume; returns a [`Volume`](#volume) |
+
+### VolumeConfig
+
+Frozen configuration produced by `VolumeBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Volume name |
+| quotaMib | `number \| null` | Maximum storage size in MiB |
+| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
+
+### VolumeHandle
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `string` | Volume name |
+| quotaMib | `number \| null` | Storage quota |
+| usedBytes | `number` | Current disk usage in bytes |
+| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
+| createdAt | `Date \| null` | Creation timestamp |
+| fs() | [`VolumeFs`](#volumefs) | Host-side filesystem on this volume (live handles only) |
+| remove() | `Promise<void>` | Delete this volume (live handles only) |
+
+Handles in the array returned by `Volume.list()` are read-only: calling `.fs()` or `.remove()` throws. Use `Volume.get(name)` to upgrade.
+
+### VolumeFs
+
+Host-side filesystem operations on a volume's directory. Same surface area as [`SandboxFs`](/sdk/typescript/filesystem) (read, readToString, readStream, write, writeStream, list, mkdir, removeDir, remove, copy, rename, stat, exists) — but operates directly on the host without booting a sandbox.

--- a/docs/fr/cli/image-commands.mdx
+++ b/docs/fr/cli/image-commands.mdx
@@ -1,0 +1,112 @@
+---
+title: Image Commands
+description: Pull and manage OCI images from the CLI
+icon: "layer-group"
+---
+
+## msb pull
+
+Pre-pull an image to the local cache. Layers are fetched in parallel with per-layer progress bars. Once cached, layers are content-addressable and deduplicated, so shared layers across images are only stored once.
+
+```bash
+msb pull python
+msb pull alpine
+msb pull ghcr.io/my-org/my-image:v1
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Force re-download even if cached |
+| `-q`, `--quiet` | Suppress progress output |
+| `--insecure` | Connect over plain HTTP instead of HTTPS |
+| `--ca-certs <PATH>` | Path to a PEM file with additional CA root certificates |
+
+<Tip>
+  Pre-pulling is useful when you want sandbox creation to be instant. Without a pre-pull, the first `Sandbox.create` with a new image will block on the download.
+</Tip>
+
+## msb image ls
+
+List images in the local cache.
+
+```bash
+msb image ls
+msb image ls --format json
+msb image ls -q               # References only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only image references |
+
+<Tip>
+  `msb images` is a shorthand alias for `msb image ls`.
+</Tip>
+
+## msb image inspect
+
+Show detailed metadata for a cached image (manifest, layers, config).
+
+```bash
+msb image inspect python
+msb image inspect python --format json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb image rm
+
+Remove one or more cached images and their layers (layers shared with other images are kept).
+
+```bash
+msb image rm python
+msb image rm alpine ubuntu   # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Remove even if the image is used by existing sandboxes |
+| `-q`, `--quiet` | Suppress output |
+
+<Tip>
+  `msb rmi` is a shorthand alias for `msb image rm`.
+</Tip>
+
+## msb registry
+
+Manage registry authentication.
+
+```bash
+msb registry login ghcr.io --username octocat
+printf '%s\n' "$GHCR_TOKEN" | msb registry login ghcr.io --username octocat --password-stdin
+msb registry logout ghcr.io
+msb registry ls
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `login` | Store credentials for a registry in the OS credential store |
+| `logout` | Remove stored credentials for a registry |
+| `list` (alias: `ls`) | List configured registries without printing secrets |
+
+**`msb registry login` flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--username` | Registry username |
+| `--password-stdin` | Read password from stdin |
+
+`msb registry login` stores the secret in the OS credential store (for example Keychain, Credential Manager, or Secret Service) and writes only metadata to `~/.microsandbox/config.json`.
+
+For CI or other headless environments, configure `registries.auth` in `~/.microsandbox/config.json` with `password_env`. Advanced host setups can also use `secret_name` to point at a file-backed secret under `~/.microsandbox/secrets/registries/`.
+
+When pulling from a registry, microsandbox resolves auth in this order:
+
+1. Explicit SDK auth (`.registry_auth(...)`)
+2. OS credential store
+3. `registries.auth` config
+4. Docker credential store/config
+5. Anonymous

--- a/docs/fr/cli/overview.mdx
+++ b/docs/fr/cli/overview.mdx
@@ -1,0 +1,97 @@
+---
+title: CLI Overview
+description: Manage sandboxes from the terminal
+icon: "book"
+---
+
+The `msb` CLI lets you create, manage, and interact with sandboxes from the terminal. It auto-detects TTY and interactivity, so no `-it` flags are needed. If your terminal is interactive, `msb` acts accordingly.
+
+## Install
+
+```bash
+curl -fsSL https://install.microsandbox.dev | sh
+```
+
+<Note>
+  microsandbox requires Linux with KVM enabled, or macOS with Apple Silicon (M-series chip). Both use hardware virtualization.
+</Note>
+
+## Quick reference
+
+```bash
+# Run a one-off command (ephemeral, auto-removed)
+msb run python -- python -c "print('Hello!')"
+
+# Interactive shell (auto-detects TTY)
+msb run alpine -- sh
+
+# Create a persistent sandbox
+msb run --name devbox ubuntu -- bash
+
+# Resume later
+msb start devbox
+
+# Execute in a running sandbox
+msb exec devbox -- sh -c "apt update && apt install -y cowsay && /usr/games/cowsay \"Hello from devbox\""
+
+# Manage
+msb ls                   # List all sandboxes
+msb ps                   # Running sandboxes only
+msb metrics              # Live CPU/memory/network stats
+msb inspect devbox       # Detailed info
+msb logs devbox          # Captured stdout/stderr (works on stopped sandboxes too)
+msb logs devbox -f       # Follow live
+msb stop devbox          # Graceful shutdown
+msb rm devbox            # Remove stopped sandbox
+
+# Images
+msb pull python     # Pre-pull to cache
+msb image ls             # List cached images
+msb image rm python # Remove a cached image
+
+# Volumes
+msb volume create data --size 10G
+msb volume ls
+msb volume rm data
+
+# Install as a system command
+msb install ubuntu       # Install as 'ubuntu' command
+msb uninstall ubuntu     # Remove installed command
+
+# Self-management
+msb self update          # Update msb to latest
+msb self uninstall       # Remove msb
+```
+
+<Tip>
+  Unnamed sandboxes (no `--name` flag) are ephemeral. They're automatically removed when the command finishes. Named sandboxes persist and can be stopped, restarted, and inspected later.
+</Tip>
+
+## Global options
+
+| Flag | Description |
+|------|-------------|
+| `--tree` | Display the complete command tree with descriptions |
+| `--error` | Show only errors |
+| `--warn` | Show warnings and errors |
+| `--info` | Show info, warnings, and errors |
+| `--debug` | Show debug output |
+| `--trace` | Show all output including trace |
+
+## Command tree
+
+Use `--tree` as an alternative to `--help` to see every command, subcommand, and flag at once:
+
+```bash
+msb --tree
+```
+
+You can scope it to a specific subcommand:
+
+```bash
+msb image --tree    # Show only image commands
+msb volume --tree   # Show only volume commands
+msb run --tree      # Show all flags for run
+```
+
+For detailed command reference, see [Sandbox Commands](/cli/sandbox-commands), [Volume Commands](/cli/volume-commands), and [Image Commands](/cli/image-commands).

--- a/docs/fr/cli/sandbox-commands.mdx
+++ b/docs/fr/cli/sandbox-commands.mdx
@@ -1,0 +1,328 @@
+---
+title: Sandbox Commands
+description: Create, run, and interact with sandboxes from the CLI
+icon: "cube"
+---
+
+## msb run
+
+Create a sandbox and optionally run a command. Without `--name`, the sandbox is ephemeral and removed when the command finishes. With `--name`, it persists for later use.
+
+```bash
+# Ephemeral: runs and cleans up
+msb run python -- python -c "print('hello')"
+
+# Named: persists after exit
+msb run --name devbox ubuntu -- bash
+
+# With volumes, ports, and environment
+msb run --name api \
+  -v ./src:/app \
+  -v pydata:/data \
+  -p 8000:8000 \
+  -e DEBUG=true \
+  -w /app \
+  python
+
+# Detached (runs in background)
+msb run -d --name worker python -- python worker.py
+```
+
+| Flag | Description |
+|------|-------------|
+| `-n`, `--name` | Sandbox name (if omitted, sandbox is ephemeral) |
+| `-c`, `--cpus` | Number of virtual CPUs to allocate |
+| `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
+| `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST`) |
+| `-p`, `--port` | Forward a host port to the sandbox (`HOST:GUEST` or `HOST:GUEST/udp`) |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-w`, `--workdir` | Working directory inside the sandbox |
+| `--shell` | Default shell for interactive sessions |
+| `-t`, `--tty` | Allocate a pseudo-terminal (enables colors, line editing) |
+| `-d`, `--detach` | Run in background and print the sandbox name |
+| `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`). Per-command; the sandbox stays alive |
+| `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`, `as=1073741824`) |
+| `--detach-keys` | Key sequence to detach from interactive session (default: `ctrl-]`) |
+| `--replace` | Replace an existing sandbox with the same name |
+| `-q`, `--quiet` | Suppress progress output |
+| `--entrypoint` | Override the image's default entrypoint command |
+| `--init` | Hand off PID 1 to this init binary (absolute path) inside the guest after agentd's setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| `--init-arg` | Argv entry appended to the handoff init. Repeatable. Defaults to `[<--init>]` when empty |
+| `--init-env` | Env var passed to the handoff init only (`KEY=VALUE`). Repeatable; merged on top of the inherited env |
+| `-H`, `--hostname` | Set the guest hostname (defaults to sandbox name) |
+| `-u`, `--user` | Run commands as the specified user (e.g. `nobody`, `1000`, `1000:1000`) |
+| `--pull` | When to pull the image: `always`, `if-missing` (default), `never` |
+| `--log-level` | Log verbosity for the sandbox runtime (`error`, `warn`, `info`, `debug`, `trace`) |
+| `--tmpfs` | Mount a temporary in-memory filesystem (`PATH` or `PATH:SIZE`) |
+| `--script` | Register an inline script (`NAME=BODY`). Available at `/.msb/scripts/<name>` and on `PATH` |
+| `--script-path` | Register a script from a host file (`NAME:PATH`). Same destination as `--script` |
+| `--max-duration` | Kill the entire sandbox after this duration (e.g. `30s`, `5m`, `1h`). Sandbox-level lifetime limit |
+| `--idle-timeout` | Stop the sandbox after this period of inactivity (e.g. `30s`, `5m`, `1h`) |
+| `--no-network` | Disable all network access |
+| `--network-policy` | Control which destinations are reachable from the sandbox. Accepted values: `none` (no network), `public-only` (default — public internet only), `nonlocal` (public + private/LAN; blocks loopback, link-local, and metadata), `allow-all` (unrestricted) |
+| `--deny-domain` | Deny egress to a domain. Repeatable. Adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback) |
+| `--deny-domain-suffix` | Deny egress to all subdomains of a suffix (e.g. `.ads.com`). Repeatable. Adds a `deny DomainSuffix("...")` policy rule |
+| `--no-dns-rebind-protection` | Allow DNS responses pointing to private/internal IP addresses |
+| `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
+| `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |
+| `--max-connections` | Limit the number of concurrent network connections |
+| `--trust-host-cas` | Ship the host's trusted root CAs into the guest so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, etc.) whose gateway CA is installed on the host but unknown to the guest's stock bundle. Opt-in; by default the guest validates against its stock Mozilla bundle only |
+| `--secret` | Inject a secret that is only sent to an allowed host (`ENV=VALUE@HOST`) |
+| `--on-secret-violation` | Action when a secret is sent to a disallowed host (`block`, `block-and-log`, `block-and-terminate`) |
+| `--tls-intercept` | Intercept and inspect HTTPS traffic via a built-in TLS proxy |
+| `--tls-intercept-port` | TCP port to apply TLS interception on (default: 443) |
+| `--tls-bypass` | Skip TLS interception for a domain (e.g. `*.internal.com`) |
+| `--no-block-quic` | Allow QUIC/HTTP3 traffic (blocked by default when TLS interception is on) |
+| `--tls-intercept-ca-cert` | Use a custom CA certificate for TLS interception (PEM file) |
+| `--tls-intercept-ca-key` | Use a custom CA private key for TLS interception (PEM file) |
+| `--tls-upstream-ca-cert` | Trust an additional CA certificate for upstream server verification (PEM file). Can be specified multiple times |
+
+When no `--` command is given, the image's `entrypoint` and `cmd` are used as the default process. If the image has neither, an interactive shell is started. When a command is given via `--`, it replaces the image `cmd` but the `entrypoint` is preserved. See [Image config inheritance](/images/overview#image-config-inheritance) for details.
+
+## msb create
+
+Create and boot a sandbox without running a command. Takes the same flags as `msb run` (except `--detach`).
+
+```bash
+msb create python --name worker -c 2 -m 1G
+msb create --replace python --name worker   # Replace existing
+```
+
+## msb start
+
+Resume a stopped sandbox.
+
+```bash
+msb start devbox
+```
+
+| Flag | Description |
+|------|-------------|
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb stop
+
+```bash
+msb stop devbox                # Graceful shutdown
+msb stop --force devbox        # Force kill immediately
+msb stop -t 10 devbox          # Wait 10s then force kill
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Immediately kill the sandbox without graceful shutdown |
+| `-t`, `--timeout` | Seconds to wait for graceful shutdown before force-killing |
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb exec
+
+Execute a command inside a running sandbox.
+
+```bash
+msb exec devbox -- python -c "print('hello')"
+msb exec devbox -- ls -la /app
+```
+
+| Flag | Description |
+|------|-------------|
+| `-t`, `--tty` | Allocate a pseudo-terminal (enables colors, line editing) |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-w`, `--workdir` | Override working directory |
+| `-u`, `--user` | Run the command as the specified guest user |
+| `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`) |
+| `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`) |
+| `-q`, `--quiet` | Suppress progress output |
+
+<Tip>
+  The CLI auto-detects whether stdin is a terminal. When interactive, `msb exec` uses `attach` mode (TTY, line editing). When piped, it captures output. No `-i` flag is needed.
+</Tip>
+
+## msb logs
+
+Read captured output from a sandbox. Each sandbox stores its captured stdio under `<sandbox-dir>/logs/exec.log` as JSON Lines, plus runtime/kernel diagnostics in `runtime.log`/`kernel.log`. The command works on running and stopped sandboxes alike — there is no protocol traffic, just a file read.
+
+```bash
+# Captured user-program output (default sources: stdout + stderr + output)
+msb logs devbox
+
+# Tail and follow
+msb logs devbox --tail 100
+msb logs devbox -f --grep ERROR
+
+# Time-bounded
+msb logs devbox --since 5m
+msb logs devbox --since 2026-04-30T20:00:00Z --until 5m
+
+# JSON Lines passthrough — feed to jq, vector, etc.
+msb logs devbox --json | jq 'select(.s == "stderr")'
+
+# Multi-session view: prefix each line with [id:N] so you can tell sessions apart
+msb logs devbox --show-id
+
+# Color each session's output a distinct color (implies --show-id)
+msb logs devbox --color-sessions
+
+# Include runtime/kernel diagnostics
+msb logs devbox --source system
+msb logs devbox --source all                # everything, chronologically merged
+```
+
+| Flag | Description |
+|------|-------------|
+| `--tail` | Show only the last N entries |
+| `--since` | Show entries at or after this time (RFC 3339 or relative `5m`/`2h`/`1d`) |
+| `--until` | Show entries strictly before this time (same formats) |
+| `-f`, `--follow` | Follow in real time (200 ms polling, rotation-aware) |
+| `--timestamps` | Prefix each line with the entry timestamp |
+| `--source` | Sources to include: `stdout`, `stderr`, `output`, `system`, `all`. Repeat or comma-separate. Default: `stdout,stderr,output` |
+| `--grep` | Client-side regex filter on the entry body |
+| `--json` | Emit raw JSON Lines without decoding (one entry per line) |
+| `--raw` | Opt into base64 encoding for non-UTF-8 bytes |
+| `--show-id` | Prefix each line with `[id:N]` (the session correlation id) |
+| `--color-sessions` | Color each session's lines a distinct color (implies `--show-id`) |
+| `--color` | ANSI handling: `auto` (default), `always`, `never` |
+| `--no-color` | Alias for `--color=never` |
+
+**Source tags** (the `s` field in `--json` output):
+
+- `stdout` / `stderr` — captured from the session's pipes when running in **pipe mode** (streams stay separated end to end).
+- `output` — captured from the session in **pty mode**. pty allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `output` rather than mislabelled as `stdout`.
+- `system` — synthetic lifecycle markers (`--- sandbox started ---` / `--- sandbox stopped ---`) plus diagnostic lines from `runtime.log`/`kernel.log` when `--source system` is requested.
+
+<Tip>
+  If a sandbox failed to start, `msb logs` prepends a styled error block reconstructed from `boot-error.json`. The block tells you the failure stage, errno, and a hint — even though no user-program output was ever captured.
+</Tip>
+
+## msb ls
+
+List all stored sandboxes.
+
+```bash
+msb ls                    # All sandboxes (running and stopped)
+msb ls --running          # Running sandboxes only
+msb ls --stopped          # Stopped sandboxes only
+msb ls --format json      # JSON output
+msb ls -q                 # Names only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--running` | Show only running sandboxes |
+| `--stopped` | Show only stopped sandboxes |
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only sandbox names |
+
+## msb status / ps
+
+Show sandbox status with process details.
+
+```bash
+msb ps                    # Running sandboxes
+msb ps my-app             # Single sandbox
+msb ps -a                 # All sandboxes (including stopped)
+msb ps --format json      # JSON output
+```
+
+| Flag | Description |
+|------|-------------|
+| `-a`, `--all` | Show all sandboxes, not just running ones |
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only sandbox names |
+
+## msb metrics
+
+Show live CPU, memory, disk, and network metrics for running sandboxes.
+
+```bash
+msb metrics               # All running sandboxes
+msb metrics my-app        # Single sandbox
+msb metrics --format json # JSON output
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb inspect
+
+Show detailed configuration and status.
+
+```bash
+msb inspect devbox
+msb inspect devbox --format json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb rm
+
+Remove one or more sandboxes and their associated state.
+
+```bash
+msb rm devbox
+msb rm --force devbox     # Stop and remove in one step
+msb rm worker-1 worker-2  # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Stop the sandbox if running, then remove it |
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb install
+
+Install a sandbox as a system command. Creates an executable in `~/.microsandbox/bin/` that launches `msb run` with the specified image and options.
+
+```bash
+msb install ubuntu                   # Install as 'ubuntu' command
+msb install --name nodebox node      # Custom command name
+msb install --tmp alpine             # Fresh sandbox every invocation
+msb install -c 2 -m 1G python  # With resource limits
+msb install --list                   # List installed commands
+```
+
+| Flag | Description |
+|------|-------------|
+| `-n`, `--name` | Command name for the alias (defaults to image name) |
+| `-c`, `--cpus` | Number of virtual CPUs to allocate |
+| `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
+| `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST`) |
+| `-w`, `--workdir` | Working directory inside the sandbox |
+| `--shell` | Shell for interactive sessions |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-f`, `--force` | Overwrite an existing alias with the same name |
+| `--no-pull` | Don't pull the image before installing |
+| `--tmp` | Create a fresh sandbox on every invocation (no persistent state) |
+| `-l`, `--list` | List all installed sandbox commands |
+
+## msb uninstall
+
+Remove an installed sandbox command.
+
+```bash
+msb uninstall nodebox
+msb uninstall ubuntu alpine   # Remove multiple
+```
+
+## msb self
+
+Manage the msb installation itself.
+
+```bash
+msb self update               # Update msb and libkrunfw to latest
+msb self update --force       # Re-download even if up to date
+msb self uninstall            # Remove msb (with confirmation prompt)
+msb self uninstall --yes      # Skip confirmation
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `update` (alias: `upgrade`) | Update msb and libkrunfw to the latest release |
+| `uninstall` | Remove msb, libkrunfw, and shell configuration |
+
+| Flag | Subcommand | Description |
+|------|------------|-------------|
+| `-f`, `--force` | `update` | Re-download even if already on the latest version |
+| `-y`, `--yes` | `uninstall` | Skip confirmation prompt |

--- a/docs/fr/cli/volume-commands.mdx
+++ b/docs/fr/cli/volume-commands.mdx
@@ -1,0 +1,67 @@
+---
+title: Volume Commands
+description: Create and manage named volumes from the CLI
+icon: "hard-drive"
+---
+
+Named volumes persist independently of sandboxes and are stored at `~/.microsandbox/volumes/`.
+
+## msb volume create
+
+```bash
+msb volume create my-data
+msb volume create my-data --size 10G
+```
+
+| Flag | Description |
+|------|-------------|
+| `--size` | Storage quota (e.g. `100M`, `1G`, `10G`) |
+| `-q`, `--quiet` | Suppress output (only print the volume name) |
+
+## msb volume ls
+
+```bash
+msb volume ls
+msb volume ls --format json
+msb volume ls -q               # Names only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only volume names |
+
+## msb volume inspect
+
+```bash
+msb volume inspect my-data
+```
+
+## msb volume rm
+
+```bash
+msb volume rm my-data
+msb volume rm cache-1 cache-2   # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-q`, `--quiet` | Suppress output |
+
+## Using volumes with sandboxes
+
+Mount a named volume when creating or running a sandbox. The volume name goes before the colon, the guest path after.
+
+```bash
+# Create a volume, then mount it
+msb volume create app-data --size 5G
+msb run --name worker -v app-data:/data python
+
+# Share between sandboxes
+msb run --name writer -v shared:/data alpine -- sh -c "echo hello > /data/msg.txt"
+msb run --name reader -v shared:/data alpine -- cat /data/msg.txt
+```
+
+<Tip>
+  The CLI distinguishes bind mounts from named volumes by looking for a `/` or `.` prefix. `./src:/app` is a bind mount (host path). `myvolume:/data` is a named volume. This matches Docker's convention.
+</Tip>

--- a/docs/fr/configuration.mdx
+++ b/docs/fr/configuration.mdx
@@ -1,0 +1,140 @@
+---
+title: config.json
+description: Global config.json reference
+icon: "gear"
+---
+
+microsandbox reads its global configuration from `~/.microsandbox/config.json`. All fields are optional. A missing file or empty JSON object is equivalent to using the defaults.
+
+<Accordion title="Full example">
+```json
+{
+  "home": "/custom/path/.microsandbox",
+  "log_level": "info",
+  "database": {
+    "url": "sqlite:///tmp/msb.db",
+    "max_connections": 10,
+    "connect_timeout_secs": 30
+  },
+  "paths": {
+    "msb": "/usr/local/bin/msb",
+    "libkrunfw": "/usr/local/lib/libkrunfw.so",
+    "cache": "/mnt/fast/msb-cache",
+    "sandboxes": null,
+    "volumes": null,
+    "logs": null,
+    "secrets": null
+  },
+  "sandbox_defaults": {
+    "cpus": 2,
+    "memory_mib": 1024,
+    "shell": "/bin/bash",
+    "workdir": "/app"
+  },
+  "registries": {
+    "auth": {
+      "ghcr.io": {
+        "username": "octocat",
+        "store": "keyring"
+      },
+      "registry.example.com": {
+        "username": "deploy",
+        "password_env": "REGISTRY_TOKEN"
+      },
+      "docker.io": {
+        "username": "user",
+        "secret_name": "dockerhub-token"
+      }
+    }
+  }
+}
+```
+</Accordion>
+
+## Top-level fields
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `home` | `~/.microsandbox` | Root directory for all microsandbox data |
+| `log_level` | `null` (silent) | Log level for sandbox processes: `error`, `warn`, `info`, `debug`, `trace` |
+| `database` | [reference](#database) | Database connection settings |
+| `paths` | [reference](#paths) | Path overrides for binaries and directories |
+| `sandbox_defaults` | [reference](#sandbox_defaults) | Defaults applied to every sandbox |
+| `registries` | [reference](#registries) | Container registry authentication |
+
+## `database`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `url` | `null` | Database URL. Uses SQLite under `home` when null |
+| `max_connections` | `5` | Maximum connection pool size |
+| `connect_timeout_secs` | `30` | Timeout when acquiring a database connection from the pool |
+
+## `paths`
+
+All path fields are optional. When `null`, they resolve relative to `home`.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `msb` | `{home}/bin/msb` | `msb` binary. Resolved via: `MSB_PATH` env, this field, default path, `PATH` |
+| `libkrunfw` | `{home}/lib/libkrunfw` | Path to a custom VM kernel (`.so` on Linux, `.dylib` on macOS) |
+| `cache` | `{home}/cache` | Image layer cache |
+| `sandboxes` | `{home}/sandboxes` | Per-sandbox state |
+| `volumes` | `{home}/volumes` | Named volumes |
+| `logs` | `{home}/logs` | Sandbox logs |
+| `secrets` | `{home}/secrets` | Secrets. Registry secrets live under `secrets/registries/` |
+
+## `sandbox_defaults`
+
+Defaults applied to every sandbox unless overridden per-sandbox.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `cpus` | `1` | Number of vCPUs |
+| `memory_mib` | `512` | Guest memory in MiB |
+| `shell` | `"/bin/sh"` | Shell for interactive sessions and scripts |
+| `workdir` | `null` | Working directory inside the sandbox |
+| `metrics_sample_interval_ms` | `1000` | Runtime metrics sampling interval in milliseconds. Set to `0` to disable sampling. |
+| `disable_metrics_sample` | `false` | Force-disable metrics sampling regardless of `metrics_sample_interval_ms`. |
+
+## `registries`
+
+### `registries.auth`
+
+A map of registry hostnames to authentication entries. Each entry specifies a username and exactly **one** credential source.
+
+```json
+{
+  "registries": {
+    "auth": {
+      "ghcr.io": {
+        "username": "octocat",
+        "store": "keyring"
+      }
+    }
+  }
+}
+```
+
+#### Auth entry fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `username` | Yes | Registry username |
+| `store` | No | Credential store. Only `"keyring"` is supported (macOS Keychain, Windows Credential Manager, Linux Secret Service) |
+| `password_env` | No | Environment variable containing the password or token |
+| `secret_name` | No | Filename under `{home}/secrets/registries/` containing the password or token |
+
+<Note>
+  Exactly one of `store`, `password_env`, or `secret_name` must be set per entry. Setting none or more than one is an error.
+</Note>
+
+### Auth resolution order
+
+When pulling from a registry, credentials are resolved in this order:
+
+1. **Explicit SDK auth** via `.registry_auth()` on the sandbox builder
+2. **OS keyring** entries created by `msb registry login`
+3. **Config file** `registries.auth` entries in `config.json`
+4. **Docker config** `~/.docker/config.json` credential helpers
+5. **Anonymous** (no authentication)

--- a/docs/fr/getting-started/agents.mdx
+++ b/docs/fr/getting-started/agents.mdx
@@ -1,0 +1,108 @@
+---
+title: AI Agents
+description: Give AI agents the ability to create and manage their own sandboxes
+icon: "robot"
+---
+
+microsandbox is built for AI agents. The SDK and CLI give you full programmatic control, but there are two additional ways to connect agents directly: **Agent Skills** for coding assistants and an **MCP server** for any MCP-compatible client.
+
+## Agent Skills
+
+[Agent Skills](https://github.com/superradcompany/skills) teach AI coding agents how to use microsandbox without any custom integration code. Once installed, the agent can create sandboxes, run commands, manage files, and control the full sandbox lifecycle through natural language.
+
+Works with Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, and other agents that support the skills format.
+
+```bash
+npx skills add superradcompany/skills
+```
+
+This installs a set of skill files into your project that the agent reads as context. No server process, no configuration, just files that describe how to use microsandbox.
+
+## MCP Server
+
+The [microsandbox MCP server](https://github.com/superradcompany/microsandbox-mcp) exposes microsandbox as a set of structured tool calls over the [Model Context Protocol](https://modelcontextprotocol.io). Any MCP-compatible client can use it to manage sandbox lifecycle, execute commands, access the filesystem, work with volumes, and monitor sandbox state.
+
+<CodeGroup>
+
+```bash Claude Code
+claude mcp add --transport stdio microsandbox -- npx -y microsandbox-mcp
+```
+
+```json Cursor
+// ~/.cursor/mcp.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json VS Code
+// .vscode/mcp.json
+{
+  "servers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Claude Desktop
+// ~/Library/Application Support/Claude/claude_desktop_config.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Windsurf
+// ~/.codeium/windsurf/mcp_config.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Open Code
+// .opencode.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Zed
+// Zed settings
+{
+  "context_servers": {
+    "microsandbox": {
+      "command": {
+        "path": "npx",
+        "args": ["-y", "microsandbox-mcp"]
+      }
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+Once connected, the agent gets access to tools for creating sandboxes, running commands inside them, reading and writing files, and managing the sandbox lifecycle, all through the MCP protocol.

--- a/docs/fr/getting-started/introduction.mdx
+++ b/docs/fr/getting-started/introduction.mdx
@@ -1,0 +1,370 @@
+---
+title: "Introduction"
+description: "Every agent deserves its own computer"
+icon: "house"
+---
+
+AI agents run with whatever privileges you give them, and most of the time that's too many. They can see API keys sitting in the environment, reach the network freely (including cloud metadata at `169.254.169.254`), and nothing stops a prompt injection from running `rm -rf /` on the host filesystem. Containers help with some of this, but they share the host kernel, and namespace escapes are a well-documented class of vulnerability.
+
+microsandbox takes a different approach: every sandbox is a real VM with its own Linux kernel. It provides security primitives for preventing exploits like secret exfiltration. And it **runs locally** on your machine.
+
+<CodeGroup>
+
+```rust Rust
+use microsandbox::{Sandbox, NetworkPolicy};
+
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .secret(|s| s
+        .env("OPENAI_API_KEY")
+        .value(std::env::var("OPENAI_API_KEY")?)
+        .allow_host("api.openai.com")
+    )
+    .network(|n| n.policy(NetworkPolicy::public_only()))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { NetworkPolicy, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .secret((s) =>
+        s.env("OPENAI_API_KEY")
+            .value(process.env.OPENAI_API_KEY!)
+            .allowHost("api.openai.com"),
+    )
+    .network((n) => n.policy(NetworkPolicy.publicOnly()))
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import Network, Sandbox, Secret
+
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    memory=512,
+    cpus=2,
+    secrets=[
+        Secret.env("OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+    network=Network.public_only(),
+)
+```
+
+</CodeGroup>
+
+<Callout icon="bolt" color="#7C3AED">
+  microsandbox spins up lightweight VMs in **under a second**, right from your code on your machine. **No servers, no daemons**, no infrastructure to manage.
+</Callout>
+
+## The basics
+
+- **Under 100ms boot.** Sandboxes boot in under 100 milliseconds.
+- **No daemon.** The runtime spawns directly as a child process of whatever application creates the sandbox. No root, no server, no background service.
+- **Any OCI image.** Docker Hub, GHCR, ECR, GCR, or any OCI-compatible registry. Shared layers are deduplicated and only stored once.
+- **Cross-platform.** Native on macOS (Apple Silicon) and Linux (KVM). Same CLI, same SDKs.
+- **Multi-language SDKs.** Rust, TypeScript, and Python, all with consistent APIs.
+- **Programmable.** Network policies, filesystem hooks, secret bindings, and TLS interception are all configured from the host side through the SDK.
+
+## What makes it different
+
+### Secrets that can't leak
+
+Most sandboxes protect secrets by restricting what the guest can do. microsandbox goes further: **the guest never has the secret at all**.
+
+Instead of injecting real credentials into the sandbox, microsandbox generates random placeholders. The actual value never enters the VM. The only way it reaches the outside world is when a request goes to an allowed host, at which point microsandbox swaps the placeholder for the real value. Everywhere else, the placeholder is just a meaningless string.
+
+So even with full code execution inside the sandbox, there's nothing to exfiltrate. The credential was never there. DNS rebinding protection and cloud metadata blocking kick in automatically when secrets are configured, closing the remaining side channels.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .secret_env("OPENAI_API_KEY", api_key, "api.openai.com")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    secrets=[
+        Secret.env("OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+)
+```
+
+</CodeGroup>
+
+### Programmable network layer <sup><sup>coming soon</sup></sup>
+
+Every packet leaving a sandbox passes through a networking stack controlled entirely from the host side, where policy is enforced at the IP, DNS, or HTTP level. From inside the sandbox it looks like a normal network interface, but on the host side you decide what gets through.
+
+There's no underlying host network to bridge to, no rules to circumvent, and no way for the guest to reach around the filter.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .network(|n| n
+        .policy(NetworkPolicy::allowlist(["api.openai.com", "pypi.org"]))
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Destination, NetworkPolicy, Rule, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .network((n) => n.policy({
+        defaultEgress: "deny",
+        defaultIngress: "allow",
+        rules: [
+            Rule.allowEgress(Destination.domain("api.openai.com")),
+            Rule.allowEgress(Destination.domain("pypi.org")),
+        ],
+    }))
+    .create();
+```
+
+```python Python
+from microsandbox import Network, NetworkPolicy, Rule, Sandbox
+
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    network=Network(
+        policy=NetworkPolicy(rules=(
+            Rule.allow(destination="api.openai.com"),
+            Rule.allow(destination="pypi.org"),
+        )),
+    ),
+)
+```
+
+</CodeGroup>
+
+### Extensible filesystem backends <sup><sup>coming soon</sup></sup>
+
+The host controls what the guest sees at the filesystem level. Mount host directories, use managed volumes, or attach custom filesystem backends entirely. Hooks let you intercept reads and writes to do things like encrypt everything going to disk or proxy to remote storage, and the guest never knows the difference.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("encrypted")
+    .image("python")
+    .volume("/secrets", |v| v
+        .bind("/data/secrets")
+        .on_read(move |_path, data| decrypt(data, &key))
+        .on_write(move |_path, data| encrypt(data, &key))
+    )
+    .create().await?;
+```
+
+```typescript TypeScript
+// Filesystem hooks (onRead / onWrite) are coming soon for Node. For now,
+// you can mount the host directory directly:
+await using sb = await Sandbox.builder("encrypted")
+    .image("python")
+    .volume("/secrets", (m) => m.bind("/data/secrets"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+key = get_encryption_key()
+sb = await Sandbox.create(
+    "encrypted",
+    image="python",
+    volumes={
+        "/secrets": Volume.bind("/data/secrets",
+            on_read=lambda path, data: decrypt(data, key),
+            on_write=lambda path, data: encrypt(data, key),
+        ),
+    },
+)
+```
+
+</CodeGroup>
+
+### Snapshot and reuse setup state
+
+Capture a stopped sandbox's writable upper layer as a portable artifact, then boot fresh sandboxes from it. Install dependencies once, snapshot, and `msb run --snapshot ...` workers that skip the setup phase. The artifact is a directory you can `scp` between machines or bundle into a `.tar.zst`. Snapshots today are disk-only and stopped-only; live VM-state snapshots are tracked as future work.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("baseline")
+    .image("python")
+    .create()
+    .await?;
+
+sb.exec("pip", ["install", "-r", "requirements.txt"]).await?;
+sb.stop_and_wait().await?;
+
+// Snapshot the stopped sandbox under a bare name
+let h = Sandbox::get("baseline").await?;
+let _snap = h.snapshot("after-pip-install").await?;
+
+// Boot 10 workers from the same snapshot (each gets its own upper layer)
+let workers: Vec<Sandbox> = futures::future::try_join_all(
+    (0..10).map(|i| async move {
+        Sandbox::builder(format!("worker-{i}"))
+            .from_snapshot("after-pip-install")
+            .create()
+            .await
+    })
+).await?;
+```
+
+```bash CLI
+msb run --name baseline --detach python -- sleep 3600
+msb exec baseline -- pip install -r requirements.txt
+msb stop baseline
+
+msb snapshot create after-pip-install --from baseline
+
+# Boot 10 workers from the snapshot
+for i in $(seq 1 10); do
+    msb run --name worker-$i --detach --snapshot after-pip-install -- sleep 3600
+done
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.builder("baseline").image("python").create();
+await sb.exec("pip", ["install", "-r", "requirements.txt"]);
+await sb.stopAndWait();
+
+const h = await Sandbox.get("baseline");
+await h.snapshot("after-pip-install");
+
+// Boot 10 workers from the same snapshot
+const workers = await Promise.all(
+    Array.from({ length: 10 }, (_, i) =>
+        Sandbox.builder(`worker-${i}`).fromSnapshot("after-pip-install").create(),
+    ),
+);
+```
+
+```python Python
+import asyncio
+from microsandbox import Sandbox
+
+sb = await Sandbox.create("baseline", image="python")
+await sb.exec("pip", ["install", "-r", "requirements.txt"])
+await sb.stop_and_wait()
+
+h = await Sandbox.get("baseline")
+await h.snapshot("after-pip-install")
+
+# Boot 10 workers from the same snapshot
+workers = await asyncio.gather(
+    *(Sandbox.create(f"worker-{i}", snapshot="after-pip-install") for i in range(10))
+)
+```
+
+</CodeGroup>
+
+### Spawn sandboxes from sandboxes <sup><sup>coming soon</sup></sup>
+
+Code running inside a sandbox can spawn peer sandboxes alongside itself. This is designed for multi-agent systems where agents need to create sub-environments. Peer sandboxes inherit nothing by default (their own network, filesystem, secrets), and the orchestrator coordinates via the SDK, not shared state. If the code isn't running inside a microsandbox, the spawn call fails safely.
+
+### Composable plugin system <sup><sup>coming soon</sup></sup>
+
+Extend microsandbox with in-process Rust plugins or out-of-process plugins in any language. Plugins hook into lifecycle events, exec calls, filesystem operations, or network traffic. They compose naturally, so you can stack an audit logger, a rate limiter, and a network monitor without them knowing about each other.
+
+### Bidirectional events <sup><sup>coming soon</sup></sup>
+
+Guest processes can emit typed events to the host, and the host can send events back. No special libraries required in the guest since any language can write JSON to a socket. This enables structured communication beyond stdin/stdout, like progress reporting, task completion signals, or custom RPC.
+
+<CodeGroup>
+
+```rust Rust
+// Receive events from guest
+let _sub = sb.on_event("task.progress", |event: EventData| {
+    if let Ok(p) = event.data.unwrap().deserialized::<Progress>() {
+        println!("[{}%] {}", p.percent, p.message);
+    }
+});
+
+// Send events to guest
+sb.emit("task.start", TaskConfig {
+    input_file: "/data/input.txt".into(),
+    output_dir: "/data/output".into(),
+}).await?;
+```
+
+```typescript TypeScript
+// Receive events from guest
+const sub = sb.onEvent("task.progress", (event: EventData) => {
+    const { percent, message } = event.data as { percent: number; message: string }
+    console.log(`[${percent}%] ${message}`)
+})
+
+// Send events to guest
+await sb.emit("task.start", { inputFile: "/data/input.txt", options: ["--verbose"] })
+```
+
+```python Python
+# Receive events from guest
+sub = sb.on_event("task.progress", lambda event: (
+    print(f"[{event.data['percent']}%] {event.data['message']}")
+))
+
+# Send events to guest
+await sb.emit("task.start", {
+    "input_file": "/data/input.txt",
+    "output_dir": "/data/output",
+})
+```
+
+</CodeGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="bolt" href="/getting-started/quickstart">
+    Get a sandbox running in under 5 minutes
+  </Card>
+
+  <Card title="Sandbox overview" icon="box" href="/sandboxes/overview">
+    Configuration, rootfs sources, and lifecycle
+  </Card>
+
+  <Card title="CLI reference" icon="square-terminal" href="/cli/overview">
+    Manage sandboxes from the terminal
+  </Card>
+
+  <Card title="SDK reference" icon="code" href="/sdk/rust">
+    Full API documentation for all SDKs
+  </Card>
+</CardGroup>

--- a/docs/fr/getting-started/quickstart.mdx
+++ b/docs/fr/getting-started/quickstart.mdx
@@ -1,0 +1,125 @@
+---
+title: Quickstart
+description: Get a sandbox running in under 5 minutes
+icon: "bolt"
+---
+
+<Note>
+  microsandbox requires **Linux with KVM** enabled, or **macOS with Apple Silicon** (M-series chip). Both use hardware virtualization.
+</Note>
+
+<Tip>
+  Boot a microVM in one command.
+
+  ```bash
+  npx microsandbox run debian
+  ```
+</Tip>
+
+<Steps>
+  <Step title="Install microsandbox">
+    The SDK **embeds the runtime directly**, so no separate server process is needed. Only install the `msb` CLI if you want to manage images, volumes, and sandboxes from the terminal.
+
+    <CodeGroup>
+    ```bash Rust
+    cargo add microsandbox
+    ```
+
+    ```bash TypeScript
+    npm install microsandbox
+    ```
+
+    ```bash Python
+    pip install microsandbox
+    ```
+
+    ```bash CLI
+    curl -fsSL https://install.microsandbox.dev | sh
+    ```
+
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run code in a sandbox">
+    Create a sandbox, execute code inside it, and get the result back.
+
+    <CodeGroup>
+    ```rust Rust
+    use microsandbox::Sandbox;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let sb = Sandbox::builder("hello")
+            .image("python")
+            .memory(512)
+            .create()
+            .await?;
+
+        let output = sb.exec("python", ["-c", "print('Hello from a microVM!')"]).await?;
+        println!("{}", output.stdout()?); // Hello from a microVM!
+
+        sb.stop().await?;
+        Ok(())
+    }
+    ```
+
+    ```typescript TypeScript
+    import { Sandbox } from "microsandbox";
+
+    await using sb = await Sandbox.builder("hello")
+        .image("python")
+        .memory(512)
+        .create();
+
+    const output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"]);
+    console.log(output.stdout()); // Hello from a microVM!
+    ```
+
+    ```python Python
+    import asyncio
+    from microsandbox import Sandbox
+
+    async def main():
+        sb = await Sandbox.create(
+            "hello",
+            image="python",
+            memory=512,
+        )
+
+        output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"])
+        print(output.stdout_text)  # Hello from a microVM!
+
+        await sb.stop()
+
+    asyncio.run(main())
+    ```
+
+    ```bash CLI
+    msb run python -- python3 -c "print('Hello from a microVM!')"
+    ```
+
+    </CodeGroup>
+  </Step>
+</Steps>
+
+## What just happened?
+
+Here's what actually happened behind that `Sandbox.builder(...).create()` call:
+
+1. **Pulled the image** from Docker Hub (or skipped this if it was already cached, since shared layers are deduplicated).
+2. **Assembled the filesystem** by stacking the image layers into a copy-on-write filesystem, so nothing you do inside the sandbox modifies the base image.
+3. **Booted a microVM** as a child process. The 512 MiB you specified is a limit, not a reservation, so the VM only uses what it actually needs.
+4. **Started the guest agent** inside the VM, which set up the environment and opened a communication channel back to the host.
+
+The `exec` call sent a message to that guest agent, which spawned `python` inside the VM, streamed stdout back, and returned the exit code. No SSH involved, no network overhead. The command channel is completely separate from the sandbox's network stack.
+
+<Tip>
+  Because exec doesn't go through the network, it works even when a sandbox has networking disabled via `.disable_network()` and no network interfaces at all.
+</Tip>
+
+## Next steps
+
+- [Understand sandbox configuration](/sandboxes/overview): how the VM, filesystem, and networking fit together
+- [Run commands and stream output](/sandboxes/commands): `exec`, `shell`, `attach`, and streaming
+- [Control network access](/networking/overview): policies, DNS interception, and secret protection
+- [Manage sandboxes with the CLI](/cli/overview): create, inspect, and manage sandboxes from the terminal

--- a/docs/fr/images/disk-images.mdx
+++ b/docs/fr/images/disk-images.mdx
@@ -1,0 +1,82 @@
+---
+title: Disk Images
+description: Boot from QCOW2, Raw, or VMDK disk images
+icon: "compact-disc"
+---
+
+In addition to OCI container images, microsandbox can boot a sandbox directly from a disk image file. The guest gets raw block device access, and its kernel mounts the filesystem from the device directly.
+
+This is a fundamentally different path from OCI images. With OCI, microsandbox stacks image layers as a copy-on-write filesystem. With disk images, the guest owns the block device. No overlay, no copy-on-write between sandboxes.
+
+Use disk images when you need a pre-built VM template, a custom kernel configuration, or an OS that isn't available as a container image.
+
+## Supported formats
+
+| Format | Description |
+|--------|-------------|
+| **QCOW2** | QEMU Copy-On-Write v2. Supports thin provisioning and backing files. The most common format. |
+| **Raw** | Uncompressed raw disk image. No overhead, but no thin provisioning. |
+| **VMDK** | VMware virtual disk format. |
+
+## Usage
+
+When you pass a file path ending in `.qcow2`, `.raw`, or `.vmdk`, microsandbox auto-detects the format. For ambiguous cases, specify the format and filesystem type explicitly.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::size::SizeExt;
+
+// Auto-detect
+let sb = Sandbox::builder("custom-vm")
+    .image("./ubuntu-22.04.qcow2")
+    .cpus(2)
+    .memory(2.gib())
+    .create()
+    .await?;
+
+// Explicit
+let sb2 = Sandbox::builder("custom-vm")
+    .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
+    .cpus(1)
+    .memory(512)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+// Auto-detect format from the file extension
+await using sb = await Sandbox.builder("custom-vm")
+    .image("./ubuntu-22.04.qcow2")
+    .cpus(2)
+    .memory(2048)
+    .create();
+
+// Explicit format / fstype via a RootfsSource literal
+await using sb2 = await Sandbox.builder("custom-vm")
+    .image({
+        kind: "disk",
+        path: "./alpine.raw",
+        format: "raw",
+        fstype: "ext4",
+    })
+    .cpus(1)
+    .memory(512)
+    .create();
+```
+
+```python Python
+from microsandbox import Image, Sandbox
+
+# Auto-detect format from file extension
+sb = await Sandbox.create("custom-vm", image="./ubuntu-22.04.qcow2", cpus=2, memory=2048)
+
+# Explicit filesystem type
+sb2 = await Sandbox.create("custom-vm", image=Image.disk("./alpine.raw", fstype="ext4"), cpus=1, memory=512)
+```
+</CodeGroup>
+
+<Note>
+  The filesystem type (`ext4`, `xfs`, etc.) must match what's actually on the disk image. The guest kernel mounts it using the specified filesystem driver.
+</Note>

--- a/docs/fr/images/overview.mdx
+++ b/docs/fr/images/overview.mdx
@@ -1,0 +1,177 @@
+---
+title: OCI Images
+description: Use standard container images from any registry
+icon: "layer-group"
+---
+
+microsandbox uses standard OCI container images as root filesystems. Docker Hub, GHCR, ECR, GCR, any OCI-compatible registry works. Existing images run as-is.
+
+When you specify an image like `python`, microsandbox pulls the manifest, downloads the layers in parallel, and stacks them as a copy-on-write filesystem. Changes inside the sandbox don't modify the base image. Two sandboxes using the same image share the same cached layers on disk.
+
+## Pull policies
+
+By default, microsandbox pulls an image only if it isn't already cached. You can change this behavior.
+
+| Policy | Behavior |
+|--------|----------|
+| `"if-missing"` | Pull only if not cached (default) |
+| `"always"` | Always check the registry for updates |
+| `"never"` | Use local cache only, fail if missing |
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+from microsandbox import PullPolicy, Sandbox
+
+sb = await Sandbox.create("worker", image="python", pull_policy=PullPolicy.ALWAYS)
+```
+</CodeGroup>
+
+<Tip>
+  Once an image reference is resolved, microsandbox pins the exact layers. `python` is resolved to a specific set of immutable layers at first pull. Subsequent `start()` calls use the pinned layers without re-resolving the mutable tag, so your sandbox is reproducible even if the upstream tag moves.
+</Tip>
+
+## Private registries
+
+Authenticate to private registries by passing credentials.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry(|r| r.auth(RegistryAuth::Basic {
+        username: "deploy".into(),
+        password: std::env::var("REGISTRY_PASSWORD")?,
+    }))
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry((r) => r.auth({
+        kind: "basic",
+        username: "deploy",
+        password: process.env.REGISTRY_TOKEN!,
+    }))
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import PullPolicy, RegistryAuth, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="registry.corp.io/team/app:latest",
+    registry_auth=RegistryAuth.basic("deploy", os.environ["REGISTRY_PASSWORD"]),
+    pull_policy=PullPolicy.ALWAYS,
+)
+```
+</CodeGroup>
+
+## Registry TLS
+
+By default, microsandbox connects to registries over HTTPS using system CA roots. You can customize this per-registry in `~/.microsandbox/config.json`.
+
+### Plain HTTP registries
+
+Local registries often run without TLS. Mark them as insecure to connect over plain HTTP:
+
+```json
+{
+  "registries": {
+    "hosts": {
+      "localhost:5050": {
+        "insecure": true
+      }
+    }
+  }
+}
+```
+
+### Custom CA certificates
+
+For registries using self-signed or internal CA certificates, point `ca_certs` to a PEM file. This applies globally to all registry connections:
+
+```json
+{
+  "registries": {
+    "ca_certs": "/path/to/ca-bundle.pem"
+  }
+}
+```
+
+The certificates are added to the default system roots — public registries continue to work normally.
+
+### Combined configuration
+
+```json
+{
+  "registries": {
+    "ca_certs": "/path/to/corporate-ca.pem",
+    "hosts": {
+      "localhost:5050": {
+        "insecure": true,
+        "auth": { "username": "deploy", "password_env": "REGISTRY_TOKEN" }
+      },
+      "ghcr.io": {
+        "auth": { "username": "user", "store": "keyring" }
+      }
+    }
+  }
+}
+```
+
+These settings can also be set per-sandbox via the SDK, overriding global config:
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("localhost:5050/my-app:latest")
+    .registry(|r| r.insecure())
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("localhost:5050/my-app:latest")
+    .registry((r) => r.insecure())
+    .create();
+```
+</CodeGroup>
+
+## Image storage
+
+Images are cached in the global microsandbox home directory:
+
+| Path | Description |
+|------|-------------|
+| `~/.microsandbox/cache/layers/` | Downloaded and extracted image layers |
+| `~/.microsandbox/db/` | Database tracking image metadata and digests |
+
+Layers are content-addressable and deduplicated. If `python` and `python` share a base layer, it's stored once.
+
+<Tip>
+  Use `msb pull` from the CLI to pre-pull images before creating sandboxes. This avoids blocking on a download during `Sandbox.create`.
+</Tip>

--- a/docs/fr/networking/dns.mdx
+++ b/docs/fr/networking/dns.mdx
@@ -1,0 +1,169 @@
+---
+title: DNS
+description: How the sandbox resolves DNS queries
+icon: "magnifying-glass"
+---
+
+DNS queries from the sandbox are intercepted on the host. Rather than letting the guest talk to a resolver directly, microsandbox proxies each query, which lets you:
+
+- block lookups by domain or suffix,
+- pin which upstream resolvers get used,
+- tune the query timeout,
+- power domain-based policy rules (by mapping responses back to IPs).
+
+The knobs below cover the day-to-day controls. For the rebinding and TOCTOU protections that also ride on the interceptor, see the [security model](/networking/security-model).
+
+## Blocking domains
+
+Domain blocking lives in the network policy as `deny Domain(...)` / `deny DomainSuffix(...)` rules. The interceptor enforces them at three layers:
+
+1. **DNS resolution** — denied names get a local `REFUSED` response; the upstream resolver never sees them.
+2. **TLS first-flight** — when a guest hardcodes an IP and opens a TLS connection, the SNI is checked against the same rules.
+3. **TCP egress (cache fallback)** — for non-TLS traffic, the resolved-hostname cache disambiguates by IP.
+
+The bulk-deny shortcuts in each SDK are convenience for `deny Domain` / `deny DomainSuffix` rules; they prepend onto whatever policy is set so the deny takes precedence over later allow rules.
+
+<CodeGroup>
+```rust Rust
+let policy = NetworkPolicy::builder()
+    .default_allow()
+    .egress(|e| e
+        .deny_domains(["malware.example.com"])
+        .deny_domain_suffixes([".tracking.com"]))
+    .build()?;
+
+let sb = Sandbox::builder("safe-agent")
+    .image("python")
+    .network(|n| n.policy(policy))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("safe-agent")
+    .image("python")
+    .network({
+        denyDomains: ["malware.example.com"],
+        denyDomainSuffixes: [".tracking.com"],
+    })
+    .create();
+```
+
+```python Python
+from microsandbox import Network, Sandbox
+
+sb = await Sandbox.create(
+    "safe-agent",
+    image="python",
+    network=Network(
+        deny_domains=("malware.example.com",),
+        deny_domain_suffixes=(".tracking.com",),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name safe-agent \
+  --deny-domain malware.example.com \
+  --deny-domain-suffix .tracking.com
+```
+
+</CodeGroup>
+
+
+## Pinning nameservers
+
+By default the sandbox picks up the host's resolver list automatically:
+
+- **macOS**: reads `State:/Network/Global/DNS` from the system configuration store, with `/etc/resolv.conf` as a fallback when the store isn't available.
+- **Linux**: reads `/etc/resolv.conf` directly.
+
+You can override this by setting `nameservers` to pin the exact resolvers you want (e.g. `1.1.1.1`, `dns.google`), which is useful when auto-discovery picks the wrong ones.
+
+Values can be plain IPs, `IP:PORT`, hostnames, or `HOST:PORT`. Hostnames are resolved once at sandbox startup using the host's OS resolver.
+
+<CodeGroup>
+```rust Rust
+use microsandbox_network::dns::Nameserver;
+
+let sb = Sandbox::builder("safe-agent")
+    .image("python")
+    .network(|n| n
+        .dns(|d| d
+            .nameservers([
+                "1.1.1.1".parse::<Nameserver>()?,
+                "1.0.0.1".parse::<Nameserver>()?,
+            ])
+            .query_timeout_ms(3000)
+        )
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("safe-agent")
+    .image("python")
+    .network((n) => n.dns((d) =>
+        d.nameservers(["1.1.1.1", "1.0.0.1"])
+            .queryTimeoutMs(3000),
+    ))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "safe-agent",
+    image="python",
+    network=Network(
+        dns=DnsConfig(
+            nameservers=("1.1.1.1", "1.0.0.1"),
+            query_timeout_ms=3000,
+        ),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name safe-agent \
+  --dns-nameserver 1.1.1.1 \
+  --dns-nameserver 1.0.0.1 \
+  --dns-query-timeout-ms 3000
+```
+
+</CodeGroup>
+
+If the guest aims a query at a specific resolver (`dig @1.1.1.1`, an `/etc/resolv.conf` entry inside the guest, or a library call that takes a resolver IP), the interceptor forwards it to that resolver directly. The pinned defaults aren't used in this case. The network policy still applies: the query only goes through if the destination IP is allowed.
+
+## DNS over alternative transports
+
+The block list and rebind protection only apply to queries the gateway can see. A guest that routes DNS through an encrypted or non-DNS protocol bypasses both unless the gateway intercepts or refuses it.
+
+**Intercepted** (block list and rebind protection apply):
+- DNS over UDP (UDP/53)
+- DNS over TCP (TCP/53)
+- DNS over TLS (DoT, TCP/853): requires [TLS interception](/networking/tls)
+
+**Refused** (guest's stub falls back to plain DNS):
+- DNS over QUIC (DoQ, UDP/853)
+- mDNS (UDP/5353), LLMNR (UDP/5355), NetBIOS-NS (UDP/137)
+
+**Not distinguishable from regular traffic** (you must filter via network policy):
+- DNS over HTTPS (DoH, TCP/443)
+
+For strict DNS integrity, combine DoT interception with a network policy denying egress `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway.
+
+## Domain-based policy rules
+
+Network policy rules can match a destination by exact domain or by suffix. The interceptor watches DNS responses as they flow back to the guest and keeps track of which IP addresses belong to which domain.
+
+A connection to `93.184.216.34` is only allowed by a rule targeting `example.com` if that IP actually came back as an answer to a lookup for `example.com` from this sandbox.
+
+Because of that, domain rules only take effect on connections that are preceded by a DNS lookup from inside the sandbox. An application that connects to a hard-coded IP it didn't resolve through the interceptor won't match any domain rule.
+
+## See also
+
+- [Security model](/networking/security-model): rebinding protection and DNS-to-IP binding (TOCTOU defense)
+- [TLS interception](/networking/tls): domains that get intercepted also go through TLS inspection

--- a/docs/fr/networking/overview.mdx
+++ b/docs/fr/networking/overview.mdx
@@ -1,0 +1,232 @@
+---
+title: Overview
+description: Control network access and isolation
+icon: "network-wired"
+---
+
+All network traffic from a sandbox flows through a host-controlled networking stack. From inside, the sandbox sees a normal network interface, but on the host side every packet is subject to policy before it goes anywhere. The sandbox's only path to the outside world is through this stack, so blocked traffic never leaves the VM.
+
+## Defaults
+
+Without any policy flags, sandboxes get **public-internet egress only**: routable destinations work, but private (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`), loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), and the cloud metadata endpoint (`169.254.169.254`) are denied. Inbound traffic on published ports is unfiltered until you add an explicit ingress rule.
+
+To turn off networking entirely:
+
+```bash
+msb create python --name isolated --no-net
+```
+
+```rust
+let sb = Sandbox::builder("isolated")
+    .image("python")
+    .network(|n| n.enabled(false))
+    .create()
+    .await?;
+```
+
+## Custom policies
+
+A policy is a list of rules plus two direction-specific defaults:
+
+```text
+default_egress  : Allow | Deny     (action when no egress rule matches)
+default_ingress : Allow | Deny     (action when no ingress rule matches)
+rules           : [Rule, ...]      (first match wins)
+```
+
+Each rule carries its own direction (`Egress`, `Ingress`, or `Any`), a destination, an optional protocol set, an optional port set, and an action.
+
+### CLI
+
+`--net-rule` takes a comma-separated list of tokens shaped as
+`<action>[:<direction>]@<target>[:<proto>[:<ports>]]`. Direction defaults to `egress` when omitted. Repeating the flag concatenates tokens in argv order; first match wins.
+
+```bash
+# Public internet plus the host machine, deny everything else by default
+msb create python --name agent \
+    --net-rule "allow@public,allow@host"
+
+# Allow public internet plus a specific private host on tcp/443
+msb create alpine --name secure-agent \
+    --net-rule "allow@10.0.5.10:tcp:443,allow@public" \
+    --net-default-egress deny
+
+# Block tcp/445 to private IPs while keeping everything else open
+msb create alpine --name smb-blocked \
+    --net-default-egress allow \
+    --net-rule "deny@private:tcp:445"
+
+# Publish a port and only accept ingress from RFC1918 sources
+msb create python --name api \
+    --port 8080:8080 \
+    --net-rule "allow:ingress@private"
+```
+
+`<target>` accepts `any`, a group keyword (`public`, `private`, `loopback`, `link-local`, `meta`, `multicast`, `host`), an IP, a CIDR, a domain (with at least one dot), `domain=<name>` for single-label hostnames, or `suffix=<domain>` for subdomain matches.
+
+### Rust
+
+```rust
+use microsandbox::{NetworkPolicy, Sandbox};
+
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e
+        .tcp().port(443).allow_public()
+        .udp().port(53).allow_public())
+    .build()?;
+
+let sb = Sandbox::builder("secure-agent")
+    .image("alpine")
+    .network(|n| n.policy(policy))
+    .create()
+    .await?;
+```
+
+The builder accepts string inputs (`.ip("10.0.0.5")`, `.cidr("10.0.0.0/24")`, `.domain("api.example.com")`, etc.) and parses them at `.build()` time, so the chain stays clean. See the [Rust reference](/sdk/rust/networking) for the full surface (per-category shortcuts, the explicit-rule sub-builder, shadow-rule warnings).
+
+### TypeScript / Python
+
+Both SDKs accept policies as plain config objects matching the wire format. Direction strings are `"egress"`, `"ingress"`, or `"any"`. Group keywords match the CLI grammar.
+
+```typescript
+import { Destination, PortRange, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("secure-agent")
+    .image("alpine")
+    .network((n) => n.policy({
+        defaultEgress: "deny",
+        defaultIngress: "allow",
+        rules: [
+            {
+                direction: "egress",
+                destination: Destination.any(),
+                protocols: ["tcp"],
+                ports: [PortRange.single(443)],
+                action: "allow",
+            },
+            {
+                direction: "egress",
+                destination: Destination.any(),
+                protocols: ["udp"],
+                ports: [PortRange.single(53)],
+                action: "allow",
+            },
+        ],
+    }))
+    .create();
+```
+
+```python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "secure-agent",
+    image="alpine",
+    network={
+        "policy": {
+            "default_egress": "deny",
+            "default_ingress": "allow",
+            "rules": [
+                {"action": "allow", "direction": "egress", "protocol": "tcp", "port": "443"},
+                {"action": "allow", "direction": "egress", "protocol": "udp", "port": "53"},
+            ],
+        },
+    },
+)
+```
+
+Domain rules match flows where the guest resolved the name through the sandbox's DNS interceptor. See [DNS](/networking/dns) for how the resolved-hostname cache works.
+
+## Port mapping
+
+Expose ports from the sandbox to the host so services running inside the VM are reachable from your machine.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("api")
+    .image("python")
+    .port(8080, 80)
+    .port_udp(5353, 5353)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("api")
+    .image("python")
+    .port(8080, 80)
+    .portUdp(5353, 5353)
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "api",
+    image="python",
+    ports={8080: 80},
+)
+```
+
+```bash CLI
+msb create python --name api -p 8080:80
+```
+
+</CodeGroup>
+
+## Reaching the host
+
+From inside the sandbox, `host.microsandbox.internal` resolves to the host machine, same idea as Docker's `host.docker.internal`. Use it to call a dev server, database, or other process running on your machine without hard-coding an IP.
+
+```bash
+# Inside the sandbox:
+curl http://host.microsandbox.internal:8080
+```
+
+The name is wired through `/etc/hosts` and the DNS interceptor, so both standard resolvers and tools that bypass `/etc/hosts` (like `dig`) find it.
+
+The default policy denies host access — the sandbox gateway sits in a private range, same as any other local destination. Add the `host` group to open it:
+
+```bash
+msb create python --name dev-agent \
+    --net-rule "allow@public,allow@host"
+```
+
+```rust
+NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.allow_public().allow_host())
+    .build()?
+```
+
+### Loopback vs host: a common trap
+
+`Group::Loopback` (`127.0.0.0/8`, `::1`) and `Group::Host` (the per-sandbox gateway IPs) are different things. The two-word summary:
+
+- **`loopback`** = the guest's own loopback interface. Services running inside the same VM.
+- **`host`** = the host machine, reached through `host.microsandbox.internal`.
+
+If you're coming from Docker and reach for `.allow_loopback()` to "let the sandbox talk to my host's localhost," that's the trap — you want `.allow_host()` instead. `.allow_loopback()` only fires for traffic *inside* the guest, which doesn't reach the policy gate under normal kernel routing anyway.
+
+`.deny_loopback()` does have a real use case. In `--net-default-egress allow` configurations, a process inside the guest could craft a packet bound to `eth0` with `dst=127.0.0.1`, route it past the guest kernel, and have smoltcp on the host land it on the host's loopback. `.deny_loopback()` blocks that vector. Default policies (with the implicit deny on egress) already cover this.
+
+If you want "everything near the sandbox" — guest loopback, link-local, and the host machine — `.allow_local()` is sugar for that triple. `Metadata` is deliberately excluded so cloud-IMDS isn't quietly exposed; opt in via `.allow_meta()` if you need it.
+
+## Protocol support
+
+For most sandboxed workloads, networking behaves the way you'd expect:
+
+- Normal egress **TCP** and **UDP** traffic works, including common tools and libraries like `curl`, `wget`, package managers, HTTP clients, database drivers, and DNS lookups.
+- **DNS** queries are intercepted on the host side. See [DNS](/networking/dns) for blocking, pinned resolvers, and query timeouts.
+- **ICMP echo** is supported: pinging external hosts works on systems that support unprivileged ICMP echo sockets.
+- **Ingress** on published ports is gated by the same policy. Denied connections drop with TCP RST so the peer sees `ECONNRESET`.
+
+<Note>
+**Raw sockets** and **full ICMP forwarding** are not supported because they require elevated privileges on the host. Tools that depend on richer ICMP behavior, such as `traceroute`, are outside the current scope.
+</Note>
+
+## Next
+
+- [DNS](/networking/dns): domain blocking, pinned nameservers, query timeouts
+- [TLS interception](/networking/tls): HTTPS inspection with an auto-generated CA
+- [Security model](/networking/security-model): how the stack defends against SSRF, rebinding, and metadata exfiltration

--- a/docs/fr/networking/security-model.mdx
+++ b/docs/fr/networking/security-model.mdx
@@ -1,0 +1,90 @@
+---
+title: Security Model
+description: What the networking stack defends against
+icon: "shield-halved"
+---
+
+microsandbox's networking defaults are shaped around giving an AI agent, a scraper, or some other untrusted workload access to the internet without letting it pivot into your internal infrastructure. This page walks through the specific threats the stack is designed to handle and where each defense lives.
+
+## Private IPs and the host's local network
+
+The largest class of real damage comes from workloads reaching things that live *inside* your network: the host machine itself, a local database, another VM on the same subnet. The default policy addresses this by denying egress to anything outside `Group::Public` (the complement of the named local categories), which covers:
+
+- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10` (RFC1918 + CGN private ranges)
+- `127.0.0.0/8`, `::1` (loopback)
+- `169.254.0.0/16`, `fe80::/10` (link-local)
+- `169.254.169.254` (cloud metadata, takes precedence over link-local)
+- the per-sandbox gateway IPs (`Group::Host`)
+
+If an agent runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Override the default with `--net-default-egress allow` only when the workload genuinely needs broad reach, or use `--no-net` when it doesn't need network at all.
+
+## Cloud metadata endpoints
+
+On AWS, GCP, Azure, and similar platforms, `169.254.169.254` is the instance metadata service, a well-known SSRF target because it hands out temporary credentials to anything that can connect. The default policy blocks it via the `Group::Public` complement. For custom policies that flip `default_egress` to `Allow`, `Group::Metadata` lets you deny it explicitly:
+
+```bash
+msb create python --name agent \
+    --net-default-egress allow \
+    --net-rule "deny@meta"
+```
+
+```rust
+NetworkPolicy::builder()
+    .default_allow()
+    .rule(|r| r.egress().deny_meta())
+    .build()?
+```
+
+## DNS rebinding
+
+An attacker who controls a domain can set up records that resolve to a public IP during the initial allowlist check and then flip to a private IP on a subsequent lookup. The guest ends up making a request that *looked* like it was going to `evil.example.com` and actually lands on `192.168.1.10`.
+
+Rebind protection catches this at the response level: when the DNS interceptor sees an answer resolving a domain to a private, loopback, or link-local IP, the response is rewritten to `REFUSED` and the connection never gets made. This is on by default. You can turn it off when you genuinely need domains to resolve to internal hosts (local development, split-horizon DNS):
+
+<CodeGroup>
+```rust Rust
+.network(|n| n.dns(|d| d.rebind_protection(false)))
+```
+
+```typescript TypeScript
+.network((n) => n.dns((d) => d.rebindProtection(false)))
+```
+
+```python Python
+network=Network(dns=DnsConfig(rebind_protection=False))
+```
+
+```bash CLI
+msb create python --name dev --no-dns-rebind-protection
+```
+
+</CodeGroup>
+
+## DNS-to-IP binding (TOCTOU)
+
+Even without rebinding tricks, a classic time-of-check/time-of-use race exists. An allowlisted domain resolves to an allowed IP when the policy is checked. The guest then looks it up again at connect time and reaches a different IP.
+
+Domain-based policy rules close this by maintaining a pin set of observed DNS answers. A connection only matches a domain rule if its destination IP was actually returned as an answer to a DNS query for that domain from this sandbox. A guest that hard-codes an IP it didn't resolve through the interceptor can't slip past a domain-based allowlist.
+
+The same mechanism gates host-scoped secret injection. When a `SecretEntry` is restricted via `allowed_hosts`, the secret is only injected into outbound requests whose destination IP the interceptor tied to one of those hosts. An exfiltration attempt that POSTs the secret to an arbitrary IP won't receive the injection in the first place.
+
+## DNS bypass surface
+
+DNS-based defenses (block list, rebind protection, domain pinning) only work on queries the interceptor sees. The gateway intercepts UDP/53 and TCP/53 directly, and DoT (TCP/853) when TLS interception is enabled. Alternative transports are either refused at the port layer (DoQ, mDNS, LLMNR, NetBIOS-NS) or indistinguishable from regular traffic (DoH on TCP/443). Tunneled DNS (VPN, SOCKS5 hostname mode, HTTP `CONNECT`) is carried inside the outer encrypted flow and never reaches the forwarder.
+
+For workloads where DNS integrity matters, pair DoT interception with a network policy that denies egress `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway. Tunneled DNS is a network-layer concern: close it by restricting egress to an allowlist that excludes tunnel destinations. See [DNS](/networking/dns) for the transport-by-transport breakdown.
+
+## Out of scope
+
+The networking stack doesn't try to defend against:
+
+- **Kernel exploits inside the guest.** The microVM boundary is what keeps a compromised guest contained.
+- **Raw packet crafting from outside the sandbox.** Host-side privileged processes aren't in this threat model.
+- **Host tampering.** If a workload can modify host-side config, it's already past this layer.
+- **Deep ICMP behavior.** Supported ICMP is limited to unprivileged echo; `traceroute`-style flows are not proxied.
+- **Host trust store integrity.** When [`trust_host_cas`](/sdk/rust/networking#trust_host_cas) is opted into, an attacker who can plant a CA on the host has that trust inside every sandbox. Off by default for exactly this reason.
+
+## See also
+
+- [DNS](/networking/dns): the controls that ride on the DNS interceptor
+- [TLS interception](/networking/tls): plaintext visibility for per-host policy and secret injection

--- a/docs/fr/networking/tls.mdx
+++ b/docs/fr/networking/tls.mdx
@@ -1,0 +1,134 @@
+---
+title: TLS Interception
+description: HTTPS inspection with an auto-generated CA
+icon: "lock"
+---
+
+Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server, which is how features like per-host secret injection and URL-level policy checks are able to see inside what would otherwise be an opaque stream.
+
+## How it works
+
+When you enable TLS interception:
+
+1. A CA key and certificate are generated for the sandbox at creation time. The CA is scoped to that sandbox: it's not shared across sandboxes or with the host.
+2. The guest's trust store is updated to trust this CA.
+3. When the guest opens an HTTPS connection, the host-side proxy intercepts the handshake, generates a leaf certificate for the target domain on the fly, and signs it with the per-sandbox CA.
+4. The proxy opens its own TLS connection to the upstream server and bridges the two.
+
+Because the CA lives only for the sandbox's lifetime, nothing signed by it is trusted anywhere else.
+
+## Enabling interception
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("agent")
+    .image("python")
+    .network(|n| n
+        .tls(|t| t
+            .bypass("pinned-api.example.com")
+            .bypass("*.gov")
+        )
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("agent")
+    .image("python")
+    .network((n) => n.tls((t) =>
+        t.bypass("pinned-api.example.com").bypass("*.gov"),
+    ))
+    .create();
+```
+
+```python Python
+from microsandbox import Network, Sandbox, TlsConfig
+
+sb = await Sandbox.create(
+    "agent",
+    image="python",
+    network=Network(
+        tls=TlsConfig(bypass=("pinned-api.example.com", "*.gov")),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name agent \
+  --tls-intercept \
+  --tls-bypass "pinned-api.example.com" \
+  --tls-bypass "*.gov"
+```
+
+</CodeGroup>
+
+## Bypass patterns
+
+Some domains don't play well with interception, typically ones whose clients pin a specific certificate or public key instead of trusting the system CA store. Software update channels (browser autoupdate, macOS `softwareupdate`, package-manager mirrors that ship a pinned signing CA) and vendor SDKs that bundle their own pinned CA are the usual suspects. Add them to the bypass list and their traffic flows through as-is, encrypted end-to-end between the guest and the upstream server.
+
+Bypass patterns accept exact matches (`api.example.com`) and wildcards (`*.gov`, `*.apple.com`).
+
+## Limits
+
+- **Pinned clients bypass the trust store.** Any client that pins the server's certificate or public key (rather than trusting the system CA) will fail TLS interception and needs to be bypassed explicitly.
+- **Bypassed traffic is opaque.** Policy checks that depend on inspecting request content (URL-based rules, secret injection with `require_tls_identity`) don't apply on bypassed domains.
+- **Client certificates are not proxied.** mTLS flows where the guest is the one presenting a client certificate aren't supported through interception; add those hosts to the bypass list.
+
+## Trusting host CAs
+
+Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, ...) terminate outbound HTTPS at the host and re-sign it with a gateway CA. That CA is installed in your macOS Keychain or Linux trust store as part of the corporate rollout, so HTTPS works silently on the host. Inside a sandbox it doesn't: the guest's stock Mozilla bundle has never seen the gateway CA, so `apk update`, `pip install`, `curl`, and any SDK fetch fail with `server certificate not trusted`.
+
+By default the sandbox does not extend host trust into the guest, so the guest validates TLS strictly against its stock Mozilla bundle. Opt in when you need the guest to trust whatever the host trusts: at sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle.
+
+<Note>
+**Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox.
+
+It matches the existing threat model (a host-access attacker already owns the sandbox), but worth knowing before enabling on a host with an unfamiliar trust store.
+</Note>
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("agent")
+    .image("alpine")
+    .network(|n| n.trust_host_cas(true))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("agent")
+    .image("alpine")
+    .network((n) => n.trustHostCAs(true))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "agent",
+    image="alpine",
+    network=Network(trust_host_cas=True),
+)
+```
+
+```bash CLI
+msb run alpine --trust-host-cas -- apk update
+```
+
+</CodeGroup>
+
+### Interaction with TLS interception
+
+TLS interception also covers the corporate-proxy case, but only on the ports it's configured for (default `[443]`), and only for non-bypassed domains. It doesn't touch QUIC / HTTP/3 flows. Everything outside that scope (gRPC, Postgres / Redis / Mongo TLS, custom 8443, non-intercepted ports, bypassed domains) goes over raw TLS from the guest, where host-CA trust is what makes certificate validation succeed.
+
+The two features compose. Turn on [`trust_host_cas`](/sdk/rust/networking#trust_host_cas) alongside TLS interception when you need both: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Leave it off to keep the guest's TLS stack validating strictly against its stock Mozilla bundle.
+
+## See also
+
+- [DNS](/networking/dns): the DNS interceptor is what makes per-host rules possible, and DoT interception reuses this TLS path
+- [Security model](/networking/security-model): how TLS interception interacts with secret injection and SSRF defenses

--- a/docs/fr/recipes/docker.mdx
+++ b/docs/fr/recipes/docker.mdx
@@ -1,0 +1,57 @@
+---
+title: Running in Docker
+description: Deploy microsandbox as a Docker container on Linux
+icon: "box"
+---
+
+<Tip>
+  For production use, we recommend [installing microsandbox natively](/getting-started/quickstart).
+</Tip>
+
+microsandbox publishes multi-arch Docker images (amd64/arm64) to GitHub Container Registry. This is an interim solution for environments that require containerized deployment, pending microsandbox implementing the [OCI runtime spec](https://github.com/opencontainers/runtime-spec).
+
+## Prerequisites
+
+- A **Linux** host with KVM support (`/dev/kvm` must be available)
+- Docker installed
+
+## Pull the image
+
+```bash
+docker pull ghcr.io/superradcompany/microsandbox:latest
+```
+
+Or pin to a specific version:
+
+```bash
+docker pull ghcr.io/superradcompany/microsandbox:0.4.0
+```
+
+## Run a sandbox
+
+The container requires `--privileged` and `/dev/kvm` access to run microVMs:
+
+```bash
+docker run --privileged --device /dev/kvm \
+  ghcr.io/superradcompany/microsandbox:latest \
+  run python --name my-sandbox --replace
+```
+
+## Persistent data
+
+By default, sandbox data (images, cache, databases) is stored inside the container and lost when it stops. Mount a volume to persist data across restarts:
+
+```bash
+docker run --privileged --device /dev/kvm \
+  -v microsandbox_data:/root/.microsandbox \
+  ghcr.io/superradcompany/microsandbox:latest \
+  run python --name my-sandbox --replace
+```
+
+## Available tags
+
+| Tag | Description |
+|-----|-------------|
+| `latest` | Latest release |
+| `x.y.z` (e.g. `0.4.0`) | Specific version |
+| `x.y` (e.g. `0.4`) | Latest patch of a minor version |

--- a/docs/fr/recipes/local-images.mdx
+++ b/docs/fr/recipes/local-images.mdx
@@ -1,0 +1,72 @@
+---
+title: Using Local Docker Images
+description: Use locally built Docker images with microsandbox via a local registry
+icon: "boxes-stacked"
+---
+
+microsandbox pulls images from OCI-compatible registries. If you build an image locally with `docker build`, microsandbox can't access it directly from Docker's local store. The workaround is to run a local registry and push your image there.
+
+## Step 1: Start a local registry
+
+Run a local OCI registry on port 5050:
+
+```bash
+docker run -d -p 5050:5000 --name registry registry:2
+```
+
+<Tip>
+  Port 5000 is used by AirPlay on macOS. This guide uses port 5050 to avoid conflicts.
+</Tip>
+
+## Step 2: Build, tag, and push your image
+
+Build your Docker image and tag it for the local registry:
+
+```bash
+docker build -t localhost:5050/my-image:latest .
+```
+
+If you already have an existing image, re-tag it:
+
+```bash
+docker tag my-image:latest localhost:5050/my-image:latest
+```
+
+Push to the local registry:
+
+```bash
+docker push localhost:5050/my-image:latest
+```
+
+## Step 3: Pull with microsandbox
+
+Since the local registry runs over plain HTTP, use the `--insecure` flag:
+
+```bash
+msb pull localhost:5050/my-image:latest --insecure
+```
+
+## Step 4: Use it in microsandbox
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("localhost:5050/my-image:latest")
+    .registry(|r| r.insecure())
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("localhost:5050/my-image:latest")
+    .registry((r) => r.insecure())
+    .create();
+```
+</CodeGroup>
+
+<Tip>
+  For persistent configuration that applies to all CLI and SDK operations, add the registry to `~/.microsandbox/config.json` instead. See [Registry TLS](/images/overview#registry-tls).
+</Tip>

--- a/docs/fr/recipes/systemd-services.mdx
+++ b/docs/fr/recipes/systemd-services.mdx
@@ -1,0 +1,65 @@
+---
+title: Booting Under systemd
+description: Hand PID 1 to systemd inside the guest so services run under a real init
+icon: "gear"
+---
+
+By default the microsandbox agent is PID 1. That's enough for one-shot processes, but anything that calls into `systemctl`, `loginctl`, or expects a session bus will fail.
+
+`--init auto` hands PID 1 over to systemd. The rest of the guest then behaves like a normal Linux box.
+
+## Step 1: Boot
+
+```bash
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  --memory 1G --cpus 2 \
+  --init auto \
+  -- bash
+```
+
+`debian-systemd` is one of the optional bases we maintain in [guest-images](https://github.com/superradcompany/guest-images) for cases like this. `--init auto` probes a small set of well-known paths and picks the first that exists. See [Custom init system](/sandboxes/customize#custom-init-system) for the full list and for pinning to an exact path.
+
+## Step 2: Confirm systemd is PID 1
+
+```bash
+root@msb:/# systemctl status
+● msb
+    State: running
+    Units: 113 loaded (incl. loaded aliases)
+  systemd: 252.39-1~deb12u1
+```
+
+Or check directly:
+
+```bash
+root@msb:/# cat /proc/1/comm
+systemd
+```
+
+## Step 3: Manage units
+
+`systemctl` works as it does on bare metal. Inspect a unit shipped with the image:
+
+```bash
+root@msb:/# systemctl status systemd-journald
+● systemd-journald.service - Journal Service
+     Loaded: loaded (/lib/systemd/system/systemd-journald.service; static)
+     Active: active (running)
+```
+
+Install your own and start it:
+
+```bash
+root@msb:/# apt update && apt install -y nginx
+root@msb:/# systemctl enable --now nginx
+root@msb:/# curl -s localhost | head -1
+<!DOCTYPE html>
+```
+
+Microsandbox is detected as a container, so packages with `policy-rc.d` deferral install but don't auto-start. `systemctl enable --now <unit>` starts them in one step.
+
+## Notes
+
+- **Image choice matters.** Distroless / minimal images (`python:3.13-slim`, `alpine`) don't ship a systemd init binary; `--init auto` will fail and `kernel.log` will list every path it tried. Use a systemd-equipped base or layer one in.
+- **Memory budget.** systemd's idle footprint is ~50 MiB; daemons add more. Bump `--memory` if your service is hungry.
+- **Other inits work.** `--init` accepts any absolute path. s6, OpenRC, runit, or a hand-rolled `/sbin/init` shell script are all fine; `auto` just covers the systemd-on-Debian/Ubuntu case.

--- a/docs/fr/sandboxes/commands.mdx
+++ b/docs/fr/sandboxes/commands.mdx
@@ -1,0 +1,284 @@
+---
+title: Commands
+description: Execute commands, stream output, and interact with sandboxes
+icon: "terminal"
+---
+
+Command execution doesn't use SSH or the network. There's a dedicated channel between the host and a guest agent running inside the VM, completely separate from the sandbox's network stack. The agent spawns processes, streams output back, and reports exit codes.
+
+One nice consequence: `exec` works even when a sandbox has networking fully disabled.
+
+## Execute a command
+
+Run a command and wait for it to complete. You get back the exit code, stdout, and stderr.
+
+<CodeGroup>
+```rust Rust
+let output = sb.exec("python", ["-c", "print('hello')"]).await?;
+println!("{}", output.stdout()?);     // "hello\n"
+println!("{}", output.status().code); // 0
+```
+
+```typescript TypeScript
+const output = await sb.exec("python", ["-c", "print('hello')"]);
+console.log(output.stdout()); // "hello\n"
+console.log(output.success);  // true
+console.log(output.code);     // 0
+```
+
+```python Python
+output = await sb.exec("python", ["-c", "print('hello')"])
+print(output.stdout_text)     # "hello\n"
+print(output.success)         # True
+print(output.exit_code)       # 0
+```
+
+```bash CLI
+msb exec worker -- python -c "print('hello')"
+```
+
+</CodeGroup>
+
+## Execution options
+
+These options apply to a single execution and don't change the sandbox's defaults.
+
+<CodeGroup>
+```rust Rust
+let output = sb.exec_with("python", |e| e
+    .args(["compute.py"])
+    .cwd("/app")
+    .env("PYTHONPATH", "/app/lib")
+    .timeout(Duration::from_secs(30))
+    .rlimit(RlimitResource::Nofile, 1024)
+).await?;
+```
+
+```typescript TypeScript
+const output = await sb.execWith("python", (e) =>
+    e.args(["compute.py"])
+        .cwd("/app")
+        .env("PYTHONPATH", "/app/lib")
+        .timeout(30_000)
+        .rlimit("nofile", 1024),
+);
+```
+
+```python Python
+from microsandbox import ExecOptions, Rlimit
+
+output = await sb.exec("python", ExecOptions(
+    args=("compute.py",),
+    cwd="/app",
+    env={"PYTHONPATH": "/app/lib"},
+    timeout=30.0,
+    rlimits=(Rlimit.nofile(1024),),
+))
+```
+
+```bash CLI
+msb exec worker \
+  -w /app \
+  -e PYTHONPATH=/app/lib \
+  --timeout 30s \
+  --rlimit nofile=1024 \
+  -- python compute.py
+```
+
+</CodeGroup>
+
+## Shell commands
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Useful for pipelines, redirects, and other shell syntax that `exec` doesn't interpret.
+
+<CodeGroup>
+```rust Rust
+let output = sb.shell("ls -la /app && echo done").await?;
+```
+
+```typescript TypeScript
+const output = await sb.shell("ls -la /app && echo done")
+```
+
+```python Python
+output = await sb.shell("ls -la /app && echo done")
+```
+
+```bash CLI
+msb exec worker -- sh -c "ls -la /app && echo done"
+```
+
+</CodeGroup>
+
+## Stream output
+
+For long-running processes or large output, streaming gives you stdout, stderr, and exit events as they happen instead of buffering everything until the command finishes.
+
+<CodeGroup>
+```rust Rust
+let mut handle = sb.exec_stream("tail", ["-f", "/var/log/app.log"]).await?;
+
+while let Some(event) = handle.recv().await {
+    match event {
+        ExecEvent::Stdout(data) => print!("{}", String::from_utf8_lossy(&data)),
+        ExecEvent::Stderr(data) => eprint!("{}", String::from_utf8_lossy(&data)),
+        ExecEvent::Exited { code } => break,
+        _ => {}
+    }
+}
+```
+
+```typescript TypeScript
+const handle = await sb.execStream("tail", ["-f", "/var/log/app.log"]);
+
+for await (const event of handle) {
+    switch (event.kind) {
+        case "stdout": process.stdout.write(event.data); break;
+        case "stderr": process.stderr.write(event.data); break;
+        case "exited": console.log(`Exited: ${event.code}`); break;
+    }
+}
+```
+
+```python Python
+handle = await sb.exec_stream("tail", ["-f", "/var/log/app.log"])
+
+async for event in handle:
+    match event.event_type:
+        case "stdout": print(event.data.decode(), end="")
+        case "stderr": print(event.data.decode(), end="", file=sys.stderr)
+        case "exited": print(f"Exited: {event.code}")
+```
+
+</CodeGroup>
+
+## Interactive attach
+
+Bridges your terminal directly to a process inside the sandbox for a fully interactive PTY session. Useful for debugging, running REPLs, or anything that expects a real terminal.
+
+<CodeGroup>
+```rust Rust
+let exit_code = sb.attach_shell().await?;
+
+let exit_code = sb.attach_with("python", |a| a
+    .env("DEBUG", "1")
+    .cwd("/app")
+    .detach_keys("ctrl-q")
+).await?;
+```
+
+```typescript TypeScript
+// Attach to the default shell
+const exitCode = await sb.attachShell();
+
+// Attach to a specific command with custom detach keys
+await sb.attachWith("bash", (a) =>
+    a.env("DEBUG", "1").cwd("/app").detachKeys("ctrl-q"),
+);
+```
+
+```python Python
+from microsandbox import AttachOptions
+
+# Attach to the default shell
+exit_code = await sb.attach_shell()
+
+# Attach to a specific command with custom detach keys
+exit_code = await sb.attach("python", AttachOptions(
+    env={"DEBUG": "1"},
+    cwd="/app",
+    detach_keys="ctrl-q",
+))
+```
+
+```bash CLI
+# Attach to the default shell
+msb exec -t worker
+
+# Attach to a specific command
+msb exec -t worker -e DEBUG=1 -w /app -- python
+```
+
+</CodeGroup>
+
+<Tip>
+  Press `Ctrl+]` (or your configured detach keys) to detach from the session without stopping the process. The process keeps running inside the VM and you can reattach later via its session ID.
+</Tip>
+
+## Write stdin
+
+Streaming handles can also accept stdin. Enable `stdin_pipe` and write bytes to it. Combined with `tty: true`, this lets you drive interactive processes programmatically.
+
+<CodeGroup>
+```rust Rust
+let mut handle = sb.exec_stream_with("python", |e| e.stdin_pipe().tty(true)).await?;
+let stdin = handle.take_stdin().unwrap();
+stdin.write(b"print('hello')\n").await?;
+stdin.write(b"exit()\n").await?;
+handle.wait().await?;
+```
+
+```typescript TypeScript
+const handle = await sb.execStreamWith("python", (e) => e.stdinPipe().tty(true));
+const stdin = await handle.takeStdin();
+await stdin!.write("print('hello')\n");
+await stdin!.write("exit()\n");
+await stdin!.close();
+await handle.wait();
+```
+
+```python Python
+from microsandbox import ExecOptions, Stdin
+
+handle = await sb.exec_stream("python", ExecOptions(stdin=Stdin.pipe(), tty=True))
+stdin = handle.take_stdin()
+await stdin.write(b"print('hello')\n")
+await stdin.write(b"exit()\n")
+await stdin.close()
+await handle.wait()
+```
+
+</CodeGroup>
+
+## Sessions <sup><sup>coming soon</sup></sup>
+
+Each streaming exec or attach creates a session. You can list active sessions and reattach to them by ID. Up to 16 simultaneous client connections are supported, so multiple sessions can run concurrently without interfering with each other.
+
+<CodeGroup>
+```rust Rust
+// Start a background process and capture its session ID
+let handle = sb.exec_stream("python", ["server.py"]).await?;
+let session_id = handle.id().to_string();
+
+// List active sessions
+let sessions = sb.sessions().await?;
+
+// Reattach to a session by ID
+let mut handle = sb.session(&session_id).await?;
+```
+
+```typescript TypeScript
+// Start a background process and capture its session ID
+const handle = await sb.execStream("python", ["server.py"])
+const sessionId = handle.id
+
+// List active sessions
+const sessions = await sb.sessions()
+
+// Reattach to a session by ID
+const reattached = await sb.session(sessionId)
+```
+
+```python Python
+# Start a background process and capture its session ID
+handle = await sb.exec_stream("python", ["server.py"])
+session_id = handle.id
+
+# List active sessions
+sessions = await sb.sessions()
+
+# Reattach to a session by ID
+reattached = await sb.session(session_id)
+```
+
+</CodeGroup>

--- a/docs/fr/sandboxes/customize.mdx
+++ b/docs/fr/sandboxes/customize.mdx
@@ -1,0 +1,339 @@
+---
+title: Customize
+description: Inject scripts, modify the rootfs, and choose your own init
+icon: "wand-magic-sparkles"
+---
+
+Before a sandbox starts doing real work, you can prepare it three ways. **Scripts** bundle reusable commands. **Patches** modify the rootfs before the VM boots. A **custom init system** (systemd, OpenRC, s6) can run as PID 1 instead of microsandbox's minimal agent. All three are defined at creation time and keep the base image untouched.
+
+## Scripts
+
+Scripts are files mounted at `/.msb/scripts/` inside the sandbox. The directory is on `PATH`, so each script is callable by name through `exec()` or `shell()`.
+
+It provides a clean way to bundle setup procedures or entry points with a sandbox without baking them into the image.
+
+<CodeGroup>
+```rust Rust
+use indoc::indoc;
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("ubuntu")
+    .script("setup", indoc! {"
+        #!/bin/bash
+        apt-get update && apt-get install -y python3 curl
+    "})
+    .script("start", indoc! {"
+        #!/bin/bash
+        exec python3 /app/main.py
+    "})
+    .create()
+    .await?;
+
+sb.shell("setup").await?;
+let output = sb.shell("start").await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("ubuntu")
+    .script("setup", "#!/bin/bash\napt-get update && apt-get install -y python3 curl")
+    .script("run",   "#!/bin/bash\nexec python3 /app/main.py")
+    .create();
+
+await sb.shell("setup");
+const output = await sb.shell("run");
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ubuntu",
+    scripts={
+        "setup": "#!/bin/bash\napt-get update && apt-get install -y python3 curl",
+        "start": "#!/bin/bash\nexec python3 /app/main.py",
+    },
+)
+
+await sb.shell("setup")
+output = await sb.shell("start")
+```
+
+</CodeGroup>
+
+## Patches
+
+Patches modify the rootfs **before the VM boots**. Write config files, copy directories from the host, create symlinks, append to existing files, remove things you don't need. The base image stays untouched since patches are written to the writable layer on top.
+
+Patches are applied in order and work with OCI images and bind-mounted rootfs. They're not supported with disk image roots (QCOW2, Raw).
+
+<Tip>
+  By default, patching a path that already exists in the image will error. Pass `replace: true` on the operation to allow it. `Mkdir` and `Remove` are idempotent and won't error either way.
+</Tip>
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("alpine")
+    .patch(|p| p
+        .text("/etc/greeting.txt", "Hello from a patched rootfs!\n", None, false)
+        .text("/etc/motd", "Custom message of the day.\n", None, true) // replace existing
+        .mkdir("/app", Some(0o755))
+        .text("/app/config.json", r#"{"debug": true}"#, Some(0o644), false)
+        .copy_file("./cert.pem", "/etc/ssl/cert.pem", None, false)
+        .append("/etc/hosts", "127.0.0.1 myapp.local\n")
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("alpine")
+    .patch((p) => p
+        .text("/etc/greeting.txt", "Hello from a patched rootfs!\n")
+        .text("/etc/motd", "Custom message of the day.\n", { replace: true })
+        .mkdir("/app", { mode: 0o755 })
+        .text("/app/config.json", '{"debug": true}', { mode: 0o644 })
+        .copyFile("./cert.pem", "/etc/ssl/cert.pem")
+        .append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+    )
+    .create();
+```
+
+```python Python
+from microsandbox import Patch, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="alpine",
+    patches=[
+        Patch.text("/etc/greeting.txt", "Hello from a patched rootfs!\n"),
+        Patch.text("/etc/motd", "Custom message of the day.\n", replace=True),
+        Patch.mkdir("/app", mode=0o755),
+        Patch.text("/app/config.json", '{"debug": true}', mode=0o644),
+        Patch.copy_file("./cert.pem", "/etc/ssl/cert.pem"),
+        Patch.append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+    ],
+)
+```
+
+</CodeGroup>
+
+### Available operations
+
+The patch builder appends operations in the order you call them; calls are chainable. Available operations across SDKs: `text`, `file`, `mkdir`, `append`, `copyFile` / `copy_file`, `copyDir` / `copy_dir`, `symlink`, `remove`.
+
+Full per-language signatures, parameters, and option shapes are documented in the SDK references:
+
+- Rust: [`PatchBuilder`](/sdk/rust/sandbox#patchbuilder)
+- TypeScript: [`PatchBuilder`](/sdk/typescript/sandbox#patchbuilder)
+- Python: [`Patch`](/sdk/python/sandbox#patch) (factory) and [`PatchConfig`](/sdk/python/sandbox#patchconfig) (the value type)
+
+## Custom init system
+
+By default the microsandbox agent runs as PID 1 inside the guest: small, fast, minimal. For workloads that expect a real init (systemd, OpenRC, s6, runit, etc.), `--init` hands PID 1 over to the init binary of your choice.
+
+The handoff sequence:
+
+- Agent does the boot-time setup: mount filesystems, configure network, prepare runtime dirs.
+- Agent forks.
+- Parent execs your init and becomes PID 1.
+- Child agent continues serving host requests over the same channel.
+
+Common reasons to opt in: long-lived daemons, system service tests, anything that talks to dbus or expects `systemctl` to work.
+
+The simplest entry point is `auto`, which probes a small list of well-known paths inside the guest rootfs and picks the first one that exists:
+
+- `/sbin/init`
+- `/lib/systemd/systemd`
+- `/usr/lib/systemd/systemd`
+
+Pass an absolute path instead when you need pinning (e.g. for reproducible CI).
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .memory(1024)
+    .cpus(2)
+    .init("auto")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { MiB, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .memory(MiB(1024))
+    .cpus(2)
+    .init("auto")
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ghcr.io/superradcompany/debian-systemd:12",
+    memory=1024,
+    cpus=2,
+    init="auto",
+)
+```
+
+```bash CLI
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  -m 1G -c 2 \
+  --init auto \
+  -- bash
+```
+</CodeGroup>
+
+To verify the handoff worked, check `/proc/1/comm` inside the sandbox. It should print the init's name (`systemd`, `init`, etc.):
+
+```bash
+$ msb run ghcr.io/superradcompany/debian-systemd:12 --init auto -- cat /proc/1/comm
+systemd
+```
+
+If `--init=auto` can't find anything in its candidate list, agentd fails boot with a clear error in `kernel.log` listing every path it checked. Switch to an explicit path (`--init=/lib/systemd/systemd`) when you know exactly where the init lives, or follow the image-picking guidance below to choose an image that actually ships one.
+
+### Argv and env
+
+Pass extra argv and env to the init:
+
+- **Rust / TypeScript**: `init_with(...)` / `initWith(...)`.
+- **Python**: pass an `InitConfig` to `init=`.
+- **CLI**: repeat `--init-arg` once per entry, and `--init-env KEY=VAL` once per env var.
+
+Argv defaults to `[<cmd>]` when none is given; env is merged on top of the inherited environment.
+
+<CodeGroup>
+```bash CLI
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  --init /lib/systemd/systemd \
+  --init-arg --unit=multi-user.target \
+  --init-env container=microsandbox \
+  -- bash
+```
+
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .init_with("/lib/systemd/systemd", |i| i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .initWith("/lib/systemd/systemd", (i) => i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create();
+```
+
+```python Python
+from microsandbox import InitConfig, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ghcr.io/superradcompany/debian-systemd:12",
+    init=InitConfig(
+        cmd="/lib/systemd/systemd",
+        args=("--unit=multi-user.target",),
+        env={"container": "microsandbox"},
+    ),
+)
+```
+</CodeGroup>
+
+### Picking an image
+
+Most slim Docker base images (`debian:bookworm-slim`, `ubuntu:24.04`, `python:3.12-slim`) are stripped of init binaries; they're built for "one process per container" and don't ship systemd at all. If you point `--init` at a path the image doesn't contain, the agent's pre-flight check fails boot with a clear error in the kernel log (no kernel panic).
+
+Three ways to get an image with an init:
+
+<AccordionGroup>
+  <Accordion title="Use one of our published guest images">
+    We maintain a small collection at [`superradcompany/guest-images`](https://github.com/superradcompany/guest-images) for the cases where you specifically need a real init. Current set:
+
+    | Image | Pull |
+    |-------|------|
+    | Debian + systemd | `ghcr.io/superradcompany/debian-systemd:12` |
+    | Ubuntu + systemd | `ghcr.io/superradcompany/ubuntu-systemd:24.04` |
+    | Fedora + systemd | `ghcr.io/superradcompany/fedora-systemd:40` |
+    | Alpine + OpenRC | `ghcr.io/superradcompany/alpine-openrc:3.20` |
+
+    Multi-arch (`linux/amd64` + `linux/arm64`), rebuilt weekly so they pick up upstream security patches, smoke-tested on every rebuild. Each image's GHCR page documents its specific tag aliases and contents.
+  </Accordion>
+  <Accordion title="Build a small custom image">
+    ```dockerfile
+    # Dockerfile.systemd
+    FROM debian:bookworm
+    RUN apt-get update \
+        && apt-get install -y --no-install-recommends systemd \
+        && rm -rf /var/lib/apt/lists/*
+    ```
+
+    ```bash
+    docker buildx build -t local-systemd:debian -f Dockerfile.systemd .
+    msb run local-systemd:debian --init /lib/systemd/systemd -- bash
+    ```
+  </Accordion>
+  <Accordion title="Use a community-built systemd image">
+    Examples: `jrei/systemd-debian:12`, `jrei/systemd-ubuntu:22.04`. These work out of the box but are published by community maintainers, not the distros themselves. Vet them like any other third-party image before running real workloads.
+  </Accordion>
+</AccordionGroup>
+
+For a sanity check that doesn't need systemd, `alpine:3.20` ships BusyBox at `/sbin/init`, which is enough to exercise the handoff mechanics:
+
+```bash
+msb run alpine:3.20 --init /sbin/init -- sh -c "cat /proc/1/comm"
+# busybox
+```
+
+### Shutdown semantics
+
+Without `--init`, microsandbox shuts the guest down by remounting root read-only and calling `reboot(RB_POWER_OFF)`. Typically &lt;100 ms.
+
+With `--init`, the agent isn't PID 1 anymore, so it asks your init to shut down:
+
+- `SIGRTMIN+4` first (systemd's poweroff signal).
+- `SIGTERM` fallback for inits that don't speak it.
+
+Your init then runs its own teardown (stop services, unmount, halt), which is slower:
+
+| Init | Typical shutdown |
+|------|------------------|
+| BusyBox / s6 / runit | &lt;100 ms |
+| OpenRC | 50-500 ms |
+| systemd | 1-5 s |
+
+This is the price of a real init. If your test harness measures end-to-end sandbox lifecycle and you're comparing to a no-handoff baseline, account for this.
+
+### Init and entrypoint
+
+`--init` and `--entrypoint` are orthogonal:
+
+- `--init` controls **PID 1**: what runs the system.
+- `--entrypoint` (and the trailing `-- cmd`) controls **what your workload runs**.
+
+They can be combined. Boot systemd as PID 1 and have microsandbox `exec` calls land your shell, scripts, or app inside the systemd-managed environment.

--- a/docs/fr/sandboxes/events.mdx
+++ b/docs/fr/sandboxes/events.mdx
@@ -1,0 +1,110 @@
+---
+title: Events
+description: Bidirectional host-guest communication
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+The events API is for structured communication between host and guest beyond stdin/stdout. The host can subscribe to named events from the guest and emit events back, all through the same channel used by `exec`.
+
+On the guest side, processes just write JSON to `/run/agent.sock`, which is a standard Unix domain socket. No special library needed. Any language that can open a socket and write a newline-delimited JSON message will work.
+
+## Basic example
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, EventData};
+use serde::Deserialize;
+
+let sb = Sandbox::get("worker").await?.start().await?;
+
+let _sub = sb.on_event("task.progress", |event: EventData| {
+    #[derive(Deserialize)]
+    struct Progress { percent: u32, message: String }
+
+    if let Some(data) = event.data {
+        if let Ok(p) = data.deserialized::<Progress>() {
+            println!("[{}%] {}", p.percent, p.message);
+        }
+    }
+});
+```
+
+```typescript TypeScript
+import { Sandbox, EventData } from 'microsandbox'
+
+const sb = await Sandbox.get("worker")
+
+const sub = sb.onEvent("task.progress", (event: EventData) => {
+    const { percent, message } = event.data as { percent: number; message: string }
+    console.log(`[${percent}%] ${message}`)
+})
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await (await Sandbox.get("worker")).start()
+
+sub = sb.on_event("task.progress", lambda event: (
+    print(f"[{event.data['percent']}%] {event.data['message']}")
+))
+```
+
+</CodeGroup>
+
+## Send events to guest
+
+Emit a named event with typed data into the guest. Any process listening on the agent socket receives it.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct TaskConfig { input_file: String, output_dir: String }
+
+sb.emit("task.start", TaskConfig {
+    input_file: "/data/input.txt".into(),
+    output_dir: "/data/output".into(),
+}).await?;
+```
+
+```typescript TypeScript
+await sb.emit("task.start", {
+    inputFile: "/data/input.txt",
+    options: ["--verbose"],
+})
+```
+
+```python Python
+await sb.emit("task.start", {
+    "input_file": "/data/input.txt",
+    "output_dir": "/data/output",
+})
+```
+
+</CodeGroup>
+
+## Guest-side emitting
+
+Inside the guest, any process can emit events by writing JSON to the Unix domain socket at `/run/agent.sock`. No SDK required.
+
+```python
+# Inside the guest, plain Python, no SDK
+import json, socket
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect("/run/agent.sock")
+sock.sendall(json.dumps({
+    "event": "task.progress",
+    "data": {"percent": 50, "message": "Halfway done"},
+}).encode() + b"\n")
+sock.close()
+```
+
+The host subscription registered with `on_event("task.progress", ...)` receives this message automatically.

--- a/docs/fr/sandboxes/filesystem.mdx
+++ b/docs/fr/sandboxes/filesystem.mdx
@@ -1,0 +1,240 @@
+---
+title: Filesystem
+description: Read and write files inside a running sandbox
+icon: "folder-open"
+---
+
+The filesystem API lets you read, write, and manage files inside a sandbox without mounting volumes or SSH. It uses the same channel as command execution, so it doesn't touch the sandbox's network.
+
+Handy for pushing generated code into a sandbox, pulling back results, or inspecting logs without having to pre-mount a shared directory.
+
+## Write a file
+
+<CodeGroup>
+```rust Rust
+sb.fs().write("/app/config.json", r#"{"debug": true}"#).await?;
+```
+
+```typescript TypeScript
+await sb.fs().write("/app/config.json", '{"debug": true}');
+```
+
+```python Python
+await sb.fs.write("/app/config.json", b'{"debug": true}')
+```
+
+</CodeGroup>
+
+## Read a file
+
+<CodeGroup>
+```rust Rust
+let content = sb.fs().read_to_string("/app/config.json").await?;
+```
+
+```typescript TypeScript
+const content = await sb.fs().readToString("/app/config.json");
+```
+
+```python Python
+content = await sb.fs.read_text("/app/config.json")
+```
+
+</CodeGroup>
+
+## List a directory
+
+<CodeGroup>
+```rust Rust
+let entries = sb.fs().list("/app").await?;
+for entry in entries {
+    println!("{}: {:?}", entry.path, entry.kind);
+}
+```
+
+```typescript TypeScript
+const entries = await sb.fs().list("/app");
+for (const entry of entries) {
+    console.log(`${entry.path}: ${entry.kind}`);
+}
+```
+
+```python Python
+entries = await sb.fs.list("/app")
+for entry in entries:
+    print(f"{entry.path}: {entry.kind}")
+```
+
+</CodeGroup>
+
+## Stream large files
+
+For files too large to fit in memory, use streaming. Data is transferred in chunks of approximately 3 MiB each.
+
+<CodeGroup>
+```rust Rust
+let mut stream = sb.fs().read_stream("/app/data.bin").await?;
+while let Some(chunk) = stream.recv().await? {
+    process(&chunk);
+}
+```
+
+```typescript TypeScript
+const stream = await sb.fs().readStream("/app/data.bin");
+for await (const chunk of stream) {
+    processChunk(chunk); // chunk is a Uint8Array
+}
+```
+
+```python Python
+stream = await sb.fs.read_stream("/app/data.bin")
+async for chunk in stream:
+    process(chunk)
+```
+
+</CodeGroup>
+
+## Copy from host
+
+Copy a file from the host machine into the sandbox in a single call.
+
+<CodeGroup>
+```rust Rust
+sb.fs().copy_from_host("./local-file.txt", "/app/remote-file.txt").await?;
+```
+
+```typescript TypeScript
+await sb.fs().copyFromHost("./local-file.txt", "/app/remote-file.txt");
+```
+
+```python Python
+await sb.fs.copy_from_host("./local-file.txt", "/app/remote-file.txt")
+```
+
+</CodeGroup>
+
+<Tip>
+  If you need to transfer many files at once, consider using a [bind-mounted volume](/sandboxes/volumes) instead. Volumes give the guest direct filesystem access, whereas the filesystem API transfers each file individually. For bulk operations, volumes are significantly faster.
+</Tip>
+
+## Extensible backends
+
+The default filesystem backends handle most use cases. For advanced scenarios, you can attach hooks to intercept operations on a volume, or implement a full custom backend.
+
+### Hooks <sup><sup>coming soon</sup></sup>
+
+Intercept file reads and writes on a volume without replacing the entire backend. Hooks receive the path and data, and return transformed data. The underlying filesystem handles everything else (permissions, directories, metadata).
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let key = get_encryption_key();
+let sb = Sandbox::builder("encrypted")
+    .image("python")
+    .volume("/secrets", |v| v
+        .bind("/data/secrets")
+        .on_read(move |_path, data| decrypt(data, &key))
+        .on_write(move |_path, data| encrypt(data, &key))
+    )
+    .create().await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+// Hooks are coming soon. The planned shape will sit alongside the regular
+// mount methods on the volume builder, e.g.:
+//
+//   .volume("/secrets", (m) => m
+//       .bind("/data/secrets")
+//       .onRead((path, data) => decrypt(data, key))
+//       .onWrite((path, data) => encrypt(data, key)),
+//   )
+//
+// For now the closest equivalent is a plain bind:
+await using sb = await Sandbox.builder("encrypted")
+    .image("python")
+    .volume("/secrets", (m) => m.bind("/data/secrets"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+key = get_encryption_key()
+sb = await Sandbox.create(
+    "encrypted",
+    image="python",
+    volumes={
+        "/secrets": Volume.bind("/data/secrets",
+            on_read=lambda path, data: decrypt(data, key),
+            on_write=lambda path, data: encrypt(data, key),
+        ),
+    },
+)
+```
+
+</CodeGroup>
+
+### Custom backend <sup><sup>coming soon</sup></sup>
+
+For full control, implement the `FsBackend` trait (Rust) or class (TypeScript). This gives you access to every POSIX operation: `read`, `write`, `lookup`, `getattr`, `readdir`, etc. You can delegate to a built-in backend (like `PassthroughFs`) for operations you don't need to customize.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{FsBackend, PassthroughFs};
+use std::io;
+
+struct EncryptedFs { key: [u8; 32], inner: PassthroughFs }
+
+impl FsBackend for EncryptedFs {
+    fn read(&self, ctx: Context, inode: u64, handle: u64,
+            buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        let n = self.inner.read(ctx, inode, handle, buf, offset)?;
+        self.decrypt_in_place(&mut buf[..n]);
+        Ok(n)
+    }
+    fn write(&self, ctx: Context, inode: u64, handle: u64,
+             buf: &[u8], offset: u64) -> io::Result<usize> {
+        let encrypted = self.encrypt(buf);
+        self.inner.write(ctx, inode, handle, &encrypted, offset)
+    }
+    // ... remaining methods delegate to self.inner
+}
+
+let sb = Sandbox::builder("custom")
+    .volume("/secrets", |v| v.backend(EncryptedFs::new(key, "/data")?))
+    .create().await?;
+```
+
+```typescript TypeScript
+// FsBackend is coming soon. The planned API will let you plug a custom
+// backend into a volume:
+//
+//   class EncryptedFs implements FsBackend {
+//     // ... implement read, write, and other required methods
+//   }
+//
+//   const sb = await Sandbox.builder("custom")
+//     .volume("/secrets", (m) => m.backend(new EncryptedFs(key, "/data")))
+//     .create();
+```
+
+```python Python
+from microsandbox import FsBackend, Sandbox, Volume
+
+# Implement the FsBackend interface
+class EncryptedFs(FsBackend):
+    # ... implement read, write, and other required methods
+    pass
+
+sb = await Sandbox.create(
+    "custom",
+    volumes={
+        "/secrets": Volume.backend(EncryptedFs(key, "/data")),
+    },
+)
+```
+
+</CodeGroup>

--- a/docs/fr/sandboxes/lifecycle.mdx
+++ b/docs/fr/sandboxes/lifecycle.mdx
@@ -1,0 +1,401 @@
+---
+title: Lifecycle
+description: Create, start, stop, and manage sandbox state
+icon: "rotate"
+---
+
+Each sandbox runs as a child process of whatever application creates it. `Sandbox.builder(...).create()` boots a microVM, starts the guest agent inside it, and establishes a communication channel back to the host.
+
+Understanding the lifecycle is useful once you start managing long-running sandboxes, graceful shutdown, or resilient agent workflows.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Creating: create()
+    Creating --> Running: boot complete
+    Running --> Paused: pause()
+    Paused --> Running: resume()
+    Running --> Draining: drain()
+    Running --> Stopped: stop()
+    Running --> Crashed: unexpected exit
+    Draining --> Stopped: drain complete
+    Stopped --> Running: start()
+    Stopped --> [*]: remove()
+    Crashed --> [*]: remove()
+```
+
+## States
+
+| Status | Description |
+|--------|-------------|
+| **Creating** | The VM is booting. The kernel is loaded, the filesystem is mounted, and the guest agent is initializing (configuring network, setting up the environment). |
+| **Running** | The guest agent is ready. You can call `exec`, `shell`, `fs`, and `emit`. |
+| **Paused** | All guest processes are frozen. No CPU cycles consumed. Resume is instant with no re-boot or re-init. |
+| **Draining** | Graceful shutdown in progress. Existing commands run to completion, but new `exec` calls are rejected. Transitions to Stopped when all commands finish. |
+| **Stopped** | The VM has shut down. Sandbox configuration and state are persisted to the database and can be restarted. |
+| **Crashed** | The VM exited unexpectedly (e.g., kernel panic, OOM kill). |
+
+## Create a sandbox
+
+Creating a sandbox boots the microVM, mounts the filesystem, initializes the guest agent, and waits until it's ready to accept commands.
+
+<CodeGroup>
+```rust Rust
+// Attached: sandbox stops when your process exits
+let sb = Sandbox::builder("worker").image("python").create().await?;
+
+// Detached: sandbox survives after your process exits
+let sb = Sandbox::builder("worker").image("python").create_detached().await?;
+```
+
+```typescript TypeScript
+// Attached: sandbox stops when your process exits
+await using sb = await Sandbox.builder("worker").image("python").create();
+
+// Detached: sandbox survives after your process exits
+const detached = await Sandbox.builder("worker").image("python").createDetached();
+```
+
+```python Python
+# Attached: sandbox stops when your process exits
+sb = await Sandbox.create("worker", image="python")
+
+# Detached: sandbox survives after your process exits
+sb = await Sandbox.create("worker", image="python", detached=True)
+```
+
+```bash CLI
+# Attached
+msb create python --name worker
+
+# Detached
+msb run -d python --name worker
+```
+
+</CodeGroup>
+
+## Stop and restart
+
+Stopping gracefully terminates guest processes and shuts down the VM. The sandbox moves to `Stopped` and can be restarted later with all its configuration preserved.
+
+<CodeGroup>
+```rust Rust
+sb.stop().await?;
+
+let sb = Sandbox::start("worker").await?;
+```
+
+```typescript TypeScript
+await sb.stop()
+
+// Later, resume where you left off
+const sb = await Sandbox.start("worker")
+```
+
+```python Python
+await sb.stop()
+
+# Later, resume where you left off
+sb = await Sandbox.start("worker")
+```
+
+```bash CLI
+msb stop worker
+
+# Later, resume where you left off
+msb start worker
+```
+
+</CodeGroup>
+
+## Kill immediately
+
+If a sandbox is unresponsive (e.g., stuck in a tight loop or a panic), force-kill it. The sandbox is terminated immediately with no graceful shutdown.
+
+<CodeGroup>
+```rust Rust
+sb.kill().await?;
+```
+
+```typescript TypeScript
+await sb.kill()
+```
+
+```python Python
+await sb.kill()
+```
+
+```bash CLI
+msb stop --force worker
+```
+
+</CodeGroup>
+
+## Pause and resume <sup><sup>coming soon</sup></sup>
+
+Freeze all guest processes without shutting down. The VM uses zero CPU while paused, and resume is instant. The guest continues exactly where it left off with no boot time and no re-init.
+
+<CodeGroup>
+```rust Rust
+sb.pause().await?;
+sb.resume().await?;
+```
+
+```typescript TypeScript
+await sb.pause()
+await sb.resume()
+```
+
+```python Python
+await sb.pause()
+await sb.resume()
+```
+
+</CodeGroup>
+
+## Detach
+
+Keeps a sandbox running after the parent process exits. It becomes a background process that you can reconnect to later with `Sandbox::get("worker")`.
+
+<CodeGroup>
+```rust Rust
+sb.detach().await;
+```
+
+```typescript TypeScript
+await sb.detach()
+```
+
+```python Python
+await sb.detach()
+```
+
+</CodeGroup>
+
+<Tip>
+  Detached sandboxes are tracked at `~/.microsandbox/db/`. A background reaper periodically checks for stale sandboxes that have exited unexpectedly and cleans up their records.
+</Tip>
+
+## Drain
+
+Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and transitions to `Stopped` when all in-flight commands complete. This is useful for zero-downtime rotation of worker sandboxes.
+
+<CodeGroup>
+```rust Rust
+sb.drain().await?;
+```
+
+```typescript TypeScript
+await sb.drain()
+```
+
+```python Python
+await sb.drain()
+```
+
+</CodeGroup>
+
+## Wait
+
+Block until the sandbox exits on its own, without triggering a stop.
+
+<CodeGroup>
+```rust Rust
+let exit_status = sb.wait().await?;
+```
+
+```typescript TypeScript
+const exitStatus = await sb.wait()
+```
+
+```python Python
+code, success = await sb.wait()
+```
+
+</CodeGroup>
+
+## Remove
+
+Delete a stopped sandbox and its associated state from disk.
+
+<CodeGroup>
+```rust Rust
+Sandbox::remove("worker").await?;
+```
+
+```typescript TypeScript
+await Sandbox.remove("worker")
+```
+
+```python Python
+await Sandbox.remove("worker")
+```
+
+```bash CLI
+msb rm worker
+```
+
+</CodeGroup>
+
+## List and inspect
+
+<CodeGroup>
+```rust Rust
+for handle in Sandbox::list().await? {
+    println!("{}: {:?}", handle.name(), handle.status());
+}
+```
+
+```typescript TypeScript
+const sandboxes = await Sandbox.list();
+for (const handle of sandboxes) {
+    console.log(`${handle.name}: ${handle.status}`);
+}
+
+const handle = await Sandbox.get("worker");
+console.log(handle.status); // "running" | "stopped" | ...
+```
+
+```python Python
+for handle in await Sandbox.list():
+    print(f"{handle.name}: {handle.status}")
+
+handle = await Sandbox.get("worker")
+print(handle.status)  # "running" | "stopped" | ...
+```
+
+```bash CLI
+msb ls
+msb ps worker
+```
+
+</CodeGroup>
+
+## Runtime process architecture
+
+Here's what's running and how the pieces talk to each other.
+
+```mermaid
+graph TD
+    subgraph Host["Host"]
+        A["Your Application<br/><small>microsandbox SDK</small>"]
+        B["Sandbox Process<br/><small>VM + networking + lifecycle</small>"]
+    end
+
+    subgraph Guest["Guest VM"]
+        F["agentd<br/><small>exec, fs, events</small>"]
+    end
+
+    A -- "spawn" --> B
+    B -- "boot" --> F
+    A -. "commands & responses" .-> F
+
+    style Host fill:#f5f0ff,stroke:#a770ef,color:#333
+    style Guest fill:#fef4e8,stroke:#e8a838,color:#333
+    style A fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
+    style B fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
+    style F fill:#fdd49e,stroke:#d97706,color:#1a1a1a
+```
+
+There are two layers here. The **sandbox process** runs the VM and the networking stack on the host side, and relays messages between the application and the **guest agent** inside the VM. Up to 16 clients can connect to the same sandbox simultaneously.
+
+The sandbox process also handles:
+
+- Graceful stop and drain signals
+- Cleanup when the sandbox exits
+- Idle detection (auto-drain after a configurable timeout)
+- Maximum sandbox lifetime enforcement
+
+The sandbox process does not execute guest commands itself. It only relays traffic between your application and the guest agent.
+
+## Logs and diagnostics
+
+Each sandbox keeps four files under `<sandbox-dir>/logs/`:
+
+| File | Producer | Contents |
+|------|----------|----------|
+| `exec.log` | Host relay (tap on guest frames) | User-program stdout/stderr/output as JSON Lines |
+| `runtime.log` | Sandbox process (host) | Runtime tracing — relay setup, lifecycle, network |
+| `kernel.log` | Guest VM virtio-console | Kernel boot messages and `agentd` console |
+| `boot-error.json` | Sandbox process | Present only when the most recent start failed before the agent came up |
+
+The user-facing surface for these is [`msb logs`](/cli/sandbox-commands#msb-logs) and the SDK [`logs()`](/sandboxes/logs) method — both work on running and stopped sandboxes alike. See the [Logs](/sandboxes/logs) page for the capture model, source semantics, and diagnostic flows.
+
+When a sandbox is in the **Crashed** state, its log directory is left in place so you can read what happened. Use `msb logs --source system <name>` to see the runtime/kernel diagnostic merge.
+
+## Graceful shutdown with timeout fallback
+
+Attempt a graceful stop, then force-kill if the sandbox doesn't shut down in time.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+use std::time::Duration;
+
+let mut handle = Sandbox::get("worker").await?;
+match tokio::time::timeout(Duration::from_secs(30), handle.stop()).await {
+    Ok(Ok(())) => println!("Stopped"),
+    Ok(Err(e)) => eprintln!("Error: {e}"),
+    Err(_) => handle.kill().await?,
+}
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.get("worker");
+try {
+    await Promise.race([
+        sb.stop(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 30_000)),
+    ]);
+} catch {
+    await sb.kill();
+}
+```
+
+```python Python
+import asyncio
+from microsandbox import Sandbox
+
+handle = await Sandbox.get("worker")
+sb = await handle.connect()
+try:
+    await asyncio.wait_for(sb.stop(), timeout=30)
+except asyncio.TimeoutError:
+    await sb.kill()
+```
+
+</CodeGroup>
+
+## Sandbox process policies
+
+For production workloads, configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .max_duration(3600)
+    .idle_timeout(300)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .maxDuration(3600)   // maximum sandbox lifetime in seconds
+    .idleTimeout(300)    // auto-drain after 5 minutes of inactivity
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    max_duration=3600,
+    idle_timeout=300,
+)
+```
+
+</CodeGroup>

--- a/docs/fr/sandboxes/logs.mdx
+++ b/docs/fr/sandboxes/logs.mdx
@@ -1,0 +1,288 @@
+---
+title: Logs
+description: Capture, read, and diagnose sandbox output
+icon: "scroll"
+---
+
+Every sandbox records its captured output to disk so you can read it later — even after the sandbox stops or crashes. The CLI surface is `msb logs <name>`; the SDK surface is `logs()` on `Sandbox` and `SandboxHandle`. Both work on running and stopped sandboxes alike, with no protocol traffic — just a file read.
+
+## What's captured
+
+When a sandbox is running, the host-side **relay tap** intercepts the protocol frames flowing from the guest agent (`agentd`) and writes a copy of every exec session's stdout/stderr to `exec.log` as JSON Lines. Every session is captured, tagged with its own monotonic id so readers can group or filter by session.
+
+```jsonl
+{"t":"2026-04-30T20:32:59.688Z","s":"system","d":"--- sandbox started ---\n"}
+{"t":"2026-04-30T20:32:59.689Z","s":"stdout","d":"Listening on :8080\n","id":1}
+{"t":"2026-04-30T20:32:59.690Z","s":"stderr","d":"warn: no TLS\n","id":1}
+{"t":"2026-04-30T20:33:01.112Z","s":"stdout","d":"got request\n","id":2}
+{"t":"2026-04-30T20:33:05.220Z","s":"system","d":"--- sandbox stopped ---\n"}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `t` | RFC 3339 timestamp at the moment the chunk was captured |
+| `s` | Source tag — see [Sources](#sources) |
+| `d` | The chunk's bytes, UTF-8 lossy decoded by default |
+| `id` | Relay-monotonic session id (starts at 1, +1 per `exec`); absent on `system` entries |
+
+## Sources
+
+The `s` field tells you where each chunk came from. Four values:
+
+| Source | When emitted |
+|--------|--------------|
+| `stdout` | Captured from a session's stdout, **pipe mode** — streams stayed separated end to end. |
+| `stderr` | Captured from a session's stderr, **pipe mode**. |
+| `output` | Captured from a session running in **PTY mode**. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream. We tag them `output` rather than mislabel as `stdout` so a reader doing `jq 'select(.s == "stderr")'` doesn't accidentally pick up merged PTY bytes. |
+| `system` | Synthetic entries: lifecycle markers (`--- sandbox started ---` / `--- sandbox stopped ---`) plus runtime/kernel diagnostic lines from `runtime.log` / `kernel.log` merged in at read time when `--source system` is requested. |
+
+The default `msb logs <name>` and SDK `logs()` show `stdout` + `stderr` + `output` — all user-program output, regardless of pipe vs PTY. Add `system` explicitly when you want the diagnostics merge.
+
+<Tip>
+  **Pipe vs PTY modes.** Non-interactive `msb run` (with stdin piped or redirected) and `Sandbox.exec()` use pipe mode — streams stay separate. Interactive `msb run` from a real terminal, `msb attach`, and explicit `--tty` use PTY mode — streams are merged in the kernel. Choose pipe mode when you want clean per-stream filtering in your logs.
+</Tip>
+
+## Reading logs
+
+### From the CLI
+
+```bash
+# Default — user-program output (stdout + stderr + output)
+msb logs devbox
+
+# Tail the most recent entries
+msb logs devbox --tail 100
+
+# Follow live
+msb logs devbox -f
+
+# Filter by source
+msb logs devbox --source stderr           # just stderr (pipe-mode only)
+msb logs devbox --source output           # just PTY-merged
+msb logs devbox --source system           # runtime + kernel diagnostics
+msb logs devbox --source all              # everything, chronologically merged
+
+# Time-bounded
+msb logs devbox --since 5m                # last 5 minutes
+msb logs devbox --since 2026-04-30T20:00:00Z
+
+# Grep
+msb logs devbox --grep ERROR
+
+# Multi-session view: prefix each line with [id:N]
+msb logs devbox --show-id
+
+# Color each session distinctly (implies --show-id)
+msb logs devbox --color-sessions
+
+# Programmatic: raw JSON Lines
+msb logs devbox --json | jq 'select(.s == "stderr")'
+```
+
+See [`msb logs` reference](/cli/sandbox-commands#msb-logs) for the full flag list.
+
+### From the SDK
+
+<CodeGroup>
+```rust Rust
+use microsandbox::sandbox::{LogOptions, LogSource, Sandbox};
+
+let handle = Sandbox::get("web").await?;
+
+let entries = handle.logs(&LogOptions::default())?;
+
+for e in entries {
+    let source = match e.source {
+        LogSource::Stdout => "OUT",
+        LogSource::Stderr => "ERR",
+        LogSource::Output => "PTY",
+        LogSource::System => "SYS",
+    };
+    println!(
+        "[{}] {} {:?}: {}",
+        e.timestamp.to_rfc3339(),
+        source,
+        e.session_id,
+        String::from_utf8_lossy(&e.data).trim_end()
+    );
+}
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const handle = await Sandbox.get("web");
+
+const entries = await handle.logs();
+
+for (const e of entries) {
+    const source =
+        e.source === "stdout" ? "OUT" :
+        e.source === "stderr" ? "ERR" :
+        e.source === "output" ? "PTY" :
+        "SYS";
+
+    console.log(
+        `[${e.timestamp.toISOString()}] ${source} ${e.sessionId}: ${e.text().trimEnd()}`
+    );
+}
+```
+
+```python Python
+import asyncio
+import microsandbox
+
+async def main():
+    handle = await microsandbox.Sandbox.get("web")
+
+    entries = await handle.logs()
+
+    for e in entries:
+        source = {
+            "stdout": "OUT",
+            "stderr": "ERR",
+            "output": "PTY",
+            "system": "SYS",
+        }[e.source]
+
+        print(
+            f"[{e.timestamp_ms / 1000:.3f}] "
+            f"{source} {e.session_id}: {e.text().rstrip()}"
+        )
+
+asyncio.run(main())
+```
+</CodeGroup>
+
+### Filtering at read time
+
+All filters are client-side. The on-disk file is bounded (10 MiB rotated × 3 = 30 MiB ceiling per sandbox), so a linear scan is always cheap.
+
+<CodeGroup>
+```rust Rust
+use chrono::{Duration, Utc};
+use microsandbox::sandbox::{LogOptions, LogSource};
+
+let recent = handle.logs(&LogOptions {
+    tail: Some(50),
+    since: Some(Utc::now() - Duration::hours(1)),
+    sources: vec![
+        LogSource::Stdout,
+        LogSource::Stderr,
+        LogSource::Output,
+        LogSource::System,
+    ],
+    ..Default::default()
+})?;
+```
+
+```typescript TypeScript
+const recent = await handle.logs({
+    tail: 50,
+    since: new Date(Date.now() - 60 * 60 * 1000),
+    sources: ["stdout", "stderr", "output", "system"],
+});
+```
+
+```python Python
+import time
+
+recent = await handle.logs(
+    tail=50,
+    since_ms=(time.time() - 3600) * 1000,
+    sources=["stdout", "stderr", "output", "system"],
+)
+```
+</CodeGroup>
+
+## On-disk layout
+
+Each sandbox has its own log directory under `<sandbox-dir>/logs/`:
+
+| File | Producer | Format | Bounded? |
+|------|----------|--------|----------|
+| `exec.log` | Host relay tap | JSON Lines (one entry per chunk) | Yes — `RotatingLog`, 10 MiB × 3 |
+| `runtime.log` | Sandbox process tracing | Plain text (RFC 3339 prefix) | Yes — `RotatingLog`, 10 MiB × 3 |
+| `kernel.log` | Guest VM virtio-console | Plain text (kernel + `agentd`) | Append-only |
+| `boot-error.json` | Sandbox process (failed start only) | JSON object | Single file, atomically replaced |
+
+Lifecycle: the directory is created on `msb create`. `exec.log` gets `--- sandbox started ---` injected when the agent reports `core.ready`, and `--- sandbox stopped ---` when the sandbox process exits (the latter from the VMM's `on_exit` observer, so it fires reliably even on crashes). On `msb remove`, the entire directory is deleted.
+
+## Boot errors
+
+When a sandbox process exits before the agent relay is ready — typically a mount error, missing rootfs, or network setup failure — there's no `exec.log` content yet. The runtime writes a small structured `boot-error.json` instead:
+
+```json
+{
+  "t": "2026-04-30T20:32:59.690Z",
+  "stage": "mount",
+  "errno": 2,
+  "message": "mount tmp_x_…: No such file or directory (os error 2)"
+}
+```
+
+The CLI prepends a styled error block reconstructed from this file before any captured log content:
+
+```
+error: failed to start "dind"
+  → mount: mount tmp_x_…: No such file or directory (os error 2)
+  → the host path for one of the mounts does not exist
+  → run `msb logs --source system dind` for full diagnostics
+```
+
+`stage` values: `mount`, `build_vm`, `config`, `network`, `image`, `other`. The CLI's stage-to-hint mapper turns `(stage, errno)` into the actionable hint line.
+
+SDK callers see this as a typed [`BootStart` error](/sdk/errors#sandbox-start-failures) — match on it to recover or report cleanly.
+
+## Common diagnostic flows
+
+**"My sandbox crashed — what happened?"**
+
+```bash
+msb ls                              # confirm Crashed state
+msb logs <name>                     # what was the program doing right before?
+msb logs <name> --source system     # runtime + kernel diagnostics
+```
+
+**"My sandbox won't start."**
+
+```bash
+msb create --name nope ...          # observe the styled error block
+cat ~/.microsandbox/sandboxes/nope/logs/boot-error.json
+msb logs nope --source system       # full diagnostics from runtime.log/kernel.log
+```
+
+**"My program isn't logging."**
+
+If `exec.log` only has `--- sandbox started ---` and nothing else, no exec session ever opened. Check that you actually ran something — `msb create` alone doesn't run any user program.
+
+**"My program is logging but I can't tell which session."**
+
+```bash
+msb logs <name> --show-id           # prefix every line with the session id
+msb logs <name> --color-sessions    # one color per session
+```
+
+**"I want to feed logs to my own pipeline."**
+
+```bash
+# JSON Lines — schema in this page's "What's captured" section
+msb logs <name> --json | jq -c 'select(.s == "stderr")'
+
+# Or programmatic via the SDK — same data, typed.
+```
+
+## Capture model in detail
+
+A sandbox can host many concurrent exec sessions: an `msb run` at creation, plus arbitrary `msb exec` calls, plus SDK-driven sessions. **Every session is captured** to `exec.log`, tagged with its own monotonic `id` field so readers can group or filter without losing data.
+
+The id is minted by the relay (`next_session_id: AtomicU64`, starts at 1, +1 per observed `ExecRequest`). It's distinct from the protocol correlation id — the latter is per-client and gets reused across slot recycling, which would make sequential `msb exec` calls indistinguishable. The relay-minted id never repeats within a sandbox lifetime.
+
+System entries (`--- sandbox started ---`, `--- sandbox stopped ---`) have no `id` field — they aren't tied to a specific session.
+
+## Troubleshooting log capture
+
+- **`exec.log` is empty.** No exec session ever opened. `msb create` alone doesn't run anything; you need `msb run` or `msb exec` to produce output.
+- **Stderr appears as `stdout`.** The session is in PTY mode (interactive). PTY merges streams in the kernel — by the time bytes leave the guest, they're indistinguishable. Use `< /dev/null` or non-interactive invocation to take the pipe path. PTY-mode bytes are tagged `output`, not `stdout` — make sure your filters cover both.
+- **`runtime.log` has weird `[2m...` characters.** Older sandboxes may still have ANSI color codes from `tracing`. Newly-created sandboxes don't (we disable ANSI at the source for the sandbox subprocess).
+- **`msb logs -f` exits immediately.** The sandbox is stopped. Follow mode against a stopped sandbox dumps the existing contents and exits — it doesn't block waiting for it to start.

--- a/docs/fr/sandboxes/metrics.mdx
+++ b/docs/fr/sandboxes/metrics.mdx
@@ -1,0 +1,83 @@
+---
+title: Metrics
+description: Monitor sandbox resource usage
+icon: "chart-line"
+---
+
+Query resource usage for a running sandbox: CPU, memory, and more. Get a single point-in-time snapshot, or open a streaming subscription that delivers updates at a fixed interval.
+
+## Point-in-time
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let metrics = sb.metrics().await?;
+println!("CPU: {:.1}%, Mem: {} MB", metrics.cpu_percent, metrics.memory_bytes / 1024 / 1024);
+```
+
+```typescript TypeScript
+const metrics = await sb.metrics();
+console.log(`CPU: ${metrics.cpuPercent.toFixed(1)}%, Mem: ${Math.floor(metrics.memoryBytes / 1024 / 1024)} MB`);
+```
+
+```python Python
+m = await sb.metrics()
+print(f"CPU: {m.cpu_percent:.1f}%, Mem: {m.memory_bytes // 1024 // 1024} MB")
+```
+
+</CodeGroup>
+
+## Streaming
+
+Subscribe to metric updates at a regular interval. Each update arrives as a separate event.
+
+<CodeGroup>
+```rust Rust
+use std::time::Duration;
+use futures::StreamExt;
+
+let mut stream = sb.metrics_stream(Duration::from_secs(1));
+while let Some(m) = stream.next().await {
+    let m = m?;
+    println!("CPU: {:.1}%, Mem: {} MB", m.cpu_percent, m.memory_bytes / 1024 / 1024);
+}
+```
+
+```typescript TypeScript
+for await (const m of await sb.metricsStream(1000)) {
+    console.log(`[${m.timestamp.toISOString()}] CPU: ${m.cpuPercent.toFixed(1)}%`);
+}
+```
+
+```python Python
+async for m in await sb.metrics_stream(interval=1.0):
+    print(f"[{m.timestamp_ms}] CPU: {m.cpu_percent:.1f}%")
+```
+
+</CodeGroup>
+
+## Fleet-wide metrics
+
+Get metrics for all running sandboxes at once. Useful for dashboards or capacity planning.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::all_sandbox_metrics;
+
+let all = all_sandbox_metrics().await?;
+```
+
+```typescript TypeScript
+import { allSandboxMetrics } from "microsandbox";
+
+const all = await allSandboxMetrics();
+```
+
+```python Python
+from microsandbox import all_sandbox_metrics
+
+all_metrics = await all_sandbox_metrics()
+```
+
+</CodeGroup>

--- a/docs/fr/sandboxes/overview.mdx
+++ b/docs/fr/sandboxes/overview.mdx
@@ -1,0 +1,355 @@
+---
+title: Overview
+description: What sandboxes are and how to configure them
+icon: "circle-info"
+---
+
+A sandbox is a microVM: a real virtual machine with its own Linux kernel, filesystem, and network stack, running as a child process of whatever application creates it.
+
+The security boundary here is hardware virtualization, not Linux namespaces. Container escapes are a well-documented class of vulnerability; breaking out of a microVM requires exploiting the hypervisor itself, which is a fundamentally harder problem.
+
+## Creating a sandbox
+
+At minimum, a sandbox needs a name and an image. Everything else has sensible defaults: 1 vCPU, 512 MiB memory, public-only networking, `/bin/sh` as the shell.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create("worker", image="python")
+```
+
+```bash CLI
+msb create python --name worker
+```
+
+</CodeGroup>
+
+## Configuration options
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .memory(1024)
+    .cpus(2)
+    .env("DEBUG", "true")
+    .env("API_PORT", "8000")
+    .volume("/app/src", |v| v.bind("./src").readonly())
+    .volume("/data", |v| v.named("my-data"))
+    .volume("/tmp/scratch", |v| v.tmpfs().size(100))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .memory(1024)
+    .cpus(2)
+    .env("DEBUG", "true")
+    .env("API_PORT", "8000")
+    .volume("/app/src",     (m) => m.bind("./src").readonly())
+    .volume("/data",        (m) => m.named("my-data"))
+    .volume("/tmp/scratch", (m) => m.tmpfs().size(100))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    memory=1024,
+    cpus=2,
+
+    env={"DEBUG": "true", "API_PORT": "8000"},
+    volumes={
+        "/app/src": Volume.bind("./src", readonly=True),
+        "/data": Volume.named("my-data"),
+        "/tmp/scratch": Volume.tmpfs(size_mib=100),
+    },
+)
+```
+
+```bash CLI
+msb create python --name worker \
+  -c 2 \
+  -m 1G \
+  -e DEBUG=true \
+  -e API_PORT=8000 \
+  -v ./src:/app/src:ro \
+  -v my-data:/data \
+  --tmpfs /tmp/scratch:100
+```
+
+</CodeGroup>
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `image` | — | OCI image, local path, or disk image |
+| `cpus` | `1` | Number of virtual CPUs |
+| `memory` | `512` | Guest memory in MiB |
+| `workdir` | — | Default working directory for commands |
+| `shell` | `/bin/sh` | Shell used by `shell()` calls |
+| `env` | `{}` | Environment variables |
+| `volumes` | `[]` | Volume mounts (bind, named, or tmpfs) |
+| `network` | `public` | Network policy and port mappings |
+| `scripts` | `{}` | Named scripts stored at `/.msb/scripts/` |
+
+<Tip>
+  `cpus` and `memory` are **limits, not reservations**. Setting `memory: 512` doesn't allocate 512 MiB upfront. Physical pages are only allocated as the guest actually touches them, so you can comfortably run many sandboxes on a single host without worrying about overcommitting.
+</Tip>
+
+## Rootfs sources
+
+microsandbox supports three ways to provide a root filesystem. The choice affects how the filesystem is assembled and what features are available.
+
+### OCI images
+
+The most common option. microsandbox pulls the image and stacks its layers as a copy-on-write filesystem. Changes inside the sandbox don't modify the base image. If two sandboxes use the same image, they share the same cached layers on disk.
+
+<CodeGroup>
+```rust Rust
+Sandbox::builder("worker").image("python").create().await?;
+```
+
+```typescript TypeScript
+await Sandbox.builder("worker").image("python").create();
+```
+
+```python Python
+await Sandbox.create("worker", image="python")
+```
+
+```bash CLI
+msb create python --name worker
+```
+
+</CodeGroup>
+
+### Bind mounts
+
+Use a local directory on the host as the root filesystem directly. The guest sees the directory contents as its `/`. This is useful for development when you have a pre-built rootfs, or for minimal environments where you've assembled the filesystem yourself.
+
+<CodeGroup>
+```rust Rust
+Sandbox::builder("worker").image("./my-rootfs").create().await?;
+```
+
+```typescript TypeScript
+await Sandbox.builder("worker").image("./my-rootfs").create();
+```
+
+```python Python
+await Sandbox.create("worker", image="./my-rootfs")
+```
+
+```bash CLI
+msb create ./my-rootfs --name worker
+```
+
+</CodeGroup>
+
+<Note>
+  The guest agent is automatically included in the rootfs during sandbox creation, regardless of rootfs source. You don't need to add anything to your image or directory.
+</Note>
+
+### Disk images
+
+Boot from a QCOW2, Raw, or VMDK disk image. Unlike OCI images (which use a copy-on-write overlay), disk images give the guest raw block device access. See [Disk Images](/images/disk-images) for details.
+
+<CodeGroup>
+```rust Rust
+// Auto-detect filesystem
+Sandbox::builder("worker")
+    .image("./ubuntu-22.04.qcow2")
+    .create()
+    .await?;
+
+// Explicit filesystem type
+Sandbox::builder("worker")
+    .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+// Auto-detect the disk image format from the file extension.
+await Sandbox.builder("worker")
+    .image("./alpine.qcow2")
+    .create();
+```
+
+```python Python
+from microsandbox import Image, Sandbox
+
+# Auto-detect filesystem
+await Sandbox.create("worker", image="./ubuntu-22.04.qcow2")
+
+# Explicit filesystem type
+await Sandbox.create("worker", image=Image.disk("./alpine.raw", fstype="ext4"))
+```
+
+```bash CLI
+msb create ./alpine.qcow2 --name worker
+```
+
+</CodeGroup>
+
+<Note>
+  With OCI images, microsandbox stacks layers and adds a copy-on-write overlay so sandboxes share the base. With disk images, the guest gets the block device directly, so there's no copy-on-write isolation between sandboxes using the same disk image. Each sandbox needs its own copy (or use QCOW2's built-in snapshot/backing file support).
+</Note>
+
+## Replace existing
+
+Replace a stopped sandbox with the same name instead of failing on conflict. This stops the old sandbox (if still running), removes it, and creates a fresh one.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .replace()
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .replace()
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create("worker", image="python", replace=True)
+```
+
+```bash CLI
+msb create --replace python --name worker
+```
+
+</CodeGroup>
+
+## Private registry
+
+Authenticate to private container registries and control when images are pulled.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, RegistryAuth, PullPolicy};
+
+let sb = Sandbox::builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry_auth(RegistryAuth::Basic {
+        username: "deploy".into(),
+        password: std::env::var("REGISTRY_PASSWORD")?,
+    })
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("private.registry.io/org/app:v1")
+    .registry((r) => r.auth({
+        kind: "basic",
+        username: "deploy",
+        password: process.env.REGISTRY_TOKEN!,
+    }))
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import PullPolicy, RegistryAuth, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="private.registry.io/org/app:v1",
+    registry_auth=RegistryAuth.basic("deploy", os.environ["REGISTRY_PASSWORD"]),
+    pull_policy=PullPolicy.ALWAYS,
+)
+```
+
+```bash CLI
+msb registry login private.registry.io -u deploy
+msb create private.registry.io/org/app:v1 \
+  --name worker --pull always
+```
+
+</CodeGroup>
+
+| Policy | Behavior |
+|--------|----------|
+| `"always"` | Pull the image every time, even if cached locally |
+| `"if-missing"` | Pull only if the image is not already cached (default) |
+| `"never"` | Never pull; fail if the image is not cached |
+
+<Tip>
+  Once an OCI image is resolved, microsandbox pins the exact layers. A `python` reference is resolved to an immutable set of layers at first pull. Subsequent `start()` calls use the pinned layers without re-resolving the mutable tag, so your sandbox is reproducible even if the upstream tag is updated.
+</Tip>
+
+## Config inspection <sup><sup>coming soon</sup></sup>
+
+Build a sandbox configuration without booting the VM. Useful for serializing, storing, validating, or modifying configs before creation.
+
+<CodeGroup>
+```rust Rust
+let config = Sandbox::builder("preview")
+    .image("python")
+    .memory(1024)
+    .build()?;
+
+println!("{}", serde_json::to_string_pretty(&config)?);
+let sb = Sandbox::create(config).await?;
+```
+
+```typescript TypeScript
+const builder = Sandbox.builder("preview").image("python").memory(1024);
+const config = builder.build();
+
+console.log(JSON.stringify(config, null, 2));
+const sb = await builder.create();
+```
+
+```python Python
+import json
+from microsandbox import Sandbox
+
+config = Sandbox.build_config(
+    "preview",
+    image="python",
+    memory=1024,
+)
+
+print(json.dumps(config, indent=2))
+sb = await Sandbox.create(config)
+```
+
+</CodeGroup>
+
+## Customizing the guest environment
+
+If you need to run setup logic, install packages, or inject files before a sandbox starts doing real work, there are two ways to do it without building a custom image:
+
+- **[Scripts](/sandboxes/customize#scripts)** are files mounted into the sandbox at `/.msb/scripts/` and added to `PATH`. Define them at creation time and call them by name with `exec()` or `shell()`. Good for multi-step setup procedures or named entry points.
+- **[Patches](/sandboxes/customize#patches)** modify the rootfs before the VM boots: write config files, copy directories from the host, create symlinks, append to existing files, etc. The base image stays untouched since patches go into the writable layer.

--- a/docs/fr/sandboxes/secrets.mdx
+++ b/docs/fr/sandboxes/secrets.mdx
@@ -1,0 +1,76 @@
+---
+title: Secrets
+description: Secure credential injection for sandboxes
+icon: "key"
+---
+
+Secrets use a **placeholder substitution** model. The guest VM never sees the real credential.
+
+When you bind a secret to an environment variable and one or more allowed hosts, microsandbox generates a random placeholder (e.g., `OPENAI_API_KEY=msb_ph_a8f3c2...`) and injects that into the guest instead. The real value never enters the VM. The only way it reaches the outside world is when a request goes to an allowed host, at which point microsandbox swaps the placeholder for the real value. Everywhere else, the placeholder is just a meaningless string.
+
+So even with full code execution inside the sandbox, there's nothing to steal. The credential was never there.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("agent")
+    .image("python")
+    .secret(|s| s
+        .env("GITHUB_TOKEN")
+        .value(std::env::var("GITHUB_TOKEN")?)
+        .allow_host("api.github.com")
+        .allow_host_pattern("*.githubusercontent.com")
+    )
+    .secret_env("OPENAI_API_KEY", api_key, "api.openai.com")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("agent")
+    .image("python")
+    .secret((s) =>
+        s.env("GITHUB_TOKEN")
+            .value(process.env.GITHUB_TOKEN!)
+            .allowHost("api.github.com")
+            .allowHostPattern("*.githubusercontent.com"),
+    )
+    .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import Sandbox, Secret
+
+sb = await Sandbox.create(
+    "agent",
+    image="python",
+    secrets=[
+        Secret.env(
+            "GITHUB_TOKEN",
+            value=os.environ["GITHUB_TOKEN"],
+            allow_hosts=["api.github.com"],
+            allow_host_patterns=["*.githubusercontent.com"],
+        ),
+        Secret.env(
+            "OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+)
+```
+
+```bash CLI
+msb create python --name agent \
+  --secret "GITHUB_TOKEN=$GITHUB_TOKEN@api.github.com" \
+  --secret "OPENAI_API_KEY=$OPENAI_API_KEY@api.openai.com"
+```
+
+</CodeGroup>
+
+See the SDK Reference for the full API: [Rust](/sdk/rust/secrets) | [TypeScript](/sdk/typescript/secrets) | [Python](/sdk/python/secrets).

--- a/docs/fr/sandboxes/snapshots.mdx
+++ b/docs/fr/sandboxes/snapshots.mdx
@@ -1,0 +1,338 @@
+---
+title: Snapshots
+description: Capture a stopped sandbox's writable layer as a portable artifact
+icon: "code-branch"
+---
+
+A snapshot is a portable, on-disk capture of a sandbox's writable filesystem. Move it with `scp`, archive it as `.tar.zst`, or boot fresh sandboxes from it.
+
+<Note>
+Snapshots are **disk-only and stopped-only**: the sandbox can't be running when you take one. Memory and CPU state, plus qcow2 backing chains, are future work.
+</Note>
+
+## What gets captured
+
+| Captured                                     | Not captured                      |
+| -------------------------------------------- | --------------------------------- |
+| `upper.ext4`, the sandbox's writable overlay | Memory contents                   |
+| Pinned image reference + manifest digest     | CPU registers / running processes |
+| `fstype`, `format`, optional labels          | Network state                     |
+| Optional content-integrity hash              | Open file handles                 |
+
+Booting from a snapshot is a cold boot of a fresh VM that reuses the captured upper layer as its starting filesystem. The image (lower layer) is re-resolved by digest from the local OCI cache, or re-pulled from the registry if missing.
+
+## Quick start
+
+You'll usually reach for the CLI first:
+
+```bash
+# 1. Run something, install state, then stop it
+msb run --name baseline --detach python:3.12 -- sleep 3600
+msb exec baseline -- pip install requests
+msb stop baseline
+
+# 2. Snapshot the stopped sandbox
+msb snapshot create after-pip-install --from baseline
+
+# 3. Boot a fresh sandbox from the snapshot
+msb run --name worker --snapshot after-pip-install \
+    -- python -c "import requests; print(requests.__version__)"
+```
+
+<Tip>
+The snapshot lives at `~/.microsandbox/snapshots/after-pip-install/`. That whole directory is the snapshot.
+</Tip>
+
+## Snapshot a stopped sandbox
+
+Snapshot under a bare name (resolved to `~/.microsandbox/snapshots/<name>/`) or to an explicit path:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let h = Sandbox::get("baseline").await?;
+
+// Bare name resolves under ~/.microsandbox/snapshots/<name>/
+let snap = h.snapshot("after-pip-install").await?;
+
+// Or write to an explicit path
+let snap = h.snapshot_to("/tmp/snaps/v1").await?;
+
+println!("{}", snap.digest()); // sha256:...
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const h = await Sandbox.get("baseline");
+
+// Bare name resolves under ~/.microsandbox/snapshots/<name>/
+const snap = await h.snapshot("after-pip-install");
+
+// Or write to an explicit path
+const snap2 = await h.snapshotTo("/tmp/snaps/v1");
+
+console.log(snap.digest); // sha256:...
+```
+
+```python Python
+from microsandbox import Sandbox
+
+h = await Sandbox.get("baseline")
+
+# Bare name resolves under ~/.microsandbox/snapshots/<name>/
+snap = await h.snapshot("after-pip-install")
+
+# Or write to an explicit path
+snap2 = await h.snapshot_to("/tmp/snaps/v1")
+
+print(snap.digest)  # sha256:...
+```
+
+```bash CLI
+msb snapshot create after-pip-install --from baseline
+msb snapshot create ./snaps/v1     --from baseline   # Explicit path
+msb snapshot create after-pip-install --from baseline --label stage=ready
+```
+
+</CodeGroup>
+
+The sandbox must be stopped or crashed; running sandboxes are rejected.
+
+## Boot from a snapshot
+
+A snapshot already pins its image, so booting from one is mutually exclusive with the image source:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .from_snapshot("after-pip-install")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.builder("worker")
+    .fromSnapshot("after-pip-install")
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox
+
+# `snapshot=` is a peer of `image=` and mutually exclusive with it
+sb = await Sandbox.create("worker", snapshot="after-pip-install")
+```
+
+```bash CLI
+msb run --name worker --snapshot after-pip-install -- python -V
+```
+
+</CodeGroup>
+
+Booting validates the snapshot's manifest, re-resolves the pinned image from the local OCI cache (re-pulling and verifying the digest if it's missing), and reflinks the captured `upper.ext4` into the new sandbox's directory. Reflinks use `clonefile` on macOS APFS, `FICLONE` on btrfs/XFS, with a sparse-aware fallback on ext4, so each new sandbox gets an independent COW copy without paying the bytes again.
+
+## List, inspect, and remove
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Snapshot;
+
+let all = Snapshot::list().await?; // Indexed snapshots
+let h = Snapshot::get("after-pip-install").await?; // By name, digest, or path
+println!("{} ({})", h.name().unwrap_or("-"), h.digest());
+
+Snapshot::remove("after-pip-install", false).await?;
+Snapshot::reindex("~/.microsandbox/snapshots").await?;
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+const all = await Snapshot.list();                       // Indexed snapshots
+const h = await Snapshot.get("after-pip-install");       // By name, digest, or path
+console.log(`${h.name ?? "-"} (${h.digest})`);
+
+await Snapshot.remove("after-pip-install");
+await Snapshot.reindex("~/.microsandbox/snapshots");
+```
+
+```python Python
+from microsandbox import Snapshot
+
+all = await Snapshot.list()                              # Indexed snapshots
+h = await Snapshot.get("after-pip-install")              # By name, digest, or path
+print(f"{h.name or '-'} ({h.digest})")
+
+await Snapshot.remove("after-pip-install")
+await Snapshot.reindex("~/.microsandbox/snapshots")
+```
+
+```bash CLI
+msb snapshot ls
+msb snapshot inspect after-pip-install
+msb snapshot rm after-pip-install
+
+# Also if it has indexed children
+msb snapshot rm after-pip-install --force
+
+# Rebuild the index from artifacts on disk
+msb snapshot reindex
+```
+
+</CodeGroup>
+
+Opening a snapshot is cheap: it validates the manifest and checks the upper file's size, but does **not** read the file's contents. The same path powers `inspect` and the boot flow; the load-bearing local operation has to stay fast.
+
+`list` and `get` are backed by a small local index DB. The index is just a cache for fast lookups, not a source of truth; if it ever gets out of sync (or you delete it), `reindex` rebuilds it from the artifacts on disk.
+
+## Move snapshots between machines
+
+The artifact is a directory containing `manifest.json` (canonical JSON; identity is the SHA-256 of these bytes) plus the captured `upper.ext4`. The directory **is** the snapshot; there's no hidden daemon state, so any of these three transports work:
+
+```bash
+# Copy the directory directly with scp (image must be cached or pullable on the target)
+scp -r ~/.microsandbox/snapshots/after-pip-install \
+    other-host:~/.microsandbox/snapshots/
+
+# Bundle into a .tar.zst, transport, then import
+msb snapshot export after-pip-install /tmp/snap.tar.zst
+scp /tmp/snap.tar.zst other-host:
+ssh other-host msb snapshot import /tmp/snap.tar.zst
+
+# Fully offline: include the OCI image cache so the target needs no network
+msb snapshot export after-pip-install /tmp/snap.tar.zst --with-image
+ssh other-host msb snapshot import /tmp/snap.tar.zst
+```
+
+Archives default to `.tar.zst` since zstd collapses sparse zero runs cheaply. Pass `--plain-tar` for a plain `.tar`; both are accepted on import via magic-byte detection.
+
+Or drive `export` and `import` from code:
+
+<CodeGroup>
+```rust Rust
+use std::path::Path;
+use microsandbox::Snapshot;
+use microsandbox::snapshot::ExportOpts;
+
+Snapshot::export(
+    "after-pip-install",
+    Path::new("/tmp/snap.tar.zst"),
+    ExportOpts { with_image: true, ..Default::default() },
+).await?;
+
+let snap = Snapshot::import(
+    Path::new("/tmp/snap.tar.zst"),
+    None,
+).await?;
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+await Snapshot.export("after-pip-install", "/tmp/snap.tar.zst", {
+  withImage: true,
+});
+
+const snap = await Snapshot.import("/tmp/snap.tar.zst");
+```
+
+```python Python
+from microsandbox import Snapshot
+
+await Snapshot.export(
+    "after-pip-install",
+    "/tmp/snap.tar.zst",
+    with_image=True,
+)
+
+snap = await Snapshot.import_("/tmp/snap.tar.zst")  # Trailing _ avoids the keyword
+```
+
+```bash CLI
+msb snapshot export after-pip-install /tmp/snap.tar.zst --with-image
+msb snapshot import /tmp/snap.tar.zst
+```
+
+</CodeGroup>
+
+## Integrity verification
+
+By default, snapshot creation does **not** hash the upper file. The artifact carries the upper's size and the pinned image's manifest digest, which together catch any corruption that would stop it from booting. Skipping the hash keeps `inspect` fast on multi-GB sparse upper layers, where the cost would otherwise dominate.
+
+Opt in to a content-integrity hash when crossing a trust boundary:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Snapshot;
+
+// Compute and record an integrity hash at create time
+let snap = Snapshot::builder("baseline")
+    .name("after-pip-install")
+    .record_integrity()
+    .create()
+    .await?;
+
+// Verify a snapshot's recorded integrity on demand
+let report = snap.verify().await?;
+
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+// Compute and record an integrity hash at create time
+const snap = await Snapshot.builder("baseline")
+  .name("after-pip-install")
+  .recordIntegrity()
+  .create();
+
+// Verify a snapshot's recorded integrity on demand
+const report = await snap.verify();
+```
+
+```python Python
+from microsandbox import Snapshot
+
+# Compute and record an integrity hash at create time
+snap = await Snapshot.create(
+    "baseline",
+    name="after-pip-install",
+    record_integrity=True,
+)
+
+# Verify a snapshot's recorded integrity on demand
+report = await snap.verify()
+```
+
+```bash CLI
+# Compute and record an integrity hash at create time
+msb snapshot create after-pip-install --from baseline --integrity
+
+# Verify a snapshot's recorded integrity on demand
+msb snapshot verify after-pip-install
+msb snapshot inspect after-pip-install --verify
+```
+
+</CodeGroup>
+
+`msb snapshot export` automatically populates the integrity hash before bundling, and `msb snapshot import` verifies it on the way in. The local index path stays fast; the cross-machine path stays trustworthy.
+
+## Use cases
+
+- **Reusable build state.** Install dependencies once, snapshot, then `msb run --snapshot ...` repeatedly without paying the install cost. Common pattern for CI, agent workloads, and reproducible dev environments.
+- **Portable scratch state.** Capture a sandbox after a long setup, hand the artifact to a teammate or push it to shared storage, and let them boot from the same starting point.
+- **Local fork-by-copy.** Multiple sandboxes from one snapshot are independent; each copy of the upper layer diverges on its own.
+- **Disaster recovery.** Snapshot a sandbox before a risky migration; if it goes wrong, `msb rm` the broken one and `msb run --snapshot` from the pre-migration artifact.
+
+## What's not yet supported
+
+- **Live (running) snapshots.** The sandbox must be stopped first. Live capture requires an in-guest filesystem freeze and memory checkpointing that's tracked as future work.
+- **qcow2 backing chains.** Snapshots always copy the upper layer today. The manifest's `format` and `parent` fields are reserved so qcow2 chains can land additively without a schema break.
+- **Push/pull from a registry.** The artifact format is registry-shaped on purpose, but transport tooling beyond `scp` and `tar.zst` is a separate piece of work.
+- **Snapshotting `DiskImage` volumes.** The same mechanism would apply (reflink the disk file), but is currently out of scope.

--- a/docs/fr/sandboxes/volumes.mdx
+++ b/docs/fr/sandboxes/volumes.mdx
@@ -1,0 +1,271 @@
+---
+title: Volumes
+description: Persist and share data across sandboxes
+icon: "hard-drive"
+---
+
+Volumes give a sandbox direct filesystem access to host-side directories. They're useful for persisting data across restarts, sharing data between sandboxes, or mounting host directories into the guest. They're also significantly faster than the [filesystem API](/sandboxes/filesystem) (which transfers files individually), so for anything beyond ad-hoc reads and writes, volumes are the way to go.
+
+microsandbox supports three types of mounts: bind mounts, named volumes, and tmpfs.
+
+## Bind mounts
+
+Mount a directory from the host directly into the sandbox. Changes inside the sandbox are reflected on the host, and vice versa.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("dev")
+    .image("python")
+    .volume("/app/src", |v| v.bind("./src").readonly())
+    .volume("/app/data", |v| v.bind("./data"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("dev")
+    .image("python")
+    .volume("/app/src",  (m) => m.bind("./src").readonly())
+    .volume("/app/data", (m) => m.bind("./data"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+sb = await Sandbox.create(
+    "dev",
+    image="python",
+    volumes={
+        "/app/src": Volume.bind("./src", readonly=True),
+        "/app/data": Volume.bind("./data"),
+    },
+)
+```
+
+```bash CLI
+msb create python --name dev \
+  -v ./src:/app/src:ro \
+  -v ./data:/app/data
+```
+
+</CodeGroup>
+
+## Named volumes
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox, so you can create a volume, populate it, and mount it into different sandboxes over time.
+
+### Create a volume
+
+<CodeGroup>
+```rust Rust
+let cache = Volume::builder("pip-cache")
+    .quota(1024)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Volume } from "microsandbox";
+
+const cache = await Volume.builder("pip-cache").quota(1024).create();
+```
+
+```python Python
+cache = await Volume.create("pip-cache", quota_mib=1024)
+```
+
+```bash CLI
+msb volume create pip-cache --size 1024
+```
+
+</CodeGroup>
+
+### Mount in a sandbox
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .volume("/root/.cache/pip", |v| v.named(cache.name()))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .volume("/root/.cache/pip", (m) => m.named(cache.name))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    volumes={
+        "/root/.cache/pip": Volume.named(cache.name),
+    },
+)
+```
+
+```bash CLI
+msb create python --name worker \
+  -v pip-cache:/root/.cache/pip
+```
+
+</CodeGroup>
+
+### Share between sandboxes
+
+Named volumes are the simplest way to share data between sandboxes. Mount the same volume into multiple sandboxes: one writes, another reads.
+
+<CodeGroup>
+```rust Rust
+// Writer
+let writer = Sandbox::builder("writer")
+    .image("alpine")
+    .volume("/data", |v| v.named("shared-data"))
+    .create()
+    .await?;
+writer.shell("echo 'hello' > /data/message.txt").await?;
+
+// Reader (read-only)
+let reader = Sandbox::builder("reader")
+    .image("alpine")
+    .volume("/data", |v| v.named("shared-data").readonly())
+    .create()
+    .await?;
+let output = reader.exec("cat", ["/data/message.txt"]).await?;
+// => "hello"
+```
+
+```typescript TypeScript
+// Writer
+await using writer = await Sandbox.builder("writer")
+    .image("alpine")
+    .volume("/data", (m) => m.named("shared-data"))
+    .create();
+await writer.shell("echo 'hello' > /data/message.txt");
+
+// Reader (read-only)
+await using reader = await Sandbox.builder("reader")
+    .image("alpine")
+    .volume("/data", (m) => m.named("shared-data").readonly())
+    .create();
+const output = await reader.exec("cat", ["/data/message.txt"]);
+// => "hello"
+```
+
+```python Python
+# Writer
+writer = await Sandbox.create(
+    "writer",
+    image="alpine",
+    volumes={"/data": Volume.named("shared-data")},
+)
+await writer.shell("echo 'hello' > /data/message.txt")
+
+# Reader (read-only)
+reader = await Sandbox.create(
+    "reader",
+    image="alpine",
+    volumes={"/data": Volume.named("shared-data", readonly=True)},
+)
+output = await reader.exec("cat", ["/data/message.txt"])
+# => "hello"
+```
+
+</CodeGroup>
+
+<Tip>
+  When sharing volumes between sandboxes, both sandboxes access the same underlying host directory. There's no built-in locking, so if two sandboxes write to the same file concurrently, you'll get the usual race conditions. Use the read-only flag on the reader side to make intent explicit.
+</Tip>
+
+### Host-side access
+
+Named volumes are accessible from the host even without a running sandbox, which is handy for pre-populating data before any sandbox mounts it.
+
+<CodeGroup>
+```rust Rust
+let vol = Volume::get("pip-cache").await?;
+vol.fs().write("/requirements.txt", "requests==2.28.0").await?;
+```
+
+```typescript TypeScript
+const vol = await Volume.get("pip-cache");
+await vol.fs().write("requirements.txt", "requests==2.28.0");
+```
+
+```python Python
+vol = await Volume.get("pip-cache")
+await vol.fs.write("/requirements.txt", b"requests==2.28.0")
+```
+
+</CodeGroup>
+
+### Manage volumes
+
+<CodeGroup>
+```rust Rust
+let volumes = Volume::list().await?;
+Volume::remove("old-cache").await?;
+```
+
+```typescript TypeScript
+const volumes = await Volume.list();
+await Volume.remove("old-cache");
+```
+
+```python Python
+volumes = await Volume.list()
+await Volume.remove("old-cache")
+```
+
+```bash CLI
+msb volume ls
+msb volume rm old-cache
+```
+
+</CodeGroup>
+
+## Tmpfs
+
+An in-memory filesystem that disappears when the sandbox stops. Useful for scratch space, build artifacts, or anything that doesn't need to outlive the sandbox.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("alpine")
+    .volume("/tmp/scratch", |v| v.tmpfs().size(100))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("alpine")
+    .volume("/tmp/scratch", (m) => m.tmpfs().size(100))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="alpine",
+    volumes={
+        "/tmp/scratch": Volume.tmpfs(size_mib=100),
+    },
+)
+```
+
+```bash CLI
+msb create alpine --name worker \
+  --tmpfs /tmp/scratch:100
+```
+
+</CodeGroup>

--- a/docs/fr/sdk/errors.mdx
+++ b/docs/fr/sdk/errors.mdx
@@ -1,0 +1,266 @@
+---
+title: Error Handling
+description: Typed errors and resource cleanup patterns
+icon: "triangle-exclamation"
+---
+
+All SDKs surface typed errors so you can match on specific failure modes instead of parsing strings. Rust has an `Error` enum, TypeScript exposes a dedicated subclass per variant (use `instanceof`), and Python provides dedicated exception classes.
+
+## Matching errors
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, Error};
+
+async fn get_or_create(name: &str) -> Result<Sandbox, Error> {
+    match Sandbox::get(name).await {
+        Ok(handle) => handle.start().await,
+        Err(Error::SandboxNotFound(_)) => {
+            Sandbox::builder(name).image("python").create().await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+match sb.exec("python", ["script.py"]).await {
+    Ok(output) if output.status().success => {
+        println!("{}", output.stdout()?);
+    }
+    Ok(output) => {
+        eprintln!("Exit {}: {}", output.status().code, output.stderr()?);
+    }
+    Err(Error::ExecTimeout) => eprintln!("Timed out"),
+    Err(Error::Runtime(msg)) => eprintln!("Runtime: {msg}"),
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import {
+    ExecTimeoutError,
+    RuntimeError,
+    Sandbox,
+    SandboxNotFoundError,
+} from "microsandbox";
+
+async function getOrCreate(name: string): Promise<Sandbox> {
+    try {
+        const handle = await Sandbox.get(name);
+        return await handle.start();
+    } catch (e) {
+        if (e instanceof SandboxNotFoundError) {
+            return Sandbox.builder(name).image("python").create();
+        }
+        throw e;
+    }
+}
+
+try {
+    const output = await sb.exec("python", ["script.py"]);
+    if (!output.success) {
+        console.error(`Failed (exit ${output.code}):`, output.stderr());
+    }
+} catch (e) {
+    if (e instanceof ExecTimeoutError) {
+        console.error(`Timed out after ${e.timeoutMs}ms`);
+    } else if (e instanceof RuntimeError) {
+        console.error("Runtime:", e.message);
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import (
+    ExecTimeoutError, Sandbox, SandboxNotFoundError
+)
+
+async def get_or_create(name: str):
+    try:
+        handle = await Sandbox.get(name)
+        return await handle.start()
+    except SandboxNotFoundError:
+        return await Sandbox.create(name, image="python")
+
+try:
+    output = await sb.exec("python", ["script.py"])
+    if not output.success:
+        print(f"Exit {output.exit_code}: {output.stderr_text}")
+except ExecTimeoutError:
+    print("Timed out")
+```
+
+</CodeGroup>
+
+## Spawn-time exec failures
+
+`exec()` distinguishes between:
+
+- **A program that ran and exited non-zero** — the call returns an `ExecOutput` with a non-zero `code`. This is *not* an error in the SDK sense; it's a normal result.
+- **A program that never started** — the binary doesn't exist, isn't executable, the working directory is unreachable, etc. This surfaces as a typed error variant: `ExecFailed` (Rust), `ExecFailedError` (TypeScript), `ExecFailedError` (Python).
+
+The typed error carries a classified `kind` plus the underlying `errno`, so callers can branch on the cause and react. Common kinds: `NotFound` (binary missing on PATH), `PermissionDenied`, `NotExecutable`, `BadCwd`, `BadArgs`, `ResourceLimit`, `UserSetupFailed`, `OutOfMemory`, `PtySetupFailed`, `Other`.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Error;
+use microsandbox_protocol::exec::ExecFailureKind;
+
+match sb.exec("nonexistent", []).await {
+    Ok(output) => { /* program ran, check output.status() */ }
+    Err(Error::ExecFailed(payload)) => {
+        match payload.kind {
+            ExecFailureKind::NotFound => {
+                eprintln!("Binary not found on PATH: {}", payload.message);
+            }
+            ExecFailureKind::PermissionDenied => {
+                eprintln!("Not executable (chmod +x?): {}", payload.message);
+            }
+            kind => {
+                eprintln!("Spawn failed ({:?}): {}", kind, payload.message);
+            }
+        }
+        // payload.errno, payload.errno_name, payload.stage are also available
+    }
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import { ExecFailedError, Sandbox } from "microsandbox";
+
+try {
+    const output = await sb.exec("nonexistent");
+    // program ran, check output.success / output.code
+} catch (e) {
+    if (e instanceof ExecFailedError) {
+        switch (e.kind) {
+            case "not_found":
+                console.error("Binary not on PATH:", e.message);
+                break;
+            case "permission_denied":
+                console.error("Not executable (chmod +x?):", e.message);
+                break;
+            default:
+                console.error(`Spawn failed (${e.kind}):`, e.message);
+        }
+        // e.errno, e.errnoName, e.stage are also available
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import ExecFailedError
+
+try:
+    output = await sb.exec("nonexistent")
+    # program ran, check output.success / output.exit_code
+except ExecFailedError as e:
+    if e.kind == "not_found":
+        print(f"Binary not on PATH: {e.message}")
+    elif e.kind == "permission_denied":
+        print(f"Not executable (chmod +x?): {e.message}")
+    else:
+        print(f"Spawn failed ({e.kind}): {e.message}")
+    # e.errno, e.errno_name, e.stage are also available
+```
+</CodeGroup>
+
+The CLI maps these kinds to POSIX-style exit codes: `127` for `NotFound`, `126` for `PermissionDenied` and `NotExecutable`, `1` otherwise. SDK callers reading the error directly don't need to think about exit codes — branch on `kind` instead.
+
+## Sandbox start failures
+
+When a sandbox process exits before the agent relay is ready (mount errors, missing rootfs, network setup failures), the SDK surfaces a typed `BootStart` / `BootStartError`. The payload carries the failure stage and errno so callers can recover or report cleanly.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Error;
+use microsandbox_runtime::boot_error::BootErrorStage;
+
+match Sandbox::builder("svc").image("alpine").create().await {
+    Ok(sb) => { /* ... */ }
+    Err(Error::BootStart { name, err }) => {
+        eprintln!("Sandbox {name:?} failed at stage {:?}: {}", err.stage, err.message);
+        if matches!(err.stage, BootErrorStage::Mount) {
+            eprintln!("Hint: a host volume path may not exist.");
+        }
+    }
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import { BootStartError } from "microsandbox";
+
+try {
+    const sb = await Sandbox.builder("svc").image("alpine").create();
+} catch (e) {
+    if (e instanceof BootStartError) {
+        console.error(`Sandbox "${e.name}" failed at stage ${e.stage}: ${e.message}`);
+        if (e.stage === "mount") {
+            console.error("Hint: a host volume path may not exist.");
+        }
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import BootStartError
+
+try:
+    sb = await Sandbox.create("svc", image="alpine")
+except BootStartError as e:
+    print(f"Sandbox {e.name!r} failed at stage {e.stage}: {e.message}")
+    if e.stage == "mount":
+        print("Hint: a host volume path may not exist.")
+```
+</CodeGroup>
+
+The CLI prepends the same payload as a styled `error:` block before any captured log output, so you see "what went wrong + a hint" inline. SDK callers get the structured payload to make their own decisions.
+
+## Resource cleanup
+
+Sandboxes hold compute resources, so release them when done. In Rust, `Drop` handles cleanup when the sandbox goes out of scope. In TypeScript, prefer `await using` (Node 22+) which calls `Sandbox.stop()` automatically when the binding leaves scope.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+// Sandbox implements Drop, so resources are released when `sb` goes out of scope.
+// For explicit control, call stop() or kill().
+{
+    let sb = Sandbox::builder("temp")
+        .image("python")
+        .create()
+        .await?;
+
+    let output = sb.exec("python", ["-c", "print('hello')"]).await?;
+} // sb is dropped here, resources are cleaned up
+```
+
+```typescript TypeScript
+async function runTemporary(): Promise<string> {
+    // `await using` calls Sandbox.stop() when the binding leaves scope.
+    await using sb = await Sandbox.builder("temp")
+        .image("python")
+        .replace()
+        .create();
+
+    const out = await sb.exec("python", ["-c", "print('hello')"]);
+    return out.stdout();
+}
+```
+
+```python Python
+# Use async context manager — auto-kills and removes on exit.
+async with await Sandbox.create("temp", image="python") as sb:
+    output = await sb.exec("python", ["-c", "print('hello')"])
+    print(output.stdout_text)
+```
+
+</CodeGroup>

--- a/docs/fr/sdk/overview.mdx
+++ b/docs/fr/sdk/overview.mdx
@@ -1,0 +1,96 @@
+---
+title: Overview
+description: Install the SDK and create your first sandbox
+icon: "play"
+---
+
+The SDK embeds the microsandbox runtime directly into whatever application uses it. `Sandbox.builder(name).create()` spawns the VM as a child process. No daemon to install, no server to connect to.
+
+## Installation
+
+<CodeGroup>
+```bash Rust
+cargo add microsandbox
+```
+
+```bash TypeScript
+npm install microsandbox
+```
+
+```bash Python
+pip install microsandbox
+```
+</CodeGroup>
+
+## Quick start
+
+Create a sandbox from a container image, run a command, print the output, and stop it.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, NetworkPolicy};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let sb = Sandbox::builder("my-sandbox")
+        .image("python")
+        .memory(512)
+        .cpus(2)
+        .env("PYTHONDONTWRITEBYTECODE", "1")
+        .volume("/app/src", |v| v.bind("./src").readonly())
+        .network(|n| n.policy(NetworkPolicy::public_only()))
+        .create()
+        .await?;
+
+    let output = sb.exec("python", ["-c", "print('Hello, World!')"]).await?;
+    println!("{}", output.stdout()?);
+
+    sb.stop().await?;
+    Ok(())
+}
+```
+
+```typescript TypeScript
+import { NetworkPolicy, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("my-sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .env("PYTHONDONTWRITEBYTECODE", "1")
+    .volume("/app/src", (m) => m.bind("./src").readonly())
+    .network((n) => n.policy(NetworkPolicy.publicOnly()))
+    .create();
+
+const output = await sb.exec("python", ["-c", "print('Hello, World!')"]);
+console.log("Output:", output.stdout());
+```
+
+```python Python
+import asyncio
+from microsandbox import Network, Sandbox, Volume
+
+async def main():
+    sb = await Sandbox.create(
+        "my-sandbox",
+        image="python",
+        memory=512,
+        cpus=2,
+        env={"PYTHONDONTWRITEBYTECODE": "1"},
+        volumes={
+            "/app/src": Volume.bind("./src", readonly=True),
+        },
+        network=Network.public_only(),
+    )
+
+    output = await sb.exec("python", ["-c", "print('Hello, World!')"])
+    print("Output:", output.stdout_text)
+
+    await sb.stop()
+
+asyncio.run(main())
+```
+
+</CodeGroup>
+
+The SDK reference is split by language - choose [Rust SDK](/sdk/rust/sandbox), [TypeScript SDK](/sdk/typescript/sandbox), or [Python SDK](/sdk/python/sandbox) for the full API. See also [error handling](/sdk/errors).

--- a/docs/fr/sdk/python/events.mdx
+++ b/docs/fr/sdk/python/events.mdx
@@ -1,0 +1,11 @@
+---
+title: Events
+description: Python SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for a preview of event concepts and planned API.

--- a/docs/fr/sdk/python/execution.mdx
+++ b/docs/fr/sdk/python/execution.mdx
@@ -1,0 +1,212 @@
+---
+title: Execution
+description: Python SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+## Types
+
+### ExecOutput
+
+The result of a completed command execution.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| exit_code | `int` | Exit code |
+| success | `bool` | `True` if exit_code is `0` |
+| stdout_text | `str` | Collected stdout decoded as UTF-8. Raises on invalid encoding. |
+| stderr_text | `str` | Collected stderr decoded as UTF-8 |
+| stdout_bytes | `bytes` | Raw stdout bytes |
+| stderr_bytes | `bytes` | Raw stderr bytes |
+
+---
+
+### ExecHandle
+
+A handle to a running streaming execution. Supports `async for event in handle:` to iterate over events until the stream ends.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| id | `str` | Correlation ID for this execution |
+| take_stdin() | [`ExecSink`](#execsink) ` \| None` | Take the stdin writer. Returns `None` after first call. |
+| recv() | `ExecEvent \| None` | *(async)* Receive the next event. Returns `None` when done. |
+| wait() | `tuple[int, bool]` | *(async)* Wait for the process to exit. Returns `(code, success)`. |
+| collect() | [`ExecOutput`](#execoutput) | *(async)* Wait and collect all remaining output |
+| signal(sig) | `None` | *(async)* Send a POSIX signal to the process |
+| kill() | `None` | *(async)* Send SIGKILL |
+
+---
+
+### ExecSink
+
+Writer for sending data to a running process's stdin.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| write() | `data: bytes` | *(async)* Write bytes to the process's stdin |
+| close() | - | *(async)* Close stdin. The process sees EOF. |
+
+---
+
+### ExecEvent
+
+Low-level event from PyO3 bindings.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| event_type | `str` | `"started"`, `"stdout"`, `"stderr"`, or `"exited"` |
+| pid | `int \| None` | Guest PID (on `"started"`) |
+| data | `bytes \| None` | Output data (on `"stdout"` / `"stderr"`) |
+| code | `int \| None` | Exit code (on `"exited"`) |
+
+Python dataclass variants are also available for pattern matching:
+
+| Class | Fields | Description |
+|-------|--------|-------------|
+| `StartedEvent` | `pid: int` | The process has started |
+| `StdoutEvent` | `data: bytes` | A chunk of stdout data |
+| `StderrEvent` | `data: bytes` | A chunk of stderr data |
+| `ExitedEvent` | `code: int` | The process has exited |
+
+The union type `ExecEvent = StartedEvent | StdoutEvent | StderrEvent | ExitedEvent` is available from `events.py`.
+
+---
+
+### ExecOptions
+
+```python
+ExecOptions(
+    args: tuple[str, ...] = (),
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] = {},
+    timeout: float | None = None,  # seconds
+    stdin: Stdin = Stdin.null(),
+    tty: bool = False,
+    rlimits: tuple[Rlimit, ...] = (),
+)
+```
+
+Frozen dataclass for per-execution overrides.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| args | `tuple[str, ...]` | `()` | Command arguments |
+| cwd | `str \| None` | `None` | Working directory |
+| user | `str \| None` | `None` | Guest user |
+| env | `Mapping[str, str]` | `{}` | Environment variables |
+| timeout | `float \| None` | `None` | Kill the process after this many seconds |
+| stdin | [`Stdin`](#stdin) | `Stdin.null()` | Stdin source |
+| tty | `bool` | `False` | Allocate a pseudo-terminal |
+| rlimits | `tuple[`[`Rlimit`](#rlimit)`, ...]` | `()` | Resource limits |
+
+---
+
+### AttachOptions
+
+```python
+AttachOptions(
+    args: tuple[str, ...] = (),
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] = {},
+    detach_keys: str | None = None,
+)
+```
+
+Frozen dataclass for interactive PTY attach configuration.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| args | `tuple[str, ...]` | `()` | Command arguments |
+| cwd | `str \| None` | `None` | Working directory |
+| user | `str \| None` | `None` | Guest user |
+| env | `Mapping[str, str]` | `{}` | Environment variables |
+| detach_keys | `str \| None` | `None` | Key sequence to detach without stopping |
+
+---
+
+### Stdin
+
+Frozen dataclass with factory methods for configuring process stdin.
+
+| Factory | Parameters | Description |
+|---------|-----------|-------------|
+| Stdin.null() | - | `/dev/null` (default) |
+| Stdin.pipe() | - | Piped stdin. Use [`take_stdin()`](#exechandle) on the handle to write. |
+| Stdin.bytes() | `data: bytes` | Inline data sent before the process starts |
+
+---
+
+### Rlimit
+
+Frozen dataclass with factory methods for POSIX resource limits.
+
+| Factory | Parameters | Description |
+|---------|-----------|-------------|
+| Rlimit.nofile(limit) | `limit: int` | Max open file descriptors |
+| Rlimit.cpu(secs) | `secs: int` | CPU time limit in seconds |
+| Rlimit.as_(*, soft, hard) | `soft: int, hard: int` | Virtual memory size |
+| Rlimit.nproc(limit) | `limit: int` | Max number of processes |
+| Rlimit.fsize(limit) | `limit: int` | Max file size |
+| Rlimit.memlock(limit) | `limit: int` | Max locked memory |
+| Rlimit.stack(limit) | `limit: int` | Max stack size |
+
+**Properties**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| resource | [`RlimitResource`](#rlimitresource) | Resource type |
+| soft | `int` | Soft limit |
+| hard | `int` | Hard limit |
+
+---
+
+### RlimitResource
+
+Enum of POSIX resource types.
+
+| Value | Description |
+|-------|-------------|
+| `cpu` | CPU time |
+| `fsize` | File size |
+| `data` | Data segment size |
+| `stack` | Stack size |
+| `core` | Core file size |
+| `rss` | Resident set size |
+| `nproc` | Number of processes |
+| `nofile` | Open file descriptors |
+| `memlock` | Locked memory |
+| `as` | Virtual memory |
+| `locks` | File locks |
+| `sigpending` | Pending signals |
+| `msgqueue` | Message queue size |
+| `nice` | Nice priority ceiling |
+| `rtprio` | Real-time priority ceiling |
+| `rttime` | Real-time CPU time |
+
+---
+
+### SandboxMetrics
+
+Metrics snapshot for a running sandbox.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| cpu_percent | `float` | CPU utilization percentage |
+| memory_bytes | `int` | Current memory usage in bytes |
+| memory_limit_bytes | `int` | Memory limit in bytes |
+| disk_read_bytes | `int` | Total bytes read from disk |
+| disk_write_bytes | `int` | Total bytes written to disk |
+| net_rx_bytes | `int` | Total bytes received over the network |
+| net_tx_bytes | `int` | Total bytes sent over the network |
+| uptime_ms | `int` | Sandbox uptime in milliseconds |
+| timestamp_ms | `float` | Timestamp of the snapshot in milliseconds |
+
+---
+
+### MetricsStream
+
+Async iterator yielding [`SandboxMetrics`](#sandboxmetrics). Use `async for metrics in stream:` to consume.

--- a/docs/fr/sdk/python/filesystem.mdx
+++ b/docs/fr/sdk/python/filesystem.mdx
@@ -1,0 +1,357 @@
+---
+title: Filesystem
+description: Python SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via the `sandbox.fs` property. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
+
+---
+
+#### copy()
+
+```python
+async def copy(src: str, dst: str) -> None
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Source path |
+| dst | `str` | Destination path |
+
+---
+
+#### copy_from_host()
+
+```python
+async def copy_from_host(host_path: str, guest_path: str) -> None
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `str` | Path on the host filesystem |
+| guest_path | `str` | Destination path inside the sandbox |
+
+---
+
+#### copy_to_host()
+
+```python
+async def copy_to_host(guest_path: str, host_path: str) -> None
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `str` | Path inside the sandbox |
+| host_path | `str` | Destination path on the host |
+
+---
+
+#### exists()
+
+```python
+async def exists(path: str) -> bool
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `True` if the path exists |
+
+---
+
+#### list()
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`FsEntry`](#fsentry)`]` | Directory entries |
+
+---
+
+#### mkdir()
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory and all parent directories.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path |
+
+---
+
+#### read()
+
+```python
+async def read(path: str) -> bytes
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bytes` | File contents as raw bytes |
+
+---
+
+#### read_stream()
+
+```python
+async def read_stream(path: str) -> FsReadStream
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsReadStream`](#fsreadstream) | Async iterator that yields chunks of file data |
+
+---
+
+#### read_text()
+
+```python
+async def read_text(path: str) -> str
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `str` | File contents as a string |
+
+---
+
+#### remove()
+
+```python
+async def remove(path: str) -> None
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute file path |
+
+---
+
+#### remove_dir()
+
+```python
+async def remove_dir(path: str) -> None
+```
+
+Remove a directory recursively.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path |
+
+---
+
+#### rename()
+
+```python
+async def rename(src: str, dst: str) -> None
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Current path |
+| dst | `str` | New path |
+
+---
+
+#### stat()
+
+```python
+async def stat(path: str) -> FsMetadata
+```
+
+Get detailed metadata for a file or directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsMetadata`](#fsmetadata) | File metadata |
+
+---
+
+#### write()
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| data | `bytes` | File content |
+
+---
+
+#### write_stream()
+
+```python
+async def write_stream(path: str) -> FsWriteSink
+```
+
+Open a streaming writer for a file. Use this for files too large to fit in memory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsWriteSink`](#fswritesink) | Async writer that accepts chunks of data |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
+| mode | `int` | Unix permission bits |
+| modified | `float \| None` | Last modified timestamp (ms since epoch) |
+| path | `str` | File path |
+| size | `int` | File size in bytes |
+
+### FsEntryKind
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) representing the type of a filesystem entry.
+
+| Value | Description |
+|-------|-------------|
+| `"directory"` | Directory |
+| `"file"` | Regular file |
+| `"other"` | Other entry type |
+| `"symlink"` | Symbolic link |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| created | `float \| None` | Creation timestamp (ms since epoch) |
+| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
+| mode | `int` | Unix permission bits |
+| modified | `float \| None` | Last modified timestamp (ms since epoch) |
+| readonly | `bool` | Whether the file is read-only |
+| size | `int` | File size in bytes |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`read_stream()`](#read_stream).
+
+| Method / Protocol | Returns | Description |
+|-------------------|---------|-------------|
+| `__aiter__` / `__anext__` | `bytes` | Async iterator - use with `async for chunk in stream:` |
+| `collect()` | `bytes` | Collect all remaining data into a single `bytes` object |
+
+### FsWriteSink
+
+Async writer for streaming data into a file. Obtained via [`write_stream()`](#write_stream). Supports the async context manager protocol (`async with`).
+
+| Method / Protocol | Returns | Description |
+|-------------------|---------|-------------|
+| `write(data)` | `None` | Write a chunk of `bytes` to the file |
+| `close()` | `None` | Send EOF and finalize the file |
+| `__aenter__` / `__aexit__` | `FsWriteSink` | Use with `async with` for automatic close on exit |

--- a/docs/fr/sdk/python/networking.mdx
+++ b/docs/fr/sdk/python/networking.mdx
@@ -1,0 +1,333 @@
+---
+title: Networking
+description: Python SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## Network
+
+Frozen dataclass for sandbox network configuration. Use a class-method preset for the common cases, or construct directly with custom options.
+
+```python
+Network(
+    policy: str | NetworkPolicy | None = None,
+    ports: Mapping[int, int] = {},
+    deny_domains: tuple[str, ...] = (),
+    deny_domain_suffixes: tuple[str, ...] = (),
+    dns: DnsConfig | None = None,
+    tls: TlsConfig | None = None,
+    max_connections: int | None = None,
+    trust_host_cas: bool | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| policy | `str \| NetworkPolicy \| None` | Preset name (`"none"`, `"public_only"`, `"allow_all"`) or custom [`NetworkPolicy`](#networkpolicy-1) |
+| ports | `Mapping[int, int]` | Port mappings from host to guest |
+| deny_domains | `tuple[str, ...]` | Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy so it takes precedence over later allow rules |
+| deny_domain_suffixes | `tuple[str, ...]` | Deny egress to all subdomains of these suffixes. Adds `deny DomainSuffix("...")` rules; same enforcement layers as `deny_domains` |
+| dns | [`DnsConfig`](#dnsconfig) ` \| None` | DNS interception configuration |
+| tls | [`TlsConfig`](#tlsconfig) ` \| None` | TLS interception configuration |
+| max_connections | `int \| None` | Maximum concurrent connections |
+| trust_host_cas | `bool \| None` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle. Opt-in |
+
+---
+
+#### Network.allow_all()
+
+```python
+@classmethod
+def allow_all() -> Network
+```
+
+Unrestricted network access, including to private addresses and the host machine.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Unrestricted network configuration |
+
+---
+
+#### Network.none()
+
+```python
+@classmethod
+def none() -> Network
+```
+
+Deny all traffic. No network interface is created; the guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Fully airgapped network configuration |
+
+---
+
+#### Network.public_only()
+
+```python
+@classmethod
+def public_only() -> Network
+```
+
+Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Public-only network configuration |
+
+---
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Pass to `Network(policy=...)` for custom policies:
+
+```python
+from microsandbox import NetworkPolicy, Rule, Action, Direction, Protocol
+
+policy = NetworkPolicy(
+    default_egress=Action.DENY,
+    default_ingress=Action.ALLOW,
+    rules=(
+        Rule.allow(protocol=Protocol.TCP, port=443, destination="public"),
+        Rule.deny(destination="198.51.100.5"),
+    ),
+)
+```
+
+The default policy denies egress except for an implicit `allow public`, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry.
+
+```python
+NetworkPolicy(
+    default_egress: Action = Action.DENY,
+    default_ingress: Action = Action.ALLOW,
+    rules: tuple[Rule, ...] = (),
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
+| rules | `tuple[`[`Rule`](#rule)`, ...]` | Rules evaluated first-match-wins per direction |
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```python
+policy = NetworkPolicy(
+    default_egress=Action.DENY,
+    default_ingress=Action.ALLOW,
+    rules=(
+        Rule.allow(destination="10.0.0.0/8"),     # matches everything in 10.x
+        Rule.deny(destination="10.0.0.5"),        # never reached
+    ),
+)
+```
+
+Put specific rules before general ones.
+
+---
+
+## Rule
+
+Frozen dataclass for a single network policy rule.
+
+```python
+Rule(
+    action: Action,
+    direction: Direction = Direction.EGRESS,
+    destination: str | None = None,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| action | [`Action`](#action) | What to do when this rule matches |
+| direction | [`Direction`](#direction) | Which evaluator considers this rule. `Direction.ANY` matches in either direction |
+| destination | `str \| None` | Target filter: a [`DestGroup`](#destgroup) value, domain, CIDR range, domain suffix (prefixed with `"."`), or `"*"` for any. Domain and suffix strings are validated at sandbox creation; invalid names raise `ValueError` |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Single port (`443`) or range (`"8000-9000"`) |
+
+Ingress rules carrying ICMP protocols are rejected at sandbox creation; the host has no inbound ICMP path. Use `Direction.EGRESS` for ICMP allow/deny.
+
+---
+
+#### Rule.allow()
+
+```python
+@classmethod
+def allow(
+    *,
+    direction: Direction = Direction.EGRESS,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+    destination: str | None = None,
+) -> Rule
+```
+
+Create a rule that permits matching traffic.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| direction | [`Direction`](#direction) | Traffic direction |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Port or port range |
+| destination | `str \| None` | Destination filter |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | An allow rule |
+
+---
+
+#### Rule.deny()
+
+```python
+@classmethod
+def deny(
+    *,
+    direction: Direction = Direction.EGRESS,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+    destination: str | None = None,
+) -> Rule
+```
+
+Create a rule that blocks matching traffic.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| direction | [`Direction`](#direction) | Traffic direction |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Port or port range |
+| destination | `str \| None` | Destination filter |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | A deny rule |
+
+---
+
+## DnsConfig
+
+Frozen dataclass for DNS interception settings.
+
+```python
+DnsConfig(
+    rebind_protection: bool = True,
+    nameservers: tuple[str, ...] = (),
+    query_timeout_ms: int | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| nameservers | `tuple[str, ...]` | Nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). Overrides the host's `/etc/resolv.conf` when set. Hostnames are resolved once at startup via the host's OS resolver |
+| query_timeout_ms | `int \| None` | Per-DNS-query timeout in milliseconds |
+| rebind_protection | `bool` | Block DNS responses resolving to private IPs |
+
+---
+
+## TlsConfig
+
+Frozen dataclass for TLS interception settings within [`Network`](#network).
+
+```python
+TlsConfig(
+    bypass: tuple[str, ...] = (),
+    verify_upstream: bool = True,
+    intercepted_ports: tuple[int, ...] = (443,),
+    block_quic: bool = False,
+    ca_cert: str | None = None,
+    ca_key: str | None = None,
+    ca_cn: str | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| block_quic | `bool` | Block QUIC/HTTP3 (UDP) on intercepted ports, forcing TCP/TLS fallback |
+| bypass | `tuple[str, ...]` | Domains to skip interception. Use for domains with certificate pinning |
+| ca_cert | `str \| None` | Path to a custom interception CA certificate PEM file |
+| ca_cn | `str \| None` | Common name for the generated interception CA |
+| ca_key | `str \| None` | Path to a custom interception CA private key PEM file |
+| intercepted_ports | `tuple[int, ...]` | TCP ports where TLS interception is active |
+| verify_upstream | `bool` | Verify upstream server certificates. Set to `False` only for self-signed servers |
+
+---
+
+## Types
+
+### Action
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) for policy actions.
+
+| Value | Description |
+|-------|-------------|
+| `"allow"` | Permit the traffic |
+| `"deny"` | Drop the traffic silently |
+
+### Direction
+
+String enum for traffic direction.
+
+| Value | Description |
+|-------|-------------|
+| `"egress"` | Traffic leaving the sandbox |
+| `"ingress"` | Traffic entering the sandbox (via published ports) |
+| `"any"` | Rule applies in either direction |
+
+### Protocol
+
+String enum for network protocols in policy rules.
+
+| Value | Description |
+|-------|-------------|
+| `"tcp"` | TCP traffic |
+| `"udp"` | UDP traffic |
+| `"icmpv4"` | ICMPv4 traffic |
+| `"icmpv6"` | ICMPv6 traffic |
+
+### PortProtocol
+
+String enum for port-level protocol selection.
+
+| Value | Description |
+|-------|-------------|
+| `"tcp"` | TCP port |
+| `"udp"` | UDP port |
+
+### DestGroup
+
+String enum for well-known destination groups used in [`Rule.destination`](#rule).
+
+| Value | Description |
+|-------|-------------|
+| `"public"` | Complement of the named categories: every address not in any other group |
+| `"private"` | Private/RFC 1918 addresses + ULA + CGN (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7`) |
+| `"loopback"` | Loopback addresses (`127.0.0.0/8`, `::1`); the **guest's own** loopback, not the host. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap) |
+| `"link-local"` | Link-local addresses (`169.254.0.0/16`, `fe80::/10`) excluding metadata |
+| `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
+| `"multicast"` | Multicast addresses (`224.0.0.0/4`, `ff00::/8`) |
+| `"host"` | The host machine, reached via `host.microsandbox.internal`. This is the right group for "let the sandbox reach my host's localhost", not `"loopback"` |

--- a/docs/fr/sdk/python/sandbox.mdx
+++ b/docs/fr/sdk/python/sandbox.mdx
@@ -1,0 +1,898 @@
+---
+title: Sandbox
+description: Python SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+## Static methods
+
+---
+
+#### Sandbox.create()
+
+```python
+@staticmethod
+async def create(name_or_config: str | dict, **kwargs) -> Sandbox
+```
+
+Create and boot a sandbox. The first argument is either a name (`str`) or a full config (`dict`). Keyword arguments provide individual config fields. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name_or_config | `str \| dict` | Sandbox name or full configuration dict |
+| image | `str \| ImageSource` | OCI image, local path, or disk image (required) |
+| cpus | `int` | Virtual CPUs (default `1`) |
+| memory | `int` | Guest memory in MiB (default `512`) |
+| workdir | `str` | Default working directory for commands |
+| shell | `str` | Shell for `shell()` calls (default `"/bin/sh"`) |
+| hostname | `str` | Guest hostname |
+| user | `str` | Default guest user |
+| entrypoint | `list[str]` | Override image entrypoint |
+| init | `str \| dict \|` [`InitConfig`](#initconfig) | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) and [`InitConfig`](#initconfig) for accepted shapes |
+| replace | `bool` | Replace existing sandbox with same name |
+| max_duration | `float` | Maximum sandbox lifetime in seconds |
+| idle_timeout | `float` | Idle timeout in seconds |
+| env | `dict[str, str]` | Environment variables visible to all commands |
+| scripts | `dict[str, str]` | Named scripts mounted at `/.msb/scripts/` |
+| pull_policy | `str \| PullPolicy` | Image pull behavior |
+| log_level | `str \| LogLevel` | Override log verbosity |
+| registry_auth | [`RegistryAuth`](#registryauth) | Private registry credentials |
+| volumes | `dict[str, dict]` | Volume mounts. See [Volumes](/sdk/python/volumes). |
+| patches | `list[PatchConfig]` | Rootfs modifications applied before boot |
+| ports | `dict[int, int]` | Port mappings (`host_port: guest_port`) |
+| network | [`Network`](/sdk/python/networking#network) | Network policy and configuration |
+| secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | Secret injection |
+| detached | `bool` | If `True`, sandbox survives after your process exits |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+The returned `Sandbox` is an async context manager. Use `async with` to guarantee cleanup; on exit the sandbox is killed and its persisted state removed:
+
+```python
+async with await Sandbox.create("my-sandbox", image="alpine") as sb:
+    output = await sb.shell("echo hello")
+    print(output.stdout_text)
+# sandbox is automatically killed and removed on exit
+```
+
+---
+
+#### Sandbox.create_with_progress()
+
+```python
+@staticmethod
+def create_with_progress(name_or_config: str | dict, **kwargs) -> PullSession
+```
+
+Same parameters as [`Sandbox.create()`](#sandboxcreate) but returns a [`PullSession`](#pullsession) that lets you track image pull progress before the sandbox is ready. This method is synchronous (not awaitable) -- the async work happens through the `PullSession`.
+
+**Parameters**
+
+Same as [`Sandbox.create()`](#sandboxcreate).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`PullSession`](#pullsession) | Session for tracking pull progress and obtaining the final sandbox |
+
+---
+
+#### Sandbox.start()
+
+```python
+@staticmethod
+async def start(name: str, *, detached: bool = False) -> Sandbox
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Name of a stopped sandbox |
+| detached | `bool` | If `True`, sandbox survives after your process exits (default `False`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox.get()
+
+```python
+@staticmethod
+async def get(name: str) -> SandboxHandle
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox.list()
+
+```python
+@staticmethod
+async def list() -> list[SandboxHandle]
+```
+
+List all sandboxes (running, stopped, and crashed).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`SandboxHandle`](#sandboxhandle)`]` | All sandboxes |
+
+---
+
+#### Sandbox.remove()
+
+```python
+@staticmethod
+async def remove(name: str) -> None
+```
+
+Delete a stopped sandbox and all its state from disk. Fails if the sandbox is still running.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Sandbox name |
+
+---
+
+## Instance properties
+
+---
+
+#### name
+
+```python
+@property
+async def name(self) -> str
+```
+
+Sandbox name. This is an async property -- use `await sb.name`.
+
+---
+
+#### owns_lifecycle
+
+```python
+@property
+async def owns_lifecycle(self) -> bool
+```
+
+Whether this handle owns the sandbox lifecycle. `True` in attached mode, `False` in detached mode. This is an async property -- use `await sb.owns_lifecycle`.
+
+---
+
+#### fs
+
+```python
+@property
+def fs(self) -> SandboxFs
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. This is a synchronous property -- use `sb.fs` (no `await`). See [Filesystem](/sdk/python/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/python/filesystem) | Filesystem handle |
+
+---
+
+## Instance methods
+
+---
+
+#### attach()
+
+```python
+async def attach(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> int
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to run |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or execution options |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `int` | Exit code of the process |
+
+---
+
+#### attach_shell()
+
+```python
+async def attach_shell() -> int
+```
+
+Attach to the sandbox's default shell.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `int` | Exit code |
+
+---
+
+#### detach()
+
+```python
+async def detach() -> None
+```
+
+Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```python
+async def drain() -> None
+```
+
+Start a graceful drain (SIGUSR1). Existing commands run to completion, new `exec` calls are rejected.
+
+---
+
+#### exec()
+
+```python
+async def exec(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecOutput
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments (e.g. `["-c", "print('hello')"]`) or [`ExecOptions`](/sdk/python/execution#execoptions) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### exec_stream()
+
+```python
+async def exec_stream(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecHandle
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to execute |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or [`ExecOptions`](/sdk/python/execution#execoptions) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### kill()
+
+```python
+async def kill() -> None
+```
+
+Force-terminate the sandbox immediately (SIGKILL). No graceful shutdown.
+
+---
+
+#### metrics()
+
+```python
+async def metrics() -> SandboxMetrics
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network metrics |
+
+---
+
+#### metrics_stream()
+
+```python
+async def metrics_stream(interval: float = 1.0) -> MetricsStream
+```
+
+Stream resource metrics at a regular interval. The returned stream supports both `recv()` and `async for`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| interval | `float` | Seconds between metric snapshots (default `1.0`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`MetricsStream`](#metricsstream) | Async stream of metrics |
+
+---
+
+#### logs()
+
+```python
+async def logs(
+    tail: int | None = None,
+    since_ms: float | None = None,
+    until_ms: float | None = None,
+    sources: list[str] | None = None,
+) -> list[LogEntry]
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```python
+import asyncio
+import microsandbox
+
+async def main():
+    handle = await microsandbox.Sandbox.get("web")
+
+    # Default — all user-program output, regardless of pipe/pty mode
+    entries = await handle.logs()
+
+    for e in entries:
+        source = {
+            "stdout": "OUT",
+            "stderr": "ERR",
+            "output": "PTY",
+            "system": "SYS",
+        }[e.source]
+        print(
+            f"[{e.timestamp_ms / 1000:.3f}] "
+            f"{source} {e.session_id}: {e.text().rstrip()}"
+        )
+
+    # Filtered: last 50 entries from the past hour, including system lines
+    import time
+    recent = await handle.logs(
+        tail=50,
+        since_ms=(time.time() - 3600) * 1000,
+        sources=["stdout", "stderr", "output", "system"],
+    )
+
+asyncio.run(main())
+```
+
+Timestamps are exposed as `float` ms since the Unix epoch (UTC) for parity with `SandboxMetrics.timestamp_ms`. Convert to `datetime` if needed:
+
+```python
+from datetime import datetime, timezone
+dt = datetime.fromtimestamp(e.timestamp_ms / 1000, timezone.utc)
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| tail | `int \| None` | Show only the last N entries after other filters apply |
+| since_ms | `float \| None` | Inclusive lower bound on entry timestamp (ms since epoch) |
+| until_ms | `float \| None` | Exclusive upper bound on entry timestamp (ms since epoch) |
+| sources | `list[str] \| None` | Sources to include. `None` = `["stdout", "stderr", "output"]`. Add `"system"` to merge runtime/kernel diagnostics. Use `"all"` as shorthand for all four. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`LogEntry`](#logentry)`]` | Matching entries in chronological order |
+
+---
+
+#### remove_persisted()
+
+```python
+async def remove_persisted() -> None
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### shell()
+
+```python
+async def shell(script: str) -> ExecOutput
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `str` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell_stream()
+
+```python
+async def shell_stream(script: str) -> ExecHandle
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `str` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle |
+
+---
+
+#### stop()
+
+```python
+async def stop() -> None
+```
+
+Gracefully shut down the sandbox (SIGTERM).
+
+---
+
+#### stop_and_wait()
+
+```python
+async def stop_and_wait() -> tuple[int, bool]
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
+
+---
+
+#### wait()
+
+```python
+async def wait() -> tuple[int, bool]
+```
+
+Block until the sandbox exits on its own.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
+
+---
+
+## Patch
+
+Factory class for rootfs patches passed to `Sandbox.create(..., patches=[...])`. Each static method returns a [`PatchConfig`](#patchconfig). By default a patch that targets a path already present in the image errors at boot; pass `replace=True` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### Patch.append()
+
+```python
+@staticmethod
+def append(path: str, content: str) -> PatchConfig
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| content | `str` | Text to append |
+
+---
+
+#### Patch.copy_dir()
+
+```python
+@staticmethod
+def copy_dir(src: str, dst: str, *, replace: bool = False) -> PatchConfig
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Host source directory |
+| dst | `str` | Absolute destination path inside the guest |
+| replace | `bool` | When `True`, overwrite an existing path at `dst` |
+
+---
+
+#### Patch.copy_file()
+
+```python
+@staticmethod
+def copy_file(
+    src: str,
+    dst: str,
+    *,
+    mode: int | None = None,
+    replace: bool = False,
+) -> PatchConfig
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Host source file |
+| dst | `str` | Absolute destination path inside the guest |
+| mode | `int \| None` | File mode, e.g. `0o644`. `None` keeps the source mode |
+| replace | `bool` | When `True`, overwrite an existing path at `dst` |
+
+---
+
+#### Patch.mkdir()
+
+```python
+@staticmethod
+def mkdir(path: str, *, mode: int | None = None) -> PatchConfig
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| mode | `int \| None` | Directory mode, e.g. `0o755` |
+
+---
+
+#### Patch.remove()
+
+```python
+@staticmethod
+def remove(path: str) -> PatchConfig
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+---
+
+#### Patch.symlink()
+
+```python
+@staticmethod
+def symlink(target: str, link: str, *, replace: bool = False) -> PatchConfig
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `str` | What the symlink points to (literal symlink target text) |
+| link | `str` | Absolute path of the symlink itself |
+| replace | `bool` | When `True`, overwrite an existing path at `link` |
+
+---
+
+#### Patch.text()
+
+```python
+@staticmethod
+def text(
+    path: str,
+    content: str,
+    *,
+    mode: int | None = None,
+    replace: bool = False,
+) -> PatchConfig
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| content | `str` | Text content |
+| mode | `int \| None` | File mode, e.g. `0o644` |
+| replace | `bool` | When `True`, overwrite an existing path |
+
+---
+
+## Types
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `"debug"` | Debug and higher |
+| `"error"` | Errors only |
+| `"info"` | Info and higher |
+| `"trace"` | Most verbose -- all diagnostic output |
+| `"warn"` | Warnings and errors only |
+
+### LogEntry
+
+A single captured log entry returned by [`logs()`](#logs).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| timestamp_ms | `float` | Wall-clock capture time (ms since Unix epoch, UTC) |
+| source | `str` | Where the chunk came from. See [LogSource](#logsource). |
+| session_id | `int \| None` | Relay-monotonic session id; `None` for `"system"` entries |
+| data | `bytes` | The chunk's bytes (UTF-8 lossy decoded by default) |
+| `text()` | `str` | Convenience: UTF-8 decode of `data` (lossy — invalid bytes are replaced) |
+
+### LogSource
+
+The string values that the `source` field on a [`LogEntry`](#logentry) can take, also accepted by `logs(sources=[...])`.
+
+| Value | Description |
+|-------|-------------|
+| `"stdout"` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `"stderr"` | Captured from a session's stderr (pipe mode) |
+| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `"output"` rather than mislabelled as `"stdout"`. |
+| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested. |
+
+In addition, `logs(sources=["all"])` is a shorthand for all four.
+
+### MetricsStream
+
+Async stream for receiving periodic metrics snapshots.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `__aiter__` | `AsyncIterator[`[`SandboxMetrics`](#sandboxmetrics)`]` | Use with `async for` |
+| `recv()` | [`SandboxMetrics`](#sandboxmetrics) `\| None` | Receive next snapshot. Returns `None` when the stream ends. |
+
+### PatchConfig
+
+A single rootfs patch. Produced by the [`Patch`](#patch) factory; you'd normally not construct one directly. Frozen dataclass.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | `str` | One of `"text"`, `"file"`, `"copy_file"`, `"copy_dir"`, `"symlink"`, `"mkdir"`, `"remove"`, `"append"` |
+| path | `str \| None` | Absolute guest path (used by text / file / mkdir / remove / append) |
+| content | `str \| None` | Text content (text / append) |
+| src | `str \| None` | Host source path (copy_file / copy_dir) |
+| dst | `str \| None` | Guest destination path (copy_file / copy_dir) |
+| target | `str \| None` | Symlink target |
+| link | `str \| None` | Symlink path |
+| mode | `int \| None` | File / directory mode (e.g. `0o644`) |
+| replace | `bool` | When `True`, overwrite an existing path at the destination. Defaults to `False` |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `"always"` | Pull the image every time, even if cached locally |
+| `"if-missing"` | Pull only if the image is not already cached. This is the default. |
+| `"never"` | Never pull; fail if the image is not cached locally |
+
+### PullSession
+
+Returned by [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress). Use as an async context manager to track image pull progress.
+
+```python
+session = Sandbox.create_with_progress("my-sandbox", image="ubuntu:latest")
+async with session:
+    async for event in session.progress:
+        print(event)
+    sb = await session.result()
+```
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| progress | `AsyncIterator[PullProgress]` | Async iterator of pull progress events |
+| result() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Await to get the final running sandbox |
+
+### RegistryAuth
+
+Private registry credentials.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| username | `str` | Registry username |
+| password | `str` | Registry password |
+
+### SandboxConfig
+
+The keyword arguments accepted by [`Sandbox.create()`](#sandboxcreate) and [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| image | `str \| ImageSource` | - | OCI image, local path, or disk image (required) |
+| cpus | `int` | `1` | Virtual CPUs |
+| memory | `int` | `512` | Guest memory in MiB. This is a limit, not a reservation. |
+| workdir | `str` | - | Default working directory for commands |
+| shell | `str` | `"/bin/sh"` | Shell for `shell()` calls |
+| hostname | `str` | - | Guest hostname |
+| user | `str` | - | Default guest user |
+| entrypoint | `list[str]` | - | Override image entrypoint |
+| init | `str \| dict \|` [`InitConfig`](#initconfig) | - | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| replace | `bool` | `False` | Replace existing sandbox with same name |
+| max_duration | `float` | - | Maximum sandbox lifetime in seconds |
+| idle_timeout | `float` | - | Idle timeout in seconds |
+| env | `dict[str, str]` | `{}` | Environment variables visible to all commands |
+| scripts | `dict[str, str]` | `{}` | Named scripts mounted at `/.msb/scripts/` |
+| pull_policy | `str \| PullPolicy` | `"if-missing"` | Image pull behavior |
+| log_level | `str \| LogLevel` | - | Override log verbosity |
+| registry_auth | [`RegistryAuth`](#registryauth) | - | Private registry credentials |
+| volumes | `dict[str, dict]` | `{}` | Volume mounts. See [Volumes](/sdk/python/volumes). |
+| patches | `list[PatchConfig]` | `[]` | Rootfs modifications applied before boot |
+| ports | `dict[int, int]` | `{}` | Port mappings (`host_port: guest_port`) |
+| network | [`Network`](/sdk/python/networking#network) | `public_only` | Network policy and configuration |
+| secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | `[]` | Secret injection |
+| detached | `bool` | `False` | If `True`, sandbox survives after your process exits |
+
+### InitConfig
+
+Custom init specification. Pass it (or one of the equivalent shorthand shapes) as the `init=` kwarg to [`Sandbox.create()`](#sandboxcreate) to hand PID 1 inside the guest off to your own init binary after agentd's setup. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks, shutdown semantics, and tradeoffs.
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True, slots=True)
+class InitConfig:
+    cmd: str
+    args: tuple[str, ...] = ()
+    env: Mapping[str, str] = {}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cmd | `str` | Absolute path or `"auto"` to the init binary inside the guest rootfs |
+| args | `tuple[str, ...]` | Supplemental argv (`argv[0]` is implicitly `cmd`) |
+| env | `dict[str, str]` | Extra env vars merged on top of the inherited env |
+
+The `init=` kwarg follows the same shape as other `Sandbox.create` kwargs that carry structured values (`image=`, `network=`, etc.): a bare scalar for the simple case, or a dataclass / dict for the rich case.
+
+| Form | Equivalent to |
+|------|---------------|
+| `init="auto"` or `init="/sbin/init"` | `InitConfig(cmd=...)` |
+| `init={"cmd": ..., "args": [...], "env": {...}}` | dict equivalent of `InitConfig` |
+| `init=InitConfig(cmd="/sbin/init", args=("--foo",))` | itself |
+
+```python
+from microsandbox import InitConfig, Sandbox
+
+# Common case: bare string.
+sb = await Sandbox.create("worker", image="jrei/systemd-debian:12", init="auto")
+
+# Argv / env: dataclass.
+sb = await Sandbox.create(
+    "worker",
+    image="jrei/systemd-debian:12",
+    init=InitConfig(
+        cmd="/lib/systemd/systemd",
+        args=("--unit=multi-user.target",),
+        env={"container": "microsandbox"},
+    ),
+)
+```
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandboxget) or [`Sandbox.list()`](#sandboxlist). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. Call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `str` | Sandbox name |
+| status | `str` | Current status (`"running"`, `"stopped"`, `"crashed"`, `"draining"`, `"paused"`) |
+| config_json | `str` | Raw JSON configuration |
+| created_at | `float \| None` | Creation timestamp (ms since epoch) |
+| updated_at | `float \| None` | Last update timestamp (ms since epoch) |
+| connect() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Connect to a running sandbox |
+| start(*, detached=False) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Start in attached or detached mode |
+| stop() | `Awaitable[None]` | Graceful shutdown |
+| kill() | `Awaitable[None]` | Force terminate |
+| remove() | `Awaitable[None]` | Delete sandbox and state |
+| metrics() | `Awaitable[`[`SandboxMetrics`](#sandboxmetrics)`]` | Point-in-time resource metrics |
+| logs() | `Awaitable[list[`[`LogEntry`](#logentry)`]]` | Read captured `exec.log` (works without starting) |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpu_percent | `float` | CPU usage as a percentage |
+| disk_read_bytes | `int` | Total bytes read from disk since boot |
+| disk_write_bytes | `int` | Total bytes written to disk since boot |
+| memory_bytes | `int` | Current memory usage in bytes |
+| memory_limit_bytes | `int` | Memory limit in bytes |
+| net_rx_bytes | `int` | Total bytes received over the network since boot |
+| net_tx_bytes | `int` | Total bytes sent over the network since boot |
+| timestamp_ms | `float` | When this measurement was taken (ms since epoch) |
+| uptime_ms | `int` | Time since the sandbox was created (ms) |

--- a/docs/fr/sdk/python/secrets.mdx
+++ b/docs/fr/sdk/python/secrets.mdx
@@ -1,0 +1,77 @@
+---
+title: Secrets
+description: Python SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## Secret
+
+Static factory for creating secret entries used in `SandboxConfig.secrets`.
+
+---
+
+#### Secret.env()
+
+```python
+@staticmethod
+def env(
+    env_var: str,
+    *,
+    value: str,
+    allow_hosts: Sequence[str] = (),
+    allow_host_patterns: Sequence[str] = (),
+    placeholder: str | None = None,
+    require_tls: bool = True,
+    on_violation: ViolationAction = ViolationAction.BLOCK_AND_LOG,
+) -> SecretEntry
+```
+
+Create a secret entry that maps an environment variable to a real value. The guest sees a placeholder - the real value is only substituted by the TLS proxy when traffic goes to an allowed host.
+
+**Parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| env_var | `str` | - | Environment variable name (e.g. `"OPENAI_API_KEY"`) |
+| value | `str` | - | The real secret value. Never enters the guest VM. **Required.** |
+| allow_hosts | `Sequence[str]` | `()` | Hosts allowed to receive the real value (exact match). The TLS proxy matches against the SNI. |
+| allow_host_patterns | `Sequence[str]` | `()` | Wildcard host patterns (e.g. `"*.googleapis.com"`) |
+| placeholder | `str \| None` | `None` | Custom placeholder string. Auto-generated as `$MSB_<env_var>` if not set. |
+| require_tls | `bool` | `True` | Only substitute on TLS-intercepted connections. Disable only if you know the traffic is safe. |
+| on_violation | [`ViolationAction`](#violationaction) | `BLOCK_AND_LOG` | Action when the placeholder is sent to a disallowed host |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SecretEntry`](#secretentry) | Secret entry for `SandboxConfig.secrets` |
+
+---
+
+## Types
+
+### SecretEntry
+
+Frozen dataclass returned by [`Secret.env()`](#secretenv) and used in `SandboxConfig.secrets`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| env_var | `str` | Environment variable name |
+| value | `str` | Secret value |
+| allow_hosts | `tuple[str, ...]` | Allowed hosts (exact match) |
+| allow_host_patterns | `tuple[str, ...]` | Wildcard patterns |
+| placeholder | `str \| None` | Placeholder string |
+| require_tls | `bool` | TLS requirement |
+| on_violation | [`ViolationAction`](#violationaction) | Violation action |
+
+### ViolationAction
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) defining the action taken when a secret placeholder is sent to a disallowed host.
+
+| Value | Description |
+|-------|-------------|
+| `"block"` | Silently drop the request. The guest sees a connection reset. |
+| `"block-and-log"` | Drop the request and emit a warning log on the host side. This is the default. |
+| `"block-and-terminate"` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/fr/sdk/python/snapshots.mdx
+++ b/docs/fr/sdk/python/snapshots.mdx
@@ -1,0 +1,270 @@
+---
+title: Snapshots
+description: Python SDK - Snapshot API reference
+icon: "code-branch"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Python SDK reference.
+
+```python
+from microsandbox import Sandbox, Snapshot, SnapshotHandle
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## Sandbox.create() — `snapshot=` kwarg
+
+```python
+@staticmethod
+async def create(name_or_config, *, snapshot: str | os.PathLike | None = None, **kwargs) -> Sandbox
+```
+
+Boot a fresh sandbox from a snapshot artifact by passing `snapshot=` as a peer of `image=`. The two are mutually exclusive — pass exactly one.
+
+```python
+# Boot from a snapshot
+sb = await Sandbox.create("worker", snapshot="after-pip-install")
+
+# Or from an image (existing flow, unchanged)
+sb = await Sandbox.create("worker", image="python:3.12")
+```
+
+**Errors**
+
+- `ValueError` — both `image=` and `snapshot=` were passed or neither, the snapshot artifact doesn't exist, or the artifact's manifest failed validation
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```python
+async def snapshot(self, name: str) -> Snapshot
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination, see [`snapshot_to()`](#snapshot-to).
+
+**Errors**
+
+- `SnapshotSandboxRunning` — the sandbox is not stopped
+- `SnapshotAlreadyExists` — destination exists (use `Snapshot.create(..., force=True)` to overwrite)
+
+---
+
+#### snapshot_to()
+
+```python
+async def snapshot_to(self, path: str | os.PathLike) -> Snapshot
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path.
+
+---
+
+## Snapshot (instance)
+
+Properties are read-only attributes (not async).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `path` | `str` | Path to the artifact directory |
+| `digest` | `str` | Canonical content digest (`sha256:hex`). The snapshot's identity. |
+| `size_bytes` | `int` | Apparent size of the captured upper layer in bytes (sparse on disk) |
+| `image_ref` | `str` | Image reference the snapshot was taken from |
+| `image_manifest_digest` | `str` | OCI manifest digest of the pinned image |
+| `format` | `str` | `"raw"` or `"qcow2"` (always `"raw"` today) |
+| `fstype` | `str` | Filesystem type inside the upper (e.g. `"ext4"`) |
+| `parent` | `str \| None` | Parent snapshot's digest, or `None` for a root |
+| `created_at` | `str` | RFC 3339 timestamp |
+| `labels` | `dict[str, str]` | User-supplied labels |
+| `source_sandbox` | `str \| None` | Best-effort source-sandbox name |
+
+---
+
+#### verify()
+
+```python
+async def verify(self) -> dict[str, Any]
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds.
+
+```python
+report = await snap.verify()
+if report["upper"]["kind"] == "verified":
+    print(f"hash matches: {report['upper']['digest']}")
+else:
+    print("no integrity hash recorded")
+```
+
+The report shape:
+
+```python
+{
+    "digest": "sha256:...",
+    "path": "/path/to/artifact",
+    "upper": {"kind": "not_recorded"}                            # no integrity recorded
+        | {"kind": "verified", "algorithm": "...", "digest": "sha256:..."},
+}
+```
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot.create()
+
+```python
+@staticmethod
+async def create(
+    source_sandbox: str,
+    *,
+    name: str | None = None,
+    path: str | os.PathLike | None = None,
+    labels: dict[str, str] | None = None,
+    force: bool = False,
+    record_integrity: bool = False,
+) -> Snapshot
+```
+
+Create a snapshot from a stopped sandbox. Exactly one of `name=` (resolved under the default snapshots directory) or `path=` (explicit filesystem destination) is required.
+
+```python
+snap = await Snapshot.create(
+    "baseline",
+    name="after-pip-install",
+    labels={"stage": "post-deps"},
+    record_integrity=True,
+)
+```
+
+---
+
+#### Snapshot.open()
+
+```python
+@staticmethod
+async def open(path_or_name: str) -> Snapshot
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot.get()
+
+```python
+@staticmethod
+async def get(name_or_digest: str) -> SnapshotHandle
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot.list()
+
+```python
+@staticmethod
+async def list() -> list[SnapshotHandle]
+```
+
+List indexed snapshots from the local DB cache.
+
+---
+
+#### Snapshot.list_dir()
+
+```python
+@staticmethod
+async def list_dir(dir: str | os.PathLike) -> list[Snapshot]
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot.remove()
+
+```python
+@staticmethod
+async def remove(path_or_name: str, *, force: bool = False) -> None
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force=True`.
+
+---
+
+#### Snapshot.reindex()
+
+```python
+@staticmethod
+async def reindex(dir: str | os.PathLike | None = None) -> int
+```
+
+Walk `dir` (default: configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot.export()
+
+```python
+@staticmethod
+async def export(
+    name_or_path: str,
+    out: str | os.PathLike,
+    *,
+    with_parents: bool = False,
+    with_image: bool = False,
+    plain_tar: bool = False,
+) -> None
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+---
+
+#### Snapshot.import_()
+
+```python
+@staticmethod
+async def import_(
+    archive: str | os.PathLike,
+    *,
+    dest: str | os.PathLike | None = None,
+) -> SnapshotHandle
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+The trailing underscore is intentional — `import` is a reserved Python keyword.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot.list()`](#snapshot-list) and [`Snapshot.get()`](#snapshot-get).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `digest` | `str` | Manifest digest — canonical identity |
+| `name` | `str \| None` | Convenience alias |
+| `parent_digest` | `str \| None` | Parent snapshot digest (`None` today; populated when chains land) |
+| `image_ref` | `str` | Image the snapshot was taken from |
+| `format` | `str` | `"raw"` or `"qcow2"` |
+| `size_bytes` | `int \| None` | Apparent upper size at index time |
+| `created_at` | `float` | ms since Unix epoch |
+| `path` | `str` | Local artifact directory path |
+
+```python
+h = await Snapshot.get("after-pip-install")
+snap = await h.open()                # metadata-validated
+await h.remove(force=False)          # refuse if has children
+```

--- a/docs/fr/sdk/python/volumes.mdx
+++ b/docs/fr/sdk/python/volumes.mdx
@@ -1,0 +1,375 @@
+---
+title: Volumes
+description: Python SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+## Static methods
+
+---
+
+#### Volume.create()
+
+```python
+async def Volume.create(
+    name: str,
+    *,
+    quota_mib: int | None = None,
+    labels: dict[str, str] | None = None,
+) -> Volume
+```
+
+Create a new named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name (required) |
+| quota_mib | `int \| None` | Maximum storage size in MiB |
+| labels | `dict[str, str] \| None` | Metadata labels |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Volume` | Created volume with `name` and `path` properties |
+
+---
+
+#### Volume.get()
+
+```python
+async def Volume.get(name: str) -> VolumeHandle
+```
+
+Get a handle to an existing named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeHandle`](#volumehandle) | Volume handle |
+
+---
+
+#### Volume.list()
+
+```python
+async def Volume.list() -> list[VolumeHandle]
+```
+
+List all named volumes.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`VolumeHandle`](#volumehandle)`]` | All volumes |
+
+---
+
+#### Volume.remove()
+
+```python
+async def Volume.remove(name: str) -> None
+```
+
+Delete a named volume and its contents. Fails if the volume is currently mounted.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+
+---
+
+## Volume instance properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| name | `str` | Volume name |
+| path | `str` | Host path to the volume directory |
+
+---
+
+## Mount config factories
+
+Static factory methods on `Volume` for creating mount configurations used in sandbox volume config.
+
+---
+
+#### Volume.bind()
+
+```python
+def Volume.bind(path: str, *, readonly: bool = False) -> dict
+```
+
+Mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Directory path on the host |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+#### Volume.named()
+
+```python
+def Volume.named(name: str, *, readonly: bool = False) -> dict
+```
+
+Mount a named volume. The volume must already exist (create it with [`Volume.create()`](#volumecreate)).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+#### Volume.tmpfs()
+
+```python
+def Volume.tmpfs(*, size_mib: int | None = None, readonly: bool = False) -> dict
+```
+
+Use an in-memory filesystem. Contents are discarded when the sandbox stops.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size_mib | `int \| None` | Maximum size in MiB |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+## VolumeHandle
+
+Handle to an existing named volume, returned by [`Volume.get()`](#volumeget) and [`Volume.list()`](#volumelist).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `str` | Volume name |
+| quota_mib | `int \| None` | Storage quota in MiB |
+| used_bytes | `int` | Current disk usage in bytes |
+| labels | `dict[str, str]` | Metadata labels |
+| created_at | `float \| None` | Creation timestamp (ms since epoch) |
+| fs | [`VolumeFs`](#volumefs) | Host-side filesystem handle |
+| remove() | *(async)* `None` | Delete this volume |
+
+---
+
+## VolumeFs
+
+Host-side filesystem operations on a named volume. Obtained via the `fs` property on [`VolumeHandle`](#volumehandle). These operations run directly on the host filesystem - no running sandbox is required.
+
+---
+
+#### read()
+
+```python
+async def read(path: str) -> bytes
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bytes` | File contents as raw bytes |
+
+---
+
+#### read_text()
+
+```python
+async def read_text(path: str) -> str
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `str` | File contents as a string |
+
+---
+
+#### write()
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+| data | `bytes` | File content |
+
+---
+
+#### list()
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`FsEntry`](/sdk/python/filesystem#fsentry)`]` | Directory entries |
+
+---
+
+#### mkdir()
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory and all parent directories.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+---
+
+#### remove_file()
+
+```python
+async def remove_file(path: str) -> None
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+---
+
+#### exists()
+
+```python
+async def exists(path: str) -> bool
+```
+
+Check whether a path exists within the volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `True` if the path exists |
+
+---
+
+## Types
+
+### MountConfig
+
+Frozen dataclass representing a mount configuration.
+
+```python
+MountConfig(
+    kind: MountKind,
+    bind: str | None = None,
+    named: str | None = None,
+    size_mib: int | None = None,
+    readonly: bool = False,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| kind | [`MountKind`](#mountkind) | - | Type of mount (required) |
+| bind | `str \| None` | `None` | Host path for bind mounts |
+| named | `str \| None` | `None` | Volume name for named mounts |
+| size_mib | `int \| None` | `None` | Size limit for tmpfs mounts |
+| readonly | `bool` | `False` | Whether the mount is read-only |
+
+### MountKind
+
+String enum representing the type of mount.
+
+| Value | Description |
+|-------|-------------|
+| `"bind"` | Host bind mount |
+| `"named"` | Named volume mount |
+| `"tmpfs"` | In-memory filesystem |

--- a/docs/fr/sdk/rust/events.mdx
+++ b/docs/fr/sdk/rust/events.mdx
@@ -1,0 +1,66 @@
+---
+title: Events
+description: Rust SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for usage examples and guest-side emitting.
+
+## Sandbox methods
+
+---
+
+#### emit()
+
+```rust
+async fn emit(&self, event_name: &str, data: impl Serialize) -> MicrosandboxResult<()>
+```
+
+Send a named event with a JSON-serializable payload into the guest. Any process listening on the agent socket (`/run/agent.sock`) receives it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| event_name | `&str` | Event name (e.g. `"task.start"`) |
+| data | `impl Serialize` | Event payload - must be serializable to JSON |
+
+---
+
+#### on_event()
+
+```rust
+fn on_event(&self, event_name: &str, callback: impl FnMut(EventData) + Send + 'static) -> Subscription
+```
+
+Subscribe to named events emitted by guest processes. The callback fires each time the guest sends a matching event through `/run/agent.sock`. Multiple subscriptions to the same event name are supported.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| event_name | `&str` | Event name to subscribe to (e.g. `"task.progress"`) |
+| callback | `impl FnMut(EventData) + Send + 'static` | Called with the event data each time |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Subscription` | Handle that unsubscribes when dropped |
+
+---
+
+## Types
+
+### EventData
+
+Data received from a guest event.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| data | `Option<serde_json::Value>` | Event payload as a JSON value. `None` if the event had no data. |
+| event | `String` | Event name |

--- a/docs/fr/sdk/rust/execution.mdx
+++ b/docs/fr/sdk/rust/execution.mdx
@@ -1,0 +1,306 @@
+---
+title: Execution
+description: Rust SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+---
+
+#### attach()
+
+```rust
+async fn attach(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<i32>
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Your terminal's stdin, stdout, and stderr are connected to the guest process. Press `Ctrl+]` (or configured detach keys) to disconnect without stopping the process - it keeps running and can be reattached via its session ID.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to run |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code of the process |
+
+---
+
+#### attach_shell()
+
+```rust
+async fn attach_shell(&self) -> MicrosandboxResult<i32>
+```
+
+Attach to the sandbox's default shell (configured via `SandboxBuilder::shell()`, defaults to `/bin/sh`).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code |
+
+---
+
+#### attach_with()
+
+```rust
+async fn attach_with(&self, cmd: impl Into<String>, f: impl FnOnce(AttachOptionsBuilder) -> AttachOptionsBuilder) -> MicrosandboxResult<i32>
+```
+
+Interactive PTY attach with options for environment variables, working directory, user, and custom detach keys.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to run |
+| f | `AttachOptionsBuilder` | Configure attach options (env, cwd, user, detach keys). |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code of the process |
+
+---
+
+#### exec()
+
+```rust
+async fn exec(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments (e.g. `["-c", "print('hello')"]`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### exec_stream()
+
+```rust
+async fn exec_stream(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<ExecHandle>
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything until the command finishes. Use this for long-running processes, large output, or when you need to process output incrementally.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### exec_stream_with()
+
+```rust
+async fn exec_stream_with(&self, cmd: impl Into<String>, f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder) -> MicrosandboxResult<ExecHandle>
+```
+
+Streaming execution with per-execution overrides. Enable `stdin_pipe()` to write to the process's stdin, and `tty(true)` to allocate a pseudo-terminal for interactive programs like shells, REPLs, or editors.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| f | [`ExecOptionsBuilder`](#execoptionsbuilder) | Configure execution options. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle |
+
+---
+
+#### exec_with()
+
+```rust
+async fn exec_with(&self, cmd: impl Into<String>, f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command with per-execution overrides. The closure receives an [`ExecOptionsBuilder`](#execoptionsbuilder) to configure working directory, environment variables, timeout, resource limits, stdin mode, and TTY allocation. These overrides apply only to this execution and don't change the sandbox's defaults.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| f | [`ExecOptionsBuilder`](#execoptionsbuilder) | Configure execution options. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell()
+
+```rust
+async fn shell(&self, script: impl Into<String>) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). The script is passed as `sh -c "<script>"`, so shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `impl Into<String>` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell_stream()
+
+```rust
+async fn shell_stream(&self, script: impl Into<String>) -> MicrosandboxResult<ExecHandle>
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `impl Into<String>` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle |
+
+---
+
+## Types
+
+### ExecEvent
+
+Events emitted by a streaming execution.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Exited` | `code: i32` | The process has exited. `code` is the exit code. |
+| `Started` | `pid: u32` | The process has started. `pid` is the guest-side PID. |
+| `Stderr` | `Bytes` | A chunk of stderr data. |
+| `Stdout` | `Bytes` | A chunk of stdout data. May arrive in arbitrary sizes. |
+
+### ExecHandle
+
+A handle to a running streaming execution. Receives events as the process produces output, and provides control over stdin and signals.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| collect() | [`ExecOutput`](#execoutput) | Wait for exit and collect all remaining stdout/stderr. |
+| id() | `String` | Session ID for this execution. Can be used to reattach later. |
+| kill() | `()` | Send SIGKILL to the process. |
+| recv() | `Option<`[`ExecEvent`](#execevent)`>` | Receive the next event. Returns `None` when the process has exited and all output has been delivered. |
+| signal(signal) | `()` | Send a POSIX signal to the process (e.g. `libc::SIGTERM`). |
+| take_stdin() | `Option<`[`ExecSink`](#execsink)`>` | Take the stdin writer. Only available if `stdin_pipe()` was enabled. Returns `None` after the first call. |
+| wait() | [`ExitStatus`](#exitstatus) | Wait for the process to exit, discarding any remaining output. |
+
+### ExecOptionsBuilder
+
+Builder for per-execution overrides. Does not change the sandbox's defaults.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| args() | `impl IntoIterator<Item = impl Into<String>>` | Append command-line arguments. |
+| cwd() | `impl Into<String>` | Override the working directory for this command. |
+| env() | - `key: impl Into<String>` <br/> - `value: impl Into<String>` | Set an environment variable. Merged on top of sandbox-level env vars. |
+| envs() | `impl IntoIterator<Item = (String, String)>` | Set multiple environment variables at once. |
+| rlimit() | - `resource:` [`RlimitResource`](#rlimitresource) <br/> - `limit: u64` | Set a POSIX resource limit (soft = hard). Applied via `setrlimit()` before exec. |
+| rlimit_range() | - `resource:` [`RlimitResource`](#rlimitresource) <br/> - `soft: u64` <br/> - `hard: u64` | Set a resource limit with different soft and hard values. |
+| stdin_bytes() | `impl Into<Vec<u8>>` | Provide fixed bytes as stdin. The process reads them and then sees EOF. |
+| stdin_null() | - | Stdin reads from `/dev/null`. This is the default. |
+| stdin_pipe() | - | Enable a stdin writer via [`ExecSink`](#execsink). Use with [`ExecHandle::take_stdin()`](#exechandle). |
+| timeout() | `Duration` | Kill the process with SIGKILL if it hasn't exited within this duration. |
+| tty() | `bool` | Allocate a pseudo-terminal. Enable for interactive programs (shells, editors, `top`); disable for scripts and batch jobs. Default: `false`. |
+| user() | `impl Into<String>` | Override the guest user for this command. |
+
+### ExecOutput
+
+The result of a completed command execution. Holds the exit status and all captured output.
+
+| Field / Method | Type | Description |
+|----------------|------|-------------|
+| status() | [`ExitStatus`](#exitstatus) | Exit code and success flag |
+| stderr() | `Result<String>` | Collected stderr decoded as UTF-8 |
+| stderr_bytes() | `&Bytes` | Raw stderr bytes without decoding |
+| stdout() | `Result<String>` | Collected stdout decoded as UTF-8. Returns `Err` if the output is not valid UTF-8. |
+| stdout_bytes() | `&Bytes` | Raw stdout bytes without decoding |
+
+### ExecSink
+
+A writer for sending data to a running process's stdin. Obtained via [`ExecHandle::take_stdin()`](#exechandle).
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| close() | - | Close stdin. The process sees EOF on its stdin. |
+| write() | `data: impl AsRef<[u8]>` | Write bytes to the process's stdin. |
+
+### ExitStatus
+
+The exit status of a completed process.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| code | `i32` | Exit code. `0` typically means success. |
+| success | `bool` | `true` if code is `0` |
+
+### RlimitResource
+
+POSIX resource limit identifiers. Maps to `RLIMIT_*` constants.
+
+| Value | Description |
+|-------|-------------|
+| `As` | Max address space size |
+| `Core` | Max core file size |
+| `Cpu` | Max CPU time in seconds |
+| `Data` | Max data segment size |
+| `Fsize` | Max file size in bytes |
+| `Locks` | Max file locks |
+| `Memlock` | Max locked memory |
+| `Msgqueue` | Max bytes in POSIX message queues |
+| `Nice` | Max nice priority |
+| `Nofile` | Max open file descriptors |
+| `Nproc` | Max number of processes |
+| `Rss` | Max resident set size |
+| `Rtprio` | Max real-time priority |
+| `Rttime` | Max real-time timeout |
+| `Sigpending` | Max pending signals |
+| `Stack` | Max stack size |

--- a/docs/fr/sdk/rust/filesystem.mdx
+++ b/docs/fr/sdk/rust/filesystem.mdx
@@ -1,0 +1,356 @@
+---
+title: Filesystem
+description: Rust SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead, which give the guest direct filesystem access.
+
+---
+
+#### copy()
+
+```rust
+async fn copy(&self, from: &str, to: &str) -> MicrosandboxResult<()>
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `&str` | Source path |
+| to | `&str` | Destination path |
+
+---
+
+#### copy_from_host()
+
+```rust
+async fn copy_from_host(&self, host_path: impl AsRef<Path>, guest_path: &str) -> MicrosandboxResult<()>
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `impl AsRef<Path>` | Path on the host filesystem |
+| guest_path | `&str` | Destination path inside the sandbox |
+
+---
+
+#### copy_to_host()
+
+```rust
+async fn copy_to_host(&self, guest_path: &str, host_path: impl AsRef<Path>) -> MicrosandboxResult<()>
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `&str` | Path inside the sandbox |
+| host_path | `impl AsRef<Path>` | Destination path on the host |
+
+---
+
+#### exists()
+
+```rust
+async fn exists(&self, path: &str) -> MicrosandboxResult<bool>
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `true` if the path exists |
+
+---
+
+#### list()
+
+```rust
+async fn list(&self, path: &str) -> MicrosandboxResult<Vec<FsEntry>>
+```
+
+List the entries in a directory. Returns metadata for each entry including name, type, size, and permissions.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`FsEntry`](#fsentry)`>` | Directory entries |
+
+---
+
+#### mkdir()
+
+```rust
+async fn mkdir(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Create a directory. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path |
+
+---
+
+#### read()
+
+```rust
+async fn read(&self, path: &str) -> MicrosandboxResult<Bytes>
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Bytes` | File contents as raw bytes |
+
+---
+
+#### read_stream()
+
+```rust
+async fn read_stream(&self, path: &str) -> MicrosandboxResult<FsReadStream>
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory, or when you want to process data incrementally.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsReadStream`](#fsreadstream) | Async stream that yields chunks of file data |
+
+---
+
+#### read_to_string()
+
+```rust
+async fn read_to_string(&self, path: &str) -> MicrosandboxResult<String>
+```
+
+Read the entire contents of a file and decode as UTF-8. Returns an error if the file contains invalid UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `String` | File contents as a UTF-8 string |
+
+---
+
+#### remove()
+
+```rust
+async fn remove(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute file path |
+
+---
+
+#### remove_dir()
+
+```rust
+async fn remove_dir(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Remove a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path |
+
+---
+
+#### rename()
+
+```rust
+async fn rename(&self, from: &str, to: &str) -> MicrosandboxResult<()>
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `&str` | Current path |
+| to | `&str` | New path |
+
+---
+
+#### stat()
+
+```rust
+async fn stat(&self, path: &str) -> MicrosandboxResult<FsMetadata>
+```
+
+Get detailed metadata for a file or directory, including type, size, permissions, and timestamps.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsMetadata`](#fsmetadata) | File metadata |
+
+---
+
+#### write()
+
+```rust
+async fn write(&self, path: &str, data: impl AsRef<[u8]>) -> MicrosandboxResult<()>
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+| data | `impl AsRef<[u8]>` | File content |
+
+---
+
+#### write_stream()
+
+```rust
+async fn write_stream(&self, path: &str) -> MicrosandboxResult<FsWriteSink>
+```
+
+Open a streaming writer for large files. Write chunks incrementally and close when done.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsWriteSink`](#fswritesink) | Async writer for sending chunks |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| mode | `u32` | Unix permission bits (e.g. `0o644`) |
+| modified | `Option<DateTime<Utc>>` | Last modified timestamp |
+| path | `String` | File path |
+| size | `u64` | File size in bytes |
+
+### FsEntryKind
+
+The type of a filesystem entry.
+
+| Value | Description |
+|-------|-------------|
+| `Directory` | Directory |
+| `File` | Regular file |
+| `Other` | Other entry type (device, socket, etc.) |
+| `Symlink` | Symbolic link |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| created | `Option<DateTime<Utc>>` | Creation timestamp (not available on all filesystems) |
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| mode | `u32` | Unix permission bits |
+| modified | `Option<DateTime<Utc>>` | Last modified timestamp |
+| readonly | `bool` | Whether the file is read-only |
+| size | `u64` | File size in bytes |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`read_stream()`](#read_stream).
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| collect() | `Bytes` | Collect all remaining chunks into a single `Bytes` buffer. |
+| recv() | `Option<Bytes>` | Receive the next chunk. Returns `None` when the file has been fully read. |
+
+### FsWriteSink
+
+Async writer for streaming data into a file. Obtained via [`write_stream()`](#write_stream).
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| close() | - | Finalize the write and close the stream. Must be called to ensure all data is flushed. |
+| write() | `data: impl AsRef<[u8]>` | Write a chunk of data to the file. |

--- a/docs/fr/sdk/rust/networking.mdx
+++ b/docs/fr/sdk/rust/networking.mdx
@@ -1,0 +1,916 @@
+---
+title: Networking
+description: Rust SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Build one with [`NetworkPolicy::builder()`](#networkpolicybuilder):
+
+```rust
+use microsandbox::NetworkPolicy;
+
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.tcp().port(443).allow_public().allow_private())
+    .rule(|r| r.any().deny().ip("198.51.100.5"))
+    .build()?;
+```
+
+The default policy denies egress except for an implicit `allow public`, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
+| rules | `Vec<`[`Rule`](#rule)`>` | Ordered list of rules; first match wins |
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```rust
+NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e
+        .allow().cidr("10.0.0.0/8")     // matches everything in 10.x
+        .deny().ip("10.0.0.5"))          // never reached
+    .build()?;
+```
+
+Put specific rules before general ones.
+
+### Shadow detection
+
+`.build()` walks the rules and warns (via `tracing::warn!`) when a rule is fully covered by an earlier one in the same direction. Only `Ip`, `Cidr`, and `Group` destinations are checked; domain coverage depends on runtime DNS and is skipped. Builds still succeed:
+
+```text
+WARN rule #1 (Egress Cidr(10.0.0.5/32) Deny) is shadowed by rule #0 (Egress Cidr(10.0.0.0/8) Allow); to narrow, place the more specific rule first
+```
+
+### State accumulation
+
+State setters (`.tcp()`, `.port()`, etc.) inside a closure carry into every rule-adder that follows. State is **not reset** between adders:
+
+```rust
+.rule(|r| r.egress()
+    .tcp().port(443).allow_public()    // rule 1: egress, TCP, 443, allow Public
+    .udp().allow_private())            // rule 2: egress, [TCP, UDP], 443, allow Private
+```
+
+Use separate closures for rules that need different state.
+
+---
+
+## NetworkPolicy::builder()
+
+The fluent builder is the primary construction path. String inputs (`.ip(&str)`, `.cidr(&str)`, `.domain(&str)`, `.domain_suffix(&str)`) are stored raw and parsed at `.build()` time, so the chain stays clean. The first parse / validation failure surfaces as [`BuildError`](#builderror).
+
+The closure signature for `.rule()` / `.egress()` / `.ingress()` / `.any()` is `FnOnce(&mut RuleBuilder) -> &mut RuleBuilder`. A chain ending in any rule-adder (`.allow_public()`, `.deny().ip(...)`, etc.) returns the builder reference and satisfies the bound. Multi-statement bodies end with an explicit `r` return.
+
+---
+
+#### any()
+
+```rust
+fn any<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Any`. Rules committed inside apply in both directions.
+
+---
+
+#### build()
+
+```rust
+fn build(self) -> Result<NetworkPolicy, BuildError>
+```
+
+Consume the builder and produce a [`NetworkPolicy`](#networkpolicy). Lazy-parses every `.ip()` / `.cidr()` / `.domain()` / `.domain_suffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a `tracing::warn!` for each shadowed rule pair detected.
+
+---
+
+#### default_allow()
+
+```rust
+fn default_allow(self) -> Self
+```
+
+Set both `default_egress` and `default_ingress` to `Allow`.
+
+---
+
+#### default_deny()
+
+```rust
+fn default_deny(self) -> Self
+```
+
+Set both `default_egress` and `default_ingress` to `Deny`.
+
+---
+
+#### default_egress()
+
+```rust
+fn default_egress(self, action: Action) -> Self
+```
+
+Per-direction override for the egress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`Action`](#action) | Default action for egress |
+
+---
+
+#### default_ingress()
+
+```rust
+fn default_ingress(self, action: Action) -> Self
+```
+
+Per-direction override for the ingress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`Action`](#action) | Default action for ingress |
+
+---
+
+#### egress()
+
+```rust
+fn egress<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Egress`.
+
+---
+
+#### ingress()
+
+```rust
+fn ingress<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Ingress`.
+
+---
+
+#### rule()
+
+```rust
+fn rule<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Open a multi-rule batch closure. Direction must be set inside via `.egress()`, `.ingress()`, or `.any()` before any rule-adder.
+
+---
+
+## RuleBuilder
+
+The closure passed to `.rule(...)` (or any of the direction sugar methods) gives you a `RuleBuilder`. State setters and rule-adders interleave freely. State accumulates eagerly across the closure (see [State accumulation](#state-accumulation)).
+
+### Direction setters
+
+Last-write-wins. ICMP rule-adders are egress-only at build time.
+
+---
+
+#### any()
+
+```rust
+fn any(&mut self) -> &mut Self
+```
+
+Set direction to `Any` for subsequent rule-adders. Rules committed after this apply in both directions.
+
+---
+
+#### egress()
+
+```rust
+fn egress(&mut self) -> &mut Self
+```
+
+Set direction to `Egress` for subsequent rule-adders.
+
+---
+
+#### ingress()
+
+```rust
+fn ingress(&mut self) -> &mut Self
+```
+
+Set direction to `Ingress` for subsequent rule-adders.
+
+---
+
+### Protocol setters
+
+Protocols accumulate as a set; duplicates dedupe.
+
+---
+
+#### icmpv4()
+
+```rust
+fn icmpv4(&mut self) -> &mut Self
+```
+
+Add `Icmpv4` to the protocols set. Egress-only; an ICMP rule on an `Ingress` or `Any` direction fails build with [`BuildError::IngressDoesNotSupportIcmp`](#builderror).
+
+---
+
+#### icmpv6()
+
+```rust
+fn icmpv6(&mut self) -> &mut Self
+```
+
+Add `Icmpv6` to the protocols set. Egress-only; same rules as [`icmpv4()`](#icmpv4).
+
+---
+
+#### tcp()
+
+```rust
+fn tcp(&mut self) -> &mut Self
+```
+
+Add `Tcp` to the protocols set.
+
+---
+
+#### udp()
+
+```rust
+fn udp(&mut self) -> &mut Self
+```
+
+Add `Udp` to the protocols set.
+
+---
+
+### Port setters
+
+Ports accumulate as a set; duplicates dedupe. Always guest-side (egress destination port / ingress listening port).
+
+---
+
+#### port()
+
+```rust
+fn port(&mut self, port: u16) -> &mut Self
+```
+
+Add a single port to the ports set.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `u16` | Port number |
+
+---
+
+#### port_range()
+
+```rust
+fn port_range(&mut self, lo: u16, hi: u16) -> &mut Self
+```
+
+Add an inclusive port range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| lo | `u16` | Lower bound (inclusive) |
+| hi | `u16` | Upper bound (inclusive). `lo > hi` records [`BuildError::InvalidPortRange`](#builderror) |
+
+---
+
+#### ports()
+
+```rust
+fn ports<I: IntoIterator<Item = u16>>(&mut self, ports: I) -> &mut Self
+```
+
+Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
+
+---
+
+### Group rule-adders
+
+Each adder commits one rule using the current state and the named destination group.
+
+---
+
+#### allow_host()
+
+```rust
+fn allow_host(&mut self) -> &mut Self
+```
+
+Allow the `Host` group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allow_loopback()`](#allow_loopback).
+
+---
+
+#### allow_link_local()
+
+```rust
+fn allow_link_local(&mut self) -> &mut Self
+```
+
+Allow the `LinkLocal` group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
+
+---
+
+#### allow_loopback()
+
+```rust
+fn allow_loopback(&mut self) -> &mut Self
+```
+
+Allow the `Loopback` group (`127.0.0.0/8`, `::1`). The **guest's own** loopback, not the host. To reach a service on the host's localhost, use [`allow_host()`](#allow_host) instead. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
+
+---
+
+#### allow_meta()
+
+```rust
+fn allow_meta(&mut self) -> &mut Self
+```
+
+Allow the `Metadata` group (`169.254.169.254`). **Dangerous on cloud hosts** (exposes IAM credentials).
+
+---
+
+#### allow_multicast()
+
+```rust
+fn allow_multicast(&mut self) -> &mut Self
+```
+
+Allow the `Multicast` group (`224.0.0.0/4`, `ff00::/8`).
+
+---
+
+#### allow_private()
+
+```rust
+fn allow_private(&mut self) -> &mut Self
+```
+
+Allow the `Private` group (RFC1918 + ULA + CGN).
+
+---
+
+#### allow_public()
+
+```rust
+fn allow_public(&mut self) -> &mut Self
+```
+
+Allow the `Public` group (complement of named categories: every IP not in any other group).
+
+---
+
+#### deny_host()
+
+```rust
+fn deny_host(&mut self) -> &mut Self
+```
+
+Deny the `Host` group.
+
+---
+
+#### deny_link_local()
+
+```rust
+fn deny_link_local(&mut self) -> &mut Self
+```
+
+Deny the `LinkLocal` group.
+
+---
+
+#### deny_loopback()
+
+```rust
+fn deny_loopback(&mut self) -> &mut Self
+```
+
+Deny the `Loopback` group.
+
+---
+
+#### deny_meta()
+
+```rust
+fn deny_meta(&mut self) -> &mut Self
+```
+
+Deny the `Metadata` group.
+
+---
+
+#### deny_multicast()
+
+```rust
+fn deny_multicast(&mut self) -> &mut Self
+```
+
+Deny the `Multicast` group.
+
+---
+
+#### deny_private()
+
+```rust
+fn deny_private(&mut self) -> &mut Self
+```
+
+Deny the `Private` group.
+
+---
+
+#### deny_public()
+
+```rust
+fn deny_public(&mut self) -> &mut Self
+```
+
+Deny the `Public` group.
+
+---
+
+### Bulk-domain rule-adders
+
+Each call adds one rule per name, inheriting the current direction / protocol / port state. Lazy-parse: invalid names surface as [`BuildError::InvalidDomain`](#builderror) from `.build()`.
+
+```rust
+NetworkPolicy::builder()
+    .default_allow()
+    .egress(|e| e
+        .deny_domains(["evil.com", "tracker.example"])
+        .deny_domain_suffixes([".ads.example", ".doubleclick.net"]))
+    .build()?
+```
+
+---
+
+#### allow_domain_suffixes()
+
+```rust
+fn allow_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::DomainSuffix` allow rule per suffix.
+
+---
+
+#### allow_domains()
+
+```rust
+fn allow_domains<I, S>(&mut self, names: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::Domain` allow rule per name.
+
+---
+
+#### deny_domain_suffixes()
+
+```rust
+fn deny_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::DomainSuffix` deny rule per suffix.
+
+---
+
+#### deny_domains()
+
+```rust
+fn deny_domains<I, S>(&mut self, names: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::Domain` deny rule per name.
+
+---
+
+### Composite rule-adders
+
+---
+
+#### allow_local()
+
+```rust
+fn allow_local(&mut self) -> &mut Self
+```
+
+Add three allow rules atomically: `Loopback + LinkLocal + Host`. Each uses the closure's current state. `Metadata` is intentionally not included; opt in via [`allow_meta()`](#allow_meta) separately.
+
+---
+
+#### deny_local()
+
+```rust
+fn deny_local(&mut self) -> &mut Self
+```
+
+Add three deny rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is intentionally not included.
+
+---
+
+### Explicit-destination rule-adders
+
+`.allow()` / `.deny()` open an [`ExplicitRuleBuilder`](#explicitrulebuilder) that requires a destination call to commit.
+
+```rust
+.rule(|r| r.egress().tcp().port(443).allow().domain("api.example.com"))
+.rule(|r| r.any().deny().cidr("198.51.100.0/24"))
+```
+
+Dropping without a destination call adds no rule (the type is `#[must_use]`).
+
+---
+
+#### allow()
+
+```rust
+fn allow(&mut self) -> ExplicitRuleBuilder<'_>
+```
+
+Begin an explicit-destination rule with action `Allow`.
+
+---
+
+#### deny()
+
+```rust
+fn deny(&mut self) -> ExplicitRuleBuilder<'_>
+```
+
+Begin an explicit-destination rule with action `Deny`.
+
+---
+
+## NetworkBuilder
+
+Builder for configuring the sandbox's network stack. Used in `SandboxBuilder::network(|n| n...)`. Errors accumulated by nested builders cascade up; the outermost `SandboxBuilder::build()` surfaces them as `MicrosandboxError::NetworkBuilder(BuildError)`.
+
+---
+
+#### dns()
+
+```rust
+fn dns(self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self
+```
+
+Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
+
+```rust
+.network(|n| n
+    .dns(|d| d
+        .nameservers(["1.1.1.1".parse::<Nameserver>()?])
+        .query_timeout_ms(3000)
+    )
+)
+```
+
+---
+
+#### max_connections()
+
+```rust
+fn max_connections(self, max: usize) -> Self
+```
+
+Limit the maximum number of concurrent network connections from the sandbox.
+
+---
+
+#### on_secret_violation()
+
+```rust
+fn on_secret_violation(self, action: ViolationAction) -> Self
+```
+
+Set the action taken when a secret placeholder is detected in traffic destined for a host not in the secret's allow list. See [`ViolationAction`](#violationaction).
+
+---
+
+#### policy()
+
+```rust
+fn policy(self, policy: NetworkPolicy) -> Self
+```
+
+Set the network access policy. Pass a builder-constructed [`NetworkPolicy`](#networkpolicy):
+
+```rust
+.network(|n| n.policy(NetworkPolicy::builder().default_deny().build()?))
+```
+
+---
+
+#### tls()
+
+```rust
+fn tls(self, f: impl FnOnce(TlsBuilder) -> TlsBuilder) -> Self
+```
+
+Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
+
+---
+
+#### trust_host_cas()
+
+```rust
+fn trust_host_cas(self, enabled: bool) -> Self
+```
+
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in when egress HTTPS inside the sandbox needs to work behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle.
+
+---
+
+## DnsBuilder
+
+Builder for DNS interception settings. Used in `NetworkBuilder::dns(|d| d...)`. Owns rebind protection, nameserver pinning, and the per-query timeout.
+
+---
+
+#### nameservers()
+
+```rust
+fn nameservers<I>(self, nameservers: I) -> Self
+where
+    I: IntoIterator,
+    I::Item: Into<Nameserver>
+```
+
+Set the upstream nameservers to forward DNS queries to. Replaces any previously-set nameservers. Each element is convertible into `Nameserver` (`SocketAddr`, `IpAddr`, or a parsed string via `"dns.google:53".parse::<Nameserver>()?`).
+
+---
+
+#### query_timeout_ms()
+
+```rust
+fn query_timeout_ms(self, ms: u64) -> Self
+```
+
+Set the per-DNS-query timeout in milliseconds. Default: `5000`.
+
+---
+
+#### rebind_protection()
+
+```rust
+fn rebind_protection(self, enabled: bool) -> Self
+```
+
+When enabled, DNS responses that resolve to private IP addresses are blocked. Prevents DNS rebinding attacks. Default: `true`.
+
+---
+
+## TlsBuilder
+
+Builder for TLS interception settings. Used in `NetworkBuilder::tls(|t| t...)`.
+
+---
+
+#### block_quic()
+
+```rust
+fn block_quic(self, block: bool) -> Self
+```
+
+Block QUIC/HTTP3 on intercepted ports, forcing TCP/TLS fallback. Default: `true`.
+
+---
+
+#### bypass()
+
+```rust
+fn bypass(self, pattern: impl Into<String>) -> Self
+```
+
+Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). Use for domains with certificate pinning.
+
+---
+
+#### intercept_ca_cert()
+
+```rust
+fn intercept_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file used as the intercepting CA's certificate. Pair with [`intercept_ca_key()`](#intercept_ca_key) to provide a stable CA across sandbox restarts.
+
+---
+
+#### intercept_ca_key()
+
+```rust
+fn intercept_ca_key(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file used as the intercepting CA's private key.
+
+---
+
+#### intercepted_ports()
+
+```rust
+fn intercepted_ports(self, ports: Vec<u16>) -> Self
+```
+
+TCP ports where TLS interception is active. Default: `[443]`.
+
+---
+
+#### upstream_ca_cert()
+
+```rust
+fn upstream_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file with extra root CAs the proxy should trust when verifying upstream servers.
+
+---
+
+#### verify_upstream()
+
+```rust
+fn verify_upstream(self, verify: bool) -> Self
+```
+
+Whether the proxy verifies upstream server certificates. Default: `true`. Set to `false` only for self-signed servers.
+
+---
+
+## Types
+
+### Action
+
+| Value | Wire format | Description |
+|-------|-------------|-------------|
+| `Allow` | `"allow"` | Permit the traffic |
+| `Deny` | `"deny"` | Drop the traffic silently |
+
+### Direction
+
+| Value | Wire format | Description |
+|-------|-------------|-------------|
+| `Egress` | `"egress"` | Traffic leaving the sandbox |
+| `Ingress` | `"ingress"` | Traffic entering the sandbox (via published ports) |
+| `Any` | `"any"` | Rule applies in either direction |
+
+### Destination
+
+| Variant | Description |
+|---------|-------------|
+| `Any` | Match any address |
+| `Cidr(IpNetwork)` | Match a CIDR range (e.g. `10.0.0.0/8`); single IPs are stored as `/32` or `/128` |
+| `Domain(`[`DomainName`](#domainname)`)` | Match an exact domain (e.g. `example.com`) |
+| `DomainSuffix(`[`DomainName`](#domainname)`)` | Match the apex domain and every subdomain (e.g. `example.com` and `api.example.com`) |
+| `Group(`[`DestinationGroup`](#destinationgroup)`)` | Match a predefined address group |
+
+### DestinationGroup
+
+| Value | Wire format | Matches |
+|-------|-------------|---------|
+| `Public` | `"public"` | Complement of the other categories: every address not in any other group |
+| `Private` | `"private"` | `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7` |
+| `Loopback` | `"loopback"` | `127.0.0.0/8`, `::1` (the **guest's own** loopback, not the host) |
+| `LinkLocal` | `"link_local"` | `169.254.0.0/16`, `fe80::/10` (excludes metadata) |
+| `Metadata` | `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
+| `Multicast` | `"multicast"` | `224.0.0.0/4`, `ff00::/8` |
+| `Host` | `"host"` | Per-sandbox gateway IPs that back `host.microsandbox.internal` |
+
+### DomainName
+
+A validated DNS name. Construction goes through `str::parse` (or `TryFrom<String>`), which delegates to `hickory_proto::rr::Name` and canonicalizes the input (lowercased ASCII, leading and trailing dots stripped) so rule matching is a byte-wise compare against the DNS cache. Invalid inputs return a `DomainNameError`.
+
+```rust
+use microsandbox_network::policy::{Destination, DomainName};
+
+let exact: DomainName = "PyPI.Org.".parse()?;     // -> "pypi.org"
+let suffix: DomainName = ".example.com".parse()?;  // -> "example.com"
+```
+
+Labels follow the permissive DNS grammar (RFC 2181 §11), so underscore-prefixed names like `_service._tcp.example.com` are accepted.
+
+The builder methods (`.domain(&str)`, `.domain_suffix(&str)`) take strings and parse them lazily at `.build()`; callers don't need to construct `DomainName` directly.
+
+### Protocol
+
+| Value | Wire format |
+|-------|-------------|
+| `Tcp` | `"tcp"` |
+| `Udp` | `"udp"` |
+| `Icmpv4` | `"icmpv4"` |
+| `Icmpv6` | `"icmpv6"` |
+
+ICMP protocols are egress-only. A rule with direction `Ingress` or `Any` carrying an ICMP protocol fails build with [`BuildError::IngressDoesNotSupportIcmp`](#builderror).
+
+### PortRange
+
+```rust
+struct PortRange {
+    start: u16,  // inclusive
+    end: u16,    // inclusive
+}
+```
+
+| Method | Description |
+|--------|-------------|
+| `PortRange::single(port)` | Match a single port |
+| `PortRange::range(start, end)` | Match an inclusive range |
+
+### Rule
+
+A single network policy rule.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| direction | [`Direction`](#direction) | Which evaluator considers this rule |
+| destination | [`Destination`](#destination) | Target filter (egress destination / ingress source) |
+| protocols | `Vec<`[`Protocol`](#protocol)`>` | Set semantics; empty = any protocol |
+| ports | `Vec<`[`PortRange`](#portrange)`>` | Set semantics; empty = any port. Always guest-side (egress destination port / ingress listening port) |
+| action | [`Action`](#action) | What to do on match |
+
+Convenience constructors:
+
+| Method | Description |
+|--------|-------------|
+| `Rule::allow_egress(destination)` | Allow rule, direction `Egress` |
+| `Rule::deny_egress(destination)` | Deny rule, direction `Egress` |
+| `Rule::allow_ingress(destination)` | Allow rule, direction `Ingress` |
+| `Rule::deny_ingress(destination)` | Deny rule, direction `Ingress` |
+| `Rule::allow_any(destination)` | Allow rule, direction `Any` |
+| `Rule::deny_any(destination)` | Deny rule, direction `Any` |
+
+### ExplicitRuleBuilder
+
+Returned by [`RuleBuilder`](#rulebuilder)`::allow()` / `::deny()`. Requires exactly one destination method call to commit the rule. The type is `#[must_use]`; dropping without a call adds no rule.
+
+| Method | Description |
+|--------|-------------|
+| `.ip(impl Into<String>)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
+| `.cidr(impl Into<String>)` | Commit with `Destination::Cidr` |
+| `.domain(impl Into<String>)` | Commit with `Destination::Domain` |
+| `.domain_suffix(impl Into<String>)` | Commit with `Destination::DomainSuffix` |
+| `.group(DestinationGroup)` | Commit with `Destination::Group` |
+| `.any()` | Commit with `Destination::Any` |
+
+### BuildError
+
+Errors surfaced by the builders' `.build()` methods. The same enum covers `NetworkPolicy::builder()`, `DnsBuilder`, and `NetworkBuilder` (the network and DNS builders accumulate errors lazily; the first failure surfaces from the outermost `.build()` in the chain).
+
+| Variant | Cause |
+|---------|-------|
+| `DirectionNotSet { rule_index }` | A rule was committed without `.egress() / .ingress() / .any()` |
+| `MissingDestination { rule_index }` | `.allow()` or `.deny()` was called but no destination method followed |
+| `InvalidIp { rule_index, raw }` | `.ip(&str)` got an unparseable value |
+| `InvalidCidr { rule_index, raw }` | `.cidr(&str)` got an unparseable value |
+| `InvalidDomain { rule_index, raw, source }` | `.domain` or `.domain_suffix` got a value that failed `DomainName` parse |
+| `InvalidPortRange { rule_index, lo, hi }` | `.port_range(lo, hi)` had `lo > hi` |
+| `IngressDoesNotSupportIcmp { rule_index }` | ICMP protocol on a non-egress rule |
+
+Inside `SandboxBuilder::build()`, `BuildError` is wrapped as `MicrosandboxError::NetworkBuilder(BuildError)`.
+
+### ViolationAction
+
+Action taken when a secret placeholder is sent to a disallowed host.
+
+| Value | Description |
+|-------|-------------|
+| `Block` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `BlockAndLog` | Drop the request and emit a warning log on the host side. |
+| `BlockAndTerminate` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/fr/sdk/rust/sandbox.mdx
+++ b/docs/fr/sdk/rust/sandbox.mdx
@@ -1,0 +1,1176 @@
+---
+title: Sandbox
+description: Rust SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+## Static methods
+
+---
+
+#### Sandbox::builder()
+
+```rust
+fn builder(name: impl Into<String>) -> SandboxBuilder
+```
+
+Create a builder for configuring a new sandbox. The builder lets you set the image, resources, volumes, networking, secrets, and other options before booting the VM. See [`SandboxBuilder`](#sandboxbuilder) for all available options.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Sandbox name - must be unique among running sandboxes |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxBuilder`](#sandboxbuilder) | Builder for configuring the sandbox |
+
+---
+
+#### Sandbox::get()
+
+```rust
+async fn get(name: &str) -> MicrosandboxResult<SandboxHandle>
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control without requiring a full connection to the guest agent.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<SandboxHandle>>
+```
+
+List all sandboxes (running, stopped, and crashed).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`SandboxHandle`](#sandboxhandle)`>` | All sandbox handles |
+
+---
+
+#### Sandbox::remove()
+
+```rust
+async fn remove(name: &str) -> MicrosandboxResult<()>
+```
+
+Delete a stopped sandbox and all its state from disk (configuration, logs, runtime directory). Fails if the sandbox is still running - stop it first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Sandbox name |
+
+---
+
+#### Sandbox::start()
+
+```rust
+async fn start(name: &str) -> MicrosandboxResult<Sandbox>
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration. The sandbox enters attached mode - it stops when your process exits.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox::start_detached()
+
+```rust
+async fn start_detached(name: &str) -> MicrosandboxResult<Sandbox>
+```
+
+Restart a stopped sandbox in detached mode. The sandbox survives after your process exits.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+## Instance methods
+
+---
+
+#### config()
+
+```rust
+fn config(&self) -> &SandboxConfig
+```
+
+Access the sandbox's full configuration.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`&SandboxConfig`](#sandboxconfig) | Sandbox configuration |
+
+---
+
+#### detach()
+
+```rust
+async fn detach(self)
+```
+
+Release the handle without stopping the sandbox. The sandbox continues running as a background process. Reconnect later with [`Sandbox::get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```rust
+async fn drain(&self) -> MicrosandboxResult<()>
+```
+
+Start a graceful drain. Existing commands run to completion, but new `exec` calls are rejected. The sandbox transitions to `Stopped` when all in-flight commands finish. Useful for zero-downtime rotation of worker sandboxes.
+
+---
+
+#### fs()
+
+```rust
+fn fs(&self) -> SandboxFs<'_>
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/rust/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/rust/filesystem) | Filesystem handle |
+
+---
+
+#### kill()
+
+```rust
+async fn kill(&self) -> MicrosandboxResult<()>
+```
+
+Force-terminate the sandbox immediately with SIGKILL. No graceful shutdown - use when the sandbox is unresponsive.
+
+---
+
+#### metrics()
+
+```rust
+async fn metrics(&self) -> MicrosandboxResult<SandboxMetrics>
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk I/O, network I/O, and uptime.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | Resource metrics |
+
+---
+
+#### metrics_stream()
+
+```rust
+fn metrics_stream(&self, interval: Duration) -> impl Stream<Item = MicrosandboxResult<SandboxMetrics>>
+```
+
+Stream resource metrics at a regular interval. Returns an async stream that yields a new snapshot every `interval` duration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| interval | `Duration` | Time between metric snapshots |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `impl Stream<Item = Result<`[`SandboxMetrics`](#sandboxmetrics)`>>` | Async stream of metrics |
+
+---
+
+#### logs()
+
+```rust
+fn logs(&self, opts: &LogOptions) -> MicrosandboxResult<Vec<LogEntry>>
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `Stdout`, `Stderr`, and `Output` (PTY-merged). Pass `LogSource::System` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```rust
+use microsandbox::sandbox::{LogOptions, LogSource, Sandbox};
+
+let handle = Sandbox::get("web").await?;
+
+// Default — all user-program output, regardless of pipe/pty mode
+let entries = handle.logs(&LogOptions::default())?;
+
+for e in entries {
+    let source = match e.source {
+        LogSource::Stdout => "OUT",
+        LogSource::Stderr => "ERR",
+        LogSource::Output => "PTY",
+        LogSource::System => "SYS",
+    };
+    println!(
+        "[{}] {} {:?}: {}",
+        e.timestamp.to_rfc3339(),
+        source,
+        e.session_id,
+        String::from_utf8_lossy(&e.data).trim_end()
+    );
+}
+
+// Filtered: last 50 entries from the past hour, including system lines
+let recent = handle.logs(&LogOptions {
+    tail: Some(50),
+    since: Some(chrono::Utc::now() - chrono::Duration::hours(1)),
+    sources: vec![
+        LogSource::Stdout,
+        LogSource::Stderr,
+        LogSource::Output,
+        LogSource::System,
+    ],
+    ..Default::default()
+})?;
+```
+
+`logs()` is **synchronous** because it's a pure file read.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| opts | `&`[`LogOptions`](#logoptions) | Filters: `tail`, `since`, `until`, `sources`. `LogOptions::default()` returns everything for the default sources. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`LogEntry`](#logentry)`>` | Matching entries in chronological order |
+
+---
+
+#### name()
+
+```rust
+fn name(&self) -> &str
+```
+
+Get the sandbox name.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `&str` | Sandbox name |
+
+---
+
+#### owns_lifecycle()
+
+```rust
+fn owns_lifecycle(&self) -> bool
+```
+
+Whether this handle owns the sandbox lifecycle. `true` in attached mode (sandbox stops when your process exits), `false` in detached mode.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `true` if attached |
+
+---
+
+#### remove_persisted()
+
+```rust
+async fn remove_persisted(self) -> MicrosandboxResult<()>
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### stop()
+
+```rust
+async fn stop(&self) -> MicrosandboxResult<()>
+```
+
+Gracefully shut down the sandbox. Sends SIGTERM to all guest processes and waits for the VM to exit.
+
+---
+
+#### stop_and_wait()
+
+```rust
+async fn stop_and_wait(&self) -> MicrosandboxResult<ExitStatus>
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### wait()
+
+```rust
+async fn wait(&self) -> MicrosandboxResult<ExitStatus>
+```
+
+Block until the sandbox exits on its own (without triggering a stop). Returns the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
+
+---
+
+## SandboxBuilder
+
+Builder for configuring a sandbox before creation. Obtained via [`Sandbox::builder(name)`](#sandboxbuilder-1).
+
+---
+
+#### cpus()
+
+```rust
+fn cpus(self, count: u8) -> Self
+```
+
+Set the number of virtual CPUs. This is a limit, not a reservation. Default: `1`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| count | `u8` | Number of vCPUs |
+
+---
+
+#### create()
+
+```rust
+async fn create(self) -> MicrosandboxResult<Sandbox>
+```
+
+Boot the sandbox in attached mode. The sandbox stops when your process exits.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### create_detached()
+
+```rust
+async fn create_detached(self) -> MicrosandboxResult<Sandbox>
+```
+
+Boot the sandbox in detached mode. The sandbox survives after your process exits.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### disable_network()
+
+```rust
+fn disable_network(self) -> Self
+```
+
+Fully disable networking. No network interface is created.
+
+---
+
+#### entrypoint()
+
+```rust
+fn entrypoint(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> Self
+```
+
+Override the OCI image's entrypoint.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl IntoIterator<Item = impl Into<String>>` | Entrypoint command and arguments |
+
+---
+
+#### env()
+
+```rust
+fn env(self, key: impl Into<String>, value: impl Into<String>) -> Self
+```
+
+Set an environment variable visible to all commands. Can be called multiple times. Per-command env vars (via `exec_with`) are merged on top.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| key | `impl Into<String>` | Variable name |
+| value | `impl Into<String>` | Variable value |
+
+---
+
+#### hostname()
+
+```rust
+fn hostname(self, hostname: impl Into<String>) -> Self
+```
+
+Set the guest hostname.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostname | `impl Into<String>` | Hostname |
+
+---
+
+#### idle_timeout()
+
+```rust
+fn idle_timeout(self, secs: u64) -> Self
+```
+
+Auto-drain the sandbox after this many seconds of inactivity (no active exec sessions). Enforced on the host side.
+
+---
+
+#### init()
+
+```rust
+fn init(self, cmd: impl Into<PathBuf>) -> Self
+```
+
+Hand off PID 1 inside the guest to `cmd` after agentd finishes its boot-time setup. The agent forks; the parent execs the init and becomes PID 1, the agent continues as a child process. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks, shutdown semantics, and tradeoffs.
+
+`cmd` is either an absolute path inside the guest rootfs or the literal `"auto"` (probes `/sbin/init`, `/lib/systemd/systemd`, `/usr/lib/systemd/systemd`). For init binaries that take argv or extra env (rare), use [`init_with`](#init_with).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<PathBuf>` | Absolute path inside the guest, or `"auto"` |
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("jrei/systemd-debian:12")
+    .init("auto")
+    .create()
+    .await?;
+```
+
+---
+
+#### init_with()
+
+```rust
+fn init_with(
+    self,
+    cmd: impl Into<PathBuf>,
+    f: impl FnOnce(InitOptionsBuilder) -> InitOptionsBuilder,
+) -> Self
+```
+
+Like [`init`](#init), but with a closure-builder for argv and env vars. Mirrors `exec_with` in shape.
+
+The builder exposes `arg`, `args`, `env`, and `envs`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<PathBuf>` | Absolute path to the init binary inside the guest |
+| f | `FnOnce(InitOptionsBuilder) -> InitOptionsBuilder` | Closure populating argv and env |
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("jrei/systemd-debian:12")
+    .init_with("/lib/systemd/systemd", |i| i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create()
+    .await?;
+```
+
+Calling `init` or `init_with` more than once overwrites — different from `env`, which appends. The init is one-shot pre-boot.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `u64` | Idle timeout in seconds |
+
+---
+
+#### image()
+
+```rust
+fn image(self, image: impl IntoImage) -> Self
+```
+
+Set the root filesystem source. Accepts OCI image names, local directory paths, or disk image paths. The format is auto-detected.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| image | `impl IntoImage` | OCI image name, local directory path, or disk image path |
+
+---
+
+#### image_with()
+
+```rust
+fn image_with(self, f: impl FnOnce(ImageBuilder) -> ImageBuilder) -> Self
+```
+
+Configure a disk image rootfs with explicit filesystem type. Use when the filesystem type can't be auto-detected.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | `ImageBuilder` | Configure the disk image rootfs. |
+
+---
+
+#### log_level()
+
+```rust
+fn log_level(self, level: LogLevel) -> Self
+```
+
+Override the sandbox process's log verbosity.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| level | [`LogLevel`](#loglevel) | Log level |
+
+---
+
+#### max_duration()
+
+```rust
+fn max_duration(self, secs: u64) -> Self
+```
+
+Set the maximum sandbox lifetime in seconds. When exceeded, the sandbox is drained and stopped. Enforced on the host side - the guest cannot override it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `u64` | Maximum lifetime in seconds |
+
+---
+
+#### memory()
+
+```rust
+fn memory(self, size: impl Into<Mebibytes>) -> Self
+```
+
+Set the guest memory size. Physical pages are only allocated as the guest touches them, so this is a limit, not an upfront reservation. Default: `512` MiB.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size | `impl Into<Mebibytes>` | Memory in MiB |
+
+---
+
+#### network()
+
+```rust
+fn network(self, f: impl FnOnce(NetworkBuilder) -> NetworkBuilder) -> Self
+```
+
+Configure networking. See [Networking](/sdk/rust/networking) for the full builder API.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`NetworkBuilder`](/sdk/rust/networking#networkbuilder) | Configure the network. |
+
+---
+
+#### patch()
+
+```rust
+fn patch(self, f: impl FnOnce(PatchBuilder) -> PatchBuilder) -> Self
+```
+
+Modify the rootfs before the VM boots. Patches go into the writable layer - the base image is untouched.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | `PatchBuilder` | Configure rootfs patches. |
+
+---
+
+#### port()
+
+```rust
+fn port(self, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a TCP port from the sandbox to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_port | `u16` | Port on the host |
+| guest_port | `u16` | Port inside the sandbox |
+
+---
+
+#### port_udp()
+
+```rust
+fn port_udp(self, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a UDP port.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_port | `u16` | Port on the host |
+| guest_port | `u16` | Port inside the sandbox |
+
+---
+
+#### pull_policy()
+
+```rust
+fn pull_policy(self, policy: PullPolicy) -> Self
+```
+
+Control when the OCI image is pulled from the registry.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| policy | [`PullPolicy`](#pullpolicy) | Pull behavior |
+
+---
+
+#### registry_auth()
+
+```rust
+fn registry_auth(self, auth: RegistryAuth) -> Self
+```
+
+Authenticate to a private container registry.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| auth | [`RegistryAuth`](#registryauth) | Registry credentials |
+
+---
+
+#### replace()
+
+```rust
+fn replace(self) -> Self
+```
+
+If a sandbox with the same name already exists, stop it, remove it, and create a fresh one. Without this, creation fails on name conflict.
+
+---
+
+#### script()
+
+```rust
+fn script(self, name: impl Into<String>, content: impl Into<String>) -> Self
+```
+
+Add a named script at `/.msb/scripts/` inside the guest. Scripts are added to `PATH` and can be called by name via `exec()` or `shell()`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Script name (becomes the filename) |
+| content | `impl Into<String>` | Script content |
+
+---
+
+#### secret()
+
+```rust
+fn secret(self, f: impl FnOnce(SecretBuilder) -> SecretBuilder) -> Self
+```
+
+Add a secret with full configuration. See [Secrets](/sdk/rust/secrets) for the builder API. Automatically enables TLS interception.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`SecretBuilder`](/sdk/rust/secrets#secretbuilder) | Configure the secret. |
+
+---
+
+#### secret_env()
+
+```rust
+fn secret_env(self, env_var: impl Into<String>, value: impl Into<String>, allowed_host: impl Into<String>) -> Self
+```
+
+Shorthand for adding a header-injected secret. Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| env_var | `impl Into<String>` | Environment variable name |
+| value | `impl Into<String>` | Secret value |
+| allowed_host | `impl Into<String>` | Allowed destination host |
+
+---
+
+#### shell()
+
+```rust
+fn shell(self, shell: impl Into<String>) -> Self
+```
+
+Set the shell used by [`Sandbox::shell()`](#shell). Default: `/bin/sh`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| shell | `impl Into<String>` | Shell path (e.g. `"/bin/bash"`) |
+
+---
+
+#### user()
+
+```rust
+fn user(self, user: impl Into<String>) -> Self
+```
+
+Set the default guest user for all commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| user | `impl Into<String>` | User name or UID |
+
+---
+
+#### volume()
+
+```rust
+fn volume(self, guest_path: impl Into<String>, f: impl FnOnce(MountBuilder) -> MountBuilder) -> Self
+```
+
+Add a volume mount. See [Volumes](/sdk/rust/volumes) for mount types.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `impl Into<String>` | Mount point inside the sandbox |
+| f | [`MountBuilder`](/sdk/rust/volumes#mountbuilder) | Configure the mount. |
+
+---
+
+#### workdir()
+
+```rust
+fn workdir(self, path: impl Into<String>) -> Self
+```
+
+Set the default working directory for all commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+
+---
+
+## PatchBuilder
+
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder::patch(|p| p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `replace = true` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### append()
+
+```rust
+fn append(self, path: impl Into<String>, content: impl Into<String>) -> Self
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<String>` | Text to append |
+
+---
+
+#### copy_dir()
+
+```rust
+fn copy_dir(self, src: impl Into<PathBuf>, dst: impl Into<String>, replace: bool) -> Self
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<PathBuf>` | Host source directory |
+| dst | `impl Into<String>` | Absolute destination path inside the guest |
+| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### copy_file()
+
+```rust
+fn copy_file(
+    self,
+    src: impl Into<PathBuf>,
+    dst: impl Into<String>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<PathBuf>` | Host source file |
+| dst | `impl Into<String>` | Absolute destination path inside the guest |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)`. `None` keeps the source mode |
+| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### file()
+
+```rust
+fn file(
+    self,
+    path: impl Into<String>,
+    content: impl Into<Vec<u8>>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Write raw bytes at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<Vec<u8>>` | Raw byte content |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
+| replace | `bool` | When `true`, overwrite an existing path |
+
+---
+
+#### mkdir()
+
+```rust
+fn mkdir(self, path: impl Into<String>, mode: Option<u32>) -> Self
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| mode | `Option<u32>` | Directory mode, e.g. `Some(0o755)` |
+
+---
+
+#### remove()
+
+```rust
+fn remove(self, path: impl Into<String>) -> Self
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+
+---
+
+#### symlink()
+
+```rust
+fn symlink(self, target: impl Into<String>, link: impl Into<String>, replace: bool) -> Self
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `impl Into<String>` | What the symlink points to (literal symlink target text) |
+| link | `impl Into<String>` | Absolute path of the symlink itself |
+| replace | `bool` | When `true`, overwrite an existing path at `link` |
+
+---
+
+#### text()
+
+```rust
+fn text(
+    self,
+    path: impl Into<String>,
+    content: impl Into<String>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<String>` | Text content |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
+| replace | `bool` | When `true`, overwrite an existing path |
+
+---
+
+## Types
+
+### LogEntry
+
+A single captured log entry returned by [`logs()`](#logs).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| timestamp | `DateTime<Utc>` | Wall-clock capture time on the host |
+| source | [`LogSource`](#logsource) | Where the chunk came from |
+| session_id | `Option<u64>` | Relay-monotonic session id; `None` for `System` entries |
+| data | `Bytes` | The chunk's bytes (UTF-8 lossy decoded by default; raw bytes if `--raw` mode was used) |
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `Error` | Errors only |
+| `Warn` | Warnings and errors only |
+| `Info` | Info and higher |
+| `Debug` | Debug and higher |
+| `Trace` | Most verbose - all diagnostic output |
+
+### LogOptions
+
+Filters passed to [`logs()`](#logs). All fields optional. `LogOptions::default()` returns everything for the default sources (`Stdout` + `Stderr` + `Output`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tail | `Option<usize>` | Show only the last N entries after other filters apply |
+| since | `Option<DateTime<Utc>>` | Inclusive lower bound on entry timestamp |
+| until | `Option<DateTime<Utc>>` | Exclusive upper bound on entry timestamp |
+| sources | `Vec<`[`LogSource`](#logsource)`>` | Sources to include. Empty = `[Stdout, Stderr, Output]` (the default user-program sources). Add `System` to merge runtime/kernel diagnostics. |
+
+### LogSource
+
+Tag indicating where a captured log entry came from.
+
+| Value | Description |
+|-------|-------------|
+| `Stdout` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `Stderr` | Captured from a session's stderr (pipe mode) |
+| `Output` | Captured from a session running in pty mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `Output` rather than mislabelled as `Stdout`. |
+| `System` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `System` is requested. |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `Always` | Pull the image every time, even if cached locally |
+| `IfMissing` | Pull only if the image is not already cached. This is the default. |
+| `Never` | Never pull; fail if the image is not cached locally |
+
+### RegistryAuth
+
+Credentials for authenticating to a private container registry.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Basic` | - `username: String` <br/> - `password: String` | Username and password authentication |
+
+### SandboxConfig
+
+The full configuration of a sandbox. Obtained via [`config()`](#config) or built via [`SandboxBuilder`](#sandboxbuilder). Contains all settings used to create the sandbox.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpus | `u8` | Number of virtual CPUs |
+| env | `Vec<(String, String)>` | Environment variables |
+| idle_timeout_secs | `Option<u64>` | Idle timeout |
+| image | `RootfsSource` | Root filesystem source (OCI, bind, or disk image) |
+| max_duration_secs | `Option<u64>` | Maximum lifetime |
+| memory_mib | `u32` | Guest memory in MiB |
+| name | `String` | Sandbox name |
+| patches | `Vec<Patch>` | Rootfs patches |
+| scripts | `Vec<(String, String)>` | Named scripts |
+| shell | `Option<String>` | Shell for `shell()` calls |
+| volumes | `Vec<VolumeMount>` | Volume mounts |
+| workdir | `Option<String>` | Default working directory |
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox::get()`](#sandboxget) or [`Sandbox::list()`](#sandboxlist). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. You cannot `exec` or `fs` on a handle - call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| config() | `Result<`[`SandboxConfig`](#sandboxconfig)`>` | Parsed configuration |
+| config_json() | `&str` | Raw JSON configuration |
+| connect() | `Result<`[`Sandbox`](#instance-methods)`>` | Connect to a running sandbox |
+| created_at() | `Option<DateTime<Utc>>` | Creation timestamp |
+| kill() | `Result<()>` | Force terminate |
+| logs() | `Result<Vec<`[`LogEntry`](#logentry)`>>` | Read captured `exec.log` (works without starting) |
+| metrics() | `Result<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
+| name() | `&str` | Sandbox name |
+| remove() | `Result<()>` | Delete sandbox and state |
+| start() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
+| start_detached() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |
+| status() | [`SandboxStatus`](#sandboxstatus) | Current status |
+| stop() | `Result<()>` | Graceful shutdown |
+| updated_at() | `Option<DateTime<Utc>>` | Last update timestamp |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpu_percent | `f32` | CPU usage as a percentage |
+| disk_read_bytes | `u64` | Total bytes read from disk since boot |
+| disk_write_bytes | `u64` | Total bytes written to disk since boot |
+| memory_bytes | `u64` | Current memory usage in bytes |
+| memory_limit_bytes | `u64` | Memory limit in bytes |
+| net_rx_bytes | `u64` | Total bytes received over the network since boot |
+| net_tx_bytes | `u64` | Total bytes sent over the network since boot |
+| timestamp | `DateTime<Utc>` | When this measurement was taken |
+| uptime | `Duration` | Time since the sandbox was created |
+
+### SandboxStatus
+
+| Value | Description |
+|-------|-------------|
+| `Crashed` | VM exited unexpectedly (kernel panic, OOM, etc.) |
+| `Draining` | Graceful shutdown in progress; existing commands finish, new ones rejected |
+| `Running` | Guest agent is ready; `exec`, `shell`, `fs` work |
+| `Stopped` | VM shut down; configuration persisted; can be restarted |

--- a/docs/fr/sdk/rust/secrets.mdx
+++ b/docs/fr/sdk/rust/secrets.mdx
@@ -1,0 +1,221 @@
+---
+title: Secrets
+description: Rust SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## SecretBuilder
+
+Builder for configuring a secret's placeholder, allowed hosts, and injection scopes. Obtained through `SandboxBuilder::secret(|s| s...)`. Each secret maps an environment variable to a real value that is only revealed when traffic goes to an allowed host via the TLS proxy.
+
+---
+
+#### allow_any_host_dangerous()
+
+```rust
+fn allow_any_host_dangerous(self, i_understand_the_risk: bool) -> Self
+```
+
+Allow substitution on **any** host. This means any server the guest connects to will receive the real secret - effectively disabling host-based protection. Only use this when the secret is not sensitive or the sandbox network is fully locked down.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| i_understand_the_risk | `bool` | Must be `true` to take effect |
+
+---
+
+#### allow_host()
+
+```rust
+fn allow_host(self, host: impl Into<String>) -> Self
+```
+
+Add a host that is allowed to receive the real secret value. The TLS proxy matches this against the SNI (Server Name Indication) in the TLS ClientHello. Can be called multiple times to allow multiple hosts.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `impl Into<String>` | Exact hostname (e.g. `"api.openai.com"`) |
+
+---
+
+#### allow_host_pattern()
+
+```rust
+fn allow_host_pattern(self, pattern: impl Into<String>) -> Self
+```
+
+Add a wildcard host pattern. The `*` matches any subdomain prefix.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pattern | `impl Into<String>` | Wildcard pattern (e.g. `"*.googleapis.com"`) |
+
+---
+
+#### env()
+
+```rust
+fn env(self, var: impl Into<String>) -> Self
+```
+
+Set the environment variable name that will hold the placeholder inside the guest. The guest sees `$MSB_<var>` (or a custom placeholder) - never the real value. **Required.**
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| var | `impl Into<String>` | Environment variable name (e.g. `"OPENAI_API_KEY"`) |
+
+---
+
+#### inject_basic_auth()
+
+```rust
+fn inject_basic_auth(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced specifically in `Authorization` header lines. When `inject_headers` is `true`, this has no additional effect since all headers are already covered.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### inject_body()
+
+```rust
+fn inject_body(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced in the HTTP request body. When enabled, the TLS proxy also updates the `Content-Length` header to match the new body size after substitution.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `false` |
+
+---
+
+#### inject_headers()
+
+```rust
+fn inject_headers(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced anywhere in HTTP headers. This is the most common injection scope - covers `Authorization: Bearer $MSB_...` and similar patterns.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### inject_query()
+
+```rust
+fn inject_query(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced in the URL query string (the `?key=value` portion of the request line).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `false` |
+
+---
+
+#### placeholder()
+
+```rust
+fn placeholder(self, placeholder: impl Into<String>) -> Self
+```
+
+Override the auto-generated placeholder string. By default, microsandbox generates `$MSB_<env_var>`. Use this when you need a specific format or when the placeholder must match a particular byte length.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| placeholder | `impl Into<String>` | Custom placeholder string |
+
+---
+
+#### require_tls_identity()
+
+```rust
+fn require_tls_identity(self, enabled: bool) -> Self
+```
+
+When `true`, the secret is only substituted on TLS-intercepted connections where the proxy has verified it is performing MITM. When `false`, substitution also happens on non-intercepted (bypass) connections. Disable only if you know the traffic is safe.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### value()
+
+```rust
+fn value(self, value: impl Into<String>) -> Self
+```
+
+Set the real secret value. This is the string that replaces the placeholder when a request reaches an allowed host. It never enters the guest VM. **Required.**
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| value | `impl Into<String>` | The actual credential or token |
+
+---
+
+## Shorthand
+
+#### secret_env()
+
+```rust
+fn secret_env(self, env_var: impl Into<String>, value: impl Into<String>, allowed_host: impl Into<String>) -> Self
+```
+
+Convenience method on `SandboxBuilder`. Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`. Uses default injection scopes (headers enabled, body disabled).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| env_var | `impl Into<String>` | Environment variable name |
+| value | `impl Into<String>` | Secret value |
+| allowed_host | `impl Into<String>` | Allowed destination host |
+
+---
+
+## Types
+
+### ViolationAction
+
+Configured via [`NetworkBuilder::on_secret_violation()`](/sdk/rust/networking#on_secret_violation). Determines what happens when the guest sends a request containing a secret placeholder to a host that is **not** in the secret's allow list.
+
+| Value | Description |
+|-------|-------------|
+| `Block` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `BlockAndLog` | Drop the request and emit a warning log on the host side. |
+| `BlockAndTerminate` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/fr/sdk/rust/snapshots.mdx
+++ b/docs/fr/sdk/rust/snapshots.mdx
@@ -1,0 +1,343 @@
+---
+title: Snapshots
+description: Rust SDK - Snapshot API reference
+icon: "camera"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Rust SDK reference.
+
+```rust
+use microsandbox::{Sandbox, Snapshot, SnapshotHandle, SnapshotFormat};
+use microsandbox::snapshot::ExportOpts;
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## SandboxBuilder
+
+---
+
+#### from_snapshot()
+
+```rust
+fn from_snapshot(self, src: impl Into<String>) -> Self
+```
+
+Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`image()`](/sdk/rust/sandbox#image) and [`image_with()`](/sdk/rust/sandbox#image-with) — the snapshot already pins the image.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<String>` | Bare name (resolved under `~/.microsandbox/snapshots/`) or filesystem path to an artifact directory |
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```rust
+async fn snapshot(&self, name: &str) -> MicrosandboxResult<Snapshot>
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination see [`snapshot_to()`](#snapshot-to).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Bare snapshot name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Snapshot` | The created artifact handle |
+
+**Errors**
+
+- `MicrosandboxError::SnapshotSandboxRunning` — the sandbox is not stopped
+- `MicrosandboxError::SnapshotAlreadyExists` — destination already exists (use the builder with `.force()` to overwrite)
+
+---
+
+#### snapshot_to()
+
+```rust
+async fn snapshot_to(&self, path: impl AsRef<Path>) -> MicrosandboxResult<Snapshot>
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path. For the common case of writing under the default snapshots directory see [`snapshot()`](#snapshot).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl AsRef<Path>` | Destination directory |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Snapshot` | The created artifact handle |
+
+---
+
+## Snapshot (instance)
+
+---
+
+#### path()
+
+```rust
+fn path(&self) -> &Path
+```
+
+Path to the artifact directory.
+
+---
+
+#### digest()
+
+```rust
+fn digest(&self) -> &str
+```
+
+Canonical content digest (`sha256:hex`) over the manifest bytes. The snapshot's identity.
+
+---
+
+#### manifest()
+
+```rust
+fn manifest(&self) -> &Manifest
+```
+
+Parsed manifest — image reference, image manifest digest, fstype, format, labels, upper-layer metadata, and optional integrity hash.
+
+---
+
+#### size_bytes()
+
+```rust
+fn size_bytes(&self) -> u64
+```
+
+Apparent size of the captured upper layer in bytes (the ext4 virtual size, sparse on disk).
+
+---
+
+#### verify()
+
+```rust
+async fn verify(&self) -> MicrosandboxResult<SnapshotVerifyReport>
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds. Returns `NotRecorded` when the manifest has no integrity hash.
+
+---
+
+## Snapshot::builder
+
+---
+
+#### Snapshot::builder()
+
+```rust
+fn builder(source_sandbox: impl Into<String>) -> SnapshotBuilder
+```
+
+Start configuring a new snapshot. The fluent builder is the API the CLI uses internally.
+
+```rust
+let snap = Snapshot::builder("baseline")
+    .name("after-pip-install")        // bare name in default dir
+    .label("stage", "post-deps")
+    .force()                           // overwrite if it exists
+    .record_integrity()                // hash the upper layer
+    .create()
+    .await?;
+```
+
+**Builder methods**
+
+| Method | Description |
+|--------|-------------|
+| `.destination(SnapshotDestination)` | Explicit destination variant |
+| `.name(&str)` | Convenience: bare name under the default snapshots directory |
+| `.path(PathBuf)` | Convenience: explicit filesystem path |
+| `.label(k, v)` | Add a `key=value` label (sorted in canonical form) |
+| `.force()` | Overwrite an existing artifact at the destination |
+| `.record_integrity()` | Compute and record a content-integrity hash at creation |
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot::create()
+
+```rust
+async fn create(config: SnapshotConfig) -> MicrosandboxResult<Snapshot>
+```
+
+Create a snapshot from a [`SnapshotConfig`](#snapshotconfig). Equivalent to using the builder.
+
+---
+
+#### Snapshot::open()
+
+```rust
+async fn open(path_or_name: impl AsRef<str>) -> MicrosandboxResult<Snapshot>
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot::get()
+
+```rust
+async fn get(name_or_digest: &str) -> MicrosandboxResult<SnapshotHandle>
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<SnapshotHandle>>
+```
+
+List indexed snapshots from the local DB cache. External-path artifacts opened via `Snapshot::open(/some/path)` may not appear here unless they live under the configured snapshots directory.
+
+---
+
+#### Snapshot::list_dir()
+
+```rust
+async fn list_dir(dir: impl AsRef<Path>) -> MicrosandboxResult<Vec<Snapshot>>
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index. Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot::remove()
+
+```rust
+async fn remove(path_or_name: &str, force: bool) -> MicrosandboxResult<()>
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force` is `true`.
+
+---
+
+#### Snapshot::reindex()
+
+```rust
+async fn reindex(dir: impl AsRef<Path>) -> MicrosandboxResult<usize>
+```
+
+Walk `dir`, upsert index rows for every artifact found, recompute parent-edge child counts. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot::export()
+
+```rust
+async fn export(name_or_path: &str, out: &Path, opts: ExportOpts) -> MicrosandboxResult<()>
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+**ExportOpts**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `with_parents` | `bool` | Walk the parent chain and include each ancestor (no-op today) |
+| `with_image` | `bool` | Bundle the OCI image cache (`cache/{layers,fsmeta,vmdk}`) for offline transport |
+| `plain_tar` | `bool` | Skip zstd compression and write a plain `.tar` |
+
+---
+
+#### Snapshot::import()
+
+```rust
+async fn import(archive: &Path, dest: Option<&Path>) -> MicrosandboxResult<SnapshotHandle>
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot::list()`](#snapshotlist) and [`Snapshot::get()`](#snapshotget).
+
+```rust
+let h = Snapshot::get("after-pip-install").await?;
+
+h.digest();           // &str — sha256:...
+h.name();             // Option<&str>
+h.parent_digest();    // Option<&str> — None today; populated when chains land
+h.image_ref();        // &str
+h.format();           // SnapshotFormat::Raw | Qcow2
+h.size_bytes();       // Option<u64>
+h.created_at();       // chrono::NaiveDateTime
+h.path();             // &Path
+
+let snap = h.open().await?;       // verify metadata, return Snapshot
+h.remove(false).await?;            // false = refuse if has children
+```
+
+---
+
+## Types
+
+#### SnapshotDestination
+
+```rust
+pub enum SnapshotDestination {
+    Name(String),
+    Path(PathBuf),
+}
+```
+
+Used by [`SnapshotBuilder::destination()`](#snapshotbuilder). The handle methods [`snapshot()`](#snapshot) and [`snapshot_to()`](#snapshot-to) construct this enum internally so callers don't need to import it.
+
+#### SnapshotFormat
+
+```rust
+pub enum SnapshotFormat {
+    Raw,
+    Qcow2,    // future
+}
+```
+
+Always emits `Raw` today. The `Qcow2` variant is reserved for backing-chain checkpoints.
+
+#### SnapshotVerifyReport
+
+```rust
+pub struct SnapshotVerifyReport {
+    pub digest: String,
+    pub path: PathBuf,
+    pub upper: UpperVerifyStatus,
+}
+
+pub enum UpperVerifyStatus {
+    NotRecorded,
+    Verified { algorithm: String, digest: String },
+}
+```
+
+Returned by [`Snapshot::verify()`](#verify).

--- a/docs/fr/sdk/rust/volumes.mdx
+++ b/docs/fr/sdk/rust/volumes.mdx
@@ -1,0 +1,213 @@
+---
+title: Volumes
+description: Rust SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+---
+
+#### Volume::builder()
+
+```rust
+fn builder(name: impl Into<String>) -> VolumeBuilder
+```
+
+Create a builder for a new named volume. Call `.quota()` to set a storage limit, then `.create()` to finalize.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Volume name (e.g. `"pip-cache"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeBuilder`](#volumebuilder) | Builder with `.quota()` and `.create()` |
+
+---
+
+#### Volume::get()
+
+```rust
+async fn get(name: &str) -> MicrosandboxResult<VolumeHandle>
+```
+
+Get a handle to an existing named volume. Use the handle to access the volume's filesystem from the host or to delete it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeHandle`](#volumehandle) | Handle for host-side operations |
+
+---
+
+#### Volume::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<VolumeHandle>>
+```
+
+List all named volumes.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`VolumeHandle`](#volumehandle)`>` | All volume handles |
+
+---
+
+#### Volume::remove()
+
+```rust
+async fn remove(name: &str) -> MicrosandboxResult<()>
+```
+
+Delete a named volume and its contents from disk. Fails if the volume is currently mounted by a running sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Volume name |
+
+---
+
+## VolumeBuilder
+
+Builder for creating a named volume.
+
+---
+
+#### create()
+
+```rust
+async fn create(self) -> MicrosandboxResult<Volume>
+```
+
+Create the volume on disk.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Volume` | The created volume |
+
+---
+
+#### quota()
+
+```rust
+fn quota(self, mib: u64) -> Self
+```
+
+Set the maximum storage size for this volume. The guest cannot write beyond this limit.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| mib | `u64` | Quota in MiB |
+
+---
+
+## MountBuilder
+
+Builder for configuring a volume mount. Used in `SandboxBuilder::volume(path, |v| v...)`.
+
+---
+
+#### bind()
+
+```rust
+fn bind(self, host_path: impl Into<PathBuf>) -> Self
+```
+
+Mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `impl Into<PathBuf>` | Directory path on the host |
+
+---
+
+#### named()
+
+```rust
+fn named(self, name: impl Into<String>) -> Self
+```
+
+Mount a named volume. The volume must already exist (create it with [`Volume::builder()`](#volumebuilder)).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Volume name |
+
+---
+
+#### readonly()
+
+```rust
+fn readonly(self) -> Self
+```
+
+Mount as read-only. The guest can read but not write.
+
+---
+
+#### size()
+
+```rust
+fn size(self, mib: impl Into<Mebibytes>) -> Self
+```
+
+Set the size limit for a tmpfs mount. Has no effect on bind or named mounts.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| mib | `impl Into<Mebibytes>` | Size limit in MiB |
+
+---
+
+#### tmpfs()
+
+```rust
+fn tmpfs(self) -> Self
+```
+
+Use an in-memory filesystem. Contents are discarded when the sandbox stops. Good for scratch space, temp files, and build artifacts.
+
+---
+
+## Types
+
+### VolumeHandle
+
+Handle for interacting with a named volume from the host side.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| fs() | `VolumeFsHandle` | Host-side filesystem access - read and write files without a running sandbox |
+| name() | `&str` | Volume name |
+| remove() | `()` | Delete this volume from disk |

--- a/docs/fr/sdk/typescript/events.mdx
+++ b/docs/fr/sdk/typescript/events.mdx
@@ -1,0 +1,66 @@
+---
+title: Events
+description: TypeScript SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for usage examples and guest-side emitting.
+
+## Sandbox methods
+
+---
+
+#### emit()
+
+```typescript
+emit(eventName: string, data: any): Promise<void>
+```
+
+Send a named event with a JSON-serializable payload into the guest. Any process listening on the agent socket (`/run/agent.sock`) receives it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| eventName | `string` | Event name (e.g. `"task.start"`) |
+| data | `any` | Event payload - must be JSON-serializable |
+
+---
+
+#### onEvent()
+
+```typescript
+onEvent(eventName: string, callback: (event: EventData) => void): Subscription
+```
+
+Subscribe to named events emitted by guest processes. The callback fires each time the guest sends a matching event through `/run/agent.sock`. Multiple subscriptions to the same event name are supported.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| eventName | `string` | Event name to subscribe to (e.g. `"task.progress"`) |
+| callback | `(event: EventData) => void` | Called with the event data each time |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Subscription` | Call `.unsubscribe()` to stop receiving events |
+
+---
+
+## Types
+
+### EventData
+
+Data received from a guest event.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| data | `any` | Event payload. `undefined` if the event had no data. |
+| event | `string` | Event name |

--- a/docs/fr/sdk/typescript/execution.mdx
+++ b/docs/fr/sdk/typescript/execution.mdx
@@ -1,0 +1,364 @@
+---
+title: Execution
+description: TypeScript SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+---
+
+#### attach()
+
+```typescript
+attach(cmd: string, args?: Iterable<string>): Promise<number>
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Press `Ctrl+]` (or configured detach keys) to disconnect without stopping the process.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to run |
+| args? | `Iterable<string>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code of the process |
+
+---
+
+#### attachShell()
+
+```typescript
+attachShell(): Promise<number>
+```
+
+Attach to the sandbox's default shell.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code |
+
+---
+
+#### attachWith()
+
+```typescript
+attachWith(
+  cmd: string,
+  configure: (b: AttachOptionsBuilder) => AttachOptionsBuilder,
+): Promise<number>
+```
+
+Interactive PTY attach with options for environment variables, working directory, user, and custom detach keys. Configure via the builder callback.
+
+```typescript
+const code = await sandbox.attachWith("bash", (a) =>
+  a.cwd("/app")
+    .env("EDITOR", "vim")
+    .detachKeys("ctrl-]"),
+);
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to run |
+| configure | `(b: AttachOptionsBuilder) => AttachOptionsBuilder` | Builder callback — see [`AttachOptionsBuilder`](#attachoptionsbuilder) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code |
+
+---
+
+#### exec()
+
+```typescript
+exec(cmd: string, args?: Iterable<string>): Promise<ExecOutput>
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`execStream()`](#execstream) instead.
+
+```typescript
+const result = await sandbox.exec("python3", ["-c", "print(1 + 1)"]);
+console.log(result.stdout()); // "2\n"
+console.log(result.code);     // 0
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args? | `Iterable<string>` | Command arguments (e.g. `["-c", "print('hello')"]`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### execStream()
+
+```typescript
+execStream(cmd: string, args?: Iterable<string>): Promise<ExecHandle>
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
+
+```typescript
+const handle = await sandbox.execStream("tail", ["-f", "/var/log/app.log"]);
+for await (const event of handle) {
+  if (event.kind === "stdout") process.stdout.write(event.data);
+  if (event.kind === "exited") break;
+}
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute |
+| args? | `Iterable<string>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecHandle`](#exechandle)`>` | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### execStreamWith()
+
+```typescript
+execStreamWith(
+  cmd: string,
+  configure: (b: ExecOptionsBuilder) => ExecOptionsBuilder,
+): Promise<ExecHandle>
+```
+
+Streaming variant of [`execWith()`](#execwith) — same configuration via [`ExecOptionsBuilder`](#execoptionsbuilder), but returns an [`ExecHandle`](#exechandle).
+
+---
+
+#### execWith()
+
+```typescript
+execWith(
+  cmd: string,
+  configure: (b: ExecOptionsBuilder) => ExecOptionsBuilder,
+): Promise<ExecOutput>
+```
+
+Run a command with per-execution overrides. Configure working directory, environment variables, timeout, stdin, TTY allocation, and rlimits via the builder callback. These overrides apply only to this execution and don't change the sandbox's defaults.
+
+```typescript
+const out = await sandbox.execWith("python3", (e) =>
+  e.args(["script.py"])
+    .cwd("/app")
+    .env("PYTHONPATH", "/app/lib")
+    .timeout(30_000),
+);
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute |
+| configure | `(b: ExecOptionsBuilder) => ExecOptionsBuilder` | Builder callback — see [`ExecOptionsBuilder`](#execoptionsbuilder) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell()
+
+```typescript
+shell(script: string): Promise<ExecOutput>
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `string` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### shellStream()
+
+```typescript
+shellStream(script: string): Promise<ExecHandle>
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `string` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecHandle`](#exechandle)`>` | Streaming handle |
+
+---
+
+## Types
+
+### AttachOptionsBuilder
+
+Fluent builder used inside `Sandbox.attachWith(cmd, b => ...)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `arg(s)` | Append a single argument |
+| `args(iter)` | Append many arguments |
+| `cwd(path)` | Working directory |
+| `user(user)` | Guest user |
+| `env(key, value)` | Add a single env var |
+| `envs(record \| iter)` | Add many env vars |
+| `detachKeys(spec)` | Detach key sequence (e.g. `"ctrl-]"` or `"ctrl-p,ctrl-q"`) |
+| `rlimit(resource, n)` | Set both soft and hard rlimit |
+| `rlimitRange(resource, soft, hard)` | Set distinct soft/hard rlimits |
+| `build()` | Produce an immutable [`AttachOptions`](#attachoptions) |
+
+### AttachOptions
+
+The immutable object produced by `AttachOptionsBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| args | `readonly string[]` | Command arguments |
+| cwd | `string \| null` | Working directory |
+| user | `string \| null` | Guest user |
+| env | `ReadonlyArray<readonly [string, string]>` | Environment variables |
+| detachKeys | `string \| null` | Detach key sequence |
+| rlimits | `readonly Rlimit[]` | rlimits for the process |
+
+### ExecOptionsBuilder
+
+Fluent builder used inside `Sandbox.execWith(cmd, b => ...)`.
+
+| Method | Description |
+|--------|-------------|
+| `arg(s)` / `args(iter)` | Append arguments |
+| `cwd(path)` | Working directory |
+| `user(user)` | Guest user |
+| `env(key, value)` / `envs(record \| iter)` | Environment variables |
+| `timeout(ms)` | Kill the process after this many milliseconds |
+| `stdinNull()` | Stdin connected to `/dev/null` (default) |
+| `stdinPipe()` | Open a writable stdin pipe — read it back with `ExecHandle.takeStdin()` |
+| `stdinBytes(data)` | Pre-supply stdin (`Uint8Array \| string`) |
+| `tty(enabled)` | Allocate a pseudo-terminal |
+| `rlimit(resource, n)` / `rlimitRange(resource, soft, hard)` | rlimits |
+| `build()` | Produce an immutable [`ExecOptions`](#execoptions) |
+
+### ExecOptions
+
+The immutable object produced by `ExecOptionsBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| args | `readonly string[]` | Command arguments |
+| cwd | `string \| null` | Working directory |
+| user | `string \| null` | Guest user |
+| env | `ReadonlyArray<readonly [string, string]>` | Environment variables |
+| timeoutMs | `number \| null` | Timeout in milliseconds |
+| stdin | `StdinMode` | `null`, `pipe`, or pre-supplied `bytes` |
+| tty | `boolean` | TTY allocation |
+| rlimits | `readonly Rlimit[]` | rlimits |
+
+### ExecEvent
+
+Discriminated union emitted by `ExecHandle`. The discriminator is `kind` (not `eventType`).
+
+```typescript
+type ExecEvent =
+  | { kind: "started"; pid: number }
+  | { kind: "stdout"; data: Uint8Array }
+  | { kind: "stderr"; data: Uint8Array }
+  | { kind: "exited"; code: number };
+```
+
+| `kind` | Payload | Description |
+|--------|---------|-------------|
+| `'started'` | `pid: number` | The process has started |
+| `'stdout'` | `data: Uint8Array` | A chunk of stdout data |
+| `'stderr'` | `data: Uint8Array` | A chunk of stderr data |
+| `'exited'` | `code: number` | The process has exited |
+
+### ExecHandle
+
+A handle to a running streaming execution. `AsyncIterable<ExecEvent>` and `AsyncDisposable`.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `recv()` | `Promise<`[`ExecEvent`](#execevent)` \| null>` | Receive the next event. Returns `null` when done. |
+| `takeStdin()` | `Promise<`[`ExecSink`](#execsink)` \| null>` | Take the stdin writer. Returns `null` after first call. |
+| `wait()` | `Promise<`[`ExitStatus`](#exitstatus)`>` | Wait for the process to exit |
+| `collect()` | `Promise<`[`ExecOutput`](#execoutput)`>` | Drain remaining output and wait |
+| `signal(n)` | `Promise<void>` | Send a POSIX signal |
+| `kill()` | `Promise<void>` | Send SIGKILL |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<`[`ExecEvent`](#execevent)`>` | Iterate events with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Best-effort kill on `await using` exit |
+
+### ExecOutput
+
+The result of a completed command execution.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `code` | `number` (getter) | Exit code |
+| `success` | `boolean` (getter) | `true` if code is `0` |
+| `status` | [`ExitStatus`](#exitstatus) (getter) | Exit status object |
+| `stdout()` | `string` | Collected stdout decoded as UTF-8 |
+| `stderr()` | `string` | Collected stderr decoded as UTF-8 |
+| `stdoutBytes()` | `Uint8Array` | Raw stdout bytes |
+| `stderrBytes()` | `Uint8Array` | Raw stderr bytes |
+
+### ExecSink
+
+Writer for sending data to a running process's stdin.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `write(data)` | `Uint8Array \| string` | Write bytes to the process's stdin |
+| `close()` | - | Close stdin. The process sees EOF. |
+| `[Symbol.asyncDispose]()` | - | Calls `close()` |
+
+### ExitStatus
+
+| Field | Type | Description |
+|-------|------|-------------|
+| code | `number` | Exit code. `0` typically means success. |
+| success | `boolean` | `true` if code is `0` |

--- a/docs/fr/sdk/typescript/filesystem.mdx
+++ b/docs/fr/sdk/typescript/filesystem.mdx
@@ -1,0 +1,379 @@
+---
+title: Filesystem
+description: TypeScript SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution — no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
+
+```typescript
+const fs = sandbox.fs();
+
+await fs.write("/tmp/config.json", '{"debug": true}');
+const content = await fs.readToString("/tmp/config.json");
+```
+
+---
+
+#### copy()
+
+```typescript
+copy(from: string, to: string): Promise<void>
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `string` | Source path |
+| to | `string` | Destination path |
+
+---
+
+#### copyFromHost()
+
+```typescript
+copyFromHost(hostPath: string, guestPath: string): Promise<void>
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostPath | `string` | Path on the host filesystem |
+| guestPath | `string` | Destination path inside the sandbox |
+
+---
+
+#### copyToHost()
+
+```typescript
+copyToHost(guestPath: string, hostPath: string): Promise<void>
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guestPath | `string` | Path inside the sandbox |
+| hostPath | `string` | Destination path on the host |
+
+---
+
+#### exists()
+
+```typescript
+exists(path: string): Promise<boolean>
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<boolean>` | `true` if the path exists |
+
+---
+
+#### list()
+
+```typescript
+list(path: string): Promise<FsEntry[]>
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsEntry`](#fsentry)`[]>` | Directory entries |
+
+---
+
+#### mkdir()
+
+```typescript
+mkdir(path: string): Promise<void>
+```
+
+Create a directory. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path |
+
+---
+
+#### read()
+
+```typescript
+read(path: string): Promise<Uint8Array>
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<Uint8Array>` | File contents as raw bytes |
+
+---
+
+#### readStream()
+
+```typescript
+readStream(path: string): Promise<FsReadStream>
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory.
+
+```typescript
+for await (const chunk of await fs.readStream("/var/log/syslog")) {
+  process.stdout.write(chunk); // chunk is a Uint8Array
+}
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsReadStream`](#fsreadstream)`>` | Async stream that yields chunks of file data |
+
+---
+
+#### readToString()
+
+```typescript
+readToString(path: string): Promise<string>
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<string>` | File contents as a string |
+
+---
+
+#### remove()
+
+```typescript
+remove(path: string): Promise<void>
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute file path |
+
+---
+
+#### removeDir()
+
+```typescript
+removeDir(path: string): Promise<void>
+```
+
+Remove a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path |
+
+---
+
+#### rename()
+
+```typescript
+rename(from: string, to: string): Promise<void>
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `string` | Current path |
+| to | `string` | New path |
+
+---
+
+#### stat()
+
+```typescript
+stat(path: string): Promise<FsMetadata>
+```
+
+Get detailed metadata for a file or directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsMetadata`](#fsmetadata)`>` | File metadata |
+
+---
+
+#### write()
+
+```typescript
+write(path: string, data: Uint8Array | string): Promise<void>
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does. Parent directories must already exist. `string` payloads are encoded as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| data | `Uint8Array \| string` | File content |
+
+---
+
+#### writeStream()
+
+```typescript
+writeStream(path: string): Promise<FsWriteSink>
+```
+
+Open a streaming writer for a file. Use for files too large to hold in memory; pair with `await using` so the sink closes itself.
+
+```typescript
+await using sink = await fs.writeStream("/tmp/big.bin");
+await sink.write(new Uint8Array(1 << 20));
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsWriteSink`](#fswritesink)`>` | Streaming writer |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| path | `string` | File path |
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| size | `number` | File size in bytes |
+| mode | `number` | Unix permission bits |
+| modified | `Date \| null` | Last modified timestamp |
+
+### FsEntryKind
+
+```typescript
+type FsEntryKind = "file" | "directory" | "symlink" | "other";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'file'` | Regular file |
+| `'directory'` | Directory |
+| `'symlink'` | Symbolic link |
+| `'other'` | Other entry type |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| size | `number` | File size in bytes |
+| mode | `number` | Unix permission bits |
+| readonly | `boolean` | Whether the file is read-only |
+| modified | `Date \| null` | Last modified timestamp |
+| created | `Date \| null` | Creation timestamp |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`readStream()`](#readstream). `AsyncIterable<Uint8Array>` and `AsyncDisposable`.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `recv()` | `Promise<Uint8Array \| null>` | Receive the next chunk. Returns `null` when the file has been fully read. |
+| `collect()` | `Promise<Uint8Array>` | Drain the stream into a single buffer |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<Uint8Array>` | Use with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop reading; safe to use with `await using` |
+
+### FsWriteSink
+
+Streaming writer returned by [`writeStream()`](#writestream). `AsyncDisposable`.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `write(data)` | `Uint8Array \| string` | Append a chunk |
+| `close()` | - | Flush and close. Idempotent. |
+| `[Symbol.asyncDispose]()` | - | Calls `close()` |

--- a/docs/fr/sdk/typescript/networking.mdx
+++ b/docs/fr/sdk/typescript/networking.mdx
@@ -1,0 +1,1361 @@
+---
+title: Networking
+description: TypeScript SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Use a static factory for a preset, build a literal, or chain through [`NetworkPolicy.builder()`](#networkpolicybuilder) for the fluent builder:
+
+```typescript
+import { NetworkPolicy, Rule, Destination } from "microsandbox";
+
+// Custom policy literal
+const custom = {
+  defaultEgress: "deny",
+  defaultIngress: "allow",
+  rules: [
+    Rule.allowEgress(Destination.domain("api.openai.com")),
+    Rule.denyEgress(Destination.group("metadata")),
+  ],
+};
+
+// Or via the builder
+const built = NetworkPolicy.builder()
+  .defaultDeny()
+  .egress((e) => e.tcp().port(443).allowPublic())
+  .build();
+```
+
+Pass any of these to `NetworkBuilder.policy(...)`.
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```typescript
+const policy = {
+  defaultEgress: "deny",
+  defaultIngress: "allow",
+  rules: [
+    Rule.allowEgress(Destination.cidr("10.0.0.0/8")),  // matches everything in 10.x
+    Rule.denyEgress(Destination.cidr("10.0.0.5/32")),  // never reached
+  ],
+};
+```
+
+Put specific rules before general ones.
+
+### Shadow detection
+
+[`NetworkPolicyBuilder.build()`](#networkpolicybuilder) walks the rules and warns when a rule is fully covered by an earlier one in the same direction. Only `ip`, `cidr`, and `group` destinations are checked; domain coverage depends on runtime DNS and is skipped. Builds still succeed; the warning surfaces as a host-side `tracing::warn!` from the rust core:
+
+```text
+WARN rule #1 (Egress Cidr(10.0.0.5/32) Deny) is shadowed by rule #0 (Egress Cidr(10.0.0.0/8) Allow); to narrow, place the more specific rule first
+```
+
+Policy literals constructed via `Rule.allowEgress(...)` etc. do not run through the builder and skip this check.
+
+### State accumulation
+
+State setters (`.tcp()`, `.port()`, etc.) inside a [`RuleBuilder`](#rulebuilder) callback carry into every rule-adder that follows. State is **not reset** between adders:
+
+```typescript
+NetworkPolicy.builder()
+  .egress((r) => r
+    .tcp().port(443).allowPublic()    // rule 1: egress, TCP, 443, allow Public
+    .udp().allowPrivate()             // rule 2: egress, [TCP, UDP], 443, allow Private
+  )
+  .build();
+```
+
+Use separate `.rule()` / `.egress()` callbacks for rules that need different state.
+
+---
+
+#### NetworkPolicy.allowAll()
+
+```typescript
+static allowAll(): NetworkPolicy
+```
+
+Unrestricted network access, including to private addresses and the host machine.
+
+---
+
+#### NetworkPolicy.builder()
+
+```typescript
+static builder(): NetworkPolicyBuilder
+```
+
+Start a fluent [`NetworkPolicyBuilder`](#networkpolicybuilder). Equivalent to `new NetworkPolicyBuilder()`.
+
+---
+
+#### NetworkPolicy.none()
+
+```typescript
+static none(): NetworkPolicy
+```
+
+Deny all traffic. The guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+
+---
+
+#### NetworkPolicy.nonLocal()
+
+```typescript
+static nonLocal(): NetworkPolicy
+```
+
+Allow egress to public + private (LAN) destinations; ingress allowed by default.
+
+---
+
+#### NetworkPolicy.publicOnly()
+
+```typescript
+static publicOnly(): NetworkPolicy
+```
+
+Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+
+---
+
+## NetworkPolicyBuilder
+
+Fluent builder for [`NetworkPolicy`](#networkpolicy). The closure passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` receives a [`RuleBuilder`](#rulebuilder); state setters and rule-adders chain freely. The first parse / validation failure surfaces from `.build()`.
+
+```typescript
+import { NetworkPolicy } from "microsandbox";
+
+const policy = NetworkPolicy.builder()
+  .defaultDeny()
+  .egress((e) => e.tcp().port(443).allowPublic().allowPrivate())
+  .rule((r) => r.any().deny((d) => d.ip("198.51.100.5")))
+  .build();
+```
+
+---
+
+#### any()
+
+```typescript
+any(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Any`. Rules committed inside apply in both directions.
+
+---
+
+#### build()
+
+```typescript
+build(): NetworkPolicy
+```
+
+Materialize the accumulated state into a [`NetworkPolicy`](#networkpolicy-1). Lazily parses every recorded `.ip()` / `.cidr()` / `.domain()` / `.domainSuffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a host-side warning for each shadowed rule pair.
+
+---
+
+#### defaultAllow()
+
+```typescript
+defaultAllow(): this
+```
+
+Set both `defaultEgress` and `defaultIngress` to `"allow"`.
+
+---
+
+#### defaultDeny()
+
+```typescript
+defaultDeny(): this
+```
+
+Set both `defaultEgress` and `defaultIngress` to `"deny"`.
+
+---
+
+#### defaultEgress()
+
+```typescript
+defaultEgress(action: "allow" | "deny"): this
+```
+
+Per-direction override for the egress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | `"allow" \| "deny"` | Default action for egress |
+
+---
+
+#### defaultIngress()
+
+```typescript
+defaultIngress(action: "allow" | "deny"): this
+```
+
+Per-direction override for the ingress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | `"allow" \| "deny"` | Default action for ingress |
+
+---
+
+#### egress()
+
+```typescript
+egress(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Egress`.
+
+---
+
+#### ingress()
+
+```typescript
+ingress(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Ingress`.
+
+---
+
+#### rule()
+
+```typescript
+rule(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Open a multi-rule batch closure. Direction must be set inside via `.egress()`, `.ingress()`, or `.any()` before any rule-adder.
+
+---
+
+## RuleBuilder
+
+Per-rule-batch builder. Lives only inside the callback passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` on a [`NetworkPolicyBuilder`](#networkpolicybuilder). State setters and rule-adders interleave freely; state accumulates eagerly across the callback (see [State accumulation](#state-accumulation)).
+
+### Direction setters
+
+Last-write-wins. ICMP rule-adders are egress-only at build time.
+
+---
+
+#### any()
+
+```typescript
+any(): this
+```
+
+Set direction to `Any` for subsequent rule-adders. Rules committed after this apply in both directions.
+
+---
+
+#### egress()
+
+```typescript
+egress(): this
+```
+
+Set direction to `Egress` for subsequent rule-adders.
+
+---
+
+#### ingress()
+
+```typescript
+ingress(): this
+```
+
+Set direction to `Ingress` for subsequent rule-adders.
+
+---
+
+### Protocol setters
+
+Protocols accumulate as a set; duplicates dedupe.
+
+---
+
+#### icmpv4()
+
+```typescript
+icmpv4(): this
+```
+
+Add `Icmpv4` to the protocols set. Egress-only; an ICMP rule on an `Ingress` or `Any` direction fails build.
+
+---
+
+#### icmpv6()
+
+```typescript
+icmpv6(): this
+```
+
+Add `Icmpv6` to the protocols set. Egress-only; same rules as [`icmpv4()`](#icmpv4).
+
+---
+
+#### tcp()
+
+```typescript
+tcp(): this
+```
+
+Add `Tcp` to the protocols set.
+
+---
+
+#### udp()
+
+```typescript
+udp(): this
+```
+
+Add `Udp` to the protocols set.
+
+---
+
+### Port setters
+
+Ports accumulate as a set; duplicates dedupe. Always guest-side (egress destination port / ingress listening port).
+
+---
+
+#### port()
+
+```typescript
+port(port: number): this
+```
+
+Add a single port to the ports set.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `number` | Port number `0..=65535` |
+
+---
+
+#### portRange()
+
+```typescript
+portRange(lo: number, hi: number): this
+```
+
+Add an inclusive port range. `lo > hi` records an error surfaced at `.build()` time.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| lo | `number` | Lower bound (inclusive) |
+| hi | `number` | Upper bound (inclusive) |
+
+---
+
+#### ports()
+
+```typescript
+ports(ports: number[]): this
+```
+
+Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
+
+---
+
+### Group rule-adders
+
+Each adder commits one rule using the current state and the named destination group.
+
+---
+
+#### allowHost()
+
+```typescript
+allowHost(): this
+```
+
+Allow the `Host` group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allowLoopback()`](#allowloopback).
+
+---
+
+#### allowLinkLocal()
+
+```typescript
+allowLinkLocal(): this
+```
+
+Allow the `LinkLocal` group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
+
+---
+
+#### allowLoopback()
+
+```typescript
+allowLoopback(): this
+```
+
+Allow the `Loopback` group (`127.0.0.0/8`, `::1`). The **guest's own** loopback, not the host. To reach a service on the host's localhost, use [`allowHost()`](#allowhost) instead. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
+
+---
+
+#### allowMeta()
+
+```typescript
+allowMeta(): this
+```
+
+Allow the `Metadata` group (`169.254.169.254`). **Dangerous on cloud hosts** (exposes IAM credentials).
+
+---
+
+#### allowMulticast()
+
+```typescript
+allowMulticast(): this
+```
+
+Allow the `Multicast` group (`224.0.0.0/4`, `ff00::/8`).
+
+---
+
+#### allowPrivate()
+
+```typescript
+allowPrivate(): this
+```
+
+Allow the `Private` group (RFC1918 + ULA + CGN).
+
+---
+
+#### allowPublic()
+
+```typescript
+allowPublic(): this
+```
+
+Allow the `Public` group (complement of named categories: every IP not in any other group).
+
+---
+
+#### denyHost()
+
+```typescript
+denyHost(): this
+```
+
+Deny the `Host` group.
+
+---
+
+#### denyLinkLocal()
+
+```typescript
+denyLinkLocal(): this
+```
+
+Deny the `LinkLocal` group.
+
+---
+
+#### denyLoopback()
+
+```typescript
+denyLoopback(): this
+```
+
+Deny the `Loopback` group.
+
+---
+
+#### denyMeta()
+
+```typescript
+denyMeta(): this
+```
+
+Deny the `Metadata` group.
+
+---
+
+#### denyMulticast()
+
+```typescript
+denyMulticast(): this
+```
+
+Deny the `Multicast` group.
+
+---
+
+#### denyPrivate()
+
+```typescript
+denyPrivate(): this
+```
+
+Deny the `Private` group.
+
+---
+
+#### denyPublic()
+
+```typescript
+denyPublic(): this
+```
+
+Deny the `Public` group.
+
+---
+
+### Domain rule-adders
+
+Singular forms add one rule; plural forms add one rule per element.
+
+---
+
+#### allowDomain()
+
+```typescript
+allowDomain(name: string): this
+```
+
+Add one `Destination::Domain` allow rule.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Fully qualified domain name |
+
+---
+
+#### allowDomainSuffix()
+
+```typescript
+allowDomainSuffix(suffix: string): this
+```
+
+Add one `Destination::DomainSuffix` allow rule. Matches the apex and any subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### allowDomainSuffixes()
+
+```typescript
+allowDomainSuffixes(suffixes: string[]): this
+```
+
+Add one `Destination::DomainSuffix` allow rule per suffix.
+
+---
+
+#### allowDomains()
+
+```typescript
+allowDomains(names: string[]): this
+```
+
+Add one `Destination::Domain` allow rule per name.
+
+---
+
+#### denyDomain()
+
+```typescript
+denyDomain(name: string): this
+```
+
+Add one `Destination::Domain` deny rule.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Fully qualified domain name |
+
+---
+
+#### denyDomainSuffix()
+
+```typescript
+denyDomainSuffix(suffix: string): this
+```
+
+Add one `Destination::DomainSuffix` deny rule. Matches the apex and any subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### denyDomainSuffixes()
+
+```typescript
+denyDomainSuffixes(suffixes: string[]): this
+```
+
+Add one `Destination::DomainSuffix` deny rule per suffix.
+
+---
+
+#### denyDomains()
+
+```typescript
+denyDomains(names: string[]): this
+```
+
+Add one `Destination::Domain` deny rule per name.
+
+---
+
+### Composite rule-adders
+
+---
+
+#### allowLocal()
+
+```typescript
+allowLocal(): this
+```
+
+Add three allow rules atomically: `Loopback + LinkLocal + Host`. Each uses the callback's current state. `Metadata` is intentionally not included; opt in via [`allowMeta()`](#allowmeta) separately.
+
+---
+
+#### denyLocal()
+
+```typescript
+denyLocal(): this
+```
+
+Add three deny rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is intentionally not included.
+
+---
+
+### Explicit-destination rule-adders
+
+`.allow()` / `.deny()` open a [`RuleDestinationBuilder`](#ruledestinationbuilder) callback. Exactly one destination call commits the rule.
+
+```typescript
+NetworkPolicy.builder()
+  .egress((r) => r
+    .tcp().port(443).allow((d) => d.domain("api.example.com"))
+    .deny((d) => d.cidr("198.51.100.0/24"))
+  )
+  .build();
+```
+
+---
+
+#### allow()
+
+```typescript
+allow(configure: (d: RuleDestinationBuilder) => RuleDestinationBuilder): this
+```
+
+Begin an explicit-destination rule with action `Allow`.
+
+---
+
+#### deny()
+
+```typescript
+deny(configure: (d: RuleDestinationBuilder) => RuleDestinationBuilder): this
+```
+
+Begin an explicit-destination rule with action `Deny`.
+
+---
+
+## Rule
+
+Factory for individual policy rules. Each method returns a single [`Rule`](#rule-1) value.
+
+---
+
+#### Rule.allowAny()
+
+```typescript
+static allowAny(destination: Destination): Rule
+```
+
+Allow rule with direction `any` (matches in either direction).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.allowEgress()
+
+```typescript
+static allowEgress(destination: Destination): Rule
+```
+
+Allow rule with direction `egress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.allowIngress()
+
+```typescript
+static allowIngress(destination: Destination): Rule
+```
+
+Allow rule with direction `ingress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyAny()
+
+```typescript
+static denyAny(destination: Destination): Rule
+```
+
+Deny rule with direction `any` (matches in either direction).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyEgress()
+
+```typescript
+static denyEgress(destination: Destination): Rule
+```
+
+Deny rule with direction `egress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyIngress()
+
+```typescript
+static denyIngress(destination: Destination): Rule
+```
+
+Deny rule with direction `ingress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+## Destination
+
+Factory for rule destinations.
+
+---
+
+#### Destination.any()
+
+```typescript
+static any(): Destination
+```
+
+Match any destination.
+
+---
+
+#### Destination.cidr()
+
+```typescript
+static cidr(cidr: string): Destination
+```
+
+Match an IP range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cidr | `string` | CIDR notation (e.g. `"10.0.0.0/8"`) |
+
+---
+
+#### Destination.domain()
+
+```typescript
+static domain(domain: string): Destination
+```
+
+Match an exact domain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| domain | `string` | Fully qualified domain name |
+
+---
+
+#### Destination.domainSuffix()
+
+```typescript
+static domainSuffix(suffix: string): Destination
+```
+
+Match the apex domain and every subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### Destination.group()
+
+```typescript
+static group(group: DestinationGroup): Destination
+```
+
+Match a predefined address group.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| group | [`DestinationGroup`](#destinationgroup) | Group keyword |
+
+---
+
+## PortRange
+
+Factory for port ranges.
+
+---
+
+#### PortRange.range()
+
+```typescript
+static range(start: number, end: number): PortRange
+```
+
+Match an inclusive port range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| start | `number` | Lower bound (inclusive) |
+| end | `number` | Upper bound (inclusive) |
+
+---
+
+#### PortRange.single()
+
+```typescript
+static single(port: number): PortRange
+```
+
+Match a single port. `start` and `end` are set to the same value.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `number` | Port number |
+
+---
+
+## NetworkBuilder
+
+Returned to the callback you pass to `SandboxBuilder.network(...)`. Every setter returns the same builder.
+
+---
+
+#### denyDomainSuffixes()
+
+```typescript
+denyDomainSuffixes(...suffixes: string[]): this
+```
+
+Deny egress to all subdomains of these suffixes. Same enforcement layers as [`denyDomains()`](#denydomains).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffixes | `string[]` | Domain suffixes |
+
+---
+
+#### denyDomains()
+
+```typescript
+denyDomains(...names: string[]): this
+```
+
+Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| names | `string[]` | Fully qualified domain names |
+
+---
+
+#### dns()
+
+```typescript
+dns(f: (d: DnsBuilder) => DnsBuilder): this
+```
+
+Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
+
+---
+
+#### enabled()
+
+```typescript
+enabled(b: boolean): this
+```
+
+Enable or disable networking entirely.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| b | `boolean` | When `false`, no network interface is created |
+
+---
+
+#### maxConnections()
+
+```typescript
+maxConnections(n: number): this
+```
+
+Limit the maximum number of concurrent network connections from the sandbox.
+
+---
+
+#### onSecretViolation()
+
+```typescript
+onSecretViolation(action: ViolationAction): this
+```
+
+Set the action taken when a secret reaches a disallowed host. See [`ViolationAction`](/sdk/typescript/secrets#violationaction).
+
+---
+
+#### policy()
+
+```typescript
+policy(policy: NetworkPolicy): this
+```
+
+Set the policy. Use a [`NetworkPolicy`](#networkpolicy) factory or a literal.
+
+---
+
+#### port()
+
+```typescript
+port(host: number, guest: number): this
+```
+
+Publish a TCP port from the guest to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `number` | Port on the host |
+| guest | `number` | Port inside the sandbox |
+
+---
+
+#### portUdp()
+
+```typescript
+portUdp(host: number, guest: number): this
+```
+
+Publish a UDP port from the guest to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `number` | Port on the host |
+| guest | `number` | Port inside the sandbox |
+
+---
+
+#### secret()
+
+```typescript
+secret(f: (s: SecretBuilder) => SecretBuilder): this
+```
+
+Add a secret. See [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder).
+
+---
+
+#### secretEnv()
+
+```typescript
+secretEnv(envVar: string, value: string, placeholder: string, allowedHost: string): this
+```
+
+Four-arg explicit-placeholder shorthand for adding a secret without opening a builder callback.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Real secret value |
+| placeholder | `string` | Placeholder string surfaced to the guest |
+| allowedHost | `string` | Single hostname allowed to receive the real value |
+
+---
+
+#### tls()
+
+```typescript
+tls(f: (t: TlsBuilder) => TlsBuilder): this
+```
+
+Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
+
+---
+
+#### trustHostCAs()
+
+```typescript
+trustHostCAs(enabled: boolean): this
+```
+
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in for corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle.
+
+---
+
+## DnsBuilder
+
+Builder for DNS interception settings. Used in `NetworkBuilder.dns(d => ...)`. Owns rebind protection, nameserver pinning, and the per-query timeout.
+
+---
+
+#### nameservers()
+
+```typescript
+nameservers(servers: string[]): this
+```
+
+Override upstream nameservers. Replaces any previously-set nameservers.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| servers | `string[]` | Each entry is `IP`, `IP:PORT`, `HOST`, or `HOST:PORT` |
+
+---
+
+#### queryTimeoutMs()
+
+```typescript
+queryTimeoutMs(ms: number): this
+```
+
+Per-DNS-query timeout in milliseconds.
+
+---
+
+#### rebindProtection()
+
+```typescript
+rebindProtection(enabled: boolean): this
+```
+
+Toggle DNS rebinding protection. When enabled, DNS responses resolving to private IPs are blocked.
+
+---
+
+## TlsBuilder
+
+Builder for TLS interception settings. Used in `NetworkBuilder.tls(t => ...)`.
+
+---
+
+#### blockQuic()
+
+```typescript
+blockQuic(block: boolean): this
+```
+
+Block QUIC on intercepted ports, forcing TCP/TLS fallback.
+
+---
+
+#### bypass()
+
+```typescript
+bypass(pattern: string): this
+```
+
+Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). Use for domains with certificate pinning.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pattern | `string` | Glob pattern |
+
+---
+
+#### interceptCaCert()
+
+```typescript
+interceptCaCert(path: string): this
+```
+
+Path to a PEM file used as the intercepting CA's certificate.
+
+---
+
+#### interceptCaKey()
+
+```typescript
+interceptCaKey(path: string): this
+```
+
+Path to a PEM file used as the intercepting CA's private key.
+
+---
+
+#### interceptedPorts()
+
+```typescript
+interceptedPorts(ports: number[]): this
+```
+
+TCP ports where interception is active. Default: `[443]`.
+
+---
+
+#### upstreamCaCert()
+
+```typescript
+upstreamCaCert(path: string): this
+```
+
+Path to a PEM file with extra root CAs the proxy should trust.
+
+---
+
+#### verifyUpstream()
+
+```typescript
+verifyUpstream(verify: boolean): this
+```
+
+Verify upstream server certificates. Default `true`. Set to `false` only for self-signed servers.
+
+---
+
+## Types
+
+### NetworkConfig
+
+Built network configuration produced by `NetworkBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| enabled | `boolean` | Master enable flag |
+| ports | `readonly PublishedPort[]` | Port publishings |
+| policy | [`NetworkPolicy`](#networkpolicy-1) ` \| null` | Active policy |
+| dns | [`DnsConfig`](#dnsconfig) ` \| null` | DNS interception |
+| tls | [`TlsConfig`](#tlsconfig) ` \| null` | TLS interception |
+| secrets | `readonly SecretEntry[]` | Secret entries |
+| secretViolation | [`ViolationAction`](/sdk/typescript/secrets#violationaction) ` \| null` | Action on disallowed secret use |
+| maxConnections | `number \| null` | Maximum concurrent connections |
+| trustHostCAs | `boolean` | Ship host CAs into the guest |
+
+### NetworkPolicy
+
+```typescript
+interface NetworkPolicy {
+  readonly defaultEgress: Action;
+  readonly defaultIngress: Action;
+  readonly rules: readonly Rule[];
+}
+```
+
+### Rule
+
+```typescript
+interface Rule {
+  readonly direction: Direction;
+  readonly destination: Destination;
+  readonly protocols: readonly Protocol[]; // empty = any
+  readonly ports: readonly PortRange[];    // empty = any
+  readonly action: Action;
+}
+```
+
+### Destination
+
+```typescript
+type Destination =
+  | { kind: "any" }
+  | { kind: "cidr"; cidr: string }
+  | { kind: "domain"; domain: string }
+  | { kind: "domainSuffix"; suffix: string }
+  | { kind: "group"; group: DestinationGroup };
+```
+
+### Action
+
+```typescript
+type Action = "allow" | "deny";
+```
+
+### Direction
+
+```typescript
+type Direction = "egress" | "ingress" | "any";
+```
+
+### Protocol
+
+```typescript
+type Protocol = "tcp" | "udp" | "icmpv4" | "icmpv6";
+```
+
+### DestinationGroup
+
+```typescript
+type DestinationGroup =
+  | "public"
+  | "loopback"
+  | "private"
+  | "link-local"
+  | "metadata"
+  | "multicast"
+  | "host";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'public'` | Public internet (everything not in another group) |
+| `'loopback'` | Guest's own `127.0.0.0/8` / `::1` |
+| `'private'` | RFC1918 LAN ranges |
+| `'link-local'` | `169.254.0.0/16` / `fe80::/10` |
+| `'metadata'` | Cloud metadata endpoints (`169.254.169.254`, `fd00:ec2::254`) |
+| `'multicast'` | Multicast addresses |
+| `'host'` | The host machine, reached via `host.microsandbox.internal` |
+
+### PortRange
+
+```typescript
+interface PortRange {
+  readonly start: number;
+  readonly end: number;
+}
+```
+
+### RuleDestinationBuilder
+
+Returned by [`RuleBuilder`](#rulebuilder)`.allow(d => ...)` / `.deny(d => ...)`. Exactly one destination call commits the rule; dropping without a destination call silently does nothing.
+
+| Method | Description |
+|--------|-------------|
+| `.ip(ip)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
+| `.cidr(cidr)` | Commit with `Destination::Cidr` |
+| `.domain(domain)` | Commit with `Destination::Domain` |
+| `.domainSuffix(suffix)` | Commit with `Destination::DomainSuffix` |
+| `.group(group)` | Commit with `Destination::Group`. `group` is a [`DestinationGroup`](#destinationgroup) string |
+| `.any()` | Commit with `Destination::Any` |
+
+### DnsConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| nameservers | `readonly string[]` | Upstream nameservers |
+| rebindProtection | `boolean \| null` | DNS rebinding protection toggle |
+| queryTimeoutMs | `number \| null` | Per-query timeout |
+
+### TlsConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| bypass | `readonly string[]` | Bypass globs (e.g. `"*.googleapis.com"`) |
+| verifyUpstream | `boolean \| null` | Verify upstream certs |
+| interceptedPorts | `readonly number[]` | Intercepted TCP ports |
+| blockQuic | `boolean \| null` | Block QUIC on intercepted ports |
+| upstreamCaCertPaths | `readonly string[]` | Extra trust roots for upstream verification |
+| interceptCaCertPath | `string \| null` | Custom intercept CA cert (PEM) |
+| interceptCaKeyPath | `string \| null` | Custom intercept CA key (PEM) |
+
+### PublishedPort
+
+```typescript
+interface PublishedPort {
+  readonly hostPort: number;
+  readonly guestPort: number;
+  readonly protocol: "tcp" | "udp";
+}
+```

--- a/docs/fr/sdk/typescript/sandbox.mdx
+++ b/docs/fr/sdk/typescript/sandbox.mdx
@@ -1,0 +1,736 @@
+---
+title: Sandbox
+description: TypeScript SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox from `Sandbox.builder(name)` and chain configuration calls before terminating with `.create()` or `.createDetached()`.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+await using sandbox = await Sandbox.builder("demo")
+  .image("alpine")
+  .cpus(1)
+  .memory(512)
+  .create();
+```
+
+## Static methods
+
+---
+
+#### Sandbox.builder()
+
+```typescript
+static builder(name: string): SandboxBuilder
+```
+
+Begin building a new sandbox. Configure it with chainable setters, then call `.create()` or `.createDetached()` to boot it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxBuilder`](#sandboxbuilder) | Fluent builder |
+
+---
+
+#### Sandbox.get()
+
+```typescript
+static get(name: string): Promise<SandboxHandle>
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox.list()
+
+```typescript
+static list(): Promise<SandboxHandle[]>
+```
+
+List all sandboxes (running, stopped, and crashed). Handles returned from `list()` are read-only — call `Sandbox.get(name)` to get a live handle for lifecycle calls.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle[]`](#sandboxhandle) | All sandboxes (read-only handles) |
+
+---
+
+#### Sandbox.remove()
+
+```typescript
+static remove(name: string): Promise<void>
+```
+
+Delete a stopped sandbox and all its state from disk. Fails if the sandbox is still running.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+---
+
+#### Sandbox.start()
+
+```typescript
+static start(name: string): Promise<Sandbox>
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox.startDetached()
+
+```typescript
+static startDetached(name: string): Promise<Sandbox>
+```
+
+Restart a stopped sandbox in detached mode.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+## Instance properties
+
+---
+
+#### name
+
+```typescript
+readonly name: string
+```
+
+Sandbox name.
+
+---
+
+#### config
+
+```typescript
+readonly config: Readonly<SandboxConfig>
+```
+
+The frozen configuration the sandbox was built with.
+
+---
+
+#### ownsLifecycle
+
+```typescript
+readonly ownsLifecycle: boolean
+```
+
+Whether this handle owns the sandbox lifecycle. `true` in attached mode (the auto-disposer will stop the sandbox), `false` in detached mode.
+
+---
+
+## Instance methods
+
+---
+
+#### detach()
+
+```typescript
+detach(): Promise<void>
+```
+
+Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```typescript
+drain(): Promise<void>
+```
+
+Start a graceful drain. Existing commands run to completion, new `exec` calls are rejected.
+
+---
+
+#### fs()
+
+```typescript
+fs(): SandboxFs
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/typescript/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/typescript/filesystem) | Filesystem handle |
+
+---
+
+#### kill()
+
+```typescript
+kill(): Promise<void>
+```
+
+Force-terminate the sandbox immediately. No graceful shutdown.
+
+---
+
+#### metrics()
+
+```typescript
+metrics(): Promise<SandboxMetrics>
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network metrics |
+
+---
+
+#### metricsStream()
+
+```typescript
+metricsStream(intervalMs: number): Promise<MetricsStream>
+```
+
+Stream resource metrics at a regular interval. The returned stream supports both `recv()` and `for await...of`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| intervalMs | `number` | Milliseconds between metric snapshots |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`MetricsStream`](#metricsstream) | Async stream of metrics |
+
+---
+
+#### logs()
+
+```typescript
+logs(opts?: LogReadOptions): Promise<LogEntry[]>
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+const handle = await Sandbox.get("web");
+
+// Default — all user-program output, regardless of pipe/pty mode
+const entries = await handle.logs();
+
+for (const e of entries) {
+  const source =
+    e.source === "stdout" ? "OUT" :
+    e.source === "stderr" ? "ERR" :
+    e.source === "output" ? "PTY" :
+    "SYS";
+
+  console.log(
+    `[${e.timestamp.toISOString()}] ${source} ${e.sessionId}: ${e.text().trimEnd()}`
+  );
+}
+
+// Filtered: last 50 entries from the past hour, including system lines
+const recent = await handle.logs({
+  tail: 50,
+  since: new Date(Date.now() - 60 * 60 * 1000),
+  sources: ["stdout", "stderr", "output", "system"],
+});
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| opts | [`LogReadOptions`](#logreadoptions) `?` | Filters: `tail`, `since`, `until`, `sources`. Omit for the default user-program sources. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`LogEntry`](#logentry)`[]>` | Matching entries in chronological order |
+
+---
+
+#### removePersisted()
+
+```typescript
+removePersisted(): Promise<void>
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### stop()
+
+```typescript
+stop(): Promise<void>
+```
+
+Gracefully shut down the sandbox.
+
+---
+
+#### stopAndWait()
+
+```typescript
+stopAndWait(): Promise<ExitStatus>
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/typescript/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### wait()
+
+```typescript
+wait(): Promise<ExitStatus>
+```
+
+Block until the sandbox exits on its own.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/typescript/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### \[Symbol.asyncDispose\]()
+
+```typescript
+[Symbol.asyncDispose](): Promise<void>
+```
+
+Implements `AsyncDisposable` so the sandbox can be used with `await using`. When the binding goes out of scope, the sandbox is stopped (best-effort) — but only if `ownsLifecycle` is `true`.
+
+---
+
+## PatchBuilder
+
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder.patch(p => p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `{ replace: true }` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### append()
+
+```typescript
+append(path: string, content: string): this
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `string` | Text to append |
+
+---
+
+#### copyDir()
+
+```typescript
+copyDir(src: string, dst: string, opts?: { replace?: boolean }): this
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `string` | Host source directory |
+| dst | `string` | Absolute destination path inside the guest |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### copyFile()
+
+```typescript
+copyFile(
+  src: string,
+  dst: string,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `string` | Host source file |
+| dst | `string` | Absolute destination path inside the guest |
+| opts.mode | `number` | File mode, e.g. `0o644`. Omit to keep the source mode |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### file()
+
+```typescript
+file(
+  path: string,
+  content: Buffer,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Write raw bytes at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `Buffer` | Raw byte content |
+| opts.mode | `number` | File mode, e.g. `0o644` |
+| opts.replace | `boolean` | When `true`, overwrite an existing path |
+
+---
+
+#### mkdir()
+
+```typescript
+mkdir(path: string, opts?: { mode?: number }): this
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| opts.mode | `number` | Directory mode, e.g. `0o755` |
+
+---
+
+#### remove()
+
+```typescript
+remove(path: string): this
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+---
+
+#### symlink()
+
+```typescript
+symlink(target: string, link: string, opts?: { replace?: boolean }): this
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `string` | What the symlink points to (literal symlink target text) |
+| link | `string` | Absolute path of the symlink itself |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `link` |
+
+---
+
+#### text()
+
+```typescript
+text(
+  path: string,
+  content: string,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `string` | Text content |
+| opts.mode | `number` | File mode, e.g. `0o644` |
+| opts.replace | `boolean` | When `true`, overwrite an existing path |
+
+---
+
+## Types
+
+### SandboxBuilder
+
+Fluent configuration builder returned by `Sandbox.builder(name)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `image(src)` | OCI image (`"alpine"`), local rootfs path, or a `RootfsSource`. **Required.** |
+| `cpus(n)` | Virtual CPUs |
+| `memory(mib)` | Guest memory in MiB |
+| `logLevel(level)` | Override log verbosity |
+| `quietLogs()` | Suppress log output |
+| `workdir(path)` | Default working directory for commands |
+| `shell(shell)` | Shell binary used by `sandbox.shell(...)` |
+| `entrypoint(iter)` | Override the image entrypoint |
+| `init(cmd, args?)` | Hand off PID 1 to `cmd` (absolute path or `"auto"`) after agentd setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| `initWith(cmd, i => ...)` | Like `init` but with a closure-builder for argv and env (`.arg`, `.args`, `.env`, `.envs`) |
+| `hostname(name)` | Guest hostname |
+| `user(user)` | Default guest user |
+| `pullPolicy(policy)` | Image pull behavior |
+| `libkrunfwPath(path)` | Override the bundled libkrunfw shared library |
+| `env(key, value)` | Add a single env var |
+| `envs(record \| iter)` | Add many env vars |
+| `script(name, content)` | Mount a script at `/.msb/scripts/<name>` |
+| `scripts(record \| iter)` | Mount many scripts |
+| `replace()` | Replace any existing sandbox with the same name |
+| `maxDuration(secs)` | Maximum sandbox lifetime |
+| `idleTimeout(secs)` | Stop the sandbox after this many idle seconds |
+| `volume(guestPath, m => ...)` | Mount a volume — see [Volumes](/sdk/typescript/volumes) |
+| `patch(p => ...)` | Modify the rootfs before boot — see [Snapshots](/sdk/typescript/snapshots) |
+| `addPatch(patch)` | Append a pre-built `Patch` |
+| `registry(r => r.auth(...).insecure().caCertsPath(...))` | Configure the OCI registry |
+| `port(host, guest)` | Publish a TCP port |
+| `portUdp(host, guest)` | Publish a UDP port |
+| `disableNetwork()` | Disable networking entirely |
+| `network(n => ...)` | Configure DNS / TLS / policy / secrets — see [Networking](/sdk/typescript/networking) |
+| `secret(s => ...)` | Add a secret via [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder) |
+| `secretEnv(envVar, value, allowedHost)` | Auto-placeholder shorthand. Generates `$MSB_<ENV_VAR>`. |
+| `build(): SandboxConfig` | Materialize without booting |
+| `create(): Promise<Sandbox>` | Build and boot in attached mode |
+| `createDetached(): Promise<Sandbox>` | Build and boot in detached mode |
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `'debug'` | Debug and higher |
+| `'error'` | Errors only |
+| `'info'` | Info and higher |
+| `'trace'` | Most verbose - all diagnostic output |
+| `'warn'` | Warnings and errors only |
+
+### LogEntry
+
+A class wrapping one captured log entry. Returned by [`logs()`](#logs).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| timestamp | `Date` | Wall-clock capture time on the host |
+| source | [`LogSource`](#logsource) | Where the chunk came from |
+| sessionId | `number \| null` | Relay-monotonic session id; `null` for `"system"` entries |
+| data | `Uint8Array` | The chunk's bytes (UTF-8 lossy decoded by default) |
+| `text()` | `string` | Convenience: UTF-8 decode of `data` (lossy — invalid bytes are replaced) |
+
+### LogReadOptions
+
+Filters passed to [`logs()`](#logs). All fields optional. Omit the argument entirely for the default sources (`stdout` + `stderr` + `output`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tail | `number?` | Show only the last N entries after other filters apply |
+| since | `Date?` | Inclusive lower bound on entry timestamp |
+| until | `Date?` | Exclusive upper bound on entry timestamp |
+| sources | [`LogSource`](#logsource)`[]?` | Sources to include. Omit = `["stdout", "stderr", "output"]`. Add `"system"` to merge runtime/kernel diagnostics. |
+
+### LogSource
+
+Tag indicating where a captured log entry came from. String literal type:
+
+```typescript
+type LogSource = "stdout" | "stderr" | "output" | "system";
+```
+
+| Value | Description |
+|-------|-------------|
+| `"stdout"` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `"stderr"` | Captured from a session's stderr (pipe mode) |
+| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `"output"` rather than mislabelled as `"stdout"`. |
+| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested. |
+
+### MetricsStream
+
+Async stream for receiving periodic metrics snapshots.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `[Symbol.asyncIterator]` | `AsyncIterator<`[`SandboxMetrics`](#sandboxmetrics)`>` | Use with `for await...of` |
+| `recv()` | `Promise<`[`SandboxMetrics`](#sandboxmetrics)` \| null>` | Receive next snapshot. Returns `null` when the stream ends. |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop iterating; safe to use with `await using`. |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `'always'` | Pull the image every time, even if cached locally |
+| `'if-missing'` | Pull only if the image is not already cached. This is the default. |
+| `'never'` | Never pull; fail if the image is not cached locally |
+
+### SandboxConfig
+
+Frozen configuration object — produced by `SandboxBuilder.build()` and exposed as the `config` property on a `Sandbox`. You generally should not construct this by hand; use the builder.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Sandbox name |
+| image | `RootfsSource` | OCI / bind / disk discriminated union |
+| cpus | `number \| null` | Virtual CPUs |
+| memoryMib | `number \| null` | Guest memory in MiB |
+| logLevel | `LogLevel \| null` | Log verbosity |
+| quietLogs | `boolean` | Suppress log output |
+| workdir | `string \| null` | Default working directory |
+| shell | `string \| null` | Shell binary |
+| entrypoint | `string[] \| null` | Override image entrypoint |
+| cmd | `string[] \| null` | Override image cmd |
+| hostname | `string \| null` | Guest hostname |
+| user | `string \| null` | Default guest user |
+| libkrunfwPath | `string \| null` | Custom libkrunfw path |
+| env | `Array<readonly [string, string]>` | Environment variables |
+| scripts | `Array<readonly [string, string]>` | Named scripts |
+| mounts | `VolumeMount[]` | Volume mounts |
+| patches | `Patch[]` | Rootfs modifications applied before boot |
+| pullPolicy | `PullPolicy \| null` | Image pull behavior |
+| replace | `boolean` | Replace existing sandbox with same name |
+| maxDurationSecs | `number \| null` | Maximum sandbox lifetime |
+| idleTimeoutSecs | `number \| null` | Stop after idle time |
+| portsTcp | `Array<readonly [number, number]>` | TCP host→guest mappings |
+| portsUdp | `Array<readonly [number, number]>` | UDP host→guest mappings |
+| registry | `RegistryConfig \| null` | Registry connection settings |
+| network | `NetworkConfig \| null` | Network configuration |
+| disableNetwork | `boolean` | Disable networking entirely |
+| secrets | `SecretEntry[]` | Secret entries (top-level) |
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandboxget) or [`Sandbox.list()`](#sandboxlist).
+
+Handles from `Sandbox.get(name)` are **live** — they expose lifecycle methods (`start`, `stop`, `kill`, `connect`, etc). Handles in the array returned by `Sandbox.list()` are **read-only**: calling lifecycle methods on them throws. Use `Sandbox.get(name)` to upgrade to a live handle.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `string` | Sandbox name |
+| status | [`SandboxStatus`](#sandboxstatus) | Current status |
+| configJson | `string` | Raw JSON configuration |
+| createdAt | `Date \| null` | Creation timestamp |
+| updatedAt | `Date \| null` | Last update timestamp |
+| metrics() | `Promise<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
+| logs() | `Promise<`[`LogEntry`](#logentry)`[]>` | Read captured `exec.log` (works without starting) |
+| start() | `Promise<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
+| startDetached() | `Promise<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |
+| connect() | `Promise<`[`Sandbox`](#instance-methods)`>` | Connect to a running sandbox without taking ownership |
+| stop() | `Promise<void>` | Graceful shutdown |
+| kill() | `Promise<void>` | Force terminate |
+| remove() | `Promise<void>` | Delete sandbox and state |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpuPercent | `number` | CPU usage as a percentage |
+| diskReadBytes | `number` | Total bytes read from disk since boot |
+| diskWriteBytes | `number` | Total bytes written to disk since boot |
+| memoryBytes | `number` | Current memory usage in bytes |
+| memoryLimitBytes | `number` | Memory limit in bytes |
+| netRxBytes | `number` | Total bytes received over the network since boot |
+| netTxBytes | `number` | Total bytes sent over the network since boot |
+| timestamp | `Date` | When this measurement was taken |
+| uptimeMs | `number` | Time since the sandbox was created (ms) |
+
+### SandboxStatus
+
+| Value | Description |
+|-------|-------------|
+| `'crashed'` | VM exited unexpectedly |
+| `'draining'` | Graceful shutdown in progress |
+| `'running'` | Guest agent is ready |
+| `'stopped'` | VM shut down; can be restarted |

--- a/docs/fr/sdk/typescript/secrets.mdx
+++ b/docs/fr/sdk/typescript/secrets.mdx
@@ -1,0 +1,126 @@
+---
+title: Secrets
+description: TypeScript SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## Adding secrets
+
+Secrets are configured on a sandbox via `SandboxBuilder.secret(s => ...)` (or its shorthand `secretEnv`). The guest only ever sees a placeholder — the real value is substituted by the TLS proxy when traffic reaches an allowed host.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+// Auto-placeholder shorthand: generates `$MSB_OPENAI_API_KEY`.
+await using sb = await Sandbox.builder("agent")
+  .image("python")
+  .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+  .create();
+
+// Full control via SecretBuilder.
+await using sb2 = await Sandbox.builder("agent2")
+  .image("python")
+  .secret((s) =>
+    s.env("STRIPE_KEY")
+      .value(process.env.STRIPE_KEY!)
+      .allowHost("api.stripe.com")
+      .allowHostPattern("*.stripe.com")
+      .injectHeaders(true)
+      .injectQuery(false),
+  )
+  .create();
+```
+
+The same `secret(...)` and `secretEnv(...)` methods are also available inside `SandboxBuilder.network(n => n.secret(...))` and on `NetworkBuilder.secretEnv(envVar, value, placeholder, allowedHost)` (4-arg explicit-placeholder shorthand).
+
+---
+
+## SecretBuilder
+
+Fluent builder used inside `SandboxBuilder.secret(s => ...)` or `NetworkBuilder.secret(s => ...)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `env(varName)` | Environment variable to expose the placeholder under. **Required.** |
+| `value(value)` | The real secret value (stays on the host). **Required.** |
+| `placeholder(placeholder)` | Custom placeholder. Auto-generated as `$MSB_<ENV_VAR>` when omitted. |
+| `allowHost(host)` | Allow substitution to a specific host (exact match). |
+| `allowHostPattern(pattern)` | Allow substitution to any host matching a wildcard. |
+| `allowAnyHostDangerous(true)` | Permit substitution to any host. Acknowledge the risk explicitly. |
+| `requireTlsIdentity(enabled)` | Require a verified TLS identity before substituting. Default `true`. |
+| `injectHeaders(enabled)` | Allow substitution in HTTP headers. Default `true`. |
+| `injectBasicAuth(enabled)` | Allow substitution in HTTP Basic Auth. Default `true`. |
+| `injectQuery(enabled)` | Allow substitution in URL query parameters. Default `false`. |
+| `injectBody(enabled)` | Allow substitution in the HTTP request body. Default `false`. |
+| `build()` | Produce a [`SecretEntry`](#secretentry). |
+
+---
+
+## Convenience helpers
+
+#### SandboxBuilder.secretEnv()
+
+```typescript
+secretEnv(envVar: string, value: string, allowedHost: string): this
+```
+
+Three-argument shorthand. Auto-generates the placeholder as `$MSB_<ENV_VAR>` and allows substitution only on `allowedHost`.
+
+#### NetworkBuilder.secretEnv()
+
+```typescript
+secretEnv(
+  envVar: string,
+  value: string,
+  placeholder: string,
+  allowedHost: string,
+): this
+```
+
+Four-argument shorthand. Same as the `SandboxBuilder` form but lets you provide the placeholder explicitly.
+
+---
+
+## Types
+
+### SecretEntry
+
+The object produced by `SecretBuilder.build()`. You normally construct one with the builder, but the shape is exposed for advanced cases.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Real secret value (stays on the host) |
+| placeholder | `string \| null` | Custom placeholder; defaults to `$MSB_<ENV_VAR>` when `null` |
+| allowedHosts | `readonly string[]` | Allowed hosts (exact match) |
+| allowedHostPatterns | `readonly string[]` | Wildcard host patterns |
+| allowAnyHost | `boolean` | Permit substitution to any host |
+| requireTlsIdentity | `boolean` | Require verified TLS identity |
+| injection | [`SecretInjection`](#secretinjection) | Where to substitute |
+
+### SecretInjection
+
+Controls where the TLS proxy substitutes the placeholder with the real value. Each field is optional; omitted fields use the default.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| headers? | `boolean` | `true` | Replace the placeholder anywhere in HTTP headers. |
+| basicAuth? | `boolean` | `true` | Replace the placeholder specifically in HTTP Basic Auth credentials. |
+| queryParams? | `boolean` | `false` | Replace the placeholder in URL query parameters. |
+| body? | `boolean` | `false` | Replace the placeholder in the HTTP request body. `Content-Length` is rewritten. |
+
+### ViolationAction
+
+Action taken when a secret placeholder is sent to a disallowed host. Set on the network builder via `NetworkBuilder.onSecretViolation(action)`.
+
+```typescript
+type ViolationAction = "block" | "block-and-log" | "block-and-terminate";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'block'` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `'block-and-log'` | Drop the request and emit a warning log on the host side. |
+| `'block-and-terminate'` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/fr/sdk/typescript/snapshots.mdx
+++ b/docs/fr/sdk/typescript/snapshots.mdx
@@ -1,0 +1,348 @@
+---
+title: Snapshots
+description: TypeScript SDK - Snapshot API reference
+icon: "camera"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the TypeScript SDK reference.
+
+```ts
+import { Sandbox, Snapshot, SnapshotHandle } from "microsandbox";
+import type { ExportOpts, SnapshotVerifyReport } from "microsandbox";
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## SandboxBuilder
+
+---
+
+#### fromSnapshot()
+
+```ts
+fromSnapshot(pathOrName: string): SandboxBuilder
+```
+
+Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`image()`](/sdk/typescript/sandbox#image) — the snapshot already pins the image.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pathOrName | `string` | Bare name (resolved under `~/.microsandbox/snapshots/`) or filesystem path to an artifact directory |
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```ts
+snapshot(name: string): Promise<Snapshot>
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination, see [`snapshotTo()`](#snapshotto).
+
+**Errors**
+
+- `SnapshotSandboxRunning` — the sandbox is not stopped
+- `SnapshotAlreadyExists` — destination exists (use the builder with `.force()` to overwrite)
+
+---
+
+#### snapshotTo()
+
+```ts
+snapshotTo(path: string): Promise<Snapshot>
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path.
+
+---
+
+## Snapshot (instance)
+
+---
+
+#### path
+
+```ts
+readonly path: string
+```
+
+Path to the artifact directory.
+
+---
+
+#### digest
+
+```ts
+readonly digest: string
+```
+
+Canonical content digest (`sha256:hex`) over the manifest bytes. The snapshot's identity.
+
+---
+
+#### sizeBytes
+
+```ts
+readonly sizeBytes: bigint
+```
+
+Apparent size of the captured upper layer in bytes (the ext4 virtual size, sparse on disk).
+
+---
+
+#### imageRef
+
+```ts
+readonly imageRef: string
+```
+
+Image reference the snapshot was taken from.
+
+---
+
+#### imageManifestDigest
+
+```ts
+readonly imageManifestDigest: string
+```
+
+OCI manifest digest of the pinned image.
+
+---
+
+#### format
+
+```ts
+readonly format: "raw" | "qcow2"
+```
+
+On-disk format of the upper layer. Always `"raw"` today.
+
+---
+
+#### fstype
+
+```ts
+readonly fstype: string
+```
+
+Filesystem type inside the upper (e.g. `"ext4"`).
+
+---
+
+#### parent
+
+```ts
+readonly parent: string | null
+```
+
+Manifest digest of the parent snapshot, or `null` for a root.
+
+---
+
+#### createdAt
+
+```ts
+readonly createdAt: string
+```
+
+RFC 3339 timestamp when the snapshot was created.
+
+---
+
+#### labels
+
+```ts
+readonly labels: ReadonlyArray<readonly [string, string]>
+```
+
+User-supplied labels (sorted by key in canonical form).
+
+---
+
+#### verify()
+
+```ts
+verify(): Promise<SnapshotVerifyReport>
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds.
+
+```ts
+const report = await snap.verify();
+if (report.upper.kind === "verified") {
+  console.log(`hash matches: ${report.upper.digest}`);
+} else {
+  console.log("no integrity hash recorded");
+}
+```
+
+---
+
+## Snapshot.builder()
+
+```ts
+static builder(sourceSandbox: string): SnapshotBuilder
+```
+
+Start configuring a new snapshot. The fluent builder is what powers the CLI internally.
+
+```ts
+const snap = await Snapshot.builder("baseline")
+  .name("after-pip-install")        // bare name in default dir
+  .label("stage", "post-deps")
+  .force()                           // overwrite if it exists
+  .recordIntegrity()                 // hash the upper layer
+  .create();
+```
+
+**Builder methods**
+
+| Method | Description |
+|--------|-------------|
+| `.name(string)` | Bare name under the default snapshots directory |
+| `.path(string)` | Explicit filesystem path |
+| `.label(key, value)` | Add a `key=value` label (may be repeated) |
+| `.force()` | Overwrite an existing artifact at the destination |
+| `.recordIntegrity()` | Compute and record a content-integrity hash at creation |
+| `.build()` | Snapshot the accumulated configuration |
+| `.create()` | Build and execute |
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot.open()
+
+```ts
+static open(pathOrName: string): Promise<Snapshot>
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot.get()
+
+```ts
+static get(nameOrDigest: string): Promise<SnapshotHandle>
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot.list()
+
+```ts
+static list(): Promise<SnapshotHandle[]>
+```
+
+List indexed snapshots from the local DB cache.
+
+---
+
+#### Snapshot.listDir()
+
+```ts
+static listDir(dir: string): Promise<Snapshot[]>
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot.remove()
+
+```ts
+static remove(pathOrName: string, opts?: { force?: boolean }): Promise<void>
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force: true`.
+
+---
+
+#### Snapshot.reindex()
+
+```ts
+static reindex(dir?: string): Promise<number>
+```
+
+Walk `dir` (default: configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot.export()
+
+```ts
+static export(nameOrPath: string, out: string, opts?: ExportOpts): Promise<void>
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+**ExportOpts**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `withParents` | `boolean` | Walk the parent chain (no-op today) |
+| `withImage` | `boolean` | Bundle the OCI image cache for offline transport |
+| `plainTar` | `boolean` | Skip zstd compression and write a plain `.tar` |
+
+---
+
+#### Snapshot.import()
+
+```ts
+static import(archive: string, dest?: string): Promise<SnapshotHandle>
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot.list()`](#snapshotlist) and [`Snapshot.get()`](#snapshotget).
+
+```ts
+const h = await Snapshot.get("after-pip-install");
+
+h.digest;          // string ("sha256:...")
+h.name;            // string | null
+h.parentDigest;    // string | null — null today
+h.imageRef;        // string
+h.format;          // "raw" | "qcow2"
+h.sizeBytes;       // bigint | null
+h.createdAt;       // Date
+h.path;            // string
+
+const snap = await h.open();              // metadata-validated
+await h.remove({ force: false });          // refuse if has children
+```
+
+---
+
+## Types
+
+```ts
+export interface ExportOpts {
+  withParents?: boolean;
+  withImage?: boolean;
+  plainTar?: boolean;
+}
+
+export type SnapshotVerifyReport =
+  | { digest: string; path: string; upper: { kind: "notRecorded" } }
+  | { digest: string; path: string;
+      upper: { kind: "verified"; algorithm: string; digest: string } };
+```

--- a/docs/fr/sdk/typescript/volumes.mdx
+++ b/docs/fr/sdk/typescript/volumes.mdx
@@ -1,0 +1,234 @@
+---
+title: Volumes
+description: TypeScript SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+```typescript
+import { Volume } from "microsandbox";
+
+const data = await Volume.builder("my-data")
+  .quota(100)
+  .label("env", "prod")
+  .create();
+```
+
+## Static methods
+
+---
+
+#### Volume.builder()
+
+```typescript
+static builder(name: string): VolumeBuilder
+```
+
+Begin building a named volume. Configure with `.quota(...)` and `.label(...)`, then call `.create()`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeBuilder`](#volumebuilder) | Fluent builder |
+
+---
+
+#### Volume.get()
+
+```typescript
+static get(name: string): Promise<VolumeHandle>
+```
+
+Get a handle to an existing named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`VolumeHandle`](#volumehandle)`>` | Volume handle |
+
+---
+
+#### Volume.list()
+
+```typescript
+static list(): Promise<VolumeHandle[]>
+```
+
+List all named volumes. Handles returned from `list()` are read-only — call `Volume.get(name)` to get a live handle for `.remove()` / `.fs()`.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`VolumeHandle`](#volumehandle)`[]>` | All volumes |
+
+---
+
+#### Volume.remove()
+
+```typescript
+static remove(name: string): Promise<void>
+```
+
+Delete a named volume and its contents. Fails if the volume is currently mounted.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+---
+
+## Instance properties
+
+#### name
+
+```typescript
+get name(): string
+```
+
+The volume's name.
+
+---
+
+#### path
+
+```typescript
+get path(): string
+```
+
+Absolute host path to the volume's directory.
+
+---
+
+#### fs()
+
+```typescript
+fs(): VolumeFs
+```
+
+Get a host-side filesystem handle for this volume — no sandbox required.
+
+```typescript
+const vfs = data.fs();
+await vfs.write("seed.txt", "hello");
+console.log(await vfs.list(""));
+```
+
+---
+
+## Mounts
+
+Volume mounts attach a host directory, named volume, tmpfs, or disk image to a guest path. Configure them via `SandboxBuilder.volume(guestPath, m => ...)`:
+
+```typescript
+await using sb = await Sandbox.builder("worker")
+  .image("alpine")
+  .volume("/host",    (m) => m.bind("/var/data"))
+  .volume("/data",    (m) => m.named("my-data"))
+  .volume("/scratch", (m) => m.tmpfs().size(128))
+  .volume("/img",     (m) => m.disk("./data.qcow2").fstype("ext4").readonly())
+  .create();
+```
+
+### MountBuilder
+
+Used inside `SandboxBuilder.volume(guestPath, m => ...)`. Pick exactly one mount kind, then chain modifiers.
+
+| Method | Description |
+|--------|-------------|
+| `bind(host)` | Mount a host directory into the guest. |
+| `named(name)` | Mount a named volume created via [`Volume.builder`](#volumebuilder). |
+| `tmpfs()` | Mount an in-memory filesystem. |
+| `disk(host)` | Mount a host disk image as a virtio-blk device. |
+| `format(fmt)` | Disk image format (`'qcow2' \| 'raw' \| 'vmdk'`). Defaults to the file extension. Disk only. |
+| `fstype(fs)` | Inner filesystem type (e.g. `"ext4"`). Disk only; omit to autodetect. |
+| `readonly()` | Mount read-only. |
+| `size(mib)` | Cap in MiB. Tmpfs only. |
+| `build()` | Internal — produce a `VolumeMount`. |
+
+### VolumeMount
+
+Discriminated union produced by `MountBuilder.build()`.
+
+```typescript
+type VolumeMount =
+  | { kind: "bind"; host: string; guest: string; readonly: boolean }
+  | { kind: "named"; name: string; guest: string; readonly: boolean }
+  | { kind: "tmpfs"; guest: string; sizeMib: number | null; readonly: boolean }
+  | {
+      kind: "disk";
+      host: string;
+      guest: string;
+      format: DiskImageFormat;
+      fstype: string | null;
+      readonly: boolean;
+    };
+```
+
+### DiskImageFormat
+
+```typescript
+type DiskImageFormat = "qcow2" | "raw" | "vmdk";
+```
+
+---
+
+## Types
+
+### VolumeBuilder
+
+| Method | Description |
+|--------|-------------|
+| `quota(mib)` | Maximum storage size in MiB |
+| `label(key, value)` | Add a metadata label |
+| `build()` | Materialize a [`VolumeConfig`](#volumeconfig) |
+| `create()` | Build and create the volume; returns a [`Volume`](#volume) |
+
+### VolumeConfig
+
+Frozen configuration produced by `VolumeBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Volume name |
+| quotaMib | `number \| null` | Maximum storage size in MiB |
+| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
+
+### VolumeHandle
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `string` | Volume name |
+| quotaMib | `number \| null` | Storage quota |
+| usedBytes | `number` | Current disk usage in bytes |
+| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
+| createdAt | `Date \| null` | Creation timestamp |
+| fs() | [`VolumeFs`](#volumefs) | Host-side filesystem on this volume (live handles only) |
+| remove() | `Promise<void>` | Delete this volume (live handles only) |
+
+Handles in the array returned by `Volume.list()` are read-only: calling `.fs()` or `.remove()` throws. Use `Volume.get(name)` to upgrade.
+
+### VolumeFs
+
+Host-side filesystem operations on a volume's directory. Same surface area as [`SandboxFs`](/sdk/typescript/filesystem) (read, readToString, readStream, write, writeStream, list, mkdir, removeDir, remove, copy, rename, stat, exists) — but operates directly on the host without booting a sandbox.

--- a/docs/ja/cli/image-commands.mdx
+++ b/docs/ja/cli/image-commands.mdx
@@ -1,0 +1,112 @@
+---
+title: Image Commands
+description: Pull and manage OCI images from the CLI
+icon: "layer-group"
+---
+
+## msb pull
+
+Pre-pull an image to the local cache. Layers are fetched in parallel with per-layer progress bars. Once cached, layers are content-addressable and deduplicated, so shared layers across images are only stored once.
+
+```bash
+msb pull python
+msb pull alpine
+msb pull ghcr.io/my-org/my-image:v1
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Force re-download even if cached |
+| `-q`, `--quiet` | Suppress progress output |
+| `--insecure` | Connect over plain HTTP instead of HTTPS |
+| `--ca-certs <PATH>` | Path to a PEM file with additional CA root certificates |
+
+<Tip>
+  Pre-pulling is useful when you want sandbox creation to be instant. Without a pre-pull, the first `Sandbox.create` with a new image will block on the download.
+</Tip>
+
+## msb image ls
+
+List images in the local cache.
+
+```bash
+msb image ls
+msb image ls --format json
+msb image ls -q               # References only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only image references |
+
+<Tip>
+  `msb images` is a shorthand alias for `msb image ls`.
+</Tip>
+
+## msb image inspect
+
+Show detailed metadata for a cached image (manifest, layers, config).
+
+```bash
+msb image inspect python
+msb image inspect python --format json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb image rm
+
+Remove one or more cached images and their layers (layers shared with other images are kept).
+
+```bash
+msb image rm python
+msb image rm alpine ubuntu   # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Remove even if the image is used by existing sandboxes |
+| `-q`, `--quiet` | Suppress output |
+
+<Tip>
+  `msb rmi` is a shorthand alias for `msb image rm`.
+</Tip>
+
+## msb registry
+
+Manage registry authentication.
+
+```bash
+msb registry login ghcr.io --username octocat
+printf '%s\n' "$GHCR_TOKEN" | msb registry login ghcr.io --username octocat --password-stdin
+msb registry logout ghcr.io
+msb registry ls
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `login` | Store credentials for a registry in the OS credential store |
+| `logout` | Remove stored credentials for a registry |
+| `list` (alias: `ls`) | List configured registries without printing secrets |
+
+**`msb registry login` flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--username` | Registry username |
+| `--password-stdin` | Read password from stdin |
+
+`msb registry login` stores the secret in the OS credential store (for example Keychain, Credential Manager, or Secret Service) and writes only metadata to `~/.microsandbox/config.json`.
+
+For CI or other headless environments, configure `registries.auth` in `~/.microsandbox/config.json` with `password_env`. Advanced host setups can also use `secret_name` to point at a file-backed secret under `~/.microsandbox/secrets/registries/`.
+
+When pulling from a registry, microsandbox resolves auth in this order:
+
+1. Explicit SDK auth (`.registry_auth(...)`)
+2. OS credential store
+3. `registries.auth` config
+4. Docker credential store/config
+5. Anonymous

--- a/docs/ja/cli/overview.mdx
+++ b/docs/ja/cli/overview.mdx
@@ -1,0 +1,97 @@
+---
+title: CLI Overview
+description: Manage sandboxes from the terminal
+icon: "book"
+---
+
+The `msb` CLI lets you create, manage, and interact with sandboxes from the terminal. It auto-detects TTY and interactivity, so no `-it` flags are needed. If your terminal is interactive, `msb` acts accordingly.
+
+## Install
+
+```bash
+curl -fsSL https://install.microsandbox.dev | sh
+```
+
+<Note>
+  microsandbox requires Linux with KVM enabled, or macOS with Apple Silicon (M-series chip). Both use hardware virtualization.
+</Note>
+
+## Quick reference
+
+```bash
+# Run a one-off command (ephemeral, auto-removed)
+msb run python -- python -c "print('Hello!')"
+
+# Interactive shell (auto-detects TTY)
+msb run alpine -- sh
+
+# Create a persistent sandbox
+msb run --name devbox ubuntu -- bash
+
+# Resume later
+msb start devbox
+
+# Execute in a running sandbox
+msb exec devbox -- sh -c "apt update && apt install -y cowsay && /usr/games/cowsay \"Hello from devbox\""
+
+# Manage
+msb ls                   # List all sandboxes
+msb ps                   # Running sandboxes only
+msb metrics              # Live CPU/memory/network stats
+msb inspect devbox       # Detailed info
+msb logs devbox          # Captured stdout/stderr (works on stopped sandboxes too)
+msb logs devbox -f       # Follow live
+msb stop devbox          # Graceful shutdown
+msb rm devbox            # Remove stopped sandbox
+
+# Images
+msb pull python     # Pre-pull to cache
+msb image ls             # List cached images
+msb image rm python # Remove a cached image
+
+# Volumes
+msb volume create data --size 10G
+msb volume ls
+msb volume rm data
+
+# Install as a system command
+msb install ubuntu       # Install as 'ubuntu' command
+msb uninstall ubuntu     # Remove installed command
+
+# Self-management
+msb self update          # Update msb to latest
+msb self uninstall       # Remove msb
+```
+
+<Tip>
+  Unnamed sandboxes (no `--name` flag) are ephemeral. They're automatically removed when the command finishes. Named sandboxes persist and can be stopped, restarted, and inspected later.
+</Tip>
+
+## Global options
+
+| Flag | Description |
+|------|-------------|
+| `--tree` | Display the complete command tree with descriptions |
+| `--error` | Show only errors |
+| `--warn` | Show warnings and errors |
+| `--info` | Show info, warnings, and errors |
+| `--debug` | Show debug output |
+| `--trace` | Show all output including trace |
+
+## Command tree
+
+Use `--tree` as an alternative to `--help` to see every command, subcommand, and flag at once:
+
+```bash
+msb --tree
+```
+
+You can scope it to a specific subcommand:
+
+```bash
+msb image --tree    # Show only image commands
+msb volume --tree   # Show only volume commands
+msb run --tree      # Show all flags for run
+```
+
+For detailed command reference, see [Sandbox Commands](/cli/sandbox-commands), [Volume Commands](/cli/volume-commands), and [Image Commands](/cli/image-commands).

--- a/docs/ja/cli/sandbox-commands.mdx
+++ b/docs/ja/cli/sandbox-commands.mdx
@@ -1,0 +1,328 @@
+---
+title: Sandbox Commands
+description: Create, run, and interact with sandboxes from the CLI
+icon: "cube"
+---
+
+## msb run
+
+Create a sandbox and optionally run a command. Without `--name`, the sandbox is ephemeral and removed when the command finishes. With `--name`, it persists for later use.
+
+```bash
+# Ephemeral: runs and cleans up
+msb run python -- python -c "print('hello')"
+
+# Named: persists after exit
+msb run --name devbox ubuntu -- bash
+
+# With volumes, ports, and environment
+msb run --name api \
+  -v ./src:/app \
+  -v pydata:/data \
+  -p 8000:8000 \
+  -e DEBUG=true \
+  -w /app \
+  python
+
+# Detached (runs in background)
+msb run -d --name worker python -- python worker.py
+```
+
+| Flag | Description |
+|------|-------------|
+| `-n`, `--name` | Sandbox name (if omitted, sandbox is ephemeral) |
+| `-c`, `--cpus` | Number of virtual CPUs to allocate |
+| `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
+| `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST`) |
+| `-p`, `--port` | Forward a host port to the sandbox (`HOST:GUEST` or `HOST:GUEST/udp`) |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-w`, `--workdir` | Working directory inside the sandbox |
+| `--shell` | Default shell for interactive sessions |
+| `-t`, `--tty` | Allocate a pseudo-terminal (enables colors, line editing) |
+| `-d`, `--detach` | Run in background and print the sandbox name |
+| `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`). Per-command; the sandbox stays alive |
+| `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`, `as=1073741824`) |
+| `--detach-keys` | Key sequence to detach from interactive session (default: `ctrl-]`) |
+| `--replace` | Replace an existing sandbox with the same name |
+| `-q`, `--quiet` | Suppress progress output |
+| `--entrypoint` | Override the image's default entrypoint command |
+| `--init` | Hand off PID 1 to this init binary (absolute path) inside the guest after agentd's setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| `--init-arg` | Argv entry appended to the handoff init. Repeatable. Defaults to `[<--init>]` when empty |
+| `--init-env` | Env var passed to the handoff init only (`KEY=VALUE`). Repeatable; merged on top of the inherited env |
+| `-H`, `--hostname` | Set the guest hostname (defaults to sandbox name) |
+| `-u`, `--user` | Run commands as the specified user (e.g. `nobody`, `1000`, `1000:1000`) |
+| `--pull` | When to pull the image: `always`, `if-missing` (default), `never` |
+| `--log-level` | Log verbosity for the sandbox runtime (`error`, `warn`, `info`, `debug`, `trace`) |
+| `--tmpfs` | Mount a temporary in-memory filesystem (`PATH` or `PATH:SIZE`) |
+| `--script` | Register an inline script (`NAME=BODY`). Available at `/.msb/scripts/<name>` and on `PATH` |
+| `--script-path` | Register a script from a host file (`NAME:PATH`). Same destination as `--script` |
+| `--max-duration` | Kill the entire sandbox after this duration (e.g. `30s`, `5m`, `1h`). Sandbox-level lifetime limit |
+| `--idle-timeout` | Stop the sandbox after this period of inactivity (e.g. `30s`, `5m`, `1h`) |
+| `--no-network` | Disable all network access |
+| `--network-policy` | Control which destinations are reachable from the sandbox. Accepted values: `none` (no network), `public-only` (default — public internet only), `nonlocal` (public + private/LAN; blocks loopback, link-local, and metadata), `allow-all` (unrestricted) |
+| `--deny-domain` | Deny egress to a domain. Repeatable. Adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback) |
+| `--deny-domain-suffix` | Deny egress to all subdomains of a suffix (e.g. `.ads.com`). Repeatable. Adds a `deny DomainSuffix("...")` policy rule |
+| `--no-dns-rebind-protection` | Allow DNS responses pointing to private/internal IP addresses |
+| `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
+| `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |
+| `--max-connections` | Limit the number of concurrent network connections |
+| `--trust-host-cas` | Ship the host's trusted root CAs into the guest so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, etc.) whose gateway CA is installed on the host but unknown to the guest's stock bundle. Opt-in; by default the guest validates against its stock Mozilla bundle only |
+| `--secret` | Inject a secret that is only sent to an allowed host (`ENV=VALUE@HOST`) |
+| `--on-secret-violation` | Action when a secret is sent to a disallowed host (`block`, `block-and-log`, `block-and-terminate`) |
+| `--tls-intercept` | Intercept and inspect HTTPS traffic via a built-in TLS proxy |
+| `--tls-intercept-port` | TCP port to apply TLS interception on (default: 443) |
+| `--tls-bypass` | Skip TLS interception for a domain (e.g. `*.internal.com`) |
+| `--no-block-quic` | Allow QUIC/HTTP3 traffic (blocked by default when TLS interception is on) |
+| `--tls-intercept-ca-cert` | Use a custom CA certificate for TLS interception (PEM file) |
+| `--tls-intercept-ca-key` | Use a custom CA private key for TLS interception (PEM file) |
+| `--tls-upstream-ca-cert` | Trust an additional CA certificate for upstream server verification (PEM file). Can be specified multiple times |
+
+When no `--` command is given, the image's `entrypoint` and `cmd` are used as the default process. If the image has neither, an interactive shell is started. When a command is given via `--`, it replaces the image `cmd` but the `entrypoint` is preserved. See [Image config inheritance](/images/overview#image-config-inheritance) for details.
+
+## msb create
+
+Create and boot a sandbox without running a command. Takes the same flags as `msb run` (except `--detach`).
+
+```bash
+msb create python --name worker -c 2 -m 1G
+msb create --replace python --name worker   # Replace existing
+```
+
+## msb start
+
+Resume a stopped sandbox.
+
+```bash
+msb start devbox
+```
+
+| Flag | Description |
+|------|-------------|
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb stop
+
+```bash
+msb stop devbox                # Graceful shutdown
+msb stop --force devbox        # Force kill immediately
+msb stop -t 10 devbox          # Wait 10s then force kill
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Immediately kill the sandbox without graceful shutdown |
+| `-t`, `--timeout` | Seconds to wait for graceful shutdown before force-killing |
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb exec
+
+Execute a command inside a running sandbox.
+
+```bash
+msb exec devbox -- python -c "print('hello')"
+msb exec devbox -- ls -la /app
+```
+
+| Flag | Description |
+|------|-------------|
+| `-t`, `--tty` | Allocate a pseudo-terminal (enables colors, line editing) |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-w`, `--workdir` | Override working directory |
+| `-u`, `--user` | Run the command as the specified guest user |
+| `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`) |
+| `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`) |
+| `-q`, `--quiet` | Suppress progress output |
+
+<Tip>
+  The CLI auto-detects whether stdin is a terminal. When interactive, `msb exec` uses `attach` mode (TTY, line editing). When piped, it captures output. No `-i` flag is needed.
+</Tip>
+
+## msb logs
+
+Read captured output from a sandbox. Each sandbox stores its captured stdio under `<sandbox-dir>/logs/exec.log` as JSON Lines, plus runtime/kernel diagnostics in `runtime.log`/`kernel.log`. The command works on running and stopped sandboxes alike — there is no protocol traffic, just a file read.
+
+```bash
+# Captured user-program output (default sources: stdout + stderr + output)
+msb logs devbox
+
+# Tail and follow
+msb logs devbox --tail 100
+msb logs devbox -f --grep ERROR
+
+# Time-bounded
+msb logs devbox --since 5m
+msb logs devbox --since 2026-04-30T20:00:00Z --until 5m
+
+# JSON Lines passthrough — feed to jq, vector, etc.
+msb logs devbox --json | jq 'select(.s == "stderr")'
+
+# Multi-session view: prefix each line with [id:N] so you can tell sessions apart
+msb logs devbox --show-id
+
+# Color each session's output a distinct color (implies --show-id)
+msb logs devbox --color-sessions
+
+# Include runtime/kernel diagnostics
+msb logs devbox --source system
+msb logs devbox --source all                # everything, chronologically merged
+```
+
+| Flag | Description |
+|------|-------------|
+| `--tail` | Show only the last N entries |
+| `--since` | Show entries at or after this time (RFC 3339 or relative `5m`/`2h`/`1d`) |
+| `--until` | Show entries strictly before this time (same formats) |
+| `-f`, `--follow` | Follow in real time (200 ms polling, rotation-aware) |
+| `--timestamps` | Prefix each line with the entry timestamp |
+| `--source` | Sources to include: `stdout`, `stderr`, `output`, `system`, `all`. Repeat or comma-separate. Default: `stdout,stderr,output` |
+| `--grep` | Client-side regex filter on the entry body |
+| `--json` | Emit raw JSON Lines without decoding (one entry per line) |
+| `--raw` | Opt into base64 encoding for non-UTF-8 bytes |
+| `--show-id` | Prefix each line with `[id:N]` (the session correlation id) |
+| `--color-sessions` | Color each session's lines a distinct color (implies `--show-id`) |
+| `--color` | ANSI handling: `auto` (default), `always`, `never` |
+| `--no-color` | Alias for `--color=never` |
+
+**Source tags** (the `s` field in `--json` output):
+
+- `stdout` / `stderr` — captured from the session's pipes when running in **pipe mode** (streams stay separated end to end).
+- `output` — captured from the session in **pty mode**. pty allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `output` rather than mislabelled as `stdout`.
+- `system` — synthetic lifecycle markers (`--- sandbox started ---` / `--- sandbox stopped ---`) plus diagnostic lines from `runtime.log`/`kernel.log` when `--source system` is requested.
+
+<Tip>
+  If a sandbox failed to start, `msb logs` prepends a styled error block reconstructed from `boot-error.json`. The block tells you the failure stage, errno, and a hint — even though no user-program output was ever captured.
+</Tip>
+
+## msb ls
+
+List all stored sandboxes.
+
+```bash
+msb ls                    # All sandboxes (running and stopped)
+msb ls --running          # Running sandboxes only
+msb ls --stopped          # Stopped sandboxes only
+msb ls --format json      # JSON output
+msb ls -q                 # Names only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--running` | Show only running sandboxes |
+| `--stopped` | Show only stopped sandboxes |
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only sandbox names |
+
+## msb status / ps
+
+Show sandbox status with process details.
+
+```bash
+msb ps                    # Running sandboxes
+msb ps my-app             # Single sandbox
+msb ps -a                 # All sandboxes (including stopped)
+msb ps --format json      # JSON output
+```
+
+| Flag | Description |
+|------|-------------|
+| `-a`, `--all` | Show all sandboxes, not just running ones |
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only sandbox names |
+
+## msb metrics
+
+Show live CPU, memory, disk, and network metrics for running sandboxes.
+
+```bash
+msb metrics               # All running sandboxes
+msb metrics my-app        # Single sandbox
+msb metrics --format json # JSON output
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb inspect
+
+Show detailed configuration and status.
+
+```bash
+msb inspect devbox
+msb inspect devbox --format json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+
+## msb rm
+
+Remove one or more sandboxes and their associated state.
+
+```bash
+msb rm devbox
+msb rm --force devbox     # Stop and remove in one step
+msb rm worker-1 worker-2  # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Stop the sandbox if running, then remove it |
+| `-q`, `--quiet` | Suppress progress output |
+
+## msb install
+
+Install a sandbox as a system command. Creates an executable in `~/.microsandbox/bin/` that launches `msb run` with the specified image and options.
+
+```bash
+msb install ubuntu                   # Install as 'ubuntu' command
+msb install --name nodebox node      # Custom command name
+msb install --tmp alpine             # Fresh sandbox every invocation
+msb install -c 2 -m 1G python  # With resource limits
+msb install --list                   # List installed commands
+```
+
+| Flag | Description |
+|------|-------------|
+| `-n`, `--name` | Command name for the alias (defaults to image name) |
+| `-c`, `--cpus` | Number of virtual CPUs to allocate |
+| `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
+| `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST`) |
+| `-w`, `--workdir` | Working directory inside the sandbox |
+| `--shell` | Shell for interactive sessions |
+| `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
+| `-f`, `--force` | Overwrite an existing alias with the same name |
+| `--no-pull` | Don't pull the image before installing |
+| `--tmp` | Create a fresh sandbox on every invocation (no persistent state) |
+| `-l`, `--list` | List all installed sandbox commands |
+
+## msb uninstall
+
+Remove an installed sandbox command.
+
+```bash
+msb uninstall nodebox
+msb uninstall ubuntu alpine   # Remove multiple
+```
+
+## msb self
+
+Manage the msb installation itself.
+
+```bash
+msb self update               # Update msb and libkrunfw to latest
+msb self update --force       # Re-download even if up to date
+msb self uninstall            # Remove msb (with confirmation prompt)
+msb self uninstall --yes      # Skip confirmation
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `update` (alias: `upgrade`) | Update msb and libkrunfw to the latest release |
+| `uninstall` | Remove msb, libkrunfw, and shell configuration |
+
+| Flag | Subcommand | Description |
+|------|------------|-------------|
+| `-f`, `--force` | `update` | Re-download even if already on the latest version |
+| `-y`, `--yes` | `uninstall` | Skip confirmation prompt |

--- a/docs/ja/cli/volume-commands.mdx
+++ b/docs/ja/cli/volume-commands.mdx
@@ -1,0 +1,67 @@
+---
+title: Volume Commands
+description: Create and manage named volumes from the CLI
+icon: "hard-drive"
+---
+
+Named volumes persist independently of sandboxes and are stored at `~/.microsandbox/volumes/`.
+
+## msb volume create
+
+```bash
+msb volume create my-data
+msb volume create my-data --size 10G
+```
+
+| Flag | Description |
+|------|-------------|
+| `--size` | Storage quota (e.g. `100M`, `1G`, `10G`) |
+| `-q`, `--quiet` | Suppress output (only print the volume name) |
+
+## msb volume ls
+
+```bash
+msb volume ls
+msb volume ls --format json
+msb volume ls -q               # Names only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (`json`) |
+| `-q`, `--quiet` | Show only volume names |
+
+## msb volume inspect
+
+```bash
+msb volume inspect my-data
+```
+
+## msb volume rm
+
+```bash
+msb volume rm my-data
+msb volume rm cache-1 cache-2   # Remove multiple
+```
+
+| Flag | Description |
+|------|-------------|
+| `-q`, `--quiet` | Suppress output |
+
+## Using volumes with sandboxes
+
+Mount a named volume when creating or running a sandbox. The volume name goes before the colon, the guest path after.
+
+```bash
+# Create a volume, then mount it
+msb volume create app-data --size 5G
+msb run --name worker -v app-data:/data python
+
+# Share between sandboxes
+msb run --name writer -v shared:/data alpine -- sh -c "echo hello > /data/msg.txt"
+msb run --name reader -v shared:/data alpine -- cat /data/msg.txt
+```
+
+<Tip>
+  The CLI distinguishes bind mounts from named volumes by looking for a `/` or `.` prefix. `./src:/app` is a bind mount (host path). `myvolume:/data` is a named volume. This matches Docker's convention.
+</Tip>

--- a/docs/ja/configuration.mdx
+++ b/docs/ja/configuration.mdx
@@ -1,0 +1,140 @@
+---
+title: config.json
+description: Global config.json reference
+icon: "gear"
+---
+
+microsandbox reads its global configuration from `~/.microsandbox/config.json`. All fields are optional. A missing file or empty JSON object is equivalent to using the defaults.
+
+<Accordion title="Full example">
+```json
+{
+  "home": "/custom/path/.microsandbox",
+  "log_level": "info",
+  "database": {
+    "url": "sqlite:///tmp/msb.db",
+    "max_connections": 10,
+    "connect_timeout_secs": 30
+  },
+  "paths": {
+    "msb": "/usr/local/bin/msb",
+    "libkrunfw": "/usr/local/lib/libkrunfw.so",
+    "cache": "/mnt/fast/msb-cache",
+    "sandboxes": null,
+    "volumes": null,
+    "logs": null,
+    "secrets": null
+  },
+  "sandbox_defaults": {
+    "cpus": 2,
+    "memory_mib": 1024,
+    "shell": "/bin/bash",
+    "workdir": "/app"
+  },
+  "registries": {
+    "auth": {
+      "ghcr.io": {
+        "username": "octocat",
+        "store": "keyring"
+      },
+      "registry.example.com": {
+        "username": "deploy",
+        "password_env": "REGISTRY_TOKEN"
+      },
+      "docker.io": {
+        "username": "user",
+        "secret_name": "dockerhub-token"
+      }
+    }
+  }
+}
+```
+</Accordion>
+
+## Top-level fields
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `home` | `~/.microsandbox` | Root directory for all microsandbox data |
+| `log_level` | `null` (silent) | Log level for sandbox processes: `error`, `warn`, `info`, `debug`, `trace` |
+| `database` | [reference](#database) | Database connection settings |
+| `paths` | [reference](#paths) | Path overrides for binaries and directories |
+| `sandbox_defaults` | [reference](#sandbox_defaults) | Defaults applied to every sandbox |
+| `registries` | [reference](#registries) | Container registry authentication |
+
+## `database`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `url` | `null` | Database URL. Uses SQLite under `home` when null |
+| `max_connections` | `5` | Maximum connection pool size |
+| `connect_timeout_secs` | `30` | Timeout when acquiring a database connection from the pool |
+
+## `paths`
+
+All path fields are optional. When `null`, they resolve relative to `home`.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `msb` | `{home}/bin/msb` | `msb` binary. Resolved via: `MSB_PATH` env, this field, default path, `PATH` |
+| `libkrunfw` | `{home}/lib/libkrunfw` | Path to a custom VM kernel (`.so` on Linux, `.dylib` on macOS) |
+| `cache` | `{home}/cache` | Image layer cache |
+| `sandboxes` | `{home}/sandboxes` | Per-sandbox state |
+| `volumes` | `{home}/volumes` | Named volumes |
+| `logs` | `{home}/logs` | Sandbox logs |
+| `secrets` | `{home}/secrets` | Secrets. Registry secrets live under `secrets/registries/` |
+
+## `sandbox_defaults`
+
+Defaults applied to every sandbox unless overridden per-sandbox.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `cpus` | `1` | Number of vCPUs |
+| `memory_mib` | `512` | Guest memory in MiB |
+| `shell` | `"/bin/sh"` | Shell for interactive sessions and scripts |
+| `workdir` | `null` | Working directory inside the sandbox |
+| `metrics_sample_interval_ms` | `1000` | Runtime metrics sampling interval in milliseconds. Set to `0` to disable sampling. |
+| `disable_metrics_sample` | `false` | Force-disable metrics sampling regardless of `metrics_sample_interval_ms`. |
+
+## `registries`
+
+### `registries.auth`
+
+A map of registry hostnames to authentication entries. Each entry specifies a username and exactly **one** credential source.
+
+```json
+{
+  "registries": {
+    "auth": {
+      "ghcr.io": {
+        "username": "octocat",
+        "store": "keyring"
+      }
+    }
+  }
+}
+```
+
+#### Auth entry fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `username` | Yes | Registry username |
+| `store` | No | Credential store. Only `"keyring"` is supported (macOS Keychain, Windows Credential Manager, Linux Secret Service) |
+| `password_env` | No | Environment variable containing the password or token |
+| `secret_name` | No | Filename under `{home}/secrets/registries/` containing the password or token |
+
+<Note>
+  Exactly one of `store`, `password_env`, or `secret_name` must be set per entry. Setting none or more than one is an error.
+</Note>
+
+### Auth resolution order
+
+When pulling from a registry, credentials are resolved in this order:
+
+1. **Explicit SDK auth** via `.registry_auth()` on the sandbox builder
+2. **OS keyring** entries created by `msb registry login`
+3. **Config file** `registries.auth` entries in `config.json`
+4. **Docker config** `~/.docker/config.json` credential helpers
+5. **Anonymous** (no authentication)

--- a/docs/ja/getting-started/agents.mdx
+++ b/docs/ja/getting-started/agents.mdx
@@ -1,0 +1,108 @@
+---
+title: AI Agents
+description: Give AI agents the ability to create and manage their own sandboxes
+icon: "robot"
+---
+
+microsandbox is built for AI agents. The SDK and CLI give you full programmatic control, but there are two additional ways to connect agents directly: **Agent Skills** for coding assistants and an **MCP server** for any MCP-compatible client.
+
+## Agent Skills
+
+[Agent Skills](https://github.com/superradcompany/skills) teach AI coding agents how to use microsandbox without any custom integration code. Once installed, the agent can create sandboxes, run commands, manage files, and control the full sandbox lifecycle through natural language.
+
+Works with Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, and other agents that support the skills format.
+
+```bash
+npx skills add superradcompany/skills
+```
+
+This installs a set of skill files into your project that the agent reads as context. No server process, no configuration, just files that describe how to use microsandbox.
+
+## MCP Server
+
+The [microsandbox MCP server](https://github.com/superradcompany/microsandbox-mcp) exposes microsandbox as a set of structured tool calls over the [Model Context Protocol](https://modelcontextprotocol.io). Any MCP-compatible client can use it to manage sandbox lifecycle, execute commands, access the filesystem, work with volumes, and monitor sandbox state.
+
+<CodeGroup>
+
+```bash Claude Code
+claude mcp add --transport stdio microsandbox -- npx -y microsandbox-mcp
+```
+
+```json Cursor
+// ~/.cursor/mcp.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json VS Code
+// .vscode/mcp.json
+{
+  "servers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Claude Desktop
+// ~/Library/Application Support/Claude/claude_desktop_config.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Windsurf
+// ~/.codeium/windsurf/mcp_config.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Open Code
+// .opencode.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Zed
+// Zed settings
+{
+  "context_servers": {
+    "microsandbox": {
+      "command": {
+        "path": "npx",
+        "args": ["-y", "microsandbox-mcp"]
+      }
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+Once connected, the agent gets access to tools for creating sandboxes, running commands inside them, reading and writing files, and managing the sandbox lifecycle, all through the MCP protocol.

--- a/docs/ja/getting-started/introduction.mdx
+++ b/docs/ja/getting-started/introduction.mdx
@@ -1,0 +1,370 @@
+---
+title: "Introduction"
+description: "Every agent deserves its own computer"
+icon: "house"
+---
+
+AI agents run with whatever privileges you give them, and most of the time that's too many. They can see API keys sitting in the environment, reach the network freely (including cloud metadata at `169.254.169.254`), and nothing stops a prompt injection from running `rm -rf /` on the host filesystem. Containers help with some of this, but they share the host kernel, and namespace escapes are a well-documented class of vulnerability.
+
+microsandbox takes a different approach: every sandbox is a real VM with its own Linux kernel. It provides security primitives for preventing exploits like secret exfiltration. And it **runs locally** on your machine.
+
+<CodeGroup>
+
+```rust Rust
+use microsandbox::{Sandbox, NetworkPolicy};
+
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .secret(|s| s
+        .env("OPENAI_API_KEY")
+        .value(std::env::var("OPENAI_API_KEY")?)
+        .allow_host("api.openai.com")
+    )
+    .network(|n| n.policy(NetworkPolicy::public_only()))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { NetworkPolicy, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .secret((s) =>
+        s.env("OPENAI_API_KEY")
+            .value(process.env.OPENAI_API_KEY!)
+            .allowHost("api.openai.com"),
+    )
+    .network((n) => n.policy(NetworkPolicy.publicOnly()))
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import Network, Sandbox, Secret
+
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    memory=512,
+    cpus=2,
+    secrets=[
+        Secret.env("OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+    network=Network.public_only(),
+)
+```
+
+</CodeGroup>
+
+<Callout icon="bolt" color="#7C3AED">
+  microsandbox spins up lightweight VMs in **under a second**, right from your code on your machine. **No servers, no daemons**, no infrastructure to manage.
+</Callout>
+
+## The basics
+
+- **Under 100ms boot.** Sandboxes boot in under 100 milliseconds.
+- **No daemon.** The runtime spawns directly as a child process of whatever application creates the sandbox. No root, no server, no background service.
+- **Any OCI image.** Docker Hub, GHCR, ECR, GCR, or any OCI-compatible registry. Shared layers are deduplicated and only stored once.
+- **Cross-platform.** Native on macOS (Apple Silicon) and Linux (KVM). Same CLI, same SDKs.
+- **Multi-language SDKs.** Rust, TypeScript, and Python, all with consistent APIs.
+- **Programmable.** Network policies, filesystem hooks, secret bindings, and TLS interception are all configured from the host side through the SDK.
+
+## What makes it different
+
+### Secrets that can't leak
+
+Most sandboxes protect secrets by restricting what the guest can do. microsandbox goes further: **the guest never has the secret at all**.
+
+Instead of injecting real credentials into the sandbox, microsandbox generates random placeholders. The actual value never enters the VM. The only way it reaches the outside world is when a request goes to an allowed host, at which point microsandbox swaps the placeholder for the real value. Everywhere else, the placeholder is just a meaningless string.
+
+So even with full code execution inside the sandbox, there's nothing to exfiltrate. The credential was never there. DNS rebinding protection and cloud metadata blocking kick in automatically when secrets are configured, closing the remaining side channels.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .secret_env("OPENAI_API_KEY", api_key, "api.openai.com")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    secrets=[
+        Secret.env("OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+)
+```
+
+</CodeGroup>
+
+### Programmable network layer <sup><sup>coming soon</sup></sup>
+
+Every packet leaving a sandbox passes through a networking stack controlled entirely from the host side, where policy is enforced at the IP, DNS, or HTTP level. From inside the sandbox it looks like a normal network interface, but on the host side you decide what gets through.
+
+There's no underlying host network to bridge to, no rules to circumvent, and no way for the guest to reach around the filter.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("sandbox")
+    .image("python")
+    .network(|n| n
+        .policy(NetworkPolicy::allowlist(["api.openai.com", "pypi.org"]))
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Destination, NetworkPolicy, Rule, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("sandbox")
+    .image("python")
+    .network((n) => n.policy({
+        defaultEgress: "deny",
+        defaultIngress: "allow",
+        rules: [
+            Rule.allowEgress(Destination.domain("api.openai.com")),
+            Rule.allowEgress(Destination.domain("pypi.org")),
+        ],
+    }))
+    .create();
+```
+
+```python Python
+from microsandbox import Network, NetworkPolicy, Rule, Sandbox
+
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    network=Network(
+        policy=NetworkPolicy(rules=(
+            Rule.allow(destination="api.openai.com"),
+            Rule.allow(destination="pypi.org"),
+        )),
+    ),
+)
+```
+
+</CodeGroup>
+
+### Extensible filesystem backends <sup><sup>coming soon</sup></sup>
+
+The host controls what the guest sees at the filesystem level. Mount host directories, use managed volumes, or attach custom filesystem backends entirely. Hooks let you intercept reads and writes to do things like encrypt everything going to disk or proxy to remote storage, and the guest never knows the difference.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("encrypted")
+    .image("python")
+    .volume("/secrets", |v| v
+        .bind("/data/secrets")
+        .on_read(move |_path, data| decrypt(data, &key))
+        .on_write(move |_path, data| encrypt(data, &key))
+    )
+    .create().await?;
+```
+
+```typescript TypeScript
+// Filesystem hooks (onRead / onWrite) are coming soon for Node. For now,
+// you can mount the host directory directly:
+await using sb = await Sandbox.builder("encrypted")
+    .image("python")
+    .volume("/secrets", (m) => m.bind("/data/secrets"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+key = get_encryption_key()
+sb = await Sandbox.create(
+    "encrypted",
+    image="python",
+    volumes={
+        "/secrets": Volume.bind("/data/secrets",
+            on_read=lambda path, data: decrypt(data, key),
+            on_write=lambda path, data: encrypt(data, key),
+        ),
+    },
+)
+```
+
+</CodeGroup>
+
+### Snapshot and reuse setup state
+
+Capture a stopped sandbox's writable upper layer as a portable artifact, then boot fresh sandboxes from it. Install dependencies once, snapshot, and `msb run --snapshot ...` workers that skip the setup phase. The artifact is a directory you can `scp` between machines or bundle into a `.tar.zst`. Snapshots today are disk-only and stopped-only; live VM-state snapshots are tracked as future work.
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("baseline")
+    .image("python")
+    .create()
+    .await?;
+
+sb.exec("pip", ["install", "-r", "requirements.txt"]).await?;
+sb.stop_and_wait().await?;
+
+// Snapshot the stopped sandbox under a bare name
+let h = Sandbox::get("baseline").await?;
+let _snap = h.snapshot("after-pip-install").await?;
+
+// Boot 10 workers from the same snapshot (each gets its own upper layer)
+let workers: Vec<Sandbox> = futures::future::try_join_all(
+    (0..10).map(|i| async move {
+        Sandbox::builder(format!("worker-{i}"))
+            .from_snapshot("after-pip-install")
+            .create()
+            .await
+    })
+).await?;
+```
+
+```bash CLI
+msb run --name baseline --detach python -- sleep 3600
+msb exec baseline -- pip install -r requirements.txt
+msb stop baseline
+
+msb snapshot create after-pip-install --from baseline
+
+# Boot 10 workers from the snapshot
+for i in $(seq 1 10); do
+    msb run --name worker-$i --detach --snapshot after-pip-install -- sleep 3600
+done
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.builder("baseline").image("python").create();
+await sb.exec("pip", ["install", "-r", "requirements.txt"]);
+await sb.stopAndWait();
+
+const h = await Sandbox.get("baseline");
+await h.snapshot("after-pip-install");
+
+// Boot 10 workers from the same snapshot
+const workers = await Promise.all(
+    Array.from({ length: 10 }, (_, i) =>
+        Sandbox.builder(`worker-${i}`).fromSnapshot("after-pip-install").create(),
+    ),
+);
+```
+
+```python Python
+import asyncio
+from microsandbox import Sandbox
+
+sb = await Sandbox.create("baseline", image="python")
+await sb.exec("pip", ["install", "-r", "requirements.txt"])
+await sb.stop_and_wait()
+
+h = await Sandbox.get("baseline")
+await h.snapshot("after-pip-install")
+
+# Boot 10 workers from the same snapshot
+workers = await asyncio.gather(
+    *(Sandbox.create(f"worker-{i}", snapshot="after-pip-install") for i in range(10))
+)
+```
+
+</CodeGroup>
+
+### Spawn sandboxes from sandboxes <sup><sup>coming soon</sup></sup>
+
+Code running inside a sandbox can spawn peer sandboxes alongside itself. This is designed for multi-agent systems where agents need to create sub-environments. Peer sandboxes inherit nothing by default (their own network, filesystem, secrets), and the orchestrator coordinates via the SDK, not shared state. If the code isn't running inside a microsandbox, the spawn call fails safely.
+
+### Composable plugin system <sup><sup>coming soon</sup></sup>
+
+Extend microsandbox with in-process Rust plugins or out-of-process plugins in any language. Plugins hook into lifecycle events, exec calls, filesystem operations, or network traffic. They compose naturally, so you can stack an audit logger, a rate limiter, and a network monitor without them knowing about each other.
+
+### Bidirectional events <sup><sup>coming soon</sup></sup>
+
+Guest processes can emit typed events to the host, and the host can send events back. No special libraries required in the guest since any language can write JSON to a socket. This enables structured communication beyond stdin/stdout, like progress reporting, task completion signals, or custom RPC.
+
+<CodeGroup>
+
+```rust Rust
+// Receive events from guest
+let _sub = sb.on_event("task.progress", |event: EventData| {
+    if let Ok(p) = event.data.unwrap().deserialized::<Progress>() {
+        println!("[{}%] {}", p.percent, p.message);
+    }
+});
+
+// Send events to guest
+sb.emit("task.start", TaskConfig {
+    input_file: "/data/input.txt".into(),
+    output_dir: "/data/output".into(),
+}).await?;
+```
+
+```typescript TypeScript
+// Receive events from guest
+const sub = sb.onEvent("task.progress", (event: EventData) => {
+    const { percent, message } = event.data as { percent: number; message: string }
+    console.log(`[${percent}%] ${message}`)
+})
+
+// Send events to guest
+await sb.emit("task.start", { inputFile: "/data/input.txt", options: ["--verbose"] })
+```
+
+```python Python
+# Receive events from guest
+sub = sb.on_event("task.progress", lambda event: (
+    print(f"[{event.data['percent']}%] {event.data['message']}")
+))
+
+# Send events to guest
+await sb.emit("task.start", {
+    "input_file": "/data/input.txt",
+    "output_dir": "/data/output",
+})
+```
+
+</CodeGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="bolt" href="/getting-started/quickstart">
+    Get a sandbox running in under 5 minutes
+  </Card>
+
+  <Card title="Sandbox overview" icon="box" href="/sandboxes/overview">
+    Configuration, rootfs sources, and lifecycle
+  </Card>
+
+  <Card title="CLI reference" icon="square-terminal" href="/cli/overview">
+    Manage sandboxes from the terminal
+  </Card>
+
+  <Card title="SDK reference" icon="code" href="/sdk/rust">
+    Full API documentation for all SDKs
+  </Card>
+</CardGroup>

--- a/docs/ja/getting-started/quickstart.mdx
+++ b/docs/ja/getting-started/quickstart.mdx
@@ -1,0 +1,125 @@
+---
+title: Quickstart
+description: Get a sandbox running in under 5 minutes
+icon: "bolt"
+---
+
+<Note>
+  microsandbox requires **Linux with KVM** enabled, or **macOS with Apple Silicon** (M-series chip). Both use hardware virtualization.
+</Note>
+
+<Tip>
+  Boot a microVM in one command.
+
+  ```bash
+  npx microsandbox run debian
+  ```
+</Tip>
+
+<Steps>
+  <Step title="Install microsandbox">
+    The SDK **embeds the runtime directly**, so no separate server process is needed. Only install the `msb` CLI if you want to manage images, volumes, and sandboxes from the terminal.
+
+    <CodeGroup>
+    ```bash Rust
+    cargo add microsandbox
+    ```
+
+    ```bash TypeScript
+    npm install microsandbox
+    ```
+
+    ```bash Python
+    pip install microsandbox
+    ```
+
+    ```bash CLI
+    curl -fsSL https://install.microsandbox.dev | sh
+    ```
+
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run code in a sandbox">
+    Create a sandbox, execute code inside it, and get the result back.
+
+    <CodeGroup>
+    ```rust Rust
+    use microsandbox::Sandbox;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let sb = Sandbox::builder("hello")
+            .image("python")
+            .memory(512)
+            .create()
+            .await?;
+
+        let output = sb.exec("python", ["-c", "print('Hello from a microVM!')"]).await?;
+        println!("{}", output.stdout()?); // Hello from a microVM!
+
+        sb.stop().await?;
+        Ok(())
+    }
+    ```
+
+    ```typescript TypeScript
+    import { Sandbox } from "microsandbox";
+
+    await using sb = await Sandbox.builder("hello")
+        .image("python")
+        .memory(512)
+        .create();
+
+    const output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"]);
+    console.log(output.stdout()); // Hello from a microVM!
+    ```
+
+    ```python Python
+    import asyncio
+    from microsandbox import Sandbox
+
+    async def main():
+        sb = await Sandbox.create(
+            "hello",
+            image="python",
+            memory=512,
+        )
+
+        output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"])
+        print(output.stdout_text)  # Hello from a microVM!
+
+        await sb.stop()
+
+    asyncio.run(main())
+    ```
+
+    ```bash CLI
+    msb run python -- python3 -c "print('Hello from a microVM!')"
+    ```
+
+    </CodeGroup>
+  </Step>
+</Steps>
+
+## What just happened?
+
+Here's what actually happened behind that `Sandbox.builder(...).create()` call:
+
+1. **Pulled the image** from Docker Hub (or skipped this if it was already cached, since shared layers are deduplicated).
+2. **Assembled the filesystem** by stacking the image layers into a copy-on-write filesystem, so nothing you do inside the sandbox modifies the base image.
+3. **Booted a microVM** as a child process. The 512 MiB you specified is a limit, not a reservation, so the VM only uses what it actually needs.
+4. **Started the guest agent** inside the VM, which set up the environment and opened a communication channel back to the host.
+
+The `exec` call sent a message to that guest agent, which spawned `python` inside the VM, streamed stdout back, and returned the exit code. No SSH involved, no network overhead. The command channel is completely separate from the sandbox's network stack.
+
+<Tip>
+  Because exec doesn't go through the network, it works even when a sandbox has networking disabled via `.disable_network()` and no network interfaces at all.
+</Tip>
+
+## Next steps
+
+- [Understand sandbox configuration](/sandboxes/overview): how the VM, filesystem, and networking fit together
+- [Run commands and stream output](/sandboxes/commands): `exec`, `shell`, `attach`, and streaming
+- [Control network access](/networking/overview): policies, DNS interception, and secret protection
+- [Manage sandboxes with the CLI](/cli/overview): create, inspect, and manage sandboxes from the terminal

--- a/docs/ja/images/disk-images.mdx
+++ b/docs/ja/images/disk-images.mdx
@@ -1,0 +1,82 @@
+---
+title: Disk Images
+description: Boot from QCOW2, Raw, or VMDK disk images
+icon: "compact-disc"
+---
+
+In addition to OCI container images, microsandbox can boot a sandbox directly from a disk image file. The guest gets raw block device access, and its kernel mounts the filesystem from the device directly.
+
+This is a fundamentally different path from OCI images. With OCI, microsandbox stacks image layers as a copy-on-write filesystem. With disk images, the guest owns the block device. No overlay, no copy-on-write between sandboxes.
+
+Use disk images when you need a pre-built VM template, a custom kernel configuration, or an OS that isn't available as a container image.
+
+## Supported formats
+
+| Format | Description |
+|--------|-------------|
+| **QCOW2** | QEMU Copy-On-Write v2. Supports thin provisioning and backing files. The most common format. |
+| **Raw** | Uncompressed raw disk image. No overhead, but no thin provisioning. |
+| **VMDK** | VMware virtual disk format. |
+
+## Usage
+
+When you pass a file path ending in `.qcow2`, `.raw`, or `.vmdk`, microsandbox auto-detects the format. For ambiguous cases, specify the format and filesystem type explicitly.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::size::SizeExt;
+
+// Auto-detect
+let sb = Sandbox::builder("custom-vm")
+    .image("./ubuntu-22.04.qcow2")
+    .cpus(2)
+    .memory(2.gib())
+    .create()
+    .await?;
+
+// Explicit
+let sb2 = Sandbox::builder("custom-vm")
+    .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
+    .cpus(1)
+    .memory(512)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+// Auto-detect format from the file extension
+await using sb = await Sandbox.builder("custom-vm")
+    .image("./ubuntu-22.04.qcow2")
+    .cpus(2)
+    .memory(2048)
+    .create();
+
+// Explicit format / fstype via a RootfsSource literal
+await using sb2 = await Sandbox.builder("custom-vm")
+    .image({
+        kind: "disk",
+        path: "./alpine.raw",
+        format: "raw",
+        fstype: "ext4",
+    })
+    .cpus(1)
+    .memory(512)
+    .create();
+```
+
+```python Python
+from microsandbox import Image, Sandbox
+
+# Auto-detect format from file extension
+sb = await Sandbox.create("custom-vm", image="./ubuntu-22.04.qcow2", cpus=2, memory=2048)
+
+# Explicit filesystem type
+sb2 = await Sandbox.create("custom-vm", image=Image.disk("./alpine.raw", fstype="ext4"), cpus=1, memory=512)
+```
+</CodeGroup>
+
+<Note>
+  The filesystem type (`ext4`, `xfs`, etc.) must match what's actually on the disk image. The guest kernel mounts it using the specified filesystem driver.
+</Note>

--- a/docs/ja/images/overview.mdx
+++ b/docs/ja/images/overview.mdx
@@ -1,0 +1,177 @@
+---
+title: OCI Images
+description: Use standard container images from any registry
+icon: "layer-group"
+---
+
+microsandbox uses standard OCI container images as root filesystems. Docker Hub, GHCR, ECR, GCR, any OCI-compatible registry works. Existing images run as-is.
+
+When you specify an image like `python`, microsandbox pulls the manifest, downloads the layers in parallel, and stacks them as a copy-on-write filesystem. Changes inside the sandbox don't modify the base image. Two sandboxes using the same image share the same cached layers on disk.
+
+## Pull policies
+
+By default, microsandbox pulls an image only if it isn't already cached. You can change this behavior.
+
+| Policy | Behavior |
+|--------|----------|
+| `"if-missing"` | Pull only if not cached (default) |
+| `"always"` | Always check the registry for updates |
+| `"never"` | Use local cache only, fail if missing |
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+from microsandbox import PullPolicy, Sandbox
+
+sb = await Sandbox.create("worker", image="python", pull_policy=PullPolicy.ALWAYS)
+```
+</CodeGroup>
+
+<Tip>
+  Once an image reference is resolved, microsandbox pins the exact layers. `python` is resolved to a specific set of immutable layers at first pull. Subsequent `start()` calls use the pinned layers without re-resolving the mutable tag, so your sandbox is reproducible even if the upstream tag moves.
+</Tip>
+
+## Private registries
+
+Authenticate to private registries by passing credentials.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry(|r| r.auth(RegistryAuth::Basic {
+        username: "deploy".into(),
+        password: std::env::var("REGISTRY_PASSWORD")?,
+    }))
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry((r) => r.auth({
+        kind: "basic",
+        username: "deploy",
+        password: process.env.REGISTRY_TOKEN!,
+    }))
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import PullPolicy, RegistryAuth, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="registry.corp.io/team/app:latest",
+    registry_auth=RegistryAuth.basic("deploy", os.environ["REGISTRY_PASSWORD"]),
+    pull_policy=PullPolicy.ALWAYS,
+)
+```
+</CodeGroup>
+
+## Registry TLS
+
+By default, microsandbox connects to registries over HTTPS using system CA roots. You can customize this per-registry in `~/.microsandbox/config.json`.
+
+### Plain HTTP registries
+
+Local registries often run without TLS. Mark them as insecure to connect over plain HTTP:
+
+```json
+{
+  "registries": {
+    "hosts": {
+      "localhost:5050": {
+        "insecure": true
+      }
+    }
+  }
+}
+```
+
+### Custom CA certificates
+
+For registries using self-signed or internal CA certificates, point `ca_certs` to a PEM file. This applies globally to all registry connections:
+
+```json
+{
+  "registries": {
+    "ca_certs": "/path/to/ca-bundle.pem"
+  }
+}
+```
+
+The certificates are added to the default system roots — public registries continue to work normally.
+
+### Combined configuration
+
+```json
+{
+  "registries": {
+    "ca_certs": "/path/to/corporate-ca.pem",
+    "hosts": {
+      "localhost:5050": {
+        "insecure": true,
+        "auth": { "username": "deploy", "password_env": "REGISTRY_TOKEN" }
+      },
+      "ghcr.io": {
+        "auth": { "username": "user", "store": "keyring" }
+      }
+    }
+  }
+}
+```
+
+These settings can also be set per-sandbox via the SDK, overriding global config:
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("localhost:5050/my-app:latest")
+    .registry(|r| r.insecure())
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("localhost:5050/my-app:latest")
+    .registry((r) => r.insecure())
+    .create();
+```
+</CodeGroup>
+
+## Image storage
+
+Images are cached in the global microsandbox home directory:
+
+| Path | Description |
+|------|-------------|
+| `~/.microsandbox/cache/layers/` | Downloaded and extracted image layers |
+| `~/.microsandbox/db/` | Database tracking image metadata and digests |
+
+Layers are content-addressable and deduplicated. If `python` and `python` share a base layer, it's stored once.
+
+<Tip>
+  Use `msb pull` from the CLI to pre-pull images before creating sandboxes. This avoids blocking on a download during `Sandbox.create`.
+</Tip>

--- a/docs/ja/networking/dns.mdx
+++ b/docs/ja/networking/dns.mdx
@@ -1,0 +1,169 @@
+---
+title: DNS
+description: How the sandbox resolves DNS queries
+icon: "magnifying-glass"
+---
+
+DNS queries from the sandbox are intercepted on the host. Rather than letting the guest talk to a resolver directly, microsandbox proxies each query, which lets you:
+
+- block lookups by domain or suffix,
+- pin which upstream resolvers get used,
+- tune the query timeout,
+- power domain-based policy rules (by mapping responses back to IPs).
+
+The knobs below cover the day-to-day controls. For the rebinding and TOCTOU protections that also ride on the interceptor, see the [security model](/networking/security-model).
+
+## Blocking domains
+
+Domain blocking lives in the network policy as `deny Domain(...)` / `deny DomainSuffix(...)` rules. The interceptor enforces them at three layers:
+
+1. **DNS resolution** — denied names get a local `REFUSED` response; the upstream resolver never sees them.
+2. **TLS first-flight** — when a guest hardcodes an IP and opens a TLS connection, the SNI is checked against the same rules.
+3. **TCP egress (cache fallback)** — for non-TLS traffic, the resolved-hostname cache disambiguates by IP.
+
+The bulk-deny shortcuts in each SDK are convenience for `deny Domain` / `deny DomainSuffix` rules; they prepend onto whatever policy is set so the deny takes precedence over later allow rules.
+
+<CodeGroup>
+```rust Rust
+let policy = NetworkPolicy::builder()
+    .default_allow()
+    .egress(|e| e
+        .deny_domains(["malware.example.com"])
+        .deny_domain_suffixes([".tracking.com"]))
+    .build()?;
+
+let sb = Sandbox::builder("safe-agent")
+    .image("python")
+    .network(|n| n.policy(policy))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("safe-agent")
+    .image("python")
+    .network({
+        denyDomains: ["malware.example.com"],
+        denyDomainSuffixes: [".tracking.com"],
+    })
+    .create();
+```
+
+```python Python
+from microsandbox import Network, Sandbox
+
+sb = await Sandbox.create(
+    "safe-agent",
+    image="python",
+    network=Network(
+        deny_domains=("malware.example.com",),
+        deny_domain_suffixes=(".tracking.com",),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name safe-agent \
+  --deny-domain malware.example.com \
+  --deny-domain-suffix .tracking.com
+```
+
+</CodeGroup>
+
+
+## Pinning nameservers
+
+By default the sandbox picks up the host's resolver list automatically:
+
+- **macOS**: reads `State:/Network/Global/DNS` from the system configuration store, with `/etc/resolv.conf` as a fallback when the store isn't available.
+- **Linux**: reads `/etc/resolv.conf` directly.
+
+You can override this by setting `nameservers` to pin the exact resolvers you want (e.g. `1.1.1.1`, `dns.google`), which is useful when auto-discovery picks the wrong ones.
+
+Values can be plain IPs, `IP:PORT`, hostnames, or `HOST:PORT`. Hostnames are resolved once at sandbox startup using the host's OS resolver.
+
+<CodeGroup>
+```rust Rust
+use microsandbox_network::dns::Nameserver;
+
+let sb = Sandbox::builder("safe-agent")
+    .image("python")
+    .network(|n| n
+        .dns(|d| d
+            .nameservers([
+                "1.1.1.1".parse::<Nameserver>()?,
+                "1.0.0.1".parse::<Nameserver>()?,
+            ])
+            .query_timeout_ms(3000)
+        )
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("safe-agent")
+    .image("python")
+    .network((n) => n.dns((d) =>
+        d.nameservers(["1.1.1.1", "1.0.0.1"])
+            .queryTimeoutMs(3000),
+    ))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "safe-agent",
+    image="python",
+    network=Network(
+        dns=DnsConfig(
+            nameservers=("1.1.1.1", "1.0.0.1"),
+            query_timeout_ms=3000,
+        ),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name safe-agent \
+  --dns-nameserver 1.1.1.1 \
+  --dns-nameserver 1.0.0.1 \
+  --dns-query-timeout-ms 3000
+```
+
+</CodeGroup>
+
+If the guest aims a query at a specific resolver (`dig @1.1.1.1`, an `/etc/resolv.conf` entry inside the guest, or a library call that takes a resolver IP), the interceptor forwards it to that resolver directly. The pinned defaults aren't used in this case. The network policy still applies: the query only goes through if the destination IP is allowed.
+
+## DNS over alternative transports
+
+The block list and rebind protection only apply to queries the gateway can see. A guest that routes DNS through an encrypted or non-DNS protocol bypasses both unless the gateway intercepts or refuses it.
+
+**Intercepted** (block list and rebind protection apply):
+- DNS over UDP (UDP/53)
+- DNS over TCP (TCP/53)
+- DNS over TLS (DoT, TCP/853): requires [TLS interception](/networking/tls)
+
+**Refused** (guest's stub falls back to plain DNS):
+- DNS over QUIC (DoQ, UDP/853)
+- mDNS (UDP/5353), LLMNR (UDP/5355), NetBIOS-NS (UDP/137)
+
+**Not distinguishable from regular traffic** (you must filter via network policy):
+- DNS over HTTPS (DoH, TCP/443)
+
+For strict DNS integrity, combine DoT interception with a network policy denying egress `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway.
+
+## Domain-based policy rules
+
+Network policy rules can match a destination by exact domain or by suffix. The interceptor watches DNS responses as they flow back to the guest and keeps track of which IP addresses belong to which domain.
+
+A connection to `93.184.216.34` is only allowed by a rule targeting `example.com` if that IP actually came back as an answer to a lookup for `example.com` from this sandbox.
+
+Because of that, domain rules only take effect on connections that are preceded by a DNS lookup from inside the sandbox. An application that connects to a hard-coded IP it didn't resolve through the interceptor won't match any domain rule.
+
+## See also
+
+- [Security model](/networking/security-model): rebinding protection and DNS-to-IP binding (TOCTOU defense)
+- [TLS interception](/networking/tls): domains that get intercepted also go through TLS inspection

--- a/docs/ja/networking/overview.mdx
+++ b/docs/ja/networking/overview.mdx
@@ -1,0 +1,232 @@
+---
+title: Overview
+description: Control network access and isolation
+icon: "network-wired"
+---
+
+All network traffic from a sandbox flows through a host-controlled networking stack. From inside, the sandbox sees a normal network interface, but on the host side every packet is subject to policy before it goes anywhere. The sandbox's only path to the outside world is through this stack, so blocked traffic never leaves the VM.
+
+## Defaults
+
+Without any policy flags, sandboxes get **public-internet egress only**: routable destinations work, but private (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`), loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), and the cloud metadata endpoint (`169.254.169.254`) are denied. Inbound traffic on published ports is unfiltered until you add an explicit ingress rule.
+
+To turn off networking entirely:
+
+```bash
+msb create python --name isolated --no-net
+```
+
+```rust
+let sb = Sandbox::builder("isolated")
+    .image("python")
+    .network(|n| n.enabled(false))
+    .create()
+    .await?;
+```
+
+## Custom policies
+
+A policy is a list of rules plus two direction-specific defaults:
+
+```text
+default_egress  : Allow | Deny     (action when no egress rule matches)
+default_ingress : Allow | Deny     (action when no ingress rule matches)
+rules           : [Rule, ...]      (first match wins)
+```
+
+Each rule carries its own direction (`Egress`, `Ingress`, or `Any`), a destination, an optional protocol set, an optional port set, and an action.
+
+### CLI
+
+`--net-rule` takes a comma-separated list of tokens shaped as
+`<action>[:<direction>]@<target>[:<proto>[:<ports>]]`. Direction defaults to `egress` when omitted. Repeating the flag concatenates tokens in argv order; first match wins.
+
+```bash
+# Public internet plus the host machine, deny everything else by default
+msb create python --name agent \
+    --net-rule "allow@public,allow@host"
+
+# Allow public internet plus a specific private host on tcp/443
+msb create alpine --name secure-agent \
+    --net-rule "allow@10.0.5.10:tcp:443,allow@public" \
+    --net-default-egress deny
+
+# Block tcp/445 to private IPs while keeping everything else open
+msb create alpine --name smb-blocked \
+    --net-default-egress allow \
+    --net-rule "deny@private:tcp:445"
+
+# Publish a port and only accept ingress from RFC1918 sources
+msb create python --name api \
+    --port 8080:8080 \
+    --net-rule "allow:ingress@private"
+```
+
+`<target>` accepts `any`, a group keyword (`public`, `private`, `loopback`, `link-local`, `meta`, `multicast`, `host`), an IP, a CIDR, a domain (with at least one dot), `domain=<name>` for single-label hostnames, or `suffix=<domain>` for subdomain matches.
+
+### Rust
+
+```rust
+use microsandbox::{NetworkPolicy, Sandbox};
+
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e
+        .tcp().port(443).allow_public()
+        .udp().port(53).allow_public())
+    .build()?;
+
+let sb = Sandbox::builder("secure-agent")
+    .image("alpine")
+    .network(|n| n.policy(policy))
+    .create()
+    .await?;
+```
+
+The builder accepts string inputs (`.ip("10.0.0.5")`, `.cidr("10.0.0.0/24")`, `.domain("api.example.com")`, etc.) and parses them at `.build()` time, so the chain stays clean. See the [Rust reference](/sdk/rust/networking) for the full surface (per-category shortcuts, the explicit-rule sub-builder, shadow-rule warnings).
+
+### TypeScript / Python
+
+Both SDKs accept policies as plain config objects matching the wire format. Direction strings are `"egress"`, `"ingress"`, or `"any"`. Group keywords match the CLI grammar.
+
+```typescript
+import { Destination, PortRange, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("secure-agent")
+    .image("alpine")
+    .network((n) => n.policy({
+        defaultEgress: "deny",
+        defaultIngress: "allow",
+        rules: [
+            {
+                direction: "egress",
+                destination: Destination.any(),
+                protocols: ["tcp"],
+                ports: [PortRange.single(443)],
+                action: "allow",
+            },
+            {
+                direction: "egress",
+                destination: Destination.any(),
+                protocols: ["udp"],
+                ports: [PortRange.single(53)],
+                action: "allow",
+            },
+        ],
+    }))
+    .create();
+```
+
+```python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "secure-agent",
+    image="alpine",
+    network={
+        "policy": {
+            "default_egress": "deny",
+            "default_ingress": "allow",
+            "rules": [
+                {"action": "allow", "direction": "egress", "protocol": "tcp", "port": "443"},
+                {"action": "allow", "direction": "egress", "protocol": "udp", "port": "53"},
+            ],
+        },
+    },
+)
+```
+
+Domain rules match flows where the guest resolved the name through the sandbox's DNS interceptor. See [DNS](/networking/dns) for how the resolved-hostname cache works.
+
+## Port mapping
+
+Expose ports from the sandbox to the host so services running inside the VM are reachable from your machine.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("api")
+    .image("python")
+    .port(8080, 80)
+    .port_udp(5353, 5353)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("api")
+    .image("python")
+    .port(8080, 80)
+    .portUdp(5353, 5353)
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "api",
+    image="python",
+    ports={8080: 80},
+)
+```
+
+```bash CLI
+msb create python --name api -p 8080:80
+```
+
+</CodeGroup>
+
+## Reaching the host
+
+From inside the sandbox, `host.microsandbox.internal` resolves to the host machine, same idea as Docker's `host.docker.internal`. Use it to call a dev server, database, or other process running on your machine without hard-coding an IP.
+
+```bash
+# Inside the sandbox:
+curl http://host.microsandbox.internal:8080
+```
+
+The name is wired through `/etc/hosts` and the DNS interceptor, so both standard resolvers and tools that bypass `/etc/hosts` (like `dig`) find it.
+
+The default policy denies host access — the sandbox gateway sits in a private range, same as any other local destination. Add the `host` group to open it:
+
+```bash
+msb create python --name dev-agent \
+    --net-rule "allow@public,allow@host"
+```
+
+```rust
+NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.allow_public().allow_host())
+    .build()?
+```
+
+### Loopback vs host: a common trap
+
+`Group::Loopback` (`127.0.0.0/8`, `::1`) and `Group::Host` (the per-sandbox gateway IPs) are different things. The two-word summary:
+
+- **`loopback`** = the guest's own loopback interface. Services running inside the same VM.
+- **`host`** = the host machine, reached through `host.microsandbox.internal`.
+
+If you're coming from Docker and reach for `.allow_loopback()` to "let the sandbox talk to my host's localhost," that's the trap — you want `.allow_host()` instead. `.allow_loopback()` only fires for traffic *inside* the guest, which doesn't reach the policy gate under normal kernel routing anyway.
+
+`.deny_loopback()` does have a real use case. In `--net-default-egress allow` configurations, a process inside the guest could craft a packet bound to `eth0` with `dst=127.0.0.1`, route it past the guest kernel, and have smoltcp on the host land it on the host's loopback. `.deny_loopback()` blocks that vector. Default policies (with the implicit deny on egress) already cover this.
+
+If you want "everything near the sandbox" — guest loopback, link-local, and the host machine — `.allow_local()` is sugar for that triple. `Metadata` is deliberately excluded so cloud-IMDS isn't quietly exposed; opt in via `.allow_meta()` if you need it.
+
+## Protocol support
+
+For most sandboxed workloads, networking behaves the way you'd expect:
+
+- Normal egress **TCP** and **UDP** traffic works, including common tools and libraries like `curl`, `wget`, package managers, HTTP clients, database drivers, and DNS lookups.
+- **DNS** queries are intercepted on the host side. See [DNS](/networking/dns) for blocking, pinned resolvers, and query timeouts.
+- **ICMP echo** is supported: pinging external hosts works on systems that support unprivileged ICMP echo sockets.
+- **Ingress** on published ports is gated by the same policy. Denied connections drop with TCP RST so the peer sees `ECONNRESET`.
+
+<Note>
+**Raw sockets** and **full ICMP forwarding** are not supported because they require elevated privileges on the host. Tools that depend on richer ICMP behavior, such as `traceroute`, are outside the current scope.
+</Note>
+
+## Next
+
+- [DNS](/networking/dns): domain blocking, pinned nameservers, query timeouts
+- [TLS interception](/networking/tls): HTTPS inspection with an auto-generated CA
+- [Security model](/networking/security-model): how the stack defends against SSRF, rebinding, and metadata exfiltration

--- a/docs/ja/networking/security-model.mdx
+++ b/docs/ja/networking/security-model.mdx
@@ -1,0 +1,90 @@
+---
+title: Security Model
+description: What the networking stack defends against
+icon: "shield-halved"
+---
+
+microsandbox's networking defaults are shaped around giving an AI agent, a scraper, or some other untrusted workload access to the internet without letting it pivot into your internal infrastructure. This page walks through the specific threats the stack is designed to handle and where each defense lives.
+
+## Private IPs and the host's local network
+
+The largest class of real damage comes from workloads reaching things that live *inside* your network: the host machine itself, a local database, another VM on the same subnet. The default policy addresses this by denying egress to anything outside `Group::Public` (the complement of the named local categories), which covers:
+
+- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10` (RFC1918 + CGN private ranges)
+- `127.0.0.0/8`, `::1` (loopback)
+- `169.254.0.0/16`, `fe80::/10` (link-local)
+- `169.254.169.254` (cloud metadata, takes precedence over link-local)
+- the per-sandbox gateway IPs (`Group::Host`)
+
+If an agent runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Override the default with `--net-default-egress allow` only when the workload genuinely needs broad reach, or use `--no-net` when it doesn't need network at all.
+
+## Cloud metadata endpoints
+
+On AWS, GCP, Azure, and similar platforms, `169.254.169.254` is the instance metadata service, a well-known SSRF target because it hands out temporary credentials to anything that can connect. The default policy blocks it via the `Group::Public` complement. For custom policies that flip `default_egress` to `Allow`, `Group::Metadata` lets you deny it explicitly:
+
+```bash
+msb create python --name agent \
+    --net-default-egress allow \
+    --net-rule "deny@meta"
+```
+
+```rust
+NetworkPolicy::builder()
+    .default_allow()
+    .rule(|r| r.egress().deny_meta())
+    .build()?
+```
+
+## DNS rebinding
+
+An attacker who controls a domain can set up records that resolve to a public IP during the initial allowlist check and then flip to a private IP on a subsequent lookup. The guest ends up making a request that *looked* like it was going to `evil.example.com` and actually lands on `192.168.1.10`.
+
+Rebind protection catches this at the response level: when the DNS interceptor sees an answer resolving a domain to a private, loopback, or link-local IP, the response is rewritten to `REFUSED` and the connection never gets made. This is on by default. You can turn it off when you genuinely need domains to resolve to internal hosts (local development, split-horizon DNS):
+
+<CodeGroup>
+```rust Rust
+.network(|n| n.dns(|d| d.rebind_protection(false)))
+```
+
+```typescript TypeScript
+.network((n) => n.dns((d) => d.rebindProtection(false)))
+```
+
+```python Python
+network=Network(dns=DnsConfig(rebind_protection=False))
+```
+
+```bash CLI
+msb create python --name dev --no-dns-rebind-protection
+```
+
+</CodeGroup>
+
+## DNS-to-IP binding (TOCTOU)
+
+Even without rebinding tricks, a classic time-of-check/time-of-use race exists. An allowlisted domain resolves to an allowed IP when the policy is checked. The guest then looks it up again at connect time and reaches a different IP.
+
+Domain-based policy rules close this by maintaining a pin set of observed DNS answers. A connection only matches a domain rule if its destination IP was actually returned as an answer to a DNS query for that domain from this sandbox. A guest that hard-codes an IP it didn't resolve through the interceptor can't slip past a domain-based allowlist.
+
+The same mechanism gates host-scoped secret injection. When a `SecretEntry` is restricted via `allowed_hosts`, the secret is only injected into outbound requests whose destination IP the interceptor tied to one of those hosts. An exfiltration attempt that POSTs the secret to an arbitrary IP won't receive the injection in the first place.
+
+## DNS bypass surface
+
+DNS-based defenses (block list, rebind protection, domain pinning) only work on queries the interceptor sees. The gateway intercepts UDP/53 and TCP/53 directly, and DoT (TCP/853) when TLS interception is enabled. Alternative transports are either refused at the port layer (DoQ, mDNS, LLMNR, NetBIOS-NS) or indistinguishable from regular traffic (DoH on TCP/443). Tunneled DNS (VPN, SOCKS5 hostname mode, HTTP `CONNECT`) is carried inside the outer encrypted flow and never reaches the forwarder.
+
+For workloads where DNS integrity matters, pair DoT interception with a network policy that denies egress `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway. Tunneled DNS is a network-layer concern: close it by restricting egress to an allowlist that excludes tunnel destinations. See [DNS](/networking/dns) for the transport-by-transport breakdown.
+
+## Out of scope
+
+The networking stack doesn't try to defend against:
+
+- **Kernel exploits inside the guest.** The microVM boundary is what keeps a compromised guest contained.
+- **Raw packet crafting from outside the sandbox.** Host-side privileged processes aren't in this threat model.
+- **Host tampering.** If a workload can modify host-side config, it's already past this layer.
+- **Deep ICMP behavior.** Supported ICMP is limited to unprivileged echo; `traceroute`-style flows are not proxied.
+- **Host trust store integrity.** When [`trust_host_cas`](/sdk/rust/networking#trust_host_cas) is opted into, an attacker who can plant a CA on the host has that trust inside every sandbox. Off by default for exactly this reason.
+
+## See also
+
+- [DNS](/networking/dns): the controls that ride on the DNS interceptor
+- [TLS interception](/networking/tls): plaintext visibility for per-host policy and secret injection

--- a/docs/ja/networking/tls.mdx
+++ b/docs/ja/networking/tls.mdx
@@ -1,0 +1,134 @@
+---
+title: TLS Interception
+description: HTTPS inspection with an auto-generated CA
+icon: "lock"
+---
+
+Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server, which is how features like per-host secret injection and URL-level policy checks are able to see inside what would otherwise be an opaque stream.
+
+## How it works
+
+When you enable TLS interception:
+
+1. A CA key and certificate are generated for the sandbox at creation time. The CA is scoped to that sandbox: it's not shared across sandboxes or with the host.
+2. The guest's trust store is updated to trust this CA.
+3. When the guest opens an HTTPS connection, the host-side proxy intercepts the handshake, generates a leaf certificate for the target domain on the fly, and signs it with the per-sandbox CA.
+4. The proxy opens its own TLS connection to the upstream server and bridges the two.
+
+Because the CA lives only for the sandbox's lifetime, nothing signed by it is trusted anywhere else.
+
+## Enabling interception
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("agent")
+    .image("python")
+    .network(|n| n
+        .tls(|t| t
+            .bypass("pinned-api.example.com")
+            .bypass("*.gov")
+        )
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("agent")
+    .image("python")
+    .network((n) => n.tls((t) =>
+        t.bypass("pinned-api.example.com").bypass("*.gov"),
+    ))
+    .create();
+```
+
+```python Python
+from microsandbox import Network, Sandbox, TlsConfig
+
+sb = await Sandbox.create(
+    "agent",
+    image="python",
+    network=Network(
+        tls=TlsConfig(bypass=("pinned-api.example.com", "*.gov")),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name agent \
+  --tls-intercept \
+  --tls-bypass "pinned-api.example.com" \
+  --tls-bypass "*.gov"
+```
+
+</CodeGroup>
+
+## Bypass patterns
+
+Some domains don't play well with interception, typically ones whose clients pin a specific certificate or public key instead of trusting the system CA store. Software update channels (browser autoupdate, macOS `softwareupdate`, package-manager mirrors that ship a pinned signing CA) and vendor SDKs that bundle their own pinned CA are the usual suspects. Add them to the bypass list and their traffic flows through as-is, encrypted end-to-end between the guest and the upstream server.
+
+Bypass patterns accept exact matches (`api.example.com`) and wildcards (`*.gov`, `*.apple.com`).
+
+## Limits
+
+- **Pinned clients bypass the trust store.** Any client that pins the server's certificate or public key (rather than trusting the system CA) will fail TLS interception and needs to be bypassed explicitly.
+- **Bypassed traffic is opaque.** Policy checks that depend on inspecting request content (URL-based rules, secret injection with `require_tls_identity`) don't apply on bypassed domains.
+- **Client certificates are not proxied.** mTLS flows where the guest is the one presenting a client certificate aren't supported through interception; add those hosts to the bypass list.
+
+## Trusting host CAs
+
+Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, ...) terminate outbound HTTPS at the host and re-sign it with a gateway CA. That CA is installed in your macOS Keychain or Linux trust store as part of the corporate rollout, so HTTPS works silently on the host. Inside a sandbox it doesn't: the guest's stock Mozilla bundle has never seen the gateway CA, so `apk update`, `pip install`, `curl`, and any SDK fetch fail with `server certificate not trusted`.
+
+By default the sandbox does not extend host trust into the guest, so the guest validates TLS strictly against its stock Mozilla bundle. Opt in when you need the guest to trust whatever the host trusts: at sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle.
+
+<Note>
+**Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox.
+
+It matches the existing threat model (a host-access attacker already owns the sandbox), but worth knowing before enabling on a host with an unfamiliar trust store.
+</Note>
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("agent")
+    .image("alpine")
+    .network(|n| n.trust_host_cas(true))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("agent")
+    .image("alpine")
+    .network((n) => n.trustHostCAs(true))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "agent",
+    image="alpine",
+    network=Network(trust_host_cas=True),
+)
+```
+
+```bash CLI
+msb run alpine --trust-host-cas -- apk update
+```
+
+</CodeGroup>
+
+### Interaction with TLS interception
+
+TLS interception also covers the corporate-proxy case, but only on the ports it's configured for (default `[443]`), and only for non-bypassed domains. It doesn't touch QUIC / HTTP/3 flows. Everything outside that scope (gRPC, Postgres / Redis / Mongo TLS, custom 8443, non-intercepted ports, bypassed domains) goes over raw TLS from the guest, where host-CA trust is what makes certificate validation succeed.
+
+The two features compose. Turn on [`trust_host_cas`](/sdk/rust/networking#trust_host_cas) alongside TLS interception when you need both: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Leave it off to keep the guest's TLS stack validating strictly against its stock Mozilla bundle.
+
+## See also
+
+- [DNS](/networking/dns): the DNS interceptor is what makes per-host rules possible, and DoT interception reuses this TLS path
+- [Security model](/networking/security-model): how TLS interception interacts with secret injection and SSRF defenses

--- a/docs/ja/recipes/docker.mdx
+++ b/docs/ja/recipes/docker.mdx
@@ -1,0 +1,57 @@
+---
+title: Running in Docker
+description: Deploy microsandbox as a Docker container on Linux
+icon: "box"
+---
+
+<Tip>
+  For production use, we recommend [installing microsandbox natively](/getting-started/quickstart).
+</Tip>
+
+microsandbox publishes multi-arch Docker images (amd64/arm64) to GitHub Container Registry. This is an interim solution for environments that require containerized deployment, pending microsandbox implementing the [OCI runtime spec](https://github.com/opencontainers/runtime-spec).
+
+## Prerequisites
+
+- A **Linux** host with KVM support (`/dev/kvm` must be available)
+- Docker installed
+
+## Pull the image
+
+```bash
+docker pull ghcr.io/superradcompany/microsandbox:latest
+```
+
+Or pin to a specific version:
+
+```bash
+docker pull ghcr.io/superradcompany/microsandbox:0.4.0
+```
+
+## Run a sandbox
+
+The container requires `--privileged` and `/dev/kvm` access to run microVMs:
+
+```bash
+docker run --privileged --device /dev/kvm \
+  ghcr.io/superradcompany/microsandbox:latest \
+  run python --name my-sandbox --replace
+```
+
+## Persistent data
+
+By default, sandbox data (images, cache, databases) is stored inside the container and lost when it stops. Mount a volume to persist data across restarts:
+
+```bash
+docker run --privileged --device /dev/kvm \
+  -v microsandbox_data:/root/.microsandbox \
+  ghcr.io/superradcompany/microsandbox:latest \
+  run python --name my-sandbox --replace
+```
+
+## Available tags
+
+| Tag | Description |
+|-----|-------------|
+| `latest` | Latest release |
+| `x.y.z` (e.g. `0.4.0`) | Specific version |
+| `x.y` (e.g. `0.4`) | Latest patch of a minor version |

--- a/docs/ja/recipes/local-images.mdx
+++ b/docs/ja/recipes/local-images.mdx
@@ -1,0 +1,72 @@
+---
+title: Using Local Docker Images
+description: Use locally built Docker images with microsandbox via a local registry
+icon: "boxes-stacked"
+---
+
+microsandbox pulls images from OCI-compatible registries. If you build an image locally with `docker build`, microsandbox can't access it directly from Docker's local store. The workaround is to run a local registry and push your image there.
+
+## Step 1: Start a local registry
+
+Run a local OCI registry on port 5050:
+
+```bash
+docker run -d -p 5050:5000 --name registry registry:2
+```
+
+<Tip>
+  Port 5000 is used by AirPlay on macOS. This guide uses port 5050 to avoid conflicts.
+</Tip>
+
+## Step 2: Build, tag, and push your image
+
+Build your Docker image and tag it for the local registry:
+
+```bash
+docker build -t localhost:5050/my-image:latest .
+```
+
+If you already have an existing image, re-tag it:
+
+```bash
+docker tag my-image:latest localhost:5050/my-image:latest
+```
+
+Push to the local registry:
+
+```bash
+docker push localhost:5050/my-image:latest
+```
+
+## Step 3: Pull with microsandbox
+
+Since the local registry runs over plain HTTP, use the `--insecure` flag:
+
+```bash
+msb pull localhost:5050/my-image:latest --insecure
+```
+
+## Step 4: Use it in microsandbox
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("localhost:5050/my-image:latest")
+    .registry(|r| r.insecure())
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("localhost:5050/my-image:latest")
+    .registry((r) => r.insecure())
+    .create();
+```
+</CodeGroup>
+
+<Tip>
+  For persistent configuration that applies to all CLI and SDK operations, add the registry to `~/.microsandbox/config.json` instead. See [Registry TLS](/images/overview#registry-tls).
+</Tip>

--- a/docs/ja/recipes/systemd-services.mdx
+++ b/docs/ja/recipes/systemd-services.mdx
@@ -1,0 +1,65 @@
+---
+title: Booting Under systemd
+description: Hand PID 1 to systemd inside the guest so services run under a real init
+icon: "gear"
+---
+
+By default the microsandbox agent is PID 1. That's enough for one-shot processes, but anything that calls into `systemctl`, `loginctl`, or expects a session bus will fail.
+
+`--init auto` hands PID 1 over to systemd. The rest of the guest then behaves like a normal Linux box.
+
+## Step 1: Boot
+
+```bash
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  --memory 1G --cpus 2 \
+  --init auto \
+  -- bash
+```
+
+`debian-systemd` is one of the optional bases we maintain in [guest-images](https://github.com/superradcompany/guest-images) for cases like this. `--init auto` probes a small set of well-known paths and picks the first that exists. See [Custom init system](/sandboxes/customize#custom-init-system) for the full list and for pinning to an exact path.
+
+## Step 2: Confirm systemd is PID 1
+
+```bash
+root@msb:/# systemctl status
+● msb
+    State: running
+    Units: 113 loaded (incl. loaded aliases)
+  systemd: 252.39-1~deb12u1
+```
+
+Or check directly:
+
+```bash
+root@msb:/# cat /proc/1/comm
+systemd
+```
+
+## Step 3: Manage units
+
+`systemctl` works as it does on bare metal. Inspect a unit shipped with the image:
+
+```bash
+root@msb:/# systemctl status systemd-journald
+● systemd-journald.service - Journal Service
+     Loaded: loaded (/lib/systemd/system/systemd-journald.service; static)
+     Active: active (running)
+```
+
+Install your own and start it:
+
+```bash
+root@msb:/# apt update && apt install -y nginx
+root@msb:/# systemctl enable --now nginx
+root@msb:/# curl -s localhost | head -1
+<!DOCTYPE html>
+```
+
+Microsandbox is detected as a container, so packages with `policy-rc.d` deferral install but don't auto-start. `systemctl enable --now <unit>` starts them in one step.
+
+## Notes
+
+- **Image choice matters.** Distroless / minimal images (`python:3.13-slim`, `alpine`) don't ship a systemd init binary; `--init auto` will fail and `kernel.log` will list every path it tried. Use a systemd-equipped base or layer one in.
+- **Memory budget.** systemd's idle footprint is ~50 MiB; daemons add more. Bump `--memory` if your service is hungry.
+- **Other inits work.** `--init` accepts any absolute path. s6, OpenRC, runit, or a hand-rolled `/sbin/init` shell script are all fine; `auto` just covers the systemd-on-Debian/Ubuntu case.

--- a/docs/ja/sandboxes/commands.mdx
+++ b/docs/ja/sandboxes/commands.mdx
@@ -1,0 +1,284 @@
+---
+title: Commands
+description: Execute commands, stream output, and interact with sandboxes
+icon: "terminal"
+---
+
+Command execution doesn't use SSH or the network. There's a dedicated channel between the host and a guest agent running inside the VM, completely separate from the sandbox's network stack. The agent spawns processes, streams output back, and reports exit codes.
+
+One nice consequence: `exec` works even when a sandbox has networking fully disabled.
+
+## Execute a command
+
+Run a command and wait for it to complete. You get back the exit code, stdout, and stderr.
+
+<CodeGroup>
+```rust Rust
+let output = sb.exec("python", ["-c", "print('hello')"]).await?;
+println!("{}", output.stdout()?);     // "hello\n"
+println!("{}", output.status().code); // 0
+```
+
+```typescript TypeScript
+const output = await sb.exec("python", ["-c", "print('hello')"]);
+console.log(output.stdout()); // "hello\n"
+console.log(output.success);  // true
+console.log(output.code);     // 0
+```
+
+```python Python
+output = await sb.exec("python", ["-c", "print('hello')"])
+print(output.stdout_text)     # "hello\n"
+print(output.success)         # True
+print(output.exit_code)       # 0
+```
+
+```bash CLI
+msb exec worker -- python -c "print('hello')"
+```
+
+</CodeGroup>
+
+## Execution options
+
+These options apply to a single execution and don't change the sandbox's defaults.
+
+<CodeGroup>
+```rust Rust
+let output = sb.exec_with("python", |e| e
+    .args(["compute.py"])
+    .cwd("/app")
+    .env("PYTHONPATH", "/app/lib")
+    .timeout(Duration::from_secs(30))
+    .rlimit(RlimitResource::Nofile, 1024)
+).await?;
+```
+
+```typescript TypeScript
+const output = await sb.execWith("python", (e) =>
+    e.args(["compute.py"])
+        .cwd("/app")
+        .env("PYTHONPATH", "/app/lib")
+        .timeout(30_000)
+        .rlimit("nofile", 1024),
+);
+```
+
+```python Python
+from microsandbox import ExecOptions, Rlimit
+
+output = await sb.exec("python", ExecOptions(
+    args=("compute.py",),
+    cwd="/app",
+    env={"PYTHONPATH": "/app/lib"},
+    timeout=30.0,
+    rlimits=(Rlimit.nofile(1024),),
+))
+```
+
+```bash CLI
+msb exec worker \
+  -w /app \
+  -e PYTHONPATH=/app/lib \
+  --timeout 30s \
+  --rlimit nofile=1024 \
+  -- python compute.py
+```
+
+</CodeGroup>
+
+## Shell commands
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Useful for pipelines, redirects, and other shell syntax that `exec` doesn't interpret.
+
+<CodeGroup>
+```rust Rust
+let output = sb.shell("ls -la /app && echo done").await?;
+```
+
+```typescript TypeScript
+const output = await sb.shell("ls -la /app && echo done")
+```
+
+```python Python
+output = await sb.shell("ls -la /app && echo done")
+```
+
+```bash CLI
+msb exec worker -- sh -c "ls -la /app && echo done"
+```
+
+</CodeGroup>
+
+## Stream output
+
+For long-running processes or large output, streaming gives you stdout, stderr, and exit events as they happen instead of buffering everything until the command finishes.
+
+<CodeGroup>
+```rust Rust
+let mut handle = sb.exec_stream("tail", ["-f", "/var/log/app.log"]).await?;
+
+while let Some(event) = handle.recv().await {
+    match event {
+        ExecEvent::Stdout(data) => print!("{}", String::from_utf8_lossy(&data)),
+        ExecEvent::Stderr(data) => eprint!("{}", String::from_utf8_lossy(&data)),
+        ExecEvent::Exited { code } => break,
+        _ => {}
+    }
+}
+```
+
+```typescript TypeScript
+const handle = await sb.execStream("tail", ["-f", "/var/log/app.log"]);
+
+for await (const event of handle) {
+    switch (event.kind) {
+        case "stdout": process.stdout.write(event.data); break;
+        case "stderr": process.stderr.write(event.data); break;
+        case "exited": console.log(`Exited: ${event.code}`); break;
+    }
+}
+```
+
+```python Python
+handle = await sb.exec_stream("tail", ["-f", "/var/log/app.log"])
+
+async for event in handle:
+    match event.event_type:
+        case "stdout": print(event.data.decode(), end="")
+        case "stderr": print(event.data.decode(), end="", file=sys.stderr)
+        case "exited": print(f"Exited: {event.code}")
+```
+
+</CodeGroup>
+
+## Interactive attach
+
+Bridges your terminal directly to a process inside the sandbox for a fully interactive PTY session. Useful for debugging, running REPLs, or anything that expects a real terminal.
+
+<CodeGroup>
+```rust Rust
+let exit_code = sb.attach_shell().await?;
+
+let exit_code = sb.attach_with("python", |a| a
+    .env("DEBUG", "1")
+    .cwd("/app")
+    .detach_keys("ctrl-q")
+).await?;
+```
+
+```typescript TypeScript
+// Attach to the default shell
+const exitCode = await sb.attachShell();
+
+// Attach to a specific command with custom detach keys
+await sb.attachWith("bash", (a) =>
+    a.env("DEBUG", "1").cwd("/app").detachKeys("ctrl-q"),
+);
+```
+
+```python Python
+from microsandbox import AttachOptions
+
+# Attach to the default shell
+exit_code = await sb.attach_shell()
+
+# Attach to a specific command with custom detach keys
+exit_code = await sb.attach("python", AttachOptions(
+    env={"DEBUG": "1"},
+    cwd="/app",
+    detach_keys="ctrl-q",
+))
+```
+
+```bash CLI
+# Attach to the default shell
+msb exec -t worker
+
+# Attach to a specific command
+msb exec -t worker -e DEBUG=1 -w /app -- python
+```
+
+</CodeGroup>
+
+<Tip>
+  Press `Ctrl+]` (or your configured detach keys) to detach from the session without stopping the process. The process keeps running inside the VM and you can reattach later via its session ID.
+</Tip>
+
+## Write stdin
+
+Streaming handles can also accept stdin. Enable `stdin_pipe` and write bytes to it. Combined with `tty: true`, this lets you drive interactive processes programmatically.
+
+<CodeGroup>
+```rust Rust
+let mut handle = sb.exec_stream_with("python", |e| e.stdin_pipe().tty(true)).await?;
+let stdin = handle.take_stdin().unwrap();
+stdin.write(b"print('hello')\n").await?;
+stdin.write(b"exit()\n").await?;
+handle.wait().await?;
+```
+
+```typescript TypeScript
+const handle = await sb.execStreamWith("python", (e) => e.stdinPipe().tty(true));
+const stdin = await handle.takeStdin();
+await stdin!.write("print('hello')\n");
+await stdin!.write("exit()\n");
+await stdin!.close();
+await handle.wait();
+```
+
+```python Python
+from microsandbox import ExecOptions, Stdin
+
+handle = await sb.exec_stream("python", ExecOptions(stdin=Stdin.pipe(), tty=True))
+stdin = handle.take_stdin()
+await stdin.write(b"print('hello')\n")
+await stdin.write(b"exit()\n")
+await stdin.close()
+await handle.wait()
+```
+
+</CodeGroup>
+
+## Sessions <sup><sup>coming soon</sup></sup>
+
+Each streaming exec or attach creates a session. You can list active sessions and reattach to them by ID. Up to 16 simultaneous client connections are supported, so multiple sessions can run concurrently without interfering with each other.
+
+<CodeGroup>
+```rust Rust
+// Start a background process and capture its session ID
+let handle = sb.exec_stream("python", ["server.py"]).await?;
+let session_id = handle.id().to_string();
+
+// List active sessions
+let sessions = sb.sessions().await?;
+
+// Reattach to a session by ID
+let mut handle = sb.session(&session_id).await?;
+```
+
+```typescript TypeScript
+// Start a background process and capture its session ID
+const handle = await sb.execStream("python", ["server.py"])
+const sessionId = handle.id
+
+// List active sessions
+const sessions = await sb.sessions()
+
+// Reattach to a session by ID
+const reattached = await sb.session(sessionId)
+```
+
+```python Python
+# Start a background process and capture its session ID
+handle = await sb.exec_stream("python", ["server.py"])
+session_id = handle.id
+
+# List active sessions
+sessions = await sb.sessions()
+
+# Reattach to a session by ID
+reattached = await sb.session(session_id)
+```
+
+</CodeGroup>

--- a/docs/ja/sandboxes/customize.mdx
+++ b/docs/ja/sandboxes/customize.mdx
@@ -1,0 +1,339 @@
+---
+title: Customize
+description: Inject scripts, modify the rootfs, and choose your own init
+icon: "wand-magic-sparkles"
+---
+
+Before a sandbox starts doing real work, you can prepare it three ways. **Scripts** bundle reusable commands. **Patches** modify the rootfs before the VM boots. A **custom init system** (systemd, OpenRC, s6) can run as PID 1 instead of microsandbox's minimal agent. All three are defined at creation time and keep the base image untouched.
+
+## Scripts
+
+Scripts are files mounted at `/.msb/scripts/` inside the sandbox. The directory is on `PATH`, so each script is callable by name through `exec()` or `shell()`.
+
+It provides a clean way to bundle setup procedures or entry points with a sandbox without baking them into the image.
+
+<CodeGroup>
+```rust Rust
+use indoc::indoc;
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("ubuntu")
+    .script("setup", indoc! {"
+        #!/bin/bash
+        apt-get update && apt-get install -y python3 curl
+    "})
+    .script("start", indoc! {"
+        #!/bin/bash
+        exec python3 /app/main.py
+    "})
+    .create()
+    .await?;
+
+sb.shell("setup").await?;
+let output = sb.shell("start").await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("ubuntu")
+    .script("setup", "#!/bin/bash\napt-get update && apt-get install -y python3 curl")
+    .script("run",   "#!/bin/bash\nexec python3 /app/main.py")
+    .create();
+
+await sb.shell("setup");
+const output = await sb.shell("run");
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ubuntu",
+    scripts={
+        "setup": "#!/bin/bash\napt-get update && apt-get install -y python3 curl",
+        "start": "#!/bin/bash\nexec python3 /app/main.py",
+    },
+)
+
+await sb.shell("setup")
+output = await sb.shell("start")
+```
+
+</CodeGroup>
+
+## Patches
+
+Patches modify the rootfs **before the VM boots**. Write config files, copy directories from the host, create symlinks, append to existing files, remove things you don't need. The base image stays untouched since patches are written to the writable layer on top.
+
+Patches are applied in order and work with OCI images and bind-mounted rootfs. They're not supported with disk image roots (QCOW2, Raw).
+
+<Tip>
+  By default, patching a path that already exists in the image will error. Pass `replace: true` on the operation to allow it. `Mkdir` and `Remove` are idempotent and won't error either way.
+</Tip>
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("alpine")
+    .patch(|p| p
+        .text("/etc/greeting.txt", "Hello from a patched rootfs!\n", None, false)
+        .text("/etc/motd", "Custom message of the day.\n", None, true) // replace existing
+        .mkdir("/app", Some(0o755))
+        .text("/app/config.json", r#"{"debug": true}"#, Some(0o644), false)
+        .copy_file("./cert.pem", "/etc/ssl/cert.pem", None, false)
+        .append("/etc/hosts", "127.0.0.1 myapp.local\n")
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("alpine")
+    .patch((p) => p
+        .text("/etc/greeting.txt", "Hello from a patched rootfs!\n")
+        .text("/etc/motd", "Custom message of the day.\n", { replace: true })
+        .mkdir("/app", { mode: 0o755 })
+        .text("/app/config.json", '{"debug": true}', { mode: 0o644 })
+        .copyFile("./cert.pem", "/etc/ssl/cert.pem")
+        .append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+    )
+    .create();
+```
+
+```python Python
+from microsandbox import Patch, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="alpine",
+    patches=[
+        Patch.text("/etc/greeting.txt", "Hello from a patched rootfs!\n"),
+        Patch.text("/etc/motd", "Custom message of the day.\n", replace=True),
+        Patch.mkdir("/app", mode=0o755),
+        Patch.text("/app/config.json", '{"debug": true}', mode=0o644),
+        Patch.copy_file("./cert.pem", "/etc/ssl/cert.pem"),
+        Patch.append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+    ],
+)
+```
+
+</CodeGroup>
+
+### Available operations
+
+The patch builder appends operations in the order you call them; calls are chainable. Available operations across SDKs: `text`, `file`, `mkdir`, `append`, `copyFile` / `copy_file`, `copyDir` / `copy_dir`, `symlink`, `remove`.
+
+Full per-language signatures, parameters, and option shapes are documented in the SDK references:
+
+- Rust: [`PatchBuilder`](/sdk/rust/sandbox#patchbuilder)
+- TypeScript: [`PatchBuilder`](/sdk/typescript/sandbox#patchbuilder)
+- Python: [`Patch`](/sdk/python/sandbox#patch) (factory) and [`PatchConfig`](/sdk/python/sandbox#patchconfig) (the value type)
+
+## Custom init system
+
+By default the microsandbox agent runs as PID 1 inside the guest: small, fast, minimal. For workloads that expect a real init (systemd, OpenRC, s6, runit, etc.), `--init` hands PID 1 over to the init binary of your choice.
+
+The handoff sequence:
+
+- Agent does the boot-time setup: mount filesystems, configure network, prepare runtime dirs.
+- Agent forks.
+- Parent execs your init and becomes PID 1.
+- Child agent continues serving host requests over the same channel.
+
+Common reasons to opt in: long-lived daemons, system service tests, anything that talks to dbus or expects `systemctl` to work.
+
+The simplest entry point is `auto`, which probes a small list of well-known paths inside the guest rootfs and picks the first one that exists:
+
+- `/sbin/init`
+- `/lib/systemd/systemd`
+- `/usr/lib/systemd/systemd`
+
+Pass an absolute path instead when you need pinning (e.g. for reproducible CI).
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .memory(1024)
+    .cpus(2)
+    .init("auto")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { MiB, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .memory(MiB(1024))
+    .cpus(2)
+    .init("auto")
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ghcr.io/superradcompany/debian-systemd:12",
+    memory=1024,
+    cpus=2,
+    init="auto",
+)
+```
+
+```bash CLI
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  -m 1G -c 2 \
+  --init auto \
+  -- bash
+```
+</CodeGroup>
+
+To verify the handoff worked, check `/proc/1/comm` inside the sandbox. It should print the init's name (`systemd`, `init`, etc.):
+
+```bash
+$ msb run ghcr.io/superradcompany/debian-systemd:12 --init auto -- cat /proc/1/comm
+systemd
+```
+
+If `--init=auto` can't find anything in its candidate list, agentd fails boot with a clear error in `kernel.log` listing every path it checked. Switch to an explicit path (`--init=/lib/systemd/systemd`) when you know exactly where the init lives, or follow the image-picking guidance below to choose an image that actually ships one.
+
+### Argv and env
+
+Pass extra argv and env to the init:
+
+- **Rust / TypeScript**: `init_with(...)` / `initWith(...)`.
+- **Python**: pass an `InitConfig` to `init=`.
+- **CLI**: repeat `--init-arg` once per entry, and `--init-env KEY=VAL` once per env var.
+
+Argv defaults to `[<cmd>]` when none is given; env is merged on top of the inherited environment.
+
+<CodeGroup>
+```bash CLI
+msb run ghcr.io/superradcompany/debian-systemd:12 \
+  --init /lib/systemd/systemd \
+  --init-arg --unit=multi-user.target \
+  --init-env container=microsandbox \
+  -- bash
+```
+
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .init_with("/lib/systemd/systemd", |i| i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .initWith("/lib/systemd/systemd", (i) => i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create();
+```
+
+```python Python
+from microsandbox import InitConfig, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ghcr.io/superradcompany/debian-systemd:12",
+    init=InitConfig(
+        cmd="/lib/systemd/systemd",
+        args=("--unit=multi-user.target",),
+        env={"container": "microsandbox"},
+    ),
+)
+```
+</CodeGroup>
+
+### Picking an image
+
+Most slim Docker base images (`debian:bookworm-slim`, `ubuntu:24.04`, `python:3.12-slim`) are stripped of init binaries; they're built for "one process per container" and don't ship systemd at all. If you point `--init` at a path the image doesn't contain, the agent's pre-flight check fails boot with a clear error in the kernel log (no kernel panic).
+
+Three ways to get an image with an init:
+
+<AccordionGroup>
+  <Accordion title="Use one of our published guest images">
+    We maintain a small collection at [`superradcompany/guest-images`](https://github.com/superradcompany/guest-images) for the cases where you specifically need a real init. Current set:
+
+    | Image | Pull |
+    |-------|------|
+    | Debian + systemd | `ghcr.io/superradcompany/debian-systemd:12` |
+    | Ubuntu + systemd | `ghcr.io/superradcompany/ubuntu-systemd:24.04` |
+    | Fedora + systemd | `ghcr.io/superradcompany/fedora-systemd:40` |
+    | Alpine + OpenRC | `ghcr.io/superradcompany/alpine-openrc:3.20` |
+
+    Multi-arch (`linux/amd64` + `linux/arm64`), rebuilt weekly so they pick up upstream security patches, smoke-tested on every rebuild. Each image's GHCR page documents its specific tag aliases and contents.
+  </Accordion>
+  <Accordion title="Build a small custom image">
+    ```dockerfile
+    # Dockerfile.systemd
+    FROM debian:bookworm
+    RUN apt-get update \
+        && apt-get install -y --no-install-recommends systemd \
+        && rm -rf /var/lib/apt/lists/*
+    ```
+
+    ```bash
+    docker buildx build -t local-systemd:debian -f Dockerfile.systemd .
+    msb run local-systemd:debian --init /lib/systemd/systemd -- bash
+    ```
+  </Accordion>
+  <Accordion title="Use a community-built systemd image">
+    Examples: `jrei/systemd-debian:12`, `jrei/systemd-ubuntu:22.04`. These work out of the box but are published by community maintainers, not the distros themselves. Vet them like any other third-party image before running real workloads.
+  </Accordion>
+</AccordionGroup>
+
+For a sanity check that doesn't need systemd, `alpine:3.20` ships BusyBox at `/sbin/init`, which is enough to exercise the handoff mechanics:
+
+```bash
+msb run alpine:3.20 --init /sbin/init -- sh -c "cat /proc/1/comm"
+# busybox
+```
+
+### Shutdown semantics
+
+Without `--init`, microsandbox shuts the guest down by remounting root read-only and calling `reboot(RB_POWER_OFF)`. Typically &lt;100 ms.
+
+With `--init`, the agent isn't PID 1 anymore, so it asks your init to shut down:
+
+- `SIGRTMIN+4` first (systemd's poweroff signal).
+- `SIGTERM` fallback for inits that don't speak it.
+
+Your init then runs its own teardown (stop services, unmount, halt), which is slower:
+
+| Init | Typical shutdown |
+|------|------------------|
+| BusyBox / s6 / runit | &lt;100 ms |
+| OpenRC | 50-500 ms |
+| systemd | 1-5 s |
+
+This is the price of a real init. If your test harness measures end-to-end sandbox lifecycle and you're comparing to a no-handoff baseline, account for this.
+
+### Init and entrypoint
+
+`--init` and `--entrypoint` are orthogonal:
+
+- `--init` controls **PID 1**: what runs the system.
+- `--entrypoint` (and the trailing `-- cmd`) controls **what your workload runs**.
+
+They can be combined. Boot systemd as PID 1 and have microsandbox `exec` calls land your shell, scripts, or app inside the systemd-managed environment.

--- a/docs/ja/sandboxes/events.mdx
+++ b/docs/ja/sandboxes/events.mdx
@@ -1,0 +1,110 @@
+---
+title: Events
+description: Bidirectional host-guest communication
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+The events API is for structured communication between host and guest beyond stdin/stdout. The host can subscribe to named events from the guest and emit events back, all through the same channel used by `exec`.
+
+On the guest side, processes just write JSON to `/run/agent.sock`, which is a standard Unix domain socket. No special library needed. Any language that can open a socket and write a newline-delimited JSON message will work.
+
+## Basic example
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, EventData};
+use serde::Deserialize;
+
+let sb = Sandbox::get("worker").await?.start().await?;
+
+let _sub = sb.on_event("task.progress", |event: EventData| {
+    #[derive(Deserialize)]
+    struct Progress { percent: u32, message: String }
+
+    if let Some(data) = event.data {
+        if let Ok(p) = data.deserialized::<Progress>() {
+            println!("[{}%] {}", p.percent, p.message);
+        }
+    }
+});
+```
+
+```typescript TypeScript
+import { Sandbox, EventData } from 'microsandbox'
+
+const sb = await Sandbox.get("worker")
+
+const sub = sb.onEvent("task.progress", (event: EventData) => {
+    const { percent, message } = event.data as { percent: number; message: string }
+    console.log(`[${percent}%] ${message}`)
+})
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await (await Sandbox.get("worker")).start()
+
+sub = sb.on_event("task.progress", lambda event: (
+    print(f"[{event.data['percent']}%] {event.data['message']}")
+))
+```
+
+</CodeGroup>
+
+## Send events to guest
+
+Emit a named event with typed data into the guest. Any process listening on the agent socket receives it.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct TaskConfig { input_file: String, output_dir: String }
+
+sb.emit("task.start", TaskConfig {
+    input_file: "/data/input.txt".into(),
+    output_dir: "/data/output".into(),
+}).await?;
+```
+
+```typescript TypeScript
+await sb.emit("task.start", {
+    inputFile: "/data/input.txt",
+    options: ["--verbose"],
+})
+```
+
+```python Python
+await sb.emit("task.start", {
+    "input_file": "/data/input.txt",
+    "output_dir": "/data/output",
+})
+```
+
+</CodeGroup>
+
+## Guest-side emitting
+
+Inside the guest, any process can emit events by writing JSON to the Unix domain socket at `/run/agent.sock`. No SDK required.
+
+```python
+# Inside the guest, plain Python, no SDK
+import json, socket
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect("/run/agent.sock")
+sock.sendall(json.dumps({
+    "event": "task.progress",
+    "data": {"percent": 50, "message": "Halfway done"},
+}).encode() + b"\n")
+sock.close()
+```
+
+The host subscription registered with `on_event("task.progress", ...)` receives this message automatically.

--- a/docs/ja/sandboxes/filesystem.mdx
+++ b/docs/ja/sandboxes/filesystem.mdx
@@ -1,0 +1,240 @@
+---
+title: Filesystem
+description: Read and write files inside a running sandbox
+icon: "folder-open"
+---
+
+The filesystem API lets you read, write, and manage files inside a sandbox without mounting volumes or SSH. It uses the same channel as command execution, so it doesn't touch the sandbox's network.
+
+Handy for pushing generated code into a sandbox, pulling back results, or inspecting logs without having to pre-mount a shared directory.
+
+## Write a file
+
+<CodeGroup>
+```rust Rust
+sb.fs().write("/app/config.json", r#"{"debug": true}"#).await?;
+```
+
+```typescript TypeScript
+await sb.fs().write("/app/config.json", '{"debug": true}');
+```
+
+```python Python
+await sb.fs.write("/app/config.json", b'{"debug": true}')
+```
+
+</CodeGroup>
+
+## Read a file
+
+<CodeGroup>
+```rust Rust
+let content = sb.fs().read_to_string("/app/config.json").await?;
+```
+
+```typescript TypeScript
+const content = await sb.fs().readToString("/app/config.json");
+```
+
+```python Python
+content = await sb.fs.read_text("/app/config.json")
+```
+
+</CodeGroup>
+
+## List a directory
+
+<CodeGroup>
+```rust Rust
+let entries = sb.fs().list("/app").await?;
+for entry in entries {
+    println!("{}: {:?}", entry.path, entry.kind);
+}
+```
+
+```typescript TypeScript
+const entries = await sb.fs().list("/app");
+for (const entry of entries) {
+    console.log(`${entry.path}: ${entry.kind}`);
+}
+```
+
+```python Python
+entries = await sb.fs.list("/app")
+for entry in entries:
+    print(f"{entry.path}: {entry.kind}")
+```
+
+</CodeGroup>
+
+## Stream large files
+
+For files too large to fit in memory, use streaming. Data is transferred in chunks of approximately 3 MiB each.
+
+<CodeGroup>
+```rust Rust
+let mut stream = sb.fs().read_stream("/app/data.bin").await?;
+while let Some(chunk) = stream.recv().await? {
+    process(&chunk);
+}
+```
+
+```typescript TypeScript
+const stream = await sb.fs().readStream("/app/data.bin");
+for await (const chunk of stream) {
+    processChunk(chunk); // chunk is a Uint8Array
+}
+```
+
+```python Python
+stream = await sb.fs.read_stream("/app/data.bin")
+async for chunk in stream:
+    process(chunk)
+```
+
+</CodeGroup>
+
+## Copy from host
+
+Copy a file from the host machine into the sandbox in a single call.
+
+<CodeGroup>
+```rust Rust
+sb.fs().copy_from_host("./local-file.txt", "/app/remote-file.txt").await?;
+```
+
+```typescript TypeScript
+await sb.fs().copyFromHost("./local-file.txt", "/app/remote-file.txt");
+```
+
+```python Python
+await sb.fs.copy_from_host("./local-file.txt", "/app/remote-file.txt")
+```
+
+</CodeGroup>
+
+<Tip>
+  If you need to transfer many files at once, consider using a [bind-mounted volume](/sandboxes/volumes) instead. Volumes give the guest direct filesystem access, whereas the filesystem API transfers each file individually. For bulk operations, volumes are significantly faster.
+</Tip>
+
+## Extensible backends
+
+The default filesystem backends handle most use cases. For advanced scenarios, you can attach hooks to intercept operations on a volume, or implement a full custom backend.
+
+### Hooks <sup><sup>coming soon</sup></sup>
+
+Intercept file reads and writes on a volume without replacing the entire backend. Hooks receive the path and data, and return transformed data. The underlying filesystem handles everything else (permissions, directories, metadata).
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let key = get_encryption_key();
+let sb = Sandbox::builder("encrypted")
+    .image("python")
+    .volume("/secrets", |v| v
+        .bind("/data/secrets")
+        .on_read(move |_path, data| decrypt(data, &key))
+        .on_write(move |_path, data| encrypt(data, &key))
+    )
+    .create().await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+// Hooks are coming soon. The planned shape will sit alongside the regular
+// mount methods on the volume builder, e.g.:
+//
+//   .volume("/secrets", (m) => m
+//       .bind("/data/secrets")
+//       .onRead((path, data) => decrypt(data, key))
+//       .onWrite((path, data) => encrypt(data, key)),
+//   )
+//
+// For now the closest equivalent is a plain bind:
+await using sb = await Sandbox.builder("encrypted")
+    .image("python")
+    .volume("/secrets", (m) => m.bind("/data/secrets"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+key = get_encryption_key()
+sb = await Sandbox.create(
+    "encrypted",
+    image="python",
+    volumes={
+        "/secrets": Volume.bind("/data/secrets",
+            on_read=lambda path, data: decrypt(data, key),
+            on_write=lambda path, data: encrypt(data, key),
+        ),
+    },
+)
+```
+
+</CodeGroup>
+
+### Custom backend <sup><sup>coming soon</sup></sup>
+
+For full control, implement the `FsBackend` trait (Rust) or class (TypeScript). This gives you access to every POSIX operation: `read`, `write`, `lookup`, `getattr`, `readdir`, etc. You can delegate to a built-in backend (like `PassthroughFs`) for operations you don't need to customize.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{FsBackend, PassthroughFs};
+use std::io;
+
+struct EncryptedFs { key: [u8; 32], inner: PassthroughFs }
+
+impl FsBackend for EncryptedFs {
+    fn read(&self, ctx: Context, inode: u64, handle: u64,
+            buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        let n = self.inner.read(ctx, inode, handle, buf, offset)?;
+        self.decrypt_in_place(&mut buf[..n]);
+        Ok(n)
+    }
+    fn write(&self, ctx: Context, inode: u64, handle: u64,
+             buf: &[u8], offset: u64) -> io::Result<usize> {
+        let encrypted = self.encrypt(buf);
+        self.inner.write(ctx, inode, handle, &encrypted, offset)
+    }
+    // ... remaining methods delegate to self.inner
+}
+
+let sb = Sandbox::builder("custom")
+    .volume("/secrets", |v| v.backend(EncryptedFs::new(key, "/data")?))
+    .create().await?;
+```
+
+```typescript TypeScript
+// FsBackend is coming soon. The planned API will let you plug a custom
+// backend into a volume:
+//
+//   class EncryptedFs implements FsBackend {
+//     // ... implement read, write, and other required methods
+//   }
+//
+//   const sb = await Sandbox.builder("custom")
+//     .volume("/secrets", (m) => m.backend(new EncryptedFs(key, "/data")))
+//     .create();
+```
+
+```python Python
+from microsandbox import FsBackend, Sandbox, Volume
+
+# Implement the FsBackend interface
+class EncryptedFs(FsBackend):
+    # ... implement read, write, and other required methods
+    pass
+
+sb = await Sandbox.create(
+    "custom",
+    volumes={
+        "/secrets": Volume.backend(EncryptedFs(key, "/data")),
+    },
+)
+```
+
+</CodeGroup>

--- a/docs/ja/sandboxes/lifecycle.mdx
+++ b/docs/ja/sandboxes/lifecycle.mdx
@@ -1,0 +1,401 @@
+---
+title: Lifecycle
+description: Create, start, stop, and manage sandbox state
+icon: "rotate"
+---
+
+Each sandbox runs as a child process of whatever application creates it. `Sandbox.builder(...).create()` boots a microVM, starts the guest agent inside it, and establishes a communication channel back to the host.
+
+Understanding the lifecycle is useful once you start managing long-running sandboxes, graceful shutdown, or resilient agent workflows.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Creating: create()
+    Creating --> Running: boot complete
+    Running --> Paused: pause()
+    Paused --> Running: resume()
+    Running --> Draining: drain()
+    Running --> Stopped: stop()
+    Running --> Crashed: unexpected exit
+    Draining --> Stopped: drain complete
+    Stopped --> Running: start()
+    Stopped --> [*]: remove()
+    Crashed --> [*]: remove()
+```
+
+## States
+
+| Status | Description |
+|--------|-------------|
+| **Creating** | The VM is booting. The kernel is loaded, the filesystem is mounted, and the guest agent is initializing (configuring network, setting up the environment). |
+| **Running** | The guest agent is ready. You can call `exec`, `shell`, `fs`, and `emit`. |
+| **Paused** | All guest processes are frozen. No CPU cycles consumed. Resume is instant with no re-boot or re-init. |
+| **Draining** | Graceful shutdown in progress. Existing commands run to completion, but new `exec` calls are rejected. Transitions to Stopped when all commands finish. |
+| **Stopped** | The VM has shut down. Sandbox configuration and state are persisted to the database and can be restarted. |
+| **Crashed** | The VM exited unexpectedly (e.g., kernel panic, OOM kill). |
+
+## Create a sandbox
+
+Creating a sandbox boots the microVM, mounts the filesystem, initializes the guest agent, and waits until it's ready to accept commands.
+
+<CodeGroup>
+```rust Rust
+// Attached: sandbox stops when your process exits
+let sb = Sandbox::builder("worker").image("python").create().await?;
+
+// Detached: sandbox survives after your process exits
+let sb = Sandbox::builder("worker").image("python").create_detached().await?;
+```
+
+```typescript TypeScript
+// Attached: sandbox stops when your process exits
+await using sb = await Sandbox.builder("worker").image("python").create();
+
+// Detached: sandbox survives after your process exits
+const detached = await Sandbox.builder("worker").image("python").createDetached();
+```
+
+```python Python
+# Attached: sandbox stops when your process exits
+sb = await Sandbox.create("worker", image="python")
+
+# Detached: sandbox survives after your process exits
+sb = await Sandbox.create("worker", image="python", detached=True)
+```
+
+```bash CLI
+# Attached
+msb create python --name worker
+
+# Detached
+msb run -d python --name worker
+```
+
+</CodeGroup>
+
+## Stop and restart
+
+Stopping gracefully terminates guest processes and shuts down the VM. The sandbox moves to `Stopped` and can be restarted later with all its configuration preserved.
+
+<CodeGroup>
+```rust Rust
+sb.stop().await?;
+
+let sb = Sandbox::start("worker").await?;
+```
+
+```typescript TypeScript
+await sb.stop()
+
+// Later, resume where you left off
+const sb = await Sandbox.start("worker")
+```
+
+```python Python
+await sb.stop()
+
+# Later, resume where you left off
+sb = await Sandbox.start("worker")
+```
+
+```bash CLI
+msb stop worker
+
+# Later, resume where you left off
+msb start worker
+```
+
+</CodeGroup>
+
+## Kill immediately
+
+If a sandbox is unresponsive (e.g., stuck in a tight loop or a panic), force-kill it. The sandbox is terminated immediately with no graceful shutdown.
+
+<CodeGroup>
+```rust Rust
+sb.kill().await?;
+```
+
+```typescript TypeScript
+await sb.kill()
+```
+
+```python Python
+await sb.kill()
+```
+
+```bash CLI
+msb stop --force worker
+```
+
+</CodeGroup>
+
+## Pause and resume <sup><sup>coming soon</sup></sup>
+
+Freeze all guest processes without shutting down. The VM uses zero CPU while paused, and resume is instant. The guest continues exactly where it left off with no boot time and no re-init.
+
+<CodeGroup>
+```rust Rust
+sb.pause().await?;
+sb.resume().await?;
+```
+
+```typescript TypeScript
+await sb.pause()
+await sb.resume()
+```
+
+```python Python
+await sb.pause()
+await sb.resume()
+```
+
+</CodeGroup>
+
+## Detach
+
+Keeps a sandbox running after the parent process exits. It becomes a background process that you can reconnect to later with `Sandbox::get("worker")`.
+
+<CodeGroup>
+```rust Rust
+sb.detach().await;
+```
+
+```typescript TypeScript
+await sb.detach()
+```
+
+```python Python
+await sb.detach()
+```
+
+</CodeGroup>
+
+<Tip>
+  Detached sandboxes are tracked at `~/.microsandbox/db/`. A background reaper periodically checks for stale sandboxes that have exited unexpectedly and cleans up their records.
+</Tip>
+
+## Drain
+
+Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and transitions to `Stopped` when all in-flight commands complete. This is useful for zero-downtime rotation of worker sandboxes.
+
+<CodeGroup>
+```rust Rust
+sb.drain().await?;
+```
+
+```typescript TypeScript
+await sb.drain()
+```
+
+```python Python
+await sb.drain()
+```
+
+</CodeGroup>
+
+## Wait
+
+Block until the sandbox exits on its own, without triggering a stop.
+
+<CodeGroup>
+```rust Rust
+let exit_status = sb.wait().await?;
+```
+
+```typescript TypeScript
+const exitStatus = await sb.wait()
+```
+
+```python Python
+code, success = await sb.wait()
+```
+
+</CodeGroup>
+
+## Remove
+
+Delete a stopped sandbox and its associated state from disk.
+
+<CodeGroup>
+```rust Rust
+Sandbox::remove("worker").await?;
+```
+
+```typescript TypeScript
+await Sandbox.remove("worker")
+```
+
+```python Python
+await Sandbox.remove("worker")
+```
+
+```bash CLI
+msb rm worker
+```
+
+</CodeGroup>
+
+## List and inspect
+
+<CodeGroup>
+```rust Rust
+for handle in Sandbox::list().await? {
+    println!("{}: {:?}", handle.name(), handle.status());
+}
+```
+
+```typescript TypeScript
+const sandboxes = await Sandbox.list();
+for (const handle of sandboxes) {
+    console.log(`${handle.name}: ${handle.status}`);
+}
+
+const handle = await Sandbox.get("worker");
+console.log(handle.status); // "running" | "stopped" | ...
+```
+
+```python Python
+for handle in await Sandbox.list():
+    print(f"{handle.name}: {handle.status}")
+
+handle = await Sandbox.get("worker")
+print(handle.status)  # "running" | "stopped" | ...
+```
+
+```bash CLI
+msb ls
+msb ps worker
+```
+
+</CodeGroup>
+
+## Runtime process architecture
+
+Here's what's running and how the pieces talk to each other.
+
+```mermaid
+graph TD
+    subgraph Host["Host"]
+        A["Your Application<br/><small>microsandbox SDK</small>"]
+        B["Sandbox Process<br/><small>VM + networking + lifecycle</small>"]
+    end
+
+    subgraph Guest["Guest VM"]
+        F["agentd<br/><small>exec, fs, events</small>"]
+    end
+
+    A -- "spawn" --> B
+    B -- "boot" --> F
+    A -. "commands & responses" .-> F
+
+    style Host fill:#f5f0ff,stroke:#a770ef,color:#333
+    style Guest fill:#fef4e8,stroke:#e8a838,color:#333
+    style A fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
+    style B fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
+    style F fill:#fdd49e,stroke:#d97706,color:#1a1a1a
+```
+
+There are two layers here. The **sandbox process** runs the VM and the networking stack on the host side, and relays messages between the application and the **guest agent** inside the VM. Up to 16 clients can connect to the same sandbox simultaneously.
+
+The sandbox process also handles:
+
+- Graceful stop and drain signals
+- Cleanup when the sandbox exits
+- Idle detection (auto-drain after a configurable timeout)
+- Maximum sandbox lifetime enforcement
+
+The sandbox process does not execute guest commands itself. It only relays traffic between your application and the guest agent.
+
+## Logs and diagnostics
+
+Each sandbox keeps four files under `<sandbox-dir>/logs/`:
+
+| File | Producer | Contents |
+|------|----------|----------|
+| `exec.log` | Host relay (tap on guest frames) | User-program stdout/stderr/output as JSON Lines |
+| `runtime.log` | Sandbox process (host) | Runtime tracing — relay setup, lifecycle, network |
+| `kernel.log` | Guest VM virtio-console | Kernel boot messages and `agentd` console |
+| `boot-error.json` | Sandbox process | Present only when the most recent start failed before the agent came up |
+
+The user-facing surface for these is [`msb logs`](/cli/sandbox-commands#msb-logs) and the SDK [`logs()`](/sandboxes/logs) method — both work on running and stopped sandboxes alike. See the [Logs](/sandboxes/logs) page for the capture model, source semantics, and diagnostic flows.
+
+When a sandbox is in the **Crashed** state, its log directory is left in place so you can read what happened. Use `msb logs --source system <name>` to see the runtime/kernel diagnostic merge.
+
+## Graceful shutdown with timeout fallback
+
+Attempt a graceful stop, then force-kill if the sandbox doesn't shut down in time.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+use std::time::Duration;
+
+let mut handle = Sandbox::get("worker").await?;
+match tokio::time::timeout(Duration::from_secs(30), handle.stop()).await {
+    Ok(Ok(())) => println!("Stopped"),
+    Ok(Err(e)) => eprintln!("Error: {e}"),
+    Err(_) => handle.kill().await?,
+}
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.get("worker");
+try {
+    await Promise.race([
+        sb.stop(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 30_000)),
+    ]);
+} catch {
+    await sb.kill();
+}
+```
+
+```python Python
+import asyncio
+from microsandbox import Sandbox
+
+handle = await Sandbox.get("worker")
+sb = await handle.connect()
+try:
+    await asyncio.wait_for(sb.stop(), timeout=30)
+except asyncio.TimeoutError:
+    await sb.kill()
+```
+
+</CodeGroup>
+
+## Sandbox process policies
+
+For production workloads, configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .max_duration(3600)
+    .idle_timeout(300)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .maxDuration(3600)   // maximum sandbox lifetime in seconds
+    .idleTimeout(300)    // auto-drain after 5 minutes of inactivity
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    max_duration=3600,
+    idle_timeout=300,
+)
+```
+
+</CodeGroup>

--- a/docs/ja/sandboxes/logs.mdx
+++ b/docs/ja/sandboxes/logs.mdx
@@ -1,0 +1,288 @@
+---
+title: Logs
+description: Capture, read, and diagnose sandbox output
+icon: "scroll"
+---
+
+Every sandbox records its captured output to disk so you can read it later — even after the sandbox stops or crashes. The CLI surface is `msb logs <name>`; the SDK surface is `logs()` on `Sandbox` and `SandboxHandle`. Both work on running and stopped sandboxes alike, with no protocol traffic — just a file read.
+
+## What's captured
+
+When a sandbox is running, the host-side **relay tap** intercepts the protocol frames flowing from the guest agent (`agentd`) and writes a copy of every exec session's stdout/stderr to `exec.log` as JSON Lines. Every session is captured, tagged with its own monotonic id so readers can group or filter by session.
+
+```jsonl
+{"t":"2026-04-30T20:32:59.688Z","s":"system","d":"--- sandbox started ---\n"}
+{"t":"2026-04-30T20:32:59.689Z","s":"stdout","d":"Listening on :8080\n","id":1}
+{"t":"2026-04-30T20:32:59.690Z","s":"stderr","d":"warn: no TLS\n","id":1}
+{"t":"2026-04-30T20:33:01.112Z","s":"stdout","d":"got request\n","id":2}
+{"t":"2026-04-30T20:33:05.220Z","s":"system","d":"--- sandbox stopped ---\n"}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `t` | RFC 3339 timestamp at the moment the chunk was captured |
+| `s` | Source tag — see [Sources](#sources) |
+| `d` | The chunk's bytes, UTF-8 lossy decoded by default |
+| `id` | Relay-monotonic session id (starts at 1, +1 per `exec`); absent on `system` entries |
+
+## Sources
+
+The `s` field tells you where each chunk came from. Four values:
+
+| Source | When emitted |
+|--------|--------------|
+| `stdout` | Captured from a session's stdout, **pipe mode** — streams stayed separated end to end. |
+| `stderr` | Captured from a session's stderr, **pipe mode**. |
+| `output` | Captured from a session running in **PTY mode**. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream. We tag them `output` rather than mislabel as `stdout` so a reader doing `jq 'select(.s == "stderr")'` doesn't accidentally pick up merged PTY bytes. |
+| `system` | Synthetic entries: lifecycle markers (`--- sandbox started ---` / `--- sandbox stopped ---`) plus runtime/kernel diagnostic lines from `runtime.log` / `kernel.log` merged in at read time when `--source system` is requested. |
+
+The default `msb logs <name>` and SDK `logs()` show `stdout` + `stderr` + `output` — all user-program output, regardless of pipe vs PTY. Add `system` explicitly when you want the diagnostics merge.
+
+<Tip>
+  **Pipe vs PTY modes.** Non-interactive `msb run` (with stdin piped or redirected) and `Sandbox.exec()` use pipe mode — streams stay separate. Interactive `msb run` from a real terminal, `msb attach`, and explicit `--tty` use PTY mode — streams are merged in the kernel. Choose pipe mode when you want clean per-stream filtering in your logs.
+</Tip>
+
+## Reading logs
+
+### From the CLI
+
+```bash
+# Default — user-program output (stdout + stderr + output)
+msb logs devbox
+
+# Tail the most recent entries
+msb logs devbox --tail 100
+
+# Follow live
+msb logs devbox -f
+
+# Filter by source
+msb logs devbox --source stderr           # just stderr (pipe-mode only)
+msb logs devbox --source output           # just PTY-merged
+msb logs devbox --source system           # runtime + kernel diagnostics
+msb logs devbox --source all              # everything, chronologically merged
+
+# Time-bounded
+msb logs devbox --since 5m                # last 5 minutes
+msb logs devbox --since 2026-04-30T20:00:00Z
+
+# Grep
+msb logs devbox --grep ERROR
+
+# Multi-session view: prefix each line with [id:N]
+msb logs devbox --show-id
+
+# Color each session distinctly (implies --show-id)
+msb logs devbox --color-sessions
+
+# Programmatic: raw JSON Lines
+msb logs devbox --json | jq 'select(.s == "stderr")'
+```
+
+See [`msb logs` reference](/cli/sandbox-commands#msb-logs) for the full flag list.
+
+### From the SDK
+
+<CodeGroup>
+```rust Rust
+use microsandbox::sandbox::{LogOptions, LogSource, Sandbox};
+
+let handle = Sandbox::get("web").await?;
+
+let entries = handle.logs(&LogOptions::default())?;
+
+for e in entries {
+    let source = match e.source {
+        LogSource::Stdout => "OUT",
+        LogSource::Stderr => "ERR",
+        LogSource::Output => "PTY",
+        LogSource::System => "SYS",
+    };
+    println!(
+        "[{}] {} {:?}: {}",
+        e.timestamp.to_rfc3339(),
+        source,
+        e.session_id,
+        String::from_utf8_lossy(&e.data).trim_end()
+    );
+}
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const handle = await Sandbox.get("web");
+
+const entries = await handle.logs();
+
+for (const e of entries) {
+    const source =
+        e.source === "stdout" ? "OUT" :
+        e.source === "stderr" ? "ERR" :
+        e.source === "output" ? "PTY" :
+        "SYS";
+
+    console.log(
+        `[${e.timestamp.toISOString()}] ${source} ${e.sessionId}: ${e.text().trimEnd()}`
+    );
+}
+```
+
+```python Python
+import asyncio
+import microsandbox
+
+async def main():
+    handle = await microsandbox.Sandbox.get("web")
+
+    entries = await handle.logs()
+
+    for e in entries:
+        source = {
+            "stdout": "OUT",
+            "stderr": "ERR",
+            "output": "PTY",
+            "system": "SYS",
+        }[e.source]
+
+        print(
+            f"[{e.timestamp_ms / 1000:.3f}] "
+            f"{source} {e.session_id}: {e.text().rstrip()}"
+        )
+
+asyncio.run(main())
+```
+</CodeGroup>
+
+### Filtering at read time
+
+All filters are client-side. The on-disk file is bounded (10 MiB rotated × 3 = 30 MiB ceiling per sandbox), so a linear scan is always cheap.
+
+<CodeGroup>
+```rust Rust
+use chrono::{Duration, Utc};
+use microsandbox::sandbox::{LogOptions, LogSource};
+
+let recent = handle.logs(&LogOptions {
+    tail: Some(50),
+    since: Some(Utc::now() - Duration::hours(1)),
+    sources: vec![
+        LogSource::Stdout,
+        LogSource::Stderr,
+        LogSource::Output,
+        LogSource::System,
+    ],
+    ..Default::default()
+})?;
+```
+
+```typescript TypeScript
+const recent = await handle.logs({
+    tail: 50,
+    since: new Date(Date.now() - 60 * 60 * 1000),
+    sources: ["stdout", "stderr", "output", "system"],
+});
+```
+
+```python Python
+import time
+
+recent = await handle.logs(
+    tail=50,
+    since_ms=(time.time() - 3600) * 1000,
+    sources=["stdout", "stderr", "output", "system"],
+)
+```
+</CodeGroup>
+
+## On-disk layout
+
+Each sandbox has its own log directory under `<sandbox-dir>/logs/`:
+
+| File | Producer | Format | Bounded? |
+|------|----------|--------|----------|
+| `exec.log` | Host relay tap | JSON Lines (one entry per chunk) | Yes — `RotatingLog`, 10 MiB × 3 |
+| `runtime.log` | Sandbox process tracing | Plain text (RFC 3339 prefix) | Yes — `RotatingLog`, 10 MiB × 3 |
+| `kernel.log` | Guest VM virtio-console | Plain text (kernel + `agentd`) | Append-only |
+| `boot-error.json` | Sandbox process (failed start only) | JSON object | Single file, atomically replaced |
+
+Lifecycle: the directory is created on `msb create`. `exec.log` gets `--- sandbox started ---` injected when the agent reports `core.ready`, and `--- sandbox stopped ---` when the sandbox process exits (the latter from the VMM's `on_exit` observer, so it fires reliably even on crashes). On `msb remove`, the entire directory is deleted.
+
+## Boot errors
+
+When a sandbox process exits before the agent relay is ready — typically a mount error, missing rootfs, or network setup failure — there's no `exec.log` content yet. The runtime writes a small structured `boot-error.json` instead:
+
+```json
+{
+  "t": "2026-04-30T20:32:59.690Z",
+  "stage": "mount",
+  "errno": 2,
+  "message": "mount tmp_x_…: No such file or directory (os error 2)"
+}
+```
+
+The CLI prepends a styled error block reconstructed from this file before any captured log content:
+
+```
+error: failed to start "dind"
+  → mount: mount tmp_x_…: No such file or directory (os error 2)
+  → the host path for one of the mounts does not exist
+  → run `msb logs --source system dind` for full diagnostics
+```
+
+`stage` values: `mount`, `build_vm`, `config`, `network`, `image`, `other`. The CLI's stage-to-hint mapper turns `(stage, errno)` into the actionable hint line.
+
+SDK callers see this as a typed [`BootStart` error](/sdk/errors#sandbox-start-failures) — match on it to recover or report cleanly.
+
+## Common diagnostic flows
+
+**"My sandbox crashed — what happened?"**
+
+```bash
+msb ls                              # confirm Crashed state
+msb logs <name>                     # what was the program doing right before?
+msb logs <name> --source system     # runtime + kernel diagnostics
+```
+
+**"My sandbox won't start."**
+
+```bash
+msb create --name nope ...          # observe the styled error block
+cat ~/.microsandbox/sandboxes/nope/logs/boot-error.json
+msb logs nope --source system       # full diagnostics from runtime.log/kernel.log
+```
+
+**"My program isn't logging."**
+
+If `exec.log` only has `--- sandbox started ---` and nothing else, no exec session ever opened. Check that you actually ran something — `msb create` alone doesn't run any user program.
+
+**"My program is logging but I can't tell which session."**
+
+```bash
+msb logs <name> --show-id           # prefix every line with the session id
+msb logs <name> --color-sessions    # one color per session
+```
+
+**"I want to feed logs to my own pipeline."**
+
+```bash
+# JSON Lines — schema in this page's "What's captured" section
+msb logs <name> --json | jq -c 'select(.s == "stderr")'
+
+# Or programmatic via the SDK — same data, typed.
+```
+
+## Capture model in detail
+
+A sandbox can host many concurrent exec sessions: an `msb run` at creation, plus arbitrary `msb exec` calls, plus SDK-driven sessions. **Every session is captured** to `exec.log`, tagged with its own monotonic `id` field so readers can group or filter without losing data.
+
+The id is minted by the relay (`next_session_id: AtomicU64`, starts at 1, +1 per observed `ExecRequest`). It's distinct from the protocol correlation id — the latter is per-client and gets reused across slot recycling, which would make sequential `msb exec` calls indistinguishable. The relay-minted id never repeats within a sandbox lifetime.
+
+System entries (`--- sandbox started ---`, `--- sandbox stopped ---`) have no `id` field — they aren't tied to a specific session.
+
+## Troubleshooting log capture
+
+- **`exec.log` is empty.** No exec session ever opened. `msb create` alone doesn't run anything; you need `msb run` or `msb exec` to produce output.
+- **Stderr appears as `stdout`.** The session is in PTY mode (interactive). PTY merges streams in the kernel — by the time bytes leave the guest, they're indistinguishable. Use `< /dev/null` or non-interactive invocation to take the pipe path. PTY-mode bytes are tagged `output`, not `stdout` — make sure your filters cover both.
+- **`runtime.log` has weird `[2m...` characters.** Older sandboxes may still have ANSI color codes from `tracing`. Newly-created sandboxes don't (we disable ANSI at the source for the sandbox subprocess).
+- **`msb logs -f` exits immediately.** The sandbox is stopped. Follow mode against a stopped sandbox dumps the existing contents and exits — it doesn't block waiting for it to start.

--- a/docs/ja/sandboxes/metrics.mdx
+++ b/docs/ja/sandboxes/metrics.mdx
@@ -1,0 +1,83 @@
+---
+title: Metrics
+description: Monitor sandbox resource usage
+icon: "chart-line"
+---
+
+Query resource usage for a running sandbox: CPU, memory, and more. Get a single point-in-time snapshot, or open a streaming subscription that delivers updates at a fixed interval.
+
+## Point-in-time
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let metrics = sb.metrics().await?;
+println!("CPU: {:.1}%, Mem: {} MB", metrics.cpu_percent, metrics.memory_bytes / 1024 / 1024);
+```
+
+```typescript TypeScript
+const metrics = await sb.metrics();
+console.log(`CPU: ${metrics.cpuPercent.toFixed(1)}%, Mem: ${Math.floor(metrics.memoryBytes / 1024 / 1024)} MB`);
+```
+
+```python Python
+m = await sb.metrics()
+print(f"CPU: {m.cpu_percent:.1f}%, Mem: {m.memory_bytes // 1024 // 1024} MB")
+```
+
+</CodeGroup>
+
+## Streaming
+
+Subscribe to metric updates at a regular interval. Each update arrives as a separate event.
+
+<CodeGroup>
+```rust Rust
+use std::time::Duration;
+use futures::StreamExt;
+
+let mut stream = sb.metrics_stream(Duration::from_secs(1));
+while let Some(m) = stream.next().await {
+    let m = m?;
+    println!("CPU: {:.1}%, Mem: {} MB", m.cpu_percent, m.memory_bytes / 1024 / 1024);
+}
+```
+
+```typescript TypeScript
+for await (const m of await sb.metricsStream(1000)) {
+    console.log(`[${m.timestamp.toISOString()}] CPU: ${m.cpuPercent.toFixed(1)}%`);
+}
+```
+
+```python Python
+async for m in await sb.metrics_stream(interval=1.0):
+    print(f"[{m.timestamp_ms}] CPU: {m.cpu_percent:.1f}%")
+```
+
+</CodeGroup>
+
+## Fleet-wide metrics
+
+Get metrics for all running sandboxes at once. Useful for dashboards or capacity planning.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::all_sandbox_metrics;
+
+let all = all_sandbox_metrics().await?;
+```
+
+```typescript TypeScript
+import { allSandboxMetrics } from "microsandbox";
+
+const all = await allSandboxMetrics();
+```
+
+```python Python
+from microsandbox import all_sandbox_metrics
+
+all_metrics = await all_sandbox_metrics()
+```
+
+</CodeGroup>

--- a/docs/ja/sandboxes/overview.mdx
+++ b/docs/ja/sandboxes/overview.mdx
@@ -1,0 +1,355 @@
+---
+title: Overview
+description: What sandboxes are and how to configure them
+icon: "circle-info"
+---
+
+A sandbox is a microVM: a real virtual machine with its own Linux kernel, filesystem, and network stack, running as a child process of whatever application creates it.
+
+The security boundary here is hardware virtualization, not Linux namespaces. Container escapes are a well-documented class of vulnerability; breaking out of a microVM requires exploiting the hypervisor itself, which is a fundamentally harder problem.
+
+## Creating a sandbox
+
+At minimum, a sandbox needs a name and an image. Everything else has sensible defaults: 1 vCPU, 512 MiB memory, public-only networking, `/bin/sh` as the shell.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create("worker", image="python")
+```
+
+```bash CLI
+msb create python --name worker
+```
+
+</CodeGroup>
+
+## Configuration options
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .memory(1024)
+    .cpus(2)
+    .env("DEBUG", "true")
+    .env("API_PORT", "8000")
+    .volume("/app/src", |v| v.bind("./src").readonly())
+    .volume("/data", |v| v.named("my-data"))
+    .volume("/tmp/scratch", |v| v.tmpfs().size(100))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .memory(1024)
+    .cpus(2)
+    .env("DEBUG", "true")
+    .env("API_PORT", "8000")
+    .volume("/app/src",     (m) => m.bind("./src").readonly())
+    .volume("/data",        (m) => m.named("my-data"))
+    .volume("/tmp/scratch", (m) => m.tmpfs().size(100))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    memory=1024,
+    cpus=2,
+
+    env={"DEBUG": "true", "API_PORT": "8000"},
+    volumes={
+        "/app/src": Volume.bind("./src", readonly=True),
+        "/data": Volume.named("my-data"),
+        "/tmp/scratch": Volume.tmpfs(size_mib=100),
+    },
+)
+```
+
+```bash CLI
+msb create python --name worker \
+  -c 2 \
+  -m 1G \
+  -e DEBUG=true \
+  -e API_PORT=8000 \
+  -v ./src:/app/src:ro \
+  -v my-data:/data \
+  --tmpfs /tmp/scratch:100
+```
+
+</CodeGroup>
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `image` | — | OCI image, local path, or disk image |
+| `cpus` | `1` | Number of virtual CPUs |
+| `memory` | `512` | Guest memory in MiB |
+| `workdir` | — | Default working directory for commands |
+| `shell` | `/bin/sh` | Shell used by `shell()` calls |
+| `env` | `{}` | Environment variables |
+| `volumes` | `[]` | Volume mounts (bind, named, or tmpfs) |
+| `network` | `public` | Network policy and port mappings |
+| `scripts` | `{}` | Named scripts stored at `/.msb/scripts/` |
+
+<Tip>
+  `cpus` and `memory` are **limits, not reservations**. Setting `memory: 512` doesn't allocate 512 MiB upfront. Physical pages are only allocated as the guest actually touches them, so you can comfortably run many sandboxes on a single host without worrying about overcommitting.
+</Tip>
+
+## Rootfs sources
+
+microsandbox supports three ways to provide a root filesystem. The choice affects how the filesystem is assembled and what features are available.
+
+### OCI images
+
+The most common option. microsandbox pulls the image and stacks its layers as a copy-on-write filesystem. Changes inside the sandbox don't modify the base image. If two sandboxes use the same image, they share the same cached layers on disk.
+
+<CodeGroup>
+```rust Rust
+Sandbox::builder("worker").image("python").create().await?;
+```
+
+```typescript TypeScript
+await Sandbox.builder("worker").image("python").create();
+```
+
+```python Python
+await Sandbox.create("worker", image="python")
+```
+
+```bash CLI
+msb create python --name worker
+```
+
+</CodeGroup>
+
+### Bind mounts
+
+Use a local directory on the host as the root filesystem directly. The guest sees the directory contents as its `/`. This is useful for development when you have a pre-built rootfs, or for minimal environments where you've assembled the filesystem yourself.
+
+<CodeGroup>
+```rust Rust
+Sandbox::builder("worker").image("./my-rootfs").create().await?;
+```
+
+```typescript TypeScript
+await Sandbox.builder("worker").image("./my-rootfs").create();
+```
+
+```python Python
+await Sandbox.create("worker", image="./my-rootfs")
+```
+
+```bash CLI
+msb create ./my-rootfs --name worker
+```
+
+</CodeGroup>
+
+<Note>
+  The guest agent is automatically included in the rootfs during sandbox creation, regardless of rootfs source. You don't need to add anything to your image or directory.
+</Note>
+
+### Disk images
+
+Boot from a QCOW2, Raw, or VMDK disk image. Unlike OCI images (which use a copy-on-write overlay), disk images give the guest raw block device access. See [Disk Images](/images/disk-images) for details.
+
+<CodeGroup>
+```rust Rust
+// Auto-detect filesystem
+Sandbox::builder("worker")
+    .image("./ubuntu-22.04.qcow2")
+    .create()
+    .await?;
+
+// Explicit filesystem type
+Sandbox::builder("worker")
+    .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+// Auto-detect the disk image format from the file extension.
+await Sandbox.builder("worker")
+    .image("./alpine.qcow2")
+    .create();
+```
+
+```python Python
+from microsandbox import Image, Sandbox
+
+# Auto-detect filesystem
+await Sandbox.create("worker", image="./ubuntu-22.04.qcow2")
+
+# Explicit filesystem type
+await Sandbox.create("worker", image=Image.disk("./alpine.raw", fstype="ext4"))
+```
+
+```bash CLI
+msb create ./alpine.qcow2 --name worker
+```
+
+</CodeGroup>
+
+<Note>
+  With OCI images, microsandbox stacks layers and adds a copy-on-write overlay so sandboxes share the base. With disk images, the guest gets the block device directly, so there's no copy-on-write isolation between sandboxes using the same disk image. Each sandbox needs its own copy (or use QCOW2's built-in snapshot/backing file support).
+</Note>
+
+## Replace existing
+
+Replace a stopped sandbox with the same name instead of failing on conflict. This stops the old sandbox (if still running), removes it, and creates a fresh one.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .replace()
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .replace()
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create("worker", image="python", replace=True)
+```
+
+```bash CLI
+msb create --replace python --name worker
+```
+
+</CodeGroup>
+
+## Private registry
+
+Authenticate to private container registries and control when images are pulled.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, RegistryAuth, PullPolicy};
+
+let sb = Sandbox::builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry_auth(RegistryAuth::Basic {
+        username: "deploy".into(),
+        password: std::env::var("REGISTRY_PASSWORD")?,
+    })
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("private.registry.io/org/app:v1")
+    .registry((r) => r.auth({
+        kind: "basic",
+        username: "deploy",
+        password: process.env.REGISTRY_TOKEN!,
+    }))
+    .pullPolicy("always")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import PullPolicy, RegistryAuth, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="private.registry.io/org/app:v1",
+    registry_auth=RegistryAuth.basic("deploy", os.environ["REGISTRY_PASSWORD"]),
+    pull_policy=PullPolicy.ALWAYS,
+)
+```
+
+```bash CLI
+msb registry login private.registry.io -u deploy
+msb create private.registry.io/org/app:v1 \
+  --name worker --pull always
+```
+
+</CodeGroup>
+
+| Policy | Behavior |
+|--------|----------|
+| `"always"` | Pull the image every time, even if cached locally |
+| `"if-missing"` | Pull only if the image is not already cached (default) |
+| `"never"` | Never pull; fail if the image is not cached |
+
+<Tip>
+  Once an OCI image is resolved, microsandbox pins the exact layers. A `python` reference is resolved to an immutable set of layers at first pull. Subsequent `start()` calls use the pinned layers without re-resolving the mutable tag, so your sandbox is reproducible even if the upstream tag is updated.
+</Tip>
+
+## Config inspection <sup><sup>coming soon</sup></sup>
+
+Build a sandbox configuration without booting the VM. Useful for serializing, storing, validating, or modifying configs before creation.
+
+<CodeGroup>
+```rust Rust
+let config = Sandbox::builder("preview")
+    .image("python")
+    .memory(1024)
+    .build()?;
+
+println!("{}", serde_json::to_string_pretty(&config)?);
+let sb = Sandbox::create(config).await?;
+```
+
+```typescript TypeScript
+const builder = Sandbox.builder("preview").image("python").memory(1024);
+const config = builder.build();
+
+console.log(JSON.stringify(config, null, 2));
+const sb = await builder.create();
+```
+
+```python Python
+import json
+from microsandbox import Sandbox
+
+config = Sandbox.build_config(
+    "preview",
+    image="python",
+    memory=1024,
+)
+
+print(json.dumps(config, indent=2))
+sb = await Sandbox.create(config)
+```
+
+</CodeGroup>
+
+## Customizing the guest environment
+
+If you need to run setup logic, install packages, or inject files before a sandbox starts doing real work, there are two ways to do it without building a custom image:
+
+- **[Scripts](/sandboxes/customize#scripts)** are files mounted into the sandbox at `/.msb/scripts/` and added to `PATH`. Define them at creation time and call them by name with `exec()` or `shell()`. Good for multi-step setup procedures or named entry points.
+- **[Patches](/sandboxes/customize#patches)** modify the rootfs before the VM boots: write config files, copy directories from the host, create symlinks, append to existing files, etc. The base image stays untouched since patches go into the writable layer.

--- a/docs/ja/sandboxes/secrets.mdx
+++ b/docs/ja/sandboxes/secrets.mdx
@@ -1,0 +1,76 @@
+---
+title: Secrets
+description: Secure credential injection for sandboxes
+icon: "key"
+---
+
+Secrets use a **placeholder substitution** model. The guest VM never sees the real credential.
+
+When you bind a secret to an environment variable and one or more allowed hosts, microsandbox generates a random placeholder (e.g., `OPENAI_API_KEY=msb_ph_a8f3c2...`) and injects that into the guest instead. The real value never enters the VM. The only way it reaches the outside world is when a request goes to an allowed host, at which point microsandbox swaps the placeholder for the real value. Everywhere else, the placeholder is just a meaningless string.
+
+So even with full code execution inside the sandbox, there's nothing to steal. The credential was never there.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("agent")
+    .image("python")
+    .secret(|s| s
+        .env("GITHUB_TOKEN")
+        .value(std::env::var("GITHUB_TOKEN")?)
+        .allow_host("api.github.com")
+        .allow_host_pattern("*.githubusercontent.com")
+    )
+    .secret_env("OPENAI_API_KEY", api_key, "api.openai.com")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("agent")
+    .image("python")
+    .secret((s) =>
+        s.env("GITHUB_TOKEN")
+            .value(process.env.GITHUB_TOKEN!)
+            .allowHost("api.github.com")
+            .allowHostPattern("*.githubusercontent.com"),
+    )
+    .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+    .create();
+```
+
+```python Python
+import os
+from microsandbox import Sandbox, Secret
+
+sb = await Sandbox.create(
+    "agent",
+    image="python",
+    secrets=[
+        Secret.env(
+            "GITHUB_TOKEN",
+            value=os.environ["GITHUB_TOKEN"],
+            allow_hosts=["api.github.com"],
+            allow_host_patterns=["*.githubusercontent.com"],
+        ),
+        Secret.env(
+            "OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+)
+```
+
+```bash CLI
+msb create python --name agent \
+  --secret "GITHUB_TOKEN=$GITHUB_TOKEN@api.github.com" \
+  --secret "OPENAI_API_KEY=$OPENAI_API_KEY@api.openai.com"
+```
+
+</CodeGroup>
+
+See the SDK Reference for the full API: [Rust](/sdk/rust/secrets) | [TypeScript](/sdk/typescript/secrets) | [Python](/sdk/python/secrets).

--- a/docs/ja/sandboxes/snapshots.mdx
+++ b/docs/ja/sandboxes/snapshots.mdx
@@ -1,0 +1,338 @@
+---
+title: Snapshots
+description: Capture a stopped sandbox's writable layer as a portable artifact
+icon: "code-branch"
+---
+
+A snapshot is a portable, on-disk capture of a sandbox's writable filesystem. Move it with `scp`, archive it as `.tar.zst`, or boot fresh sandboxes from it.
+
+<Note>
+Snapshots are **disk-only and stopped-only**: the sandbox can't be running when you take one. Memory and CPU state, plus qcow2 backing chains, are future work.
+</Note>
+
+## What gets captured
+
+| Captured                                     | Not captured                      |
+| -------------------------------------------- | --------------------------------- |
+| `upper.ext4`, the sandbox's writable overlay | Memory contents                   |
+| Pinned image reference + manifest digest     | CPU registers / running processes |
+| `fstype`, `format`, optional labels          | Network state                     |
+| Optional content-integrity hash              | Open file handles                 |
+
+Booting from a snapshot is a cold boot of a fresh VM that reuses the captured upper layer as its starting filesystem. The image (lower layer) is re-resolved by digest from the local OCI cache, or re-pulled from the registry if missing.
+
+## Quick start
+
+You'll usually reach for the CLI first:
+
+```bash
+# 1. Run something, install state, then stop it
+msb run --name baseline --detach python:3.12 -- sleep 3600
+msb exec baseline -- pip install requests
+msb stop baseline
+
+# 2. Snapshot the stopped sandbox
+msb snapshot create after-pip-install --from baseline
+
+# 3. Boot a fresh sandbox from the snapshot
+msb run --name worker --snapshot after-pip-install \
+    -- python -c "import requests; print(requests.__version__)"
+```
+
+<Tip>
+The snapshot lives at `~/.microsandbox/snapshots/after-pip-install/`. That whole directory is the snapshot.
+</Tip>
+
+## Snapshot a stopped sandbox
+
+Snapshot under a bare name (resolved to `~/.microsandbox/snapshots/<name>/`) or to an explicit path:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let h = Sandbox::get("baseline").await?;
+
+// Bare name resolves under ~/.microsandbox/snapshots/<name>/
+let snap = h.snapshot("after-pip-install").await?;
+
+// Or write to an explicit path
+let snap = h.snapshot_to("/tmp/snaps/v1").await?;
+
+println!("{}", snap.digest()); // sha256:...
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const h = await Sandbox.get("baseline");
+
+// Bare name resolves under ~/.microsandbox/snapshots/<name>/
+const snap = await h.snapshot("after-pip-install");
+
+// Or write to an explicit path
+const snap2 = await h.snapshotTo("/tmp/snaps/v1");
+
+console.log(snap.digest); // sha256:...
+```
+
+```python Python
+from microsandbox import Sandbox
+
+h = await Sandbox.get("baseline")
+
+# Bare name resolves under ~/.microsandbox/snapshots/<name>/
+snap = await h.snapshot("after-pip-install")
+
+# Or write to an explicit path
+snap2 = await h.snapshot_to("/tmp/snaps/v1")
+
+print(snap.digest)  # sha256:...
+```
+
+```bash CLI
+msb snapshot create after-pip-install --from baseline
+msb snapshot create ./snaps/v1     --from baseline   # Explicit path
+msb snapshot create after-pip-install --from baseline --label stage=ready
+```
+
+</CodeGroup>
+
+The sandbox must be stopped or crashed; running sandboxes are rejected.
+
+## Boot from a snapshot
+
+A snapshot already pins its image, so booting from one is mutually exclusive with the image source:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("worker")
+    .from_snapshot("after-pip-install")
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.builder("worker")
+    .fromSnapshot("after-pip-install")
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox
+
+# `snapshot=` is a peer of `image=` and mutually exclusive with it
+sb = await Sandbox.create("worker", snapshot="after-pip-install")
+```
+
+```bash CLI
+msb run --name worker --snapshot after-pip-install -- python -V
+```
+
+</CodeGroup>
+
+Booting validates the snapshot's manifest, re-resolves the pinned image from the local OCI cache (re-pulling and verifying the digest if it's missing), and reflinks the captured `upper.ext4` into the new sandbox's directory. Reflinks use `clonefile` on macOS APFS, `FICLONE` on btrfs/XFS, with a sparse-aware fallback on ext4, so each new sandbox gets an independent COW copy without paying the bytes again.
+
+## List, inspect, and remove
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Snapshot;
+
+let all = Snapshot::list().await?; // Indexed snapshots
+let h = Snapshot::get("after-pip-install").await?; // By name, digest, or path
+println!("{} ({})", h.name().unwrap_or("-"), h.digest());
+
+Snapshot::remove("after-pip-install", false).await?;
+Snapshot::reindex("~/.microsandbox/snapshots").await?;
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+const all = await Snapshot.list();                       // Indexed snapshots
+const h = await Snapshot.get("after-pip-install");       // By name, digest, or path
+console.log(`${h.name ?? "-"} (${h.digest})`);
+
+await Snapshot.remove("after-pip-install");
+await Snapshot.reindex("~/.microsandbox/snapshots");
+```
+
+```python Python
+from microsandbox import Snapshot
+
+all = await Snapshot.list()                              # Indexed snapshots
+h = await Snapshot.get("after-pip-install")              # By name, digest, or path
+print(f"{h.name or '-'} ({h.digest})")
+
+await Snapshot.remove("after-pip-install")
+await Snapshot.reindex("~/.microsandbox/snapshots")
+```
+
+```bash CLI
+msb snapshot ls
+msb snapshot inspect after-pip-install
+msb snapshot rm after-pip-install
+
+# Also if it has indexed children
+msb snapshot rm after-pip-install --force
+
+# Rebuild the index from artifacts on disk
+msb snapshot reindex
+```
+
+</CodeGroup>
+
+Opening a snapshot is cheap: it validates the manifest and checks the upper file's size, but does **not** read the file's contents. The same path powers `inspect` and the boot flow; the load-bearing local operation has to stay fast.
+
+`list` and `get` are backed by a small local index DB. The index is just a cache for fast lookups, not a source of truth; if it ever gets out of sync (or you delete it), `reindex` rebuilds it from the artifacts on disk.
+
+## Move snapshots between machines
+
+The artifact is a directory containing `manifest.json` (canonical JSON; identity is the SHA-256 of these bytes) plus the captured `upper.ext4`. The directory **is** the snapshot; there's no hidden daemon state, so any of these three transports work:
+
+```bash
+# Copy the directory directly with scp (image must be cached or pullable on the target)
+scp -r ~/.microsandbox/snapshots/after-pip-install \
+    other-host:~/.microsandbox/snapshots/
+
+# Bundle into a .tar.zst, transport, then import
+msb snapshot export after-pip-install /tmp/snap.tar.zst
+scp /tmp/snap.tar.zst other-host:
+ssh other-host msb snapshot import /tmp/snap.tar.zst
+
+# Fully offline: include the OCI image cache so the target needs no network
+msb snapshot export after-pip-install /tmp/snap.tar.zst --with-image
+ssh other-host msb snapshot import /tmp/snap.tar.zst
+```
+
+Archives default to `.tar.zst` since zstd collapses sparse zero runs cheaply. Pass `--plain-tar` for a plain `.tar`; both are accepted on import via magic-byte detection.
+
+Or drive `export` and `import` from code:
+
+<CodeGroup>
+```rust Rust
+use std::path::Path;
+use microsandbox::Snapshot;
+use microsandbox::snapshot::ExportOpts;
+
+Snapshot::export(
+    "after-pip-install",
+    Path::new("/tmp/snap.tar.zst"),
+    ExportOpts { with_image: true, ..Default::default() },
+).await?;
+
+let snap = Snapshot::import(
+    Path::new("/tmp/snap.tar.zst"),
+    None,
+).await?;
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+await Snapshot.export("after-pip-install", "/tmp/snap.tar.zst", {
+  withImage: true,
+});
+
+const snap = await Snapshot.import("/tmp/snap.tar.zst");
+```
+
+```python Python
+from microsandbox import Snapshot
+
+await Snapshot.export(
+    "after-pip-install",
+    "/tmp/snap.tar.zst",
+    with_image=True,
+)
+
+snap = await Snapshot.import_("/tmp/snap.tar.zst")  # Trailing _ avoids the keyword
+```
+
+```bash CLI
+msb snapshot export after-pip-install /tmp/snap.tar.zst --with-image
+msb snapshot import /tmp/snap.tar.zst
+```
+
+</CodeGroup>
+
+## Integrity verification
+
+By default, snapshot creation does **not** hash the upper file. The artifact carries the upper's size and the pinned image's manifest digest, which together catch any corruption that would stop it from booting. Skipping the hash keeps `inspect` fast on multi-GB sparse upper layers, where the cost would otherwise dominate.
+
+Opt in to a content-integrity hash when crossing a trust boundary:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Snapshot;
+
+// Compute and record an integrity hash at create time
+let snap = Snapshot::builder("baseline")
+    .name("after-pip-install")
+    .record_integrity()
+    .create()
+    .await?;
+
+// Verify a snapshot's recorded integrity on demand
+let report = snap.verify().await?;
+
+```
+
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+// Compute and record an integrity hash at create time
+const snap = await Snapshot.builder("baseline")
+  .name("after-pip-install")
+  .recordIntegrity()
+  .create();
+
+// Verify a snapshot's recorded integrity on demand
+const report = await snap.verify();
+```
+
+```python Python
+from microsandbox import Snapshot
+
+# Compute and record an integrity hash at create time
+snap = await Snapshot.create(
+    "baseline",
+    name="after-pip-install",
+    record_integrity=True,
+)
+
+# Verify a snapshot's recorded integrity on demand
+report = await snap.verify()
+```
+
+```bash CLI
+# Compute and record an integrity hash at create time
+msb snapshot create after-pip-install --from baseline --integrity
+
+# Verify a snapshot's recorded integrity on demand
+msb snapshot verify after-pip-install
+msb snapshot inspect after-pip-install --verify
+```
+
+</CodeGroup>
+
+`msb snapshot export` automatically populates the integrity hash before bundling, and `msb snapshot import` verifies it on the way in. The local index path stays fast; the cross-machine path stays trustworthy.
+
+## Use cases
+
+- **Reusable build state.** Install dependencies once, snapshot, then `msb run --snapshot ...` repeatedly without paying the install cost. Common pattern for CI, agent workloads, and reproducible dev environments.
+- **Portable scratch state.** Capture a sandbox after a long setup, hand the artifact to a teammate or push it to shared storage, and let them boot from the same starting point.
+- **Local fork-by-copy.** Multiple sandboxes from one snapshot are independent; each copy of the upper layer diverges on its own.
+- **Disaster recovery.** Snapshot a sandbox before a risky migration; if it goes wrong, `msb rm` the broken one and `msb run --snapshot` from the pre-migration artifact.
+
+## What's not yet supported
+
+- **Live (running) snapshots.** The sandbox must be stopped first. Live capture requires an in-guest filesystem freeze and memory checkpointing that's tracked as future work.
+- **qcow2 backing chains.** Snapshots always copy the upper layer today. The manifest's `format` and `parent` fields are reserved so qcow2 chains can land additively without a schema break.
+- **Push/pull from a registry.** The artifact format is registry-shaped on purpose, but transport tooling beyond `scp` and `tar.zst` is a separate piece of work.
+- **Snapshotting `DiskImage` volumes.** The same mechanism would apply (reflink the disk file), but is currently out of scope.

--- a/docs/ja/sandboxes/volumes.mdx
+++ b/docs/ja/sandboxes/volumes.mdx
@@ -1,0 +1,271 @@
+---
+title: Volumes
+description: Persist and share data across sandboxes
+icon: "hard-drive"
+---
+
+Volumes give a sandbox direct filesystem access to host-side directories. They're useful for persisting data across restarts, sharing data between sandboxes, or mounting host directories into the guest. They're also significantly faster than the [filesystem API](/sandboxes/filesystem) (which transfers files individually), so for anything beyond ad-hoc reads and writes, volumes are the way to go.
+
+microsandbox supports three types of mounts: bind mounts, named volumes, and tmpfs.
+
+## Bind mounts
+
+Mount a directory from the host directly into the sandbox. Changes inside the sandbox are reflected on the host, and vice versa.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("dev")
+    .image("python")
+    .volume("/app/src", |v| v.bind("./src").readonly())
+    .volume("/app/data", |v| v.bind("./data"))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("dev")
+    .image("python")
+    .volume("/app/src",  (m) => m.bind("./src").readonly())
+    .volume("/app/data", (m) => m.bind("./data"))
+    .create();
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+sb = await Sandbox.create(
+    "dev",
+    image="python",
+    volumes={
+        "/app/src": Volume.bind("./src", readonly=True),
+        "/app/data": Volume.bind("./data"),
+    },
+)
+```
+
+```bash CLI
+msb create python --name dev \
+  -v ./src:/app/src:ro \
+  -v ./data:/app/data
+```
+
+</CodeGroup>
+
+## Named volumes
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox, so you can create a volume, populate it, and mount it into different sandboxes over time.
+
+### Create a volume
+
+<CodeGroup>
+```rust Rust
+let cache = Volume::builder("pip-cache")
+    .quota(1024)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Volume } from "microsandbox";
+
+const cache = await Volume.builder("pip-cache").quota(1024).create();
+```
+
+```python Python
+cache = await Volume.create("pip-cache", quota_mib=1024)
+```
+
+```bash CLI
+msb volume create pip-cache --size 1024
+```
+
+</CodeGroup>
+
+### Mount in a sandbox
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .volume("/root/.cache/pip", |v| v.named(cache.name()))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .volume("/root/.cache/pip", (m) => m.named(cache.name))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    volumes={
+        "/root/.cache/pip": Volume.named(cache.name),
+    },
+)
+```
+
+```bash CLI
+msb create python --name worker \
+  -v pip-cache:/root/.cache/pip
+```
+
+</CodeGroup>
+
+### Share between sandboxes
+
+Named volumes are the simplest way to share data between sandboxes. Mount the same volume into multiple sandboxes: one writes, another reads.
+
+<CodeGroup>
+```rust Rust
+// Writer
+let writer = Sandbox::builder("writer")
+    .image("alpine")
+    .volume("/data", |v| v.named("shared-data"))
+    .create()
+    .await?;
+writer.shell("echo 'hello' > /data/message.txt").await?;
+
+// Reader (read-only)
+let reader = Sandbox::builder("reader")
+    .image("alpine")
+    .volume("/data", |v| v.named("shared-data").readonly())
+    .create()
+    .await?;
+let output = reader.exec("cat", ["/data/message.txt"]).await?;
+// => "hello"
+```
+
+```typescript TypeScript
+// Writer
+await using writer = await Sandbox.builder("writer")
+    .image("alpine")
+    .volume("/data", (m) => m.named("shared-data"))
+    .create();
+await writer.shell("echo 'hello' > /data/message.txt");
+
+// Reader (read-only)
+await using reader = await Sandbox.builder("reader")
+    .image("alpine")
+    .volume("/data", (m) => m.named("shared-data").readonly())
+    .create();
+const output = await reader.exec("cat", ["/data/message.txt"]);
+// => "hello"
+```
+
+```python Python
+# Writer
+writer = await Sandbox.create(
+    "writer",
+    image="alpine",
+    volumes={"/data": Volume.named("shared-data")},
+)
+await writer.shell("echo 'hello' > /data/message.txt")
+
+# Reader (read-only)
+reader = await Sandbox.create(
+    "reader",
+    image="alpine",
+    volumes={"/data": Volume.named("shared-data", readonly=True)},
+)
+output = await reader.exec("cat", ["/data/message.txt"])
+# => "hello"
+```
+
+</CodeGroup>
+
+<Tip>
+  When sharing volumes between sandboxes, both sandboxes access the same underlying host directory. There's no built-in locking, so if two sandboxes write to the same file concurrently, you'll get the usual race conditions. Use the read-only flag on the reader side to make intent explicit.
+</Tip>
+
+### Host-side access
+
+Named volumes are accessible from the host even without a running sandbox, which is handy for pre-populating data before any sandbox mounts it.
+
+<CodeGroup>
+```rust Rust
+let vol = Volume::get("pip-cache").await?;
+vol.fs().write("/requirements.txt", "requests==2.28.0").await?;
+```
+
+```typescript TypeScript
+const vol = await Volume.get("pip-cache");
+await vol.fs().write("requirements.txt", "requests==2.28.0");
+```
+
+```python Python
+vol = await Volume.get("pip-cache")
+await vol.fs.write("/requirements.txt", b"requests==2.28.0")
+```
+
+</CodeGroup>
+
+### Manage volumes
+
+<CodeGroup>
+```rust Rust
+let volumes = Volume::list().await?;
+Volume::remove("old-cache").await?;
+```
+
+```typescript TypeScript
+const volumes = await Volume.list();
+await Volume.remove("old-cache");
+```
+
+```python Python
+volumes = await Volume.list()
+await Volume.remove("old-cache")
+```
+
+```bash CLI
+msb volume ls
+msb volume rm old-cache
+```
+
+</CodeGroup>
+
+## Tmpfs
+
+An in-memory filesystem that disappears when the sandbox stops. Useful for scratch space, build artifacts, or anything that doesn't need to outlive the sandbox.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("alpine")
+    .volume("/tmp/scratch", |v| v.tmpfs().size(100))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("alpine")
+    .volume("/tmp/scratch", (m) => m.tmpfs().size(100))
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="alpine",
+    volumes={
+        "/tmp/scratch": Volume.tmpfs(size_mib=100),
+    },
+)
+```
+
+```bash CLI
+msb create alpine --name worker \
+  --tmpfs /tmp/scratch:100
+```
+
+</CodeGroup>

--- a/docs/ja/sdk/errors.mdx
+++ b/docs/ja/sdk/errors.mdx
@@ -1,0 +1,266 @@
+---
+title: Error Handling
+description: Typed errors and resource cleanup patterns
+icon: "triangle-exclamation"
+---
+
+All SDKs surface typed errors so you can match on specific failure modes instead of parsing strings. Rust has an `Error` enum, TypeScript exposes a dedicated subclass per variant (use `instanceof`), and Python provides dedicated exception classes.
+
+## Matching errors
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, Error};
+
+async fn get_or_create(name: &str) -> Result<Sandbox, Error> {
+    match Sandbox::get(name).await {
+        Ok(handle) => handle.start().await,
+        Err(Error::SandboxNotFound(_)) => {
+            Sandbox::builder(name).image("python").create().await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+match sb.exec("python", ["script.py"]).await {
+    Ok(output) if output.status().success => {
+        println!("{}", output.stdout()?);
+    }
+    Ok(output) => {
+        eprintln!("Exit {}: {}", output.status().code, output.stderr()?);
+    }
+    Err(Error::ExecTimeout) => eprintln!("Timed out"),
+    Err(Error::Runtime(msg)) => eprintln!("Runtime: {msg}"),
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import {
+    ExecTimeoutError,
+    RuntimeError,
+    Sandbox,
+    SandboxNotFoundError,
+} from "microsandbox";
+
+async function getOrCreate(name: string): Promise<Sandbox> {
+    try {
+        const handle = await Sandbox.get(name);
+        return await handle.start();
+    } catch (e) {
+        if (e instanceof SandboxNotFoundError) {
+            return Sandbox.builder(name).image("python").create();
+        }
+        throw e;
+    }
+}
+
+try {
+    const output = await sb.exec("python", ["script.py"]);
+    if (!output.success) {
+        console.error(`Failed (exit ${output.code}):`, output.stderr());
+    }
+} catch (e) {
+    if (e instanceof ExecTimeoutError) {
+        console.error(`Timed out after ${e.timeoutMs}ms`);
+    } else if (e instanceof RuntimeError) {
+        console.error("Runtime:", e.message);
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import (
+    ExecTimeoutError, Sandbox, SandboxNotFoundError
+)
+
+async def get_or_create(name: str):
+    try:
+        handle = await Sandbox.get(name)
+        return await handle.start()
+    except SandboxNotFoundError:
+        return await Sandbox.create(name, image="python")
+
+try:
+    output = await sb.exec("python", ["script.py"])
+    if not output.success:
+        print(f"Exit {output.exit_code}: {output.stderr_text}")
+except ExecTimeoutError:
+    print("Timed out")
+```
+
+</CodeGroup>
+
+## Spawn-time exec failures
+
+`exec()` distinguishes between:
+
+- **A program that ran and exited non-zero** — the call returns an `ExecOutput` with a non-zero `code`. This is *not* an error in the SDK sense; it's a normal result.
+- **A program that never started** — the binary doesn't exist, isn't executable, the working directory is unreachable, etc. This surfaces as a typed error variant: `ExecFailed` (Rust), `ExecFailedError` (TypeScript), `ExecFailedError` (Python).
+
+The typed error carries a classified `kind` plus the underlying `errno`, so callers can branch on the cause and react. Common kinds: `NotFound` (binary missing on PATH), `PermissionDenied`, `NotExecutable`, `BadCwd`, `BadArgs`, `ResourceLimit`, `UserSetupFailed`, `OutOfMemory`, `PtySetupFailed`, `Other`.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Error;
+use microsandbox_protocol::exec::ExecFailureKind;
+
+match sb.exec("nonexistent", []).await {
+    Ok(output) => { /* program ran, check output.status() */ }
+    Err(Error::ExecFailed(payload)) => {
+        match payload.kind {
+            ExecFailureKind::NotFound => {
+                eprintln!("Binary not found on PATH: {}", payload.message);
+            }
+            ExecFailureKind::PermissionDenied => {
+                eprintln!("Not executable (chmod +x?): {}", payload.message);
+            }
+            kind => {
+                eprintln!("Spawn failed ({:?}): {}", kind, payload.message);
+            }
+        }
+        // payload.errno, payload.errno_name, payload.stage are also available
+    }
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import { ExecFailedError, Sandbox } from "microsandbox";
+
+try {
+    const output = await sb.exec("nonexistent");
+    // program ran, check output.success / output.code
+} catch (e) {
+    if (e instanceof ExecFailedError) {
+        switch (e.kind) {
+            case "not_found":
+                console.error("Binary not on PATH:", e.message);
+                break;
+            case "permission_denied":
+                console.error("Not executable (chmod +x?):", e.message);
+                break;
+            default:
+                console.error(`Spawn failed (${e.kind}):`, e.message);
+        }
+        // e.errno, e.errnoName, e.stage are also available
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import ExecFailedError
+
+try:
+    output = await sb.exec("nonexistent")
+    # program ran, check output.success / output.exit_code
+except ExecFailedError as e:
+    if e.kind == "not_found":
+        print(f"Binary not on PATH: {e.message}")
+    elif e.kind == "permission_denied":
+        print(f"Not executable (chmod +x?): {e.message}")
+    else:
+        print(f"Spawn failed ({e.kind}): {e.message}")
+    # e.errno, e.errno_name, e.stage are also available
+```
+</CodeGroup>
+
+The CLI maps these kinds to POSIX-style exit codes: `127` for `NotFound`, `126` for `PermissionDenied` and `NotExecutable`, `1` otherwise. SDK callers reading the error directly don't need to think about exit codes — branch on `kind` instead.
+
+## Sandbox start failures
+
+When a sandbox process exits before the agent relay is ready (mount errors, missing rootfs, network setup failures), the SDK surfaces a typed `BootStart` / `BootStartError`. The payload carries the failure stage and errno so callers can recover or report cleanly.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Error;
+use microsandbox_runtime::boot_error::BootErrorStage;
+
+match Sandbox::builder("svc").image("alpine").create().await {
+    Ok(sb) => { /* ... */ }
+    Err(Error::BootStart { name, err }) => {
+        eprintln!("Sandbox {name:?} failed at stage {:?}: {}", err.stage, err.message);
+        if matches!(err.stage, BootErrorStage::Mount) {
+            eprintln!("Hint: a host volume path may not exist.");
+        }
+    }
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import { BootStartError } from "microsandbox";
+
+try {
+    const sb = await Sandbox.builder("svc").image("alpine").create();
+} catch (e) {
+    if (e instanceof BootStartError) {
+        console.error(`Sandbox "${e.name}" failed at stage ${e.stage}: ${e.message}`);
+        if (e.stage === "mount") {
+            console.error("Hint: a host volume path may not exist.");
+        }
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import BootStartError
+
+try:
+    sb = await Sandbox.create("svc", image="alpine")
+except BootStartError as e:
+    print(f"Sandbox {e.name!r} failed at stage {e.stage}: {e.message}")
+    if e.stage == "mount":
+        print("Hint: a host volume path may not exist.")
+```
+</CodeGroup>
+
+The CLI prepends the same payload as a styled `error:` block before any captured log output, so you see "what went wrong + a hint" inline. SDK callers get the structured payload to make their own decisions.
+
+## Resource cleanup
+
+Sandboxes hold compute resources, so release them when done. In Rust, `Drop` handles cleanup when the sandbox goes out of scope. In TypeScript, prefer `await using` (Node 22+) which calls `Sandbox.stop()` automatically when the binding leaves scope.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+// Sandbox implements Drop, so resources are released when `sb` goes out of scope.
+// For explicit control, call stop() or kill().
+{
+    let sb = Sandbox::builder("temp")
+        .image("python")
+        .create()
+        .await?;
+
+    let output = sb.exec("python", ["-c", "print('hello')"]).await?;
+} // sb is dropped here, resources are cleaned up
+```
+
+```typescript TypeScript
+async function runTemporary(): Promise<string> {
+    // `await using` calls Sandbox.stop() when the binding leaves scope.
+    await using sb = await Sandbox.builder("temp")
+        .image("python")
+        .replace()
+        .create();
+
+    const out = await sb.exec("python", ["-c", "print('hello')"]);
+    return out.stdout();
+}
+```
+
+```python Python
+# Use async context manager — auto-kills and removes on exit.
+async with await Sandbox.create("temp", image="python") as sb:
+    output = await sb.exec("python", ["-c", "print('hello')"])
+    print(output.stdout_text)
+```
+
+</CodeGroup>

--- a/docs/ja/sdk/overview.mdx
+++ b/docs/ja/sdk/overview.mdx
@@ -1,0 +1,96 @@
+---
+title: Overview
+description: Install the SDK and create your first sandbox
+icon: "play"
+---
+
+The SDK embeds the microsandbox runtime directly into whatever application uses it. `Sandbox.builder(name).create()` spawns the VM as a child process. No daemon to install, no server to connect to.
+
+## Installation
+
+<CodeGroup>
+```bash Rust
+cargo add microsandbox
+```
+
+```bash TypeScript
+npm install microsandbox
+```
+
+```bash Python
+pip install microsandbox
+```
+</CodeGroup>
+
+## Quick start
+
+Create a sandbox from a container image, run a command, print the output, and stop it.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{Sandbox, NetworkPolicy};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let sb = Sandbox::builder("my-sandbox")
+        .image("python")
+        .memory(512)
+        .cpus(2)
+        .env("PYTHONDONTWRITEBYTECODE", "1")
+        .volume("/app/src", |v| v.bind("./src").readonly())
+        .network(|n| n.policy(NetworkPolicy::public_only()))
+        .create()
+        .await?;
+
+    let output = sb.exec("python", ["-c", "print('Hello, World!')"]).await?;
+    println!("{}", output.stdout()?);
+
+    sb.stop().await?;
+    Ok(())
+}
+```
+
+```typescript TypeScript
+import { NetworkPolicy, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("my-sandbox")
+    .image("python")
+    .memory(512)
+    .cpus(2)
+    .env("PYTHONDONTWRITEBYTECODE", "1")
+    .volume("/app/src", (m) => m.bind("./src").readonly())
+    .network((n) => n.policy(NetworkPolicy.publicOnly()))
+    .create();
+
+const output = await sb.exec("python", ["-c", "print('Hello, World!')"]);
+console.log("Output:", output.stdout());
+```
+
+```python Python
+import asyncio
+from microsandbox import Network, Sandbox, Volume
+
+async def main():
+    sb = await Sandbox.create(
+        "my-sandbox",
+        image="python",
+        memory=512,
+        cpus=2,
+        env={"PYTHONDONTWRITEBYTECODE": "1"},
+        volumes={
+            "/app/src": Volume.bind("./src", readonly=True),
+        },
+        network=Network.public_only(),
+    )
+
+    output = await sb.exec("python", ["-c", "print('Hello, World!')"])
+    print("Output:", output.stdout_text)
+
+    await sb.stop()
+
+asyncio.run(main())
+```
+
+</CodeGroup>
+
+The SDK reference is split by language - choose [Rust SDK](/sdk/rust/sandbox), [TypeScript SDK](/sdk/typescript/sandbox), or [Python SDK](/sdk/python/sandbox) for the full API. See also [error handling](/sdk/errors).

--- a/docs/ja/sdk/python/events.mdx
+++ b/docs/ja/sdk/python/events.mdx
@@ -1,0 +1,11 @@
+---
+title: Events
+description: Python SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for a preview of event concepts and planned API.

--- a/docs/ja/sdk/python/execution.mdx
+++ b/docs/ja/sdk/python/execution.mdx
@@ -1,0 +1,212 @@
+---
+title: Execution
+description: Python SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+## Types
+
+### ExecOutput
+
+The result of a completed command execution.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| exit_code | `int` | Exit code |
+| success | `bool` | `True` if exit_code is `0` |
+| stdout_text | `str` | Collected stdout decoded as UTF-8. Raises on invalid encoding. |
+| stderr_text | `str` | Collected stderr decoded as UTF-8 |
+| stdout_bytes | `bytes` | Raw stdout bytes |
+| stderr_bytes | `bytes` | Raw stderr bytes |
+
+---
+
+### ExecHandle
+
+A handle to a running streaming execution. Supports `async for event in handle:` to iterate over events until the stream ends.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| id | `str` | Correlation ID for this execution |
+| take_stdin() | [`ExecSink`](#execsink) ` \| None` | Take the stdin writer. Returns `None` after first call. |
+| recv() | `ExecEvent \| None` | *(async)* Receive the next event. Returns `None` when done. |
+| wait() | `tuple[int, bool]` | *(async)* Wait for the process to exit. Returns `(code, success)`. |
+| collect() | [`ExecOutput`](#execoutput) | *(async)* Wait and collect all remaining output |
+| signal(sig) | `None` | *(async)* Send a POSIX signal to the process |
+| kill() | `None` | *(async)* Send SIGKILL |
+
+---
+
+### ExecSink
+
+Writer for sending data to a running process's stdin.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| write() | `data: bytes` | *(async)* Write bytes to the process's stdin |
+| close() | - | *(async)* Close stdin. The process sees EOF. |
+
+---
+
+### ExecEvent
+
+Low-level event from PyO3 bindings.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| event_type | `str` | `"started"`, `"stdout"`, `"stderr"`, or `"exited"` |
+| pid | `int \| None` | Guest PID (on `"started"`) |
+| data | `bytes \| None` | Output data (on `"stdout"` / `"stderr"`) |
+| code | `int \| None` | Exit code (on `"exited"`) |
+
+Python dataclass variants are also available for pattern matching:
+
+| Class | Fields | Description |
+|-------|--------|-------------|
+| `StartedEvent` | `pid: int` | The process has started |
+| `StdoutEvent` | `data: bytes` | A chunk of stdout data |
+| `StderrEvent` | `data: bytes` | A chunk of stderr data |
+| `ExitedEvent` | `code: int` | The process has exited |
+
+The union type `ExecEvent = StartedEvent | StdoutEvent | StderrEvent | ExitedEvent` is available from `events.py`.
+
+---
+
+### ExecOptions
+
+```python
+ExecOptions(
+    args: tuple[str, ...] = (),
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] = {},
+    timeout: float | None = None,  # seconds
+    stdin: Stdin = Stdin.null(),
+    tty: bool = False,
+    rlimits: tuple[Rlimit, ...] = (),
+)
+```
+
+Frozen dataclass for per-execution overrides.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| args | `tuple[str, ...]` | `()` | Command arguments |
+| cwd | `str \| None` | `None` | Working directory |
+| user | `str \| None` | `None` | Guest user |
+| env | `Mapping[str, str]` | `{}` | Environment variables |
+| timeout | `float \| None` | `None` | Kill the process after this many seconds |
+| stdin | [`Stdin`](#stdin) | `Stdin.null()` | Stdin source |
+| tty | `bool` | `False` | Allocate a pseudo-terminal |
+| rlimits | `tuple[`[`Rlimit`](#rlimit)`, ...]` | `()` | Resource limits |
+
+---
+
+### AttachOptions
+
+```python
+AttachOptions(
+    args: tuple[str, ...] = (),
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] = {},
+    detach_keys: str | None = None,
+)
+```
+
+Frozen dataclass for interactive PTY attach configuration.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| args | `tuple[str, ...]` | `()` | Command arguments |
+| cwd | `str \| None` | `None` | Working directory |
+| user | `str \| None` | `None` | Guest user |
+| env | `Mapping[str, str]` | `{}` | Environment variables |
+| detach_keys | `str \| None` | `None` | Key sequence to detach without stopping |
+
+---
+
+### Stdin
+
+Frozen dataclass with factory methods for configuring process stdin.
+
+| Factory | Parameters | Description |
+|---------|-----------|-------------|
+| Stdin.null() | - | `/dev/null` (default) |
+| Stdin.pipe() | - | Piped stdin. Use [`take_stdin()`](#exechandle) on the handle to write. |
+| Stdin.bytes() | `data: bytes` | Inline data sent before the process starts |
+
+---
+
+### Rlimit
+
+Frozen dataclass with factory methods for POSIX resource limits.
+
+| Factory | Parameters | Description |
+|---------|-----------|-------------|
+| Rlimit.nofile(limit) | `limit: int` | Max open file descriptors |
+| Rlimit.cpu(secs) | `secs: int` | CPU time limit in seconds |
+| Rlimit.as_(*, soft, hard) | `soft: int, hard: int` | Virtual memory size |
+| Rlimit.nproc(limit) | `limit: int` | Max number of processes |
+| Rlimit.fsize(limit) | `limit: int` | Max file size |
+| Rlimit.memlock(limit) | `limit: int` | Max locked memory |
+| Rlimit.stack(limit) | `limit: int` | Max stack size |
+
+**Properties**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| resource | [`RlimitResource`](#rlimitresource) | Resource type |
+| soft | `int` | Soft limit |
+| hard | `int` | Hard limit |
+
+---
+
+### RlimitResource
+
+Enum of POSIX resource types.
+
+| Value | Description |
+|-------|-------------|
+| `cpu` | CPU time |
+| `fsize` | File size |
+| `data` | Data segment size |
+| `stack` | Stack size |
+| `core` | Core file size |
+| `rss` | Resident set size |
+| `nproc` | Number of processes |
+| `nofile` | Open file descriptors |
+| `memlock` | Locked memory |
+| `as` | Virtual memory |
+| `locks` | File locks |
+| `sigpending` | Pending signals |
+| `msgqueue` | Message queue size |
+| `nice` | Nice priority ceiling |
+| `rtprio` | Real-time priority ceiling |
+| `rttime` | Real-time CPU time |
+
+---
+
+### SandboxMetrics
+
+Metrics snapshot for a running sandbox.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| cpu_percent | `float` | CPU utilization percentage |
+| memory_bytes | `int` | Current memory usage in bytes |
+| memory_limit_bytes | `int` | Memory limit in bytes |
+| disk_read_bytes | `int` | Total bytes read from disk |
+| disk_write_bytes | `int` | Total bytes written to disk |
+| net_rx_bytes | `int` | Total bytes received over the network |
+| net_tx_bytes | `int` | Total bytes sent over the network |
+| uptime_ms | `int` | Sandbox uptime in milliseconds |
+| timestamp_ms | `float` | Timestamp of the snapshot in milliseconds |
+
+---
+
+### MetricsStream
+
+Async iterator yielding [`SandboxMetrics`](#sandboxmetrics). Use `async for metrics in stream:` to consume.

--- a/docs/ja/sdk/python/filesystem.mdx
+++ b/docs/ja/sdk/python/filesystem.mdx
@@ -1,0 +1,357 @@
+---
+title: Filesystem
+description: Python SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via the `sandbox.fs` property. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
+
+---
+
+#### copy()
+
+```python
+async def copy(src: str, dst: str) -> None
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Source path |
+| dst | `str` | Destination path |
+
+---
+
+#### copy_from_host()
+
+```python
+async def copy_from_host(host_path: str, guest_path: str) -> None
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `str` | Path on the host filesystem |
+| guest_path | `str` | Destination path inside the sandbox |
+
+---
+
+#### copy_to_host()
+
+```python
+async def copy_to_host(guest_path: str, host_path: str) -> None
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `str` | Path inside the sandbox |
+| host_path | `str` | Destination path on the host |
+
+---
+
+#### exists()
+
+```python
+async def exists(path: str) -> bool
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `True` if the path exists |
+
+---
+
+#### list()
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`FsEntry`](#fsentry)`]` | Directory entries |
+
+---
+
+#### mkdir()
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory and all parent directories.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path |
+
+---
+
+#### read()
+
+```python
+async def read(path: str) -> bytes
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bytes` | File contents as raw bytes |
+
+---
+
+#### read_stream()
+
+```python
+async def read_stream(path: str) -> FsReadStream
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsReadStream`](#fsreadstream) | Async iterator that yields chunks of file data |
+
+---
+
+#### read_text()
+
+```python
+async def read_text(path: str) -> str
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `str` | File contents as a string |
+
+---
+
+#### remove()
+
+```python
+async def remove(path: str) -> None
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute file path |
+
+---
+
+#### remove_dir()
+
+```python
+async def remove_dir(path: str) -> None
+```
+
+Remove a directory recursively.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path |
+
+---
+
+#### rename()
+
+```python
+async def rename(src: str, dst: str) -> None
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Current path |
+| dst | `str` | New path |
+
+---
+
+#### stat()
+
+```python
+async def stat(path: str) -> FsMetadata
+```
+
+Get detailed metadata for a file or directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsMetadata`](#fsmetadata) | File metadata |
+
+---
+
+#### write()
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| data | `bytes` | File content |
+
+---
+
+#### write_stream()
+
+```python
+async def write_stream(path: str) -> FsWriteSink
+```
+
+Open a streaming writer for a file. Use this for files too large to fit in memory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsWriteSink`](#fswritesink) | Async writer that accepts chunks of data |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
+| mode | `int` | Unix permission bits |
+| modified | `float \| None` | Last modified timestamp (ms since epoch) |
+| path | `str` | File path |
+| size | `int` | File size in bytes |
+
+### FsEntryKind
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) representing the type of a filesystem entry.
+
+| Value | Description |
+|-------|-------------|
+| `"directory"` | Directory |
+| `"file"` | Regular file |
+| `"other"` | Other entry type |
+| `"symlink"` | Symbolic link |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| created | `float \| None` | Creation timestamp (ms since epoch) |
+| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
+| mode | `int` | Unix permission bits |
+| modified | `float \| None` | Last modified timestamp (ms since epoch) |
+| readonly | `bool` | Whether the file is read-only |
+| size | `int` | File size in bytes |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`read_stream()`](#read_stream).
+
+| Method / Protocol | Returns | Description |
+|-------------------|---------|-------------|
+| `__aiter__` / `__anext__` | `bytes` | Async iterator - use with `async for chunk in stream:` |
+| `collect()` | `bytes` | Collect all remaining data into a single `bytes` object |
+
+### FsWriteSink
+
+Async writer for streaming data into a file. Obtained via [`write_stream()`](#write_stream). Supports the async context manager protocol (`async with`).
+
+| Method / Protocol | Returns | Description |
+|-------------------|---------|-------------|
+| `write(data)` | `None` | Write a chunk of `bytes` to the file |
+| `close()` | `None` | Send EOF and finalize the file |
+| `__aenter__` / `__aexit__` | `FsWriteSink` | Use with `async with` for automatic close on exit |

--- a/docs/ja/sdk/python/networking.mdx
+++ b/docs/ja/sdk/python/networking.mdx
@@ -1,0 +1,333 @@
+---
+title: Networking
+description: Python SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## Network
+
+Frozen dataclass for sandbox network configuration. Use a class-method preset for the common cases, or construct directly with custom options.
+
+```python
+Network(
+    policy: str | NetworkPolicy | None = None,
+    ports: Mapping[int, int] = {},
+    deny_domains: tuple[str, ...] = (),
+    deny_domain_suffixes: tuple[str, ...] = (),
+    dns: DnsConfig | None = None,
+    tls: TlsConfig | None = None,
+    max_connections: int | None = None,
+    trust_host_cas: bool | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| policy | `str \| NetworkPolicy \| None` | Preset name (`"none"`, `"public_only"`, `"allow_all"`) or custom [`NetworkPolicy`](#networkpolicy-1) |
+| ports | `Mapping[int, int]` | Port mappings from host to guest |
+| deny_domains | `tuple[str, ...]` | Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy so it takes precedence over later allow rules |
+| deny_domain_suffixes | `tuple[str, ...]` | Deny egress to all subdomains of these suffixes. Adds `deny DomainSuffix("...")` rules; same enforcement layers as `deny_domains` |
+| dns | [`DnsConfig`](#dnsconfig) ` \| None` | DNS interception configuration |
+| tls | [`TlsConfig`](#tlsconfig) ` \| None` | TLS interception configuration |
+| max_connections | `int \| None` | Maximum concurrent connections |
+| trust_host_cas | `bool \| None` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle. Opt-in |
+
+---
+
+#### Network.allow_all()
+
+```python
+@classmethod
+def allow_all() -> Network
+```
+
+Unrestricted network access, including to private addresses and the host machine.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Unrestricted network configuration |
+
+---
+
+#### Network.none()
+
+```python
+@classmethod
+def none() -> Network
+```
+
+Deny all traffic. No network interface is created; the guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Fully airgapped network configuration |
+
+---
+
+#### Network.public_only()
+
+```python
+@classmethod
+def public_only() -> Network
+```
+
+Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Public-only network configuration |
+
+---
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Pass to `Network(policy=...)` for custom policies:
+
+```python
+from microsandbox import NetworkPolicy, Rule, Action, Direction, Protocol
+
+policy = NetworkPolicy(
+    default_egress=Action.DENY,
+    default_ingress=Action.ALLOW,
+    rules=(
+        Rule.allow(protocol=Protocol.TCP, port=443, destination="public"),
+        Rule.deny(destination="198.51.100.5"),
+    ),
+)
+```
+
+The default policy denies egress except for an implicit `allow public`, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry.
+
+```python
+NetworkPolicy(
+    default_egress: Action = Action.DENY,
+    default_ingress: Action = Action.ALLOW,
+    rules: tuple[Rule, ...] = (),
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
+| rules | `tuple[`[`Rule`](#rule)`, ...]` | Rules evaluated first-match-wins per direction |
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```python
+policy = NetworkPolicy(
+    default_egress=Action.DENY,
+    default_ingress=Action.ALLOW,
+    rules=(
+        Rule.allow(destination="10.0.0.0/8"),     # matches everything in 10.x
+        Rule.deny(destination="10.0.0.5"),        # never reached
+    ),
+)
+```
+
+Put specific rules before general ones.
+
+---
+
+## Rule
+
+Frozen dataclass for a single network policy rule.
+
+```python
+Rule(
+    action: Action,
+    direction: Direction = Direction.EGRESS,
+    destination: str | None = None,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| action | [`Action`](#action) | What to do when this rule matches |
+| direction | [`Direction`](#direction) | Which evaluator considers this rule. `Direction.ANY` matches in either direction |
+| destination | `str \| None` | Target filter: a [`DestGroup`](#destgroup) value, domain, CIDR range, domain suffix (prefixed with `"."`), or `"*"` for any. Domain and suffix strings are validated at sandbox creation; invalid names raise `ValueError` |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Single port (`443`) or range (`"8000-9000"`) |
+
+Ingress rules carrying ICMP protocols are rejected at sandbox creation; the host has no inbound ICMP path. Use `Direction.EGRESS` for ICMP allow/deny.
+
+---
+
+#### Rule.allow()
+
+```python
+@classmethod
+def allow(
+    *,
+    direction: Direction = Direction.EGRESS,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+    destination: str | None = None,
+) -> Rule
+```
+
+Create a rule that permits matching traffic.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| direction | [`Direction`](#direction) | Traffic direction |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Port or port range |
+| destination | `str \| None` | Destination filter |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | An allow rule |
+
+---
+
+#### Rule.deny()
+
+```python
+@classmethod
+def deny(
+    *,
+    direction: Direction = Direction.EGRESS,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+    destination: str | None = None,
+) -> Rule
+```
+
+Create a rule that blocks matching traffic.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| direction | [`Direction`](#direction) | Traffic direction |
+| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
+| port | `int \| str \| None` | Port or port range |
+| destination | `str \| None` | Destination filter |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | A deny rule |
+
+---
+
+## DnsConfig
+
+Frozen dataclass for DNS interception settings.
+
+```python
+DnsConfig(
+    rebind_protection: bool = True,
+    nameservers: tuple[str, ...] = (),
+    query_timeout_ms: int | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| nameservers | `tuple[str, ...]` | Nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). Overrides the host's `/etc/resolv.conf` when set. Hostnames are resolved once at startup via the host's OS resolver |
+| query_timeout_ms | `int \| None` | Per-DNS-query timeout in milliseconds |
+| rebind_protection | `bool` | Block DNS responses resolving to private IPs |
+
+---
+
+## TlsConfig
+
+Frozen dataclass for TLS interception settings within [`Network`](#network).
+
+```python
+TlsConfig(
+    bypass: tuple[str, ...] = (),
+    verify_upstream: bool = True,
+    intercepted_ports: tuple[int, ...] = (443,),
+    block_quic: bool = False,
+    ca_cert: str | None = None,
+    ca_key: str | None = None,
+    ca_cn: str | None = None,
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| block_quic | `bool` | Block QUIC/HTTP3 (UDP) on intercepted ports, forcing TCP/TLS fallback |
+| bypass | `tuple[str, ...]` | Domains to skip interception. Use for domains with certificate pinning |
+| ca_cert | `str \| None` | Path to a custom interception CA certificate PEM file |
+| ca_cn | `str \| None` | Common name for the generated interception CA |
+| ca_key | `str \| None` | Path to a custom interception CA private key PEM file |
+| intercepted_ports | `tuple[int, ...]` | TCP ports where TLS interception is active |
+| verify_upstream | `bool` | Verify upstream server certificates. Set to `False` only for self-signed servers |
+
+---
+
+## Types
+
+### Action
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) for policy actions.
+
+| Value | Description |
+|-------|-------------|
+| `"allow"` | Permit the traffic |
+| `"deny"` | Drop the traffic silently |
+
+### Direction
+
+String enum for traffic direction.
+
+| Value | Description |
+|-------|-------------|
+| `"egress"` | Traffic leaving the sandbox |
+| `"ingress"` | Traffic entering the sandbox (via published ports) |
+| `"any"` | Rule applies in either direction |
+
+### Protocol
+
+String enum for network protocols in policy rules.
+
+| Value | Description |
+|-------|-------------|
+| `"tcp"` | TCP traffic |
+| `"udp"` | UDP traffic |
+| `"icmpv4"` | ICMPv4 traffic |
+| `"icmpv6"` | ICMPv6 traffic |
+
+### PortProtocol
+
+String enum for port-level protocol selection.
+
+| Value | Description |
+|-------|-------------|
+| `"tcp"` | TCP port |
+| `"udp"` | UDP port |
+
+### DestGroup
+
+String enum for well-known destination groups used in [`Rule.destination`](#rule).
+
+| Value | Description |
+|-------|-------------|
+| `"public"` | Complement of the named categories: every address not in any other group |
+| `"private"` | Private/RFC 1918 addresses + ULA + CGN (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7`) |
+| `"loopback"` | Loopback addresses (`127.0.0.0/8`, `::1`); the **guest's own** loopback, not the host. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap) |
+| `"link-local"` | Link-local addresses (`169.254.0.0/16`, `fe80::/10`) excluding metadata |
+| `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
+| `"multicast"` | Multicast addresses (`224.0.0.0/4`, `ff00::/8`) |
+| `"host"` | The host machine, reached via `host.microsandbox.internal`. This is the right group for "let the sandbox reach my host's localhost", not `"loopback"` |

--- a/docs/ja/sdk/python/sandbox.mdx
+++ b/docs/ja/sdk/python/sandbox.mdx
@@ -1,0 +1,898 @@
+---
+title: Sandbox
+description: Python SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+## Static methods
+
+---
+
+#### Sandbox.create()
+
+```python
+@staticmethod
+async def create(name_or_config: str | dict, **kwargs) -> Sandbox
+```
+
+Create and boot a sandbox. The first argument is either a name (`str`) or a full config (`dict`). Keyword arguments provide individual config fields. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name_or_config | `str \| dict` | Sandbox name or full configuration dict |
+| image | `str \| ImageSource` | OCI image, local path, or disk image (required) |
+| cpus | `int` | Virtual CPUs (default `1`) |
+| memory | `int` | Guest memory in MiB (default `512`) |
+| workdir | `str` | Default working directory for commands |
+| shell | `str` | Shell for `shell()` calls (default `"/bin/sh"`) |
+| hostname | `str` | Guest hostname |
+| user | `str` | Default guest user |
+| entrypoint | `list[str]` | Override image entrypoint |
+| init | `str \| dict \|` [`InitConfig`](#initconfig) | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) and [`InitConfig`](#initconfig) for accepted shapes |
+| replace | `bool` | Replace existing sandbox with same name |
+| max_duration | `float` | Maximum sandbox lifetime in seconds |
+| idle_timeout | `float` | Idle timeout in seconds |
+| env | `dict[str, str]` | Environment variables visible to all commands |
+| scripts | `dict[str, str]` | Named scripts mounted at `/.msb/scripts/` |
+| pull_policy | `str \| PullPolicy` | Image pull behavior |
+| log_level | `str \| LogLevel` | Override log verbosity |
+| registry_auth | [`RegistryAuth`](#registryauth) | Private registry credentials |
+| volumes | `dict[str, dict]` | Volume mounts. See [Volumes](/sdk/python/volumes). |
+| patches | `list[PatchConfig]` | Rootfs modifications applied before boot |
+| ports | `dict[int, int]` | Port mappings (`host_port: guest_port`) |
+| network | [`Network`](/sdk/python/networking#network) | Network policy and configuration |
+| secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | Secret injection |
+| detached | `bool` | If `True`, sandbox survives after your process exits |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+The returned `Sandbox` is an async context manager. Use `async with` to guarantee cleanup; on exit the sandbox is killed and its persisted state removed:
+
+```python
+async with await Sandbox.create("my-sandbox", image="alpine") as sb:
+    output = await sb.shell("echo hello")
+    print(output.stdout_text)
+# sandbox is automatically killed and removed on exit
+```
+
+---
+
+#### Sandbox.create_with_progress()
+
+```python
+@staticmethod
+def create_with_progress(name_or_config: str | dict, **kwargs) -> PullSession
+```
+
+Same parameters as [`Sandbox.create()`](#sandboxcreate) but returns a [`PullSession`](#pullsession) that lets you track image pull progress before the sandbox is ready. This method is synchronous (not awaitable) -- the async work happens through the `PullSession`.
+
+**Parameters**
+
+Same as [`Sandbox.create()`](#sandboxcreate).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`PullSession`](#pullsession) | Session for tracking pull progress and obtaining the final sandbox |
+
+---
+
+#### Sandbox.start()
+
+```python
+@staticmethod
+async def start(name: str, *, detached: bool = False) -> Sandbox
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Name of a stopped sandbox |
+| detached | `bool` | If `True`, sandbox survives after your process exits (default `False`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox.get()
+
+```python
+@staticmethod
+async def get(name: str) -> SandboxHandle
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox.list()
+
+```python
+@staticmethod
+async def list() -> list[SandboxHandle]
+```
+
+List all sandboxes (running, stopped, and crashed).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`SandboxHandle`](#sandboxhandle)`]` | All sandboxes |
+
+---
+
+#### Sandbox.remove()
+
+```python
+@staticmethod
+async def remove(name: str) -> None
+```
+
+Delete a stopped sandbox and all its state from disk. Fails if the sandbox is still running.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Sandbox name |
+
+---
+
+## Instance properties
+
+---
+
+#### name
+
+```python
+@property
+async def name(self) -> str
+```
+
+Sandbox name. This is an async property -- use `await sb.name`.
+
+---
+
+#### owns_lifecycle
+
+```python
+@property
+async def owns_lifecycle(self) -> bool
+```
+
+Whether this handle owns the sandbox lifecycle. `True` in attached mode, `False` in detached mode. This is an async property -- use `await sb.owns_lifecycle`.
+
+---
+
+#### fs
+
+```python
+@property
+def fs(self) -> SandboxFs
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. This is a synchronous property -- use `sb.fs` (no `await`). See [Filesystem](/sdk/python/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/python/filesystem) | Filesystem handle |
+
+---
+
+## Instance methods
+
+---
+
+#### attach()
+
+```python
+async def attach(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> int
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to run |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or execution options |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `int` | Exit code of the process |
+
+---
+
+#### attach_shell()
+
+```python
+async def attach_shell() -> int
+```
+
+Attach to the sandbox's default shell.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `int` | Exit code |
+
+---
+
+#### detach()
+
+```python
+async def detach() -> None
+```
+
+Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```python
+async def drain() -> None
+```
+
+Start a graceful drain (SIGUSR1). Existing commands run to completion, new `exec` calls are rejected.
+
+---
+
+#### exec()
+
+```python
+async def exec(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecOutput
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments (e.g. `["-c", "print('hello')"]`) or [`ExecOptions`](/sdk/python/execution#execoptions) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### exec_stream()
+
+```python
+async def exec_stream(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecHandle
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to execute |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or [`ExecOptions`](/sdk/python/execution#execoptions) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### kill()
+
+```python
+async def kill() -> None
+```
+
+Force-terminate the sandbox immediately (SIGKILL). No graceful shutdown.
+
+---
+
+#### metrics()
+
+```python
+async def metrics() -> SandboxMetrics
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network metrics |
+
+---
+
+#### metrics_stream()
+
+```python
+async def metrics_stream(interval: float = 1.0) -> MetricsStream
+```
+
+Stream resource metrics at a regular interval. The returned stream supports both `recv()` and `async for`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| interval | `float` | Seconds between metric snapshots (default `1.0`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`MetricsStream`](#metricsstream) | Async stream of metrics |
+
+---
+
+#### logs()
+
+```python
+async def logs(
+    tail: int | None = None,
+    since_ms: float | None = None,
+    until_ms: float | None = None,
+    sources: list[str] | None = None,
+) -> list[LogEntry]
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```python
+import asyncio
+import microsandbox
+
+async def main():
+    handle = await microsandbox.Sandbox.get("web")
+
+    # Default — all user-program output, regardless of pipe/pty mode
+    entries = await handle.logs()
+
+    for e in entries:
+        source = {
+            "stdout": "OUT",
+            "stderr": "ERR",
+            "output": "PTY",
+            "system": "SYS",
+        }[e.source]
+        print(
+            f"[{e.timestamp_ms / 1000:.3f}] "
+            f"{source} {e.session_id}: {e.text().rstrip()}"
+        )
+
+    # Filtered: last 50 entries from the past hour, including system lines
+    import time
+    recent = await handle.logs(
+        tail=50,
+        since_ms=(time.time() - 3600) * 1000,
+        sources=["stdout", "stderr", "output", "system"],
+    )
+
+asyncio.run(main())
+```
+
+Timestamps are exposed as `float` ms since the Unix epoch (UTC) for parity with `SandboxMetrics.timestamp_ms`. Convert to `datetime` if needed:
+
+```python
+from datetime import datetime, timezone
+dt = datetime.fromtimestamp(e.timestamp_ms / 1000, timezone.utc)
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| tail | `int \| None` | Show only the last N entries after other filters apply |
+| since_ms | `float \| None` | Inclusive lower bound on entry timestamp (ms since epoch) |
+| until_ms | `float \| None` | Exclusive upper bound on entry timestamp (ms since epoch) |
+| sources | `list[str] \| None` | Sources to include. `None` = `["stdout", "stderr", "output"]`. Add `"system"` to merge runtime/kernel diagnostics. Use `"all"` as shorthand for all four. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`LogEntry`](#logentry)`]` | Matching entries in chronological order |
+
+---
+
+#### remove_persisted()
+
+```python
+async def remove_persisted() -> None
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### shell()
+
+```python
+async def shell(script: str) -> ExecOutput
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `str` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell_stream()
+
+```python
+async def shell_stream(script: str) -> ExecHandle
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `str` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle |
+
+---
+
+#### stop()
+
+```python
+async def stop() -> None
+```
+
+Gracefully shut down the sandbox (SIGTERM).
+
+---
+
+#### stop_and_wait()
+
+```python
+async def stop_and_wait() -> tuple[int, bool]
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
+
+---
+
+#### wait()
+
+```python
+async def wait() -> tuple[int, bool]
+```
+
+Block until the sandbox exits on its own.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
+
+---
+
+## Patch
+
+Factory class for rootfs patches passed to `Sandbox.create(..., patches=[...])`. Each static method returns a [`PatchConfig`](#patchconfig). By default a patch that targets a path already present in the image errors at boot; pass `replace=True` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### Patch.append()
+
+```python
+@staticmethod
+def append(path: str, content: str) -> PatchConfig
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| content | `str` | Text to append |
+
+---
+
+#### Patch.copy_dir()
+
+```python
+@staticmethod
+def copy_dir(src: str, dst: str, *, replace: bool = False) -> PatchConfig
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Host source directory |
+| dst | `str` | Absolute destination path inside the guest |
+| replace | `bool` | When `True`, overwrite an existing path at `dst` |
+
+---
+
+#### Patch.copy_file()
+
+```python
+@staticmethod
+def copy_file(
+    src: str,
+    dst: str,
+    *,
+    mode: int | None = None,
+    replace: bool = False,
+) -> PatchConfig
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Host source file |
+| dst | `str` | Absolute destination path inside the guest |
+| mode | `int \| None` | File mode, e.g. `0o644`. `None` keeps the source mode |
+| replace | `bool` | When `True`, overwrite an existing path at `dst` |
+
+---
+
+#### Patch.mkdir()
+
+```python
+@staticmethod
+def mkdir(path: str, *, mode: int | None = None) -> PatchConfig
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| mode | `int \| None` | Directory mode, e.g. `0o755` |
+
+---
+
+#### Patch.remove()
+
+```python
+@staticmethod
+def remove(path: str) -> PatchConfig
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+---
+
+#### Patch.symlink()
+
+```python
+@staticmethod
+def symlink(target: str, link: str, *, replace: bool = False) -> PatchConfig
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `str` | What the symlink points to (literal symlink target text) |
+| link | `str` | Absolute path of the symlink itself |
+| replace | `bool` | When `True`, overwrite an existing path at `link` |
+
+---
+
+#### Patch.text()
+
+```python
+@staticmethod
+def text(
+    path: str,
+    content: str,
+    *,
+    mode: int | None = None,
+    replace: bool = False,
+) -> PatchConfig
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| content | `str` | Text content |
+| mode | `int \| None` | File mode, e.g. `0o644` |
+| replace | `bool` | When `True`, overwrite an existing path |
+
+---
+
+## Types
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `"debug"` | Debug and higher |
+| `"error"` | Errors only |
+| `"info"` | Info and higher |
+| `"trace"` | Most verbose -- all diagnostic output |
+| `"warn"` | Warnings and errors only |
+
+### LogEntry
+
+A single captured log entry returned by [`logs()`](#logs).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| timestamp_ms | `float` | Wall-clock capture time (ms since Unix epoch, UTC) |
+| source | `str` | Where the chunk came from. See [LogSource](#logsource). |
+| session_id | `int \| None` | Relay-monotonic session id; `None` for `"system"` entries |
+| data | `bytes` | The chunk's bytes (UTF-8 lossy decoded by default) |
+| `text()` | `str` | Convenience: UTF-8 decode of `data` (lossy — invalid bytes are replaced) |
+
+### LogSource
+
+The string values that the `source` field on a [`LogEntry`](#logentry) can take, also accepted by `logs(sources=[...])`.
+
+| Value | Description |
+|-------|-------------|
+| `"stdout"` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `"stderr"` | Captured from a session's stderr (pipe mode) |
+| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `"output"` rather than mislabelled as `"stdout"`. |
+| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested. |
+
+In addition, `logs(sources=["all"])` is a shorthand for all four.
+
+### MetricsStream
+
+Async stream for receiving periodic metrics snapshots.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `__aiter__` | `AsyncIterator[`[`SandboxMetrics`](#sandboxmetrics)`]` | Use with `async for` |
+| `recv()` | [`SandboxMetrics`](#sandboxmetrics) `\| None` | Receive next snapshot. Returns `None` when the stream ends. |
+
+### PatchConfig
+
+A single rootfs patch. Produced by the [`Patch`](#patch) factory; you'd normally not construct one directly. Frozen dataclass.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | `str` | One of `"text"`, `"file"`, `"copy_file"`, `"copy_dir"`, `"symlink"`, `"mkdir"`, `"remove"`, `"append"` |
+| path | `str \| None` | Absolute guest path (used by text / file / mkdir / remove / append) |
+| content | `str \| None` | Text content (text / append) |
+| src | `str \| None` | Host source path (copy_file / copy_dir) |
+| dst | `str \| None` | Guest destination path (copy_file / copy_dir) |
+| target | `str \| None` | Symlink target |
+| link | `str \| None` | Symlink path |
+| mode | `int \| None` | File / directory mode (e.g. `0o644`) |
+| replace | `bool` | When `True`, overwrite an existing path at the destination. Defaults to `False` |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `"always"` | Pull the image every time, even if cached locally |
+| `"if-missing"` | Pull only if the image is not already cached. This is the default. |
+| `"never"` | Never pull; fail if the image is not cached locally |
+
+### PullSession
+
+Returned by [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress). Use as an async context manager to track image pull progress.
+
+```python
+session = Sandbox.create_with_progress("my-sandbox", image="ubuntu:latest")
+async with session:
+    async for event in session.progress:
+        print(event)
+    sb = await session.result()
+```
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| progress | `AsyncIterator[PullProgress]` | Async iterator of pull progress events |
+| result() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Await to get the final running sandbox |
+
+### RegistryAuth
+
+Private registry credentials.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| username | `str` | Registry username |
+| password | `str` | Registry password |
+
+### SandboxConfig
+
+The keyword arguments accepted by [`Sandbox.create()`](#sandboxcreate) and [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| image | `str \| ImageSource` | - | OCI image, local path, or disk image (required) |
+| cpus | `int` | `1` | Virtual CPUs |
+| memory | `int` | `512` | Guest memory in MiB. This is a limit, not a reservation. |
+| workdir | `str` | - | Default working directory for commands |
+| shell | `str` | `"/bin/sh"` | Shell for `shell()` calls |
+| hostname | `str` | - | Guest hostname |
+| user | `str` | - | Default guest user |
+| entrypoint | `list[str]` | - | Override image entrypoint |
+| init | `str \| dict \|` [`InitConfig`](#initconfig) | - | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| replace | `bool` | `False` | Replace existing sandbox with same name |
+| max_duration | `float` | - | Maximum sandbox lifetime in seconds |
+| idle_timeout | `float` | - | Idle timeout in seconds |
+| env | `dict[str, str]` | `{}` | Environment variables visible to all commands |
+| scripts | `dict[str, str]` | `{}` | Named scripts mounted at `/.msb/scripts/` |
+| pull_policy | `str \| PullPolicy` | `"if-missing"` | Image pull behavior |
+| log_level | `str \| LogLevel` | - | Override log verbosity |
+| registry_auth | [`RegistryAuth`](#registryauth) | - | Private registry credentials |
+| volumes | `dict[str, dict]` | `{}` | Volume mounts. See [Volumes](/sdk/python/volumes). |
+| patches | `list[PatchConfig]` | `[]` | Rootfs modifications applied before boot |
+| ports | `dict[int, int]` | `{}` | Port mappings (`host_port: guest_port`) |
+| network | [`Network`](/sdk/python/networking#network) | `public_only` | Network policy and configuration |
+| secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | `[]` | Secret injection |
+| detached | `bool` | `False` | If `True`, sandbox survives after your process exits |
+
+### InitConfig
+
+Custom init specification. Pass it (or one of the equivalent shorthand shapes) as the `init=` kwarg to [`Sandbox.create()`](#sandboxcreate) to hand PID 1 inside the guest off to your own init binary after agentd's setup. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks, shutdown semantics, and tradeoffs.
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True, slots=True)
+class InitConfig:
+    cmd: str
+    args: tuple[str, ...] = ()
+    env: Mapping[str, str] = {}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cmd | `str` | Absolute path or `"auto"` to the init binary inside the guest rootfs |
+| args | `tuple[str, ...]` | Supplemental argv (`argv[0]` is implicitly `cmd`) |
+| env | `dict[str, str]` | Extra env vars merged on top of the inherited env |
+
+The `init=` kwarg follows the same shape as other `Sandbox.create` kwargs that carry structured values (`image=`, `network=`, etc.): a bare scalar for the simple case, or a dataclass / dict for the rich case.
+
+| Form | Equivalent to |
+|------|---------------|
+| `init="auto"` or `init="/sbin/init"` | `InitConfig(cmd=...)` |
+| `init={"cmd": ..., "args": [...], "env": {...}}` | dict equivalent of `InitConfig` |
+| `init=InitConfig(cmd="/sbin/init", args=("--foo",))` | itself |
+
+```python
+from microsandbox import InitConfig, Sandbox
+
+# Common case: bare string.
+sb = await Sandbox.create("worker", image="jrei/systemd-debian:12", init="auto")
+
+# Argv / env: dataclass.
+sb = await Sandbox.create(
+    "worker",
+    image="jrei/systemd-debian:12",
+    init=InitConfig(
+        cmd="/lib/systemd/systemd",
+        args=("--unit=multi-user.target",),
+        env={"container": "microsandbox"},
+    ),
+)
+```
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandboxget) or [`Sandbox.list()`](#sandboxlist). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. Call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `str` | Sandbox name |
+| status | `str` | Current status (`"running"`, `"stopped"`, `"crashed"`, `"draining"`, `"paused"`) |
+| config_json | `str` | Raw JSON configuration |
+| created_at | `float \| None` | Creation timestamp (ms since epoch) |
+| updated_at | `float \| None` | Last update timestamp (ms since epoch) |
+| connect() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Connect to a running sandbox |
+| start(*, detached=False) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Start in attached or detached mode |
+| stop() | `Awaitable[None]` | Graceful shutdown |
+| kill() | `Awaitable[None]` | Force terminate |
+| remove() | `Awaitable[None]` | Delete sandbox and state |
+| metrics() | `Awaitable[`[`SandboxMetrics`](#sandboxmetrics)`]` | Point-in-time resource metrics |
+| logs() | `Awaitable[list[`[`LogEntry`](#logentry)`]]` | Read captured `exec.log` (works without starting) |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpu_percent | `float` | CPU usage as a percentage |
+| disk_read_bytes | `int` | Total bytes read from disk since boot |
+| disk_write_bytes | `int` | Total bytes written to disk since boot |
+| memory_bytes | `int` | Current memory usage in bytes |
+| memory_limit_bytes | `int` | Memory limit in bytes |
+| net_rx_bytes | `int` | Total bytes received over the network since boot |
+| net_tx_bytes | `int` | Total bytes sent over the network since boot |
+| timestamp_ms | `float` | When this measurement was taken (ms since epoch) |
+| uptime_ms | `int` | Time since the sandbox was created (ms) |

--- a/docs/ja/sdk/python/secrets.mdx
+++ b/docs/ja/sdk/python/secrets.mdx
@@ -1,0 +1,77 @@
+---
+title: Secrets
+description: Python SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## Secret
+
+Static factory for creating secret entries used in `SandboxConfig.secrets`.
+
+---
+
+#### Secret.env()
+
+```python
+@staticmethod
+def env(
+    env_var: str,
+    *,
+    value: str,
+    allow_hosts: Sequence[str] = (),
+    allow_host_patterns: Sequence[str] = (),
+    placeholder: str | None = None,
+    require_tls: bool = True,
+    on_violation: ViolationAction = ViolationAction.BLOCK_AND_LOG,
+) -> SecretEntry
+```
+
+Create a secret entry that maps an environment variable to a real value. The guest sees a placeholder - the real value is only substituted by the TLS proxy when traffic goes to an allowed host.
+
+**Parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| env_var | `str` | - | Environment variable name (e.g. `"OPENAI_API_KEY"`) |
+| value | `str` | - | The real secret value. Never enters the guest VM. **Required.** |
+| allow_hosts | `Sequence[str]` | `()` | Hosts allowed to receive the real value (exact match). The TLS proxy matches against the SNI. |
+| allow_host_patterns | `Sequence[str]` | `()` | Wildcard host patterns (e.g. `"*.googleapis.com"`) |
+| placeholder | `str \| None` | `None` | Custom placeholder string. Auto-generated as `$MSB_<env_var>` if not set. |
+| require_tls | `bool` | `True` | Only substitute on TLS-intercepted connections. Disable only if you know the traffic is safe. |
+| on_violation | [`ViolationAction`](#violationaction) | `BLOCK_AND_LOG` | Action when the placeholder is sent to a disallowed host |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SecretEntry`](#secretentry) | Secret entry for `SandboxConfig.secrets` |
+
+---
+
+## Types
+
+### SecretEntry
+
+Frozen dataclass returned by [`Secret.env()`](#secretenv) and used in `SandboxConfig.secrets`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| env_var | `str` | Environment variable name |
+| value | `str` | Secret value |
+| allow_hosts | `tuple[str, ...]` | Allowed hosts (exact match) |
+| allow_host_patterns | `tuple[str, ...]` | Wildcard patterns |
+| placeholder | `str \| None` | Placeholder string |
+| require_tls | `bool` | TLS requirement |
+| on_violation | [`ViolationAction`](#violationaction) | Violation action |
+
+### ViolationAction
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) defining the action taken when a secret placeholder is sent to a disallowed host.
+
+| Value | Description |
+|-------|-------------|
+| `"block"` | Silently drop the request. The guest sees a connection reset. |
+| `"block-and-log"` | Drop the request and emit a warning log on the host side. This is the default. |
+| `"block-and-terminate"` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/ja/sdk/python/snapshots.mdx
+++ b/docs/ja/sdk/python/snapshots.mdx
@@ -1,0 +1,270 @@
+---
+title: Snapshots
+description: Python SDK - Snapshot API reference
+icon: "code-branch"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Python SDK reference.
+
+```python
+from microsandbox import Sandbox, Snapshot, SnapshotHandle
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## Sandbox.create() — `snapshot=` kwarg
+
+```python
+@staticmethod
+async def create(name_or_config, *, snapshot: str | os.PathLike | None = None, **kwargs) -> Sandbox
+```
+
+Boot a fresh sandbox from a snapshot artifact by passing `snapshot=` as a peer of `image=`. The two are mutually exclusive — pass exactly one.
+
+```python
+# Boot from a snapshot
+sb = await Sandbox.create("worker", snapshot="after-pip-install")
+
+# Or from an image (existing flow, unchanged)
+sb = await Sandbox.create("worker", image="python:3.12")
+```
+
+**Errors**
+
+- `ValueError` — both `image=` and `snapshot=` were passed or neither, the snapshot artifact doesn't exist, or the artifact's manifest failed validation
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```python
+async def snapshot(self, name: str) -> Snapshot
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination, see [`snapshot_to()`](#snapshot-to).
+
+**Errors**
+
+- `SnapshotSandboxRunning` — the sandbox is not stopped
+- `SnapshotAlreadyExists` — destination exists (use `Snapshot.create(..., force=True)` to overwrite)
+
+---
+
+#### snapshot_to()
+
+```python
+async def snapshot_to(self, path: str | os.PathLike) -> Snapshot
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path.
+
+---
+
+## Snapshot (instance)
+
+Properties are read-only attributes (not async).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `path` | `str` | Path to the artifact directory |
+| `digest` | `str` | Canonical content digest (`sha256:hex`). The snapshot's identity. |
+| `size_bytes` | `int` | Apparent size of the captured upper layer in bytes (sparse on disk) |
+| `image_ref` | `str` | Image reference the snapshot was taken from |
+| `image_manifest_digest` | `str` | OCI manifest digest of the pinned image |
+| `format` | `str` | `"raw"` or `"qcow2"` (always `"raw"` today) |
+| `fstype` | `str` | Filesystem type inside the upper (e.g. `"ext4"`) |
+| `parent` | `str \| None` | Parent snapshot's digest, or `None` for a root |
+| `created_at` | `str` | RFC 3339 timestamp |
+| `labels` | `dict[str, str]` | User-supplied labels |
+| `source_sandbox` | `str \| None` | Best-effort source-sandbox name |
+
+---
+
+#### verify()
+
+```python
+async def verify(self) -> dict[str, Any]
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds.
+
+```python
+report = await snap.verify()
+if report["upper"]["kind"] == "verified":
+    print(f"hash matches: {report['upper']['digest']}")
+else:
+    print("no integrity hash recorded")
+```
+
+The report shape:
+
+```python
+{
+    "digest": "sha256:...",
+    "path": "/path/to/artifact",
+    "upper": {"kind": "not_recorded"}                            # no integrity recorded
+        | {"kind": "verified", "algorithm": "...", "digest": "sha256:..."},
+}
+```
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot.create()
+
+```python
+@staticmethod
+async def create(
+    source_sandbox: str,
+    *,
+    name: str | None = None,
+    path: str | os.PathLike | None = None,
+    labels: dict[str, str] | None = None,
+    force: bool = False,
+    record_integrity: bool = False,
+) -> Snapshot
+```
+
+Create a snapshot from a stopped sandbox. Exactly one of `name=` (resolved under the default snapshots directory) or `path=` (explicit filesystem destination) is required.
+
+```python
+snap = await Snapshot.create(
+    "baseline",
+    name="after-pip-install",
+    labels={"stage": "post-deps"},
+    record_integrity=True,
+)
+```
+
+---
+
+#### Snapshot.open()
+
+```python
+@staticmethod
+async def open(path_or_name: str) -> Snapshot
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot.get()
+
+```python
+@staticmethod
+async def get(name_or_digest: str) -> SnapshotHandle
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot.list()
+
+```python
+@staticmethod
+async def list() -> list[SnapshotHandle]
+```
+
+List indexed snapshots from the local DB cache.
+
+---
+
+#### Snapshot.list_dir()
+
+```python
+@staticmethod
+async def list_dir(dir: str | os.PathLike) -> list[Snapshot]
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot.remove()
+
+```python
+@staticmethod
+async def remove(path_or_name: str, *, force: bool = False) -> None
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force=True`.
+
+---
+
+#### Snapshot.reindex()
+
+```python
+@staticmethod
+async def reindex(dir: str | os.PathLike | None = None) -> int
+```
+
+Walk `dir` (default: configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot.export()
+
+```python
+@staticmethod
+async def export(
+    name_or_path: str,
+    out: str | os.PathLike,
+    *,
+    with_parents: bool = False,
+    with_image: bool = False,
+    plain_tar: bool = False,
+) -> None
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+---
+
+#### Snapshot.import_()
+
+```python
+@staticmethod
+async def import_(
+    archive: str | os.PathLike,
+    *,
+    dest: str | os.PathLike | None = None,
+) -> SnapshotHandle
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+The trailing underscore is intentional — `import` is a reserved Python keyword.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot.list()`](#snapshot-list) and [`Snapshot.get()`](#snapshot-get).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `digest` | `str` | Manifest digest — canonical identity |
+| `name` | `str \| None` | Convenience alias |
+| `parent_digest` | `str \| None` | Parent snapshot digest (`None` today; populated when chains land) |
+| `image_ref` | `str` | Image the snapshot was taken from |
+| `format` | `str` | `"raw"` or `"qcow2"` |
+| `size_bytes` | `int \| None` | Apparent upper size at index time |
+| `created_at` | `float` | ms since Unix epoch |
+| `path` | `str` | Local artifact directory path |
+
+```python
+h = await Snapshot.get("after-pip-install")
+snap = await h.open()                # metadata-validated
+await h.remove(force=False)          # refuse if has children
+```

--- a/docs/ja/sdk/python/volumes.mdx
+++ b/docs/ja/sdk/python/volumes.mdx
@@ -1,0 +1,375 @@
+---
+title: Volumes
+description: Python SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+## Static methods
+
+---
+
+#### Volume.create()
+
+```python
+async def Volume.create(
+    name: str,
+    *,
+    quota_mib: int | None = None,
+    labels: dict[str, str] | None = None,
+) -> Volume
+```
+
+Create a new named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name (required) |
+| quota_mib | `int \| None` | Maximum storage size in MiB |
+| labels | `dict[str, str] \| None` | Metadata labels |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Volume` | Created volume with `name` and `path` properties |
+
+---
+
+#### Volume.get()
+
+```python
+async def Volume.get(name: str) -> VolumeHandle
+```
+
+Get a handle to an existing named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeHandle`](#volumehandle) | Volume handle |
+
+---
+
+#### Volume.list()
+
+```python
+async def Volume.list() -> list[VolumeHandle]
+```
+
+List all named volumes.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`VolumeHandle`](#volumehandle)`]` | All volumes |
+
+---
+
+#### Volume.remove()
+
+```python
+async def Volume.remove(name: str) -> None
+```
+
+Delete a named volume and its contents. Fails if the volume is currently mounted.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+
+---
+
+## Volume instance properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| name | `str` | Volume name |
+| path | `str` | Host path to the volume directory |
+
+---
+
+## Mount config factories
+
+Static factory methods on `Volume` for creating mount configurations used in sandbox volume config.
+
+---
+
+#### Volume.bind()
+
+```python
+def Volume.bind(path: str, *, readonly: bool = False) -> dict
+```
+
+Mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Directory path on the host |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+#### Volume.named()
+
+```python
+def Volume.named(name: str, *, readonly: bool = False) -> dict
+```
+
+Mount a named volume. The volume must already exist (create it with [`Volume.create()`](#volumecreate)).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+#### Volume.tmpfs()
+
+```python
+def Volume.tmpfs(*, size_mib: int | None = None, readonly: bool = False) -> dict
+```
+
+Use an in-memory filesystem. Contents are discarded when the sandbox stops.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size_mib | `int \| None` | Maximum size in MiB |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+## VolumeHandle
+
+Handle to an existing named volume, returned by [`Volume.get()`](#volumeget) and [`Volume.list()`](#volumelist).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `str` | Volume name |
+| quota_mib | `int \| None` | Storage quota in MiB |
+| used_bytes | `int` | Current disk usage in bytes |
+| labels | `dict[str, str]` | Metadata labels |
+| created_at | `float \| None` | Creation timestamp (ms since epoch) |
+| fs | [`VolumeFs`](#volumefs) | Host-side filesystem handle |
+| remove() | *(async)* `None` | Delete this volume |
+
+---
+
+## VolumeFs
+
+Host-side filesystem operations on a named volume. Obtained via the `fs` property on [`VolumeHandle`](#volumehandle). These operations run directly on the host filesystem - no running sandbox is required.
+
+---
+
+#### read()
+
+```python
+async def read(path: str) -> bytes
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bytes` | File contents as raw bytes |
+
+---
+
+#### read_text()
+
+```python
+async def read_text(path: str) -> str
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `str` | File contents as a string |
+
+---
+
+#### write()
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+| data | `bytes` | File content |
+
+---
+
+#### list()
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`FsEntry`](/sdk/python/filesystem#fsentry)`]` | Directory entries |
+
+---
+
+#### mkdir()
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory and all parent directories.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+---
+
+#### remove_file()
+
+```python
+async def remove_file(path: str) -> None
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+---
+
+#### exists()
+
+```python
+async def exists(path: str) -> bool
+```
+
+Check whether a path exists within the volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `True` if the path exists |
+
+---
+
+## Types
+
+### MountConfig
+
+Frozen dataclass representing a mount configuration.
+
+```python
+MountConfig(
+    kind: MountKind,
+    bind: str | None = None,
+    named: str | None = None,
+    size_mib: int | None = None,
+    readonly: bool = False,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| kind | [`MountKind`](#mountkind) | - | Type of mount (required) |
+| bind | `str \| None` | `None` | Host path for bind mounts |
+| named | `str \| None` | `None` | Volume name for named mounts |
+| size_mib | `int \| None` | `None` | Size limit for tmpfs mounts |
+| readonly | `bool` | `False` | Whether the mount is read-only |
+
+### MountKind
+
+String enum representing the type of mount.
+
+| Value | Description |
+|-------|-------------|
+| `"bind"` | Host bind mount |
+| `"named"` | Named volume mount |
+| `"tmpfs"` | In-memory filesystem |

--- a/docs/ja/sdk/rust/events.mdx
+++ b/docs/ja/sdk/rust/events.mdx
@@ -1,0 +1,66 @@
+---
+title: Events
+description: Rust SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for usage examples and guest-side emitting.
+
+## Sandbox methods
+
+---
+
+#### emit()
+
+```rust
+async fn emit(&self, event_name: &str, data: impl Serialize) -> MicrosandboxResult<()>
+```
+
+Send a named event with a JSON-serializable payload into the guest. Any process listening on the agent socket (`/run/agent.sock`) receives it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| event_name | `&str` | Event name (e.g. `"task.start"`) |
+| data | `impl Serialize` | Event payload - must be serializable to JSON |
+
+---
+
+#### on_event()
+
+```rust
+fn on_event(&self, event_name: &str, callback: impl FnMut(EventData) + Send + 'static) -> Subscription
+```
+
+Subscribe to named events emitted by guest processes. The callback fires each time the guest sends a matching event through `/run/agent.sock`. Multiple subscriptions to the same event name are supported.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| event_name | `&str` | Event name to subscribe to (e.g. `"task.progress"`) |
+| callback | `impl FnMut(EventData) + Send + 'static` | Called with the event data each time |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Subscription` | Handle that unsubscribes when dropped |
+
+---
+
+## Types
+
+### EventData
+
+Data received from a guest event.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| data | `Option<serde_json::Value>` | Event payload as a JSON value. `None` if the event had no data. |
+| event | `String` | Event name |

--- a/docs/ja/sdk/rust/execution.mdx
+++ b/docs/ja/sdk/rust/execution.mdx
@@ -1,0 +1,306 @@
+---
+title: Execution
+description: Rust SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+---
+
+#### attach()
+
+```rust
+async fn attach(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<i32>
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Your terminal's stdin, stdout, and stderr are connected to the guest process. Press `Ctrl+]` (or configured detach keys) to disconnect without stopping the process - it keeps running and can be reattached via its session ID.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to run |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code of the process |
+
+---
+
+#### attach_shell()
+
+```rust
+async fn attach_shell(&self) -> MicrosandboxResult<i32>
+```
+
+Attach to the sandbox's default shell (configured via `SandboxBuilder::shell()`, defaults to `/bin/sh`).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code |
+
+---
+
+#### attach_with()
+
+```rust
+async fn attach_with(&self, cmd: impl Into<String>, f: impl FnOnce(AttachOptionsBuilder) -> AttachOptionsBuilder) -> MicrosandboxResult<i32>
+```
+
+Interactive PTY attach with options for environment variables, working directory, user, and custom detach keys.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to run |
+| f | `AttachOptionsBuilder` | Configure attach options (env, cwd, user, detach keys). |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `i32` | Exit code of the process |
+
+---
+
+#### exec()
+
+```rust
+async fn exec(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments (e.g. `["-c", "print('hello')"]`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### exec_stream()
+
+```rust
+async fn exec_stream(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<ExecHandle>
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything until the command finishes. Use this for long-running processes, large output, or when you need to process output incrementally.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### exec_stream_with()
+
+```rust
+async fn exec_stream_with(&self, cmd: impl Into<String>, f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder) -> MicrosandboxResult<ExecHandle>
+```
+
+Streaming execution with per-execution overrides. Enable `stdin_pipe()` to write to the process's stdin, and `tty(true)` to allocate a pseudo-terminal for interactive programs like shells, REPLs, or editors.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| f | [`ExecOptionsBuilder`](#execoptionsbuilder) | Configure execution options. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle |
+
+---
+
+#### exec_with()
+
+```rust
+async fn exec_with(&self, cmd: impl Into<String>, f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command with per-execution overrides. The closure receives an [`ExecOptionsBuilder`](#execoptionsbuilder) to configure working directory, environment variables, timeout, resource limits, stdin mode, and TTY allocation. These overrides apply only to this execution and don't change the sandbox's defaults.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<String>` | Command to execute |
+| f | [`ExecOptionsBuilder`](#execoptionsbuilder) | Configure execution options. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell()
+
+```rust
+async fn shell(&self, script: impl Into<String>) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). The script is passed as `sh -c "<script>"`, so shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `impl Into<String>` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell_stream()
+
+```rust
+async fn shell_stream(&self, script: impl Into<String>) -> MicrosandboxResult<ExecHandle>
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `impl Into<String>` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](#exechandle) | Streaming handle |
+
+---
+
+## Types
+
+### ExecEvent
+
+Events emitted by a streaming execution.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Exited` | `code: i32` | The process has exited. `code` is the exit code. |
+| `Started` | `pid: u32` | The process has started. `pid` is the guest-side PID. |
+| `Stderr` | `Bytes` | A chunk of stderr data. |
+| `Stdout` | `Bytes` | A chunk of stdout data. May arrive in arbitrary sizes. |
+
+### ExecHandle
+
+A handle to a running streaming execution. Receives events as the process produces output, and provides control over stdin and signals.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| collect() | [`ExecOutput`](#execoutput) | Wait for exit and collect all remaining stdout/stderr. |
+| id() | `String` | Session ID for this execution. Can be used to reattach later. |
+| kill() | `()` | Send SIGKILL to the process. |
+| recv() | `Option<`[`ExecEvent`](#execevent)`>` | Receive the next event. Returns `None` when the process has exited and all output has been delivered. |
+| signal(signal) | `()` | Send a POSIX signal to the process (e.g. `libc::SIGTERM`). |
+| take_stdin() | `Option<`[`ExecSink`](#execsink)`>` | Take the stdin writer. Only available if `stdin_pipe()` was enabled. Returns `None` after the first call. |
+| wait() | [`ExitStatus`](#exitstatus) | Wait for the process to exit, discarding any remaining output. |
+
+### ExecOptionsBuilder
+
+Builder for per-execution overrides. Does not change the sandbox's defaults.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| args() | `impl IntoIterator<Item = impl Into<String>>` | Append command-line arguments. |
+| cwd() | `impl Into<String>` | Override the working directory for this command. |
+| env() | - `key: impl Into<String>` <br/> - `value: impl Into<String>` | Set an environment variable. Merged on top of sandbox-level env vars. |
+| envs() | `impl IntoIterator<Item = (String, String)>` | Set multiple environment variables at once. |
+| rlimit() | - `resource:` [`RlimitResource`](#rlimitresource) <br/> - `limit: u64` | Set a POSIX resource limit (soft = hard). Applied via `setrlimit()` before exec. |
+| rlimit_range() | - `resource:` [`RlimitResource`](#rlimitresource) <br/> - `soft: u64` <br/> - `hard: u64` | Set a resource limit with different soft and hard values. |
+| stdin_bytes() | `impl Into<Vec<u8>>` | Provide fixed bytes as stdin. The process reads them and then sees EOF. |
+| stdin_null() | - | Stdin reads from `/dev/null`. This is the default. |
+| stdin_pipe() | - | Enable a stdin writer via [`ExecSink`](#execsink). Use with [`ExecHandle::take_stdin()`](#exechandle). |
+| timeout() | `Duration` | Kill the process with SIGKILL if it hasn't exited within this duration. |
+| tty() | `bool` | Allocate a pseudo-terminal. Enable for interactive programs (shells, editors, `top`); disable for scripts and batch jobs. Default: `false`. |
+| user() | `impl Into<String>` | Override the guest user for this command. |
+
+### ExecOutput
+
+The result of a completed command execution. Holds the exit status and all captured output.
+
+| Field / Method | Type | Description |
+|----------------|------|-------------|
+| status() | [`ExitStatus`](#exitstatus) | Exit code and success flag |
+| stderr() | `Result<String>` | Collected stderr decoded as UTF-8 |
+| stderr_bytes() | `&Bytes` | Raw stderr bytes without decoding |
+| stdout() | `Result<String>` | Collected stdout decoded as UTF-8. Returns `Err` if the output is not valid UTF-8. |
+| stdout_bytes() | `&Bytes` | Raw stdout bytes without decoding |
+
+### ExecSink
+
+A writer for sending data to a running process's stdin. Obtained via [`ExecHandle::take_stdin()`](#exechandle).
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| close() | - | Close stdin. The process sees EOF on its stdin. |
+| write() | `data: impl AsRef<[u8]>` | Write bytes to the process's stdin. |
+
+### ExitStatus
+
+The exit status of a completed process.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| code | `i32` | Exit code. `0` typically means success. |
+| success | `bool` | `true` if code is `0` |
+
+### RlimitResource
+
+POSIX resource limit identifiers. Maps to `RLIMIT_*` constants.
+
+| Value | Description |
+|-------|-------------|
+| `As` | Max address space size |
+| `Core` | Max core file size |
+| `Cpu` | Max CPU time in seconds |
+| `Data` | Max data segment size |
+| `Fsize` | Max file size in bytes |
+| `Locks` | Max file locks |
+| `Memlock` | Max locked memory |
+| `Msgqueue` | Max bytes in POSIX message queues |
+| `Nice` | Max nice priority |
+| `Nofile` | Max open file descriptors |
+| `Nproc` | Max number of processes |
+| `Rss` | Max resident set size |
+| `Rtprio` | Max real-time priority |
+| `Rttime` | Max real-time timeout |
+| `Sigpending` | Max pending signals |
+| `Stack` | Max stack size |

--- a/docs/ja/sdk/rust/filesystem.mdx
+++ b/docs/ja/sdk/rust/filesystem.mdx
@@ -1,0 +1,356 @@
+---
+title: Filesystem
+description: Rust SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead, which give the guest direct filesystem access.
+
+---
+
+#### copy()
+
+```rust
+async fn copy(&self, from: &str, to: &str) -> MicrosandboxResult<()>
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `&str` | Source path |
+| to | `&str` | Destination path |
+
+---
+
+#### copy_from_host()
+
+```rust
+async fn copy_from_host(&self, host_path: impl AsRef<Path>, guest_path: &str) -> MicrosandboxResult<()>
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `impl AsRef<Path>` | Path on the host filesystem |
+| guest_path | `&str` | Destination path inside the sandbox |
+
+---
+
+#### copy_to_host()
+
+```rust
+async fn copy_to_host(&self, guest_path: &str, host_path: impl AsRef<Path>) -> MicrosandboxResult<()>
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `&str` | Path inside the sandbox |
+| host_path | `impl AsRef<Path>` | Destination path on the host |
+
+---
+
+#### exists()
+
+```rust
+async fn exists(&self, path: &str) -> MicrosandboxResult<bool>
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `true` if the path exists |
+
+---
+
+#### list()
+
+```rust
+async fn list(&self, path: &str) -> MicrosandboxResult<Vec<FsEntry>>
+```
+
+List the entries in a directory. Returns metadata for each entry including name, type, size, and permissions.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`FsEntry`](#fsentry)`>` | Directory entries |
+
+---
+
+#### mkdir()
+
+```rust
+async fn mkdir(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Create a directory. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path |
+
+---
+
+#### read()
+
+```rust
+async fn read(&self, path: &str) -> MicrosandboxResult<Bytes>
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Bytes` | File contents as raw bytes |
+
+---
+
+#### read_stream()
+
+```rust
+async fn read_stream(&self, path: &str) -> MicrosandboxResult<FsReadStream>
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory, or when you want to process data incrementally.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsReadStream`](#fsreadstream) | Async stream that yields chunks of file data |
+
+---
+
+#### read_to_string()
+
+```rust
+async fn read_to_string(&self, path: &str) -> MicrosandboxResult<String>
+```
+
+Read the entire contents of a file and decode as UTF-8. Returns an error if the file contains invalid UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `String` | File contents as a UTF-8 string |
+
+---
+
+#### remove()
+
+```rust
+async fn remove(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute file path |
+
+---
+
+#### remove_dir()
+
+```rust
+async fn remove_dir(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Remove a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute directory path |
+
+---
+
+#### rename()
+
+```rust
+async fn rename(&self, from: &str, to: &str) -> MicrosandboxResult<()>
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `&str` | Current path |
+| to | `&str` | New path |
+
+---
+
+#### stat()
+
+```rust
+async fn stat(&self, path: &str) -> MicrosandboxResult<FsMetadata>
+```
+
+Get detailed metadata for a file or directory, including type, size, permissions, and timestamps.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsMetadata`](#fsmetadata) | File metadata |
+
+---
+
+#### write()
+
+```rust
+async fn write(&self, path: &str, data: impl AsRef<[u8]>) -> MicrosandboxResult<()>
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+| data | `impl AsRef<[u8]>` | File content |
+
+---
+
+#### write_stream()
+
+```rust
+async fn write_stream(&self, path: &str) -> MicrosandboxResult<FsWriteSink>
+```
+
+Open a streaming writer for large files. Write chunks incrementally and close when done.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `&str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsWriteSink`](#fswritesink) | Async writer for sending chunks |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| mode | `u32` | Unix permission bits (e.g. `0o644`) |
+| modified | `Option<DateTime<Utc>>` | Last modified timestamp |
+| path | `String` | File path |
+| size | `u64` | File size in bytes |
+
+### FsEntryKind
+
+The type of a filesystem entry.
+
+| Value | Description |
+|-------|-------------|
+| `Directory` | Directory |
+| `File` | Regular file |
+| `Other` | Other entry type (device, socket, etc.) |
+| `Symlink` | Symbolic link |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| created | `Option<DateTime<Utc>>` | Creation timestamp (not available on all filesystems) |
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| mode | `u32` | Unix permission bits |
+| modified | `Option<DateTime<Utc>>` | Last modified timestamp |
+| readonly | `bool` | Whether the file is read-only |
+| size | `u64` | File size in bytes |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`read_stream()`](#read_stream).
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| collect() | `Bytes` | Collect all remaining chunks into a single `Bytes` buffer. |
+| recv() | `Option<Bytes>` | Receive the next chunk. Returns `None` when the file has been fully read. |
+
+### FsWriteSink
+
+Async writer for streaming data into a file. Obtained via [`write_stream()`](#write_stream).
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| close() | - | Finalize the write and close the stream. Must be called to ensure all data is flushed. |
+| write() | `data: impl AsRef<[u8]>` | Write a chunk of data to the file. |

--- a/docs/ja/sdk/rust/networking.mdx
+++ b/docs/ja/sdk/rust/networking.mdx
@@ -1,0 +1,916 @@
+---
+title: Networking
+description: Rust SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Build one with [`NetworkPolicy::builder()`](#networkpolicybuilder):
+
+```rust
+use microsandbox::NetworkPolicy;
+
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.tcp().port(443).allow_public().allow_private())
+    .rule(|r| r.any().deny().ip("198.51.100.5"))
+    .build()?;
+```
+
+The default policy denies egress except for an implicit `allow public`, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
+| rules | `Vec<`[`Rule`](#rule)`>` | Ordered list of rules; first match wins |
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```rust
+NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e
+        .allow().cidr("10.0.0.0/8")     // matches everything in 10.x
+        .deny().ip("10.0.0.5"))          // never reached
+    .build()?;
+```
+
+Put specific rules before general ones.
+
+### Shadow detection
+
+`.build()` walks the rules and warns (via `tracing::warn!`) when a rule is fully covered by an earlier one in the same direction. Only `Ip`, `Cidr`, and `Group` destinations are checked; domain coverage depends on runtime DNS and is skipped. Builds still succeed:
+
+```text
+WARN rule #1 (Egress Cidr(10.0.0.5/32) Deny) is shadowed by rule #0 (Egress Cidr(10.0.0.0/8) Allow); to narrow, place the more specific rule first
+```
+
+### State accumulation
+
+State setters (`.tcp()`, `.port()`, etc.) inside a closure carry into every rule-adder that follows. State is **not reset** between adders:
+
+```rust
+.rule(|r| r.egress()
+    .tcp().port(443).allow_public()    // rule 1: egress, TCP, 443, allow Public
+    .udp().allow_private())            // rule 2: egress, [TCP, UDP], 443, allow Private
+```
+
+Use separate closures for rules that need different state.
+
+---
+
+## NetworkPolicy::builder()
+
+The fluent builder is the primary construction path. String inputs (`.ip(&str)`, `.cidr(&str)`, `.domain(&str)`, `.domain_suffix(&str)`) are stored raw and parsed at `.build()` time, so the chain stays clean. The first parse / validation failure surfaces as [`BuildError`](#builderror).
+
+The closure signature for `.rule()` / `.egress()` / `.ingress()` / `.any()` is `FnOnce(&mut RuleBuilder) -> &mut RuleBuilder`. A chain ending in any rule-adder (`.allow_public()`, `.deny().ip(...)`, etc.) returns the builder reference and satisfies the bound. Multi-statement bodies end with an explicit `r` return.
+
+---
+
+#### any()
+
+```rust
+fn any<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Any`. Rules committed inside apply in both directions.
+
+---
+
+#### build()
+
+```rust
+fn build(self) -> Result<NetworkPolicy, BuildError>
+```
+
+Consume the builder and produce a [`NetworkPolicy`](#networkpolicy). Lazy-parses every `.ip()` / `.cidr()` / `.domain()` / `.domain_suffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a `tracing::warn!` for each shadowed rule pair detected.
+
+---
+
+#### default_allow()
+
+```rust
+fn default_allow(self) -> Self
+```
+
+Set both `default_egress` and `default_ingress` to `Allow`.
+
+---
+
+#### default_deny()
+
+```rust
+fn default_deny(self) -> Self
+```
+
+Set both `default_egress` and `default_ingress` to `Deny`.
+
+---
+
+#### default_egress()
+
+```rust
+fn default_egress(self, action: Action) -> Self
+```
+
+Per-direction override for the egress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`Action`](#action) | Default action for egress |
+
+---
+
+#### default_ingress()
+
+```rust
+fn default_ingress(self, action: Action) -> Self
+```
+
+Per-direction override for the ingress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`Action`](#action) | Default action for ingress |
+
+---
+
+#### egress()
+
+```rust
+fn egress<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Egress`.
+
+---
+
+#### ingress()
+
+```rust
+fn ingress<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule-1) with direction pre-set to `Ingress`.
+
+---
+
+#### rule()
+
+```rust
+fn rule<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Open a multi-rule batch closure. Direction must be set inside via `.egress()`, `.ingress()`, or `.any()` before any rule-adder.
+
+---
+
+## RuleBuilder
+
+The closure passed to `.rule(...)` (or any of the direction sugar methods) gives you a `RuleBuilder`. State setters and rule-adders interleave freely. State accumulates eagerly across the closure (see [State accumulation](#state-accumulation)).
+
+### Direction setters
+
+Last-write-wins. ICMP rule-adders are egress-only at build time.
+
+---
+
+#### any()
+
+```rust
+fn any(&mut self) -> &mut Self
+```
+
+Set direction to `Any` for subsequent rule-adders. Rules committed after this apply in both directions.
+
+---
+
+#### egress()
+
+```rust
+fn egress(&mut self) -> &mut Self
+```
+
+Set direction to `Egress` for subsequent rule-adders.
+
+---
+
+#### ingress()
+
+```rust
+fn ingress(&mut self) -> &mut Self
+```
+
+Set direction to `Ingress` for subsequent rule-adders.
+
+---
+
+### Protocol setters
+
+Protocols accumulate as a set; duplicates dedupe.
+
+---
+
+#### icmpv4()
+
+```rust
+fn icmpv4(&mut self) -> &mut Self
+```
+
+Add `Icmpv4` to the protocols set. Egress-only; an ICMP rule on an `Ingress` or `Any` direction fails build with [`BuildError::IngressDoesNotSupportIcmp`](#builderror).
+
+---
+
+#### icmpv6()
+
+```rust
+fn icmpv6(&mut self) -> &mut Self
+```
+
+Add `Icmpv6` to the protocols set. Egress-only; same rules as [`icmpv4()`](#icmpv4).
+
+---
+
+#### tcp()
+
+```rust
+fn tcp(&mut self) -> &mut Self
+```
+
+Add `Tcp` to the protocols set.
+
+---
+
+#### udp()
+
+```rust
+fn udp(&mut self) -> &mut Self
+```
+
+Add `Udp` to the protocols set.
+
+---
+
+### Port setters
+
+Ports accumulate as a set; duplicates dedupe. Always guest-side (egress destination port / ingress listening port).
+
+---
+
+#### port()
+
+```rust
+fn port(&mut self, port: u16) -> &mut Self
+```
+
+Add a single port to the ports set.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `u16` | Port number |
+
+---
+
+#### port_range()
+
+```rust
+fn port_range(&mut self, lo: u16, hi: u16) -> &mut Self
+```
+
+Add an inclusive port range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| lo | `u16` | Lower bound (inclusive) |
+| hi | `u16` | Upper bound (inclusive). `lo > hi` records [`BuildError::InvalidPortRange`](#builderror) |
+
+---
+
+#### ports()
+
+```rust
+fn ports<I: IntoIterator<Item = u16>>(&mut self, ports: I) -> &mut Self
+```
+
+Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
+
+---
+
+### Group rule-adders
+
+Each adder commits one rule using the current state and the named destination group.
+
+---
+
+#### allow_host()
+
+```rust
+fn allow_host(&mut self) -> &mut Self
+```
+
+Allow the `Host` group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allow_loopback()`](#allow_loopback).
+
+---
+
+#### allow_link_local()
+
+```rust
+fn allow_link_local(&mut self) -> &mut Self
+```
+
+Allow the `LinkLocal` group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
+
+---
+
+#### allow_loopback()
+
+```rust
+fn allow_loopback(&mut self) -> &mut Self
+```
+
+Allow the `Loopback` group (`127.0.0.0/8`, `::1`). The **guest's own** loopback, not the host. To reach a service on the host's localhost, use [`allow_host()`](#allow_host) instead. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
+
+---
+
+#### allow_meta()
+
+```rust
+fn allow_meta(&mut self) -> &mut Self
+```
+
+Allow the `Metadata` group (`169.254.169.254`). **Dangerous on cloud hosts** (exposes IAM credentials).
+
+---
+
+#### allow_multicast()
+
+```rust
+fn allow_multicast(&mut self) -> &mut Self
+```
+
+Allow the `Multicast` group (`224.0.0.0/4`, `ff00::/8`).
+
+---
+
+#### allow_private()
+
+```rust
+fn allow_private(&mut self) -> &mut Self
+```
+
+Allow the `Private` group (RFC1918 + ULA + CGN).
+
+---
+
+#### allow_public()
+
+```rust
+fn allow_public(&mut self) -> &mut Self
+```
+
+Allow the `Public` group (complement of named categories: every IP not in any other group).
+
+---
+
+#### deny_host()
+
+```rust
+fn deny_host(&mut self) -> &mut Self
+```
+
+Deny the `Host` group.
+
+---
+
+#### deny_link_local()
+
+```rust
+fn deny_link_local(&mut self) -> &mut Self
+```
+
+Deny the `LinkLocal` group.
+
+---
+
+#### deny_loopback()
+
+```rust
+fn deny_loopback(&mut self) -> &mut Self
+```
+
+Deny the `Loopback` group.
+
+---
+
+#### deny_meta()
+
+```rust
+fn deny_meta(&mut self) -> &mut Self
+```
+
+Deny the `Metadata` group.
+
+---
+
+#### deny_multicast()
+
+```rust
+fn deny_multicast(&mut self) -> &mut Self
+```
+
+Deny the `Multicast` group.
+
+---
+
+#### deny_private()
+
+```rust
+fn deny_private(&mut self) -> &mut Self
+```
+
+Deny the `Private` group.
+
+---
+
+#### deny_public()
+
+```rust
+fn deny_public(&mut self) -> &mut Self
+```
+
+Deny the `Public` group.
+
+---
+
+### Bulk-domain rule-adders
+
+Each call adds one rule per name, inheriting the current direction / protocol / port state. Lazy-parse: invalid names surface as [`BuildError::InvalidDomain`](#builderror) from `.build()`.
+
+```rust
+NetworkPolicy::builder()
+    .default_allow()
+    .egress(|e| e
+        .deny_domains(["evil.com", "tracker.example"])
+        .deny_domain_suffixes([".ads.example", ".doubleclick.net"]))
+    .build()?
+```
+
+---
+
+#### allow_domain_suffixes()
+
+```rust
+fn allow_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::DomainSuffix` allow rule per suffix.
+
+---
+
+#### allow_domains()
+
+```rust
+fn allow_domains<I, S>(&mut self, names: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::Domain` allow rule per name.
+
+---
+
+#### deny_domain_suffixes()
+
+```rust
+fn deny_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::DomainSuffix` deny rule per suffix.
+
+---
+
+#### deny_domains()
+
+```rust
+fn deny_domains<I, S>(&mut self, names: I) -> &mut Self
+where I: IntoIterator<Item = S>, S: Into<String>
+```
+
+Add one `Destination::Domain` deny rule per name.
+
+---
+
+### Composite rule-adders
+
+---
+
+#### allow_local()
+
+```rust
+fn allow_local(&mut self) -> &mut Self
+```
+
+Add three allow rules atomically: `Loopback + LinkLocal + Host`. Each uses the closure's current state. `Metadata` is intentionally not included; opt in via [`allow_meta()`](#allow_meta) separately.
+
+---
+
+#### deny_local()
+
+```rust
+fn deny_local(&mut self) -> &mut Self
+```
+
+Add three deny rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is intentionally not included.
+
+---
+
+### Explicit-destination rule-adders
+
+`.allow()` / `.deny()` open an [`ExplicitRuleBuilder`](#explicitrulebuilder) that requires a destination call to commit.
+
+```rust
+.rule(|r| r.egress().tcp().port(443).allow().domain("api.example.com"))
+.rule(|r| r.any().deny().cidr("198.51.100.0/24"))
+```
+
+Dropping without a destination call adds no rule (the type is `#[must_use]`).
+
+---
+
+#### allow()
+
+```rust
+fn allow(&mut self) -> ExplicitRuleBuilder<'_>
+```
+
+Begin an explicit-destination rule with action `Allow`.
+
+---
+
+#### deny()
+
+```rust
+fn deny(&mut self) -> ExplicitRuleBuilder<'_>
+```
+
+Begin an explicit-destination rule with action `Deny`.
+
+---
+
+## NetworkBuilder
+
+Builder for configuring the sandbox's network stack. Used in `SandboxBuilder::network(|n| n...)`. Errors accumulated by nested builders cascade up; the outermost `SandboxBuilder::build()` surfaces them as `MicrosandboxError::NetworkBuilder(BuildError)`.
+
+---
+
+#### dns()
+
+```rust
+fn dns(self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self
+```
+
+Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
+
+```rust
+.network(|n| n
+    .dns(|d| d
+        .nameservers(["1.1.1.1".parse::<Nameserver>()?])
+        .query_timeout_ms(3000)
+    )
+)
+```
+
+---
+
+#### max_connections()
+
+```rust
+fn max_connections(self, max: usize) -> Self
+```
+
+Limit the maximum number of concurrent network connections from the sandbox.
+
+---
+
+#### on_secret_violation()
+
+```rust
+fn on_secret_violation(self, action: ViolationAction) -> Self
+```
+
+Set the action taken when a secret placeholder is detected in traffic destined for a host not in the secret's allow list. See [`ViolationAction`](#violationaction).
+
+---
+
+#### policy()
+
+```rust
+fn policy(self, policy: NetworkPolicy) -> Self
+```
+
+Set the network access policy. Pass a builder-constructed [`NetworkPolicy`](#networkpolicy):
+
+```rust
+.network(|n| n.policy(NetworkPolicy::builder().default_deny().build()?))
+```
+
+---
+
+#### tls()
+
+```rust
+fn tls(self, f: impl FnOnce(TlsBuilder) -> TlsBuilder) -> Self
+```
+
+Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
+
+---
+
+#### trust_host_cas()
+
+```rust
+fn trust_host_cas(self, enabled: bool) -> Self
+```
+
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in when egress HTTPS inside the sandbox needs to work behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle.
+
+---
+
+## DnsBuilder
+
+Builder for DNS interception settings. Used in `NetworkBuilder::dns(|d| d...)`. Owns rebind protection, nameserver pinning, and the per-query timeout.
+
+---
+
+#### nameservers()
+
+```rust
+fn nameservers<I>(self, nameservers: I) -> Self
+where
+    I: IntoIterator,
+    I::Item: Into<Nameserver>
+```
+
+Set the upstream nameservers to forward DNS queries to. Replaces any previously-set nameservers. Each element is convertible into `Nameserver` (`SocketAddr`, `IpAddr`, or a parsed string via `"dns.google:53".parse::<Nameserver>()?`).
+
+---
+
+#### query_timeout_ms()
+
+```rust
+fn query_timeout_ms(self, ms: u64) -> Self
+```
+
+Set the per-DNS-query timeout in milliseconds. Default: `5000`.
+
+---
+
+#### rebind_protection()
+
+```rust
+fn rebind_protection(self, enabled: bool) -> Self
+```
+
+When enabled, DNS responses that resolve to private IP addresses are blocked. Prevents DNS rebinding attacks. Default: `true`.
+
+---
+
+## TlsBuilder
+
+Builder for TLS interception settings. Used in `NetworkBuilder::tls(|t| t...)`.
+
+---
+
+#### block_quic()
+
+```rust
+fn block_quic(self, block: bool) -> Self
+```
+
+Block QUIC/HTTP3 on intercepted ports, forcing TCP/TLS fallback. Default: `true`.
+
+---
+
+#### bypass()
+
+```rust
+fn bypass(self, pattern: impl Into<String>) -> Self
+```
+
+Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). Use for domains with certificate pinning.
+
+---
+
+#### intercept_ca_cert()
+
+```rust
+fn intercept_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file used as the intercepting CA's certificate. Pair with [`intercept_ca_key()`](#intercept_ca_key) to provide a stable CA across sandbox restarts.
+
+---
+
+#### intercept_ca_key()
+
+```rust
+fn intercept_ca_key(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file used as the intercepting CA's private key.
+
+---
+
+#### intercepted_ports()
+
+```rust
+fn intercepted_ports(self, ports: Vec<u16>) -> Self
+```
+
+TCP ports where TLS interception is active. Default: `[443]`.
+
+---
+
+#### upstream_ca_cert()
+
+```rust
+fn upstream_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file with extra root CAs the proxy should trust when verifying upstream servers.
+
+---
+
+#### verify_upstream()
+
+```rust
+fn verify_upstream(self, verify: bool) -> Self
+```
+
+Whether the proxy verifies upstream server certificates. Default: `true`. Set to `false` only for self-signed servers.
+
+---
+
+## Types
+
+### Action
+
+| Value | Wire format | Description |
+|-------|-------------|-------------|
+| `Allow` | `"allow"` | Permit the traffic |
+| `Deny` | `"deny"` | Drop the traffic silently |
+
+### Direction
+
+| Value | Wire format | Description |
+|-------|-------------|-------------|
+| `Egress` | `"egress"` | Traffic leaving the sandbox |
+| `Ingress` | `"ingress"` | Traffic entering the sandbox (via published ports) |
+| `Any` | `"any"` | Rule applies in either direction |
+
+### Destination
+
+| Variant | Description |
+|---------|-------------|
+| `Any` | Match any address |
+| `Cidr(IpNetwork)` | Match a CIDR range (e.g. `10.0.0.0/8`); single IPs are stored as `/32` or `/128` |
+| `Domain(`[`DomainName`](#domainname)`)` | Match an exact domain (e.g. `example.com`) |
+| `DomainSuffix(`[`DomainName`](#domainname)`)` | Match the apex domain and every subdomain (e.g. `example.com` and `api.example.com`) |
+| `Group(`[`DestinationGroup`](#destinationgroup)`)` | Match a predefined address group |
+
+### DestinationGroup
+
+| Value | Wire format | Matches |
+|-------|-------------|---------|
+| `Public` | `"public"` | Complement of the other categories: every address not in any other group |
+| `Private` | `"private"` | `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7` |
+| `Loopback` | `"loopback"` | `127.0.0.0/8`, `::1` (the **guest's own** loopback, not the host) |
+| `LinkLocal` | `"link_local"` | `169.254.0.0/16`, `fe80::/10` (excludes metadata) |
+| `Metadata` | `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
+| `Multicast` | `"multicast"` | `224.0.0.0/4`, `ff00::/8` |
+| `Host` | `"host"` | Per-sandbox gateway IPs that back `host.microsandbox.internal` |
+
+### DomainName
+
+A validated DNS name. Construction goes through `str::parse` (or `TryFrom<String>`), which delegates to `hickory_proto::rr::Name` and canonicalizes the input (lowercased ASCII, leading and trailing dots stripped) so rule matching is a byte-wise compare against the DNS cache. Invalid inputs return a `DomainNameError`.
+
+```rust
+use microsandbox_network::policy::{Destination, DomainName};
+
+let exact: DomainName = "PyPI.Org.".parse()?;     // -> "pypi.org"
+let suffix: DomainName = ".example.com".parse()?;  // -> "example.com"
+```
+
+Labels follow the permissive DNS grammar (RFC 2181 §11), so underscore-prefixed names like `_service._tcp.example.com` are accepted.
+
+The builder methods (`.domain(&str)`, `.domain_suffix(&str)`) take strings and parse them lazily at `.build()`; callers don't need to construct `DomainName` directly.
+
+### Protocol
+
+| Value | Wire format |
+|-------|-------------|
+| `Tcp` | `"tcp"` |
+| `Udp` | `"udp"` |
+| `Icmpv4` | `"icmpv4"` |
+| `Icmpv6` | `"icmpv6"` |
+
+ICMP protocols are egress-only. A rule with direction `Ingress` or `Any` carrying an ICMP protocol fails build with [`BuildError::IngressDoesNotSupportIcmp`](#builderror).
+
+### PortRange
+
+```rust
+struct PortRange {
+    start: u16,  // inclusive
+    end: u16,    // inclusive
+}
+```
+
+| Method | Description |
+|--------|-------------|
+| `PortRange::single(port)` | Match a single port |
+| `PortRange::range(start, end)` | Match an inclusive range |
+
+### Rule
+
+A single network policy rule.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| direction | [`Direction`](#direction) | Which evaluator considers this rule |
+| destination | [`Destination`](#destination) | Target filter (egress destination / ingress source) |
+| protocols | `Vec<`[`Protocol`](#protocol)`>` | Set semantics; empty = any protocol |
+| ports | `Vec<`[`PortRange`](#portrange)`>` | Set semantics; empty = any port. Always guest-side (egress destination port / ingress listening port) |
+| action | [`Action`](#action) | What to do on match |
+
+Convenience constructors:
+
+| Method | Description |
+|--------|-------------|
+| `Rule::allow_egress(destination)` | Allow rule, direction `Egress` |
+| `Rule::deny_egress(destination)` | Deny rule, direction `Egress` |
+| `Rule::allow_ingress(destination)` | Allow rule, direction `Ingress` |
+| `Rule::deny_ingress(destination)` | Deny rule, direction `Ingress` |
+| `Rule::allow_any(destination)` | Allow rule, direction `Any` |
+| `Rule::deny_any(destination)` | Deny rule, direction `Any` |
+
+### ExplicitRuleBuilder
+
+Returned by [`RuleBuilder`](#rulebuilder)`::allow()` / `::deny()`. Requires exactly one destination method call to commit the rule. The type is `#[must_use]`; dropping without a call adds no rule.
+
+| Method | Description |
+|--------|-------------|
+| `.ip(impl Into<String>)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
+| `.cidr(impl Into<String>)` | Commit with `Destination::Cidr` |
+| `.domain(impl Into<String>)` | Commit with `Destination::Domain` |
+| `.domain_suffix(impl Into<String>)` | Commit with `Destination::DomainSuffix` |
+| `.group(DestinationGroup)` | Commit with `Destination::Group` |
+| `.any()` | Commit with `Destination::Any` |
+
+### BuildError
+
+Errors surfaced by the builders' `.build()` methods. The same enum covers `NetworkPolicy::builder()`, `DnsBuilder`, and `NetworkBuilder` (the network and DNS builders accumulate errors lazily; the first failure surfaces from the outermost `.build()` in the chain).
+
+| Variant | Cause |
+|---------|-------|
+| `DirectionNotSet { rule_index }` | A rule was committed without `.egress() / .ingress() / .any()` |
+| `MissingDestination { rule_index }` | `.allow()` or `.deny()` was called but no destination method followed |
+| `InvalidIp { rule_index, raw }` | `.ip(&str)` got an unparseable value |
+| `InvalidCidr { rule_index, raw }` | `.cidr(&str)` got an unparseable value |
+| `InvalidDomain { rule_index, raw, source }` | `.domain` or `.domain_suffix` got a value that failed `DomainName` parse |
+| `InvalidPortRange { rule_index, lo, hi }` | `.port_range(lo, hi)` had `lo > hi` |
+| `IngressDoesNotSupportIcmp { rule_index }` | ICMP protocol on a non-egress rule |
+
+Inside `SandboxBuilder::build()`, `BuildError` is wrapped as `MicrosandboxError::NetworkBuilder(BuildError)`.
+
+### ViolationAction
+
+Action taken when a secret placeholder is sent to a disallowed host.
+
+| Value | Description |
+|-------|-------------|
+| `Block` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `BlockAndLog` | Drop the request and emit a warning log on the host side. |
+| `BlockAndTerminate` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/ja/sdk/rust/sandbox.mdx
+++ b/docs/ja/sdk/rust/sandbox.mdx
@@ -1,0 +1,1176 @@
+---
+title: Sandbox
+description: Rust SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+## Static methods
+
+---
+
+#### Sandbox::builder()
+
+```rust
+fn builder(name: impl Into<String>) -> SandboxBuilder
+```
+
+Create a builder for configuring a new sandbox. The builder lets you set the image, resources, volumes, networking, secrets, and other options before booting the VM. See [`SandboxBuilder`](#sandboxbuilder) for all available options.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Sandbox name - must be unique among running sandboxes |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxBuilder`](#sandboxbuilder) | Builder for configuring the sandbox |
+
+---
+
+#### Sandbox::get()
+
+```rust
+async fn get(name: &str) -> MicrosandboxResult<SandboxHandle>
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control without requiring a full connection to the guest agent.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<SandboxHandle>>
+```
+
+List all sandboxes (running, stopped, and crashed).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`SandboxHandle`](#sandboxhandle)`>` | All sandbox handles |
+
+---
+
+#### Sandbox::remove()
+
+```rust
+async fn remove(name: &str) -> MicrosandboxResult<()>
+```
+
+Delete a stopped sandbox and all its state from disk (configuration, logs, runtime directory). Fails if the sandbox is still running - stop it first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Sandbox name |
+
+---
+
+#### Sandbox::start()
+
+```rust
+async fn start(name: &str) -> MicrosandboxResult<Sandbox>
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration. The sandbox enters attached mode - it stops when your process exits.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox::start_detached()
+
+```rust
+async fn start_detached(name: &str) -> MicrosandboxResult<Sandbox>
+```
+
+Restart a stopped sandbox in detached mode. The sandbox survives after your process exits.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+## Instance methods
+
+---
+
+#### config()
+
+```rust
+fn config(&self) -> &SandboxConfig
+```
+
+Access the sandbox's full configuration.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`&SandboxConfig`](#sandboxconfig) | Sandbox configuration |
+
+---
+
+#### detach()
+
+```rust
+async fn detach(self)
+```
+
+Release the handle without stopping the sandbox. The sandbox continues running as a background process. Reconnect later with [`Sandbox::get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```rust
+async fn drain(&self) -> MicrosandboxResult<()>
+```
+
+Start a graceful drain. Existing commands run to completion, but new `exec` calls are rejected. The sandbox transitions to `Stopped` when all in-flight commands finish. Useful for zero-downtime rotation of worker sandboxes.
+
+---
+
+#### fs()
+
+```rust
+fn fs(&self) -> SandboxFs<'_>
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/rust/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/rust/filesystem) | Filesystem handle |
+
+---
+
+#### kill()
+
+```rust
+async fn kill(&self) -> MicrosandboxResult<()>
+```
+
+Force-terminate the sandbox immediately with SIGKILL. No graceful shutdown - use when the sandbox is unresponsive.
+
+---
+
+#### metrics()
+
+```rust
+async fn metrics(&self) -> MicrosandboxResult<SandboxMetrics>
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk I/O, network I/O, and uptime.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | Resource metrics |
+
+---
+
+#### metrics_stream()
+
+```rust
+fn metrics_stream(&self, interval: Duration) -> impl Stream<Item = MicrosandboxResult<SandboxMetrics>>
+```
+
+Stream resource metrics at a regular interval. Returns an async stream that yields a new snapshot every `interval` duration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| interval | `Duration` | Time between metric snapshots |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `impl Stream<Item = Result<`[`SandboxMetrics`](#sandboxmetrics)`>>` | Async stream of metrics |
+
+---
+
+#### logs()
+
+```rust
+fn logs(&self, opts: &LogOptions) -> MicrosandboxResult<Vec<LogEntry>>
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `Stdout`, `Stderr`, and `Output` (PTY-merged). Pass `LogSource::System` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```rust
+use microsandbox::sandbox::{LogOptions, LogSource, Sandbox};
+
+let handle = Sandbox::get("web").await?;
+
+// Default — all user-program output, regardless of pipe/pty mode
+let entries = handle.logs(&LogOptions::default())?;
+
+for e in entries {
+    let source = match e.source {
+        LogSource::Stdout => "OUT",
+        LogSource::Stderr => "ERR",
+        LogSource::Output => "PTY",
+        LogSource::System => "SYS",
+    };
+    println!(
+        "[{}] {} {:?}: {}",
+        e.timestamp.to_rfc3339(),
+        source,
+        e.session_id,
+        String::from_utf8_lossy(&e.data).trim_end()
+    );
+}
+
+// Filtered: last 50 entries from the past hour, including system lines
+let recent = handle.logs(&LogOptions {
+    tail: Some(50),
+    since: Some(chrono::Utc::now() - chrono::Duration::hours(1)),
+    sources: vec![
+        LogSource::Stdout,
+        LogSource::Stderr,
+        LogSource::Output,
+        LogSource::System,
+    ],
+    ..Default::default()
+})?;
+```
+
+`logs()` is **synchronous** because it's a pure file read.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| opts | `&`[`LogOptions`](#logoptions) | Filters: `tail`, `since`, `until`, `sources`. `LogOptions::default()` returns everything for the default sources. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`LogEntry`](#logentry)`>` | Matching entries in chronological order |
+
+---
+
+#### name()
+
+```rust
+fn name(&self) -> &str
+```
+
+Get the sandbox name.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `&str` | Sandbox name |
+
+---
+
+#### owns_lifecycle()
+
+```rust
+fn owns_lifecycle(&self) -> bool
+```
+
+Whether this handle owns the sandbox lifecycle. `true` in attached mode (sandbox stops when your process exits), `false` in detached mode.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `true` if attached |
+
+---
+
+#### remove_persisted()
+
+```rust
+async fn remove_persisted(self) -> MicrosandboxResult<()>
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### stop()
+
+```rust
+async fn stop(&self) -> MicrosandboxResult<()>
+```
+
+Gracefully shut down the sandbox. Sends SIGTERM to all guest processes and waits for the VM to exit.
+
+---
+
+#### stop_and_wait()
+
+```rust
+async fn stop_and_wait(&self) -> MicrosandboxResult<ExitStatus>
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### wait()
+
+```rust
+async fn wait(&self) -> MicrosandboxResult<ExitStatus>
+```
+
+Block until the sandbox exits on its own (without triggering a stop). Returns the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
+
+---
+
+## SandboxBuilder
+
+Builder for configuring a sandbox before creation. Obtained via [`Sandbox::builder(name)`](#sandboxbuilder-1).
+
+---
+
+#### cpus()
+
+```rust
+fn cpus(self, count: u8) -> Self
+```
+
+Set the number of virtual CPUs. This is a limit, not a reservation. Default: `1`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| count | `u8` | Number of vCPUs |
+
+---
+
+#### create()
+
+```rust
+async fn create(self) -> MicrosandboxResult<Sandbox>
+```
+
+Boot the sandbox in attached mode. The sandbox stops when your process exits.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### create_detached()
+
+```rust
+async fn create_detached(self) -> MicrosandboxResult<Sandbox>
+```
+
+Boot the sandbox in detached mode. The sandbox survives after your process exits.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### disable_network()
+
+```rust
+fn disable_network(self) -> Self
+```
+
+Fully disable networking. No network interface is created.
+
+---
+
+#### entrypoint()
+
+```rust
+fn entrypoint(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> Self
+```
+
+Override the OCI image's entrypoint.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl IntoIterator<Item = impl Into<String>>` | Entrypoint command and arguments |
+
+---
+
+#### env()
+
+```rust
+fn env(self, key: impl Into<String>, value: impl Into<String>) -> Self
+```
+
+Set an environment variable visible to all commands. Can be called multiple times. Per-command env vars (via `exec_with`) are merged on top.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| key | `impl Into<String>` | Variable name |
+| value | `impl Into<String>` | Variable value |
+
+---
+
+#### hostname()
+
+```rust
+fn hostname(self, hostname: impl Into<String>) -> Self
+```
+
+Set the guest hostname.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostname | `impl Into<String>` | Hostname |
+
+---
+
+#### idle_timeout()
+
+```rust
+fn idle_timeout(self, secs: u64) -> Self
+```
+
+Auto-drain the sandbox after this many seconds of inactivity (no active exec sessions). Enforced on the host side.
+
+---
+
+#### init()
+
+```rust
+fn init(self, cmd: impl Into<PathBuf>) -> Self
+```
+
+Hand off PID 1 inside the guest to `cmd` after agentd finishes its boot-time setup. The agent forks; the parent execs the init and becomes PID 1, the agent continues as a child process. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks, shutdown semantics, and tradeoffs.
+
+`cmd` is either an absolute path inside the guest rootfs or the literal `"auto"` (probes `/sbin/init`, `/lib/systemd/systemd`, `/usr/lib/systemd/systemd`). For init binaries that take argv or extra env (rare), use [`init_with`](#init_with).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<PathBuf>` | Absolute path inside the guest, or `"auto"` |
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("jrei/systemd-debian:12")
+    .init("auto")
+    .create()
+    .await?;
+```
+
+---
+
+#### init_with()
+
+```rust
+fn init_with(
+    self,
+    cmd: impl Into<PathBuf>,
+    f: impl FnOnce(InitOptionsBuilder) -> InitOptionsBuilder,
+) -> Self
+```
+
+Like [`init`](#init), but with a closure-builder for argv and env vars. Mirrors `exec_with` in shape.
+
+The builder exposes `arg`, `args`, `env`, and `envs`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `impl Into<PathBuf>` | Absolute path to the init binary inside the guest |
+| f | `FnOnce(InitOptionsBuilder) -> InitOptionsBuilder` | Closure populating argv and env |
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("jrei/systemd-debian:12")
+    .init_with("/lib/systemd/systemd", |i| i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create()
+    .await?;
+```
+
+Calling `init` or `init_with` more than once overwrites — different from `env`, which appends. The init is one-shot pre-boot.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `u64` | Idle timeout in seconds |
+
+---
+
+#### image()
+
+```rust
+fn image(self, image: impl IntoImage) -> Self
+```
+
+Set the root filesystem source. Accepts OCI image names, local directory paths, or disk image paths. The format is auto-detected.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| image | `impl IntoImage` | OCI image name, local directory path, or disk image path |
+
+---
+
+#### image_with()
+
+```rust
+fn image_with(self, f: impl FnOnce(ImageBuilder) -> ImageBuilder) -> Self
+```
+
+Configure a disk image rootfs with explicit filesystem type. Use when the filesystem type can't be auto-detected.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | `ImageBuilder` | Configure the disk image rootfs. |
+
+---
+
+#### log_level()
+
+```rust
+fn log_level(self, level: LogLevel) -> Self
+```
+
+Override the sandbox process's log verbosity.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| level | [`LogLevel`](#loglevel) | Log level |
+
+---
+
+#### max_duration()
+
+```rust
+fn max_duration(self, secs: u64) -> Self
+```
+
+Set the maximum sandbox lifetime in seconds. When exceeded, the sandbox is drained and stopped. Enforced on the host side - the guest cannot override it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `u64` | Maximum lifetime in seconds |
+
+---
+
+#### memory()
+
+```rust
+fn memory(self, size: impl Into<Mebibytes>) -> Self
+```
+
+Set the guest memory size. Physical pages are only allocated as the guest touches them, so this is a limit, not an upfront reservation. Default: `512` MiB.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size | `impl Into<Mebibytes>` | Memory in MiB |
+
+---
+
+#### network()
+
+```rust
+fn network(self, f: impl FnOnce(NetworkBuilder) -> NetworkBuilder) -> Self
+```
+
+Configure networking. See [Networking](/sdk/rust/networking) for the full builder API.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`NetworkBuilder`](/sdk/rust/networking#networkbuilder) | Configure the network. |
+
+---
+
+#### patch()
+
+```rust
+fn patch(self, f: impl FnOnce(PatchBuilder) -> PatchBuilder) -> Self
+```
+
+Modify the rootfs before the VM boots. Patches go into the writable layer - the base image is untouched.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | `PatchBuilder` | Configure rootfs patches. |
+
+---
+
+#### port()
+
+```rust
+fn port(self, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a TCP port from the sandbox to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_port | `u16` | Port on the host |
+| guest_port | `u16` | Port inside the sandbox |
+
+---
+
+#### port_udp()
+
+```rust
+fn port_udp(self, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a UDP port.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_port | `u16` | Port on the host |
+| guest_port | `u16` | Port inside the sandbox |
+
+---
+
+#### pull_policy()
+
+```rust
+fn pull_policy(self, policy: PullPolicy) -> Self
+```
+
+Control when the OCI image is pulled from the registry.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| policy | [`PullPolicy`](#pullpolicy) | Pull behavior |
+
+---
+
+#### registry_auth()
+
+```rust
+fn registry_auth(self, auth: RegistryAuth) -> Self
+```
+
+Authenticate to a private container registry.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| auth | [`RegistryAuth`](#registryauth) | Registry credentials |
+
+---
+
+#### replace()
+
+```rust
+fn replace(self) -> Self
+```
+
+If a sandbox with the same name already exists, stop it, remove it, and create a fresh one. Without this, creation fails on name conflict.
+
+---
+
+#### script()
+
+```rust
+fn script(self, name: impl Into<String>, content: impl Into<String>) -> Self
+```
+
+Add a named script at `/.msb/scripts/` inside the guest. Scripts are added to `PATH` and can be called by name via `exec()` or `shell()`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Script name (becomes the filename) |
+| content | `impl Into<String>` | Script content |
+
+---
+
+#### secret()
+
+```rust
+fn secret(self, f: impl FnOnce(SecretBuilder) -> SecretBuilder) -> Self
+```
+
+Add a secret with full configuration. See [Secrets](/sdk/rust/secrets) for the builder API. Automatically enables TLS interception.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`SecretBuilder`](/sdk/rust/secrets#secretbuilder) | Configure the secret. |
+
+---
+
+#### secret_env()
+
+```rust
+fn secret_env(self, env_var: impl Into<String>, value: impl Into<String>, allowed_host: impl Into<String>) -> Self
+```
+
+Shorthand for adding a header-injected secret. Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| env_var | `impl Into<String>` | Environment variable name |
+| value | `impl Into<String>` | Secret value |
+| allowed_host | `impl Into<String>` | Allowed destination host |
+
+---
+
+#### shell()
+
+```rust
+fn shell(self, shell: impl Into<String>) -> Self
+```
+
+Set the shell used by [`Sandbox::shell()`](#shell). Default: `/bin/sh`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| shell | `impl Into<String>` | Shell path (e.g. `"/bin/bash"`) |
+
+---
+
+#### user()
+
+```rust
+fn user(self, user: impl Into<String>) -> Self
+```
+
+Set the default guest user for all commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| user | `impl Into<String>` | User name or UID |
+
+---
+
+#### volume()
+
+```rust
+fn volume(self, guest_path: impl Into<String>, f: impl FnOnce(MountBuilder) -> MountBuilder) -> Self
+```
+
+Add a volume mount. See [Volumes](/sdk/rust/volumes) for mount types.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `impl Into<String>` | Mount point inside the sandbox |
+| f | [`MountBuilder`](/sdk/rust/volumes#mountbuilder) | Configure the mount. |
+
+---
+
+#### workdir()
+
+```rust
+fn workdir(self, path: impl Into<String>) -> Self
+```
+
+Set the default working directory for all commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+
+---
+
+## PatchBuilder
+
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder::patch(|p| p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `replace = true` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### append()
+
+```rust
+fn append(self, path: impl Into<String>, content: impl Into<String>) -> Self
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<String>` | Text to append |
+
+---
+
+#### copy_dir()
+
+```rust
+fn copy_dir(self, src: impl Into<PathBuf>, dst: impl Into<String>, replace: bool) -> Self
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<PathBuf>` | Host source directory |
+| dst | `impl Into<String>` | Absolute destination path inside the guest |
+| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### copy_file()
+
+```rust
+fn copy_file(
+    self,
+    src: impl Into<PathBuf>,
+    dst: impl Into<String>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<PathBuf>` | Host source file |
+| dst | `impl Into<String>` | Absolute destination path inside the guest |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)`. `None` keeps the source mode |
+| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### file()
+
+```rust
+fn file(
+    self,
+    path: impl Into<String>,
+    content: impl Into<Vec<u8>>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Write raw bytes at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<Vec<u8>>` | Raw byte content |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
+| replace | `bool` | When `true`, overwrite an existing path |
+
+---
+
+#### mkdir()
+
+```rust
+fn mkdir(self, path: impl Into<String>, mode: Option<u32>) -> Self
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| mode | `Option<u32>` | Directory mode, e.g. `Some(0o755)` |
+
+---
+
+#### remove()
+
+```rust
+fn remove(self, path: impl Into<String>) -> Self
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+
+---
+
+#### symlink()
+
+```rust
+fn symlink(self, target: impl Into<String>, link: impl Into<String>, replace: bool) -> Self
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `impl Into<String>` | What the symlink points to (literal symlink target text) |
+| link | `impl Into<String>` | Absolute path of the symlink itself |
+| replace | `bool` | When `true`, overwrite an existing path at `link` |
+
+---
+
+#### text()
+
+```rust
+fn text(
+    self,
+    path: impl Into<String>,
+    content: impl Into<String>,
+    mode: Option<u32>,
+    replace: bool,
+) -> Self
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<String>` | Absolute path inside the guest |
+| content | `impl Into<String>` | Text content |
+| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
+| replace | `bool` | When `true`, overwrite an existing path |
+
+---
+
+## Types
+
+### LogEntry
+
+A single captured log entry returned by [`logs()`](#logs).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| timestamp | `DateTime<Utc>` | Wall-clock capture time on the host |
+| source | [`LogSource`](#logsource) | Where the chunk came from |
+| session_id | `Option<u64>` | Relay-monotonic session id; `None` for `System` entries |
+| data | `Bytes` | The chunk's bytes (UTF-8 lossy decoded by default; raw bytes if `--raw` mode was used) |
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `Error` | Errors only |
+| `Warn` | Warnings and errors only |
+| `Info` | Info and higher |
+| `Debug` | Debug and higher |
+| `Trace` | Most verbose - all diagnostic output |
+
+### LogOptions
+
+Filters passed to [`logs()`](#logs). All fields optional. `LogOptions::default()` returns everything for the default sources (`Stdout` + `Stderr` + `Output`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tail | `Option<usize>` | Show only the last N entries after other filters apply |
+| since | `Option<DateTime<Utc>>` | Inclusive lower bound on entry timestamp |
+| until | `Option<DateTime<Utc>>` | Exclusive upper bound on entry timestamp |
+| sources | `Vec<`[`LogSource`](#logsource)`>` | Sources to include. Empty = `[Stdout, Stderr, Output]` (the default user-program sources). Add `System` to merge runtime/kernel diagnostics. |
+
+### LogSource
+
+Tag indicating where a captured log entry came from.
+
+| Value | Description |
+|-------|-------------|
+| `Stdout` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `Stderr` | Captured from a session's stderr (pipe mode) |
+| `Output` | Captured from a session running in pty mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `Output` rather than mislabelled as `Stdout`. |
+| `System` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `System` is requested. |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `Always` | Pull the image every time, even if cached locally |
+| `IfMissing` | Pull only if the image is not already cached. This is the default. |
+| `Never` | Never pull; fail if the image is not cached locally |
+
+### RegistryAuth
+
+Credentials for authenticating to a private container registry.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Basic` | - `username: String` <br/> - `password: String` | Username and password authentication |
+
+### SandboxConfig
+
+The full configuration of a sandbox. Obtained via [`config()`](#config) or built via [`SandboxBuilder`](#sandboxbuilder). Contains all settings used to create the sandbox.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpus | `u8` | Number of virtual CPUs |
+| env | `Vec<(String, String)>` | Environment variables |
+| idle_timeout_secs | `Option<u64>` | Idle timeout |
+| image | `RootfsSource` | Root filesystem source (OCI, bind, or disk image) |
+| max_duration_secs | `Option<u64>` | Maximum lifetime |
+| memory_mib | `u32` | Guest memory in MiB |
+| name | `String` | Sandbox name |
+| patches | `Vec<Patch>` | Rootfs patches |
+| scripts | `Vec<(String, String)>` | Named scripts |
+| shell | `Option<String>` | Shell for `shell()` calls |
+| volumes | `Vec<VolumeMount>` | Volume mounts |
+| workdir | `Option<String>` | Default working directory |
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox::get()`](#sandboxget) or [`Sandbox::list()`](#sandboxlist). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. You cannot `exec` or `fs` on a handle - call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| config() | `Result<`[`SandboxConfig`](#sandboxconfig)`>` | Parsed configuration |
+| config_json() | `&str` | Raw JSON configuration |
+| connect() | `Result<`[`Sandbox`](#instance-methods)`>` | Connect to a running sandbox |
+| created_at() | `Option<DateTime<Utc>>` | Creation timestamp |
+| kill() | `Result<()>` | Force terminate |
+| logs() | `Result<Vec<`[`LogEntry`](#logentry)`>>` | Read captured `exec.log` (works without starting) |
+| metrics() | `Result<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
+| name() | `&str` | Sandbox name |
+| remove() | `Result<()>` | Delete sandbox and state |
+| start() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
+| start_detached() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |
+| status() | [`SandboxStatus`](#sandboxstatus) | Current status |
+| stop() | `Result<()>` | Graceful shutdown |
+| updated_at() | `Option<DateTime<Utc>>` | Last update timestamp |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpu_percent | `f32` | CPU usage as a percentage |
+| disk_read_bytes | `u64` | Total bytes read from disk since boot |
+| disk_write_bytes | `u64` | Total bytes written to disk since boot |
+| memory_bytes | `u64` | Current memory usage in bytes |
+| memory_limit_bytes | `u64` | Memory limit in bytes |
+| net_rx_bytes | `u64` | Total bytes received over the network since boot |
+| net_tx_bytes | `u64` | Total bytes sent over the network since boot |
+| timestamp | `DateTime<Utc>` | When this measurement was taken |
+| uptime | `Duration` | Time since the sandbox was created |
+
+### SandboxStatus
+
+| Value | Description |
+|-------|-------------|
+| `Crashed` | VM exited unexpectedly (kernel panic, OOM, etc.) |
+| `Draining` | Graceful shutdown in progress; existing commands finish, new ones rejected |
+| `Running` | Guest agent is ready; `exec`, `shell`, `fs` work |
+| `Stopped` | VM shut down; configuration persisted; can be restarted |

--- a/docs/ja/sdk/rust/secrets.mdx
+++ b/docs/ja/sdk/rust/secrets.mdx
@@ -1,0 +1,221 @@
+---
+title: Secrets
+description: Rust SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## SecretBuilder
+
+Builder for configuring a secret's placeholder, allowed hosts, and injection scopes. Obtained through `SandboxBuilder::secret(|s| s...)`. Each secret maps an environment variable to a real value that is only revealed when traffic goes to an allowed host via the TLS proxy.
+
+---
+
+#### allow_any_host_dangerous()
+
+```rust
+fn allow_any_host_dangerous(self, i_understand_the_risk: bool) -> Self
+```
+
+Allow substitution on **any** host. This means any server the guest connects to will receive the real secret - effectively disabling host-based protection. Only use this when the secret is not sensitive or the sandbox network is fully locked down.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| i_understand_the_risk | `bool` | Must be `true` to take effect |
+
+---
+
+#### allow_host()
+
+```rust
+fn allow_host(self, host: impl Into<String>) -> Self
+```
+
+Add a host that is allowed to receive the real secret value. The TLS proxy matches this against the SNI (Server Name Indication) in the TLS ClientHello. Can be called multiple times to allow multiple hosts.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `impl Into<String>` | Exact hostname (e.g. `"api.openai.com"`) |
+
+---
+
+#### allow_host_pattern()
+
+```rust
+fn allow_host_pattern(self, pattern: impl Into<String>) -> Self
+```
+
+Add a wildcard host pattern. The `*` matches any subdomain prefix.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pattern | `impl Into<String>` | Wildcard pattern (e.g. `"*.googleapis.com"`) |
+
+---
+
+#### env()
+
+```rust
+fn env(self, var: impl Into<String>) -> Self
+```
+
+Set the environment variable name that will hold the placeholder inside the guest. The guest sees `$MSB_<var>` (or a custom placeholder) - never the real value. **Required.**
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| var | `impl Into<String>` | Environment variable name (e.g. `"OPENAI_API_KEY"`) |
+
+---
+
+#### inject_basic_auth()
+
+```rust
+fn inject_basic_auth(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced specifically in `Authorization` header lines. When `inject_headers` is `true`, this has no additional effect since all headers are already covered.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### inject_body()
+
+```rust
+fn inject_body(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced in the HTTP request body. When enabled, the TLS proxy also updates the `Content-Length` header to match the new body size after substitution.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `false` |
+
+---
+
+#### inject_headers()
+
+```rust
+fn inject_headers(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced anywhere in HTTP headers. This is the most common injection scope - covers `Authorization: Bearer $MSB_...` and similar patterns.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### inject_query()
+
+```rust
+fn inject_query(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced in the URL query string (the `?key=value` portion of the request line).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `false` |
+
+---
+
+#### placeholder()
+
+```rust
+fn placeholder(self, placeholder: impl Into<String>) -> Self
+```
+
+Override the auto-generated placeholder string. By default, microsandbox generates `$MSB_<env_var>`. Use this when you need a specific format or when the placeholder must match a particular byte length.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| placeholder | `impl Into<String>` | Custom placeholder string |
+
+---
+
+#### require_tls_identity()
+
+```rust
+fn require_tls_identity(self, enabled: bool) -> Self
+```
+
+When `true`, the secret is only substituted on TLS-intercepted connections where the proxy has verified it is performing MITM. When `false`, substitution also happens on non-intercepted (bypass) connections. Disable only if you know the traffic is safe.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | Default: `true` |
+
+---
+
+#### value()
+
+```rust
+fn value(self, value: impl Into<String>) -> Self
+```
+
+Set the real secret value. This is the string that replaces the placeholder when a request reaches an allowed host. It never enters the guest VM. **Required.**
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| value | `impl Into<String>` | The actual credential or token |
+
+---
+
+## Shorthand
+
+#### secret_env()
+
+```rust
+fn secret_env(self, env_var: impl Into<String>, value: impl Into<String>, allowed_host: impl Into<String>) -> Self
+```
+
+Convenience method on `SandboxBuilder`. Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`. Uses default injection scopes (headers enabled, body disabled).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| env_var | `impl Into<String>` | Environment variable name |
+| value | `impl Into<String>` | Secret value |
+| allowed_host | `impl Into<String>` | Allowed destination host |
+
+---
+
+## Types
+
+### ViolationAction
+
+Configured via [`NetworkBuilder::on_secret_violation()`](/sdk/rust/networking#on_secret_violation). Determines what happens when the guest sends a request containing a secret placeholder to a host that is **not** in the secret's allow list.
+
+| Value | Description |
+|-------|-------------|
+| `Block` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `BlockAndLog` | Drop the request and emit a warning log on the host side. |
+| `BlockAndTerminate` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/ja/sdk/rust/snapshots.mdx
+++ b/docs/ja/sdk/rust/snapshots.mdx
@@ -1,0 +1,343 @@
+---
+title: Snapshots
+description: Rust SDK - Snapshot API reference
+icon: "camera"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Rust SDK reference.
+
+```rust
+use microsandbox::{Sandbox, Snapshot, SnapshotHandle, SnapshotFormat};
+use microsandbox::snapshot::ExportOpts;
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## SandboxBuilder
+
+---
+
+#### from_snapshot()
+
+```rust
+fn from_snapshot(self, src: impl Into<String>) -> Self
+```
+
+Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`image()`](/sdk/rust/sandbox#image) and [`image_with()`](/sdk/rust/sandbox#image-with) — the snapshot already pins the image.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `impl Into<String>` | Bare name (resolved under `~/.microsandbox/snapshots/`) or filesystem path to an artifact directory |
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```rust
+async fn snapshot(&self, name: &str) -> MicrosandboxResult<Snapshot>
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination see [`snapshot_to()`](#snapshot-to).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Bare snapshot name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Snapshot` | The created artifact handle |
+
+**Errors**
+
+- `MicrosandboxError::SnapshotSandboxRunning` — the sandbox is not stopped
+- `MicrosandboxError::SnapshotAlreadyExists` — destination already exists (use the builder with `.force()` to overwrite)
+
+---
+
+#### snapshot_to()
+
+```rust
+async fn snapshot_to(&self, path: impl AsRef<Path>) -> MicrosandboxResult<Snapshot>
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path. For the common case of writing under the default snapshots directory see [`snapshot()`](#snapshot).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl AsRef<Path>` | Destination directory |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Snapshot` | The created artifact handle |
+
+---
+
+## Snapshot (instance)
+
+---
+
+#### path()
+
+```rust
+fn path(&self) -> &Path
+```
+
+Path to the artifact directory.
+
+---
+
+#### digest()
+
+```rust
+fn digest(&self) -> &str
+```
+
+Canonical content digest (`sha256:hex`) over the manifest bytes. The snapshot's identity.
+
+---
+
+#### manifest()
+
+```rust
+fn manifest(&self) -> &Manifest
+```
+
+Parsed manifest — image reference, image manifest digest, fstype, format, labels, upper-layer metadata, and optional integrity hash.
+
+---
+
+#### size_bytes()
+
+```rust
+fn size_bytes(&self) -> u64
+```
+
+Apparent size of the captured upper layer in bytes (the ext4 virtual size, sparse on disk).
+
+---
+
+#### verify()
+
+```rust
+async fn verify(&self) -> MicrosandboxResult<SnapshotVerifyReport>
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds. Returns `NotRecorded` when the manifest has no integrity hash.
+
+---
+
+## Snapshot::builder
+
+---
+
+#### Snapshot::builder()
+
+```rust
+fn builder(source_sandbox: impl Into<String>) -> SnapshotBuilder
+```
+
+Start configuring a new snapshot. The fluent builder is the API the CLI uses internally.
+
+```rust
+let snap = Snapshot::builder("baseline")
+    .name("after-pip-install")        // bare name in default dir
+    .label("stage", "post-deps")
+    .force()                           // overwrite if it exists
+    .record_integrity()                // hash the upper layer
+    .create()
+    .await?;
+```
+
+**Builder methods**
+
+| Method | Description |
+|--------|-------------|
+| `.destination(SnapshotDestination)` | Explicit destination variant |
+| `.name(&str)` | Convenience: bare name under the default snapshots directory |
+| `.path(PathBuf)` | Convenience: explicit filesystem path |
+| `.label(k, v)` | Add a `key=value` label (sorted in canonical form) |
+| `.force()` | Overwrite an existing artifact at the destination |
+| `.record_integrity()` | Compute and record a content-integrity hash at creation |
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot::create()
+
+```rust
+async fn create(config: SnapshotConfig) -> MicrosandboxResult<Snapshot>
+```
+
+Create a snapshot from a [`SnapshotConfig`](#snapshotconfig). Equivalent to using the builder.
+
+---
+
+#### Snapshot::open()
+
+```rust
+async fn open(path_or_name: impl AsRef<str>) -> MicrosandboxResult<Snapshot>
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot::get()
+
+```rust
+async fn get(name_or_digest: &str) -> MicrosandboxResult<SnapshotHandle>
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<SnapshotHandle>>
+```
+
+List indexed snapshots from the local DB cache. External-path artifacts opened via `Snapshot::open(/some/path)` may not appear here unless they live under the configured snapshots directory.
+
+---
+
+#### Snapshot::list_dir()
+
+```rust
+async fn list_dir(dir: impl AsRef<Path>) -> MicrosandboxResult<Vec<Snapshot>>
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index. Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot::remove()
+
+```rust
+async fn remove(path_or_name: &str, force: bool) -> MicrosandboxResult<()>
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force` is `true`.
+
+---
+
+#### Snapshot::reindex()
+
+```rust
+async fn reindex(dir: impl AsRef<Path>) -> MicrosandboxResult<usize>
+```
+
+Walk `dir`, upsert index rows for every artifact found, recompute parent-edge child counts. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot::export()
+
+```rust
+async fn export(name_or_path: &str, out: &Path, opts: ExportOpts) -> MicrosandboxResult<()>
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+**ExportOpts**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `with_parents` | `bool` | Walk the parent chain and include each ancestor (no-op today) |
+| `with_image` | `bool` | Bundle the OCI image cache (`cache/{layers,fsmeta,vmdk}`) for offline transport |
+| `plain_tar` | `bool` | Skip zstd compression and write a plain `.tar` |
+
+---
+
+#### Snapshot::import()
+
+```rust
+async fn import(archive: &Path, dest: Option<&Path>) -> MicrosandboxResult<SnapshotHandle>
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot::list()`](#snapshotlist) and [`Snapshot::get()`](#snapshotget).
+
+```rust
+let h = Snapshot::get("after-pip-install").await?;
+
+h.digest();           // &str — sha256:...
+h.name();             // Option<&str>
+h.parent_digest();    // Option<&str> — None today; populated when chains land
+h.image_ref();        // &str
+h.format();           // SnapshotFormat::Raw | Qcow2
+h.size_bytes();       // Option<u64>
+h.created_at();       // chrono::NaiveDateTime
+h.path();             // &Path
+
+let snap = h.open().await?;       // verify metadata, return Snapshot
+h.remove(false).await?;            // false = refuse if has children
+```
+
+---
+
+## Types
+
+#### SnapshotDestination
+
+```rust
+pub enum SnapshotDestination {
+    Name(String),
+    Path(PathBuf),
+}
+```
+
+Used by [`SnapshotBuilder::destination()`](#snapshotbuilder). The handle methods [`snapshot()`](#snapshot) and [`snapshot_to()`](#snapshot-to) construct this enum internally so callers don't need to import it.
+
+#### SnapshotFormat
+
+```rust
+pub enum SnapshotFormat {
+    Raw,
+    Qcow2,    // future
+}
+```
+
+Always emits `Raw` today. The `Qcow2` variant is reserved for backing-chain checkpoints.
+
+#### SnapshotVerifyReport
+
+```rust
+pub struct SnapshotVerifyReport {
+    pub digest: String,
+    pub path: PathBuf,
+    pub upper: UpperVerifyStatus,
+}
+
+pub enum UpperVerifyStatus {
+    NotRecorded,
+    Verified { algorithm: String, digest: String },
+}
+```
+
+Returned by [`Snapshot::verify()`](#verify).

--- a/docs/ja/sdk/rust/volumes.mdx
+++ b/docs/ja/sdk/rust/volumes.mdx
@@ -1,0 +1,213 @@
+---
+title: Volumes
+description: Rust SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+---
+
+#### Volume::builder()
+
+```rust
+fn builder(name: impl Into<String>) -> VolumeBuilder
+```
+
+Create a builder for a new named volume. Call `.quota()` to set a storage limit, then `.create()` to finalize.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Volume name (e.g. `"pip-cache"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeBuilder`](#volumebuilder) | Builder with `.quota()` and `.create()` |
+
+---
+
+#### Volume::get()
+
+```rust
+async fn get(name: &str) -> MicrosandboxResult<VolumeHandle>
+```
+
+Get a handle to an existing named volume. Use the handle to access the volume's filesystem from the host or to delete it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeHandle`](#volumehandle) | Handle for host-side operations |
+
+---
+
+#### Volume::list()
+
+```rust
+async fn list() -> MicrosandboxResult<Vec<VolumeHandle>>
+```
+
+List all named volumes.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Vec<`[`VolumeHandle`](#volumehandle)`>` | All volume handles |
+
+---
+
+#### Volume::remove()
+
+```rust
+async fn remove(name: &str) -> MicrosandboxResult<()>
+```
+
+Delete a named volume and its contents from disk. Fails if the volume is currently mounted by a running sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `&str` | Volume name |
+
+---
+
+## VolumeBuilder
+
+Builder for creating a named volume.
+
+---
+
+#### create()
+
+```rust
+async fn create(self) -> MicrosandboxResult<Volume>
+```
+
+Create the volume on disk.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Volume` | The created volume |
+
+---
+
+#### quota()
+
+```rust
+fn quota(self, mib: u64) -> Self
+```
+
+Set the maximum storage size for this volume. The guest cannot write beyond this limit.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| mib | `u64` | Quota in MiB |
+
+---
+
+## MountBuilder
+
+Builder for configuring a volume mount. Used in `SandboxBuilder::volume(path, |v| v...)`.
+
+---
+
+#### bind()
+
+```rust
+fn bind(self, host_path: impl Into<PathBuf>) -> Self
+```
+
+Mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `impl Into<PathBuf>` | Directory path on the host |
+
+---
+
+#### named()
+
+```rust
+fn named(self, name: impl Into<String>) -> Self
+```
+
+Mount a named volume. The volume must already exist (create it with [`Volume::builder()`](#volumebuilder)).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `impl Into<String>` | Volume name |
+
+---
+
+#### readonly()
+
+```rust
+fn readonly(self) -> Self
+```
+
+Mount as read-only. The guest can read but not write.
+
+---
+
+#### size()
+
+```rust
+fn size(self, mib: impl Into<Mebibytes>) -> Self
+```
+
+Set the size limit for a tmpfs mount. Has no effect on bind or named mounts.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| mib | `impl Into<Mebibytes>` | Size limit in MiB |
+
+---
+
+#### tmpfs()
+
+```rust
+fn tmpfs(self) -> Self
+```
+
+Use an in-memory filesystem. Contents are discarded when the sandbox stops. Good for scratch space, temp files, and build artifacts.
+
+---
+
+## Types
+
+### VolumeHandle
+
+Handle for interacting with a named volume from the host side.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| fs() | `VolumeFsHandle` | Host-side filesystem access - read and write files without a running sandbox |
+| name() | `&str` | Volume name |
+| remove() | `()` | Delete this volume from disk |

--- a/docs/ja/sdk/typescript/events.mdx
+++ b/docs/ja/sdk/typescript/events.mdx
@@ -1,0 +1,66 @@
+---
+title: Events
+description: TypeScript SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for usage examples and guest-side emitting.
+
+## Sandbox methods
+
+---
+
+#### emit()
+
+```typescript
+emit(eventName: string, data: any): Promise<void>
+```
+
+Send a named event with a JSON-serializable payload into the guest. Any process listening on the agent socket (`/run/agent.sock`) receives it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| eventName | `string` | Event name (e.g. `"task.start"`) |
+| data | `any` | Event payload - must be JSON-serializable |
+
+---
+
+#### onEvent()
+
+```typescript
+onEvent(eventName: string, callback: (event: EventData) => void): Subscription
+```
+
+Subscribe to named events emitted by guest processes. The callback fires each time the guest sends a matching event through `/run/agent.sock`. Multiple subscriptions to the same event name are supported.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| eventName | `string` | Event name to subscribe to (e.g. `"task.progress"`) |
+| callback | `(event: EventData) => void` | Called with the event data each time |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Subscription` | Call `.unsubscribe()` to stop receiving events |
+
+---
+
+## Types
+
+### EventData
+
+Data received from a guest event.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| data | `any` | Event payload. `undefined` if the event had no data. |
+| event | `string` | Event name |

--- a/docs/ja/sdk/typescript/execution.mdx
+++ b/docs/ja/sdk/typescript/execution.mdx
@@ -1,0 +1,364 @@
+---
+title: Execution
+description: TypeScript SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+---
+
+#### attach()
+
+```typescript
+attach(cmd: string, args?: Iterable<string>): Promise<number>
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Press `Ctrl+]` (or configured detach keys) to disconnect without stopping the process.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to run |
+| args? | `Iterable<string>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code of the process |
+
+---
+
+#### attachShell()
+
+```typescript
+attachShell(): Promise<number>
+```
+
+Attach to the sandbox's default shell.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code |
+
+---
+
+#### attachWith()
+
+```typescript
+attachWith(
+  cmd: string,
+  configure: (b: AttachOptionsBuilder) => AttachOptionsBuilder,
+): Promise<number>
+```
+
+Interactive PTY attach with options for environment variables, working directory, user, and custom detach keys. Configure via the builder callback.
+
+```typescript
+const code = await sandbox.attachWith("bash", (a) =>
+  a.cwd("/app")
+    .env("EDITOR", "vim")
+    .detachKeys("ctrl-]"),
+);
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to run |
+| configure | `(b: AttachOptionsBuilder) => AttachOptionsBuilder` | Builder callback — see [`AttachOptionsBuilder`](#attachoptionsbuilder) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<number>` | Exit code |
+
+---
+
+#### exec()
+
+```typescript
+exec(cmd: string, args?: Iterable<string>): Promise<ExecOutput>
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`execStream()`](#execstream) instead.
+
+```typescript
+const result = await sandbox.exec("python3", ["-c", "print(1 + 1)"]);
+console.log(result.stdout()); // "2\n"
+console.log(result.code);     // 0
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args? | `Iterable<string>` | Command arguments (e.g. `["-c", "print('hello')"]`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### execStream()
+
+```typescript
+execStream(cmd: string, args?: Iterable<string>): Promise<ExecHandle>
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
+
+```typescript
+const handle = await sandbox.execStream("tail", ["-f", "/var/log/app.log"]);
+for await (const event of handle) {
+  if (event.kind === "stdout") process.stdout.write(event.data);
+  if (event.kind === "exited") break;
+}
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute |
+| args? | `Iterable<string>` | Command arguments |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecHandle`](#exechandle)`>` | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### execStreamWith()
+
+```typescript
+execStreamWith(
+  cmd: string,
+  configure: (b: ExecOptionsBuilder) => ExecOptionsBuilder,
+): Promise<ExecHandle>
+```
+
+Streaming variant of [`execWith()`](#execwith) — same configuration via [`ExecOptionsBuilder`](#execoptionsbuilder), but returns an [`ExecHandle`](#exechandle).
+
+---
+
+#### execWith()
+
+```typescript
+execWith(
+  cmd: string,
+  configure: (b: ExecOptionsBuilder) => ExecOptionsBuilder,
+): Promise<ExecOutput>
+```
+
+Run a command with per-execution overrides. Configure working directory, environment variables, timeout, stdin, TTY allocation, and rlimits via the builder callback. These overrides apply only to this execution and don't change the sandbox's defaults.
+
+```typescript
+const out = await sandbox.execWith("python3", (e) =>
+  e.args(["script.py"])
+    .cwd("/app")
+    .env("PYTHONPATH", "/app/lib")
+    .timeout(30_000),
+);
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `string` | Command to execute |
+| configure | `(b: ExecOptionsBuilder) => ExecOptionsBuilder` | Builder callback — see [`ExecOptionsBuilder`](#execoptionsbuilder) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell()
+
+```typescript
+shell(script: string): Promise<ExecOutput>
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `string` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+
+---
+
+#### shellStream()
+
+```typescript
+shellStream(script: string): Promise<ExecHandle>
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `string` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`ExecHandle`](#exechandle)`>` | Streaming handle |
+
+---
+
+## Types
+
+### AttachOptionsBuilder
+
+Fluent builder used inside `Sandbox.attachWith(cmd, b => ...)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `arg(s)` | Append a single argument |
+| `args(iter)` | Append many arguments |
+| `cwd(path)` | Working directory |
+| `user(user)` | Guest user |
+| `env(key, value)` | Add a single env var |
+| `envs(record \| iter)` | Add many env vars |
+| `detachKeys(spec)` | Detach key sequence (e.g. `"ctrl-]"` or `"ctrl-p,ctrl-q"`) |
+| `rlimit(resource, n)` | Set both soft and hard rlimit |
+| `rlimitRange(resource, soft, hard)` | Set distinct soft/hard rlimits |
+| `build()` | Produce an immutable [`AttachOptions`](#attachoptions) |
+
+### AttachOptions
+
+The immutable object produced by `AttachOptionsBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| args | `readonly string[]` | Command arguments |
+| cwd | `string \| null` | Working directory |
+| user | `string \| null` | Guest user |
+| env | `ReadonlyArray<readonly [string, string]>` | Environment variables |
+| detachKeys | `string \| null` | Detach key sequence |
+| rlimits | `readonly Rlimit[]` | rlimits for the process |
+
+### ExecOptionsBuilder
+
+Fluent builder used inside `Sandbox.execWith(cmd, b => ...)`.
+
+| Method | Description |
+|--------|-------------|
+| `arg(s)` / `args(iter)` | Append arguments |
+| `cwd(path)` | Working directory |
+| `user(user)` | Guest user |
+| `env(key, value)` / `envs(record \| iter)` | Environment variables |
+| `timeout(ms)` | Kill the process after this many milliseconds |
+| `stdinNull()` | Stdin connected to `/dev/null` (default) |
+| `stdinPipe()` | Open a writable stdin pipe — read it back with `ExecHandle.takeStdin()` |
+| `stdinBytes(data)` | Pre-supply stdin (`Uint8Array \| string`) |
+| `tty(enabled)` | Allocate a pseudo-terminal |
+| `rlimit(resource, n)` / `rlimitRange(resource, soft, hard)` | rlimits |
+| `build()` | Produce an immutable [`ExecOptions`](#execoptions) |
+
+### ExecOptions
+
+The immutable object produced by `ExecOptionsBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| args | `readonly string[]` | Command arguments |
+| cwd | `string \| null` | Working directory |
+| user | `string \| null` | Guest user |
+| env | `ReadonlyArray<readonly [string, string]>` | Environment variables |
+| timeoutMs | `number \| null` | Timeout in milliseconds |
+| stdin | `StdinMode` | `null`, `pipe`, or pre-supplied `bytes` |
+| tty | `boolean` | TTY allocation |
+| rlimits | `readonly Rlimit[]` | rlimits |
+
+### ExecEvent
+
+Discriminated union emitted by `ExecHandle`. The discriminator is `kind` (not `eventType`).
+
+```typescript
+type ExecEvent =
+  | { kind: "started"; pid: number }
+  | { kind: "stdout"; data: Uint8Array }
+  | { kind: "stderr"; data: Uint8Array }
+  | { kind: "exited"; code: number };
+```
+
+| `kind` | Payload | Description |
+|--------|---------|-------------|
+| `'started'` | `pid: number` | The process has started |
+| `'stdout'` | `data: Uint8Array` | A chunk of stdout data |
+| `'stderr'` | `data: Uint8Array` | A chunk of stderr data |
+| `'exited'` | `code: number` | The process has exited |
+
+### ExecHandle
+
+A handle to a running streaming execution. `AsyncIterable<ExecEvent>` and `AsyncDisposable`.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `recv()` | `Promise<`[`ExecEvent`](#execevent)` \| null>` | Receive the next event. Returns `null` when done. |
+| `takeStdin()` | `Promise<`[`ExecSink`](#execsink)` \| null>` | Take the stdin writer. Returns `null` after first call. |
+| `wait()` | `Promise<`[`ExitStatus`](#exitstatus)`>` | Wait for the process to exit |
+| `collect()` | `Promise<`[`ExecOutput`](#execoutput)`>` | Drain remaining output and wait |
+| `signal(n)` | `Promise<void>` | Send a POSIX signal |
+| `kill()` | `Promise<void>` | Send SIGKILL |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<`[`ExecEvent`](#execevent)`>` | Iterate events with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Best-effort kill on `await using` exit |
+
+### ExecOutput
+
+The result of a completed command execution.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `code` | `number` (getter) | Exit code |
+| `success` | `boolean` (getter) | `true` if code is `0` |
+| `status` | [`ExitStatus`](#exitstatus) (getter) | Exit status object |
+| `stdout()` | `string` | Collected stdout decoded as UTF-8 |
+| `stderr()` | `string` | Collected stderr decoded as UTF-8 |
+| `stdoutBytes()` | `Uint8Array` | Raw stdout bytes |
+| `stderrBytes()` | `Uint8Array` | Raw stderr bytes |
+
+### ExecSink
+
+Writer for sending data to a running process's stdin.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `write(data)` | `Uint8Array \| string` | Write bytes to the process's stdin |
+| `close()` | - | Close stdin. The process sees EOF. |
+| `[Symbol.asyncDispose]()` | - | Calls `close()` |
+
+### ExitStatus
+
+| Field | Type | Description |
+|-------|------|-------------|
+| code | `number` | Exit code. `0` typically means success. |
+| success | `boolean` | `true` if code is `0` |

--- a/docs/ja/sdk/typescript/filesystem.mdx
+++ b/docs/ja/sdk/typescript/filesystem.mdx
@@ -1,0 +1,379 @@
+---
+title: Filesystem
+description: TypeScript SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution — no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
+
+```typescript
+const fs = sandbox.fs();
+
+await fs.write("/tmp/config.json", '{"debug": true}');
+const content = await fs.readToString("/tmp/config.json");
+```
+
+---
+
+#### copy()
+
+```typescript
+copy(from: string, to: string): Promise<void>
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `string` | Source path |
+| to | `string` | Destination path |
+
+---
+
+#### copyFromHost()
+
+```typescript
+copyFromHost(hostPath: string, guestPath: string): Promise<void>
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostPath | `string` | Path on the host filesystem |
+| guestPath | `string` | Destination path inside the sandbox |
+
+---
+
+#### copyToHost()
+
+```typescript
+copyToHost(guestPath: string, hostPath: string): Promise<void>
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guestPath | `string` | Path inside the sandbox |
+| hostPath | `string` | Destination path on the host |
+
+---
+
+#### exists()
+
+```typescript
+exists(path: string): Promise<boolean>
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<boolean>` | `true` if the path exists |
+
+---
+
+#### list()
+
+```typescript
+list(path: string): Promise<FsEntry[]>
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsEntry`](#fsentry)`[]>` | Directory entries |
+
+---
+
+#### mkdir()
+
+```typescript
+mkdir(path: string): Promise<void>
+```
+
+Create a directory. Parent directories must already exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path |
+
+---
+
+#### read()
+
+```typescript
+read(path: string): Promise<Uint8Array>
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<Uint8Array>` | File contents as raw bytes |
+
+---
+
+#### readStream()
+
+```typescript
+readStream(path: string): Promise<FsReadStream>
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory.
+
+```typescript
+for await (const chunk of await fs.readStream("/var/log/syslog")) {
+  process.stdout.write(chunk); // chunk is a Uint8Array
+}
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsReadStream`](#fsreadstream)`>` | Async stream that yields chunks of file data |
+
+---
+
+#### readToString()
+
+```typescript
+readToString(path: string): Promise<string>
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<string>` | File contents as a string |
+
+---
+
+#### remove()
+
+```typescript
+remove(path: string): Promise<void>
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute file path |
+
+---
+
+#### removeDir()
+
+```typescript
+removeDir(path: string): Promise<void>
+```
+
+Remove a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute directory path |
+
+---
+
+#### rename()
+
+```typescript
+rename(from: string, to: string): Promise<void>
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| from | `string` | Current path |
+| to | `string` | New path |
+
+---
+
+#### stat()
+
+```typescript
+stat(path: string): Promise<FsMetadata>
+```
+
+Get detailed metadata for a file or directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsMetadata`](#fsmetadata)`>` | File metadata |
+
+---
+
+#### write()
+
+```typescript
+write(path: string, data: Uint8Array | string): Promise<void>
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does. Parent directories must already exist. `string` payloads are encoded as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| data | `Uint8Array \| string` | File content |
+
+---
+
+#### writeStream()
+
+```typescript
+writeStream(path: string): Promise<FsWriteSink>
+```
+
+Open a streaming writer for a file. Use for files too large to hold in memory; pair with `await using` so the sink closes itself.
+
+```typescript
+await using sink = await fs.writeStream("/tmp/big.bin");
+await sink.write(new Uint8Array(1 << 20));
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`FsWriteSink`](#fswritesink)`>` | Streaming writer |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| path | `string` | File path |
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| size | `number` | File size in bytes |
+| mode | `number` | Unix permission bits |
+| modified | `Date \| null` | Last modified timestamp |
+
+### FsEntryKind
+
+```typescript
+type FsEntryKind = "file" | "directory" | "symlink" | "other";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'file'` | Regular file |
+| `'directory'` | Directory |
+| `'symlink'` | Symbolic link |
+| `'other'` | Other entry type |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| size | `number` | File size in bytes |
+| mode | `number` | Unix permission bits |
+| readonly | `boolean` | Whether the file is read-only |
+| modified | `Date \| null` | Last modified timestamp |
+| created | `Date \| null` | Creation timestamp |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`readStream()`](#readstream). `AsyncIterable<Uint8Array>` and `AsyncDisposable`.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `recv()` | `Promise<Uint8Array \| null>` | Receive the next chunk. Returns `null` when the file has been fully read. |
+| `collect()` | `Promise<Uint8Array>` | Drain the stream into a single buffer |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<Uint8Array>` | Use with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop reading; safe to use with `await using` |
+
+### FsWriteSink
+
+Streaming writer returned by [`writeStream()`](#writestream). `AsyncDisposable`.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `write(data)` | `Uint8Array \| string` | Append a chunk |
+| `close()` | - | Flush and close. Idempotent. |
+| `[Symbol.asyncDispose]()` | - | Calls `close()` |

--- a/docs/ja/sdk/typescript/networking.mdx
+++ b/docs/ja/sdk/typescript/networking.mdx
@@ -1,0 +1,1361 @@
+---
+title: Networking
+description: TypeScript SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## NetworkPolicy
+
+A list of rules plus two per-direction defaults, evaluated first-match-wins. Use a static factory for a preset, build a literal, or chain through [`NetworkPolicy.builder()`](#networkpolicybuilder) for the fluent builder:
+
+```typescript
+import { NetworkPolicy, Rule, Destination } from "microsandbox";
+
+// Custom policy literal
+const custom = {
+  defaultEgress: "deny",
+  defaultIngress: "allow",
+  rules: [
+    Rule.allowEgress(Destination.domain("api.openai.com")),
+    Rule.denyEgress(Destination.group("metadata")),
+  ],
+};
+
+// Or via the builder
+const built = NetworkPolicy.builder()
+  .defaultDeny()
+  .egress((e) => e.tcp().port(443).allowPublic())
+  .build();
+```
+
+Pass any of these to `NetworkBuilder.policy(...)`.
+
+### Rule order matters
+
+The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+
+```typescript
+const policy = {
+  defaultEgress: "deny",
+  defaultIngress: "allow",
+  rules: [
+    Rule.allowEgress(Destination.cidr("10.0.0.0/8")),  // matches everything in 10.x
+    Rule.denyEgress(Destination.cidr("10.0.0.5/32")),  // never reached
+  ],
+};
+```
+
+Put specific rules before general ones.
+
+### Shadow detection
+
+[`NetworkPolicyBuilder.build()`](#networkpolicybuilder) walks the rules and warns when a rule is fully covered by an earlier one in the same direction. Only `ip`, `cidr`, and `group` destinations are checked; domain coverage depends on runtime DNS and is skipped. Builds still succeed; the warning surfaces as a host-side `tracing::warn!` from the rust core:
+
+```text
+WARN rule #1 (Egress Cidr(10.0.0.5/32) Deny) is shadowed by rule #0 (Egress Cidr(10.0.0.0/8) Allow); to narrow, place the more specific rule first
+```
+
+Policy literals constructed via `Rule.allowEgress(...)` etc. do not run through the builder and skip this check.
+
+### State accumulation
+
+State setters (`.tcp()`, `.port()`, etc.) inside a [`RuleBuilder`](#rulebuilder) callback carry into every rule-adder that follows. State is **not reset** between adders:
+
+```typescript
+NetworkPolicy.builder()
+  .egress((r) => r
+    .tcp().port(443).allowPublic()    // rule 1: egress, TCP, 443, allow Public
+    .udp().allowPrivate()             // rule 2: egress, [TCP, UDP], 443, allow Private
+  )
+  .build();
+```
+
+Use separate `.rule()` / `.egress()` callbacks for rules that need different state.
+
+---
+
+#### NetworkPolicy.allowAll()
+
+```typescript
+static allowAll(): NetworkPolicy
+```
+
+Unrestricted network access, including to private addresses and the host machine.
+
+---
+
+#### NetworkPolicy.builder()
+
+```typescript
+static builder(): NetworkPolicyBuilder
+```
+
+Start a fluent [`NetworkPolicyBuilder`](#networkpolicybuilder). Equivalent to `new NetworkPolicyBuilder()`.
+
+---
+
+#### NetworkPolicy.none()
+
+```typescript
+static none(): NetworkPolicy
+```
+
+Deny all traffic. The guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+
+---
+
+#### NetworkPolicy.nonLocal()
+
+```typescript
+static nonLocal(): NetworkPolicy
+```
+
+Allow egress to public + private (LAN) destinations; ingress allowed by default.
+
+---
+
+#### NetworkPolicy.publicOnly()
+
+```typescript
+static publicOnly(): NetworkPolicy
+```
+
+Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+
+---
+
+## NetworkPolicyBuilder
+
+Fluent builder for [`NetworkPolicy`](#networkpolicy). The closure passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` receives a [`RuleBuilder`](#rulebuilder); state setters and rule-adders chain freely. The first parse / validation failure surfaces from `.build()`.
+
+```typescript
+import { NetworkPolicy } from "microsandbox";
+
+const policy = NetworkPolicy.builder()
+  .defaultDeny()
+  .egress((e) => e.tcp().port(443).allowPublic().allowPrivate())
+  .rule((r) => r.any().deny((d) => d.ip("198.51.100.5")))
+  .build();
+```
+
+---
+
+#### any()
+
+```typescript
+any(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Any`. Rules committed inside apply in both directions.
+
+---
+
+#### build()
+
+```typescript
+build(): NetworkPolicy
+```
+
+Materialize the accumulated state into a [`NetworkPolicy`](#networkpolicy-1). Lazily parses every recorded `.ip()` / `.cidr()` / `.domain()` / `.domainSuffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a host-side warning for each shadowed rule pair.
+
+---
+
+#### defaultAllow()
+
+```typescript
+defaultAllow(): this
+```
+
+Set both `defaultEgress` and `defaultIngress` to `"allow"`.
+
+---
+
+#### defaultDeny()
+
+```typescript
+defaultDeny(): this
+```
+
+Set both `defaultEgress` and `defaultIngress` to `"deny"`.
+
+---
+
+#### defaultEgress()
+
+```typescript
+defaultEgress(action: "allow" | "deny"): this
+```
+
+Per-direction override for the egress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | `"allow" \| "deny"` | Default action for egress |
+
+---
+
+#### defaultIngress()
+
+```typescript
+defaultIngress(action: "allow" | "deny"): this
+```
+
+Per-direction override for the ingress default action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | `"allow" \| "deny"` | Default action for ingress |
+
+---
+
+#### egress()
+
+```typescript
+egress(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Egress`.
+
+---
+
+#### ingress()
+
+```typescript
+ingress(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule-2) with direction pre-set to `Ingress`.
+
+---
+
+#### rule()
+
+```typescript
+rule(configure: (r: RuleBuilder) => RuleBuilder): this
+```
+
+Open a multi-rule batch closure. Direction must be set inside via `.egress()`, `.ingress()`, or `.any()` before any rule-adder.
+
+---
+
+## RuleBuilder
+
+Per-rule-batch builder. Lives only inside the callback passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` on a [`NetworkPolicyBuilder`](#networkpolicybuilder). State setters and rule-adders interleave freely; state accumulates eagerly across the callback (see [State accumulation](#state-accumulation)).
+
+### Direction setters
+
+Last-write-wins. ICMP rule-adders are egress-only at build time.
+
+---
+
+#### any()
+
+```typescript
+any(): this
+```
+
+Set direction to `Any` for subsequent rule-adders. Rules committed after this apply in both directions.
+
+---
+
+#### egress()
+
+```typescript
+egress(): this
+```
+
+Set direction to `Egress` for subsequent rule-adders.
+
+---
+
+#### ingress()
+
+```typescript
+ingress(): this
+```
+
+Set direction to `Ingress` for subsequent rule-adders.
+
+---
+
+### Protocol setters
+
+Protocols accumulate as a set; duplicates dedupe.
+
+---
+
+#### icmpv4()
+
+```typescript
+icmpv4(): this
+```
+
+Add `Icmpv4` to the protocols set. Egress-only; an ICMP rule on an `Ingress` or `Any` direction fails build.
+
+---
+
+#### icmpv6()
+
+```typescript
+icmpv6(): this
+```
+
+Add `Icmpv6` to the protocols set. Egress-only; same rules as [`icmpv4()`](#icmpv4).
+
+---
+
+#### tcp()
+
+```typescript
+tcp(): this
+```
+
+Add `Tcp` to the protocols set.
+
+---
+
+#### udp()
+
+```typescript
+udp(): this
+```
+
+Add `Udp` to the protocols set.
+
+---
+
+### Port setters
+
+Ports accumulate as a set; duplicates dedupe. Always guest-side (egress destination port / ingress listening port).
+
+---
+
+#### port()
+
+```typescript
+port(port: number): this
+```
+
+Add a single port to the ports set.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `number` | Port number `0..=65535` |
+
+---
+
+#### portRange()
+
+```typescript
+portRange(lo: number, hi: number): this
+```
+
+Add an inclusive port range. `lo > hi` records an error surfaced at `.build()` time.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| lo | `number` | Lower bound (inclusive) |
+| hi | `number` | Upper bound (inclusive) |
+
+---
+
+#### ports()
+
+```typescript
+ports(ports: number[]): this
+```
+
+Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
+
+---
+
+### Group rule-adders
+
+Each adder commits one rule using the current state and the named destination group.
+
+---
+
+#### allowHost()
+
+```typescript
+allowHost(): this
+```
+
+Allow the `Host` group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allowLoopback()`](#allowloopback).
+
+---
+
+#### allowLinkLocal()
+
+```typescript
+allowLinkLocal(): this
+```
+
+Allow the `LinkLocal` group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
+
+---
+
+#### allowLoopback()
+
+```typescript
+allowLoopback(): this
+```
+
+Allow the `Loopback` group (`127.0.0.0/8`, `::1`). The **guest's own** loopback, not the host. To reach a service on the host's localhost, use [`allowHost()`](#allowhost) instead. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
+
+---
+
+#### allowMeta()
+
+```typescript
+allowMeta(): this
+```
+
+Allow the `Metadata` group (`169.254.169.254`). **Dangerous on cloud hosts** (exposes IAM credentials).
+
+---
+
+#### allowMulticast()
+
+```typescript
+allowMulticast(): this
+```
+
+Allow the `Multicast` group (`224.0.0.0/4`, `ff00::/8`).
+
+---
+
+#### allowPrivate()
+
+```typescript
+allowPrivate(): this
+```
+
+Allow the `Private` group (RFC1918 + ULA + CGN).
+
+---
+
+#### allowPublic()
+
+```typescript
+allowPublic(): this
+```
+
+Allow the `Public` group (complement of named categories: every IP not in any other group).
+
+---
+
+#### denyHost()
+
+```typescript
+denyHost(): this
+```
+
+Deny the `Host` group.
+
+---
+
+#### denyLinkLocal()
+
+```typescript
+denyLinkLocal(): this
+```
+
+Deny the `LinkLocal` group.
+
+---
+
+#### denyLoopback()
+
+```typescript
+denyLoopback(): this
+```
+
+Deny the `Loopback` group.
+
+---
+
+#### denyMeta()
+
+```typescript
+denyMeta(): this
+```
+
+Deny the `Metadata` group.
+
+---
+
+#### denyMulticast()
+
+```typescript
+denyMulticast(): this
+```
+
+Deny the `Multicast` group.
+
+---
+
+#### denyPrivate()
+
+```typescript
+denyPrivate(): this
+```
+
+Deny the `Private` group.
+
+---
+
+#### denyPublic()
+
+```typescript
+denyPublic(): this
+```
+
+Deny the `Public` group.
+
+---
+
+### Domain rule-adders
+
+Singular forms add one rule; plural forms add one rule per element.
+
+---
+
+#### allowDomain()
+
+```typescript
+allowDomain(name: string): this
+```
+
+Add one `Destination::Domain` allow rule.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Fully qualified domain name |
+
+---
+
+#### allowDomainSuffix()
+
+```typescript
+allowDomainSuffix(suffix: string): this
+```
+
+Add one `Destination::DomainSuffix` allow rule. Matches the apex and any subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### allowDomainSuffixes()
+
+```typescript
+allowDomainSuffixes(suffixes: string[]): this
+```
+
+Add one `Destination::DomainSuffix` allow rule per suffix.
+
+---
+
+#### allowDomains()
+
+```typescript
+allowDomains(names: string[]): this
+```
+
+Add one `Destination::Domain` allow rule per name.
+
+---
+
+#### denyDomain()
+
+```typescript
+denyDomain(name: string): this
+```
+
+Add one `Destination::Domain` deny rule.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Fully qualified domain name |
+
+---
+
+#### denyDomainSuffix()
+
+```typescript
+denyDomainSuffix(suffix: string): this
+```
+
+Add one `Destination::DomainSuffix` deny rule. Matches the apex and any subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### denyDomainSuffixes()
+
+```typescript
+denyDomainSuffixes(suffixes: string[]): this
+```
+
+Add one `Destination::DomainSuffix` deny rule per suffix.
+
+---
+
+#### denyDomains()
+
+```typescript
+denyDomains(names: string[]): this
+```
+
+Add one `Destination::Domain` deny rule per name.
+
+---
+
+### Composite rule-adders
+
+---
+
+#### allowLocal()
+
+```typescript
+allowLocal(): this
+```
+
+Add three allow rules atomically: `Loopback + LinkLocal + Host`. Each uses the callback's current state. `Metadata` is intentionally not included; opt in via [`allowMeta()`](#allowmeta) separately.
+
+---
+
+#### denyLocal()
+
+```typescript
+denyLocal(): this
+```
+
+Add three deny rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is intentionally not included.
+
+---
+
+### Explicit-destination rule-adders
+
+`.allow()` / `.deny()` open a [`RuleDestinationBuilder`](#ruledestinationbuilder) callback. Exactly one destination call commits the rule.
+
+```typescript
+NetworkPolicy.builder()
+  .egress((r) => r
+    .tcp().port(443).allow((d) => d.domain("api.example.com"))
+    .deny((d) => d.cidr("198.51.100.0/24"))
+  )
+  .build();
+```
+
+---
+
+#### allow()
+
+```typescript
+allow(configure: (d: RuleDestinationBuilder) => RuleDestinationBuilder): this
+```
+
+Begin an explicit-destination rule with action `Allow`.
+
+---
+
+#### deny()
+
+```typescript
+deny(configure: (d: RuleDestinationBuilder) => RuleDestinationBuilder): this
+```
+
+Begin an explicit-destination rule with action `Deny`.
+
+---
+
+## Rule
+
+Factory for individual policy rules. Each method returns a single [`Rule`](#rule-1) value.
+
+---
+
+#### Rule.allowAny()
+
+```typescript
+static allowAny(destination: Destination): Rule
+```
+
+Allow rule with direction `any` (matches in either direction).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.allowEgress()
+
+```typescript
+static allowEgress(destination: Destination): Rule
+```
+
+Allow rule with direction `egress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.allowIngress()
+
+```typescript
+static allowIngress(destination: Destination): Rule
+```
+
+Allow rule with direction `ingress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyAny()
+
+```typescript
+static denyAny(destination: Destination): Rule
+```
+
+Deny rule with direction `any` (matches in either direction).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyEgress()
+
+```typescript
+static denyEgress(destination: Destination): Rule
+```
+
+Deny rule with direction `egress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+#### Rule.denyIngress()
+
+```typescript
+static denyIngress(destination: Destination): Rule
+```
+
+Deny rule with direction `ingress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination-1) | Target filter |
+
+---
+
+## Destination
+
+Factory for rule destinations.
+
+---
+
+#### Destination.any()
+
+```typescript
+static any(): Destination
+```
+
+Match any destination.
+
+---
+
+#### Destination.cidr()
+
+```typescript
+static cidr(cidr: string): Destination
+```
+
+Match an IP range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cidr | `string` | CIDR notation (e.g. `"10.0.0.0/8"`) |
+
+---
+
+#### Destination.domain()
+
+```typescript
+static domain(domain: string): Destination
+```
+
+Match an exact domain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| domain | `string` | Fully qualified domain name |
+
+---
+
+#### Destination.domainSuffix()
+
+```typescript
+static domainSuffix(suffix: string): Destination
+```
+
+Match the apex domain and every subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix |
+
+---
+
+#### Destination.group()
+
+```typescript
+static group(group: DestinationGroup): Destination
+```
+
+Match a predefined address group.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| group | [`DestinationGroup`](#destinationgroup) | Group keyword |
+
+---
+
+## PortRange
+
+Factory for port ranges.
+
+---
+
+#### PortRange.range()
+
+```typescript
+static range(start: number, end: number): PortRange
+```
+
+Match an inclusive port range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| start | `number` | Lower bound (inclusive) |
+| end | `number` | Upper bound (inclusive) |
+
+---
+
+#### PortRange.single()
+
+```typescript
+static single(port: number): PortRange
+```
+
+Match a single port. `start` and `end` are set to the same value.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `number` | Port number |
+
+---
+
+## NetworkBuilder
+
+Returned to the callback you pass to `SandboxBuilder.network(...)`. Every setter returns the same builder.
+
+---
+
+#### denyDomainSuffixes()
+
+```typescript
+denyDomainSuffixes(...suffixes: string[]): this
+```
+
+Deny egress to all subdomains of these suffixes. Same enforcement layers as [`denyDomains()`](#denydomains).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffixes | `string[]` | Domain suffixes |
+
+---
+
+#### denyDomains()
+
+```typescript
+denyDomains(...names: string[]): this
+```
+
+Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| names | `string[]` | Fully qualified domain names |
+
+---
+
+#### dns()
+
+```typescript
+dns(f: (d: DnsBuilder) => DnsBuilder): this
+```
+
+Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
+
+---
+
+#### enabled()
+
+```typescript
+enabled(b: boolean): this
+```
+
+Enable or disable networking entirely.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| b | `boolean` | When `false`, no network interface is created |
+
+---
+
+#### maxConnections()
+
+```typescript
+maxConnections(n: number): this
+```
+
+Limit the maximum number of concurrent network connections from the sandbox.
+
+---
+
+#### onSecretViolation()
+
+```typescript
+onSecretViolation(action: ViolationAction): this
+```
+
+Set the action taken when a secret reaches a disallowed host. See [`ViolationAction`](/sdk/typescript/secrets#violationaction).
+
+---
+
+#### policy()
+
+```typescript
+policy(policy: NetworkPolicy): this
+```
+
+Set the policy. Use a [`NetworkPolicy`](#networkpolicy) factory or a literal.
+
+---
+
+#### port()
+
+```typescript
+port(host: number, guest: number): this
+```
+
+Publish a TCP port from the guest to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `number` | Port on the host |
+| guest | `number` | Port inside the sandbox |
+
+---
+
+#### portUdp()
+
+```typescript
+portUdp(host: number, guest: number): this
+```
+
+Publish a UDP port from the guest to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `number` | Port on the host |
+| guest | `number` | Port inside the sandbox |
+
+---
+
+#### secret()
+
+```typescript
+secret(f: (s: SecretBuilder) => SecretBuilder): this
+```
+
+Add a secret. See [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder).
+
+---
+
+#### secretEnv()
+
+```typescript
+secretEnv(envVar: string, value: string, placeholder: string, allowedHost: string): this
+```
+
+Four-arg explicit-placeholder shorthand for adding a secret without opening a builder callback.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Real secret value |
+| placeholder | `string` | Placeholder string surfaced to the guest |
+| allowedHost | `string` | Single hostname allowed to receive the real value |
+
+---
+
+#### tls()
+
+```typescript
+tls(f: (t: TlsBuilder) => TlsBuilder): this
+```
+
+Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
+
+---
+
+#### trustHostCAs()
+
+```typescript
+trustHostCAs(enabled: boolean): this
+```
+
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in for corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle.
+
+---
+
+## DnsBuilder
+
+Builder for DNS interception settings. Used in `NetworkBuilder.dns(d => ...)`. Owns rebind protection, nameserver pinning, and the per-query timeout.
+
+---
+
+#### nameservers()
+
+```typescript
+nameservers(servers: string[]): this
+```
+
+Override upstream nameservers. Replaces any previously-set nameservers.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| servers | `string[]` | Each entry is `IP`, `IP:PORT`, `HOST`, or `HOST:PORT` |
+
+---
+
+#### queryTimeoutMs()
+
+```typescript
+queryTimeoutMs(ms: number): this
+```
+
+Per-DNS-query timeout in milliseconds.
+
+---
+
+#### rebindProtection()
+
+```typescript
+rebindProtection(enabled: boolean): this
+```
+
+Toggle DNS rebinding protection. When enabled, DNS responses resolving to private IPs are blocked.
+
+---
+
+## TlsBuilder
+
+Builder for TLS interception settings. Used in `NetworkBuilder.tls(t => ...)`.
+
+---
+
+#### blockQuic()
+
+```typescript
+blockQuic(block: boolean): this
+```
+
+Block QUIC on intercepted ports, forcing TCP/TLS fallback.
+
+---
+
+#### bypass()
+
+```typescript
+bypass(pattern: string): this
+```
+
+Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). Use for domains with certificate pinning.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pattern | `string` | Glob pattern |
+
+---
+
+#### interceptCaCert()
+
+```typescript
+interceptCaCert(path: string): this
+```
+
+Path to a PEM file used as the intercepting CA's certificate.
+
+---
+
+#### interceptCaKey()
+
+```typescript
+interceptCaKey(path: string): this
+```
+
+Path to a PEM file used as the intercepting CA's private key.
+
+---
+
+#### interceptedPorts()
+
+```typescript
+interceptedPorts(ports: number[]): this
+```
+
+TCP ports where interception is active. Default: `[443]`.
+
+---
+
+#### upstreamCaCert()
+
+```typescript
+upstreamCaCert(path: string): this
+```
+
+Path to a PEM file with extra root CAs the proxy should trust.
+
+---
+
+#### verifyUpstream()
+
+```typescript
+verifyUpstream(verify: boolean): this
+```
+
+Verify upstream server certificates. Default `true`. Set to `false` only for self-signed servers.
+
+---
+
+## Types
+
+### NetworkConfig
+
+Built network configuration produced by `NetworkBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| enabled | `boolean` | Master enable flag |
+| ports | `readonly PublishedPort[]` | Port publishings |
+| policy | [`NetworkPolicy`](#networkpolicy-1) ` \| null` | Active policy |
+| dns | [`DnsConfig`](#dnsconfig) ` \| null` | DNS interception |
+| tls | [`TlsConfig`](#tlsconfig) ` \| null` | TLS interception |
+| secrets | `readonly SecretEntry[]` | Secret entries |
+| secretViolation | [`ViolationAction`](/sdk/typescript/secrets#violationaction) ` \| null` | Action on disallowed secret use |
+| maxConnections | `number \| null` | Maximum concurrent connections |
+| trustHostCAs | `boolean` | Ship host CAs into the guest |
+
+### NetworkPolicy
+
+```typescript
+interface NetworkPolicy {
+  readonly defaultEgress: Action;
+  readonly defaultIngress: Action;
+  readonly rules: readonly Rule[];
+}
+```
+
+### Rule
+
+```typescript
+interface Rule {
+  readonly direction: Direction;
+  readonly destination: Destination;
+  readonly protocols: readonly Protocol[]; // empty = any
+  readonly ports: readonly PortRange[];    // empty = any
+  readonly action: Action;
+}
+```
+
+### Destination
+
+```typescript
+type Destination =
+  | { kind: "any" }
+  | { kind: "cidr"; cidr: string }
+  | { kind: "domain"; domain: string }
+  | { kind: "domainSuffix"; suffix: string }
+  | { kind: "group"; group: DestinationGroup };
+```
+
+### Action
+
+```typescript
+type Action = "allow" | "deny";
+```
+
+### Direction
+
+```typescript
+type Direction = "egress" | "ingress" | "any";
+```
+
+### Protocol
+
+```typescript
+type Protocol = "tcp" | "udp" | "icmpv4" | "icmpv6";
+```
+
+### DestinationGroup
+
+```typescript
+type DestinationGroup =
+  | "public"
+  | "loopback"
+  | "private"
+  | "link-local"
+  | "metadata"
+  | "multicast"
+  | "host";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'public'` | Public internet (everything not in another group) |
+| `'loopback'` | Guest's own `127.0.0.0/8` / `::1` |
+| `'private'` | RFC1918 LAN ranges |
+| `'link-local'` | `169.254.0.0/16` / `fe80::/10` |
+| `'metadata'` | Cloud metadata endpoints (`169.254.169.254`, `fd00:ec2::254`) |
+| `'multicast'` | Multicast addresses |
+| `'host'` | The host machine, reached via `host.microsandbox.internal` |
+
+### PortRange
+
+```typescript
+interface PortRange {
+  readonly start: number;
+  readonly end: number;
+}
+```
+
+### RuleDestinationBuilder
+
+Returned by [`RuleBuilder`](#rulebuilder)`.allow(d => ...)` / `.deny(d => ...)`. Exactly one destination call commits the rule; dropping without a destination call silently does nothing.
+
+| Method | Description |
+|--------|-------------|
+| `.ip(ip)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
+| `.cidr(cidr)` | Commit with `Destination::Cidr` |
+| `.domain(domain)` | Commit with `Destination::Domain` |
+| `.domainSuffix(suffix)` | Commit with `Destination::DomainSuffix` |
+| `.group(group)` | Commit with `Destination::Group`. `group` is a [`DestinationGroup`](#destinationgroup) string |
+| `.any()` | Commit with `Destination::Any` |
+
+### DnsConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| nameservers | `readonly string[]` | Upstream nameservers |
+| rebindProtection | `boolean \| null` | DNS rebinding protection toggle |
+| queryTimeoutMs | `number \| null` | Per-query timeout |
+
+### TlsConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| bypass | `readonly string[]` | Bypass globs (e.g. `"*.googleapis.com"`) |
+| verifyUpstream | `boolean \| null` | Verify upstream certs |
+| interceptedPorts | `readonly number[]` | Intercepted TCP ports |
+| blockQuic | `boolean \| null` | Block QUIC on intercepted ports |
+| upstreamCaCertPaths | `readonly string[]` | Extra trust roots for upstream verification |
+| interceptCaCertPath | `string \| null` | Custom intercept CA cert (PEM) |
+| interceptCaKeyPath | `string \| null` | Custom intercept CA key (PEM) |
+
+### PublishedPort
+
+```typescript
+interface PublishedPort {
+  readonly hostPort: number;
+  readonly guestPort: number;
+  readonly protocol: "tcp" | "udp";
+}
+```

--- a/docs/ja/sdk/typescript/sandbox.mdx
+++ b/docs/ja/sdk/typescript/sandbox.mdx
@@ -1,0 +1,736 @@
+---
+title: Sandbox
+description: TypeScript SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox from `Sandbox.builder(name)` and chain configuration calls before terminating with `.create()` or `.createDetached()`.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+await using sandbox = await Sandbox.builder("demo")
+  .image("alpine")
+  .cpus(1)
+  .memory(512)
+  .create();
+```
+
+## Static methods
+
+---
+
+#### Sandbox.builder()
+
+```typescript
+static builder(name: string): SandboxBuilder
+```
+
+Begin building a new sandbox. Configure it with chainable setters, then call `.create()` or `.createDetached()` to boot it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxBuilder`](#sandboxbuilder) | Fluent builder |
+
+---
+
+#### Sandbox.get()
+
+```typescript
+static get(name: string): Promise<SandboxHandle>
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox.list()
+
+```typescript
+static list(): Promise<SandboxHandle[]>
+```
+
+List all sandboxes (running, stopped, and crashed). Handles returned from `list()` are read-only — call `Sandbox.get(name)` to get a live handle for lifecycle calls.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle[]`](#sandboxhandle) | All sandboxes (read-only handles) |
+
+---
+
+#### Sandbox.remove()
+
+```typescript
+static remove(name: string): Promise<void>
+```
+
+Delete a stopped sandbox and all its state from disk. Fails if the sandbox is still running.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Sandbox name |
+
+---
+
+#### Sandbox.start()
+
+```typescript
+static start(name: string): Promise<Sandbox>
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox.startDetached()
+
+```typescript
+static startDetached(name: string): Promise<Sandbox>
+```
+
+Restart a stopped sandbox in detached mode.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Name of a stopped sandbox |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+## Instance properties
+
+---
+
+#### name
+
+```typescript
+readonly name: string
+```
+
+Sandbox name.
+
+---
+
+#### config
+
+```typescript
+readonly config: Readonly<SandboxConfig>
+```
+
+The frozen configuration the sandbox was built with.
+
+---
+
+#### ownsLifecycle
+
+```typescript
+readonly ownsLifecycle: boolean
+```
+
+Whether this handle owns the sandbox lifecycle. `true` in attached mode (the auto-disposer will stop the sandbox), `false` in detached mode.
+
+---
+
+## Instance methods
+
+---
+
+#### detach()
+
+```typescript
+detach(): Promise<void>
+```
+
+Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```typescript
+drain(): Promise<void>
+```
+
+Start a graceful drain. Existing commands run to completion, new `exec` calls are rejected.
+
+---
+
+#### fs()
+
+```typescript
+fs(): SandboxFs
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/typescript/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/typescript/filesystem) | Filesystem handle |
+
+---
+
+#### kill()
+
+```typescript
+kill(): Promise<void>
+```
+
+Force-terminate the sandbox immediately. No graceful shutdown.
+
+---
+
+#### metrics()
+
+```typescript
+metrics(): Promise<SandboxMetrics>
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network metrics |
+
+---
+
+#### metricsStream()
+
+```typescript
+metricsStream(intervalMs: number): Promise<MetricsStream>
+```
+
+Stream resource metrics at a regular interval. The returned stream supports both `recv()` and `for await...of`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| intervalMs | `number` | Milliseconds between metric snapshots |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`MetricsStream`](#metricsstream) | Async stream of metrics |
+
+---
+
+#### logs()
+
+```typescript
+logs(opts?: LogReadOptions): Promise<LogEntry[]>
+```
+
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+const handle = await Sandbox.get("web");
+
+// Default — all user-program output, regardless of pipe/pty mode
+const entries = await handle.logs();
+
+for (const e of entries) {
+  const source =
+    e.source === "stdout" ? "OUT" :
+    e.source === "stderr" ? "ERR" :
+    e.source === "output" ? "PTY" :
+    "SYS";
+
+  console.log(
+    `[${e.timestamp.toISOString()}] ${source} ${e.sessionId}: ${e.text().trimEnd()}`
+  );
+}
+
+// Filtered: last 50 entries from the past hour, including system lines
+const recent = await handle.logs({
+  tail: 50,
+  since: new Date(Date.now() - 60 * 60 * 1000),
+  sources: ["stdout", "stderr", "output", "system"],
+});
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| opts | [`LogReadOptions`](#logreadoptions) `?` | Filters: `tail`, `since`, `until`, `sources`. Omit for the default user-program sources. |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`LogEntry`](#logentry)`[]>` | Matching entries in chronological order |
+
+---
+
+#### removePersisted()
+
+```typescript
+removePersisted(): Promise<void>
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### stop()
+
+```typescript
+stop(): Promise<void>
+```
+
+Gracefully shut down the sandbox.
+
+---
+
+#### stopAndWait()
+
+```typescript
+stopAndWait(): Promise<ExitStatus>
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/typescript/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### wait()
+
+```typescript
+wait(): Promise<ExitStatus>
+```
+
+Block until the sandbox exits on its own.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExitStatus`](/sdk/typescript/execution#exitstatus) | Exit code and success flag |
+
+---
+
+#### \[Symbol.asyncDispose\]()
+
+```typescript
+[Symbol.asyncDispose](): Promise<void>
+```
+
+Implements `AsyncDisposable` so the sandbox can be used with `await using`. When the binding goes out of scope, the sandbox is stopped (best-effort) — but only if `ownsLifecycle` is `true`.
+
+---
+
+## PatchBuilder
+
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder.patch(p => p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `{ replace: true }` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
+
+See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### append()
+
+```typescript
+append(path: string, content: string): this
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `string` | Text to append |
+
+---
+
+#### copyDir()
+
+```typescript
+copyDir(src: string, dst: string, opts?: { replace?: boolean }): this
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `string` | Host source directory |
+| dst | `string` | Absolute destination path inside the guest |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### copyFile()
+
+```typescript
+copyFile(
+  src: string,
+  dst: string,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `string` | Host source file |
+| dst | `string` | Absolute destination path inside the guest |
+| opts.mode | `number` | File mode, e.g. `0o644`. Omit to keep the source mode |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+
+---
+
+#### file()
+
+```typescript
+file(
+  path: string,
+  content: Buffer,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Write raw bytes at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `Buffer` | Raw byte content |
+| opts.mode | `number` | File mode, e.g. `0o644` |
+| opts.replace | `boolean` | When `true`, overwrite an existing path |
+
+---
+
+#### mkdir()
+
+```typescript
+mkdir(path: string, opts?: { mode?: number }): this
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| opts.mode | `number` | Directory mode, e.g. `0o755` |
+
+---
+
+#### remove()
+
+```typescript
+remove(path: string): this
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+---
+
+#### symlink()
+
+```typescript
+symlink(target: string, link: string, opts?: { replace?: boolean }): this
+```
+
+Create a symlink at `link` pointing to `target`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| target | `string` | What the symlink points to (literal symlink target text) |
+| link | `string` | Absolute path of the symlink itself |
+| opts.replace | `boolean` | When `true`, overwrite an existing path at `link` |
+
+---
+
+#### text()
+
+```typescript
+text(
+  path: string,
+  content: string,
+  opts?: { mode?: number; replace?: boolean },
+): this
+```
+
+Write UTF-8 text content at `path`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+| content | `string` | Text content |
+| opts.mode | `number` | File mode, e.g. `0o644` |
+| opts.replace | `boolean` | When `true`, overwrite an existing path |
+
+---
+
+## Types
+
+### SandboxBuilder
+
+Fluent configuration builder returned by `Sandbox.builder(name)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `image(src)` | OCI image (`"alpine"`), local rootfs path, or a `RootfsSource`. **Required.** |
+| `cpus(n)` | Virtual CPUs |
+| `memory(mib)` | Guest memory in MiB |
+| `logLevel(level)` | Override log verbosity |
+| `quietLogs()` | Suppress log output |
+| `workdir(path)` | Default working directory for commands |
+| `shell(shell)` | Shell binary used by `sandbox.shell(...)` |
+| `entrypoint(iter)` | Override the image entrypoint |
+| `init(cmd, args?)` | Hand off PID 1 to `cmd` (absolute path or `"auto"`) after agentd setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| `initWith(cmd, i => ...)` | Like `init` but with a closure-builder for argv and env (`.arg`, `.args`, `.env`, `.envs`) |
+| `hostname(name)` | Guest hostname |
+| `user(user)` | Default guest user |
+| `pullPolicy(policy)` | Image pull behavior |
+| `libkrunfwPath(path)` | Override the bundled libkrunfw shared library |
+| `env(key, value)` | Add a single env var |
+| `envs(record \| iter)` | Add many env vars |
+| `script(name, content)` | Mount a script at `/.msb/scripts/<name>` |
+| `scripts(record \| iter)` | Mount many scripts |
+| `replace()` | Replace any existing sandbox with the same name |
+| `maxDuration(secs)` | Maximum sandbox lifetime |
+| `idleTimeout(secs)` | Stop the sandbox after this many idle seconds |
+| `volume(guestPath, m => ...)` | Mount a volume — see [Volumes](/sdk/typescript/volumes) |
+| `patch(p => ...)` | Modify the rootfs before boot — see [Snapshots](/sdk/typescript/snapshots) |
+| `addPatch(patch)` | Append a pre-built `Patch` |
+| `registry(r => r.auth(...).insecure().caCertsPath(...))` | Configure the OCI registry |
+| `port(host, guest)` | Publish a TCP port |
+| `portUdp(host, guest)` | Publish a UDP port |
+| `disableNetwork()` | Disable networking entirely |
+| `network(n => ...)` | Configure DNS / TLS / policy / secrets — see [Networking](/sdk/typescript/networking) |
+| `secret(s => ...)` | Add a secret via [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder) |
+| `secretEnv(envVar, value, allowedHost)` | Auto-placeholder shorthand. Generates `$MSB_<ENV_VAR>`. |
+| `build(): SandboxConfig` | Materialize without booting |
+| `create(): Promise<Sandbox>` | Build and boot in attached mode |
+| `createDetached(): Promise<Sandbox>` | Build and boot in detached mode |
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `'debug'` | Debug and higher |
+| `'error'` | Errors only |
+| `'info'` | Info and higher |
+| `'trace'` | Most verbose - all diagnostic output |
+| `'warn'` | Warnings and errors only |
+
+### LogEntry
+
+A class wrapping one captured log entry. Returned by [`logs()`](#logs).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| timestamp | `Date` | Wall-clock capture time on the host |
+| source | [`LogSource`](#logsource) | Where the chunk came from |
+| sessionId | `number \| null` | Relay-monotonic session id; `null` for `"system"` entries |
+| data | `Uint8Array` | The chunk's bytes (UTF-8 lossy decoded by default) |
+| `text()` | `string` | Convenience: UTF-8 decode of `data` (lossy — invalid bytes are replaced) |
+
+### LogReadOptions
+
+Filters passed to [`logs()`](#logs). All fields optional. Omit the argument entirely for the default sources (`stdout` + `stderr` + `output`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tail | `number?` | Show only the last N entries after other filters apply |
+| since | `Date?` | Inclusive lower bound on entry timestamp |
+| until | `Date?` | Exclusive upper bound on entry timestamp |
+| sources | [`LogSource`](#logsource)`[]?` | Sources to include. Omit = `["stdout", "stderr", "output"]`. Add `"system"` to merge runtime/kernel diagnostics. |
+
+### LogSource
+
+Tag indicating where a captured log entry came from. String literal type:
+
+```typescript
+type LogSource = "stdout" | "stderr" | "output" | "system";
+```
+
+| Value | Description |
+|-------|-------------|
+| `"stdout"` | Captured from a session's stdout (pipe mode — streams stayed separated) |
+| `"stderr"` | Captured from a session's stderr (pipe mode) |
+| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `"output"` rather than mislabelled as `"stdout"`. |
+| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested. |
+
+### MetricsStream
+
+Async stream for receiving periodic metrics snapshots.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `[Symbol.asyncIterator]` | `AsyncIterator<`[`SandboxMetrics`](#sandboxmetrics)`>` | Use with `for await...of` |
+| `recv()` | `Promise<`[`SandboxMetrics`](#sandboxmetrics)` \| null>` | Receive next snapshot. Returns `null` when the stream ends. |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop iterating; safe to use with `await using`. |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `'always'` | Pull the image every time, even if cached locally |
+| `'if-missing'` | Pull only if the image is not already cached. This is the default. |
+| `'never'` | Never pull; fail if the image is not cached locally |
+
+### SandboxConfig
+
+Frozen configuration object — produced by `SandboxBuilder.build()` and exposed as the `config` property on a `Sandbox`. You generally should not construct this by hand; use the builder.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Sandbox name |
+| image | `RootfsSource` | OCI / bind / disk discriminated union |
+| cpus | `number \| null` | Virtual CPUs |
+| memoryMib | `number \| null` | Guest memory in MiB |
+| logLevel | `LogLevel \| null` | Log verbosity |
+| quietLogs | `boolean` | Suppress log output |
+| workdir | `string \| null` | Default working directory |
+| shell | `string \| null` | Shell binary |
+| entrypoint | `string[] \| null` | Override image entrypoint |
+| cmd | `string[] \| null` | Override image cmd |
+| hostname | `string \| null` | Guest hostname |
+| user | `string \| null` | Default guest user |
+| libkrunfwPath | `string \| null` | Custom libkrunfw path |
+| env | `Array<readonly [string, string]>` | Environment variables |
+| scripts | `Array<readonly [string, string]>` | Named scripts |
+| mounts | `VolumeMount[]` | Volume mounts |
+| patches | `Patch[]` | Rootfs modifications applied before boot |
+| pullPolicy | `PullPolicy \| null` | Image pull behavior |
+| replace | `boolean` | Replace existing sandbox with same name |
+| maxDurationSecs | `number \| null` | Maximum sandbox lifetime |
+| idleTimeoutSecs | `number \| null` | Stop after idle time |
+| portsTcp | `Array<readonly [number, number]>` | TCP host→guest mappings |
+| portsUdp | `Array<readonly [number, number]>` | UDP host→guest mappings |
+| registry | `RegistryConfig \| null` | Registry connection settings |
+| network | `NetworkConfig \| null` | Network configuration |
+| disableNetwork | `boolean` | Disable networking entirely |
+| secrets | `SecretEntry[]` | Secret entries (top-level) |
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandboxget) or [`Sandbox.list()`](#sandboxlist).
+
+Handles from `Sandbox.get(name)` are **live** — they expose lifecycle methods (`start`, `stop`, `kill`, `connect`, etc). Handles in the array returned by `Sandbox.list()` are **read-only**: calling lifecycle methods on them throws. Use `Sandbox.get(name)` to upgrade to a live handle.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `string` | Sandbox name |
+| status | [`SandboxStatus`](#sandboxstatus) | Current status |
+| configJson | `string` | Raw JSON configuration |
+| createdAt | `Date \| null` | Creation timestamp |
+| updatedAt | `Date \| null` | Last update timestamp |
+| metrics() | `Promise<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
+| logs() | `Promise<`[`LogEntry`](#logentry)`[]>` | Read captured `exec.log` (works without starting) |
+| start() | `Promise<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
+| startDetached() | `Promise<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |
+| connect() | `Promise<`[`Sandbox`](#instance-methods)`>` | Connect to a running sandbox without taking ownership |
+| stop() | `Promise<void>` | Graceful shutdown |
+| kill() | `Promise<void>` | Force terminate |
+| remove() | `Promise<void>` | Delete sandbox and state |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpuPercent | `number` | CPU usage as a percentage |
+| diskReadBytes | `number` | Total bytes read from disk since boot |
+| diskWriteBytes | `number` | Total bytes written to disk since boot |
+| memoryBytes | `number` | Current memory usage in bytes |
+| memoryLimitBytes | `number` | Memory limit in bytes |
+| netRxBytes | `number` | Total bytes received over the network since boot |
+| netTxBytes | `number` | Total bytes sent over the network since boot |
+| timestamp | `Date` | When this measurement was taken |
+| uptimeMs | `number` | Time since the sandbox was created (ms) |
+
+### SandboxStatus
+
+| Value | Description |
+|-------|-------------|
+| `'crashed'` | VM exited unexpectedly |
+| `'draining'` | Graceful shutdown in progress |
+| `'running'` | Guest agent is ready |
+| `'stopped'` | VM shut down; can be restarted |

--- a/docs/ja/sdk/typescript/secrets.mdx
+++ b/docs/ja/sdk/typescript/secrets.mdx
@@ -1,0 +1,126 @@
+---
+title: Secrets
+description: TypeScript SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## Adding secrets
+
+Secrets are configured on a sandbox via `SandboxBuilder.secret(s => ...)` (or its shorthand `secretEnv`). The guest only ever sees a placeholder — the real value is substituted by the TLS proxy when traffic reaches an allowed host.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+// Auto-placeholder shorthand: generates `$MSB_OPENAI_API_KEY`.
+await using sb = await Sandbox.builder("agent")
+  .image("python")
+  .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+  .create();
+
+// Full control via SecretBuilder.
+await using sb2 = await Sandbox.builder("agent2")
+  .image("python")
+  .secret((s) =>
+    s.env("STRIPE_KEY")
+      .value(process.env.STRIPE_KEY!)
+      .allowHost("api.stripe.com")
+      .allowHostPattern("*.stripe.com")
+      .injectHeaders(true)
+      .injectQuery(false),
+  )
+  .create();
+```
+
+The same `secret(...)` and `secretEnv(...)` methods are also available inside `SandboxBuilder.network(n => n.secret(...))` and on `NetworkBuilder.secretEnv(envVar, value, placeholder, allowedHost)` (4-arg explicit-placeholder shorthand).
+
+---
+
+## SecretBuilder
+
+Fluent builder used inside `SandboxBuilder.secret(s => ...)` or `NetworkBuilder.secret(s => ...)`. Every setter returns the same builder so calls can be chained.
+
+| Method | Description |
+|--------|-------------|
+| `env(varName)` | Environment variable to expose the placeholder under. **Required.** |
+| `value(value)` | The real secret value (stays on the host). **Required.** |
+| `placeholder(placeholder)` | Custom placeholder. Auto-generated as `$MSB_<ENV_VAR>` when omitted. |
+| `allowHost(host)` | Allow substitution to a specific host (exact match). |
+| `allowHostPattern(pattern)` | Allow substitution to any host matching a wildcard. |
+| `allowAnyHostDangerous(true)` | Permit substitution to any host. Acknowledge the risk explicitly. |
+| `requireTlsIdentity(enabled)` | Require a verified TLS identity before substituting. Default `true`. |
+| `injectHeaders(enabled)` | Allow substitution in HTTP headers. Default `true`. |
+| `injectBasicAuth(enabled)` | Allow substitution in HTTP Basic Auth. Default `true`. |
+| `injectQuery(enabled)` | Allow substitution in URL query parameters. Default `false`. |
+| `injectBody(enabled)` | Allow substitution in the HTTP request body. Default `false`. |
+| `build()` | Produce a [`SecretEntry`](#secretentry). |
+
+---
+
+## Convenience helpers
+
+#### SandboxBuilder.secretEnv()
+
+```typescript
+secretEnv(envVar: string, value: string, allowedHost: string): this
+```
+
+Three-argument shorthand. Auto-generates the placeholder as `$MSB_<ENV_VAR>` and allows substitution only on `allowedHost`.
+
+#### NetworkBuilder.secretEnv()
+
+```typescript
+secretEnv(
+  envVar: string,
+  value: string,
+  placeholder: string,
+  allowedHost: string,
+): this
+```
+
+Four-argument shorthand. Same as the `SandboxBuilder` form but lets you provide the placeholder explicitly.
+
+---
+
+## Types
+
+### SecretEntry
+
+The object produced by `SecretBuilder.build()`. You normally construct one with the builder, but the shape is exposed for advanced cases.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Real secret value (stays on the host) |
+| placeholder | `string \| null` | Custom placeholder; defaults to `$MSB_<ENV_VAR>` when `null` |
+| allowedHosts | `readonly string[]` | Allowed hosts (exact match) |
+| allowedHostPatterns | `readonly string[]` | Wildcard host patterns |
+| allowAnyHost | `boolean` | Permit substitution to any host |
+| requireTlsIdentity | `boolean` | Require verified TLS identity |
+| injection | [`SecretInjection`](#secretinjection) | Where to substitute |
+
+### SecretInjection
+
+Controls where the TLS proxy substitutes the placeholder with the real value. Each field is optional; omitted fields use the default.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| headers? | `boolean` | `true` | Replace the placeholder anywhere in HTTP headers. |
+| basicAuth? | `boolean` | `true` | Replace the placeholder specifically in HTTP Basic Auth credentials. |
+| queryParams? | `boolean` | `false` | Replace the placeholder in URL query parameters. |
+| body? | `boolean` | `false` | Replace the placeholder in the HTTP request body. `Content-Length` is rewritten. |
+
+### ViolationAction
+
+Action taken when a secret placeholder is sent to a disallowed host. Set on the network builder via `NetworkBuilder.onSecretViolation(action)`.
+
+```typescript
+type ViolationAction = "block" | "block-and-log" | "block-and-terminate";
+```
+
+| Value | Description |
+|-------|-------------|
+| `'block'` | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `'block-and-log'` | Drop the request and emit a warning log on the host side. |
+| `'block-and-terminate'` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/ja/sdk/typescript/snapshots.mdx
+++ b/docs/ja/sdk/typescript/snapshots.mdx
@@ -1,0 +1,348 @@
+---
+title: Snapshots
+description: TypeScript SDK - Snapshot API reference
+icon: "camera"
+---
+
+Disk-only snapshots of a stopped sandbox. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the TypeScript SDK reference.
+
+```ts
+import { Sandbox, Snapshot, SnapshotHandle } from "microsandbox";
+import type { ExportOpts, SnapshotVerifyReport } from "microsandbox";
+```
+
+<Note>
+  Snapshots are **disk-only and stopped-only**. Live snapshots and qcow2 backing chains are tracked as future work.
+</Note>
+
+## SandboxBuilder
+
+---
+
+#### fromSnapshot()
+
+```ts
+fromSnapshot(pathOrName: string): SandboxBuilder
+```
+
+Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`image()`](/sdk/typescript/sandbox#image) — the snapshot already pins the image.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pathOrName | `string` | Bare name (resolved under `~/.microsandbox/snapshots/`) or filesystem path to an artifact directory |
+
+---
+
+## SandboxHandle methods
+
+---
+
+#### snapshot()
+
+```ts
+snapshot(name: string): Promise<Snapshot>
+```
+
+Snapshot this (stopped) sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). For an explicit filesystem destination, see [`snapshotTo()`](#snapshotto).
+
+**Errors**
+
+- `SnapshotSandboxRunning` — the sandbox is not stopped
+- `SnapshotAlreadyExists` — destination exists (use the builder with `.force()` to overwrite)
+
+---
+
+#### snapshotTo()
+
+```ts
+snapshotTo(path: string): Promise<Snapshot>
+```
+
+Snapshot this (stopped) sandbox to an explicit filesystem path.
+
+---
+
+## Snapshot (instance)
+
+---
+
+#### path
+
+```ts
+readonly path: string
+```
+
+Path to the artifact directory.
+
+---
+
+#### digest
+
+```ts
+readonly digest: string
+```
+
+Canonical content digest (`sha256:hex`) over the manifest bytes. The snapshot's identity.
+
+---
+
+#### sizeBytes
+
+```ts
+readonly sizeBytes: bigint
+```
+
+Apparent size of the captured upper layer in bytes (the ext4 virtual size, sparse on disk).
+
+---
+
+#### imageRef
+
+```ts
+readonly imageRef: string
+```
+
+Image reference the snapshot was taken from.
+
+---
+
+#### imageManifestDigest
+
+```ts
+readonly imageManifestDigest: string
+```
+
+OCI manifest digest of the pinned image.
+
+---
+
+#### format
+
+```ts
+readonly format: "raw" | "qcow2"
+```
+
+On-disk format of the upper layer. Always `"raw"` today.
+
+---
+
+#### fstype
+
+```ts
+readonly fstype: string
+```
+
+Filesystem type inside the upper (e.g. `"ext4"`).
+
+---
+
+#### parent
+
+```ts
+readonly parent: string | null
+```
+
+Manifest digest of the parent snapshot, or `null` for a root.
+
+---
+
+#### createdAt
+
+```ts
+readonly createdAt: string
+```
+
+RFC 3339 timestamp when the snapshot was created.
+
+---
+
+#### labels
+
+```ts
+readonly labels: ReadonlyArray<readonly [string, string]>
+```
+
+User-supplied labels (sorted by key in canonical form).
+
+---
+
+#### verify()
+
+```ts
+verify(): Promise<SnapshotVerifyReport>
+```
+
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds.
+
+```ts
+const report = await snap.verify();
+if (report.upper.kind === "verified") {
+  console.log(`hash matches: ${report.upper.digest}`);
+} else {
+  console.log("no integrity hash recorded");
+}
+```
+
+---
+
+## Snapshot.builder()
+
+```ts
+static builder(sourceSandbox: string): SnapshotBuilder
+```
+
+Start configuring a new snapshot. The fluent builder is what powers the CLI internally.
+
+```ts
+const snap = await Snapshot.builder("baseline")
+  .name("after-pip-install")        // bare name in default dir
+  .label("stage", "post-deps")
+  .force()                           // overwrite if it exists
+  .recordIntegrity()                 // hash the upper layer
+  .create();
+```
+
+**Builder methods**
+
+| Method | Description |
+|--------|-------------|
+| `.name(string)` | Bare name under the default snapshots directory |
+| `.path(string)` | Explicit filesystem path |
+| `.label(key, value)` | Add a `key=value` label (may be repeated) |
+| `.force()` | Overwrite an existing artifact at the destination |
+| `.recordIntegrity()` | Compute and record a content-integrity hash at creation |
+| `.build()` | Snapshot the accumulated configuration |
+| `.create()` | Build and execute |
+
+---
+
+## Snapshot (static)
+
+---
+
+#### Snapshot.open()
+
+```ts
+static open(pathOrName: string): Promise<Snapshot>
+```
+
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+
+---
+
+#### Snapshot.get()
+
+```ts
+static get(nameOrDigest: string): Promise<SnapshotHandle>
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+---
+
+#### Snapshot.list()
+
+```ts
+static list(): Promise<SnapshotHandle[]>
+```
+
+List indexed snapshots from the local DB cache.
+
+---
+
+#### Snapshot.listDir()
+
+```ts
+static listDir(dir: string): Promise<Snapshot[]>
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
+
+---
+
+#### Snapshot.remove()
+
+```ts
+static remove(pathOrName: string, opts?: { force?: boolean }): Promise<void>
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force: true`.
+
+---
+
+#### Snapshot.reindex()
+
+```ts
+static reindex(dir?: string): Promise<number>
+```
+
+Walk `dir` (default: configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
+
+---
+
+#### Snapshot.export()
+
+```ts
+static export(nameOrPath: string, out: string, opts?: ExportOpts): Promise<void>
+```
+
+Bundle a snapshot into a `.tar.zst` archive. Computes and embeds the integrity hash in the bundled manifest if not already present.
+
+**ExportOpts**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `withParents` | `boolean` | Walk the parent chain (no-op today) |
+| `withImage` | `boolean` | Bundle the OCI image cache for offline transport |
+| `plainTar` | `boolean` | Skip zstd compression and write a plain `.tar` |
+
+---
+
+#### Snapshot.import()
+
+```ts
+static import(archive: string, dest?: string): Promise<SnapshotHandle>
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+---
+
+## SnapshotHandle
+
+Lightweight handle backed by an index row. Returned by [`Snapshot.list()`](#snapshotlist) and [`Snapshot.get()`](#snapshotget).
+
+```ts
+const h = await Snapshot.get("after-pip-install");
+
+h.digest;          // string ("sha256:...")
+h.name;            // string | null
+h.parentDigest;    // string | null — null today
+h.imageRef;        // string
+h.format;          // "raw" | "qcow2"
+h.sizeBytes;       // bigint | null
+h.createdAt;       // Date
+h.path;            // string
+
+const snap = await h.open();              // metadata-validated
+await h.remove({ force: false });          // refuse if has children
+```
+
+---
+
+## Types
+
+```ts
+export interface ExportOpts {
+  withParents?: boolean;
+  withImage?: boolean;
+  plainTar?: boolean;
+}
+
+export type SnapshotVerifyReport =
+  | { digest: string; path: string; upper: { kind: "notRecorded" } }
+  | { digest: string; path: string;
+      upper: { kind: "verified"; algorithm: string; digest: string } };
+```

--- a/docs/ja/sdk/typescript/volumes.mdx
+++ b/docs/ja/sdk/typescript/volumes.mdx
@@ -1,0 +1,234 @@
+---
+title: Volumes
+description: TypeScript SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+```typescript
+import { Volume } from "microsandbox";
+
+const data = await Volume.builder("my-data")
+  .quota(100)
+  .label("env", "prod")
+  .create();
+```
+
+## Static methods
+
+---
+
+#### Volume.builder()
+
+```typescript
+static builder(name: string): VolumeBuilder
+```
+
+Begin building a named volume. Configure with `.quota(...)` and `.label(...)`, then call `.create()`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeBuilder`](#volumebuilder) | Fluent builder |
+
+---
+
+#### Volume.get()
+
+```typescript
+static get(name: string): Promise<VolumeHandle>
+```
+
+Get a handle to an existing named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`VolumeHandle`](#volumehandle)`>` | Volume handle |
+
+---
+
+#### Volume.list()
+
+```typescript
+static list(): Promise<VolumeHandle[]>
+```
+
+List all named volumes. Handles returned from `list()` are read-only — call `Volume.get(name)` to get a live handle for `.remove()` / `.fs()`.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`VolumeHandle`](#volumehandle)`[]>` | All volumes |
+
+---
+
+#### Volume.remove()
+
+```typescript
+static remove(name: string): Promise<void>
+```
+
+Delete a named volume and its contents. Fails if the volume is currently mounted.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+---
+
+## Instance properties
+
+#### name
+
+```typescript
+get name(): string
+```
+
+The volume's name.
+
+---
+
+#### path
+
+```typescript
+get path(): string
+```
+
+Absolute host path to the volume's directory.
+
+---
+
+#### fs()
+
+```typescript
+fs(): VolumeFs
+```
+
+Get a host-side filesystem handle for this volume — no sandbox required.
+
+```typescript
+const vfs = data.fs();
+await vfs.write("seed.txt", "hello");
+console.log(await vfs.list(""));
+```
+
+---
+
+## Mounts
+
+Volume mounts attach a host directory, named volume, tmpfs, or disk image to a guest path. Configure them via `SandboxBuilder.volume(guestPath, m => ...)`:
+
+```typescript
+await using sb = await Sandbox.builder("worker")
+  .image("alpine")
+  .volume("/host",    (m) => m.bind("/var/data"))
+  .volume("/data",    (m) => m.named("my-data"))
+  .volume("/scratch", (m) => m.tmpfs().size(128))
+  .volume("/img",     (m) => m.disk("./data.qcow2").fstype("ext4").readonly())
+  .create();
+```
+
+### MountBuilder
+
+Used inside `SandboxBuilder.volume(guestPath, m => ...)`. Pick exactly one mount kind, then chain modifiers.
+
+| Method | Description |
+|--------|-------------|
+| `bind(host)` | Mount a host directory into the guest. |
+| `named(name)` | Mount a named volume created via [`Volume.builder`](#volumebuilder). |
+| `tmpfs()` | Mount an in-memory filesystem. |
+| `disk(host)` | Mount a host disk image as a virtio-blk device. |
+| `format(fmt)` | Disk image format (`'qcow2' \| 'raw' \| 'vmdk'`). Defaults to the file extension. Disk only. |
+| `fstype(fs)` | Inner filesystem type (e.g. `"ext4"`). Disk only; omit to autodetect. |
+| `readonly()` | Mount read-only. |
+| `size(mib)` | Cap in MiB. Tmpfs only. |
+| `build()` | Internal — produce a `VolumeMount`. |
+
+### VolumeMount
+
+Discriminated union produced by `MountBuilder.build()`.
+
+```typescript
+type VolumeMount =
+  | { kind: "bind"; host: string; guest: string; readonly: boolean }
+  | { kind: "named"; name: string; guest: string; readonly: boolean }
+  | { kind: "tmpfs"; guest: string; sizeMib: number | null; readonly: boolean }
+  | {
+      kind: "disk";
+      host: string;
+      guest: string;
+      format: DiskImageFormat;
+      fstype: string | null;
+      readonly: boolean;
+    };
+```
+
+### DiskImageFormat
+
+```typescript
+type DiskImageFormat = "qcow2" | "raw" | "vmdk";
+```
+
+---
+
+## Types
+
+### VolumeBuilder
+
+| Method | Description |
+|--------|-------------|
+| `quota(mib)` | Maximum storage size in MiB |
+| `label(key, value)` | Add a metadata label |
+| `build()` | Materialize a [`VolumeConfig`](#volumeconfig) |
+| `create()` | Build and create the volume; returns a [`Volume`](#volume) |
+
+### VolumeConfig
+
+Frozen configuration produced by `VolumeBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Volume name |
+| quotaMib | `number \| null` | Maximum storage size in MiB |
+| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
+
+### VolumeHandle
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `string` | Volume name |
+| quotaMib | `number \| null` | Storage quota |
+| usedBytes | `number` | Current disk usage in bytes |
+| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
+| createdAt | `Date \| null` | Creation timestamp |
+| fs() | [`VolumeFs`](#volumefs) | Host-side filesystem on this volume (live handles only) |
+| remove() | `Promise<void>` | Delete this volume (live handles only) |
+
+Handles in the array returned by `Volume.list()` are read-only: calling `.fs()` or `.remove()` throws. Use `Volume.get(name)` to upgrade.
+
+### VolumeFs
+
+Host-side filesystem operations on a volume's directory. Same surface area as [`SandboxFs`](/sdk/typescript/filesystem) (read, readToString, readStream, write, writeStream, list, mkdir, removeDir, remove, copy, rename, stat, exists) — but operates directly on the host without booting a sandbox.


### PR DESCRIPTION
## Summary

set up the foundation for mintlify's per-language navigation across the entire docs tree. five languages now declared in `docs.json`: **en** (existing), **es**, **fr**, **de**, **ja**.

modeled after the structure mintlify-agent introduced in [9148114f](https://github.com/superradcompany/microsandbox/commit/9148114fba5b9b8756e9bd9a8500a48c6e289268), but applied to every page rather than a single one.

## What's in the diff

- `docs/docs.json` restructured from a single `tabs[]` block into `navigation.languages[]` with a `tabs[]` block per language. tab and group names translated per-language; page slugs prefixed with the language code (en stays as-is). all 54 english pages registered in each non-en language's nav.

- `docs/{es,fr,de,ja}/` directory trees mirror the english structure. each non-en page is currently a **copy of its english counterpart** so the build resolves all 270 nav references and the site renders in every language out of the gate. proper translations land incrementally on top of these stubs.

## Translated nav strings

| English | es | fr | de | ja |
|---------|----|----|----|----|
| Documentation | Documentación | Documentation | Dokumentation | ドキュメント |
| Getting Started | Primeros pasos | Démarrage | Erste Schritte | はじめに |
| Sandboxes | Sandboxes | Sandboxes | Sandboxes | サンドボックス |
| Networking | Redes | Réseau | Netzwerk | ネットワーク |
| Images | Imágenes | Images | Images | イメージ |
| Configuration | Configuración | Configuration | Konfiguration | 設定 |
| SDK Reference | Referencia del SDK | Référence du SDK | SDK-Referenz | SDK リファレンス |
| CLI Reference | Referencia de CLI | Référence CLI | CLI-Referenz | CLI リファレンス |
| Recipes | Recetas | Recettes | Rezepte | レシピ |
| Guest | Invitado | Invité | Gast | ゲスト |

product names (Docker, CLI, Rust, TypeScript, Python) stay as-is; the surrounding "SDK de" / "SDK" / "-SDK" prefixes are added per language convention.

## Next

each non-en page can now be translated as a content-only diff against the existing stub. mintlify-agent or hand-translation can both target this layout.

## Test plan

- [ ] mintlify preview renders in all five languages and the language switcher shows them.
- [ ] every nav entry resolves to an existing `.mdx` file (verified by script: 0 missing references).
- [ ] english content still renders unchanged at the en routes.