### PR TITLE
feat(net): make ipv4 and ipv6 pool configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,6 +2766,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "ipnetwork",
  "microsandbox",
  "microsandbox-network",
  "napi",

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -169,6 +169,11 @@ pub struct SandboxOpts {
     #[arg(long, value_name = "MS")]
     pub dns_query_timeout_ms: Option<u64>,
 
+    /// IPv4 pool used for per-sandbox /30 guest subnets. Default: 198.18.0.0/15.
+    #[cfg(feature = "net")]
+    #[arg(long = "net-ipv4-pool", value_name = "CIDR")]
+    pub net_ipv4_pool: Option<String>,
+
     /// Network rule. Repeatable; each value is a comma-separated list of
     /// rule tokens. Token grammar:
     /// `<action>[:<direction>]@<target>[:<proto>[:<ports>]]`.
@@ -478,6 +483,9 @@ fn apply_network_opts(
         if opts.net_default_ingress.is_some() {
             conflicts.push("--net-default-ingress");
         }
+        if opts.net_ipv4_pool.is_some() {
+            conflicts.push("--net-ipv4-pool");
+        }
         if !conflicts.is_empty() {
             anyhow::bail!(
                 "--no-net cannot be combined with {}; --no-net disables the guest network entirely, so rules and defaults are dead code. Drop --no-net to apply rules, or drop the rule flags to keep the network off.",
@@ -502,6 +510,7 @@ fn apply_network_opts(
         || !opts.net_rule.is_empty()
         || opts.net_default_egress.is_some()
         || opts.net_default_ingress.is_some()
+        || opts.net_ipv4_pool.is_some()
         || opts.max_connections.is_some()
         || opts.trust_host_cas
         || opts.tls_intercept
@@ -529,6 +538,14 @@ fn apply_network_opts(
             &opts.deny_domain_suffix,
         )?;
         let max_conn = opts.max_connections;
+        let ipv4_pool = opts
+            .net_ipv4_pool
+            .as_deref()
+            .map(|s| {
+                s.parse::<ipnetwork::Ipv4Network>()
+                    .map_err(anyhow::Error::from)
+            })
+            .transpose()?;
         let trust_host_cas = opts.trust_host_cas;
         let tls_intercept = opts.tls_intercept;
         let tls_ports = opts.tls_intercept_port.clone();
@@ -557,6 +574,9 @@ fn apply_network_opts(
             }
             if let Some(max) = max_conn {
                 n = n.max_connections(max);
+            }
+            if let Some(pool) = ipv4_pool {
+                n = n.ipv4_pool(pool);
             }
             if trust_host_cas {
                 n = n.trust_host_cas(true);

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -169,7 +169,7 @@ pub struct SandboxOpts {
     #[arg(long, value_name = "MS")]
     pub dns_query_timeout_ms: Option<u64>,
 
-    /// IPv4 pool used for per-sandbox /30 guest subnets. Default: 198.18.0.0/15.
+    /// IPv4 pool used for per-sandbox /30 guest subnets. Default: 172.16.0.0/12.
     #[cfg(feature = "net")]
     #[arg(long = "net-ipv4-pool", value_name = "CIDR")]
     pub net_ipv4_pool: Option<String>,

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -174,6 +174,11 @@ pub struct SandboxOpts {
     #[arg(long = "net-ipv4-pool", value_name = "CIDR")]
     pub net_ipv4_pool: Option<String>,
 
+    /// IPv6 pool used for per-sandbox /64 guest prefixes. Default: fd42:6d73:62::/48.
+    #[cfg(feature = "net")]
+    #[arg(long = "net-ipv6-pool", value_name = "CIDR")]
+    pub net_ipv6_pool: Option<String>,
+
     /// Network rule. Repeatable; each value is a comma-separated list of
     /// rule tokens. Token grammar:
     /// `<action>[:<direction>]@<target>[:<proto>[:<ports>]]`.
@@ -486,6 +491,9 @@ fn apply_network_opts(
         if opts.net_ipv4_pool.is_some() {
             conflicts.push("--net-ipv4-pool");
         }
+        if opts.net_ipv6_pool.is_some() {
+            conflicts.push("--net-ipv6-pool");
+        }
         if !conflicts.is_empty() {
             anyhow::bail!(
                 "--no-net cannot be combined with {}; --no-net disables the guest network entirely, so rules and defaults are dead code. Drop --no-net to apply rules, or drop the rule flags to keep the network off.",
@@ -511,6 +519,7 @@ fn apply_network_opts(
         || opts.net_default_egress.is_some()
         || opts.net_default_ingress.is_some()
         || opts.net_ipv4_pool.is_some()
+        || opts.net_ipv6_pool.is_some()
         || opts.max_connections.is_some()
         || opts.trust_host_cas
         || opts.tls_intercept
@@ -546,6 +555,14 @@ fn apply_network_opts(
                     .map_err(anyhow::Error::from)
             })
             .transpose()?;
+        let ipv6_pool = opts
+            .net_ipv6_pool
+            .as_deref()
+            .map(|s| {
+                s.parse::<ipnetwork::Ipv6Network>()
+                    .map_err(anyhow::Error::from)
+            })
+            .transpose()?;
         let trust_host_cas = opts.trust_host_cas;
         let tls_intercept = opts.tls_intercept;
         let tls_ports = opts.tls_intercept_port.clone();
@@ -577,6 +594,9 @@ fn apply_network_opts(
             }
             if let Some(pool) = ipv4_pool {
                 n = n.ipv4_pool(pool);
+            }
+            if let Some(pool) = ipv6_pool {
+                n = n.ipv6_pool(pool);
             }
             if trust_host_cas {
                 n = n.trust_host_cas(true);

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -180,8 +180,8 @@ impl NetworkBuilder {
 
     /// Set the IPv4 pool used to derive per-sandbox `/30` guest subnets.
     ///
-    /// The default is `198.18.0.0/15`, which avoids Tailscale's
-    /// `100.64.0.0/10` CGNAT range. Pools must be at least `/30`.
+    /// The default is `172.16.0.0/12`, matching Firecracker's documented
+    /// host/guest example at slot 0. Pools must be at least `/30`.
     pub fn ipv4_pool(mut self, pool: Ipv4Network) -> Self {
         if pool.prefix() > 30 {
             self.errors.push(BuildError::InvalidIpv4Pool {

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -5,7 +5,7 @@
 use std::net::IpAddr;
 use std::path::PathBuf;
 
-use ipnetwork::Ipv4Network;
+use ipnetwork::{Ipv4Network, Ipv6Network};
 
 use crate::config::{DnsConfig, InterfaceOverrides, NetworkConfig, PortProtocol, PublishedPort};
 use crate::dns::Nameserver;
@@ -189,6 +189,20 @@ impl NetworkBuilder {
             });
         } else {
             self.config.interface.ipv4_pool = Some(pool);
+        }
+        self
+    }
+
+    /// Set the IPv6 pool used to derive per-sandbox `/64` guest prefixes.
+    ///
+    /// The default is `fd42:6d73:62::/48`. Pools must be at least `/64`.
+    pub fn ipv6_pool(mut self, pool: Ipv6Network) -> Self {
+        if pool.prefix() > 64 {
+            self.errors.push(BuildError::InvalidIpv6Pool {
+                raw: pool.to_string(),
+            });
+        } else {
+            self.config.interface.ipv6_pool = Some(pool);
         }
         self
     }

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -180,8 +180,7 @@ impl NetworkBuilder {
 
     /// Set the IPv4 pool used to derive per-sandbox `/30` guest subnets.
     ///
-    /// The default is `172.16.0.0/12`, matching Firecracker's documented
-    /// host/guest example at slot 0. Pools must be at least `/30`.
+    /// The default is `172.16.0.0/12`. Pools must be at least `/30`.
     pub fn ipv4_pool(mut self, pool: Ipv4Network) -> Self {
         if pool.prefix() > 30 {
             self.errors.push(BuildError::InvalidIpv4Pool {

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -5,6 +5,8 @@
 use std::net::IpAddr;
 use std::path::PathBuf;
 
+use ipnetwork::Ipv4Network;
+
 use crate::config::{DnsConfig, InterfaceOverrides, NetworkConfig, PortProtocol, PublishedPort};
 use crate::dns::Nameserver;
 use crate::policy::{BuildError, NetworkPolicy};
@@ -173,6 +175,21 @@ impl NetworkBuilder {
     /// Set guest interface overrides.
     pub fn interface(mut self, overrides: InterfaceOverrides) -> Self {
         self.config.interface = overrides;
+        self
+    }
+
+    /// Set the IPv4 pool used to derive per-sandbox `/30` guest subnets.
+    ///
+    /// The default is `198.18.0.0/15`, which avoids Tailscale's
+    /// `100.64.0.0/10` CGNAT range. Pools must be at least `/30`.
+    pub fn ipv4_pool(mut self, pool: Ipv4Network) -> Self {
+        if pool.prefix() > 30 {
+            self.errors.push(BuildError::InvalidIpv4Pool {
+                raw: pool.to_string(),
+            });
+        } else {
+            self.config.interface.ipv4_pool = Some(pool);
+        }
         self
     }
 

--- a/crates/network/lib/config.rs
+++ b/crates/network/lib/config.rs
@@ -5,7 +5,7 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use ipnetwork::Ipv4Network;
+use ipnetwork::{Ipv4Network, Ipv6Network};
 use serde::{Deserialize, Serialize};
 
 use crate::dns::Nameserver;
@@ -89,9 +89,13 @@ pub struct InterfaceOverrides {
     #[serde(default)]
     pub ipv4_pool: Option<Ipv4Network>,
 
-    /// Guest IPv6 address. Default: derived from slot (fd42:6d73:62::/48 pool).
+    /// Guest IPv6 address. Default: derived from slot within `ipv6_pool`.
     #[serde(default)]
     pub ipv6_address: Option<Ipv6Addr>,
+
+    /// Guest IPv6 pool. Default: derived from slot (fd42:6d73:62::/48 pool).
+    #[serde(default)]
+    pub ipv6_pool: Option<Ipv6Network>,
 }
 
 /// DNS interception settings for the sandbox.

--- a/crates/network/lib/config.rs
+++ b/crates/network/lib/config.rs
@@ -5,6 +5,7 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+use ipnetwork::Ipv4Network;
 use serde::{Deserialize, Serialize};
 
 use crate::dns::Nameserver;
@@ -80,9 +81,13 @@ pub struct InterfaceOverrides {
     #[serde(default)]
     pub mtu: Option<u16>,
 
-    /// Guest IPv4 address. Default: derived from slot (100.96.0.0/11 pool).
+    /// Guest IPv4 address. Default: derived from slot within `ipv4_pool`.
     #[serde(default)]
     pub ipv4_address: Option<Ipv4Addr>,
+
+    /// Guest IPv4 pool. Default: derived from slot (198.18.0.0/15 pool).
+    #[serde(default)]
+    pub ipv4_pool: Option<Ipv4Network>,
 
     /// Guest IPv6 address. Default: derived from slot (fd42:6d73:62::/48 pool).
     #[serde(default)]

--- a/crates/network/lib/config.rs
+++ b/crates/network/lib/config.rs
@@ -85,7 +85,7 @@ pub struct InterfaceOverrides {
     #[serde(default)]
     pub ipv4_address: Option<Ipv4Addr>,
 
-    /// Guest IPv4 pool. Default: derived from slot (198.18.0.0/15 pool).
+    /// Guest IPv4 pool. Default: derived from slot (172.16.0.0/12 pool).
     #[serde(default)]
     pub ipv4_pool: Option<Ipv4Network>,
 

--- a/crates/network/lib/network.rs
+++ b/crates/network/lib/network.rs
@@ -9,6 +9,7 @@ use std::net::{Ipv4Addr, Ipv6Addr, UdpSocket};
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
+use ipnetwork::Ipv4Network;
 use microsandbox_protocol::{ENV_HOST_ALIAS, ENV_NET, ENV_NET_IPV4, ENV_NET_IPV6};
 use msb_krun::backends::net::NetBackend;
 
@@ -23,7 +24,7 @@ use crate::tls::state::TlsState;
 //--------------------------------------------------------------------------------------------------
 
 /// Maximum sandbox slot value. Limited by MAC/IPv6 encoding (16 bits = 65535).
-/// The IPv4 pool (100.96.0.0/11 with /30 blocks) supports up to 524287 slots,
+/// The default IPv4 pool (198.18.0.0/15 with /30 blocks) supports 131072 slots,
 /// but MAC and IPv6 derivation only encode the low 16 bits, so 65535 is the
 /// effective maximum.
 const MAX_SLOT: u64 = u16::MAX as u64;
@@ -110,10 +111,17 @@ impl SmoltcpNetwork {
         let gateway_mac = derive_gateway_mac(slot);
         let mtu = config.interface.mtu.unwrap_or(1500);
 
-        let guest_ipv4 = config
-            .interface
-            .ipv4_address
-            .or_else(|| host_has_ipv4.then(|| derive_guest_ipv4(slot)));
+        let guest_ipv4 = config.interface.ipv4_address.or_else(|| {
+            host_has_ipv4.then(|| {
+                derive_guest_ipv4(
+                    config
+                        .interface
+                        .ipv4_pool
+                        .unwrap_or_else(default_guest_ipv4_pool),
+                    slot,
+                )
+            })
+        });
         let gateway_ipv4 = guest_ipv4.map(gateway_from_guest_ipv4);
         let guest_ipv6 = config
             .interface
@@ -326,10 +334,21 @@ fn derive_gateway_mac(slot: u64) -> [u8; 6] {
 
 /// Derive a guest IPv4 address from the sandbox slot.
 ///
-/// Pool: `100.96.0.0/11`. Each slot gets a `/30` block (4 IPs).
+/// Pool: `198.18.0.0/15` by default. Each slot gets a `/30` block (4 IPs).
 /// Guest is at offset +2 in the block.
-fn derive_guest_ipv4(slot: u64) -> Ipv4Addr {
-    let base: u32 = u32::from(Ipv4Addr::new(100, 96, 0, 0));
+fn derive_guest_ipv4(pool: Ipv4Network, slot: u64) -> Ipv4Addr {
+    assert!(
+        pool.prefix() <= 30,
+        "IPv4 pool {pool} must be large enough to contain at least one /30 block"
+    );
+
+    let capacity = 1u64 << (30 - pool.prefix());
+    assert!(
+        slot < capacity,
+        "sandbox slot {slot} exceeds IPv4 pool {pool} capacity ({capacity} /30 blocks)"
+    );
+
+    let base = u32::from(pool.network());
     let offset = (slot as u32) * 4 + 2; // +2 = guest within /30
     Ipv4Addr::from(base + offset)
 }
@@ -337,6 +356,11 @@ fn derive_guest_ipv4(slot: u64) -> Ipv4Addr {
 /// Gateway IPv4 from guest IPv4: guest - 1 (offset +1 in the /30 block).
 fn gateway_from_guest_ipv4(guest: Ipv4Addr) -> Ipv4Addr {
     Ipv4Addr::from(u32::from(guest) - 1)
+}
+
+fn default_guest_ipv4_pool() -> Ipv4Network {
+    Ipv4Network::new(Ipv4Addr::new(198, 18, 0, 0), 15)
+        .expect("default IPv4 pool must be a valid network")
 }
 
 /// Derive a guest IPv6 address from the sandbox slot.
@@ -393,19 +417,35 @@ mod tests {
     fn derive_addresses_slot_0() {
         assert_eq!(derive_guest_mac(0), [0x02, 0x6d, 0x73, 0x00, 0x00, 0x02]);
         assert_eq!(derive_gateway_mac(0), [0x02, 0x6d, 0x73, 0x00, 0x00, 0x01]);
-        assert_eq!(derive_guest_ipv4(0), Ipv4Addr::new(100, 96, 0, 2));
         assert_eq!(
-            gateway_from_guest_ipv4(Ipv4Addr::new(100, 96, 0, 2)),
-            Ipv4Addr::new(100, 96, 0, 1)
+            derive_guest_ipv4(default_guest_ipv4_pool(), 0),
+            Ipv4Addr::new(198, 18, 0, 2)
+        );
+        assert_eq!(
+            gateway_from_guest_ipv4(Ipv4Addr::new(198, 18, 0, 2)),
+            Ipv4Addr::new(198, 18, 0, 1)
         );
     }
 
     #[test]
     fn derive_addresses_slot_1() {
-        assert_eq!(derive_guest_ipv4(1), Ipv4Addr::new(100, 96, 0, 6));
         assert_eq!(
-            gateway_from_guest_ipv4(Ipv4Addr::new(100, 96, 0, 6)),
-            Ipv4Addr::new(100, 96, 0, 5)
+            derive_guest_ipv4(default_guest_ipv4_pool(), 1),
+            Ipv4Addr::new(198, 18, 0, 6)
+        );
+        assert_eq!(
+            gateway_from_guest_ipv4(Ipv4Addr::new(198, 18, 0, 6)),
+            Ipv4Addr::new(198, 18, 0, 5)
+        );
+    }
+
+    #[test]
+    fn derive_addresses_custom_ipv4_pool() {
+        let pool = "172.31.240.0/24".parse::<Ipv4Network>().unwrap();
+        assert_eq!(derive_guest_ipv4(pool, 0), Ipv4Addr::new(172, 31, 240, 2));
+        assert_eq!(
+            derive_guest_ipv4(pool, 63),
+            Ipv4Addr::new(172, 31, 240, 254)
         );
     }
 

--- a/crates/network/lib/network.rs
+++ b/crates/network/lib/network.rs
@@ -9,7 +9,7 @@ use std::net::{Ipv4Addr, Ipv6Addr, UdpSocket};
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
-use ipnetwork::Ipv4Network;
+use ipnetwork::{Ipv4Network, Ipv6Network};
 use microsandbox_protocol::{ENV_HOST_ALIAS, ENV_NET, ENV_NET_IPV4, ENV_NET_IPV6};
 use msb_krun::backends::net::NetBackend;
 
@@ -123,10 +123,17 @@ impl SmoltcpNetwork {
             })
         });
         let gateway_ipv4 = guest_ipv4.map(gateway_from_guest_ipv4);
-        let guest_ipv6 = config
-            .interface
-            .ipv6_address
-            .or_else(|| host_has_ipv6.then(|| derive_guest_ipv6(slot)));
+        let guest_ipv6 = config.interface.ipv6_address.or_else(|| {
+            host_has_ipv6.then(|| {
+                derive_guest_ipv6(
+                    config
+                        .interface
+                        .ipv6_pool
+                        .unwrap_or_else(default_guest_ipv6_pool),
+                    slot,
+                )
+            })
+        });
         let gateway_ipv6 = guest_ipv6.map(gateway_from_guest_ipv6);
 
         let queue_capacity = config
@@ -367,14 +374,32 @@ fn default_guest_ipv4_pool() -> Ipv4Network {
 ///
 /// Pool: `fd42:6d73:62::/48`. Each slot gets a `/64` prefix.
 /// Guest is `::2` in its prefix.
-fn derive_guest_ipv6(slot: u64) -> Ipv6Addr {
-    Ipv6Addr::new(0xfd42, 0x6d73, 0x0062, slot as u16, 0, 0, 0, 2)
+fn derive_guest_ipv6(pool: Ipv6Network, slot: u64) -> Ipv6Addr {
+    assert!(
+        pool.prefix() <= 64,
+        "IPv6 pool {pool} must be large enough to contain at least one /64 prefix"
+    );
+
+    let capacity = 1u128 << (64 - pool.prefix());
+    assert!(
+        (slot as u128) < capacity,
+        "sandbox slot {slot} exceeds IPv6 pool {pool} capacity ({capacity} /64 prefixes)"
+    );
+
+    let base = u128::from(pool.network());
+    let offset = (slot as u128) << 64;
+    Ipv6Addr::from(base + offset + 2)
 }
 
 /// Gateway IPv6 from guest IPv6: `::1` in the same prefix.
 fn gateway_from_guest_ipv6(guest: Ipv6Addr) -> Ipv6Addr {
     let segs = guest.segments();
     Ipv6Addr::new(segs[0], segs[1], segs[2], segs[3], 0, 0, 0, 1)
+}
+
+fn default_guest_ipv6_pool() -> Ipv6Network {
+    Ipv6Network::new(Ipv6Addr::new(0xfd42, 0x6d73, 0x0062, 0, 0, 0, 0, 0), 48)
+        .expect("default IPv6 pool must be a valid network")
 }
 
 /// Format a MAC address as `xx:xx:xx:xx:xx:xx`.
@@ -452,12 +477,25 @@ mod tests {
     #[test]
     fn derive_ipv6_slot_0() {
         assert_eq!(
-            derive_guest_ipv6(0),
+            derive_guest_ipv6(default_guest_ipv6_pool(), 0),
             "fd42:6d73:62:0::2".parse::<Ipv6Addr>().unwrap()
         );
         assert_eq!(
-            gateway_from_guest_ipv6(derive_guest_ipv6(0)),
+            gateway_from_guest_ipv6(derive_guest_ipv6(default_guest_ipv6_pool(), 0)),
             "fd42:6d73:62:0::1".parse::<Ipv6Addr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn derive_addresses_custom_ipv6_pool() {
+        let pool = "fd7a:115c:a1e0:100::/56".parse::<Ipv6Network>().unwrap();
+        assert_eq!(
+            derive_guest_ipv6(pool, 0),
+            "fd7a:115c:a1e0:100::2".parse::<Ipv6Addr>().unwrap()
+        );
+        assert_eq!(
+            derive_guest_ipv6(pool, 3),
+            "fd7a:115c:a1e0:103::2".parse::<Ipv6Addr>().unwrap()
         );
     }
 

--- a/crates/network/lib/network.rs
+++ b/crates/network/lib/network.rs
@@ -24,7 +24,7 @@ use crate::tls::state::TlsState;
 //--------------------------------------------------------------------------------------------------
 
 /// Maximum sandbox slot value. Limited by MAC/IPv6 encoding (16 bits = 65535).
-/// The default IPv4 pool (198.18.0.0/15 with /30 blocks) supports 131072 slots,
+/// The default IPv4 pool (172.16.0.0/12 with /30 blocks) supports 262144 slots,
 /// but MAC and IPv6 derivation only encode the low 16 bits, so 65535 is the
 /// effective maximum.
 const MAX_SLOT: u64 = u16::MAX as u64;
@@ -341,7 +341,7 @@ fn derive_gateway_mac(slot: u64) -> [u8; 6] {
 
 /// Derive a guest IPv4 address from the sandbox slot.
 ///
-/// Pool: `198.18.0.0/15` by default. Each slot gets a `/30` block (4 IPs).
+/// Pool: `172.16.0.0/12` by default. Each slot gets a `/30` block (4 IPs).
 /// Guest is at offset +2 in the block.
 fn derive_guest_ipv4(pool: Ipv4Network, slot: u64) -> Ipv4Addr {
     assert!(
@@ -366,7 +366,7 @@ fn gateway_from_guest_ipv4(guest: Ipv4Addr) -> Ipv4Addr {
 }
 
 fn default_guest_ipv4_pool() -> Ipv4Network {
-    Ipv4Network::new(Ipv4Addr::new(198, 18, 0, 0), 15)
+    Ipv4Network::new(Ipv4Addr::new(172, 16, 0, 0), 12)
         .expect("default IPv4 pool must be a valid network")
 }
 
@@ -444,11 +444,11 @@ mod tests {
         assert_eq!(derive_gateway_mac(0), [0x02, 0x6d, 0x73, 0x00, 0x00, 0x01]);
         assert_eq!(
             derive_guest_ipv4(default_guest_ipv4_pool(), 0),
-            Ipv4Addr::new(198, 18, 0, 2)
+            Ipv4Addr::new(172, 16, 0, 2)
         );
         assert_eq!(
-            gateway_from_guest_ipv4(Ipv4Addr::new(198, 18, 0, 2)),
-            Ipv4Addr::new(198, 18, 0, 1)
+            gateway_from_guest_ipv4(Ipv4Addr::new(172, 16, 0, 2)),
+            Ipv4Addr::new(172, 16, 0, 1)
         );
     }
 
@@ -456,11 +456,11 @@ mod tests {
     fn derive_addresses_slot_1() {
         assert_eq!(
             derive_guest_ipv4(default_guest_ipv4_pool(), 1),
-            Ipv4Addr::new(198, 18, 0, 6)
+            Ipv4Addr::new(172, 16, 0, 6)
         );
         assert_eq!(
-            gateway_from_guest_ipv4(Ipv4Addr::new(198, 18, 0, 6)),
-            Ipv4Addr::new(198, 18, 0, 5)
+            gateway_from_guest_ipv4(Ipv4Addr::new(172, 16, 0, 6)),
+            Ipv4Addr::new(172, 16, 0, 5)
         );
     }
 

--- a/crates/network/lib/policy/builder.rs
+++ b/crates/network/lib/policy/builder.rs
@@ -75,6 +75,10 @@ pub enum BuildError {
     #[error("rule #{rule_index}: invalid CIDR `{raw}`")]
     InvalidCidr { rule_index: usize, raw: String },
 
+    /// The configured guest IPv4 pool cannot hold a `/30` sandbox subnet.
+    #[error("invalid IPv4 pool `{raw}`: prefix must be /30 or shorter")]
+    InvalidIpv4Pool { raw: String },
+
     /// `.domain(&str)` or `.domain_suffix(&str)` received a value that
     /// doesn't parse as a [`DomainName`].
     #[error("rule #{rule_index}: invalid domain `{raw}`: {source}")]

--- a/crates/network/lib/policy/builder.rs
+++ b/crates/network/lib/policy/builder.rs
@@ -79,6 +79,10 @@ pub enum BuildError {
     #[error("invalid IPv4 pool `{raw}`: prefix must be /30 or shorter")]
     InvalidIpv4Pool { raw: String },
 
+    /// The configured guest IPv6 pool cannot hold a `/64` sandbox prefix.
+    #[error("invalid IPv6 pool `{raw}`: prefix must be /64 or shorter")]
+    InvalidIpv6Pool { raw: String },
+
     /// `.domain(&str)` or `.domain_suffix(&str)` received a value that
     /// doesn't parse as a [`DomainName`].
     #[error("rule #{rule_index}: invalid domain `{raw}`: {source}")]

--- a/crates/network/lib/policy/destination.rs
+++ b/crates/network/lib/policy/destination.rs
@@ -147,7 +147,7 @@ mod tests {
     fn with_gateway() -> SharedState {
         let s = SharedState::new(4);
         s.set_gateway_ips(
-            Some(Ipv4Addr::new(100, 96, 0, 1)),
+            Some(Ipv4Addr::new(198, 18, 0, 1)),
             Some("fd42:6d73:62::1".parse().unwrap()),
         );
         s
@@ -341,21 +341,18 @@ mod tests {
     }
 
     /// `Host` takes precedence over the static categories that would
-    /// otherwise claim the gateway IPs (CGNAT for IPv4, ULA for IPv6).
-    /// This means an `allow Public` rule won't accidentally allow host
-    /// traffic, and a `deny Private` rule won't accidentally cover the
-    /// host gateway either.
+    /// otherwise claim the gateway IPs (public fallback for IPv4, ULA
+    /// for IPv6).
     #[test]
-    fn host_takes_precedence_over_private() {
+    fn host_takes_precedence_over_static_groups() {
         let s = with_gateway();
-        let v4 = IpAddr::V4(Ipv4Addr::new(100, 96, 0, 1));
+        let v4 = IpAddr::V4(Ipv4Addr::new(198, 18, 0, 1));
         let v6 = IpAddr::V6("fd42:6d73:62::1".parse().unwrap());
 
         assert!(matches_group(DestinationGroup::Host, v4, &s));
         assert!(matches_group(DestinationGroup::Host, v6, &s));
-        assert!(!matches_group(DestinationGroup::Private, v4, &s));
-        assert!(!matches_group(DestinationGroup::Private, v6, &s));
         assert!(!matches_group(DestinationGroup::Public, v4, &s));
+        assert!(!matches_group(DestinationGroup::Private, v6, &s));
         assert!(!matches_group(DestinationGroup::Public, v6, &s));
     }
 
@@ -389,7 +386,7 @@ mod tests {
                 DestinationGroup::Multicast,
             ),
             (
-                IpAddr::V4(Ipv4Addr::new(100, 96, 0, 1)),
+                IpAddr::V4(Ipv4Addr::new(198, 18, 0, 1)),
                 DestinationGroup::Host,
             ),
         ];

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -83,7 +83,7 @@ pub const ENV_NET: &str = "MSB_NET";
 /// - `dns=A.B.C.D` — DNS server (optional)
 ///
 /// Example:
-/// - `MSB_NET_IPV4=addr=198.18.1.2/30,gw=198.18.1.1,dns=198.18.1.1`
+/// - `MSB_NET_IPV4=addr=172.16.1.2/30,gw=172.16.1.1,dns=172.16.1.1`
 pub const ENV_NET_IPV4: &str = "MSB_NET_IPV4";
 
 /// Environment variable carrying the guest IPv6 network configuration.

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -83,7 +83,7 @@ pub const ENV_NET: &str = "MSB_NET";
 /// - `dns=A.B.C.D` — DNS server (optional)
 ///
 /// Example:
-/// - `MSB_NET_IPV4=addr=100.96.1.2/30,gw=100.96.1.1,dns=100.96.1.1`
+/// - `MSB_NET_IPV4=addr=198.18.1.2/30,gw=198.18.1.1,dns=198.18.1.1`
 pub const ENV_NET_IPV4: &str = "MSB_NET_IPV4";
 
 /// Environment variable carrying the guest IPv6 network configuration.

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -66,6 +66,7 @@ msb run -d --name worker python -- python worker.py
 | `--no-dns-rebind-protection` | Allow DNS responses pointing to private/internal IP addresses |
 | `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
 | `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |
+| `--net-ipv4-pool` | IPv4 pool used for per-sandbox `/30` guest subnets (default: `198.18.0.0/15`) |
 | `--max-connections` | Limit the number of concurrent network connections |
 | `--trust-host-cas` | Ship the host's trusted root CAs into the guest so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, etc.) whose gateway CA is installed on the host but unknown to the guest's stock bundle. Opt-in; by default the guest validates against its stock Mozilla bundle only |
 | `--secret` | Inject a secret that is only sent to an allowed host (`ENV=VALUE@HOST`) |

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -67,6 +67,7 @@ msb run -d --name worker python -- python worker.py
 | `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
 | `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |
 | `--net-ipv4-pool` | IPv4 pool used for per-sandbox `/30` guest subnets (default: `198.18.0.0/15`) |
+| `--net-ipv6-pool` | IPv6 pool used for per-sandbox `/64` guest prefixes (default: `fd42:6d73:62::/48`) |
 | `--max-connections` | Limit the number of concurrent network connections |
 | `--trust-host-cas` | Ship the host's trusted root CAs into the guest so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, etc.) whose gateway CA is installed on the host but unknown to the guest's stock bundle. Opt-in; by default the guest validates against its stock Mozilla bundle only |
 | `--secret` | Inject a secret that is only sent to an allowed host (`ENV=VALUE@HOST`) |

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -66,7 +66,7 @@ msb run -d --name worker python -- python worker.py
 | `--no-dns-rebind-protection` | Allow DNS responses pointing to private/internal IP addresses |
 | `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
 | `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |
-| `--net-ipv4-pool` | IPv4 pool used for per-sandbox `/30` guest subnets (default: `198.18.0.0/15`) |
+| `--net-ipv4-pool` | IPv4 pool used for per-sandbox `/30` guest subnets (default: `172.16.0.0/12`) |
 | `--net-ipv6-pool` | IPv6 pool used for per-sandbox `/64` guest prefixes (default: `fd42:6d73:62::/48`) |
 | `--max-connections` | Limit the number of concurrent network connections |
 | `--trust-host-cas` | Ship the host's trusted root CAs into the guest so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, etc.) whose gateway CA is installed on the host but unknown to the guest's stock bundle. Opt-in; by default the guest validates against its stock Mozilla bundle only |

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -8,7 +8,17 @@ All network traffic from a sandbox flows through a host-controlled networking st
 
 ## Defaults
 
-Without any policy flags, sandboxes get **public-internet egress only**: routable destinations work, but private (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`), loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), and the cloud metadata endpoint (`169.254.169.254`) are denied. Inbound traffic on published ports is unfiltered until you add an explicit ingress rule.
+Without any policy flags, sandboxes get **public-internet egress only**: routable destinations work, but private (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7`), loopback (`127.0.0.0/8`, `::1`), link-local (`169.254.0.0/16`, `fe80::/10`), and the cloud metadata endpoint (`169.254.169.254`) are denied. Inbound traffic on published ports is unfiltered until you add an explicit ingress rule.
+
+Sandbox addresses come from internal guest pools unless you provide your own. The default IPv4 pool is `172.16.0.0/12`; slot 0 gets `172.16.0.2` with gateway `172.16.0.1`. The default IPv6 pool is `fd42:6d73:62::/48`, a Unique Local Address (ULA) range; each sandbox gets one `/64` prefix with `::2` as the guest and `::1` as the gateway.
+
+If either pool overlaps your host, VPN, VPC, or lab network, set a custom pool:
+
+```bash
+msb create python --name custom-net \
+    --net-ipv4-pool 172.24.0.0/13 \
+    --net-ipv6-pool fd7a:115c:a1e0::/48
+```
 
 To turn off networking entirely:
 

--- a/docs/networking/security-model.mdx
+++ b/docs/networking/security-model.mdx
@@ -10,7 +10,7 @@ microsandbox's networking defaults are shaped around giving an AI agent, a scrap
 
 The largest class of real damage comes from workloads reaching things that live *inside* your network: the host machine itself, a local database, another VM on the same subnet. The default policy addresses this by denying egress to anything outside `Group::Public` (the complement of the named local categories), which covers:
 
-- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10` (RFC1918 + CGN private ranges)
+- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7` (RFC1918 + CGN + ULA private ranges)
 - `127.0.0.0/8`, `::1` (loopback)
 - `169.254.0.0/16`, `fe80::/10` (link-local)
 - `169.254.169.254` (cloud metadata, takes precedence over link-local)

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -124,7 +124,7 @@ The configuration struct passed via [`WithNetwork`](/sdk/go/sandbox#withnetwork)
 | DNSRebindProtection | `*bool` | Legacy convenience for `DNS.RebindProtection`. When `DNS` is also set, the nested value wins |
 | TLS | [`*TLSConfig`](#tlsconfig) | TLS interception settings |
 | Ports | `map[uint16]uint16` | Host→guest TCP port mappings |
-| IPv4Pool | `string` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `198.18.0.0/15` |
+| IPv4Pool | `string` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12` |
 | IPv6Pool | `string` | IPv6 pool used for per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48` |
 | MaxConnections | `*uint` | Cap concurrent network connections from the sandbox |
 | OnSecretViolation | [`ViolationAction`](/sdk/go/secrets#violationaction) | Sandbox-wide action when a secret is sent to a disallowed host |

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -125,6 +125,7 @@ The configuration struct passed via [`WithNetwork`](/sdk/go/sandbox#withnetwork)
 | TLS | [`*TLSConfig`](#tlsconfig) | TLS interception settings |
 | Ports | `map[uint16]uint16` | Host→guest TCP port mappings |
 | IPv4Pool | `string` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `198.18.0.0/15` |
+| IPv6Pool | `string` | IPv6 pool used for per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48` |
 | MaxConnections | `*uint` | Cap concurrent network connections from the sandbox |
 | OnSecretViolation | [`ViolationAction`](/sdk/go/secrets#violationaction) | Sandbox-wide action when a secret is sent to a disallowed host |
 | TrustHostCAs | `*bool` | Ship the host's trusted root CAs into the guest at boot. Opt-in for corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, ...) whose gateway CA is unknown to the guest's stock Mozilla bundle |

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -124,6 +124,7 @@ The configuration struct passed via [`WithNetwork`](/sdk/go/sandbox#withnetwork)
 | DNSRebindProtection | `*bool` | Legacy convenience for `DNS.RebindProtection`. When `DNS` is also set, the nested value wins |
 | TLS | [`*TLSConfig`](#tlsconfig) | TLS interception settings |
 | Ports | `map[uint16]uint16` | Host→guest TCP port mappings |
+| IPv4Pool | `string` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `198.18.0.0/15` |
 | MaxConnections | `*uint` | Cap concurrent network connections from the sandbox |
 | OnSecretViolation | [`ViolationAction`](/sdk/go/secrets#violationaction) | Sandbox-wide action when a secret is sent to a disallowed host |
 | TrustHostCAs | `*bool` | Ship the host's trusted root CAs into the guest at boot. Opt-in for corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, ...) whose gateway CA is unknown to the guest's stock Mozilla bundle |

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -18,6 +18,7 @@ Network(
     deny_domain_suffixes: tuple[str, ...] = (),
     dns: DnsConfig | None = None,
     tls: TlsConfig | None = None,
+    ipv4_pool: str | None = None,
     max_connections: int | None = None,
     trust_host_cas: bool | None = None,
 )
@@ -31,6 +32,7 @@ Network(
 | deny_domain_suffixes | `tuple[str, ...]` | Deny egress to all subdomains of these suffixes. Adds `deny DomainSuffix("...")` rules; same enforcement layers as `deny_domains` |
 | dns | [`DnsConfig`](#dnsconfig) ` \| None` | DNS interception configuration |
 | tls | [`TlsConfig`](#tlsconfig) ` \| None` | TLS interception configuration |
+| ipv4_pool | `str \| None` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `198.18.0.0/15` |
 | max_connections | `int \| None` | Maximum concurrent connections |
 | trust_host_cas | `bool \| None` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle. Opt-in |
 

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -33,7 +33,7 @@ Network(
 | deny_domain_suffixes | `tuple[str, ...]` | Deny egress to all subdomains of these suffixes. Adds `deny DomainSuffix("...")` rules; same enforcement layers as `deny_domains` |
 | dns | [`DnsConfig`](#dnsconfig) ` \| None` | DNS interception configuration |
 | tls | [`TlsConfig`](#tlsconfig) ` \| None` | TLS interception configuration |
-| ipv4_pool | `str \| None` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `198.18.0.0/15` |
+| ipv4_pool | `str \| None` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12` |
 | ipv6_pool | `str \| None` | IPv6 pool used for per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48` |
 | max_connections | `int \| None` | Maximum concurrent connections |
 | trust_host_cas | `bool \| None` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle. Opt-in |

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -19,6 +19,7 @@ Network(
     dns: DnsConfig | None = None,
     tls: TlsConfig | None = None,
     ipv4_pool: str | None = None,
+    ipv6_pool: str | None = None,
     max_connections: int | None = None,
     trust_host_cas: bool | None = None,
 )
@@ -33,6 +34,7 @@ Network(
 | dns | [`DnsConfig`](#dnsconfig) ` \| None` | DNS interception configuration |
 | tls | [`TlsConfig`](#tlsconfig) ` \| None` | TLS interception configuration |
 | ipv4_pool | `str \| None` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `198.18.0.0/15` |
+| ipv6_pool | `str \| None` | IPv6 pool used for per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48` |
 | max_connections | `int \| None` | Maximum concurrent connections |
 | trust_host_cas | `bool \| None` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle. Opt-in |
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -621,7 +621,7 @@ Limit the maximum number of concurrent network connections from the sandbox.
 fn ipv4_pool(self, pool: Ipv4Network) -> Self
 ```
 
-Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `198.18.0.0/15`.
+Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12`.
 
 ---
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -615,6 +615,16 @@ Limit the maximum number of concurrent network connections from the sandbox.
 
 ---
 
+#### ipv4_pool()
+
+```rust
+fn ipv4_pool(self, pool: Ipv4Network) -> Self
+```
+
+Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `198.18.0.0/15`.
+
+---
+
 #### on_secret_violation()
 
 ```rust

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -625,6 +625,16 @@ Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `1
 
 ---
 
+#### ipv6_pool()
+
+```rust
+fn ipv6_pool(self, pool: Ipv6Network) -> Self
+```
+
+Set the IPv6 pool used to derive per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48`.
+
+---
+
 #### on_secret_violation()
 
 ```rust

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -1007,7 +1007,7 @@ Limit the maximum number of concurrent network connections from the sandbox.
 ipv4Pool(pool: string): this
 ```
 
-Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `198.18.0.0/15`.
+Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12`.
 
 ---
 

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -1001,6 +1001,16 @@ Limit the maximum number of concurrent network connections from the sandbox.
 
 ---
 
+#### ipv4Pool()
+
+```typescript
+ipv4Pool(pool: string): this
+```
+
+Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `198.18.0.0/15`.
+
+---
+
 #### onSecretViolation()
 
 ```typescript

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -1011,6 +1011,16 @@ Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `1
 
 ---
 
+#### ipv6Pool()
+
+```typescript
+ipv6Pool(pool: string): this
+```
+
+Set the IPv6 pool used to derive per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48`.
+
+---
+
 #### onSecretViolation()
 
 ```typescript

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -953,6 +953,7 @@ type NetworkOptions struct {
 	DenyDomainSuffixes  []string             `json:"deny_domain_suffixes,omitempty"`
 	TLS                 *TLSOptions          `json:"tls,omitempty"`
 	Ports               map[uint16]uint16    `json:"ports,omitempty"`
+	IPv4Pool            string               `json:"ipv4_pool,omitempty"`
 	MaxConnections      *uint                `json:"max_connections,omitempty"`
 	OnSecretViolation   string               `json:"on_secret_violation,omitempty"`
 	TrustHostCAs        *bool                `json:"trust_host_cas,omitempty"`

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -954,6 +954,7 @@ type NetworkOptions struct {
 	TLS                 *TLSOptions          `json:"tls,omitempty"`
 	Ports               map[uint16]uint16    `json:"ports,omitempty"`
 	IPv4Pool            string               `json:"ipv4_pool,omitempty"`
+	IPv6Pool            string               `json:"ipv6_pool,omitempty"`
 	MaxConnections      *uint                `json:"max_connections,omitempty"`
 	OnSecretViolation   string               `json:"on_secret_violation,omitempty"`
 	TrustHostCAs        *bool                `json:"trust_host_cas,omitempty"`

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -632,6 +632,8 @@ struct NetworkOpts {
     /// Ports nested inside network: {host_port: guest_port}.
     #[serde(default)]
     ports: HashMap<u16, u16>,
+    /// IPv4 pool used to derive per-sandbox /30 guest subnets.
+    ipv4_pool: Option<String>,
     max_connections: Option<usize>,
     /// Sandbox-wide secret violation action: "block", "block-and-log",
     /// "block-and-terminate".
@@ -896,6 +898,13 @@ fn apply_network(
             rules: bulk_deny,
         };
         builder = builder.network(|n| n.policy(policy));
+    }
+
+    if let Some(ref raw) = net.ipv4_pool {
+        let pool: ipnetwork::Ipv4Network = raw
+            .parse()
+            .map_err(|e| FfiError::invalid_argument(format!("ipv4_pool {raw:?}: {e}")))?;
+        builder = builder.network(|n| n.ipv4_pool(pool));
     }
 
     // DNS configuration. Either nested `dns: {...}` or the legacy flat

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -634,6 +634,8 @@ struct NetworkOpts {
     ports: HashMap<u16, u16>,
     /// IPv4 pool used to derive per-sandbox /30 guest subnets.
     ipv4_pool: Option<String>,
+    /// IPv6 pool used to derive per-sandbox /64 guest prefixes.
+    ipv6_pool: Option<String>,
     max_connections: Option<usize>,
     /// Sandbox-wide secret violation action: "block", "block-and-log",
     /// "block-and-terminate".
@@ -905,6 +907,12 @@ fn apply_network(
             .parse()
             .map_err(|e| FfiError::invalid_argument(format!("ipv4_pool {raw:?}: {e}")))?;
         builder = builder.network(|n| n.ipv4_pool(pool));
+    }
+    if let Some(ref raw) = net.ipv6_pool {
+        let pool: ipnetwork::Ipv6Network = raw
+            .parse()
+            .map_err(|e| FfiError::invalid_argument(format!("ipv6_pool {raw:?}: {e}")))?;
+        builder = builder.network(|n| n.ipv6_pool(pool));
     }
 
     // DNS configuration. Either nested `dns: {...}` or the legacy flat

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -333,7 +333,7 @@ type NetworkConfig struct {
 	Ports map[uint16]uint16
 
 	// IPv4Pool is used to derive per-sandbox /30 guest subnets.
-	// Defaults to "198.18.0.0/15".
+	// Defaults to "172.16.0.0/12".
 	IPv4Pool string
 
 	// IPv6Pool is used to derive per-sandbox /64 guest prefixes.

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -332,6 +332,10 @@ type NetworkConfig struct {
 	// Ports publishes host TCP ports into the sandbox (host→guest).
 	Ports map[uint16]uint16
 
+	// IPv4Pool is used to derive per-sandbox /30 guest subnets.
+	// Defaults to "198.18.0.0/15".
+	IPv4Pool string
+
 	// MaxConnections caps concurrent network connections from the sandbox.
 	MaxConnections *uint
 

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -336,6 +336,10 @@ type NetworkConfig struct {
 	// Defaults to "198.18.0.0/15".
 	IPv4Pool string
 
+	// IPv6Pool is used to derive per-sandbox /64 guest prefixes.
+	// Defaults to "fd42:6d73:62::/48".
+	IPv6Pool string
+
 	// MaxConnections caps concurrent network connections from the sandbox.
 	MaxConnections *uint
 

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -160,6 +160,7 @@ func buildFFINetwork(n *NetworkConfig) *ffi.NetworkOptions {
 		DenyDomainSuffixes:  n.DenyDomainSuffixes,
 		Ports:               n.Ports,
 		IPv4Pool:            n.IPv4Pool,
+		IPv6Pool:            n.IPv6Pool,
 		MaxConnections:      n.MaxConnections,
 		OnSecretViolation:   string(n.OnSecretViolation),
 		TrustHostCAs:        n.TrustHostCAs,

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -159,6 +159,7 @@ func buildFFINetwork(n *NetworkConfig) *ffi.NetworkOptions {
 		DenyDomains:         n.DenyDomains,
 		DenyDomainSuffixes:  n.DenyDomainSuffixes,
 		Ports:               n.Ports,
+		IPv4Pool:            n.IPv4Pool,
 		MaxConnections:      n.MaxConnections,
 		OnSecretViolation:   string(n.OnSecretViolation),
 		TrustHostCAs:        n.TrustHostCAs,

--- a/sdk/go/sandbox_options_test.go
+++ b/sdk/go/sandbox_options_test.go
@@ -296,6 +296,7 @@ func TestFFIWireShape_NetworkCustomRules(t *testing.T) {
 			DNS: &DNSConfig{
 				Nameservers: []string{"1.1.1.1:53"},
 			},
+			IPv4Pool: "172.31.240.0/24",
 		}),
 	)
 	net := mustField(t, got, "network").(map[string]any)
@@ -317,6 +318,9 @@ func TestFFIWireShape_NetworkCustomRules(t *testing.T) {
 	deny := net["deny_domains"].([]any)
 	if len(deny) != 1 || deny[0] != "blocked.example.com" {
 		t.Fatalf("deny_domains = %v", deny)
+	}
+	if net["ipv4_pool"] != "172.31.240.0/24" {
+		t.Fatalf("ipv4_pool = %v", net["ipv4_pool"])
 	}
 	dns := net["dns"].(map[string]any)
 	ns := dns["nameservers"].([]any)

--- a/sdk/go/sandbox_options_test.go
+++ b/sdk/go/sandbox_options_test.go
@@ -297,6 +297,7 @@ func TestFFIWireShape_NetworkCustomRules(t *testing.T) {
 				Nameservers: []string{"1.1.1.1:53"},
 			},
 			IPv4Pool: "172.31.240.0/24",
+			IPv6Pool: "fd7a:115c:a1e0:100::/56",
 		}),
 	)
 	net := mustField(t, got, "network").(map[string]any)
@@ -321,6 +322,9 @@ func TestFFIWireShape_NetworkCustomRules(t *testing.T) {
 	}
 	if net["ipv4_pool"] != "172.31.240.0/24" {
 		t.Fatalf("ipv4_pool = %v", net["ipv4_pool"])
+	}
+	if net["ipv6_pool"] != "fd7a:115c:a1e0:100::/56" {
+		t.Fatalf("ipv6_pool = %v", net["ipv6_pool"])
 	}
 	dns := net["dns"].(map[string]any)
 	ns := dns["nameservers"].([]any)

--- a/sdk/node-ts/Cargo.toml
+++ b/sdk/node-ts/Cargo.toml
@@ -13,6 +13,7 @@ path = "native/lib.rs"
 [dependencies]
 microsandbox = { version = "0.4.6", path = "../../crates/microsandbox" }
 microsandbox-network = { version = "0.4.6", path = "../../crates/network" }
+ipnetwork = { workspace = true }
 napi = { version = "3", default-features = false, features = [
     "async",
     "tokio_rt",

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -238,7 +238,7 @@ export declare class InterfaceOverridesBuilder {
   mac(mac: string): this
   /** Set the interface MTU. Default: 1500. */
   mtu(mtu: number): this
-  /** Set the guest IPv4 address (e.g. `"100.96.0.5"`). */
+  /** Set the guest IPv4 address (e.g. `"198.18.0.5"`). */
   ipv4(address: string): this
   /** Set the guest IPv6 address (e.g. `"fd42:6d73:62::5"`). */
   ipv6(address: string): this
@@ -358,6 +358,8 @@ export declare class NetworkBuilder {
   onSecretViolation(action: string): this
   /** Set the maximum number of concurrent connections. */
   maxConnections(max: number): this
+  /** Set the IPv4 pool used for per-sandbox /30 guest subnets. */
+  ipv4Pool(pool: string): this
   /** Trust the host's root CAs inside the guest. Default: false. */
   trustHostCAs(enabled: boolean): this
   /**

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -238,7 +238,7 @@ export declare class InterfaceOverridesBuilder {
   mac(mac: string): this
   /** Set the interface MTU. Default: 1500. */
   mtu(mtu: number): this
-  /** Set the guest IPv4 address (e.g. `"198.18.0.5"`). */
+  /** Set the guest IPv4 address (e.g. `"172.16.0.5"`). */
   ipv4(address: string): this
   /** Set the guest IPv6 address (e.g. `"fd42:6d73:62::5"`). */
   ipv6(address: string): this

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -360,6 +360,8 @@ export declare class NetworkBuilder {
   maxConnections(max: number): this
   /** Set the IPv4 pool used for per-sandbox /30 guest subnets. */
   ipv4Pool(pool: string): this
+  /** Set the IPv6 pool used for per-sandbox /64 guest prefixes. */
+  ipv6Pool(pool: string): this
   /** Trust the host's root CAs inside the guest. Default: false. */
   trustHostCAs(enabled: boolean): this
   /**

--- a/sdk/node-ts/native/interface_overrides_builder.rs
+++ b/sdk/node-ts/native/interface_overrides_builder.rs
@@ -55,7 +55,7 @@ impl JsInterfaceOverridesBuilder {
         Ok(self)
     }
 
-    /// Set the guest IPv4 address (e.g. `"100.96.0.5"`).
+    /// Set the guest IPv4 address (e.g. `"198.18.0.5"`).
     #[napi(js_name = "ipv4")]
     pub fn ipv4(&mut self, address: String) -> &Self {
         match Ipv4Addr::from_str(&address) {

--- a/sdk/node-ts/native/interface_overrides_builder.rs
+++ b/sdk/node-ts/native/interface_overrides_builder.rs
@@ -55,7 +55,7 @@ impl JsInterfaceOverridesBuilder {
         Ok(self)
     }
 
-    /// Set the guest IPv4 address (e.g. `"198.18.0.5"`).
+    /// Set the guest IPv4 address (e.g. `"172.16.0.5"`).
     #[napi(js_name = "ipv4")]
     pub fn ipv4(&mut self, address: String) -> &Self {
         match Ipv4Addr::from_str(&address) {

--- a/sdk/node-ts/native/network_builder.rs
+++ b/sdk/node-ts/native/network_builder.rs
@@ -1,5 +1,6 @@
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use std::str::FromStr;
 
 use microsandbox_network::builder::NetworkBuilder as RustNetworkBuilder;
 use microsandbox_network::policy::NetworkPolicy as RustNetworkPolicy;
@@ -203,6 +204,16 @@ impl JsNetworkBuilder {
         let prev = self.take_inner();
         self.inner = Some(prev.max_connections(max as usize));
         self
+    }
+
+    /// Set the IPv4 pool used for per-sandbox /30 guest subnets.
+    #[napi(js_name = "ipv4Pool")]
+    pub fn ipv4_pool(&mut self, pool: String) -> Result<&Self> {
+        let parsed = ipnetwork::Ipv4Network::from_str(&pool)
+            .map_err(|e| napi::Error::from_reason(format!("invalid IPv4 pool `{pool}`: {e}")))?;
+        let prev = self.take_inner();
+        self.inner = Some(prev.ipv4_pool(parsed));
+        Ok(self)
     }
 
     /// Trust the host's root CAs inside the guest. Default: false.

--- a/sdk/node-ts/native/network_builder.rs
+++ b/sdk/node-ts/native/network_builder.rs
@@ -216,6 +216,16 @@ impl JsNetworkBuilder {
         Ok(self)
     }
 
+    /// Set the IPv6 pool used for per-sandbox /64 guest prefixes.
+    #[napi(js_name = "ipv6Pool")]
+    pub fn ipv6_pool(&mut self, pool: String) -> Result<&Self> {
+        let parsed = ipnetwork::Ipv6Network::from_str(&pool)
+            .map_err(|e| napi::Error::from_reason(format!("invalid IPv6 pool `{pool}`: {e}")))?;
+        let prev = self.take_inner();
+        self.inner = Some(prev.ipv6_pool(parsed));
+        Ok(self)
+    }
+
     /// Trust the host's root CAs inside the guest. Default: false.
     #[napi(js_name = "trustHostCAs")]
     pub fn trust_host_cas(&mut self, enabled: bool) -> &Self {

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -633,6 +633,7 @@ export interface NapiNetworkBuilder {
   ): this;
   onSecretViolation(action: string): this;
   maxConnections(max: number): this;
+  ipv4Pool(pool: string): this;
   trustHostCAs(enabled: boolean): this;
 }
 

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -634,6 +634,7 @@ export interface NapiNetworkBuilder {
   onSecretViolation(action: string): this;
   maxConnections(max: number): this;
   ipv4Pool(pool: string): this;
+  ipv6Pool(pool: string): this;
   trustHostCAs(enabled: boolean): this;
 }
 

--- a/sdk/node-ts/src/network-config.ts
+++ b/sdk/node-ts/src/network-config.ts
@@ -58,6 +58,7 @@ export interface NetworkConfig {
   readonly maxConnections: number | null;
   readonly interface?: {
     readonly ipv4Pool?: string | null;
+    readonly ipv6Pool?: string | null;
     readonly ipv4Address?: string | null;
     readonly ipv6Address?: string | null;
     readonly mac?: readonly number[] | null;

--- a/sdk/node-ts/src/network-config.ts
+++ b/sdk/node-ts/src/network-config.ts
@@ -56,5 +56,12 @@ export interface NetworkConfig {
   readonly secrets: readonly SecretEntry[];
   readonly secretViolation: ViolationAction | null;
   readonly maxConnections: number | null;
+  readonly interface?: {
+    readonly ipv4Pool?: string | null;
+    readonly ipv4Address?: string | null;
+    readonly ipv6Address?: string | null;
+    readonly mac?: readonly number[] | null;
+    readonly mtu?: number | null;
+  };
   readonly trustHostCAs: boolean;
 }

--- a/sdk/node-ts/tests/unit/builders.test.ts
+++ b/sdk/node-ts/tests/unit/builders.test.ts
@@ -222,7 +222,7 @@ describe("InterfaceOverridesBuilder", () => {
   it("constructs cleanly and accepts MTU + IPv4 + IPv6 + MAC", () => {
     const b = new InterfaceOverridesBuilder()
       .mtu(9000)
-      .ipv4("198.18.0.5")
+      .ipv4("172.16.0.5")
       .ipv6("fd42:6d73:62::5")
       .mac("aa:bb:cc:dd:ee:ff");
     expect(b).toBeInstanceOf(InterfaceOverridesBuilder);
@@ -246,7 +246,7 @@ describe("InterfaceOverridesBuilder", () => {
 
   it("valid overrides flow through NetworkBuilder.build()", () => {
     const cfg = new NetworkBuilder()
-      .interface((io) => io.mtu(9000).ipv4("198.18.0.5"))
+      .interface((io) => io.mtu(9000).ipv4("172.16.0.5"))
       .ipv4Pool("172.31.240.0/24")
       .ipv6Pool("fd7a:115c:a1e0:100::/56")
       .build() as {
@@ -258,7 +258,7 @@ describe("InterfaceOverridesBuilder", () => {
       };
     };
     expect(cfg.interface.mtu).toBe(9000);
-    expect(cfg.interface.ipv4Address).toBe("198.18.0.5");
+    expect(cfg.interface.ipv4Address).toBe("172.16.0.5");
     expect(cfg.interface.ipv4Pool).toBe("172.31.240.0/24");
     expect(cfg.interface.ipv6Pool).toBe("fd7a:115c:a1e0:100::/56");
   });

--- a/sdk/node-ts/tests/unit/builders.test.ts
+++ b/sdk/node-ts/tests/unit/builders.test.ts
@@ -215,7 +215,7 @@ describe("InterfaceOverridesBuilder", () => {
   it("constructs cleanly and accepts MTU + IPv4 + IPv6 + MAC", () => {
     const b = new InterfaceOverridesBuilder()
       .mtu(9000)
-      .ipv4("100.96.0.5")
+      .ipv4("198.18.0.5")
       .ipv6("fd42:6d73:62::5")
       .mac("aa:bb:cc:dd:ee:ff");
     expect(b).toBeInstanceOf(InterfaceOverridesBuilder);
@@ -239,10 +239,12 @@ describe("InterfaceOverridesBuilder", () => {
 
   it("valid overrides flow through NetworkBuilder.build()", () => {
     const cfg = new NetworkBuilder()
-      .interface((io) => io.mtu(9000).ipv4("100.96.0.5"))
-      .build() as { interface: { mtu: number; ipv4Address: string } };
+      .interface((io) => io.mtu(9000).ipv4("198.18.0.5"))
+      .ipv4Pool("172.31.240.0/24")
+      .build() as { interface: { mtu: number; ipv4Address: string; ipv4Pool: string } };
     expect(cfg.interface.mtu).toBe(9000);
-    expect(cfg.interface.ipv4Address).toBe("100.96.0.5");
+    expect(cfg.interface.ipv4Address).toBe("198.18.0.5");
+    expect(cfg.interface.ipv4Pool).toBe("172.31.240.0/24");
   });
 });
 

--- a/sdk/node-ts/tests/unit/builders.test.ts
+++ b/sdk/node-ts/tests/unit/builders.test.ts
@@ -65,7 +65,11 @@ describe("MountBuilder", () => {
   });
 
   it("builds a tmpfs mount with size and uniform readonly", () => {
-    const m = new MountBuilder("/scratch").tmpfs().size(MiB(64)).readonly().build();
+    const m = new MountBuilder("/scratch")
+      .tmpfs()
+      .size(MiB(64))
+      .readonly()
+      .build();
     expect(m).toEqual({
       kind: "tmpfs",
       guest: "/scratch",
@@ -95,16 +99,12 @@ describe("MountBuilder", () => {
   });
 
   it("rejects .format() on a non-disk mount", () => {
-    const builder = new MountBuilder("/data")
-      .bind("/host")
-      .format("qcow2");
+    const builder = new MountBuilder("/data").bind("/host").format("qcow2");
     expect(() => builder.build()).toThrow(InvalidConfigError);
   });
 
   it("rejects .fstype() on a non-disk mount", () => {
-    const builder = new MountBuilder("/data")
-      .bind("/host")
-      .fstype("ext4");
+    const builder = new MountBuilder("/data").bind("/host").fstype("ext4");
     expect(() => builder.build()).toThrow(InvalidConfigError);
   });
 
@@ -113,7 +113,9 @@ describe("MountBuilder", () => {
   });
 
   it("rejects fstypes containing forbidden separators", () => {
-    const builder = new MountBuilder("/data").disk("./d.raw").fstype("ext4,foo");
+    const builder = new MountBuilder("/data")
+      .disk("./d.raw")
+      .fstype("ext4,foo");
     expect(() => builder.build()).toThrow(InvalidConfigError);
   });
 
@@ -144,11 +146,16 @@ describe("PatchBuilder", () => {
 
 describe("SandboxBuilder.build", () => {
   it("requires .image()", async () => {
-    await expect(Sandbox.builder("x").build()).rejects.toThrow(InvalidConfigError);
+    await expect(Sandbox.builder("x").build()).rejects.toThrow(
+      InvalidConfigError,
+    );
   });
 
   it("renders branded sizes back to plain numbers", async () => {
-    const cfg = await Sandbox.builder("x").image("alpine").memory(GiB(2)).build();
+    const cfg = await Sandbox.builder("x")
+      .image("alpine")
+      .memory(GiB(2))
+      .build();
     expect(cfg.memoryMib).toBe(2048);
   });
 
@@ -241,10 +248,19 @@ describe("InterfaceOverridesBuilder", () => {
     const cfg = new NetworkBuilder()
       .interface((io) => io.mtu(9000).ipv4("198.18.0.5"))
       .ipv4Pool("172.31.240.0/24")
-      .build() as { interface: { mtu: number; ipv4Address: string; ipv4Pool: string } };
+      .ipv6Pool("fd7a:115c:a1e0:100::/56")
+      .build() as {
+      interface: {
+        mtu: number;
+        ipv4Address: string;
+        ipv4Pool: string;
+        ipv6Pool: string;
+      };
+    };
     expect(cfg.interface.mtu).toBe(9000);
     expect(cfg.interface.ipv4Address).toBe("198.18.0.5");
     expect(cfg.interface.ipv4Pool).toBe("172.31.240.0/24");
+    expect(cfg.interface.ipv6Pool).toBe("fd7a:115c:a1e0:100::/56");
   });
 });
 
@@ -253,8 +269,10 @@ describe("NetworkBuilder.secretEnvSimple (3-arg shorthand)", () => {
     const cfg = new NetworkBuilder()
       .secretEnvSimple("API_KEY", "sk-abc", "api.example.com")
       .build() as {
-        secrets: { secrets: ReadonlyArray<{ envVar: string; placeholder: string }> };
+      secrets: {
+        secrets: ReadonlyArray<{ envVar: string; placeholder: string }>;
       };
+    };
     expect(cfg.secrets.secrets).toHaveLength(1);
     expect(cfg.secrets.secrets[0].envVar).toBe("API_KEY");
     // Placeholder defaults to the value when omitted.

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -665,6 +665,9 @@ class Network:
     layers as `deny_domains`."""
     dns: DnsConfig | None = None
     tls: TlsConfig | None = None
+    ipv4_pool: str | None = None
+    """IPv4 pool used to derive per-sandbox /30 guest subnets. Defaults
+    to ``198.18.0.0/15``."""
     max_connections: int | None = None
 
     @classmethod
@@ -698,6 +701,8 @@ class Network:
                 d["dns"] = dns_dict
         if self.tls is not None:
             d["tls"] = self.tls._to_dict()
+        if self.ipv4_pool is not None:
+            d["ipv4_pool"] = self.ipv4_pool
         if self.max_connections is not None:
             d["max_connections"] = self.max_connections
         return d

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -667,7 +667,7 @@ class Network:
     tls: TlsConfig | None = None
     ipv4_pool: str | None = None
     """IPv4 pool used to derive per-sandbox /30 guest subnets. Defaults
-    to ``198.18.0.0/15``."""
+    to ``172.16.0.0/12``."""
     ipv6_pool: str | None = None
     """IPv6 pool used to derive per-sandbox /64 guest prefixes. Defaults
     to ``fd42:6d73:62::/48``."""

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -668,6 +668,9 @@ class Network:
     ipv4_pool: str | None = None
     """IPv4 pool used to derive per-sandbox /30 guest subnets. Defaults
     to ``198.18.0.0/15``."""
+    ipv6_pool: str | None = None
+    """IPv6 pool used to derive per-sandbox /64 guest prefixes. Defaults
+    to ``fd42:6d73:62::/48``."""
     max_connections: int | None = None
 
     @classmethod
@@ -703,6 +706,8 @@ class Network:
             d["tls"] = self.tls._to_dict()
         if self.ipv4_pool is not None:
             d["ipv4_pool"] = self.ipv4_pool
+        if self.ipv6_pool is not None:
+            d["ipv6_pool"] = self.ipv6_pool
         if self.max_connections is not None:
             d["max_connections"] = self.max_connections
         return d

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -774,6 +774,12 @@ fn apply_network(
         })?;
         builder = builder.network(|n| n.ipv4_pool(pool));
     }
+    if let Some(raw) = extract_opt::<String>(net, "ipv6_pool")? {
+        let pool: ipnetwork::Ipv6Network = raw.parse().map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid ipv6_pool {raw:?}: {e}"))
+        })?;
+        builder = builder.network(|n| n.ipv6_pool(pool));
+    }
 
     // Host-CA trust (ship host's extra CAs into the guest at boot).
     if let Some(trust) = extract_opt::<bool>(net, "trust_host_cas")? {

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -767,6 +767,14 @@ fn apply_network(
         builder = builder.network(|n| n.max_connections(max));
     }
 
+    // Guest IPv4 pool.
+    if let Some(raw) = extract_opt::<String>(net, "ipv4_pool")? {
+        let pool: ipnetwork::Ipv4Network = raw.parse().map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid ipv4_pool {raw:?}: {e}"))
+        })?;
+        builder = builder.network(|n| n.ipv4_pool(pool));
+    }
+
     // Host-CA trust (ship host's extra CAs into the guest at boot).
     if let Some(trust) = extract_opt::<bool>(net, "trust_host_cas")? {
         builder = builder.network(move |n| n.trust_host_cas(trust));


### PR DESCRIPTION
this pr does the following:
- adds configurable IPv4 and IPv6 guest pools for deployments that need a different internal range.
- changes the default guest IPv4 allocation pool from `100.96.0.0/11` to `172.16.0.0/12` to avoid conflicting with tailscale's preferred subnet
- documents the default IPv4/IPv6 address pools.

Closes https://github.com/superradcompany/microsandbox/issues/722