### PR TITLE
fix(sandbox): SIGKILL if replace exceeds grace period

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -46,6 +46,12 @@ pub struct SandboxOpts {
     #[arg(long)]
     pub replace: bool,
 
+    /// Grace period the existing sandbox gets after SIGTERM before it
+    /// is SIGKILLed during a replace. Accepts `0`, `500ms`, `5s`, `2m`.
+    /// Implies `--replace`. Default 10s when `--replace` is set on its own.
+    #[arg(long, value_name = "DURATION")]
+    pub replace_grace: Option<String>,
+
     /// Suppress progress output.
     #[arg(short, long)]
     pub quiet: bool,
@@ -331,7 +337,10 @@ pub fn apply_sandbox_opts(
     if let Some(ref shell) = opts.shell {
         builder = builder.shell(shell);
     }
-    if opts.replace {
+    if let Some(ref grace) = opts.replace_grace {
+        let d = parse_duration(grace).map_err(|e| anyhow::anyhow!("--replace-grace: {e}"))?;
+        builder = builder.replace_grace(d);
+    } else if opts.replace {
         builder = builder.replace();
     }
 
@@ -614,6 +623,28 @@ pub fn parse_duration_secs(s: &str) -> anyhow::Result<u64> {
         Ok(n.trim().parse::<u64>()? * 3600)
     } else {
         Ok(s.parse::<u64>()?)
+    }
+}
+
+/// Parse a duration string with sub-second granularity. Accepts `0`,
+/// `500ms`, `5s`, `2m`, `1h`. Bare numbers are treated as seconds for
+/// consistency with [`parse_duration_secs`].
+pub fn parse_duration(s: &str) -> anyhow::Result<std::time::Duration> {
+    let s = s.trim();
+    if let Some(n) = s.strip_suffix("ms") {
+        Ok(std::time::Duration::from_millis(n.trim().parse::<u64>()?))
+    } else if let Some(n) = s.strip_suffix('s') {
+        Ok(std::time::Duration::from_secs(n.trim().parse::<u64>()?))
+    } else if let Some(n) = s.strip_suffix('m') {
+        Ok(std::time::Duration::from_secs(
+            n.trim().parse::<u64>()? * 60,
+        ))
+    } else if let Some(n) = s.strip_suffix('h') {
+        Ok(std::time::Duration::from_secs(
+            n.trim().parse::<u64>()? * 3600,
+        ))
+    } else {
+        Ok(std::time::Duration::from_secs(s.parse::<u64>()?))
     }
 }
 

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -100,8 +100,11 @@ pub async fn run(args: RunArgs) -> anyhow::Result<()> {
     let is_named = args.sandbox.name.is_some();
     let name = args.sandbox.name.clone().unwrap_or_else(ui::generate_name);
 
-    // Named sandboxes are reused if they already exist (unless --replace).
-    if is_named && !args.sandbox.replace && Sandbox::get(&name).await.is_ok() {
+    // Named sandboxes are reused if they already exist (unless --replace
+    // or --replace-grace). --replace-grace implies --replace, so either
+    // flag opts out of the reuse path.
+    let replace_requested = args.sandbox.replace || args.sandbox.replace_grace.is_some();
+    if is_named && !replace_requested && Sandbox::get(&name).await.is_ok() {
         return run_existing(name, args).await;
     }
 

--- a/crates/microsandbox/lib/error.rs
+++ b/crates/microsandbox/lib/error.rs
@@ -34,6 +34,14 @@ pub enum MicrosandboxError {
     #[error("sandbox not found: {0}")]
     SandboxNotFound(String),
 
+    /// A sandbox with the given name already exists. Returned by
+    /// `Sandbox::create` when the name is taken and `replace_existing`
+    /// was not set, and by `Sandbox::create` with `replace_existing`
+    /// when an in-process `Sandbox` handle for that name is still
+    /// alive (the caller must drop or stop the existing handle first).
+    #[error("sandbox already exists: {0}")]
+    SandboxAlreadyExists(String),
+
     /// The sandbox is still running and cannot be removed.
     #[error("sandbox still running: {0}")]
     SandboxStillRunning(String),

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -226,10 +226,25 @@ impl SandboxBuilder {
 
     /// Replace an existing sandbox with the same name during create.
     ///
-    /// If the existing sandbox is still active, microsandbox stops it and
-    /// waits for it to exit before recreating it.
+    /// If the existing sandbox is still active, microsandbox stops it
+    /// before recreating it. When the prior sandbox is owned by an
+    /// in-process `Sandbox` handle, the handle's underlying child is
+    /// signalled and reaped directly. Otherwise the existing PID is
+    /// signalled with SIGTERM, given [`replace_grace`](Self::replace_grace)
+    /// to exit, then SIGKILLed.
     pub fn replace(mut self) -> Self {
         self.config.replace_existing = true;
+        self
+    }
+
+    /// How long to give the existing sandbox after SIGTERM before
+    /// escalating to SIGKILL during a replace. Implies [`replace`](Self::replace).
+    ///
+    /// A zero duration skips SIGTERM entirely. Default (when only
+    /// `.replace()` is set) is ten seconds.
+    pub fn replace_grace(mut self, grace: std::time::Duration) -> Self {
+        self.config.replace_existing = true;
+        self.config.replace_grace = grace;
         self
     }
 

--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -215,6 +215,19 @@ pub struct SandboxConfig {
     #[serde(skip)]
     pub replace_existing: bool,
 
+    /// How long to wait after SIGTERM for the existing sandbox process to
+    /// exit gracefully before escalating to SIGKILL during a replace.
+    ///
+    /// Only consulted when `replace_existing` is true. A zero duration
+    /// skips SIGTERM entirely and goes straight to SIGKILL. Default is
+    /// ten seconds, which gives the exit observer plenty of headroom
+    /// to flush logs and clean up the agent socket on a healthy
+    /// sandbox before we escalate.
+    ///
+    /// This is an operation flag, not persisted sandbox state.
+    #[serde(skip)]
+    pub replace_grace: std::time::Duration,
+
     /// Manifest digest for the resolved OCI image.
     ///
     /// Set at create time. Used by spawn to derive VMDK and fsmeta paths
@@ -407,6 +420,7 @@ impl Default for SandboxConfig {
             insecure: false,
             ca_certs: Vec::new(),
             replace_existing: false,
+            replace_grace: std::time::Duration::from_secs(10),
             manifest_digest: None,
             snapshot_upper_source: None,
         }

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -1716,22 +1716,22 @@ async fn prepare_create_target(
 
     if !config.replace_existing {
         if existing.is_some() || dir_exists {
-            return Err(crate::MicrosandboxError::Custom(format!(
+            return Err(crate::MicrosandboxError::SandboxAlreadyExists(format!(
                 "sandbox '{}' already exists; remove it, start the stopped sandbox, or recreate with .replace()",
                 config.name
             )));
         }
-
         return Ok(());
     }
 
     if let Some(model) = existing {
         let model = reconcile_sandbox_runtime_state(pools, model).await?;
-        if matches!(
+        let active = matches!(
             model.status,
             SandboxStatus::Running | SandboxStatus::Draining | SandboxStatus::Paused
-        ) {
-            stop_sandbox_for_replacement(pools, &model).await?;
+        );
+        if active {
+            stop_sandbox_for_replacement(pools, &model, config.replace_grace).await?;
         }
 
         sandbox_entity::Entity::delete_by_id(model.id)
@@ -1743,9 +1743,21 @@ async fn prepare_create_target(
     Ok(())
 }
 
+/// Stop the prior sandbox before recreating it.
+///
+/// Sends SIGTERM with the configured grace, then escalates to SIGKILL
+/// and waits a short reap window. Single path for both same-process and
+/// foreign-process owners: SIGKILL bypasses any signal handler so the
+/// process is dead within kernel time, and the reap completes via the
+/// owning process's existing wait machinery (tokio's SIGCHLD driver
+/// when we're the parent, or the foreign parent's own `waitpid`).
+/// Replaces the previous "wait 30s and give up" behavior, which spun
+/// the full timeout when libkrun's SIGTERM handler did a slow
+/// graceful shutdown.
 async fn stop_sandbox_for_replacement(
     pools: &DbPools,
     sandbox: &sandbox_entity::Model,
+    grace: std::time::Duration,
 ) -> MicrosandboxResult<()> {
     let run = load_active_run(pools.read(), sandbox.id).await?;
     let pids: Vec<i32> = run
@@ -1755,20 +1767,32 @@ async fn stop_sandbox_for_replacement(
         .into_iter()
         .collect();
 
-    for pid in &pids {
-        nix::sys::signal::kill(
-            nix::unistd::Pid::from_raw(*pid),
-            nix::sys::signal::Signal::SIGTERM,
-        )?;
-    }
+    if !pids.is_empty() {
+        // Polite phase: SIGTERM and wait up to `grace` for graceful exit.
+        if !grace.is_zero() {
+            for pid in &pids {
+                let _ = nix::sys::signal::kill(
+                    nix::unistd::Pid::from_raw(*pid),
+                    nix::sys::signal::Signal::SIGTERM,
+                );
+            }
+            wait_for_pids_to_exit(&pids, grace).await;
+        }
 
-    wait_for_pids_to_exit(&pids, std::time::Duration::from_secs(30)).await;
-
-    if pids.iter().any(|pid| pid_is_alive(*pid)) {
-        return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
-            "cannot replace sandbox '{}': existing sandbox did not stop in time",
-            sandbox.name
-        )));
+        // SIGKILL anything still alive. We don't wait or verify after
+        // SIGKILL: it's uncatchable, so termination is bounded by kernel
+        // time, and the only state that would have us spin is the
+        // zombie window between exit and the parent's `waitpid`. That
+        // window is harmless: prepare_create_target wipes the DB row
+        // and the sandbox dir, the new spawn gets a fresh PID, and the
+        // zombie reaps on its own (tokio's SIGCHLD driver when we own
+        // it, or the foreign parent's wait machinery otherwise).
+        for pid in pids.iter().copied().filter(|p| pid_is_alive(*p)) {
+            let _ = nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(pid),
+                nix::sys::signal::Signal::SIGKILL,
+            );
+        }
     }
 
     mark_sandbox_stopped_for_replacement(

--- a/crates/microsandbox/tests/replace.rs
+++ b/crates/microsandbox/tests/replace.rs
@@ -1,0 +1,158 @@
+//! Integration tests for `Sandbox::builder(...).replace().create()`.
+//!
+//! Mirrors the bug pattern from PR #587 review: a second create with
+//! the same name and `.replace()` while the first `Sandbox` handle is
+//! still alive previously hung for ~30s because libkrun's SIGTERM
+//! handler did a slow graceful shutdown of the VM and the loop polled
+//! `kill(pid, 0)` against a process that was genuinely still alive.
+//! The replace path now SIGTERMs with a configurable grace, then
+//! escalates to SIGKILL — bounded by kernel time, not by handler
+//! latency — so a second `.replace().create()` returns in the time it
+//! takes to boot a VM rather than the 30s timeout.
+
+use std::time::{Duration, Instant};
+
+use microsandbox::{MicrosandboxError, Sandbox};
+use test_utils::msb_test;
+
+const IMAGE: &str = "mirror.gcr.io/library/alpine";
+
+async fn cleanup(name: &str) {
+    if let Ok(mut h) = Sandbox::get(name).await {
+        let _ = h.kill().await;
+        let _ = h.remove().await;
+    }
+}
+
+/// First create succeeds; second create with `.replace()` while sb1 is
+/// still alive completes promptly. The session timeout is generous
+/// enough to also cover slow boots, but well under the legacy 30s
+/// SIGTERM-poll deadline that was the bug's hallmark.
+#[msb_test]
+async fn replace_with_live_handle_does_not_hang() {
+    let name = "replace-live-handle";
+    cleanup(name).await;
+
+    let sb1 = Sandbox::builder(name)
+        .image(IMAGE)
+        .cpus(1)
+        .memory(256)
+        .replace()
+        .create()
+        .await
+        .expect("first create");
+
+    let started = Instant::now();
+    let result = tokio::time::timeout(
+        Duration::from_secs(120),
+        Sandbox::builder(name)
+            .image(IMAGE)
+            .cpus(1)
+            .memory(256)
+            .replace()
+            .create(),
+    )
+    .await;
+    let elapsed = started.elapsed();
+
+    let sb2 = match result {
+        Err(_) => {
+            // Best-effort cleanup before failing the assertion.
+            drop(sb1);
+            cleanup(name).await;
+            panic!(
+                "second .replace().create() did not return within 120s — bug regressed (was the 30s SIGTERM-poll path)"
+            );
+        }
+        Ok(Err(err)) => {
+            drop(sb1);
+            cleanup(name).await;
+            panic!("second .replace().create() failed: {err}");
+        }
+        Ok(Ok(sb2)) => sb2,
+    };
+
+    assert!(
+        elapsed < Duration::from_secs(60),
+        "second create took {elapsed:?}; expected sub-30s with SIGKILL escalation"
+    );
+
+    drop(sb2);
+    drop(sb1);
+    cleanup(name).await;
+}
+
+/// Without `.replace()`, a second create with the same name while sb1
+/// is alive errors immediately with `SandboxAlreadyExists` instead of
+/// blocking or surfacing a generic `Custom` error.
+#[msb_test]
+async fn create_without_replace_returns_typed_already_exists() {
+    let name = "replace-typed-error";
+    cleanup(name).await;
+
+    let sb1 = Sandbox::builder(name)
+        .image(IMAGE)
+        .cpus(1)
+        .memory(256)
+        .replace()
+        .create()
+        .await
+        .expect("first create");
+
+    let result = Sandbox::builder(name)
+        .image(IMAGE)
+        .cpus(1)
+        .memory(256)
+        .create()
+        .await;
+    let err = match result {
+        Ok(_) => {
+            drop(sb1);
+            cleanup(name).await;
+            panic!("second create without .replace() should error, got Ok");
+        }
+        Err(e) => e,
+    };
+
+    assert!(
+        matches!(err, MicrosandboxError::SandboxAlreadyExists(_)),
+        "expected SandboxAlreadyExists, got {err:?}"
+    );
+
+    drop(sb1);
+    cleanup(name).await;
+}
+
+/// `.replace_grace(0)` skips SIGTERM and goes straight to SIGKILL.
+/// Should be at least as fast as the default 10-second grace.
+#[msb_test]
+async fn replace_grace_zero_succeeds() {
+    let name = "replace-grace-zero";
+    cleanup(name).await;
+
+    let sb1 = Sandbox::builder(name)
+        .image(IMAGE)
+        .cpus(1)
+        .memory(256)
+        .replace()
+        .create()
+        .await
+        .expect("first create");
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(120),
+        Sandbox::builder(name)
+            .image(IMAGE)
+            .cpus(1)
+            .memory(256)
+            .replace_grace(Duration::from_secs(0))
+            .create(),
+    )
+    .await
+    .expect("did not hang")
+    .expect("create");
+
+    drop(result);
+    drop(sb1);
+    cleanup(name).await;
+}

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -44,6 +44,7 @@ msb run -d --name worker python -- python worker.py
 | `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`, `as=1073741824`) |
 | `--detach-keys` | Key sequence to detach from interactive session (default: `ctrl-]`) |
 | `--replace` | Replace an existing sandbox with the same name |
+| `--replace-grace` | How long to wait after `SIGTERM` before `SIGKILL` during a replace (`0`, `500ms`, `5s`, `2m`). Implies `--replace`. Default `10s` when `--replace` is set alone |
 | `-q`, `--quiet` | Suppress progress output |
 | `--entrypoint` | Override the image's default entrypoint command |
 | `--init` | Hand off PID 1 to this init binary (absolute path) inside the guest after agentd's setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
@@ -85,7 +86,9 @@ Create and boot a sandbox without running a command. Takes the same flags as `ms
 
 ```bash
 msb create python --name worker -c 2 -m 1G
-msb create --replace python --name worker   # Replace existing
+msb create --replace python --name worker            # Replace existing
+msb create --replace-grace 30s python --name worker  # Give the old one 30s to exit
+msb create --replace-grace 0 python --name worker    # SIGKILL immediately
 ```
 
 ## msb start

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -217,7 +217,7 @@ msb create ./alpine.qcow2 --name worker
 
 ## Replace existing
 
-Replace a stopped sandbox with the same name instead of failing on conflict. This stops the old sandbox (if still running), removes it, and creates a fresh one.
+Replace a stopped or running sandbox with the same name instead of failing on conflict. This stops the old sandbox (if still running), removes it, and creates a fresh one.
 
 <CodeGroup>
 ```rust Rust
@@ -244,6 +244,41 @@ msb create --replace python --name worker
 ```
 
 </CodeGroup>
+
+### Grace period
+
+If the existing sandbox is still running, microsandbox sends it `SIGTERM` and waits for it to exit before falling back to `SIGKILL`. The default wait is 10 seconds. Pass a longer grace if the workload needs more time to shut down cleanly, or `0` to skip `SIGTERM` and kill immediately.
+
+<CodeGroup>
+```rust Rust
+use std::time::Duration;
+
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .replace_grace(Duration::from_secs(30))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .replaceGrace(30_000)  // milliseconds
+    .create();
+```
+
+```python Python
+sb = await Sandbox.create("worker", image="python", replace_grace=30)  # seconds
+```
+
+```bash CLI
+msb create --replace-grace 30s python --name worker
+msb create --replace-grace 0 python --name worker  # SIGKILL immediately
+```
+
+</CodeGroup>
+
+`replace_grace` / `--replace-grace` implies `replace` / `--replace`, so you don't need to pass both.
 
 ## Private registry
 

--- a/docs/sdk/errors.mdx
+++ b/docs/sdk/errors.mdx
@@ -171,6 +171,50 @@ except ExecFailedError as e:
 
 The CLI maps these kinds to POSIX-style exit codes: `127` for `NotFound`, `126` for `PermissionDenied` and `NotExecutable`, `1` otherwise. SDK callers reading the error directly don't need to think about exit codes — branch on `kind` instead.
 
+## Name conflicts
+
+Creating a sandbox with a name that's already in use (and without `replace`) surfaces a typed error you can branch on to decide whether to recover (resume the existing one, regenerate the name, etc.).
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Error;
+
+match Sandbox::builder("worker").image("alpine").create().await {
+    Ok(sb) => { /* ... */ }
+    Err(Error::SandboxAlreadyExists(name)) => {
+        eprintln!("sandbox {name} already exists; resume or pass .replace()");
+    }
+    Err(e) => return Err(e),
+}
+```
+
+```typescript TypeScript
+import { SandboxAlreadyExistsError } from "microsandbox";
+
+try {
+    const sb = await Sandbox.builder("worker").image("alpine").create();
+} catch (e) {
+    if (e instanceof SandboxAlreadyExistsError) {
+        console.error("sandbox already exists; resume or pass replace()");
+    } else {
+        throw e;
+    }
+}
+```
+
+```python Python
+from microsandbox import SandboxAlreadyExistsError
+
+try:
+    sb = await Sandbox.create("worker", image="alpine")
+except SandboxAlreadyExistsError:
+    print("sandbox already exists; resume or pass replace=True")
+```
+
+</CodeGroup>
+
+Pass `replace()` / `replace=True` / `--replace` to stop the existing sandbox and recreate it. See [Replace existing](/sandboxes/overview#replace-existing) for the grace-period knob.
+
 ## Sandbox start failures
 
 When a sandbox process exits before the agent relay is ready (mount errors, missing rootfs, network setup failures), the SDK surfaces a typed `BootStart` / `BootStartError`. The payload carries the failure stage and errno so callers can recover or report cleanly.

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -33,7 +33,8 @@ Create and boot a sandbox. The first argument is either a name (`str`) or a full
 | user | `str` | Default guest user |
 | entrypoint | `list[str]` | Override image entrypoint |
 | init | `str \| dict \|` [`InitConfig`](#initconfig) | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) and [`InitConfig`](#initconfig) for accepted shapes |
-| replace | `bool` | Replace existing sandbox with same name |
+| replace | `bool` | Replace existing sandbox with same name (10s SIGTERM grace, then SIGKILL) |
+| replace_grace | `float` | Seconds to wait after `SIGTERM` before escalating to `SIGKILL` (default `10`; `0` skips `SIGTERM`). Implies `replace=True` |
 | max_duration | `float` | Maximum sandbox lifetime in seconds |
 | idle_timeout | `float` | Idle timeout in seconds |
 | env | `dict[str, str]` | Environment variables visible to all commands |

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -567,7 +567,8 @@ Fluent configuration builder returned by `Sandbox.builder(name)`. Every setter r
 | `envs(record \| iter)` | Add many env vars |
 | `script(name, content)` | Mount a script at `/.msb/scripts/<name>` |
 | `scripts(record \| iter)` | Mount many scripts |
-| `replace()` | Replace any existing sandbox with the same name |
+| `replace()` | Replace any existing sandbox with the same name (10s SIGTERM grace, then SIGKILL) |
+| `replaceGrace(graceMs)` | Same as `replace()` with a custom SIGTERM grace in milliseconds. `0` skips SIGTERM. Implies `replace()` |
 | `maxDuration(secs)` | Maximum sandbox lifetime |
 | `idleTimeout(secs)` | Stop the sandbox after this many idle seconds |
 | `volume(guestPath, m => ...)` | Mount a volume — see [Volumes](/sdk/typescript/volumes) |
@@ -679,6 +680,7 @@ Frozen configuration object — produced by `SandboxBuilder.build()` and exposed
 | patches | `Patch[]` | Rootfs modifications applied before boot |
 | pullPolicy | `PullPolicy \| null` | Image pull behavior |
 | replace | `boolean` | Replace existing sandbox with same name |
+| replaceGraceMs | `number` | Milliseconds to wait after `SIGTERM` before escalating to `SIGKILL` (default `10000`; `0` skips `SIGTERM`) |
 | maxDurationSecs | `number \| null` | Maximum sandbox lifetime |
 | idleTimeoutSecs | `number \| null` | Stop after idle time |
 | portsTcp | `Array<readonly [number, number]>` | TCP host→guest mappings |

--- a/sdk/node-ts/README.md
+++ b/sdk/node-ts/README.md
@@ -372,19 +372,57 @@ const reclaimed = await Image.gcLayers();
 console.log(`reclaimed ${reclaimed} orphaned layers`);
 ```
 
+### Replace Existing
+
+`replace()` stops a sandbox with the same name (if any) and recreates
+it. By default the existing sandbox gets 10 seconds to exit cleanly
+after `SIGTERM` before `SIGKILL`; pass `replaceGrace(ms)` to override.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+// Default 10s SIGTERM grace.
+await using sb = await Sandbox.builder("worker")
+  .image("alpine")
+  .replace()
+  .create();
+
+// Wait longer for a workload that needs more time to shut down.
+await using slow = await Sandbox.builder("worker")
+  .image("alpine")
+  .replaceGrace(30_000)
+  .create();
+
+// Skip SIGTERM entirely; SIGKILL immediately.
+await using fast = await Sandbox.builder("worker")
+  .image("alpine")
+  .replaceGrace(0)
+  .create();
+```
+
 ### Typed Errors
 
 Every `MicrosandboxError` variant has a dedicated subclass — use
 `instanceof` instead of parsing message strings.
 
 ```typescript
-import { ExecTimeoutError, Sandbox, SandboxNotFoundError } from "microsandbox";
+import { ExecTimeoutError, Sandbox, SandboxAlreadyExistsError, SandboxNotFoundError } from "microsandbox";
 
 try {
   await Sandbox.remove("ghost");
 } catch (e) {
   if (e instanceof SandboxNotFoundError) {
     console.log("nothing to remove:", e.message);
+  } else {
+    throw e;
+  }
+}
+
+try {
+  await Sandbox.builder("worker").image("alpine").create();
+} catch (e) {
+  if (e instanceof SandboxAlreadyExistsError) {
+    console.log("already exists; resume or pass replace()");
   } else {
     throw e;
   }

--- a/sdk/node-ts/native/error.rs
+++ b/sdk/node-ts/native/error.rs
@@ -20,6 +20,7 @@ fn error_type_str(err: &MicrosandboxError) -> &'static str {
         MicrosandboxError::Database(_) => "Database",
         MicrosandboxError::InvalidConfig(_) => "InvalidConfig",
         MicrosandboxError::SandboxNotFound(_) => "SandboxNotFound",
+        MicrosandboxError::SandboxAlreadyExists(_) => "SandboxAlreadyExists",
         MicrosandboxError::SandboxStillRunning(_) => "SandboxStillRunning",
         MicrosandboxError::Runtime(_) => "Runtime",
         MicrosandboxError::BootStart { .. } => "BootStart",

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -758,6 +758,12 @@ export declare class SandboxBuilder {
   registry(configure: (arg: RegistryConfigBuilder) => RegistryConfigBuilder): this
   /** Replace any existing sandbox with the same name. */
   replace(): this
+  /**
+   * Grace period (in milliseconds) to wait for the existing sandbox
+   * to exit after SIGTERM before escalating to SIGKILL during a
+   * replace. Implies `replace`. Zero skips SIGTERM entirely.
+   */
+  replaceGrace(graceMs: number): this
   /** Override the image entrypoint. */
   entrypoint(cmd: Array<string>): this
   /**

--- a/sdk/node-ts/native/sandbox_builder.rs
+++ b/sdk/node-ts/native/sandbox_builder.rs
@@ -201,6 +201,16 @@ impl JsSandboxBuilder {
         self
     }
 
+    /// Grace period (in milliseconds) to wait for the existing sandbox
+    /// to exit after SIGTERM before escalating to SIGKILL during a
+    /// replace. Implies `replace`. Zero skips SIGTERM entirely.
+    #[napi]
+    pub fn replace_grace(&mut self, grace_ms: u32) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.replace_grace(std::time::Duration::from_millis(grace_ms.into())));
+        self
+    }
+
     /// Override the image entrypoint.
     #[napi]
     pub fn entrypoint(&mut self, cmd: Vec<String>) -> &Self {

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -96,6 +96,7 @@ export interface NapiSandboxBuilderSetters {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registry(configure: (b: any) => any): this;
   replace(): this;
+  replaceGrace(graceMs: number): this;
   entrypoint(cmd: string[]): this;
   init(cmd: string, args?: string[]): this;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -302,6 +302,36 @@ async with await Sandbox.create("temp", image="alpine", replace=True) as sb:
 # Sandbox is automatically killed and removed on exit.
 ```
 
+### Replace Existing
+
+`replace=True` stops a sandbox with the same name (if any) and
+recreates it. By default the existing one gets 10 seconds to exit
+cleanly after `SIGTERM` before `SIGKILL`; pass `replace_grace` (in
+seconds, fractional allowed) to override. Setting `replace_grace`
+implies `replace=True`.
+
+```python
+# Default 10s SIGTERM grace.
+sb = await Sandbox.create("worker", image="alpine", replace=True)
+
+# Wait longer for a workload that needs more time to shut down.
+sb = await Sandbox.create("worker", image="alpine", replace_grace=30)
+
+# Skip SIGTERM entirely; SIGKILL immediately.
+sb = await Sandbox.create("worker", image="alpine", replace_grace=0)
+```
+
+If you'd rather handle the conflict yourself, catch the typed error:
+
+```python
+from microsandbox import SandboxAlreadyExistsError
+
+try:
+    sb = await Sandbox.create("worker", image="alpine")
+except SandboxAlreadyExistsError:
+    print("already exists; resume or pass replace=True")
+```
+
 ### TLS Interception
 
 ```python

--- a/sdk/python/src/error.rs
+++ b/sdk/python/src/error.rs
@@ -23,6 +23,7 @@ pub fn to_py_err(err: microsandbox::MicrosandboxError) -> PyErr {
         let (cls_name, msg) = match &err {
             InvalidConfig(_) => ("InvalidConfigError", err.to_string()),
             SandboxNotFound(_) => ("SandboxNotFoundError", err.to_string()),
+            SandboxAlreadyExists(_) => ("SandboxAlreadyExistsError", err.to_string()),
             SandboxStillRunning(_) => ("SandboxStillRunningError", err.to_string()),
             ExecTimeout(_) => ("ExecTimeoutError", err.to_string()),
             SandboxFs(_) => ("FilesystemError", err.to_string()),

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -145,6 +145,14 @@ pub fn build_config_from_kwargs(
     {
         builder = builder.replace();
     }
+    if let Some(grace) = extract_opt::<f64>(kwargs, "replace_grace")? {
+        if grace < 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "replace_grace must be non-negative",
+            ));
+        }
+        builder = builder.replace_grace(std::time::Duration::from_secs_f64(grace));
+    }
     if let Some(max_duration) = extract_opt::<f64>(kwargs, "max_duration")? {
         if max_duration < 0.0 {
             return Err(pyo3::exceptions::PyValueError::new_err(


### PR DESCRIPTION
## what was broken

calling `Sandbox::builder(name).replace().create()` while an existing sandbox with that name was active would hang for ~30 seconds and then fail with `SandboxStillRunning("did not stop in time")`.

the existing sandbox catches the polite shutdown signal (`SIGTERM`) and starts a graceful VM shutdown that can take a long time. the cleanup code was waiting for the process to actually exit, but the process was genuinely busy during that shutdown, not stuck, so it would wait the full 30s and give up.

surfaced by the go SDK review in #587 as: the second `CreateSandbox(..., WithReplace())` "blocks until the context is canceled."

## what changed

`replace()` now sends `SIGTERM` first (polite), waits a configurable grace period, then escalates to `SIGKILL`. `SIGKILL` can't be caught or delayed by the sandbox, so the existing one terminates within milliseconds regardless of what it was doing.

| before | after |
|---|---|
| `SIGTERM` then wait up to 30s | `SIGTERM`, wait `grace` (default 10s), then `SIGKILL` |
| spurious "did not stop in time" error | bounded; makes forward progress |

## new options

**rust SDK**

```rust
Sandbox::builder("foo")
    .replace_grace(Duration::from_secs(5))  // give the existing one 5s before SIGKILL
    .create()
    .await?;
```

**CLI**

```
msb run --replace-grace 5s alpine
msb run --replace-grace 0 alpine    # skip SIGTERM, kill immediately
```

`--replace-grace` implies `--replace`. zero skips the polite phase. accepts `0`, `500ms`, `5s`, `2m`.

**typed error**

`MicrosandboxError::SandboxAlreadyExists` is now a proper variant (was a generic `Custom`). the node and python SDKs surface it as `SandboxAlreadyExists` / `SandboxAlreadyExistsError` respectively.

## test plan

- `crates/microsandbox/tests/replace.rs` reproduces the reviewer's exact pattern, the typed error path, and the `replace_grace(0)` fast path.
- 164 lib unit tests pass.
- workspace clippy clean.