### PR TITLE
fix: trust system certs for prebuilt downloads

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -90,6 +90,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: Install agentd build deps
         run: sudo apt-get update && sudo apt-get install -y musl-tools
@@ -147,6 +149,8 @@ jobs:
           components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       # -- Linux build deps --
       - name: Install build deps (Linux)
@@ -344,6 +348,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: Install agentd build deps
         run: sudo apt-get update && sudo apt-get install -y musl-tools
@@ -134,6 +136,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       # -- Linux build deps --
       - name: Install build deps (Linux)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: Install agentd build deps
         run: sudo apt-get update && sudo apt-get install -y musl-tools
@@ -142,6 +144,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       # -- Linux build deps --
       - name: Install build deps (Linux)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2601,7 +2601,6 @@ dependencies = [
  "tokio",
  "tracing",
  "typed-builder",
- "ureq",
  "which",
 ]
 
@@ -2656,7 +2655,6 @@ dependencies = [
  "scopeguard",
  "tempfile",
  "tracing",
- "ureq",
 ]
 
 [[package]]
@@ -2807,6 +2805,7 @@ dependencies = [
  "reflink-copy",
  "scopeguard",
  "tempfile",
+ "ureq",
 ]
 
 [[package]]
@@ -5519,6 +5518,7 @@ dependencies = [
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "ureq-proto",
  "utf8-zero",
  "webpki-roots 1.0.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "sqlite",
 ] }
