### PR TITLE
docs(readme): add go sdk install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The SDK lets you create and control sandboxes directly from your application. `S
 > func main() {
 >     ctx := context.Background()
 >
+>     // Downloads the microsandbox runtime to ~/.microsandbox/ on first run.
 >     if err := microsandbox.EnsureInstalled(ctx); err != nil {
 >         log.Fatal(err)
 >     }

--- a/README.md
+++ b/README.md
@@ -45,13 +45,16 @@
 #### <img height="14" src="https://octicons-col.vercel.app/move-to-bottom/A770EF">&nbsp;&nbsp;Install the SDK
 
 > ```sh
-> cargo add microsandbox    # 🦀 Rust
+> cargo add microsandbox                                   # 🦀 Rust
 > ```
 > ```sh
-> uv add microsandbox       # 🐍 Python
+> uv add microsandbox                                      # 🐍 Python
 > ```
 > ```sh
-> npm i microsandbox        # 🟦 TypeScript
+> npm i microsandbox                                       # 🟦 TypeScript
+> ```
+> ```sh
+> go get github.com/superradcompany/microsandbox/sdk/go    # 🐹 Go
 > ```
 
 #### <img height="14" src="https://octicons-col.vercel.app/download/A770EF">&nbsp;&nbsp;Install the CLI **(Optional)**

--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ The SDK lets you create and control sandboxes directly from your application. `S
 > func main() {
 >     ctx := context.Background()
 >
+>     if err := microsandbox.EnsureInstalled(ctx); err != nil {
+>         log.Fatal(err)
+>     }
+>
 >     sandbox, err := microsandbox.CreateSandbox(ctx, "my-sandbox",
 >         microsandbox.WithImage("python"),
 >         microsandbox.WithCPUs(1),

--- a/README.md
+++ b/README.md
@@ -156,6 +156,44 @@ The SDK lets you create and control sandboxes directly from your application. `S
 > ```
 >
 > </details>
+>
+> <details>
+> <summary><b>&nbsp;Go Example →</b></summary>
+>
+> ```go
+> package main
+>
+> import (
+>     "context"
+>     "fmt"
+>     "log"
+>
+>     microsandbox "github.com/superradcompany/microsandbox/sdk/go"
+> )
+>
+> func main() {
+>     ctx := context.Background()
+>
+>     sandbox, err := microsandbox.CreateSandbox(ctx, "my-sandbox",
+>         microsandbox.WithImage("python"),
+>         microsandbox.WithCPUs(1),
+>         microsandbox.WithMemory(512),
+>     )
+>     if err != nil {
+>         log.Fatal(err)
+>     }
+>     defer sandbox.StopAndWait(ctx)
+>
+>     output, err := sandbox.Exec(ctx, "python", []string{"-c", "print('Hello from a microVM!')"})
+>     if err != nil {
+>         log.Fatal(err)
+>     }
+>
+>     fmt.Println(output.Stdout())
+> }
+> ```
+>
+> </details>
 
 
 > The first call to `create()` pulls the image if it isn't cached locally, so it may take longer depending on your connection. Subsequent runs reuse the cache.


### PR DESCRIPTION
## Summary

added `go get github.com/superradcompany/microsandbox/sdk/go` to the SDK install block alongside the existing Rust / Python / TypeScript lines. realigned the existing comments so the language labels line up with the new (longer) go line.

## Note on timing

right now `go get .../sdk/go@latest` resolves to `v0.4.7-rc1` because no stable `sdk/go/v*` tag exists yet. once `v0.4.7` (or any non-prerelease) ships, `@latest` will resolve to it automatically and RC users keep working via explicit `@v0.4.7-rc1` pins.

## Test plan

- [ ] readme renders correctly on github (alignment + emoji)