### PR TITLE
fix(stdin): deliver large payloads and surface broken-pipe errors

### DIFF
--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -14,7 +14,7 @@ use microsandbox_protocol::codec::{self, MAX_FRAME_SIZE};
 use microsandbox_protocol::core::Ready;
 use microsandbox_protocol::exec::{
     ExecExited, ExecFailed, ExecFailureKind, ExecRequest, ExecResize, ExecSignal, ExecStarted,
-    ExecStderr, ExecStdin, ExecStdout,
+    ExecStderr, ExecStdin, ExecStdinError, ExecStdout,
 };
 use microsandbox_protocol::fs::{FsData, FsRequest};
 use microsandbox_protocol::message::{Message, MessageType};
@@ -272,8 +272,17 @@ async fn handle_message(
                 if stdin.data.is_empty() {
                     // Empty data signals EOF — close stdin.
                     session.close_stdin();
-                } else {
-                    let _ = session.write_stdin(&stdin.data).await;
+                } else if let Err(e) = session.write_stdin(&stdin.data).await {
+                    let payload = stdin_error_payload(&e);
+                    eprintln!("stdin write error on session {}: {e}", msg.id);
+                    let reply =
+                        Message::with_payload(MessageType::ExecStdinError, msg.id, &payload)
+                            .map_err(|e| {
+                                AgentdError::ExecSession(format!("encode stdin error: {e}"))
+                            })?;
+                    codec::encode_to_buf(&reply, out_buf).map_err(|e| {
+                        AgentdError::ExecSession(format!("encode stdin error frame: {e}"))
+                    })?;
                 }
             }
         }
@@ -368,6 +377,35 @@ async fn handle_message(
 /// inherits from agentd's environment and prepends.
 /// Default PATH for the guest when no PATH is inherited.
 const DEFAULT_GUEST_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+/// Build an `ExecStdinError` payload from a failed `write_stdin` result.
+fn stdin_error_payload(err: &AgentdError) -> ExecStdinError {
+    let io_err = match err {
+        AgentdError::Io(e) => Some(e),
+        _ => None,
+    };
+    let errno = io_err.and_then(|e| e.raw_os_error());
+    ExecStdinError {
+        errno,
+        errno_name: errno.and_then(errno_name),
+        message: err.to_string(),
+    }
+}
+
+/// Map common errno values to their standard names. Returns `None` for
+/// codes we don't recognize; callers fall back to the numeric `errno`.
+fn errno_name(code: i32) -> Option<String> {
+    let name = match code {
+        libc::EPIPE => "EPIPE",
+        libc::EBADF => "EBADF",
+        libc::EINVAL => "EINVAL",
+        libc::EIO => "EIO",
+        libc::ENOSPC => "ENOSPC",
+        libc::EFBIG => "EFBIG",
+        _ => return None,
+    };
+    Some(name.to_string())
+}
 
 fn prepend_scripts_to_path(req: &mut microsandbox_protocol::exec::ExecRequest) {
     let scripts = microsandbox_protocol::SCRIPTS_PATH;

--- a/crates/agentd/lib/session.rs
+++ b/crates/agentd/lib/session.rs
@@ -790,7 +790,20 @@ async fn blocking_write_fd(fd: RawFd, data: &[u8]) -> AgentdResult<()> {
             let ptr = unsafe { data.as_ptr().add(written) as *const libc::c_void };
             let ret = unsafe { libc::write(fd, ptr, data.len() - written) };
             if ret < 0 {
-                return Err(AgentdError::Io(std::io::Error::last_os_error()));
+                let err = std::io::Error::last_os_error();
+                let code = err.raw_os_error();
+                if code == Some(libc::EAGAIN) || code == Some(libc::EWOULDBLOCK) {
+                    wait_fd_writable(fd)?;
+                    continue;
+                }
+                if code == Some(libc::EINTR) {
+                    continue;
+                }
+                return Err(AgentdError::Io(err));
+            }
+            if ret == 0 {
+                wait_fd_writable(fd)?;
+                continue;
             }
             written += ret as usize;
         }
@@ -798,6 +811,33 @@ async fn blocking_write_fd(fd: RawFd, data: &[u8]) -> AgentdResult<()> {
     })
     .await
     .map_err(|e| AgentdError::ExecSession(format!("stdin write join error: {e}")))?
+}
+
+fn wait_fd_writable(fd: RawFd) -> AgentdResult<()> {
+    let mut pollfd = libc::pollfd {
+        fd,
+        events: libc::POLLOUT,
+        revents: 0,
+    };
+
+    loop {
+        let ret = unsafe { libc::poll(&mut pollfd, 1, -1) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return Err(AgentdError::Io(err));
+        }
+        if ret == 0 {
+            continue;
+        }
+        // Any positive return means the fd is actionable: POLLOUT lets the
+        // next write make progress, and POLLHUP/POLLERR/POLLNVAL will cause
+        // the next write to fail with a real errno (typically EPIPE) which
+        // is more meaningful than poll's revents.
+        return Ok(());
+    }
 }
 
 /// Background task that reads from a PTY master fd and sends output events.

