### PR TITLE
chore(release): bump version to 0.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2686,14 +2686,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "sea-orm-migration",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "bytes",
  "chrono",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "chrono",
  "futures",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "bytes",
  "chrono",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "dirs",
  "libc",
@@ -5061,14 +5061,14 @@ dependencies = [
 
 [[package]]
 name = "test-init"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "test-macros"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.4.5"
+version = "0.4.6"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/crates/agentd/Cargo.lock
+++ b/crates/agentd/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "chrono",
  "ciborium",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "chrono",
  "ciborium",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -5,7 +5,7 @@ members = ["."]
 [workspace.package]
 authors = ["Super Rad Company <developemnt@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.4.5"
+version = "0.4.6"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -46,7 +46,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { version = "0.4.5", path = "../protocol" }
+microsandbox-protocol = { version = "0.4.6", path = "../protocol" }
 nix = { workspace = true, features = [
     "fs",
     "hostname",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,12 +36,12 @@ dirs.workspace = true
 indicatif.workspace = true
 ipnetwork = { workspace = true, optional = true }
 libc.workspace = true
-microsandbox = { version = "0.4.5", path = "../microsandbox", default-features = false }
-microsandbox-image = { version = "0.4.5", path = "../image" }
-microsandbox-network = { version = "0.4.5", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.5", path = "../protocol" }
-microsandbox-runtime = { version = "0.4.5", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.4.5", path = "../utils" }
+microsandbox = { version = "0.4.6", path = "../microsandbox", default-features = false }
+microsandbox-image = { version = "0.4.6", path = "../image" }
+microsandbox-network = { version = "0.4.6", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.6", path = "../protocol" }
+microsandbox-runtime = { version = "0.4.6", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.4.6", path = "../utils" }
 rand.workspace = true
 regex = "1"
 reqwest.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { version = "0.4.5", path = "../utils" }
+microsandbox-utils = { version = "0.4.6", path = "../utils" }
 msb_krun = "0.1.12"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,4 +23,4 @@ default = ["prebuilt"]
 prebuilt = ["microsandbox-utils/http-client"]
 
 [build-dependencies]
-microsandbox-utils = { version = "0.4.5", path = "../utils" }
+microsandbox-utils = { version = "0.4.6", path = "../utils" }

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { version = "0.4.5", path = "../utils" }
+microsandbox-utils = { version = "0.4.6", path = "../utils" }
 oci-client.workspace = true
 rustls-pemfile.workspace = true
 oci-spec.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -37,14 +37,14 @@ flate2.workspace = true
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-db = { version = "0.4.5", path = "../db" }
-microsandbox-filesystem = { version = "0.4.5", path = "../filesystem", default-features = false }
-microsandbox-image = { version = "0.4.5", path = "../image" }
-microsandbox-migration = { version = "0.4.5", path = "../migration" }
-microsandbox-network = { version = "0.4.5", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.5", path = "../protocol" }
-microsandbox-runtime = { version = "0.4.5", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.4.5", path = "../utils" }
+microsandbox-db = { version = "0.4.6", path = "../db" }
+microsandbox-filesystem = { version = "0.4.6", path = "../filesystem", default-features = false }
+microsandbox-image = { version = "0.4.6", path = "../image" }
+microsandbox-migration = { version = "0.4.6", path = "../migration" }
+microsandbox-network = { version = "0.4.6", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.6", path = "../protocol" }
+microsandbox-runtime = { version = "0.4.6", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.4.6", path = "../utils" }
 nix = { workspace = true, features = ["process", "signal"] }
 rand.workspace = true
 reqwest.workspace = true
@@ -63,7 +63,7 @@ which.workspace = true
 
 [build-dependencies]
 flate2.workspace = true
-microsandbox-utils = { version = "0.4.5", path = "../utils" }
+microsandbox-utils = { version = "0.4.6", path = "../utils" }
 tar.workspace = true
 
 [dev-dependencies]

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -24,8 +24,8 @@ hickory-proto = { workspace = true, features = ["tls-ring"] }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
-microsandbox-protocol = { version = "0.4.5", path = "../protocol" }
-microsandbox-utils = { version = "0.4.5", path = "../utils" }
+microsandbox-protocol = { version = "0.4.6", path = "../protocol" }
+microsandbox-utils = { version = "0.4.6", path = "../utils" }
 msb_krun = { version = "0.1.12", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,11 +22,11 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
-microsandbox-db = { version = "0.4.5", path = "../db" }
-microsandbox-filesystem = { version = "0.4.5", path = "../filesystem", default-features = false }
-microsandbox-network = { version = "0.4.5", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.5", path = "../protocol" }
-microsandbox-utils = { version = "0.4.5", path = "../utils" }
+microsandbox-db = { version = "0.4.6", path = "../db" }
+microsandbox-filesystem = { version = "0.4.6", path = "../filesystem", default-features = false }
+microsandbox-network = { version = "0.4.6", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.6", path = "../protocol" }
+microsandbox-utils = { version = "0.4.6", path = "../utils" }
 msb_krun = { version = "0.1.12", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/init-handoff/package-lock.json
+++ b/examples/typescript/init-handoff/package-lock.json
@@ -8,7 +8,7 @@
       "name": "init-handoff",
       "version": "0.1.0",
       "dependencies": {
-        "microsandbox": "0.4.5"
+        "microsandbox": "0.4.6"
       },
       "devDependencies": {
         "tsx": "^4"
@@ -457,8 +457,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.4.5.tgz",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.4.6.tgz",
       "integrity": "sha512-g9yU8UMwt9fcbG3CvCu16S7SZnH/q2eryKr/kNbBV3SjiGHOBJtvFhG+jD11i0HBnnje3ClszKvAvrXDTIEt+Q==",
       "cpu": [
         "arm64"
@@ -473,8 +473,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.4.5.tgz",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.4.6.tgz",
       "integrity": "sha512-YBS6Uuml4drOk8Dt+bAiNO6AO3dbKYF6JdUSVtYmbN3DFnA02JTvnxU01G7nfMVlq/nFySWY6801vqKMjRj75A==",
       "cpu": [
         "arm64"
@@ -492,8 +492,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.4.5.tgz",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.4.6.tgz",
       "integrity": "sha512-UXvLnjHFYdS1z8/sXiMxBzOBepQlOqIvry3xIjhT791+207fhAjcaRyhelf7r6amKHPDTo7w0Dah9xN6jNM0Qw==",
       "cpu": [
         "x64"
@@ -581,8 +581,8 @@
       }
     },
     "node_modules/microsandbox": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/microsandbox/-/microsandbox-0.4.5.tgz",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/microsandbox/-/microsandbox-0.4.6.tgz",
       "integrity": "sha512-qoNss8p0MQjR7R3Gwb8jVZPO7b99nkPBGATF6oTwVORL4f/0xPa8oEi2zMVM6GpxhJ/oBiALFK9T1mQdp3z0zA==",
       "license": "Apache-2.0",
       "bin": {
@@ -593,9 +593,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.5",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.5",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.5"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.6",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.6",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.6"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/examples/typescript/init-handoff/package.json
+++ b/examples/typescript/init-handoff/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/logs-read/package-lock.json
+++ b/examples/typescript/logs-read/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -32,9 +32,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.5",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.5",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.5"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.6",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.6",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/shell-attach/package-lock.json
+++ b/examples/typescript/shell-attach/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -32,9 +32,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.5",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.5",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.5"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.6",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.6",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/snapshot-fork/package.json
+++ b/examples/typescript/snapshot-fork/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.5"
+    "microsandbox": "0.4.6"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -3,40 +3,68 @@
 # manifest in one shot.
 #
 # Usage:
-#   scripts/bump-version.sh <new-version>
+#   scripts/bump-version.sh <new-version> [<old-version>]
 #   e.g. scripts/bump-version.sh 0.4.6
+#        scripts/bump-version.sh 0.4.6 0.4.5   # mop up a partial bump
+#
+# If <old-version> is omitted, it's auto-detected from the first
+# `version = "X.Y.Z"` line in the root Cargo.toml. Pass it explicitly when
+# re-running against a tree that's already partway through a bump (e.g. a
+# prior run touched Cargo.toml but missed the example manifests).
 #
 # Updates:
 #   - Cargo.toml (workspace.package.version + path-dep `version = "X.Y.Z"`
 #     entries across crates/*/Cargo.toml and sdk/*/Cargo.toml)
+#   - crates/agentd/Cargo.lock (the agentd sub-workspace ships its own
+#     lockfile that the root `cargo check` won't refresh — targeted sed
+#     against microsandbox-* entries)
 #   - sdk/node-ts/package.json (top-level + optionalDependencies versions)
 #   - sdk/node-ts/npm/*/package.json (per-platform npm sub-packages)
+#   - sdk/node-ts/native/index.cjs (napi-rs binding loader; pins the
+#     expected native package version for runtime mismatch checks)
+#   - examples/typescript/*/package.json (microsandbox dep pin in every
+#     TypeScript example)
+#   - sdk/node-ts/package-lock.json + examples/typescript/*/package-lock.json
+#     (microsandbox version pins and tarball URLs are text-bumped;
+#     integrity hashes are intentionally left stale, matching how past
+#     release PRs shipped these files — `npm install` overwrites them
+#     properly after the matching release is published to npm)
 #   - sdk/go/setup.go (sdkVersion constant; consumed by EnsureInstalled to
 #     resolve the GitHub release artefact URL for libmicrosandbox_go_ffi)
 #
-# Does NOT regenerate Cargo.lock or sdk/node-ts/package-lock.json — run
-# `cargo check` and `npm install` afterwards.
+# Does NOT regenerate the workspace Cargo.lock — run `cargo check`
+# afterwards. The next-steps block below lists the exact commands.
 
 set -euo pipefail
 
 NEW="${1:-}"
+OLD_ARG="${2:-}"
 if [ -z "$NEW" ]; then
-  echo "usage: $0 <new-version> (e.g. 0.4.6 or 0.4.6-rc.1)" >&2
+  echo "usage: $0 <new-version> [<old-version>] (e.g. 0.4.6 or 0.4.6-rc.1)" >&2
   exit 2
 fi
 
-if [[ ! "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-  echo "error: version must be semver (X.Y.Z or X.Y.Z-prerelease)" >&2
+semver_re='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+if [[ ! "$NEW" =~ $semver_re ]]; then
+  echo "error: <new-version> must be semver (X.Y.Z or X.Y.Z-prerelease)" >&2
+  exit 2
+fi
+if [ -n "$OLD_ARG" ] && [[ ! "$OLD_ARG" =~ $semver_re ]]; then
+  echo "error: <old-version> must be semver (X.Y.Z or X.Y.Z-prerelease)" >&2
   exit 2
 fi
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO"
 
-OLD=$(awk -F'"' '/^version = "/{print $2; exit}' Cargo.toml)
-if [ -z "$OLD" ]; then
-  echo "error: could not read current version from Cargo.toml" >&2
-  exit 1
+if [ -n "$OLD_ARG" ]; then
+  OLD="$OLD_ARG"
+else
+  OLD=$(awk -F'"' '/^version = "/{print $2; exit}' Cargo.toml)
+  if [ -z "$OLD" ]; then
+    echo "error: could not read current version from Cargo.toml" >&2
+    exit 1
+  fi
 fi
 
 if [ "$OLD" = "$NEW" ]; then
@@ -61,10 +89,45 @@ while IFS= read -r f; do
   fi
 done < <(find Cargo.toml crates sdk -name Cargo.toml 2>/dev/null)
 
+# --- Rust: Cargo.lock files ----------------------------------------------
+# Bump the workspace-versioned crate entries in both the root workspace
+# lockfile and the agentd sub-workspace lockfile. The set of crates to
+# touch is discovered from every Cargo.toml under crates/ and sdk/ that
+# declares `version.workspace = true` — that's exactly the population
+# whose Cargo.lock entries carry the workspace version. External crates
+# that happen to share the version string are left untouched. (`cargo
+# check` would refresh the root lockfile and is still listed in
+# next-steps as the source of truth, but seeding the right value here
+# keeps the post-script tree consistent.)
+WORKSPACE_CRATES=()
+while IFS= read -r toml; do
+  if grep -q '^version\.workspace = true' "$toml"; then
+    name=$(awk -F'"' '/^name = "/{print $2; exit}' "$toml")
+    [ -n "$name" ] && WORKSPACE_CRATES+=("$name")
+  fi
+done < <(find crates sdk -name Cargo.toml 2>/dev/null)
+
+for f in Cargo.lock crates/agentd/Cargo.lock; do
+  [ -f "$f" ] || continue
+  changed=0
+  for crate in "${WORKSPACE_CRATES[@]}"; do
+    if grep -q "^name = \"${crate}\"\$" "$f"; then
+      inplace "/^name = \"${crate}\"\$/{n;s/^version = \"${OLD}\"\$/version = \"${NEW}\"/;}" "$f"
+      changed=1
+    fi
+  done
+  [ "$changed" -eq 1 ] && echo "  updated ${f}"
+done
+
 # --- Node: package.json files --------------------------------------------
-# Top-level + per-platform sub-packages. The blanket "OLD" -> "NEW" inside
-# these specific files is safe: they only carry microsandbox versions.
-for f in sdk/node-ts/package.json sdk/node-ts/npm/*/package.json; do
+# Top-level SDK, per-platform sub-packages, and every TypeScript example.
+# The blanket "OLD" -> "NEW" inside these files is safe: each manifest's
+# own `version` field is independent (0.1.0 for examples) and never
+# coincides with a microsandbox release version.
+for f in \
+  sdk/node-ts/package.json \
+  sdk/node-ts/npm/*/package.json \
+  examples/typescript/*/package.json; do
   [ -e "$f" ] || continue
   if grep -q "\"${OLD}\"" "$f"; then
     inplace "s/\"${OLD}\"/\"${NEW}\"/g" "$f"
@@ -72,15 +135,43 @@ for f in sdk/node-ts/package.json sdk/node-ts/npm/*/package.json; do
   fi
 done
 
+# --- Node: package-lock.json files ---------------------------------------
+# Text-bump the microsandbox version pins and tarball URLs inside the SDK
+# lockfile and every committed example lockfile. Integrity hashes are
+# intentionally left alone — they're stale until the new version is
+# published to npm and the user (or CI's post-publish refresh) regenerates
+# the lockfile. This mirrors what prior release PRs (#672, #655, ...)
+# shipped by hand.
+for f in \
+  sdk/node-ts/package-lock.json \
+  examples/typescript/*/package-lock.json; do
+  [ -e "$f" ] || continue
+  if grep -q "\"${OLD}\"\|-${OLD}\.tgz" "$f"; then
+    inplace "s/\"${OLD}\"/\"${NEW}\"/g; s/-${OLD//./\\.}\.tgz/-${NEW}.tgz/g" "$f"
+    echo "  updated ${f}"
+  fi
+done
+
+# --- Node: napi-rs binding loader ----------------------------------------
+# sdk/node-ts/native/index.cjs is generated by napi-rs and embeds the
+# expected native-package version (used to trip a runtime mismatch error
+# when NAPI_RS_ENFORCE_VERSION_CHECK is set). The file only ever carries
+# microsandbox versions, so a blanket bare-X.Y.Z replace is safe.
+NATIVE_INDEX="sdk/node-ts/native/index.cjs"
+if [ -f "$NATIVE_INDEX" ] && grep -q "${OLD}" "$NATIVE_INDEX"; then
+  inplace "s/${OLD//./\\.}/${NEW}/g" "$NATIVE_INDEX"
+  echo "  updated ${NATIVE_INDEX}"
+fi
+
 # --- Go: sdkVersion constant ---------------------------------------------
 GO_SETUP="sdk/go/setup.go"
-if grep -q "sdkVersion = \"${OLD}\"" "$GO_SETUP"; then
+if [ -f "$GO_SETUP" ] && grep -q "sdkVersion = \"${OLD}\"" "$GO_SETUP"; then
   inplace "s/sdkVersion = \"${OLD}\"/sdkVersion = \"${NEW}\"/" "$GO_SETUP"
   echo "  updated ${GO_SETUP}"
 fi
 
 echo
 echo "next steps:"
-echo "  cargo check                       # regenerate Cargo.lock"
-echo "  (cd sdk/node-ts && npm install)   # regenerate package-lock.json"
-echo "  git diff                          # review"
+echo "  cargo check                          # regenerate Cargo.lock"
+echo "  (cd sdk/node-ts && npm install)     # regenerate package-lock.json"
+echo "  git diff                            # review"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -32,8 +32,10 @@
 #   - sdk/go/setup.go (sdkVersion constant; consumed by EnsureInstalled to
 #     resolve the GitHub release artefact URL for libmicrosandbox_go_ffi)
 #
-# Does NOT regenerate the workspace Cargo.lock — run `cargo check`
-# afterwards. The next-steps block below lists the exact commands.
+# Cargo.lock entries for workspace-versioned crates are bumped by sed,
+# but the script does not do a full cargo-driven regen — run `cargo
+# check` afterwards if you also need any dependency-graph changes
+# reflected. The next-steps block below lists the exact commands.
 
 set -euo pipefail
 

--- a/sdk/node-ts/Cargo.toml
+++ b/sdk/node-ts/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 path = "native/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.4.5", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.4.5", path = "../../crates/network" }
+microsandbox = { version = "0.4.6", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.4.6", path = "../../crates/network" }
 napi = { version = "3", default-features = false, features = [
     "async",
     "tokio_rt",

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -22,9 +22,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.5",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.5",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.5"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.6",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.6",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.6"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1849,8 +1849,8 @@
       "license": "MIT"
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.4.5.tgz",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.4.6.tgz",
       "integrity": "sha512-g9yU8UMwt9fcbG3CvCu16S7SZnH/q2eryKr/kNbBV3SjiGHOBJtvFhG+jD11i0HBnnje3ClszKvAvrXDTIEt+Q==",
       "cpu": [
         "arm64"
@@ -1865,8 +1865,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.4.5.tgz",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.4.6.tgz",
       "integrity": "sha512-YBS6Uuml4drOk8Dt+bAiNO6AO3dbKYF6JdUSVtYmbN3DFnA02JTvnxU01G7nfMVlq/nFySWY6801vqKMjRj75A==",
       "cpu": [
         "arm64"
@@ -1881,8 +1881,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.4.5.tgz",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.4.6.tgz",
       "integrity": "sha512-UXvLnjHFYdS1z8/sXiMxBzOBepQlOqIvry3xIjhT791+207fhAjcaRyhelf7r6amKHPDTo7w0Dah9xN6jNM0Qw==",
       "cpu": [
         "x64"

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -48,9 +48,9 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.4.5",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.5",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.4.5"
+    "@superradcompany/microsandbox-darwin-arm64": "0.4.6",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.6",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.4.6"
   },
   "files": [
     "dist",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.4.5", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.4.5", path = "../../crates/network" }
+microsandbox = { version = "0.4.6", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.4.6", path = "../../crates/network" }
 chrono = { workspace = true }
 ipnetwork = { version = "0.21.0", features = ["serde"] }
 pyo3 = { version = "0.24", features = ["abi3-py310", "extension-module"] }


### PR DESCRIPTION
## Summary

bump every microsandbox crate, the node-ts and python sdks, the napi-rs binding loader, the example pins, and the committed lockfiles from 0.4.5 to 0.4.6 ahead of the next release.

also extends `scripts/bump-version.sh` so a single run covers every place a microsandbox version pin lives:

- bumps the `microsandbox-*` and workspace `test-*` entries in both `Cargo.lock` and `crates/agentd/Cargo.lock`. the set of crates to touch is discovered from any `Cargo.toml` that declares `version.workspace = true`, so renames and new workspace crates keep working. external crates that share the version string are left alone.
- bumps `examples/typescript/*/package.json` (microsandbox dep pin in every example).
- bumps `sdk/node-ts/package-lock.json` and `examples/typescript/*/package-lock.json` by text-replacing version strings and tarball URLs. integrity hashes are intentionally left stale, mirroring how past release PRs (#672, #655, ...) shipped these files. `npm install` regenerates them properly after publish.
- bumps `sdk/node-ts/native/index.cjs` (napi-rs binding loader has the expected version baked into its runtime mismatch error).
- accepts an optional `<old-version>` second positional arg, so the script can re-run idempotently against a tree that's already partway through a bump.

## Test plan

- [ ] `cargo check` on the root workspace
- [ ] `cargo check --manifest-path crates/agentd/Cargo.toml`
- [ ] `(cd sdk/node-ts && npm install)` succeeds once 0.4.6 is published to npm and refreshes the lockfile integrity hashes
- [ ] release tag `v0.4.6` triggers `release.yml` end-to-end (crates.io, npm, pypi, ghcr, `sdk/go/v0.4.6`)