-ureq = "3"
+ureq = { version = "3", features = ["platform-verifier"] }
 rustls = { version = "0.23", default-features = false, features = [
     "logging",
     "ring",

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -20,8 +20,7 @@ tracing.workspace = true
 
 [features]
 default = ["prebuilt"]
-prebuilt = ["dep:ureq"]
+prebuilt = ["microsandbox-utils/http-client"]
 
 [build-dependencies]
 microsandbox-utils = { version = "0.4.5", path = "../utils" }
-ureq = { workspace = true, optional = true }

--- a/crates/filesystem/build.rs
+++ b/crates/filesystem/build.rs
@@ -4,7 +4,7 @@ use std::time::SystemTime;
 
 use microsandbox_utils::AGENTD_BINARY;
 #[cfg(feature = "prebuilt")]
-use microsandbox_utils::{PREBUILT_VERSION, agentd_download_url};
+use microsandbox_utils::{PREBUILT_VERSION, agentd_download_url, http_client};
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
@@ -129,7 +129,7 @@ fn download_to(url: &str, dest: &Path) {
         PathBuf::from(s)
     };
 
-    let response = ureq::get(url).call().unwrap_or_else(|e| {
+    let response = http_client().get(url).call().unwrap_or_else(|e| {
         panic!("failed to download {url}: {e}");
     });
 

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -18,7 +18,11 @@ path = "bin/main.rs"
 [features]
 default = ["keyring", "net", "prebuilt"]
 keyring = ["dep:dbus", "dep:keyring"]
-prebuilt = ["microsandbox-filesystem/prebuilt", "microsandbox-runtime/prebuilt"]
+prebuilt = [
+    "microsandbox-filesystem/prebuilt",
+    "microsandbox-runtime/prebuilt",
+    "microsandbox-utils/http-client",
+]
 net = ["dep:microsandbox-network", "microsandbox-runtime/net"]
 
 [dependencies]
@@ -61,7 +65,6 @@ which.workspace = true
 flate2.workspace = true
 microsandbox-utils = { version = "0.4.5", path = "../utils" }
 tar.workspace = true
-ureq.workspace = true
 
 [dev-dependencies]
 ipnetwork.workspace = true

--- a/crates/microsandbox/build.rs
+++ b/crates/microsandbox/build.rs
@@ -1,18 +1,25 @@
 //! Build script — downloads prebuilt msb + libkrunfw to `$MSB_HOME` (or
 //! `~/.microsandbox/`) under `{bin,lib}/`.
 
+#[cfg(feature = "prebuilt")]
 use std::fs;
+#[cfg(feature = "prebuilt")]
 use std::io::{self, Cursor, Read};
+#[cfg(feature = "prebuilt")]
 use std::path::{Path, PathBuf};
+#[cfg(feature = "prebuilt")]
 use std::process::Command;
 
+#[cfg(feature = "prebuilt")]
+use microsandbox_utils::http_client;
+#[cfg(feature = "prebuilt")]
+use microsandbox_utils::{LIBKRUNFW_ABI, PREBUILT_VERSION, bundle_download_url};
 use microsandbox_utils::{
-    LIBKRUNFW_ABI, MSB_BINARY, PREBUILT_VERSION, bundle_download_url,
-    libkrunfw_filename as utils_libkrunfw_filename, resolve_home,
+    MSB_BINARY, libkrunfw_filename as utils_libkrunfw_filename, resolve_home,
 };
 
 fn main() {
-    // Re-run if MSB_HOME changes — it determines where binaries are placed.
+    // Re-run if MSB_HOME changes - it determines where binaries are placed.
     println!("cargo:rerun-if-env-changed=MSB_HOME");
     println!("cargo:rerun-if-env-changed=HOME");
 
@@ -27,11 +34,12 @@ fn main() {
         base_dir.join("lib").join(libkrunfw_filename()).display()
     );
 
-    // Only download when the prebuilt feature is enabled.
-    if std::env::var("CARGO_FEATURE_PREBUILT").is_err() {
-        return;
-    }
+    #[cfg(feature = "prebuilt")]
+    install_prebuilt(base_dir);
+}
 
+#[cfg(feature = "prebuilt")]
+fn install_prebuilt(base_dir: PathBuf) {
     let bin_dir = base_dir.join("bin");
     let lib_dir = base_dir.join("lib");
 
@@ -83,6 +91,7 @@ fn libkrunfw_filename() -> String {
     utils_libkrunfw_filename(os)
 }
 
+#[cfg(feature = "prebuilt")]
 fn bundle_url() -> String {
     let arch = std::env::consts::ARCH;
     let os = if cfg!(target_os = "macos") {
@@ -93,6 +102,7 @@ fn bundle_url() -> String {
     bundle_download_url(PREBUILT_VERSION, arch, os)
 }
 
+#[cfg(feature = "prebuilt")]
 fn installed_msb_version(path: &Path) -> Option<String> {
     if !path.exists() {
         return None;
@@ -110,6 +120,7 @@ fn installed_msb_version(path: &Path) -> Option<String> {
         .map(std::string::ToString::to_string)
 }
 
+#[cfg(feature = "prebuilt")]
 fn install_ci_local_bundle(
     bin_dir: &Path,
     lib_dir: &Path,
@@ -147,6 +158,7 @@ fn install_ci_local_bundle(
     Ok(true)
 }
 
+#[cfg(feature = "prebuilt")]
 fn workspace_build_dir() -> Option<PathBuf> {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let workspace_root = manifest_dir.parent()?.parent()?;
@@ -156,13 +168,15 @@ fn workspace_build_dir() -> Option<PathBuf> {
     Some(workspace_root.join("build"))
 }
 
+#[cfg(feature = "prebuilt")]
 fn download(url: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let resp = ureq::get(url).call()?;
+    let resp = http_client().get(url).call()?;
     let mut buf = Vec::new();
     resp.into_body().into_reader().read_to_end(&mut buf)?;
     Ok(buf)
 }
 
+#[cfg(feature = "prebuilt")]
 fn extract_bundle(data: &[u8], bin_dir: &Path, lib_dir: &Path) -> io::Result<()> {
     let decoder = flate2::read::GzDecoder::new(Cursor::new(data));
     let mut archive = tar::Archive::new(decoder);
@@ -192,6 +206,7 @@ fn extract_bundle(data: &[u8], bin_dir: &Path, lib_dir: &Path) -> io::Result<()>
     Ok(())
 }
 
+#[cfg(feature = "prebuilt")]
 fn create_symlinks(lib_dir: &Path, libkrunfw_name: &str) {
     #[cfg(unix)]
     {

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -10,11 +10,15 @@ edition.workspace = true
 [lib]
 path = "lib/lib.rs"
 
+[features]
+http-client = ["dep:ureq"]
+
 [dependencies]
 dirs.workspace = true
 libc.workspace = true
 reflink-copy.workspace = true
 scopeguard.workspace = true
+ureq = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/utils/lib/lib.rs
+++ b/crates/utils/lib/lib.rs
@@ -155,6 +155,19 @@ pub fn bundle_download_url(version: &str, arch: &str, os: &str) -> String {
     )
 }
 
+/// Returns an HTTP client configured for release asset downloads.
+#[cfg(feature = "http-client")]
+pub fn http_client() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .tls_config(
+            ureq::tls::TlsConfig::builder()
+                .root_certs(ureq::tls::RootCerts::PlatformVerifier)
+                .build(),
+        )
+        .build()
+        .new_agent()
+}
+
 //--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fix prebuilt runtime downloads so they use the platform certificate verifier instead of ureq's default webpki root bundle.

The shared download client now lives in `microsandbox-utils` behind an optional `http-client` feature, and both build scripts use that client for release asset downloads.

closes #701

## Why

Users building behind HTTP/TLS inspection proxies or with custom enterprise CAs can have those CAs installed in the OS trust store, but the previous `ureq::get(...)` path only trusted the bundled webpki roots. That caused build-script downloads for `agentd` and the microsandbox runtime bundle to fail with `InvalidCertificate(UnknownIssuer)`.

## CI hardening

Also disables caching `~/.cargo/bin` in rust-cache. This avoids restoring stale or incorrect cargo/rustup shims in CI, which can make `cargo build` accidentally execute `rustup-init build ...`.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p microsandbox-utils --features http-client`
- `cargo check -p microsandbox-utils --no-default-features`
- `cargo check -p microsandbox-filesystem --features prebuilt`
- `cargo check -p microsandbox --no-default-features --features prebuilt`
- commit hooks: workspace clippy, workspace docs, msb build