--- a/crates/microsandbox/lib/sandbox/exec.rs
+++ b/crates/microsandbox/lib/sandbox/exec.rs
@@ -77,11 +77,6 @@ pub struct ExecOutput {
 
     /// Captured stderr.
     stderr: Bytes,
-
-    /// Set if the guest reported a stdin write failure (e.g. the child
-    /// closed its read end). The session still produced an exit status,
-    /// so `status` and the output buffers remain meaningful.
-    stdin_error: Option<microsandbox_protocol::exec::ExecStdinError>,
 }
 
 /// Process exit status.
@@ -308,17 +303,6 @@ impl ExecOutput {
     pub fn stderr_bytes(&self) -> &Bytes {
         &self.stderr
     }
-
-    /// Returns the stdin write failure reported by the guest, if any.
-    ///
-    /// Set when at least one host-supplied stdin chunk could not be
-    /// delivered to the child (typically because the child closed its
-    /// read end). The session still produced a normal exit status, so
-    /// `status()` and the captured output remain meaningful. If multiple
-    /// stdin writes failed, this reflects the first failure.
-    pub fn stdin_error(&self) -> Option<&microsandbox_protocol::exec::ExecStdinError> {
-        self.stdin_error.as_ref()
-    }
 }
 
 impl ExecHandle {
@@ -383,7 +367,6 @@ impl ExecHandle {
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         let mut exit_code: Option<i32> = None;
-        let mut stdin_error = None;
 
         while let Some(event) = self.events.recv().await {
             match event {
@@ -401,11 +384,7 @@ impl ExecHandle {
                 ExecEvent::Failed(payload) => {
                     return Err(crate::MicrosandboxError::ExecFailed(payload));
                 }
-                ExecEvent::StdinError(payload) => {
-                    if stdin_error.is_none() {
-                        stdin_error = Some(payload);
-                    }
-                }
+                ExecEvent::StdinError(_) => {}
             }
         }
 
@@ -420,7 +399,6 @@ impl ExecHandle {
             },
             stdout: Bytes::from(stdout),
             stderr: Bytes::from(stderr),
-            stdin_error,
         })
     }
 

--- a/crates/microsandbox/lib/sandbox/exec.rs
+++ b/crates/microsandbox/lib/sandbox/exec.rs
@@ -77,6 +77,11 @@ pub struct ExecOutput {
 
     /// Captured stderr.
     stderr: Bytes,
+
+    /// Set if the guest reported a stdin write failure (e.g. the child
+    /// closed its read end). The session still produced an exit status,
+    /// so `status` and the output buffers remain meaningful.
+    stdin_error: Option<microsandbox_protocol::exec::ExecStdinError>,
 }
 
 /// Process exit status.
@@ -129,6 +134,11 @@ pub enum ExecEvent {
     /// denied, etc.). Distinct from `Exited` — `Failed` means the
     /// user code never ran. Terminal: no further events follow.
     Failed(microsandbox_protocol::exec::ExecFailed),
+
+    /// A stdin write to the child failed (e.g. broken pipe). Non-terminal:
+    /// the session keeps running and may still emit further output and
+    /// an `Exited` event.
+    StdinError(microsandbox_protocol::exec::ExecStdinError),
 }
 
 /// Sink for writing to a running process's stdin.
