### PR TITLE
chore(sandbox): rename `replace_grace` for clarity

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -50,7 +50,7 @@ pub struct SandboxOpts {
     /// is SIGKILLed during a replace. Accepts `0`, `500ms`, `5s`, `2m`.
     /// Implies `--replace`. Default 10s when `--replace` is set on its own.
     #[arg(long, value_name = "DURATION")]
-    pub replace_grace: Option<String>,
+    pub replace_with_grace: Option<String>,
 
     /// Suppress progress output.
     #[arg(short, long)]
@@ -337,9 +337,9 @@ pub fn apply_sandbox_opts(
     if let Some(ref shell) = opts.shell {
         builder = builder.shell(shell);
     }
-    if let Some(ref grace) = opts.replace_grace {
-        let d = parse_duration(grace).map_err(|e| anyhow::anyhow!("--replace-grace: {e}"))?;
-        builder = builder.replace_grace(d);
+    if let Some(ref grace) = opts.replace_with_grace {
+        let d = parse_duration(grace).map_err(|e| anyhow::anyhow!("--replace-with-grace: {e}"))?;
+        builder = builder.replace_with_grace(d);
     } else if opts.replace {
         builder = builder.replace();
     }

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -101,9 +101,9 @@ pub async fn run(args: RunArgs) -> anyhow::Result<()> {
     let name = args.sandbox.name.clone().unwrap_or_else(ui::generate_name);
 
     // Named sandboxes are reused if they already exist (unless --replace
-    // or --replace-grace). --replace-grace implies --replace, so either
+    // or --replace-with-grace). --replace-with-grace implies --replace, so either
     // flag opts out of the reuse path.
-    let replace_requested = args.sandbox.replace || args.sandbox.replace_grace.is_some();
+    let replace_requested = args.sandbox.replace || args.sandbox.replace_with_grace.is_some();
     if is_named && !replace_requested && Sandbox::get(&name).await.is_ok() {
         return run_existing(name, args).await;
     }

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -230,7 +230,7 @@ impl SandboxBuilder {
     /// before recreating it. When the prior sandbox is owned by an
     /// in-process `Sandbox` handle, the handle's underlying child is
     /// signalled and reaped directly. Otherwise the existing PID is
-    /// signalled with SIGTERM, given [`replace_grace`](Self::replace_grace)
+    /// signalled with SIGTERM, given [`replace_with_grace`](Self::replace_with_grace)
     /// to exit, then SIGKILLed.
     pub fn replace(mut self) -> Self {
         self.config.replace_existing = true;
@@ -242,9 +242,9 @@ impl SandboxBuilder {
     ///
     /// A zero duration skips SIGTERM entirely. Default (when only
     /// `.replace()` is set) is ten seconds.
-    pub fn replace_grace(mut self, grace: std::time::Duration) -> Self {
+    pub fn replace_with_grace(mut self, grace: std::time::Duration) -> Self {
         self.config.replace_existing = true;
-        self.config.replace_grace = grace;
+        self.config.replace_with_grace = grace;
         self
     }
 

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -226,22 +226,29 @@ impl SandboxBuilder {
 
     /// Replace an existing sandbox with the same name during create.
     ///
-    /// If the existing sandbox is still active, microsandbox stops it
-    /// before recreating it. When the prior sandbox is owned by an
-    /// in-process `Sandbox` handle, the handle's underlying child is
-    /// signalled and reaped directly. Otherwise the existing PID is
-    /// signalled with SIGTERM, given [`replace_with_grace`](Self::replace_with_grace)
-    /// to exit, then SIGKILLed.
+    /// If a sandbox with this name is already active, microsandbox stops
+    /// the prior instance before recreating it: SIGTERM, wait up to ten
+    /// seconds for a graceful exit, then SIGKILL. When the prior sandbox
+    /// is owned by an in-process `Sandbox` handle, the handle's
+    /// underlying child is signalled and reaped directly.
+    ///
+    /// To override the ten-second grace, use [`replace_with_grace`]; pass
+    /// `Duration::ZERO` to skip SIGTERM and SIGKILL immediately.
+    ///
+    /// [`replace_with_grace`]: Self::replace_with_grace
     pub fn replace(mut self) -> Self {
         self.config.replace_existing = true;
         self
     }
 
-    /// How long to give the existing sandbox after SIGTERM before
-    /// escalating to SIGKILL during a replace. Implies [`replace`](Self::replace).
+    /// Replace an existing sandbox, overriding the SIGTERM-to-SIGKILL
+    /// grace. Implies [`replace`](Self::replace) — calling this alone is
+    /// enough.
     ///
-    /// A zero duration skips SIGTERM entirely. Default (when only
-    /// `.replace()` is set) is ten seconds.
+    /// - `grace > 0`: SIGTERM, wait up to `grace`, then SIGKILL.
+    /// - `grace == Duration::ZERO`: SIGKILL immediately (skip SIGTERM).
+    ///
+    /// The default grace used by [`replace`](Self::replace) is ten seconds.
     pub fn replace_with_grace(mut self, grace: std::time::Duration) -> Self {
         self.config.replace_existing = true;
         self.config.replace_with_grace = grace;

--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -226,7 +226,7 @@ pub struct SandboxConfig {
     ///
     /// This is an operation flag, not persisted sandbox state.
     #[serde(skip)]
-    pub replace_grace: std::time::Duration,
+    pub replace_with_grace: std::time::Duration,
 
     /// Manifest digest for the resolved OCI image.
     ///
@@ -420,7 +420,7 @@ impl Default for SandboxConfig {
             insecure: false,
             ca_certs: Vec::new(),
             replace_existing: false,
-            replace_grace: std::time::Duration::from_secs(10),
+            replace_with_grace: std::time::Duration::from_secs(10),
             manifest_digest: None,
             snapshot_upper_source: None,
         }

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -1731,7 +1731,7 @@ async fn prepare_create_target(
             SandboxStatus::Running | SandboxStatus::Draining | SandboxStatus::Paused
         );
         if active {
-            stop_sandbox_for_replacement(pools, &model, config.replace_grace).await?;
+            stop_sandbox_for_replacement(pools, &model, config.replace_with_grace).await?;
         }
 
         sandbox_entity::Entity::delete_by_id(model.id)

--- a/crates/microsandbox/tests/replace.rs
+++ b/crates/microsandbox/tests/replace.rs
@@ -123,11 +123,11 @@ async fn create_without_replace_returns_typed_already_exists() {
     cleanup(name).await;
 }
 
-/// `.replace_grace(0)` skips SIGTERM and goes straight to SIGKILL.
+/// `.replace_with_grace(0)` skips SIGTERM and goes straight to SIGKILL.
 /// Should be at least as fast as the default 10-second grace.
 #[msb_test]
-async fn replace_grace_zero_succeeds() {
-    let name = "replace-grace-zero";
+async fn replace_with_grace_zero_succeeds() {
+    let name = "replace-with-grace-zero";
     cleanup(name).await;
 
     let sb1 = Sandbox::builder(name)
@@ -145,7 +145,7 @@ async fn replace_grace_zero_succeeds() {
             .image(IMAGE)
             .cpus(1)
             .memory(256)
-            .replace_grace(Duration::from_secs(0))
+            .replace_with_grace(Duration::from_secs(0))
             .create(),
     )
     .await

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -44,7 +44,7 @@ msb run -d --name worker python -- python worker.py
 | `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`, `as=1073741824`) |
 | `--detach-keys` | Key sequence to detach from interactive session (default: `ctrl-]`) |
 | `--replace` | Replace an existing sandbox with the same name |
-| `--replace-grace` | How long to wait after `SIGTERM` before `SIGKILL` during a replace (`0`, `500ms`, `5s`, `2m`). Implies `--replace`. Default `10s` when `--replace` is set alone |
+| `--replace-with-grace` | How long to wait after `SIGTERM` before `SIGKILL` during a replace (`0`, `500ms`, `5s`, `2m`). Implies `--replace`. Default `10s` when `--replace` is set alone |
 | `-q`, `--quiet` | Suppress progress output |
 | `--entrypoint` | Override the image's default entrypoint command |
 | `--init` | Hand off PID 1 to this init binary (absolute path) inside the guest after agentd's setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
@@ -87,8 +87,8 @@ Create and boot a sandbox without running a command. Takes the same flags as `ms
 ```bash
 msb create python --name worker -c 2 -m 1G
 msb create --replace python --name worker            # Replace existing
-msb create --replace-grace 30s python --name worker  # Give the old one 30s to exit
-msb create --replace-grace 0 python --name worker    # SIGKILL immediately
+msb create --replace-with-grace 30s python --name worker  # Give the old one 30s to exit
+msb create --replace-with-grace 0 python --name worker    # SIGKILL immediately
 ```
 
 ## msb start

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -255,7 +255,7 @@ use std::time::Duration;
 
 let sb = Sandbox::builder("worker")
     .image("python")
-    .replace_grace(Duration::from_secs(30))
+    .replace_with_grace(Duration::from_secs(30))
     .create()
     .await?;
 ```
@@ -263,22 +263,22 @@ let sb = Sandbox::builder("worker")
 ```typescript TypeScript
 await using sb = await Sandbox.builder("worker")
     .image("python")
-    .replaceGrace(30_000)  // milliseconds
+    .replaceWithGrace(30_000)  // milliseconds
     .create();
 ```
 
 ```python Python
-sb = await Sandbox.create("worker", image="python", replace_grace=30)  # seconds
+sb = await Sandbox.create("worker", image="python", replace_with_grace=30)  # seconds
 ```
 
 ```bash CLI
-msb create --replace-grace 30s python --name worker
-msb create --replace-grace 0 python --name worker  # SIGKILL immediately
+msb create --replace-with-grace 30s python --name worker
+msb create --replace-with-grace 0 python --name worker  # SIGKILL immediately
 ```
 
 </CodeGroup>
 
-`replace_grace` / `--replace-grace` implies `replace` / `--replace`, so you don't need to pass both.
+`replace_with_grace` / `--replace-with-grace` implies `replace` / `--replace`, so you don't need to pass both.
 
 ## Private registry
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -34,7 +34,7 @@ Create and boot a sandbox. The first argument is either a name (`str`) or a full
 | entrypoint | `list[str]` | Override image entrypoint |
 | init | `str \| dict \|` [`InitConfig`](#initconfig) | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) and [`InitConfig`](#initconfig) for accepted shapes |
 | replace | `bool` | Replace existing sandbox with same name (10s SIGTERM grace, then SIGKILL) |
-| replace_grace | `float` | Seconds to wait after `SIGTERM` before escalating to `SIGKILL` (default `10`; `0` skips `SIGTERM`). Implies `replace=True` |
+| replace_with_grace | `float` | Seconds to wait after `SIGTERM` before escalating to `SIGKILL` (default `10`; `0` skips `SIGTERM`). Implies `replace=True` |
 | max_duration | `float` | Maximum sandbox lifetime in seconds |
 | idle_timeout | `float` | Idle timeout in seconds |
 | env | `dict[str, str]` | Environment variables visible to all commands |

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -568,7 +568,7 @@ Fluent configuration builder returned by `Sandbox.builder(name)`. Every setter r
 | `script(name, content)` | Mount a script at `/.msb/scripts/<name>` |
 | `scripts(record \| iter)` | Mount many scripts |
 | `replace()` | Replace any existing sandbox with the same name (10s SIGTERM grace, then SIGKILL) |
-| `replaceGrace(graceMs)` | Same as `replace()` with a custom SIGTERM grace in milliseconds. `0` skips SIGTERM. Implies `replace()` |
+| `replaceWithGrace(graceMs)` | Same as `replace()` with a custom SIGTERM grace in milliseconds. `0` skips SIGTERM. Implies `replace()` |
 | `maxDuration(secs)` | Maximum sandbox lifetime |
 | `idleTimeout(secs)` | Stop the sandbox after this many idle seconds |
 | `volume(guestPath, m => ...)` | Mount a volume — see [Volumes](/sdk/typescript/volumes) |
@@ -680,7 +680,7 @@ Frozen configuration object — produced by `SandboxBuilder.build()` and exposed
 | patches | `Patch[]` | Rootfs modifications applied before boot |
 | pullPolicy | `PullPolicy \| null` | Image pull behavior |
 | replace | `boolean` | Replace existing sandbox with same name |
-| replaceGraceMs | `number` | Milliseconds to wait after `SIGTERM` before escalating to `SIGKILL` (default `10000`; `0` skips `SIGTERM`) |
+| replaceWithGraceMs | `number` | Milliseconds to wait after `SIGTERM` before escalating to `SIGKILL` (default `10000`; `0` skips `SIGTERM`) |
 | maxDurationSecs | `number \| null` | Maximum sandbox lifetime |
 | idleTimeoutSecs | `number \| null` | Stop after idle time |
 | portsTcp | `Array<readonly [number, number]>` | TCP host→guest mappings |

--- a/sdk/node-ts/README.md
+++ b/sdk/node-ts/README.md
@@ -376,7 +376,7 @@ console.log(`reclaimed ${reclaimed} orphaned layers`);
 
 `replace()` stops a sandbox with the same name (if any) and recreates
 it. By default the existing sandbox gets 10 seconds to exit cleanly
-after `SIGTERM` before `SIGKILL`; pass `replaceGrace(ms)` to override.
+after `SIGTERM` before `SIGKILL`; pass `replaceWithGrace(ms)` to override.
 
 ```typescript
 import { Sandbox } from "microsandbox";
@@ -390,13 +390,13 @@ await using sb = await Sandbox.builder("worker")
 // Wait longer for a workload that needs more time to shut down.
 await using slow = await Sandbox.builder("worker")
   .image("alpine")
-  .replaceGrace(30_000)
+  .replaceWithGrace(30_000)
   .create();
 
 // Skip SIGTERM entirely; SIGKILL immediately.
 await using fast = await Sandbox.builder("worker")
   .image("alpine")
-  .replaceGrace(0)
+  .replaceWithGrace(0)
   .create();
 ```
 

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -763,7 +763,7 @@ export declare class SandboxBuilder {
    * to exit after SIGTERM before escalating to SIGKILL during a
    * replace. Implies `replace`. Zero skips SIGTERM entirely.
    */
-  replaceGrace(graceMs: number): this
+  replaceWithGrace(graceMs: number): this
   /** Override the image entrypoint. */
   entrypoint(cmd: Array<string>): this
   /**

--- a/sdk/node-ts/native/sandbox_builder.rs
+++ b/sdk/node-ts/native/sandbox_builder.rs
@@ -205,9 +205,10 @@ impl JsSandboxBuilder {
     /// to exit after SIGTERM before escalating to SIGKILL during a
     /// replace. Implies `replace`. Zero skips SIGTERM entirely.
     #[napi]
-    pub fn replace_grace(&mut self, grace_ms: u32) -> &Self {
+    pub fn replace_with_grace(&mut self, grace_ms: u32) -> &Self {
         let prev = self.take_inner();
-        self.inner = Some(prev.replace_grace(std::time::Duration::from_millis(grace_ms.into())));
+        self.inner =
+            Some(prev.replace_with_grace(std::time::Duration::from_millis(grace_ms.into())));
         self
     }
 

--- a/sdk/node-ts/native/sandbox_builder.rs
+++ b/sdk/node-ts/native/sandbox_builder.rs
@@ -194,6 +194,11 @@ impl JsSandboxBuilder {
     }
 
     /// Replace any existing sandbox with the same name.
+    ///
+    /// SIGTERMs the prior instance, waits up to 10 seconds for a
+    /// graceful exit, then SIGKILLs. To override the grace, use
+    /// `replaceWithGrace(ms)`; `replaceWithGrace(0)` skips SIGTERM and
+    /// SIGKILLs immediately.
     #[napi]
     pub fn replace(&mut self) -> &Self {
         let prev = self.take_inner();
@@ -201,9 +206,13 @@ impl JsSandboxBuilder {
         self
     }
 
-    /// Grace period (in milliseconds) to wait for the existing sandbox
-    /// to exit after SIGTERM before escalating to SIGKILL during a
-    /// replace. Implies `replace`. Zero skips SIGTERM entirely.
+    /// Replace any existing sandbox, overriding the SIGTERM-to-SIGKILL
+    /// grace. Implies `replace` — calling this alone is enough.
+    ///
+    /// - `graceMs > 0`: SIGTERM, wait up to `graceMs`, then SIGKILL.
+    /// - `graceMs == 0`: SIGKILL immediately (skip SIGTERM).
+    ///
+    /// The default grace used by `replace` is 10_000 ms.
     #[napi]
     pub fn replace_with_grace(&mut self, grace_ms: u32) -> &Self {
         let prev = self.take_inner();

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -95,7 +95,7 @@ export interface NapiSandboxBuilderSetters {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registry(configure: (b: any) => any): this;
   replace(): this;
-  replaceGrace(graceMs: number): this;
+  replaceWithGrace(graceMs: number): this;
   entrypoint(cmd: string[]): this;
   init(cmd: string, args?: string[]): this;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -306,8 +306,8 @@ async with await Sandbox.create("temp", image="alpine", replace=True) as sb:
 
 `replace=True` stops a sandbox with the same name (if any) and
 recreates it. By default the existing one gets 10 seconds to exit
-cleanly after `SIGTERM` before `SIGKILL`; pass `replace_grace` (in
-seconds, fractional allowed) to override. Setting `replace_grace`
+cleanly after `SIGTERM` before `SIGKILL`; pass `replace_with_grace` (in
+seconds, fractional allowed) to override. Setting `replace_with_grace`
 implies `replace=True`.
 
 ```python
@@ -315,10 +315,10 @@ implies `replace=True`.
 sb = await Sandbox.create("worker", image="alpine", replace=True)
 
 # Wait longer for a workload that needs more time to shut down.
-sb = await Sandbox.create("worker", image="alpine", replace_grace=30)
+sb = await Sandbox.create("worker", image="alpine", replace_with_grace=30)
 
 # Skip SIGTERM entirely; SIGKILL immediately.
-sb = await Sandbox.create("worker", image="alpine", replace_grace=0)
+sb = await Sandbox.create("worker", image="alpine", replace_with_grace=0)
 ```
 
 If you'd rather handle the conflict yourself, catch the typed error:

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -145,13 +145,13 @@ pub fn build_config_from_kwargs(
     {
         builder = builder.replace();
     }
-    if let Some(grace) = extract_opt::<f64>(kwargs, "replace_grace")? {
+    if let Some(grace) = extract_opt::<f64>(kwargs, "replace_with_grace")? {
         if grace < 0.0 {
             return Err(pyo3::exceptions::PyValueError::new_err(
-                "replace_grace must be non-negative",
+                "replace_with_grace must be non-negative",
             ));
         }
-        builder = builder.replace_grace(std::time::Duration::from_secs_f64(grace));
+        builder = builder.replace_with_grace(std::time::Duration::from_secs_f64(grace));
     }
     if let Some(max_duration) = extract_opt::<f64>(kwargs, "max_duration")? {
         if max_duration < 0.0 {


### PR DESCRIPTION
renames the sandbox option that controls how long `replace()` waits for the old sandbox to shut down. the previous name read as a noun ("the grace for replace"); the new name reads as the action ("replace with this grace period").

no behavior change. extracted out of #587 so that PR stays focused on the go SDK.