### PR TITLE
fix(runtime): skip xattr-strict probe for user bind mounts

### DIFF
--- a/crates/microsandbox/tests/bind_mount.rs
+++ b/crates/microsandbox/tests/bind_mount.rs
@@ -1,0 +1,79 @@
+//! Integration test for bind mounts whose source directory is owned by
+//! another user.
+//!
+//! Reproducer for the bug fixed in this PR: `PassthroughFs::build()` in
+//! strict mode probes xattr support by writing
+//! `setxattr user.containers._probe` on the source directory. On Linux,
+//! writing a `user.*` xattr requires owning the file or holding
+//! CAP_SYS_ADMIN, so binding any directory the calling user doesn't own
+//! (`/tmp`, `/var`, `/etc`, …) failed up front with EPERM. The fix
+//! turns strict off for the user-bind-mount path in
+//! `crates/runtime/lib/vm.rs`.
+//!
+//! Pre-fix expectation (vm.rs unchanged): create-sandbox errored with
+//!   io error: mount <tag>: Operation not permitted (os error 1)
+//!
+//! Post-fix expectation: sandbox boots cleanly; bind contents are
+//! visible inside the guest; readonly is enforced at the kernel level.
+
+use microsandbox::Sandbox;
+use test_utils::msb_test;
+
+const IMAGE: &str = "mirror.gcr.io/library/alpine";
+
+async fn cleanup(name: &str) {
+    if let Ok(mut h) = Sandbox::get(name).await {
+        let _ = h.kill().await;
+        let _ = h.remove().await;
+    }
+}
+
+/// Bind `/tmp` (root-owned on every standard Linux) readonly into the
+/// guest. With strict-xattr enabled on user mounts, this would error
+/// out during sandbox start because the calling user can't write
+/// `user.*` xattrs to a directory they don't own.
+#[msb_test]
+async fn bind_mount_of_foreign_owned_directory_succeeds() {
+    let name = "bind-foreign-owned";
+    cleanup(name).await;
+
+    let sb = Sandbox::builder(name)
+        .image(IMAGE)
+        .cpus(1)
+        .memory(256)
+        .replace()
+        .volume("/host-tmp", |m| m.bind("/tmp").readonly())
+        .create()
+        .await
+        .expect("create sandbox with bind of /tmp");
+
+    // The mount point should exist and be enumerable.
+    let ls = sb
+        .shell("ls -1 /host-tmp >/dev/null 2>&1; echo $?")
+        .await
+        .expect("ls /host-tmp");
+    assert_eq!(
+        ls.stdout().expect("utf8").trim(),
+        "0",
+        "expected ls /host-tmp to succeed; got {ls:?}"
+    );
+
+    // Readonly is enforced by the guest kernel: touch should fail with
+    // "Read-only file system".
+    let write = sb
+        .shell("touch /host-tmp/probe-write 2>&1; true")
+        .await
+        .expect("touch attempt");
+    let combined = format!(
+        "{}{}",
+        write.stdout().unwrap_or_default(),
+        write.stderr().unwrap_or_default()
+    );
+    assert!(
+        combined.to_lowercase().contains("read-only"),
+        "expected read-only error, got: {combined:?}"
+    );
+
+    sb.stop_and_wait().await.expect("stop");
+    let _ = Sandbox::remove(name).await;
+}

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -663,9 +663,22 @@ fn build_vm(
 
         if let Some((tag, path)) = spec.split_once(':') {
             let tag = tag.to_string();
+            // `strict` makes PassthroughFs::build() probe xattr support
+            // by writing `setxattr user.containers._probe` on the source
+            // directory. Linux requires the caller to own the file (or
+            // hold CAP_SYS_ADMIN) to write a `user.*` xattr, so binding
+            // any directory the user doesn't own — /tmp, /var, /etc,
+            // foreign-owned dirs — fails up front with EPERM. The OCI
+            // rootfs path keeps strict because msb owns the rootfs it
+            // builds; user bind mounts are different.
+            //
+            // `xattr` stays true so opportunistic per-file stat
+            // virtualization remains available for callers who set the
+            // override xattrs.
             let cfg = PassthroughConfig {
                 root_dir: PathBuf::from(path),
                 inject_init: false,
+                strict: false,
                 ..Default::default()
             };
             let backend = PassthroughFs::new(cfg)


### PR DESCRIPTION
## Summary

One-line change in `crates/runtime/lib/vm.rs`: drop `strict` for user bind mounts so `PassthroughFs::build()` doesn't probe `setxattr user.*` on a source the calling user may not own.

## The bug

Try this on any standard Linux box as a non-root user:

```
msb run alpine --volume /tmp:/host-tmp ls /host-tmp
```

It fails before the VM boots with:

```
io error: mount <tag>: Operation not permitted (os error 1)
```

Same for `/var`, `/etc`, mounted USB drives owned by another user — anything the caller doesn't own. macOS APFS produces the identical error for the same reason.

## Root cause

`crates/runtime/lib/vm.rs` builds a `PassthroughFs` backend for each user volume:

```rust
let cfg = PassthroughConfig {
    root_dir: PathBuf::from(path),
    inject_init: false,
    ..Default::default()   // strict: true, xattr: true
};
```

With `strict: true`, `PassthroughFs::build()` probes xattr support by writing `setxattr user.containers._probe` on the source directory. On Linux, writing a `user.*` xattr requires the caller to own the file (or hold `CAP_SYS_ADMIN`). So the probe returns `EPERM`, build returns the io error, msb wraps as ``mount <tag>: ...``, and start fails.

I verified the failure in isolation with a small driver that calls `PassthroughFs::new` directly against `/var` from an unprivileged shell on macOS:

```
target: /var (uid=501)
  xattr=true,strict=true   (default): ERR -> Operation not permitted (os error 1)
  xattr=true,strict=false           : OK
  xattr=false,strict=false          : OK
```

So `strict: false` alone is sufficient — the per-file xattr translation feature (when `xattr: true`) is not what's failing; it's the eager probe.

## The fix

```diff
 let cfg = PassthroughConfig {
     root_dir: PathBuf::from(path),
     inject_init: false,
+    strict: false,
     ..Default::default()
 };
```

Scoped strictly to the user-bind-mount loop. The OCI rootfs (msb builds and owns it) and runtime-dir paths keep their strict defaults — xattr-based stat virtualization is load-bearing there for uid/gid translation between host and guest. User bind mounts don't use that machinery.

`xattr` stays `true` so any future code path that pre-stamps `user.containers.*` override xattrs still gets per-file translation opportunistically.

## Why is this surfacing now

The strict+xattr defaults have been in `PassthroughFs` since the original backend (#390, March 8). `vm.rs` has wired user bind mounts through `..Default::default()` since #448 (March 26). No regression — the bug is ~2 months old.

Users haven't reported it because the dominant bind-mount workflow is *bind my own project directory*, where the caller owns the source and the probe succeeds. `/tmp`, `/var`, `/etc`, etc., are the unusual case.

No SDK has had an integration test that boots a sandbox with a bind-mount of a foreign-owned directory **until the Go SDK's TestBindMountReadonly in #587**. That's the first test to hit this code path against a root-owned source on the self-hosted Linux runner, and that's where it surfaced. The Go test is currently skipped (with a comment pointing at this PR) while this one is in review.

## Security

Walked through the threat model:

- **Privilege boundary**: unchanged. virtio-fs serves files at the calling user's permissions. The probe was a UX guard that failed up front; without it, the mount succeeds and per-file permission enforcement is still done by the host kernel during each FUSE op.
- **Sandbox escape**: unchanged. The FUSE op model is identical pre/post fix.
- **Xattr deception**: writing `user.*` xattrs already requires owning the file. An attacker who can plant fake metadata xattrs can already modify the file itself. No new capability.
- **OCI rootfs sandboxing**: untouched. Rootfs `PassthroughConfig` keeps strict + xattr.
- **TOCTOU**: the probe wrote and immediately removed an xattr. Removing the probe closes that (theoretical) race window. Net positive.

## Test

New `crates/microsandbox/tests/bind_mount.rs`:

- Boots an alpine sandbox.
- Binds `/tmp` (root-owned on every standard Linux) readonly into the guest.
- Pre-fix: errored at start with EPERM.
- Post-fix: sandbox boots; `ls /host-tmp` succeeds inside the guest; `touch /host-tmp/probe` fails with "Read-only file system" (kernel-level enforcement, proves the mount is actually readonly).

## Test plan

- [ ] CI `Integration Tests` job runs `bind_mount.rs` and passes
- [ ] `cargo test -p microsandbox --test bind_mount` locally on Linux
- [ ] Spot-check that other PassthroughFs callers (rootfs, runtime-dir, trampolines) still hold strict by reading the surrounding code
- [ ] Once merged, unblock the Go SDK's `TestBindMountReadonly` skip in #587