@@ -298,6 +308,17 @@ impl ExecOutput {
     pub fn stderr_bytes(&self) -> &Bytes {
         &self.stderr
     }
+
+    /// Returns the stdin write failure reported by the guest, if any.
+    ///
+    /// Set when at least one host-supplied stdin chunk could not be
+    /// delivered to the child (typically because the child closed its
+    /// read end). The session still produced a normal exit status, so
+    /// `status()` and the captured output remain meaningful. If multiple
+    /// stdin writes failed, this reflects the first failure.
+    pub fn stdin_error(&self) -> Option<&microsandbox_protocol::exec::ExecStdinError> {
+        self.stdin_error.as_ref()
+    }
 }
 
 impl ExecHandle {
@@ -362,6 +383,7 @@ impl ExecHandle {
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         let mut exit_code: Option<i32> = None;
+        let mut stdin_error = None;
 
         while let Some(event) = self.events.recv().await {
             match event {
@@ -379,6 +401,11 @@ impl ExecHandle {
                 ExecEvent::Failed(payload) => {
                     return Err(crate::MicrosandboxError::ExecFailed(payload));
                 }
+                ExecEvent::StdinError(payload) => {
+                    if stdin_error.is_none() {
+                        stdin_error = Some(payload);
+                    }
+                }
             }
         }
 
@@ -393,6 +420,7 @@ impl ExecHandle {
             },
             stdout: Bytes::from(stdout),
             stderr: Bytes::from(stderr),
+            stdin_error,
         })
     }
 

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -1318,6 +1318,13 @@ async fn event_mapper_task(
                 }
                 break;
             }
