### PR TITLE
drop redundant MSB_PATH reads at python + node sdk layers

### DIFF
--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -1,10 +1,11 @@
 import { createRequire } from "node:module";
 import { msbPath } from "./resolve-binary.js";
 
-// Resolve the runtime binary once. User-provided MSB_PATH still wins, but the
-// SDK passes the resolved path to native code explicitly instead of relying on
-// JS-side process.env mutations being visible to Rust.
-const resolvedMsbPath = process.env.MSB_PATH || msbPath();
+// Resolve the bundled runtime binary once and push it into the Rust
+// resolver's SDK tier. User-provided MSB_PATH still wins — Rust reads it
+// natively as its highest-precedence tier — so we don't duplicate the
+// env-var read here.
+const resolvedMsbPath = msbPath();
 
 const require = createRequire(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/sdk/node-ts/src/internal/resolve-binary.ts
+++ b/sdk/node-ts/src/internal/resolve-binary.ts
@@ -59,10 +59,13 @@ function resolveBinDir(): string {
   return cachedBinDir;
 }
 
-/** Path to the bundled `msb` binary, or null if not yet installed. */
+/** Path to the bundled `msb` binary, or null if not yet installed.
+ *
+ * No MSB_PATH env-var read here on purpose — the Rust resolver honours
+ * MSB_PATH natively as its highest-precedence tier, so duplicating the
+ * read at the JS layer just adds an alternate code path for the same
+ * outcome. */
 export function msbPath(): string | null {
-  const explicit = process.env.MSB_PATH;
-  if (explicit) return existsSync(explicit) ? explicit : null;
   const p = join(resolveBinDir(), "msb");
   return existsSync(p) ? p : null;
 }

--- a/sdk/python/microsandbox/_runtime.py
+++ b/sdk/python/microsandbox/_runtime.py
@@ -4,8 +4,10 @@ The Python SDK bundles msb + libkrunfw inside the wheel at
 ``microsandbox/_bundled/{bin,lib}/``.  At runtime these paths are resolved
 via ``importlib.resources`` so they work regardless of install location.
 
-Environment variable overrides (for local dev against unreleased builds):
-  - ``MICROSANDBOX_MSB_PATH`` — absolute path to ``msb`` binary
+To override the resolved msb binary (e.g. for local dev against an
+unreleased build), set the ``MSB_PATH`` env var. The Rust resolver
+honours it natively as its highest-precedence tier — no SDK-side
+wrapping needed.
 
 libkrunfw is located by the Rust resolver relative to ``msb`` (``../lib/``),
 which matches the wheel bundle layout. Pass ``libkrunfw_path`` to
@@ -14,7 +16,6 @@ which matches the wheel bundle layout. Pass ``libkrunfw_path`` to
 
 from __future__ import annotations
 
-import os
 from importlib.resources import files
 from pathlib import Path
 
@@ -22,8 +23,5 @@ _BUNDLED = files("microsandbox._bundled")
 
 
 def msb_path() -> Path:
-    """Return the absolute path to the ``msb`` binary."""
-    override = os.environ.get("MICROSANDBOX_MSB_PATH")
-    if override:
-        return Path(override)
+    """Return the absolute path to the bundled ``msb`` binary."""
     return Path(str(_BUNDLED.joinpath("bin", "msb")))


### PR DESCRIPTION
## summary

dropped redundant msb-path env-var reads at the sdk layer in python and node. both sdks were funnelling env values into rust's tier 2 via `set_sdk_msb_path`, while rust's tier 1 already honoured the same env natively at spawn time.

- python: removed `MICROSANDBOX_MSB_PATH` read in `_runtime.py`
- node: removed `process.env.MSB_PATH` read in `resolve-binary.ts` + `napi.ts`

aligns both sdks with the go sdk pattern.

## breaking change

python users with `MICROSANDBOX_MSB_PATH=…` in their scripts must migrate to `MSB_PATH=…`. node users see no behaviour change. the `npx microsandbox` cli shim is unchanged.

## test plan

- [x] python: lint, unit tests, end-to-end sandbox with + without env vars
- [x] node: typecheck, build, end-to-end sandbox with + without env vars
- [x] confirmed `MICROSANDBOX_MSB_PATH` is silently ignored by python after the change