### PR TITLE
chore(release): automate version bumping

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,0 +1,79 @@
+name: Release version bump
+
+# Self-service version bump: dispatch with a target version and the
+# workflow runs scripts/bump-version.sh, regenerates lockfiles, and opens
+# a PR titled `chore: release vX.Y.Z`. After the PR merges, push the
+# `vX.Y.Z` tag manually to trigger release.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "new version (e.g. 0.4.6 or 0.4.6-rc.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Bump and open release PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate semver
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::version must be semver (X.Y.Z or X.Y.Z-prerelease), got: $VERSION"
+            exit 1
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install build deps for cargo check
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
+
+      - name: Bump manifests
+        run: ./scripts/bump-version.sh "${{ inputs.version }}"
+
+      - name: Refresh Cargo.lock
+        run: cargo check --workspace
+
+      - name: Refresh npm lockfile
+        working-directory: sdk/node-ts
+        run: npm install --package-lock-only --ignore-scripts
+
+      - name: Open release PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: "chore: release v${{ inputs.version }}"
+          body: |
+            release preparation for `v${{ inputs.version }}`.
+
+            bumped by `scripts/bump-version.sh`:
+            - `Cargo.toml` workspace + path-dep versions
+            - `sdk/node-ts/package.json` and per-platform sub-packages
+            - `sdk/go/setup.go` `sdkVersion` (if present)
+
+            regenerated:
+            - `Cargo.lock`
+            - `sdk/node-ts/package-lock.json`
+
+            after this PR merges:
+            1. `git tag v${{ inputs.version }} <merge-commit>`
+            2. `git push --tags`
+            3. `release.yml` runs and publishes to crates.io, npm, pypi, ghcr, and tags `sdk/go/v${{ inputs.version }}`.
+          branch: release/v${{ inputs.version }}
+          commit-message: "chore: bump to v${{ inputs.version }}"
+          base: main
+          delete-branch: true

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# bump-version.sh — set the microsandbox release version across every SDK
+# manifest in one shot.
+#
+# Usage:
+#   scripts/bump-version.sh <new-version>
+#   e.g. scripts/bump-version.sh 0.4.6
+#
+# Updates:
+#   - Cargo.toml (workspace.package.version + path-dep `version = "X.Y.Z"`
+#     entries across crates/*/Cargo.toml and sdk/*/Cargo.toml)
+#   - sdk/node-ts/package.json (top-level + optionalDependencies versions)
+#   - sdk/node-ts/npm/*/package.json (per-platform npm sub-packages)
+#   - sdk/go/setup.go (sdkVersion constant; consumed by EnsureInstalled to
+#     resolve the GitHub release artefact URL for libmicrosandbox_go_ffi)
+#
+# Does NOT regenerate Cargo.lock or sdk/node-ts/package-lock.json — run
+# `cargo check` and `npm install` afterwards.
+
+set -euo pipefail
+
+NEW="${1:-}"
+if [ -z "$NEW" ]; then
+  echo "usage: $0 <new-version> (e.g. 0.4.6 or 0.4.6-rc.1)" >&2
+  exit 2
+fi
+
+if [[ ! "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "error: version must be semver (X.Y.Z or X.Y.Z-prerelease)" >&2
+  exit 2
+fi
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+OLD=$(awk -F'"' '/^version = "/{print $2; exit}' Cargo.toml)
+if [ -z "$OLD" ]; then
+  echo "error: could not read current version from Cargo.toml" >&2
+  exit 1
+fi
+
+if [ "$OLD" = "$NEW" ]; then
+  echo "version already at ${NEW}, nothing to do"
+  exit 0
+fi
+
+echo "bumping ${OLD} -> ${NEW}"
+
+# Portable in-place sed (BSD/macOS and GNU/Linux).
+inplace() {
+  local expr="$1" file="$2"
+  sed -i.bak "$expr" "$file"
+  rm -- "${file}.bak"
+}
+
+# --- Rust: workspace + every path-dep version reference ------------------
+while IFS= read -r f; do
+  if grep -q "version = \"${OLD}\"" "$f"; then
+    inplace "s/version = \"${OLD}\"/version = \"${NEW}\"/g" "$f"
+    echo "  updated ${f}"
+  fi
+done < <(find Cargo.toml crates sdk -name Cargo.toml 2>/dev/null)
+
+# --- Node: package.json files --------------------------------------------
+# Top-level + per-platform sub-packages. The blanket "OLD" -> "NEW" inside
+# these specific files is safe: they only carry microsandbox versions.
+for f in sdk/node-ts/package.json sdk/node-ts/npm/*/package.json; do
+  [ -e "$f" ] || continue
+  if grep -q "\"${OLD}\"" "$f"; then
+    inplace "s/\"${OLD}\"/\"${NEW}\"/g" "$f"
+    echo "  updated ${f}"
+  fi
+done
+
+# --- Go: sdkVersion constant ---------------------------------------------
+GO_SETUP="sdk/go/setup.go"
+if grep -q "sdkVersion = \"${OLD}\"" "$GO_SETUP"; then
+  inplace "s/sdkVersion = \"${OLD}\"/sdkVersion = \"${NEW}\"/" "$GO_SETUP"
+  echo "  updated ${GO_SETUP}"
+fi
+
+echo
+echo "next steps:"
+echo "  cargo check                       # regenerate Cargo.lock"
+echo "  (cd sdk/node-ts && npm install)   # regenerate package-lock.json"
+echo "  git diff                          # review"


### PR DESCRIPTION
adds a GitHub Action that bumps the version number across every SDK at once.

today, before cutting a release you have to manually edit every version field (Cargo.toml, package.json, etc.), open a PR, and merge it before tagging. this Action does that bookkeeping in one click.

how to use:
1. go to the Actions tab and run "Release version bump"
2. enter the new version (e.g. `0.4.6`)
3. review and merge the PR it opens
4. tag the merge commit and push the tag to start the release