### PR TITLE
fix(sdk): fix zero uptime reported by AllSandboxMetrics

### DIFF
--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -2099,6 +2099,9 @@ func AllSandboxMetrics(ctx context.Context) (map[string]*Metrics, error) {
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		return nil, fmt.Errorf("parse all_sandbox_metrics: %w", err)
 	}
+	for _, s := range resp.Sandboxes {
+		s.Uptime = time.Duration(s.UptimeSecs) * time.Second
+	}
 	return resp.Sandboxes, nil
 }
 


### PR DESCRIPTION
Closes #737.

The other wrapping funcs already convert `UptimeSecs` to `time.Duration` - this was the only place it was missing.

A `UnmarshalJSON` implementation for the `Metrics` type could be nice to ensure consistency.