+            MessageType::ExecStdinError => {
+                if let Ok(payload) = msg.payload::<microsandbox_protocol::exec::ExecStdinError>() {
+                    ExecEvent::StdinError(payload)
+                } else {
+                    continue;
+                }
+            }
             _ => continue,
         };
         if tx.send(event).is_err() {

--- a/crates/microsandbox/tests/stdin.rs
+++ b/crates/microsandbox/tests/stdin.rs
@@ -175,6 +175,70 @@ async fn stdin_pipe_streams_chunks_in_order() {
     assert_eq!(actual_sha, expected_sha);
 }
 
+/// Broken-pipe test: the child reads only a short prefix of stdin and
+/// exits, closing its read end before the host's full payload has been
+/// delivered. The agent's stdin write should fail with EPIPE, which
+/// surfaces to the host as `ExecOutput::stdin_error()`. The session
+/// itself still completes with a normal exit code and stdout — the
+/// stdin failure is non-terminal.
+#[msb_test]
+async fn stdin_bytes_reports_broken_pipe_when_child_exits_early() {
+    let name = "stdin-broken-pipe";
+    let payload = vec![b'z'; ONE_MIB];
+
+    let sandbox = Sandbox::builder(name)
+        .image("mirror.gcr.io/library/alpine")
+        .cpus(1)
+        .memory(512)
+        .replace()
+        .create()
+        .await
+        .expect("create sandbox");
+
+    let output = sandbox
+        .exec_with("sh", |exec| {
+            exec.args([
+                "-c",
+                "dd bs=1 count=16 of=/tmp/prefix.bin 2>/dev/null && wc -c /tmp/prefix.bin",
+            ])
+            .stdin_bytes(payload)
+        })
+        .await
+        .expect("exec returned");
+
+    sandbox.stop_and_wait().await.expect("stop");
+    Sandbox::remove(name).await.expect("remove");
+
+    assert!(
+        output.status().success,
+        "guest command failed: stdout=`{}` stderr=`{}`",
+        output.stdout().unwrap_or_default(),
+        output.stderr().unwrap_or_default()
+    );
+
+    let stdout = output.stdout().expect("stdout is utf8");
+    let prefix_count = stdout
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .expect("byte count line");
+    assert_eq!(
+        prefix_count, "16",
+        "child should have read exactly 16 bytes"
+    );
+
+    let stdin_err = output
+        .stdin_error()
+        .expect("host should observe a stdin write failure");
+    assert_eq!(
+        stdin_err.errno,
+        Some(libc::EPIPE),
+        "expected EPIPE on broken pipe, got errno={:?} message={}",
+        stdin_err.errno,
+        stdin_err.message,
+    );
+}
+
 fn parse_wc_and_sha(stdout: &str) -> (String, String) {
     let mut lines = stdout.lines();
     let byte_count = lines

--- a/crates/microsandbox/tests/stdin.rs
+++ b/crates/microsandbox/tests/stdin.rs
@@ -177,10 +177,10 @@ async fn stdin_pipe_streams_chunks_in_order() {
 
 /// Broken-pipe test: the child reads only a short prefix of stdin and
 /// exits, closing its read end before the host's full payload has been
-/// delivered. The agent's stdin write should fail with EPIPE, which
-/// surfaces to the host as `ExecOutput::stdin_error()`. The session
-/// itself still completes with a normal exit code and stdout — the
-/// stdin failure is non-terminal.
+/// delivered. The agent's stdin write fails with EPIPE and surfaces
+/// mid-stream as `ExecEvent::StdinError`, while the session itself
+/// still produces a normal `Exited { code: 0 }` event — the stdin
+/// failure is non-terminal.
 #[msb_test]
 async fn stdin_bytes_reports_broken_pipe_when_child_exits_early() {
     let name = "stdin-broken-pipe";
@@ -195,8 +195,8 @@ async fn stdin_bytes_reports_broken_pipe_when_child_exits_early() {
         .await
         .expect("create sandbox");
 
-    let output = sandbox
-        .exec_with("sh", |exec| {
+    let mut handle = sandbox
+        .exec_stream_with("sh", |exec| {
             exec.args([
                 "-c",
                 "dd bs=1 count=16 of=/tmp/prefix.bin 2>/dev/null && wc -c /tmp/prefix.bin",
@@ -204,20 +204,37 @@ async fn stdin_bytes_reports_broken_pipe_when_child_exits_early() {
             .stdin_bytes(payload)
         })
         .await
-        .expect("exec returned");
+        .expect("start exec");
+
+    let mut stdout = Vec::new();
+    let mut exit_code: Option<i32> = None;
+    let mut stdin_error = None;
+    while let Some(event) = handle.recv().await {
+        match event {
+            ExecEvent::Stdout(data) => stdout.extend_from_slice(&data),
+            ExecEvent::StdinError(payload) => {
+                if stdin_error.is_none() {
+                    stdin_error = Some(payload);
+                }
+            }
+            ExecEvent::Exited { code } => {
+                exit_code = Some(code);
+                break;
+            }
+            ExecEvent::Failed(payload) => {
+                panic!("exec failed: {payload:?}");
+            }
+            _ => {}
+        }
+    }
 
     sandbox.stop_and_wait().await.expect("stop");
     Sandbox::remove(name).await.expect("remove");
 
-    assert!(
-        output.status().success,
-        "guest command failed: stdout=`{}` stderr=`{}`",
-        output.stdout().unwrap_or_default(),
-        output.stderr().unwrap_or_default()
-    );
+    assert_eq!(exit_code, Some(0), "guest command exited non-zero");
 
-    let stdout = output.stdout().expect("stdout is utf8");
-    let prefix_count = stdout
+    let stdout_text = String::from_utf8(stdout).expect("stdout is utf8");
+    let prefix_count = stdout_text
         .lines()
         .next()
         .and_then(|line| line.split_whitespace().next())
@@ -227,9 +244,7 @@ async fn stdin_bytes_reports_broken_pipe_when_child_exits_early() {
         "child should have read exactly 16 bytes"
     );
 
-    let stdin_err = output
-        .stdin_error()
-        .expect("host should observe a stdin write failure");
+    let stdin_err = stdin_error.expect("host should observe a StdinError event");
     assert_eq!(
         stdin_err.errno,
         Some(libc::EPIPE),

--- a/crates/microsandbox/tests/stdin.rs
+++ b/crates/microsandbox/tests/stdin.rs
@@ -1,0 +1,191 @@
+//! Integration tests for stdin delivery.
+//!
+//! These tests require KVM (or libkrun on macOS). The `#[msb_test]`
+//! attribute marks them `#[ignore]`, so plain `cargo test --workspace`
+//! skips them. Run them via:
+//!
+//!     cargo nextest run -p microsandbox --test stdin --run-ignored=only
+
+use microsandbox::{ExecEvent, Sandbox};
+use sha2::{Digest, Sha256};
+use test_utils::msb_test;
+
+const ONE_MIB: usize = 1024 * 1024;
+
+/// Realistic large-payload test: reader (`cat`) starts immediately and
+/// drains in parallel with the host write. Whether the guest pipe ever
+/// fills (and trips EAGAIN) depends on scheduling, but the payload is
+/// large enough that on most hosts it does at least once.
+#[msb_test]
+async fn stdin_bytes_writes_payload_larger_than_pipe_capacity() {
+    let name = "stdin-bytes-1mib";
+    let payload = vec![b'x'; ONE_MIB];
+    let expected_sha = hex::encode(Sha256::digest(&payload));
+
+    let sandbox = Sandbox::builder(name)
+        .image("mirror.gcr.io/library/alpine")
+        .cpus(1)
+        .memory(512)
+        .replace()
+        .create()
+        .await
+        .expect("create sandbox");
+
+    let output = sandbox
+        .exec_with("sh", |exec| {
+            exec.args([
+                "-c",
+                "cat > /tmp/stdin-1mb.bin && wc -c /tmp/stdin-1mb.bin && sha256sum /tmp/stdin-1mb.bin",
+            ])
+            .stdin_bytes(payload)
+        })
+        .await
+        .expect("write stdin payload");
+
+    sandbox.stop_and_wait().await.expect("stop");
+    Sandbox::remove(name).await.expect("remove");
+
+    assert!(
+        output.status().success,
+        "guest command failed: stdout=`{}` stderr=`{}`",
+        output.stdout().unwrap_or_default(),
+        output.stderr().unwrap_or_default()
+    );
+
+    let (byte_count, actual_sha) = parse_wc_and_sha(&output.stdout().expect("stdout is utf8"));
+    assert_eq!(byte_count, ONE_MIB.to_string());
+    assert_eq!(actual_sha, expected_sha);
+}
+
+/// Deterministic EAGAIN test: the guest reader sleeps for a second before
+/// starting to drain stdin. The host write therefore fills the kernel pipe
+/// buffer and *must* hit EAGAIN, exercising the poll-and-retry path in
+/// `blocking_write_fd` rather than relying on scheduling.
+#[msb_test]
+async fn stdin_bytes_waits_for_slow_reader() {
+    let name = "stdin-bytes-slow-reader";
+    let payload = vec![b'y'; ONE_MIB];
+    let expected_sha = hex::encode(Sha256::digest(&payload));
+
+    let sandbox = Sandbox::builder(name)
+        .image("mirror.gcr.io/library/alpine")
+        .cpus(1)
+        .memory(512)
+        .replace()
+        .create()
+        .await
+        .expect("create sandbox");
+
+    let output = sandbox
+        .exec_with("sh", |exec| {
+            exec.args([
+                "-c",
+                "sleep 1; cat > /tmp/stdin-slow.bin && wc -c /tmp/stdin-slow.bin && sha256sum /tmp/stdin-slow.bin",
+            ])
+            .stdin_bytes(payload)
+        })
+        .await
+        .expect("write stdin payload");
+
+    sandbox.stop_and_wait().await.expect("stop");
+    Sandbox::remove(name).await.expect("remove");
+
+    assert!(
+        output.status().success,
+        "guest command failed: stdout=`{}` stderr=`{}`",
+        output.stdout().unwrap_or_default(),
+        output.stderr().unwrap_or_default()
+    );
+
+    let (byte_count, actual_sha) = parse_wc_and_sha(&output.stdout().expect("stdout is utf8"));
+    assert_eq!(byte_count, ONE_MIB.to_string());
+    assert_eq!(actual_sha, expected_sha);
+}
+
+/// Streaming test: multiple sequential `ExecSink::write` calls, each
+/// exceeding typical pipe capacity. Verifies that repeated invocations
+/// of `write_stdin` (rather than a single bytes payload) all reach the
+/// guest in order and the closing `ExecSink::close` propagates EOF.
+#[msb_test]
+async fn stdin_pipe_streams_chunks_in_order() {
+    let name = "stdin-pipe-stream";
+    let chunk_size = 256 * 1024;
+    let chunk_count = 4;
+
+    let mut payload = Vec::with_capacity(chunk_size * chunk_count);
+    let mut chunks: Vec<Vec<u8>> = Vec::with_capacity(chunk_count);
+    for i in 0..chunk_count {
+        let byte = b'a' + i as u8;
+        let chunk = vec![byte; chunk_size];
+        payload.extend_from_slice(&chunk);
+        chunks.push(chunk);
+    }
+    let expected_sha = hex::encode(Sha256::digest(&payload));
+    let total_bytes = payload.len();
+
+    let sandbox = Sandbox::builder(name)
+        .image("mirror.gcr.io/library/alpine")
+        .cpus(1)
+        .memory(512)
+        .replace()
+        .create()
+        .await
+        .expect("create sandbox");
+
+    let mut handle = sandbox
+        .exec_stream_with("sh", |exec| {
+            exec.args([
+                "-c",
+                "cat > /tmp/stdin-stream.bin && wc -c /tmp/stdin-stream.bin && sha256sum /tmp/stdin-stream.bin",
+            ])
+            .stdin_pipe()
+        })
+        .await
+        .expect("start exec");
+
+    let stdin = handle.take_stdin().expect("stdin pipe");
+    for chunk in &chunks {
+        stdin.write(chunk).await.expect("write chunk");
+    }
+    stdin.close().await.expect("close stdin");
+
+    let mut stdout = Vec::new();
+    let mut exit_code: Option<i32> = None;
+    while let Some(event) = handle.recv().await {
+        match event {
+            ExecEvent::Stdout(data) => stdout.extend_from_slice(&data),
+            ExecEvent::Exited { code } => {
+                exit_code = Some(code);
+                break;
+            }
+            ExecEvent::Failed(payload) => {
+                panic!("exec failed: {payload:?}");
+            }
+            _ => {}
+        }
+    }
+
+    sandbox.stop_and_wait().await.expect("stop");
+    Sandbox::remove(name).await.expect("remove");
+
+    assert_eq!(exit_code, Some(0), "guest command exited non-zero");
+    let stdout_text = String::from_utf8(stdout).expect("stdout is utf8");
+    let (byte_count, actual_sha) = parse_wc_and_sha(&stdout_text);
+    assert_eq!(byte_count, total_bytes.to_string());
+    assert_eq!(actual_sha, expected_sha);
+}
+
+fn parse_wc_and_sha(stdout: &str) -> (String, String) {
+    let mut lines = stdout.lines();
+    let byte_count = lines
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .expect("byte count line")
+        .to_string();
+    let sha = lines
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .expect("sha256 line")
+        .to_string();
+    (byte_count, sha)
+}

--- a/crates/protocol/lib/exec.rs
+++ b/crates/protocol/lib/exec.rs
@@ -115,6 +115,24 @@ pub struct ExecStdin {
     pub data: Vec<u8>,
 }
 
+/// Notification that an `ExecStdin` write to the child's stdin failed.
+/// The most common cause is the child closing its read end (EPIPE);
+/// the session is otherwise alive and may still produce output and an
+/// exit code, so this is delivered as a non-terminal event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecStdinError {
+    /// `errno` from the underlying write, if available.
+    #[serde(default)]
+    pub errno: Option<i32>,
+
+    /// Standard errno name like `"EPIPE"`, populated when `errno` is.
+    #[serde(default)]
+    pub errno_name: Option<String>,
+
+    /// Human-readable description from agentd.
+    pub message: String,
+}
+
 /// Stdout data from a running command.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecStdout {

--- a/crates/protocol/lib/message.rs
+++ b/crates/protocol/lib/message.rs
@@ -87,6 +87,12 @@ pub enum MessageType {
     /// Host sends stdin data.
     ExecStdin,
 
+    /// Guest reports that a prior `ExecStdin` write to the child's
+    /// stdin failed (e.g. the child closed its read end). Non-terminal:
+    /// the session continues and may still produce stdout/stderr and
+    /// an exit code.
+    ExecStdinError,
+
     /// Guest sends stdout data.
     ExecStdout,
 
@@ -177,6 +183,7 @@ impl MessageType {
             Self::ExecRequest => "core.exec.request",
             Self::ExecStarted => "core.exec.started",
             Self::ExecStdin => "core.exec.stdin",
+            Self::ExecStdinError => "core.exec.stdin.error",
             Self::ExecStdout => "core.exec.stdout",
             Self::ExecStderr => "core.exec.stderr",
             Self::ExecExited => "core.exec.exited",
@@ -197,6 +204,7 @@ impl MessageType {
             "core.exec.request" => Some(Self::ExecRequest),
             "core.exec.started" => Some(Self::ExecStarted),
             "core.exec.stdin" => Some(Self::ExecStdin),
+            "core.exec.stdin.error" => Some(Self::ExecStdinError),
             "core.exec.stdout" => Some(Self::ExecStdout),
             "core.exec.stderr" => Some(Self::ExecStderr),
             "core.exec.exited" => Some(Self::ExecExited),
@@ -251,6 +259,7 @@ mod tests {
             (MessageType::ExecRequest, "core.exec.request"),
             (MessageType::ExecStarted, "core.exec.started"),
             (MessageType::ExecStdin, "core.exec.stdin"),
+            (MessageType::ExecStdinError, "core.exec.stdin.error"),
             (MessageType::ExecStdout, "core.exec.stdout"),
             (MessageType::ExecStderr, "core.exec.stderr"),
             (MessageType::ExecExited, "core.exec.exited"),
@@ -276,6 +285,7 @@ mod tests {
             MessageType::ExecRequest,
             MessageType::ExecStarted,
             MessageType::ExecStdin,
+            MessageType::ExecStdinError,
             MessageType::ExecStdout,
             MessageType::ExecStderr,
             MessageType::ExecExited,

--- a/sdk/node-ts/native/exec.rs
+++ b/sdk/node-ts/native/exec.rs
@@ -237,5 +237,13 @@ fn exec_event_to_js(event: RustExecEvent) -> ExecEvent {
             data: Some(payload.message.into_bytes().into()),
             code: payload.errno,
         },
+        // Stdin write failure (e.g. broken pipe). Non-terminal: the
+        // session continues and an "exited" event will follow.
+        RustExecEvent::StdinError(payload) => ExecEvent {
+            event_type: "stdin_error".to_string(),
+            pid: None,
+            data: Some(payload.message.into_bytes().into()),
+            code: payload.errno,
+        },
     }
 }

--- a/sdk/python/src/exec.rs
+++ b/sdk/python/src/exec.rs
@@ -252,6 +252,14 @@ fn convert_exec_event(event: microsandbox::ExecEvent) -> PyExecEvent {
             data: Some(payload.message.into_bytes()),
             code: payload.errno,
         },
+        // Stdin write failure (e.g. broken pipe). Non-terminal: the
+        // session continues and an `exited` event will follow.
+        microsandbox::ExecEvent::StdinError(payload) => PyExecEvent {
+            event_type: "stdin_error",
+            pid: None,
+            data: Some(payload.message.into_bytes()),
+            code: payload.errno,
+        },
     }
 }
 


### PR DESCRIPTION
## description

writing stdin payloads larger than the kernel pipe buffer (~64 KiB on linux) was failing because agentd's stdin write loop didn't handle EAGAIN on the non-blocking child pipe to guest processes. anything bigger than one pipeful errored out, even when the guest was happy to drain.

## fix

whenever an `EAGAIN` is encountered while writing to the child process, proceed to poll for `POLLOUT` event. if we successfully polled a `POLLOUT` event, resume writing. otherwise, keep polling.