### PR TITLE
fix(sdk-node): accept link-local in plain-object network policies

### DIFF
--- a/sdk/node-ts/src/index.ts
+++ b/sdk/node-ts/src/index.ts
@@ -228,6 +228,8 @@ hideMethod(napi.SandboxBuilder, "attachWithBuilder");
   // serializing.
   const camelToSnake = (k: string): string =>
     k.replace(/[A-Z]/g, (c) => "_" + c.toLowerCase());
+  // The Rust enums are `serde(rename_all = "snake_case")`, while TS uses kebab-case.
+  const kebabToSnake = (s: string): string => s.replace(/-/g, "_");
   // Detect a TS-side Destination object (carries `kind` discriminator
   // produced by `Destination.any/cidr/domain/domainSuffix/group`) and
   // rewrite it to the Rust externally-tagged form.
@@ -248,7 +250,13 @@ hideMethod(napi.SandboxBuilder, "attachWithBuilder");
     // `cidr`, domain → `domain`, domainSuffix → `suffix`, group → `group`.
     // Map each to its Rust externally-tagged data slot.
     const dataField = v.kind === "domainSuffix" ? "suffix" : v.kind;
-    return { [tag]: deep(v[dataField]) };
+    // Only `group` carries an enum string ("link-local" -> "link_local").
+    // The other strings must be preserved as-is.
+    const value =
+      v.kind === "group" && typeof v.group === "string"
+        ? kebabToSnake(v.group)
+        : deep(v[dataField]);
+    return { [tag]: value };
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const remapKeys = (v: any): any => {

--- a/sdk/node-ts/tests/unit/policy.test.ts
+++ b/sdk/node-ts/tests/unit/policy.test.ts
@@ -202,6 +202,20 @@ describe("NetworkPolicyBuilder", () => {
     nb.policy(npb);
   });
 
+  it("NetworkBuilder.policy() accepts a link-local group destination", async () => {
+    const { NetworkBuilder } = await import("../../dist/index.js");
+    const nb = new NetworkBuilder();
+    // Plain object → policyJson → Rust serde (snake_case). Without
+    // kebab→snake, `"link-local"` would be rejected.
+    const policy = NetworkPolicy.builder()
+      .defaultDeny()
+      .egress((e) => e.allowLocal())
+      .build();
+    expect(policy.rules.some((r) => r.destination.kind === "group" &&
+      r.destination.group === "link-local")).toBe(true);
+    expect(() => nb.policy(policy)).not.toThrow();
+  });
+
   it("instanceof NetworkPolicyBuilder", () => {
     const npb = NetworkPolicy.builder();
     expect(npb).toBeInstanceOf(NetworkPolicyBuilder);


### PR DESCRIPTION
## Summary

`NetworkBuilder.policy(p)` rejected plain-object policies whose rules referenced a `link-local` `DestinationGroup` with `unknown variant 'link-local'`. the TS public string form is kebab-case, but the JSON path is parsed by rust serde with `rename_all = "snake_case"`, which only accepts `"link_local"`.

normalize `"link-local"` → `"link_local"` in `remapDestination` for the `group` variant only. cidr / domain / domain-suffix payloads pass through unchanged — domain names can legitimately contain hyphens.

the `NetworkPolicyBuilder` instance path (`policyFromBuilder`) was unaffected: it crosses ffi as a typed rust enum, not via serde.

## Test plan

- [x] `npm run test:unit` — 4 files / 64 tests pass
- [x] new regression test `NetworkBuilder.policy() accepts a link-local group destination` exercises the plain-object → `policyJson` path and fails without this fix