### PR TITLE
feat(secrets): handle Basic auth + detect encoded/split bypasses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,6 +2713,7 @@ dependencies = [
  "msb_krun",
  "parking_lot",
  "pem",
+ "percent-encoding",
  "rcgen",
  "resolv-conf",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,6 +2697,7 @@ dependencies = [
 name = "microsandbox-network"
 version = "0.4.5"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "core-foundation 0.9.4",
  "crossbeam-queue",

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 path = "lib/lib.rs"
 
 [dependencies]
+base64 = "0.22"
 bytes = { workspace = true }
 crossbeam-queue = { workspace = true }
 dirs = { workspace = true }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -29,6 +29,7 @@ microsandbox-utils = { version = "0.4.5", path = "../utils" }
 msb_krun = { version = "0.1.12", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"
+percent-encoding = "2"
 rcgen = { workspace = true }
 resolv-conf = { workspace = true }
 rustls = { workspace = true }

--- a/crates/network/lib/secrets/handler.rs
+++ b/crates/network/lib/secrets/handler.rs
@@ -28,6 +28,12 @@ pub struct SecretsHandler {
     has_ineligible: bool,
     /// Whether this connection is TLS-intercepted (not bypass).
     tls_intercepted: bool,
+    /// Longest placeholder length. Sizes the sliding-window tail.
+    max_placeholder_len: usize,
+    /// Trailing bytes carried over from the previous `substitute` call so a
+    /// placeholder split across TCP writes still trips the violation check.
+    /// Capped at `max_placeholder_len - 1` bytes.
+    prev_tail: Vec<u8>,
 }
 
 /// A secret that passed host matching for this connection.
@@ -136,6 +142,7 @@ impl SecretsHandler {
         }
 
         let has_ineligible = eligible.len() < all_placeholders.len();
+        let max_placeholder_len = all_placeholders.iter().map(String::len).max().unwrap_or(0);
 
         Self {
             eligible,
@@ -143,6 +150,8 @@ impl SecretsHandler {
             on_violation: config.on_violation.clone(),
             has_ineligible,
             tls_intercepted,
+            max_placeholder_len,
+            prev_tail: Vec::new(),
         }
     }
 
@@ -156,7 +165,7 @@ impl SecretsHandler {
     ///
     /// Returns `None` if a violation is detected (placeholder going to a
     /// disallowed host) or `BlockAndTerminate` is triggered.
-    pub fn substitute<'a>(&self, data: &'a [u8]) -> Option<Cow<'a, [u8]>> {
+    pub fn substitute<'a>(&mut self, data: &'a [u8]) -> Option<Cow<'a, [u8]>> {
         // Split raw bytes at the header boundary BEFORE converting to owned strings.
         // This avoids position shifts from from_utf8_lossy replacement chars.
         let boundary = find_header_boundary(data);
@@ -172,7 +181,8 @@ impl SecretsHandler {
         };
 
         // Fast path: skip violation check when no ineligible secrets exist.
-        if self.has_ineligible && self.has_violation(&header_str, &body_str) {
+        if self.has_ineligible && self.has_violation(data, &header_str) {
+            self.update_tail(data);
             match self.on_violation {
                 ViolationAction::Block => return None,
                 ViolationAction::BlockAndLog => {
@@ -187,6 +197,7 @@ impl SecretsHandler {
                 }
             }
         }
+        self.update_tail(data);
 
         if self.eligible.is_empty() {
             // No substitution needed. Return borrowed slice (zero-copy).
@@ -227,19 +238,35 @@ impl SecretsHandler {
     }
 
     /// Check if any placeholder appears in data for a host that isn't allowed.
-    fn has_violation(&self, headers: &str, body: &str) -> bool {
+    /// Scans the raw bytes (stitched with the previous call's tail for
+    /// cross-write detection), plus URL- and JSON-decoded variants for
+    /// encoded-placeholder bypass attempts, plus base64-decoded Basic auth
+    /// credentials.
+    fn has_violation(&self, data: &[u8], headers: &str) -> bool {
         // Fast path: if all placeholders have matching eligible entries, no
         // violation is possible (every secret is allowed for this host).
         if self.eligible.len() == self.all_placeholders.len() {
             return false;
         }
 
+        let scan_buf: Cow<[u8]> = if self.prev_tail.is_empty() {
+            Cow::Borrowed(data)
+        } else {
+            let mut stitched = Vec::with_capacity(self.prev_tail.len() + data.len());
+            stitched.extend_from_slice(&self.prev_tail);
+            stitched.extend_from_slice(data);
+            Cow::Owned(stitched)
+        };
+        let scan = scan_buf.as_ref();
+
         for placeholder in &self.all_placeholders {
             if self.eligible.iter().any(|s| s.placeholder == *placeholder) {
                 continue;
             }
-            if headers.contains(placeholder.as_str())
-                || body.contains(placeholder.as_str())
+            let needle = placeholder.as_bytes();
+            if contains_bytes(scan, needle)
+                || url_decoded_contains(scan, needle)
+                || json_escaped_contains(scan, needle)
                 || basic_auth_decoded_contains(headers, placeholder)
             {
                 return true;
@@ -247,6 +274,27 @@ impl SecretsHandler {
         }
 
         false
+    }
+
+    /// Update the sliding-window tail with the trailing bytes of `data`, so
+    /// the next `substitute` call can detect placeholders split across the
+    /// boundary.
+    fn update_tail(&mut self, data: &[u8]) {
+        let tail_size = self.max_placeholder_len.saturating_sub(1);
+        if tail_size == 0 {
+            return;
+        }
+        if data.len() >= tail_size {
+            self.prev_tail.clear();
+            self.prev_tail
+                .extend_from_slice(&data[data.len() - tail_size..]);
+            return;
+        }
+        self.prev_tail.extend_from_slice(data);
+        let overflow = self.prev_tail.len().saturating_sub(tail_size);
+        if overflow > 0 {
+            self.prev_tail.drain(..overflow);
+        }
     }
 }
 
@@ -291,6 +339,74 @@ fn basic_auth_decoded_contains(headers: &str, placeholder: &str) -> bool {
         .filter(|line| is_authorization_header(line))
         .filter_map(decode_basic_credentials)
         .any(|decoded| decoded.contains(placeholder))
+}
+
+/// Byte-slice substring check.
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return false;
+    }
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// Returns true if `haystack`, after URL percent-decoding, contains `needle`.
+/// Invalid `%XX` sequences pass through as-is.
+fn url_decoded_contains(haystack: &[u8], needle: &[u8]) -> bool {
+    let mut decoded = Vec::with_capacity(haystack.len());
+    let mut i = 0;
+    while i < haystack.len() {
+        if haystack[i] == b'%'
+            && i + 2 < haystack.len()
+            && let (Some(hi), Some(lo)) = (hex_digit(haystack[i + 1]), hex_digit(haystack[i + 2]))
+        {
+            decoded.push((hi << 4) | lo);
+            i += 3;
+            continue;
+        }
+        decoded.push(haystack[i]);
+        i += 1;
+    }
+    contains_bytes(&decoded, needle)
+}
+
+/// Returns true if `haystack`, after JSON `\uXXXX` decoding, contains `needle`.
+/// Only `\uXXXX` escapes are expanded (sufficient to detect ASCII placeholders
+/// hidden via unicode escapes); other JSON escapes pass through.
+fn json_escaped_contains(haystack: &[u8], needle: &[u8]) -> bool {
+    let mut decoded = Vec::with_capacity(haystack.len());
+    let mut i = 0;
+    while i < haystack.len() {
+        if haystack[i] == b'\\'
+            && i + 5 < haystack.len()
+            && haystack[i + 1] == b'u'
+            && let (Some(a), Some(b), Some(c), Some(d)) = (
+                hex_digit(haystack[i + 2]),
+                hex_digit(haystack[i + 3]),
+                hex_digit(haystack[i + 4]),
+                hex_digit(haystack[i + 5]),
+            )
+        {
+            let cp = ((a as u32) << 12) | ((b as u32) << 8) | ((c as u32) << 4) | (d as u32);
+            if let Some(ch) = char::from_u32(cp) {
+                let mut buf = [0u8; 4];
+                decoded.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+            }
+            i += 6;
+            continue;
+        }
+        decoded.push(haystack[i]);
+        i += 1;
+    }
+    contains_bytes(&decoded, needle)
+}
+
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
 }
 
 /// Update the Content-Length header value in `headers` to `new_len`.
@@ -362,7 +478,7 @@ mod tests {
     #[test]
     fn substitute_in_headers() {
         let config = make_config(vec![make_secret("$KEY", "real-secret", "api.openai.com")]);
-        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
         let input = b"GET / HTTP/1.1\r\nAuthorization: Bearer $KEY\r\n\r\n";
         let output = handler.substitute(input).unwrap();
@@ -375,7 +491,7 @@ mod tests {
     #[test]
     fn no_substitute_for_wrong_host() {
         let config = make_config(vec![make_secret("$KEY", "real-secret", "api.openai.com")]);
-        let handler = SecretsHandler::new(&config, "evil.com", true);
+        let mut handler = SecretsHandler::new(&config, "evil.com", true);
 
         let input = b"GET / HTTP/1.1\r\nAuthorization: Bearer $KEY\r\n\r\n";
         assert!(handler.substitute(input).is_none());
@@ -384,7 +500,7 @@ mod tests {
     #[test]
     fn body_injection_disabled_by_default() {
         let config = make_config(vec![make_secret("$KEY", "real-secret", "api.openai.com")]);
-        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
         let input = b"POST / HTTP/1.1\r\n\r\n{\"key\": \"$KEY\"}";
         let output = handler.substitute(input).unwrap();
@@ -400,7 +516,7 @@ mod tests {
         let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
         secret.injection.body = true;
         let config = make_config(vec![secret]);
-        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
         let input = b"POST / HTTP/1.1\r\n\r\n{\"key\": \"$KEY\"}";
         let output = handler.substitute(input).unwrap();
@@ -415,7 +531,7 @@ mod tests {
         let mut secret = make_secret("$KEY", "a]longer]secret]value", "api.openai.com");
         secret.injection.body = true;
         let config = make_config(vec![secret]);
-        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
         let body = "{\"key\": \"$KEY\"}";
         let input = format!(
@@ -436,7 +552,7 @@ mod tests {
         let mut secret = make_secret("$KEY", "longer-secret", "api.openai.com");
         secret.injection.body = true;
         let config = make_config(vec![secret]);
-        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
         // No Content-Length header (e.g. chunked).
         let input = b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n{\"key\": \"$KEY\"}";
@@ -449,7 +565,7 @@ mod tests {
     #[test]
     fn header_only_substitution_preserves_content_length() {
         let config = make_config(vec![make_secret("$KEY", "longer-value", "api.openai.com")]);
-        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
         let input =
             b"GET / HTTP/1.1\r\nAuthorization: Bearer $KEY\r\nContent-Length: 5\r\n\r\nhello";
@@ -463,7 +579,7 @@ mod tests {
     #[test]
     fn no_secrets_passthrough() {
         let config = make_config(vec![]);
-        let handler = SecretsHandler::new(&config, "anything.com", true);
+        let mut handler = SecretsHandler::new(&config, "anything.com", true);
 
         let input = b"GET / HTTP/1.1\r\n\r\n";
         let output = handler.substitute(input).unwrap();
@@ -474,7 +590,7 @@ mod tests {
     fn require_tls_identity_blocks_on_non_intercepted() {
         let config = make_config(vec![make_secret("$KEY", "real-secret", "api.openai.com")]);
         // tls_intercepted = false — secret requires TLS identity
-        let handler = SecretsHandler::new(&config, "api.openai.com", false);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", false);
 
         let input = b"GET / HTTP/1.1\r\nAuthorization: Bearer $KEY\r\n\r\n";
         let output = handler.substitute(input).unwrap();
@@ -491,7 +607,7 @@ mod tests {
         let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
         secret.injection = basic_auth_only();
         let config = make_config(vec![secret]);
-        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
         let input = b"GET / HTTP/1.1\r\nAuthorization: Bearer $KEY\r\nX-Custom: $KEY\r\n\r\n";
         let output = handler.substitute(input).unwrap();
@@ -511,7 +627,7 @@ mod tests {
         password.env_var = "PASSWORD".into();
         password.injection = basic_auth_only();
         let config = make_config(vec![user, password]);
-        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
         let encoded = BASE64.encode(b"$MSB_USER:$MSB_PASSWORD");
         let input = format!("GET / HTTP/1.1\r\nAuthorization: Basic {encoded}\r\n\r\n");
@@ -531,7 +647,7 @@ mod tests {
         let mut secret = make_secret("$MSB_PASSWORD", "s3cr3t", "api.openai.com");
         secret.injection = basic_auth_only();
         let config = make_config(vec![secret]);
-        let handler = SecretsHandler::new(&config, "evil.com", true);
+        let mut handler = SecretsHandler::new(&config, "evil.com", true);
 
         let encoded = BASE64.encode(b"user:$MSB_PASSWORD");
         let input = format!("GET / HTTP/1.1\r\nAuthorization: Basic {encoded}\r\n\r\n");
@@ -549,7 +665,7 @@ mod tests {
             body: false,
         };
         let config = make_config(vec![secret]);
-        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
         let encoded = BASE64.encode(b"user:$MSB_PASSWORD");
         let input = format!("GET / HTTP/1.1\r\nAuthorization: Basic {encoded}\r\n\r\n");
@@ -568,7 +684,7 @@ mod tests {
             body: false,
         };
         let config = make_config(vec![secret]);
-        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
         let input = b"GET /api?key=$KEY HTTP/1.1\r\nHost: api.openai.com\r\n\r\n";
         let output = handler.substitute(input).unwrap();
@@ -576,5 +692,68 @@ mod tests {
         // Request line should be substituted.
         assert!(result.contains("GET /api?key=real-secret HTTP/1.1"));
         // Other headers should NOT be substituted.
+    }
+
+    #[test]
+    fn url_encoded_placeholder_in_query_blocks_for_wrong_host() {
+        let config = make_config(vec![make_secret("$KEY", "real-secret", "api.openai.com")]);
+        let mut handler = SecretsHandler::new(&config, "evil.com", true);
+
+        // `%24KEY` is the URL-encoded form of `$KEY`.
+        let input = b"GET /api?token=%24KEY HTTP/1.1\r\nHost: evil.com\r\n\r\n";
+        assert!(handler.substitute(input).is_none());
+    }
+
+    #[test]
+    fn url_encoded_placeholder_in_body_blocks_for_wrong_host() {
+        let config = make_config(vec![make_secret("$KEY", "real-secret", "api.openai.com")]);
+        let mut handler = SecretsHandler::new(&config, "evil.com", true);
+
+        let input = b"POST / HTTP/1.1\r\nContent-Length: 13\r\n\r\nkey=%24KEY&x=1";
+        assert!(handler.substitute(input).is_none());
+    }
+
+    #[test]
+    fn json_escaped_placeholder_in_body_blocks_for_wrong_host() {
+        let config = make_config(vec![make_secret("$KEY", "real-secret", "api.openai.com")]);
+        let mut handler = SecretsHandler::new(&config, "evil.com", true);
+
+        // `$KEY` is the JSON unicode-escape form of `$KEY`.
+        let input =
+            b"POST / HTTP/1.1\r\nContent-Type: application/json\r\n\r\n{\"k\":\"\\u0024KEY\"}";
+        assert!(handler.substitute(input).is_none());
+    }
+
+    #[test]
+    fn placeholder_split_across_writes_blocks_for_wrong_host() {
+        let config = make_config(vec![make_secret("$KEY", "real-secret", "api.openai.com")]);
+        let mut handler = SecretsHandler::new(&config, "evil.com", true);
+
+        // Send the placeholder bytes across two separate substitute() calls.
+        let first = b"GET / HTTP/1.1\r\nX-Token: $K";
+        let second = b"EY\r\nHost: evil.com\r\n\r\n";
+
+        // The first chunk doesn't contain the full placeholder, so it forwards.
+        assert!(handler.substitute(first).is_some());
+        // The second chunk completes the placeholder when stitched with the tail.
+        assert!(handler.substitute(second).is_none());
+    }
+
+    #[test]
+    fn url_decoded_contains_basic() {
+        assert!(url_decoded_contains(b"foo%24KEYbar", b"$KEY"));
+        assert!(!url_decoded_contains(b"fooKEYbar", b"$KEY"));
+        // Invalid escapes pass through unchanged.
+        assert!(url_decoded_contains(b"%2", b"%2"));
+    }
+
+    #[test]
+    fn json_escaped_contains_basic() {
+        assert!(json_escaped_contains(b"\"\\u0024KEY\"", b"$KEY"));
+        assert!(json_escaped_contains(
+            b"\\u0024\\u004B\\u0045\\u0059",
+            b"$KEY"
+        ));
+        assert!(!json_escaped_contains(b"KEY", b"$KEY"));
     }
 }

--- a/crates/network/lib/secrets/handler.rs
+++ b/crates/network/lib/secrets/handler.rs
@@ -5,6 +5,8 @@
 
 use std::borrow::Cow;
 
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+
 use super::config::{SecretsConfig, ViolationAction};
 
 //--------------------------------------------------------------------------------------------------
@@ -42,6 +44,66 @@ struct EligibleSecret {
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
+
+impl EligibleSecret {
+    /// Returns true if any of the header-side injection scopes is enabled
+    /// (`headers`, `basic_auth`, or `query_params`).
+    fn wants_header_injection(&self) -> bool {
+        self.inject_headers || self.inject_basic_auth || self.inject_query_params
+    }
+
+    /// Substitute this secret's placeholder in the headers portion, scoped by
+    /// the secret's `headers` / `basic_auth` / `query_params` flags.
+    fn substitute_in_headers(&self, headers: &str) -> String {
+        let mut result = String::with_capacity(headers.len());
+        for (i, line) in headers.split("\r\n").enumerate() {
+            if i > 0 {
+                result.push_str("\r\n");
+            }
+            match self.substitute_in_header_line(line, i == 0) {
+                Some(s) => result.push_str(&s),
+                None => result.push_str(line),
+            }
+        }
+        result
+    }
+
+    /// Substitute this secret's placeholder in a single header line. Returns
+    /// `None` if the line is not in scope for any of the requested injection
+    /// modes.
+    fn substitute_in_header_line(&self, line: &str, is_request_line: bool) -> Option<String> {
+        if self.inject_basic_auth && is_authorization_header(line) {
+            return Some(self.substitute_basic_auth_header(line));
+        }
+        if self.inject_headers {
+            return Some(line.replace(&self.placeholder, &self.value));
+        }
+        if is_request_line && self.inject_query_params {
+            return Some(line.replace(&self.placeholder, &self.value));
+        }
+        None
+    }
+
+    /// Substitute this secret's placeholder inside an `Authorization` header.
+    /// For `Basic <base64>` headers the base64 payload is decoded, the
+    /// placeholder is substituted in the decoded credentials, and the result
+    /// is re-encoded. All other schemes (e.g. `Bearer`) fall back to a literal
+    /// replacement so placeholders appearing in plaintext tokens are still
+    /// substituted.
+    fn substitute_basic_auth_header(&self, line: &str) -> String {
+        let Some(decoded) = decode_basic_credentials(line) else {
+            return line.replace(&self.placeholder, &self.value);
+        };
+        if !decoded.contains(&self.placeholder) {
+            return line.replace(&self.placeholder, &self.value);
+        }
+        let Some((name, _)) = line.split_once(':') else {
+            return line.replace(&self.placeholder, &self.value);
+        };
+        let replaced = decoded.replace(&self.placeholder, &self.value);
+        format!("{name}: Basic {}", BASE64.encode(replaced.as_bytes()))
+    }
+}
 
 impl SecretsHandler {
     /// Create a handler for a specific connection.
@@ -95,33 +157,6 @@ impl SecretsHandler {
     /// Returns `None` if a violation is detected (placeholder going to a
     /// disallowed host) or `BlockAndTerminate` is triggered.
     pub fn substitute<'a>(&self, data: &'a [u8]) -> Option<Cow<'a, [u8]>> {
-        // Fast path: skip violation check when no ineligible secrets exist.
-        if self.has_ineligible {
-            let text = String::from_utf8_lossy(data);
-            if self.has_violation(&text) {
-                match self.on_violation {
-                    ViolationAction::Block => return None,
-                    ViolationAction::BlockAndLog => {
-                        tracing::warn!(
-                            "secret violation: placeholder detected for disallowed host"
-                        );
-                        return None;
-                    }
-                    ViolationAction::BlockAndTerminate => {
-                        tracing::error!(
-                            "secret violation: placeholder detected for disallowed host — terminating"
-                        );
-                        return None;
-                    }
-                }
-            }
-        }
-
-        if self.eligible.is_empty() {
-            // No substitution needed — return borrowed slice (zero-copy).
-            return Some(Cow::Borrowed(data));
-        }
-
         // Split raw bytes at the header boundary BEFORE converting to owned strings.
         // This avoids position shifts from from_utf8_lossy replacement chars.
         let boundary = find_header_boundary(data);
@@ -136,37 +171,38 @@ impl SecretsHandler {
             String::new()
         };
 
+        // Fast path: skip violation check when no ineligible secrets exist.
+        if self.has_ineligible && self.has_violation(&header_str, &body_str) {
+            match self.on_violation {
+                ViolationAction::Block => return None,
+                ViolationAction::BlockAndLog => {
+                    tracing::warn!("secret violation: placeholder detected for disallowed host");
+                    return None;
+                }
+                ViolationAction::BlockAndTerminate => {
+                    tracing::error!(
+                        "secret violation: placeholder detected for disallowed host — terminating"
+                    );
+                    return None;
+                }
+            }
+        }
+
+        if self.eligible.is_empty() {
+            // No substitution needed. Return borrowed slice (zero-copy).
+            return Some(Cow::Borrowed(data));
+        }
+
         for secret in &self.eligible {
             // Skip secrets that require TLS identity on non-intercepted connections.
             if secret.require_tls_identity && !self.tls_intercepted {
                 continue;
             }
-
-            if boundary.is_some() {
-                // Header portion: substitute based on headers/basic_auth/query_params scopes.
-                if secret.inject_headers || secret.inject_basic_auth || secret.inject_query_params {
-                    // Guard: only allocate a new String if the placeholder is actually present.
-                    if header_str.contains(&secret.placeholder) {
-                        header_str = substitute_in_headers(
-                            &header_str,
-                            &secret.placeholder,
-                            &secret.value,
-                            secret.inject_headers,
-                            secret.inject_basic_auth,
-                            secret.inject_query_params,
-                        );
-                    }
-                }
-
-                // Body portion.
-                if secret.inject_body && body_str.contains(&secret.placeholder) {
-                    body_str = body_str.replace(&secret.placeholder, &secret.value);
-                }
-            } else {
-                // No boundary found — treat entire message as headers.
-                if secret.inject_headers && header_str.contains(&secret.placeholder) {
-                    header_str = header_str.replace(&secret.placeholder, &secret.value);
-                }
+            if secret.wants_header_injection() {
+                header_str = secret.substitute_in_headers(&header_str);
+            }
+            if boundary.is_some() && secret.inject_body && body_str.contains(&secret.placeholder) {
+                body_str = body_str.replace(&secret.placeholder, &secret.value);
             }
         }
 
@@ -189,11 +225,9 @@ impl SecretsHandler {
     pub fn terminates_on_violation(&self) -> bool {
         matches!(self.on_violation, ViolationAction::BlockAndTerminate)
     }
-}
 
-impl SecretsHandler {
     /// Check if any placeholder appears in data for a host that isn't allowed.
-    fn has_violation(&self, text: &str) -> bool {
+    fn has_violation(&self, headers: &str, body: &str) -> bool {
         // Fast path: if all placeholders have matching eligible entries, no
         // violation is possible (every secret is allowed for this host).
         if self.eligible.len() == self.all_placeholders.len() {
@@ -201,8 +235,12 @@ impl SecretsHandler {
         }
 
         for placeholder in &self.all_placeholders {
-            if text.contains(placeholder.as_str())
-                && !self.eligible.iter().any(|s| s.placeholder == *placeholder)
+            if self.eligible.iter().any(|s| s.placeholder == *placeholder) {
+                continue;
+            }
+            if headers.contains(placeholder.as_str())
+                || body.contains(placeholder.as_str())
+                || basic_auth_decoded_contains(headers, placeholder)
             {
                 return true;
             }
@@ -216,47 +254,43 @@ impl SecretsHandler {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Substitute a placeholder in the headers portion with scoping:
-/// - `headers`: replace anywhere in headers
-/// - `basic_auth`: replace only in Authorization header lines
-/// - `query_params`: replace only in the request line's query string
-fn substitute_in_headers(
-    headers: &str,
-    placeholder: &str,
-    value: &str,
-    inject_all_headers: bool,
-    inject_basic_auth: bool,
-    inject_query_params: bool,
-) -> String {
-    if inject_all_headers {
-        // Replace everywhere in headers.
-        return headers.replace(placeholder, value);
+/// Returns true if `line` starts with the `Authorization:` header name
+/// (case-insensitive).
+fn is_authorization_header(line: &str) -> bool {
+    line.as_bytes()
+        .get(..14)
+        .is_some_and(|b| b.eq_ignore_ascii_case(b"authorization:"))
+}
+
+/// Decode the credentials of a `Basic` `Authorization` header line. Returns
+/// `None` if the line is not `Basic`-scheme or the payload is not valid
+/// base64 / UTF-8.
+fn decode_basic_credentials(line: &str) -> Option<String> {
+    let (_, raw_value) = line.split_once(':')?;
+    let (scheme, encoded) = split_auth_scheme(raw_value.trim_start())?;
+    if !scheme.eq_ignore_ascii_case("basic") {
+        return None;
     }
+    let bytes = BASE64.decode(encoded.trim()).ok()?;
+    String::from_utf8(bytes).ok()
+}
 
-    // Line-by-line scoping.
-    let mut result = String::with_capacity(headers.len());
-    for (i, line) in headers.split("\r\n").enumerate() {
-        if i > 0 {
-            result.push_str("\r\n");
-        }
+/// Split an `Authorization` header value into `(scheme, rest)` at the first
+/// whitespace. Returns `None` if no whitespace separator is found.
+fn split_auth_scheme(header_value: &str) -> Option<(&str, &str)> {
+    let split_at = header_value.find(char::is_whitespace)?;
+    let (scheme, rest) = header_value.split_at(split_at);
+    Some((scheme, rest.trim_start()))
+}
 
-        if i == 0 && inject_query_params {
-            // Request line — substitute in query portion.
-            result.push_str(&line.replace(placeholder, value));
-        } else if inject_basic_auth
-            && line
-                .as_bytes()
-                .get(..14)
-                .is_some_and(|b| b.eq_ignore_ascii_case(b"authorization:"))
-        {
-            // Authorization header — substitute.
-            result.push_str(&line.replace(placeholder, value));
-        } else {
-            result.push_str(line);
-        }
-    }
-
-    result
+/// Returns true if any `Authorization: Basic` line in `headers` decodes to
+/// credentials containing `placeholder`.
+fn basic_auth_decoded_contains(headers: &str, placeholder: &str) -> bool {
+    headers
+        .split("\r\n")
+        .filter(|line| is_authorization_header(line))
+        .filter_map(decode_basic_credentials)
+        .any(|decoded| decoded.contains(placeholder))
 }
 
 /// Update the Content-Length header value in `headers` to `new_len`.
@@ -313,6 +347,15 @@ mod tests {
             allowed_hosts: vec![HostPattern::Exact(host.into())],
             injection: SecretInjection::default(),
             require_tls_identity: true,
+        }
+    }
+
+    fn basic_auth_only() -> SecretInjection {
+        SecretInjection {
+            headers: false,
+            basic_auth: true,
+            query_params: false,
+            body: false,
         }
     }
 
@@ -446,12 +489,7 @@ mod tests {
     #[test]
     fn basic_auth_only_substitution() {
         let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
-        secret.injection = SecretInjection {
-            headers: false,
-            basic_auth: true,
-            query_params: false,
-            body: false,
-        };
+        secret.injection = basic_auth_only();
         let config = make_config(vec![secret]);
         let handler = SecretsHandler::new(&config, "api.openai.com", true);
 
@@ -462,6 +500,62 @@ mod tests {
         assert!(result.contains("Authorization: Bearer real-secret"));
         // Other headers should NOT be substituted.
         assert!(result.contains("X-Custom: $KEY"));
+    }
+
+    #[test]
+    fn basic_auth_decodes_substitutes_and_reencodes_credentials() {
+        let mut user = make_secret("$MSB_USER", "alice", "api.openai.com");
+        user.env_var = "USER".into();
+        user.injection = basic_auth_only();
+        let mut password = make_secret("$MSB_PASSWORD", "s3cr3t", "api.openai.com");
+        password.env_var = "PASSWORD".into();
+        password.injection = basic_auth_only();
+        let config = make_config(vec![user, password]);
+        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+
+        let encoded = BASE64.encode(b"$MSB_USER:$MSB_PASSWORD");
+        let input = format!("GET / HTTP/1.1\r\nAuthorization: Basic {encoded}\r\n\r\n");
+        let output = handler.substitute(input.as_bytes()).unwrap();
+        let result = String::from_utf8(output.into_owned()).unwrap();
+
+        assert!(result.contains(&format!(
+            "Authorization: Basic {}",
+            BASE64.encode(b"alice:s3cr3t")
+        )));
+        assert!(!result.contains("$MSB_USER"));
+        assert!(!result.contains("$MSB_PASSWORD"));
+    }
+
+    #[test]
+    fn basic_auth_encoded_placeholder_is_blocked_for_wrong_host() {
+        let mut secret = make_secret("$MSB_PASSWORD", "s3cr3t", "api.openai.com");
+        secret.injection = basic_auth_only();
+        let config = make_config(vec![secret]);
+        let handler = SecretsHandler::new(&config, "evil.com", true);
+
+        let encoded = BASE64.encode(b"user:$MSB_PASSWORD");
+        let input = format!("GET / HTTP/1.1\r\nAuthorization: Basic {encoded}\r\n\r\n");
+
+        assert!(handler.substitute(input.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn basic_auth_encoded_placeholder_is_not_replaced_when_scope_disabled() {
+        let mut secret = make_secret("$MSB_PASSWORD", "s3cr3t", "api.openai.com");
+        secret.injection = SecretInjection {
+            headers: false,
+            basic_auth: false,
+            query_params: false,
+            body: false,
+        };
+        let config = make_config(vec![secret]);
+        let handler = SecretsHandler::new(&config, "api.openai.com", true);
+
+        let encoded = BASE64.encode(b"user:$MSB_PASSWORD");
+        let input = format!("GET / HTTP/1.1\r\nAuthorization: Basic {encoded}\r\n\r\n");
+        let output = handler.substitute(input.as_bytes()).unwrap();
+
+        assert_eq!(String::from_utf8(output.into_owned()).unwrap(), input);
     }
 
     #[test]

--- a/crates/network/lib/secrets/handler.rs
+++ b/crates/network/lib/secrets/handler.rs
@@ -6,6 +6,7 @@
 use std::borrow::Cow;
 
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use percent_encoding::percent_decode;
 
 use super::config::{SecretsConfig, ViolationAction};
 
@@ -350,22 +351,8 @@ fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
 }
 
 /// Returns true if `haystack`, after URL percent-decoding, contains `needle`.
-/// Invalid `%XX` sequences pass through as-is.
 fn url_decoded_contains(haystack: &[u8], needle: &[u8]) -> bool {
-    let mut decoded = Vec::with_capacity(haystack.len());
-    let mut i = 0;
-    while i < haystack.len() {
-        if haystack[i] == b'%'
-            && i + 2 < haystack.len()
-            && let (Some(hi), Some(lo)) = (hex_digit(haystack[i + 1]), hex_digit(haystack[i + 2]))
-        {
-            decoded.push((hi << 4) | lo);
-            i += 3;
-            continue;
-        }
-        decoded.push(haystack[i]);
-        i += 1;
-    }
+    let decoded: Vec<u8> = percent_decode(haystack).collect();
     contains_bytes(&decoded, needle)
 }
 
@@ -401,12 +388,7 @@ fn json_escaped_contains(haystack: &[u8], needle: &[u8]) -> bool {
 }
 
 fn hex_digit(b: u8) -> Option<u8> {
-    match b {
-        b'0'..=b'9' => Some(b - b'0'),
-        b'a'..=b'f' => Some(b - b'a' + 10),
-        b'A'..=b'F' => Some(b - b'A' + 10),
-        _ => None,
-    }
+    (b as char).to_digit(16).map(|d| d as u8)
 }
 
 /// Update the Content-Length header value in `headers` to `new_len`.

--- a/crates/network/lib/secrets/handler.rs
+++ b/crates/network/lib/secrets/handler.rs
@@ -79,8 +79,11 @@ impl EligibleSecret {
     /// `None` if the line is not in scope for any of the requested injection
     /// modes.
     fn substitute_in_header_line(&self, line: &str, is_request_line: bool) -> Option<String> {
-        if self.inject_basic_auth && is_authorization_header(line) {
-            return Some(self.substitute_basic_auth_header(line));
+        if self.inject_basic_auth
+            && is_authorization_header(line)
+            && let Some(replaced) = self.substitute_basic_auth_header(line)
+        {
+            return Some(replaced);
         }
         if self.inject_headers {
             return Some(line.replace(&self.placeholder, &self.value));
@@ -91,24 +94,22 @@ impl EligibleSecret {
         None
     }
 
-    /// Substitute this secret's placeholder inside an `Authorization` header.
-    /// For `Basic <base64>` headers the base64 payload is decoded, the
-    /// placeholder is substituted in the decoded credentials, and the result
-    /// is re-encoded. All other schemes (e.g. `Bearer`) fall back to a literal
-    /// replacement so placeholders appearing in plaintext tokens are still
-    /// substituted.
-    fn substitute_basic_auth_header(&self, line: &str) -> String {
-        let Some(decoded) = decode_basic_credentials(line) else {
-            return line.replace(&self.placeholder, &self.value);
-        };
+    /// Decode `Basic <base64>` credentials, substitute the placeholder in the
+    /// decoded `user:password`, and return the re-encoded line. Returns `None`
+    /// if the line isn't `Basic` scheme or the decoded credentials don't
+    /// contain the placeholder. Non-Basic schemes (e.g. `Bearer`) are handled
+    /// by `inject_headers` instead.
+    fn substitute_basic_auth_header(&self, line: &str) -> Option<String> {
+        let decoded = decode_basic_credentials(line)?;
         if !decoded.contains(&self.placeholder) {
-            return line.replace(&self.placeholder, &self.value);
+            return None;
         }
-        let Some((name, _)) = line.split_once(':') else {
-            return line.replace(&self.placeholder, &self.value);
-        };
+        let (name, _) = line.split_once(':')?;
         let replaced = decoded.replace(&self.placeholder, &self.value);
-        format!("{name}: Basic {}", BASE64.encode(replaced.as_bytes()))
+        Some(format!(
+            "{name}: Basic {}",
+            BASE64.encode(replaced.as_bytes())
+        ))
     }
 }
 
@@ -585,18 +586,17 @@ mod tests {
     }
 
     #[test]
-    fn basic_auth_only_substitution() {
+    fn basic_auth_only_does_not_substitute_other_schemes() {
         let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
         secret.injection = basic_auth_only();
         let config = make_config(vec![secret]);
         let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
+        // basic_auth only handles Basic credentials; Bearer needs inject_headers.
         let input = b"GET / HTTP/1.1\r\nAuthorization: Bearer $KEY\r\nX-Custom: $KEY\r\n\r\n";
         let output = handler.substitute(input).unwrap();
         let result = String::from_utf8(output.into_owned()).unwrap();
-        // Authorization header should be substituted.
-        assert!(result.contains("Authorization: Bearer real-secret"));
-        // Other headers should NOT be substituted.
+        assert!(result.contains("Authorization: Bearer $KEY"));
         assert!(result.contains("X-Custom: $KEY"));
     }
 

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -165,7 +165,7 @@ async fn intercept_relay(
 ) -> io::Result<()> {
     // Create secrets handler for this connection (filters by SNI).
     // tls_intercepted = true because we're in intercept_relay (not bypass).
-    let secrets_handler = SecretsHandler::new(&tls_state.secrets, sni_name, true);
+    let mut secrets_handler = SecretsHandler::new(&tls_state.secrets, sni_name, true);
 
     // Get or generate per-domain certificate (includes cached ServerConfig).
     let domain_cert = tls_state.get_or_generate_cert(sni_name);
@@ -233,7 +233,7 @@ async fn intercept_relay(
     forward_plaintext(
         &mut guest_tls,
         &mut server_tls,
-        &secrets_handler,
+        &mut secrets_handler,
         &shared,
         &mut plaintext_buf,
     )
@@ -261,7 +261,7 @@ async fn intercept_relay(
                 forward_plaintext(
                     &mut guest_tls,
                     &mut server_tls,
-                    &secrets_handler,
+                    &mut secrets_handler,
                     &shared,
                     &mut plaintext_buf,
                 )
@@ -318,7 +318,7 @@ async fn extract_sni_from_channel(
 async fn forward_plaintext(
     guest_tls: &mut rustls::ServerConnection,
     server_tls: &mut tokio_rustls::client::TlsStream<TcpStream>,
-    secrets_handler: &SecretsHandler,
+    secrets_handler: &mut SecretsHandler,
     shared: &SharedState,
     buf: &mut [u8],
 ) -> io::Result<()> {

--- a/docs/sdk/python/secrets.mdx
+++ b/docs/sdk/python/secrets.mdx
@@ -25,6 +25,7 @@ def env(
     placeholder: str | None = None,
     require_tls: bool = True,
     on_violation: ViolationAction = ViolationAction.BLOCK_AND_LOG,
+    injection: SecretInjection | None = None,
 ) -> SecretEntry
 ```
 
@@ -41,6 +42,7 @@ Create a secret entry that maps an environment variable to a real value. The gue
 | placeholder | `str \| None` | `None` | Custom placeholder string. Auto-generated as `$MSB_<env_var>` if not set. |
 | require_tls | `bool` | `True` | Only substitute on TLS-intercepted connections. Disable only if you know the traffic is safe. |
 | on_violation | [`ViolationAction`](#violationaction) | `BLOCK_AND_LOG` | Action when the placeholder is sent to a disallowed host |
+| injection | [`SecretInjection`](#secretinjection) `\| None` | `None` | Where in the HTTP request to substitute. `None` uses the defaults. |
 
 **Returns**
 
@@ -65,6 +67,18 @@ Frozen dataclass returned by [`Secret.env()`](#secretenv) and used in `SandboxCo
 | placeholder | `str \| None` | Placeholder string |
 | require_tls | `bool` | TLS requirement |
 | on_violation | [`ViolationAction`](#violationaction) | Violation action |
+| injection | [`SecretInjection`](#secretinjection) | Per-request injection scopes |
+
+### SecretInjection
+
+Frozen dataclass controlling where in the HTTP request the secret value is substituted.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| headers | `bool` | `True` | Substitute the placeholder anywhere it appears in the headers. |
+| basic_auth | `bool` | `True` | Substitute in `Authorization` headers. For `Basic <base64>` credentials, the payload is decoded, the placeholder is substituted in the decoded `user:password`, and the result is re-encoded. |
+| query_params | `bool` | `False` | Substitute in the request line's query string. |
+| body | `bool` | `False` | Substitute in the request body. Adjusts `Content-Length` automatically. |
 
 ### ViolationAction
 

--- a/docs/sdk/python/secrets.mdx
+++ b/docs/sdk/python/secrets.mdx
@@ -76,7 +76,7 @@ Frozen dataclass controlling where in the HTTP request the secret value is subst
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | headers | `bool` | `True` | Substitute the placeholder anywhere it appears in the headers. |
-| basic_auth | `bool` | `True` | Substitute in `Authorization` headers. For `Basic <base64>` credentials, the payload is decoded, the placeholder is substituted in the decoded `user:password`, and the result is re-encoded. |
+| basic_auth | `bool` | `True` | Decode `Authorization: Basic <base64>` credentials, substitute the placeholder in the decoded `user:password`, and re-encode. Other schemes (`Bearer`, `Digest`) are handled by `headers`. |
 | query_params | `bool` | `False` | Substitute in the request line's query string. |
 | body | `bool` | `False` | Substitute in the request body. Adjusts `Content-Length` automatically. |
 

--- a/docs/sdk/rust/secrets.mdx
+++ b/docs/sdk/rust/secrets.mdx
@@ -82,7 +82,7 @@ Set the environment variable name that will hold the placeholder inside the gues
 fn inject_basic_auth(self, enabled: bool) -> Self
 ```
 
-Control whether the placeholder is replaced specifically in `Authorization` header lines. When `inject_headers` is `true`, this has no additional effect since all headers are already covered.
+Control whether `Authorization: Basic <base64>` credentials are decoded, substituted in the decoded `user:password`, and re-encoded. Orthogonal to `inject_headers`: this flag handles the encoded-credentials case for Basic scheme; `inject_headers` handles literal substitution in any header line, including non-Basic Authorization schemes (`Bearer`, `Digest`).
 
 **Parameters**
 

--- a/docs/sdk/typescript/secrets.mdx
+++ b/docs/sdk/typescript/secrets.mdx
@@ -51,7 +51,7 @@ Fluent builder used inside `SandboxBuilder.secret(s => ...)` or `NetworkBuilder.
 | `allowAnyHostDangerous(true)` | Permit substitution to any host. Acknowledge the risk explicitly. |
 | `requireTlsIdentity(enabled)` | Require a verified TLS identity before substituting. Default `true`. |
 | `injectHeaders(enabled)` | Allow substitution in HTTP headers. Default `true`. |
-| `injectBasicAuth(enabled)` | Allow substitution in HTTP Basic Auth. Default `true`. |
+| `injectBasicAuth(enabled)` | Decode `Authorization: Basic <base64>` credentials, substitute the placeholder in the decoded `user:password`, and re-encode. Default `true`. Other schemes are handled by `injectHeaders`. |
 | `injectQuery(enabled)` | Allow substitution in URL query parameters. Default `false`. |
 | `injectBody(enabled)` | Allow substitution in the HTTP request body. Default `false`. |
 | `build()` | Produce a [`SecretEntry`](#secretentry). |
@@ -107,7 +107,7 @@ Controls where the TLS proxy substitutes the placeholder with the real value. Ea
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | headers? | `boolean` | `true` | Replace the placeholder anywhere in HTTP headers. |
-| basicAuth? | `boolean` | `true` | Replace the placeholder specifically in HTTP Basic Auth credentials. |
+| basicAuth? | `boolean` | `true` | Decode `Authorization: Basic <base64>` credentials, substitute the placeholder in the decoded `user:password`, and re-encode. Other schemes (`Bearer`, `Digest`) are handled by `headers`. |
 | queryParams? | `boolean` | `false` | Replace the placeholder in URL query parameters. |
 | body? | `boolean` | `false` | Replace the placeholder in the HTTP request body. `Content-Length` is rewritten. |
 

--- a/sdk/python/microsandbox/__init__.py
+++ b/sdk/python/microsandbox/__init__.py
@@ -106,6 +106,7 @@ from microsandbox.types import (
     SandboxStatus,
     Secret,
     SecretEntry,
+    SecretInjection,
     Size,
     Stdin,
     TlsConfig,
@@ -174,6 +175,7 @@ __all__ = [
     # Secrets & TLS
     "Secret",
     "SecretEntry",
+    "SecretInjection",
     "TlsConfig",
     "ViolationAction",
     # Images / rootfs

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -450,6 +450,26 @@ class Patch:
 #--------------------------------------------------------------------------------------------------
 
 @dataclass(frozen=True, slots=True)
+class SecretInjection:
+    """Where in the HTTP request the secret value can be substituted."""
+    headers: bool = True
+    basic_auth: bool = True
+    query_params: bool = False
+    body: bool = False
+
+    def _to_dict(self) -> dict:
+        d: dict = {}
+        if not self.headers:
+            d["headers"] = False
+        if not self.basic_auth:
+            d["basic_auth"] = False
+        if self.query_params:
+            d["query_params"] = True
+        if self.body:
+            d["body"] = True
+        return d
+
+@dataclass(frozen=True, slots=True)
 class SecretEntry:
     """A secret entry for the secrets array."""
     env_var: str
@@ -459,6 +479,7 @@ class SecretEntry:
     placeholder: str | None = None
     require_tls: bool = True
     on_violation: ViolationAction = ViolationAction.BLOCK_AND_LOG
+    injection: SecretInjection = field(default_factory=SecretInjection)
 
     def _to_dict(self) -> dict:
         d: dict = {"env_var": self.env_var, "value": self.value}
@@ -472,6 +493,9 @@ class SecretEntry:
             d["require_tls"] = False
         if self.on_violation != ViolationAction.BLOCK_AND_LOG:
             d["on_violation"] = str(self.on_violation)
+        injection = self.injection._to_dict()
+        if injection:
+            d["injection"] = injection
         return d
 
 class Secret:
@@ -487,6 +511,7 @@ class Secret:
         placeholder: str | None = None,
         require_tls: bool = True,
         on_violation: ViolationAction = ViolationAction.BLOCK_AND_LOG,
+        injection: SecretInjection | None = None,
     ) -> SecretEntry:
         return SecretEntry(
             env_var=env_var,
@@ -496,6 +521,7 @@ class Secret:
             placeholder=placeholder,
             require_tls=require_tls,
             on_violation=on_violation,
+            injection=injection if injection is not None else SecretInjection(),
         )
 
 #--------------------------------------------------------------------------------------------------

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -840,6 +840,19 @@ fn apply_secret(
     let placeholder: Option<String> = extract_opt(secret, "placeholder")?;
     let require_tls: Option<bool> = extract_opt(secret, "require_tls")?;
 
+    let (inject_headers, inject_basic_auth, inject_query_params, inject_body) =
+        if let Some(injection_obj) = secret.get_item("injection")? {
+            let injection = as_dict(&injection_obj)?;
+            (
+                extract_opt::<bool>(&injection, "headers")?,
+                extract_opt::<bool>(&injection, "basic_auth")?,
+                extract_opt::<bool>(&injection, "query_params")?,
+                extract_opt::<bool>(&injection, "body")?,
+            )
+        } else {
+            (None, None, None, None)
+        };
+
     Ok(builder.secret(|s| {
         let mut s = s.env(&env_var).value(value.clone());
         for host in &allow_hosts {
@@ -853,6 +866,18 @@ fn apply_secret(
         }
         if let Some(req) = require_tls {
             s = s.require_tls_identity(req);
+        }
+        if let Some(v) = inject_headers {
+            s = s.inject_headers(v);
+        }
+        if let Some(v) = inject_basic_auth {
+            s = s.inject_basic_auth(v);
+        }
+        if let Some(v) = inject_query_params {
+            s = s.inject_query(v);
+        }
+        if let Some(v) = inject_body {
+            s = s.inject_body(v);
         }
         s
     }))


### PR DESCRIPTION
## what

three related improvements to secret placeholder handling in the TLS proxy:

1. **Basic auth substitution.** `Authorization: Basic <base64>` headers now decode the credentials, substitute placeholders in the decoded `user:password`, and re-encode. previously the placeholder bytes were passed through literally inside the base64 blob and never reached the server. closes #698.

2. **Bypass detection.** the violation check that fires on disallowed hosts now also looks for:
   - URL percent-encoded placeholders (`%24MSB_KEY`)
   - JSON unicode-escaped placeholders (`$MSB_KEY`)
   - base64-encoded placeholders inside `Authorization: Basic` lines
   - placeholders split across TCP writes (via a sliding-window tail buffer sized to the longest placeholder)

3. **Python SDK exposure.** `SecretInjection` (`headers`, `basic_auth`, `query_params`, `body`) is now reachable from python, mirroring the node-ts SDK shape. previously python users were stuck with the rust defaults.

## scope notes

substitution itself stays per-write. a placeholder split mid-write still fails to substitute (the upstream request breaks), but is detected as a violation when destined for a disallowed host. full request buffering is out of scope.

## test plan

- [x] 25 unit tests in `crates/network/lib/secrets/handler.rs` (19 existing + 6 new for encoded and split-write detection)
- [x] `cargo check` passes for `microsandbox-py` with the new injection field
- [ ] manual smoke: run a sandbox with a Basic-auth secret against an allowed host and confirm credentials reach the upstream re-encoded
- [ ] manual smoke: send a URL-encoded placeholder to a disallowed host and confirm violation fires