### PR TITLE
ci(release): warm go module proxy after tagging sdk/go

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -625,6 +625,18 @@ jobs:
           git tag -a "${GO_TAG}" -m "Go SDK ${ROOT_TAG}" HEAD
           git push origin "${GO_TAG}"
 
+      - name: Warm Go module proxy
+        # Force proxy.golang.org and sum.golang.org to ingest the new
+        # tag now instead of waiting for their scheduled discovery, which
+        # can take 10-60 minutes and leaves `go get @<new-version>`
+        # returning 404 for users on default GOPROXY in the meantime.
+        run: |
+          ROOT_TAG="${GITHUB_REF_NAME}"
+          MODULE="github.com/superradcompany/microsandbox/sdk/go"
+          curl -sSf "https://proxy.golang.org/${MODULE}/@v/${ROOT_TAG}.info" >/dev/null || true
+          curl -sSf "https://proxy.golang.org/${MODULE}/@v/${ROOT_TAG}.mod"  >/dev/null || true
+          curl -sSf "https://sum.golang.org/lookup/${MODULE}@${ROOT_TAG}"    >/dev/null || true
+
   # ---------------------------------------------------------------------------
   # Publish Docker image to GHCR
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

added a best-effort proxy-warming step to the `go-sdk-tag` job. after `git push origin sdk/go/vX.Y.Z`, hitting `proxy.golang.org/$MODULE/@v/$VERSION.{info,mod}` and `sum.golang.org/lookup/$MODULE@$VERSION` triggers on-demand discovery instead of waiting for the proxy's scheduled refresh, which can take 10-60 minutes. the calls are wrapped in `|| true` so transient errors do not fail the release; the proxy still discovers the tag on its own if these miss.

## Why

without this, `go get github.com/superradcompany/microsandbox/sdk/go@vX.Y.Z` fails with a 404 for the full discovery window on default GOPROXY settings, and `@latest` resolves to the prior pseudo-version. observed during the v0.4.7-rc1 cycle: tag took ~30 min to appear via the proxy; hitting the .info endpoint manually shortened that to seconds.

## Test plan

- [x] next release tag fires the workflow and the new step finishes with no curl errors in logs
- [x] on a clean machine with default GOPROXY, \`go get .../sdk/go@<that version>\` works immediately after the release job ends