### PR TITLE
feat(net): add configurable port bind addresses

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -128,7 +128,7 @@ pub struct SandboxOpts {
     pub idle_timeout: Option<String>,
 
     // --- Networking (requires "net" feature) ---
-    /// Forward a host port to the sandbox (HOST:GUEST or HOST:GUEST/udp).
+    /// Forward a host port to the sandbox (HOST:GUEST, BIND_ADDR:HOST:GUEST, and /udp variants).
     #[cfg(feature = "net")]
     #[arg(short, long)]
     pub port: Vec<String>,
@@ -464,11 +464,11 @@ fn apply_network_opts(
 
     // Port mappings.
     for port_str in &opts.port {
-        let (host, guest, udp) = parse_port(port_str)?;
+        let (bind, host, guest, udp) = parse_port_mapping(port_str)?;
         builder = if udp {
-            builder.port_udp(host, guest)
+            builder.port_udp_bind(bind, host, guest)
         } else {
-            builder.port(host, guest)
+            builder.port_bind(bind, host, guest)
         };
     }
 
@@ -766,9 +766,17 @@ fn build_network_policy(
     }))
 }
 
-/// Parse a port spec: `HOST:GUEST` or `HOST:GUEST/udp` or `HOST:GUEST/tcp`.
+/// Parse a port spec:
+/// - `HOST:GUEST`
+/// - `BIND_ADDR:HOST:GUEST`
+/// - `HOST:GUEST/udp`
+/// - `BIND_ADDR:HOST:GUEST/udp`
+///
+/// IPv6 bind addresses must be bracketed, e.g. `[::]:8080:80`.
 #[cfg(feature = "net")]
-fn parse_port(spec: &str) -> anyhow::Result<(u16, u16, bool)> {
+fn parse_port_mapping(spec: &str) -> anyhow::Result<(std::net::IpAddr, u16, u16, bool)> {
+    use std::net::{IpAddr, Ipv4Addr};
+
     let (port_part, udp) = if let Some(p) = spec.strip_suffix("/udp") {
         (p, true)
     } else if let Some(p) = spec.strip_suffix("/tcp") {
@@ -777,9 +785,34 @@ fn parse_port(spec: &str) -> anyhow::Result<(u16, u16, bool)> {
         (spec, false)
     };
 
-    let (host_str, guest_str) = port_part
-        .split_once(':')
-        .ok_or_else(|| anyhow::anyhow!("port must be in format HOST:GUEST[/udp]"))?;
+    let (bind, host_str, guest_str) = if let Some(rest) = port_part.strip_prefix('[') {
+        let (bind_str, after_bracket) = rest.split_once("]:").ok_or_else(|| {
+            anyhow::anyhow!("IPv6 port bind must be in format [ADDR]:HOST:GUEST[/udp]")
+        })?;
+        let (host_str, guest_str) = after_bracket
+            .split_once(':')
+            .ok_or_else(|| anyhow::anyhow!("port must be in format [ADDR]:HOST:GUEST[/udp]"))?;
+        let bind = bind_str
+            .parse::<IpAddr>()
+            .map_err(|_| anyhow::anyhow!("invalid bind address: {bind_str}"))?;
+        (bind, host_str, guest_str)
+    } else {
+        let parts: Vec<_> = port_part.split(':').collect();
+        match parts.as_slice() {
+            [host_str, guest_str] => (IpAddr::V4(Ipv4Addr::LOCALHOST), *host_str, *guest_str),
+            [bind_str, host_str, guest_str] => {
+                let bind = bind_str
+                    .parse::<IpAddr>()
+                    .map_err(|_| anyhow::anyhow!("invalid bind address: {bind_str}"))?;
+                (bind, *host_str, *guest_str)
+            }
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "port must be in format HOST:GUEST[/udp] or BIND_ADDR:HOST:GUEST[/udp]"
+                ));
+            }
+        }
+    };
 
     let host: u16 = host_str
         .trim()
@@ -790,7 +823,7 @@ fn parse_port(spec: &str) -> anyhow::Result<(u16, u16, bool)> {
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid guest port: {guest_str}"))?;
 
-    Ok((host, guest, udp))
+    Ok((bind, host, guest, udp))
 }
 
 /// Parse a secret spec: `ENV=VALUE@HOST`.
@@ -1067,6 +1100,38 @@ mod tests {
     fn inline_empty_name_errors() {
         let err = parse_script_inline("=echo hi").unwrap_err();
         assert!(err.to_string().contains("must not be empty"), "got: {err}");
+    }
+
+    // --- parse_port_mapping ---
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn port_without_bind_defaults_to_loopback() {
+        let (bind, host, guest, udp) = parse_port_mapping("8080:80").unwrap();
+        assert_eq!(bind, std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+        assert_eq!(host, 8080);
+        assert_eq!(guest, 80);
+        assert!(!udp);
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn port_with_ipv4_bind() {
+        let (bind, host, guest, udp) = parse_port_mapping("0.0.0.0:8080:80/udp").unwrap();
+        assert_eq!(bind, "0.0.0.0".parse::<std::net::IpAddr>().unwrap());
+        assert_eq!(host, 8080);
+        assert_eq!(guest, 80);
+        assert!(udp);
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn port_with_bracketed_ipv6_bind() {
+        let (bind, host, guest, udp) = parse_port_mapping("[::]:8080:80/tcp").unwrap();
+        assert_eq!(bind, "::".parse::<std::net::IpAddr>().unwrap());
+        assert_eq!(host, 8080);
+        assert_eq!(guest, 80);
+        assert!(!udp);
     }
 
     // --- parse_script_path ---

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -395,13 +395,40 @@ impl SandboxBuilder {
     /// ```
     #[cfg(feature = "net")]
     pub fn port(mut self, host_port: u16, guest_port: u16) -> Self {
+        self.push_port(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            host_port,
+            guest_port,
+            PortProtocol::Tcp,
+        );
+        self
+    }
+
+    /// Publish a TCP port on a specific host bind address.
+    ///
+    /// ```ignore
+    /// .port_bind("0.0.0.0".parse().unwrap(), 8080, 80)
+    /// ```
+    #[cfg(feature = "net")]
+    pub fn port_bind(mut self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self {
+        self.push_port(host_bind, host_port, guest_port, PortProtocol::Tcp);
+        self
+    }
+
+    #[cfg(feature = "net")]
+    fn push_port(
+        &mut self,
+        host_bind: IpAddr,
+        host_port: u16,
+        guest_port: u16,
+        protocol: PortProtocol,
+    ) {
         self.config.network.ports.push(PublishedPort {
             host_port,
             guest_port,
-            protocol: PortProtocol::Tcp,
-            host_bind: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            protocol,
+            host_bind,
         });
-        self
     }
 
     /// Publish a UDP port directly on the sandbox builder.
@@ -414,12 +441,19 @@ impl SandboxBuilder {
     /// ```
     #[cfg(feature = "net")]
     pub fn port_udp(mut self, host_port: u16, guest_port: u16) -> Self {
-        self.config.network.ports.push(PublishedPort {
+        self.push_port(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
             host_port,
             guest_port,
-            protocol: PortProtocol::Udp,
-            host_bind: IpAddr::V4(Ipv4Addr::LOCALHOST),
-        });
+            PortProtocol::Udp,
+        );
+        self
+    }
+
+    /// Publish a UDP port on a specific host bind address.
+    #[cfg(feature = "net")]
+    pub fn port_udp_bind(mut self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self {
+        self.push_port(host_bind, host_port, guest_port, PortProtocol::Udp);
         self
     }
 
@@ -841,6 +875,8 @@ mod tests {
     use crate::sandbox::RlimitResource;
     #[cfg(feature = "net")]
     use microsandbox_network::config::PortProtocol;
+    #[cfg(feature = "net")]
+    use std::net::{IpAddr, Ipv4Addr};
 
     #[tokio::test]
     async fn test_builder_sets_runtime_log_level() {
@@ -943,25 +979,40 @@ mod tests {
     #[cfg(feature = "net")]
     #[tokio::test]
     async fn test_builder_ports_are_repeatable() {
+        let bind = "0.0.0.0".parse().unwrap();
         let config = SandboxBuilder::new("test")
             .image("alpine")
             .port(8080, 80)
             .port(3000, 3000)
             .port_udp(5353, 53)
+            .port_bind(bind, 8081, 81)
+            .port_udp_bind(bind, 5354, 54)
             .build()
             .await
             .unwrap();
 
-        assert_eq!(config.network.ports.len(), 3);
+        assert_eq!(config.network.ports.len(), 5);
         assert_eq!(config.network.ports[0].host_port, 8080);
         assert_eq!(config.network.ports[0].guest_port, 80);
         assert_eq!(config.network.ports[0].protocol, PortProtocol::Tcp);
+        assert_eq!(
+            config.network.ports[0].host_bind,
+            IpAddr::V4(Ipv4Addr::LOCALHOST)
+        );
         assert_eq!(config.network.ports[1].host_port, 3000);
         assert_eq!(config.network.ports[1].guest_port, 3000);
         assert_eq!(config.network.ports[1].protocol, PortProtocol::Tcp);
         assert_eq!(config.network.ports[2].host_port, 5353);
         assert_eq!(config.network.ports[2].guest_port, 53);
         assert_eq!(config.network.ports[2].protocol, PortProtocol::Udp);
+        assert_eq!(config.network.ports[3].host_bind, bind);
+        assert_eq!(config.network.ports[3].host_port, 8081);
+        assert_eq!(config.network.ports[3].guest_port, 81);
+        assert_eq!(config.network.ports[3].protocol, PortProtocol::Tcp);
+        assert_eq!(config.network.ports[4].host_bind, bind);
+        assert_eq!(config.network.ports[4].host_port, 5354);
+        assert_eq!(config.network.ports[4].guest_port, 54);
+        assert_eq!(config.network.ports[4].protocol, PortProtocol::Udp);
     }
 
     #[cfg(feature = "net")]

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -81,20 +81,44 @@ impl NetworkBuilder {
 
     /// Publish a TCP port: `host_port` on the host maps to `guest_port` in the guest.
     pub fn port(self, host_port: u16, guest_port: u16) -> Self {
-        self.add_port(host_port, guest_port, PortProtocol::Tcp)
+        self.port_bind(
+            IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            host_port,
+            guest_port,
+        )
     }
 
     /// Publish a UDP port.
     pub fn port_udp(self, host_port: u16, guest_port: u16) -> Self {
-        self.add_port(host_port, guest_port, PortProtocol::Udp)
+        self.port_udp_bind(
+            IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            host_port,
+            guest_port,
+        )
     }
 
-    fn add_port(mut self, host_port: u16, guest_port: u16, protocol: PortProtocol) -> Self {
+    /// Publish a TCP port on a specific host bind address.
+    pub fn port_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self {
+        self.add_port(host_bind, host_port, guest_port, PortProtocol::Tcp)
+    }
+
+    /// Publish a UDP port on a specific host bind address.
+    pub fn port_udp_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self {
+        self.add_port(host_bind, host_port, guest_port, PortProtocol::Udp)
+    }
+
+    fn add_port(
+        mut self,
+        host_bind: IpAddr,
+        host_port: u16,
+        guest_port: u16,
+        protocol: PortProtocol,
+    ) -> Self {
         self.config.ports.push(PublishedPort {
             host_port,
             guest_port,
             protocol,
-            host_bind: IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            host_bind,
         });
         self
     }
@@ -482,5 +506,22 @@ mod tests {
             .build()
             .unwrap();
         assert!(!cfg.dns.rebind_protection);
+    }
+
+    #[test]
+    fn port_bind_sets_host_bind() {
+        let bind = "0.0.0.0".parse().unwrap();
+        let cfg = NetworkBuilder::new()
+            .port_bind(bind, 8080, 80)
+            .port_udp_bind(bind, 5353, 53)
+            .build()
+            .unwrap();
+
+        assert_eq!(cfg.ports[0].host_bind, bind);
+        assert_eq!(cfg.ports[0].host_port, 8080);
+        assert_eq!(cfg.ports[0].guest_port, 80);
+        assert_eq!(cfg.ports[0].protocol, PortProtocol::Tcp);
+        assert_eq!(cfg.ports[1].host_bind, bind);
+        assert_eq!(cfg.ports[1].protocol, PortProtocol::Udp);
     }
 }

--- a/crates/network/lib/config.rs
+++ b/crates/network/lib/config.rs
@@ -142,9 +142,11 @@ pub struct PublishedPort {
 pub enum PortProtocol {
     /// TCP (default).
     #[default]
+    #[serde(rename = "tcp", alias = "Tcp")]
     Tcp,
 
     /// UDP.
+    #[serde(rename = "udp", alias = "Udp")]
     Udp,
 }
 
@@ -192,4 +194,29 @@ fn default_host_bind() -> IpAddr {
 
 fn default_query_timeout_ms() -> u64 {
     5000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PortProtocol;
+
+    #[test]
+    fn port_protocol_serializes_lowercase_and_accepts_legacy_case() {
+        assert_eq!(
+            serde_json::to_string(&PortProtocol::Tcp).unwrap(),
+            "\"tcp\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PortProtocol::Udp).unwrap(),
+            "\"udp\""
+        );
+        assert_eq!(
+            serde_json::from_str::<PortProtocol>("\"Tcp\"").unwrap(),
+            PortProtocol::Tcp
+        );
+        assert_eq!(
+            serde_json::from_str::<PortProtocol>("\"Udp\"").unwrap(),
+            PortProtocol::Udp
+        );
+    }
 }

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -26,6 +26,9 @@ msb run --name api \
 
 # Detached (runs in background)
 msb run -d --name worker python -- python worker.py
+
+# Publish on all IPv4 host interfaces instead of the default 127.0.0.1
+msb run --name public-api -p 0.0.0.0:8000:8000 python
 ```
 
 | Flag | Description |
@@ -34,7 +37,7 @@ msb run -d --name worker python -- python worker.py
 | `-c`, `--cpus` | Number of virtual CPUs to allocate |
 | `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
 | `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST`) |
-| `-p`, `--port` | Forward a host port to the sandbox (`HOST:GUEST` or `HOST:GUEST/udp`) |
+| `-p`, `--port` | Forward a host port to the sandbox (`HOST:GUEST`, `BIND_ADDR:HOST:GUEST`, and `/udp` variants) |
 | `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
 | `-w`, `--workdir` | Working directory inside the sandbox |
 | `--shell` | Default shell for interactive sessions |

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -194,12 +194,14 @@ For deny-by-default policies, remember that DNS is delivered through the sandbox
 ## Port mapping
 
 Expose ports from the sandbox to the host so services running inside the VM are reachable from your machine.
+Published ports bind to `127.0.0.1` by default. Specify a bind address, such as `0.0.0.0`, when you intentionally want a wider listener.
 
 <CodeGroup>
 ```rust Rust
 let sb = Sandbox::builder("api")
     .image("python")
     .port(8080, 80)
+    .port_bind("0.0.0.0".parse()?, 8001, 8001)
     .port_udp(5353, 5353)
     .create()
     .await?;
@@ -209,15 +211,18 @@ let sb = Sandbox::builder("api")
 await using sb = await Sandbox.builder("api")
     .image("python")
     .port(8080, 80)
+    .portBind("0.0.0.0", 8001, 8001)
     .portUdp(5353, 5353)
     .create();
 ```
 
 ```python Python
+from microsandbox import PortBinding
+
 sb = await Sandbox.create(
     "api",
     image="python",
-    ports={8080: 80},
+    ports=[PortBinding.tcp(8001, 8001, bind="0.0.0.0")],
 )
 ```
 
@@ -225,12 +230,14 @@ sb = await Sandbox.create(
 sb, err := m.CreateSandbox(ctx, "api",
     m.WithImage("python"),
     m.WithPorts(map[uint16]uint16{8080: 80}),
+    m.WithPortBindings(m.PortBinding{Bind: "0.0.0.0", HostPort: 8001, GuestPort: 8001}),
     m.WithPortsUDP(map[uint16]uint16{5353: 5353}),
 )
 ```
 
 ```bash CLI
 msb create python --name api -p 8080:80
+msb create python --name api-public -p 0.0.0.0:8001:8001
 ```
 
 </CodeGroup>

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -123,12 +123,54 @@ The configuration struct passed via [`WithNetwork`](/sdk/go/sandbox#withnetwork)
 | DNS | [`*DNSConfig`](#dnsconfig) | DNS interception settings |
 | DNSRebindProtection | `*bool` | Legacy convenience for `DNS.RebindProtection`. When `DNS` is also set, the nested value wins |
 | TLS | [`*TLSConfig`](#tlsconfig) | TLS interception settings |
-| Ports | `map[uint16]uint16` | Host→guest TCP port mappings |
+| Ports | `map[uint16]uint16` | Host→guest TCP port mappings bound to `127.0.0.1` |
+| PortBindings | `[]`[`PortBinding`](#portbinding) | Host→guest port mappings with explicit bind addresses |
 | IPv4Pool | `string` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12` |
 | IPv6Pool | `string` | IPv6 pool used for per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48` |
 | MaxConnections | `*uint` | Cap concurrent network connections from the sandbox |
 | OnSecretViolation | [`ViolationAction`](/sdk/go/secrets#violationaction) | Sandbox-wide action when a secret is sent to a disallowed host |
 | TrustHostCAs | `*bool` | Ship the host's trusted root CAs into the guest at boot. Opt-in for corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, ...) whose gateway CA is unknown to the guest's stock Mozilla bundle |
+
+### PortBinding
+
+```go
+type PortBinding struct {
+    Bind      string
+    HostPort  uint16
+    GuestPort uint16
+    Protocol  PortProtocol
+}
+```
+
+A host-to-guest port mapping with an explicit host bind address. Use it with [`WithPortBindings`](/sdk/go/sandbox#withportbindings) or `NetworkConfig.PortBindings` when the default `127.0.0.1` bind is too restrictive.
+
+```go
+sb, err := m.CreateSandbox(ctx, "api",
+    m.WithImage("python:3.12"),
+    m.WithPortBindings(
+        m.PortBinding{Bind: "0.0.0.0", HostPort: 8001, GuestPort: 8001},
+        m.PortBinding{Bind: "127.0.0.1", HostPort: 5353, GuestPort: 53, Protocol: m.PortProtocolUDP},
+    ),
+)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Bind | `string` | Host IP address to bind, such as `127.0.0.1`, `0.0.0.0`, or `::` |
+| HostPort | `uint16` | Port on the host |
+| GuestPort | `uint16` | Port inside the sandbox |
+| Protocol | [`PortProtocol`](#portprotocol) | `PortProtocolTCP` or `PortProtocolUDP`. Empty defaults to TCP |
+
+### PortProtocol
+
+```go
+type PortProtocol string
+```
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `PortProtocolTCP` | `"tcp"` | TCP port mapping |
+| `PortProtocolUDP` | `"udp"` | UDP port mapping |
 
 ### PolicyRule
 

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -856,6 +856,17 @@ func WithPorts(ports map[uint16]uint16) SandboxOption
 ```
 
 Publish host TCP ports into the sandbox (map key = host port, value = guest port).
+The default host bind address is `127.0.0.1`.
+
+---
+
+#### WithPortBindings()
+
+```go
+func WithPortBindings(bindings ...PortBinding) SandboxOption
+```
+
+Publish host ports on explicit host bind addresses, such as `0.0.0.0`. See [`PortBinding`](/sdk/go/networking#portbinding) for the type definition and UDP examples.
 
 ---
 
@@ -865,7 +876,7 @@ Publish host TCP ports into the sandbox (map key = host port, value = guest port
 func WithPortsUDP(ports map[uint16]uint16) SandboxOption
 ```
 
-Publish host UDP ports into the sandbox.
+Publish host UDP ports into the sandbox. The default host bind address is `127.0.0.1`.
 
 ---
 
@@ -965,6 +976,7 @@ The config struct populated by [`SandboxOption`](#sandboxoption) functions. Most
 | RegistryAuth     | [`*RegistryAuth`](#registryauth)                     | Private registry credentials                                         |
 | Ports            | `map[uint16]uint16`                                  | Host→guest TCP port mappings                                         |
 | PortsUDP         | `map[uint16]uint16`                                  | Host→guest UDP port mappings                                         |
+| PortBindings     | [`[]PortBinding`](/sdk/go/networking#portbinding)    | Host→guest port mappings with explicit bind addresses                |
 | Network          | [`*NetworkConfig`](/sdk/go/networking#networkconfig) | Network policy and configuration                                     |
 | Secrets          | [`[]SecretEntry`](/sdk/go/secrets#secretentry)       | Secret injection entries                                             |
 | Patches          | [`[]PatchConfig`](#patchconfig)                      | Rootfs modifications applied before boot                             |

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -13,7 +13,7 @@ Frozen dataclass for sandbox network configuration. Use a class-method preset fo
 ```python
 Network(
     policy: str | NetworkPolicy | None = None,
-    ports: Mapping[int, int] = {},
+    ports: Mapping[int, int] | Sequence[PortBinding] = {},
     deny_domains: tuple[str, ...] = (),
     deny_domain_suffixes: tuple[str, ...] = (),
     dns: DnsConfig | None = None,
@@ -27,8 +27,8 @@ Network(
 
 | Field | Type | Description |
 |-------|------|-------------|
-| policy | `str \| NetworkPolicy \| None` | Preset name (`"none"`, `"public_only"`, `"allow_all"`) or custom [`NetworkPolicy`](#networkpolicy-1) |
-| ports | `Mapping[int, int]` | Port mappings from host to guest |
+| policy | `str \| NetworkPolicy \| None` | Preset name (`"none"`, `"public_only"`, `"allow_all"`) or custom [`NetworkPolicy`](#networkpolicy) |
+| ports | `Mapping[int, int] \| Sequence[PortBinding]` | Port mappings from host to guest. Mapping form binds to `127.0.0.1`; `PortBinding` can set an explicit bind address |
 | deny_domains | `tuple[str, ...]` | Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy so it takes precedence over later allow rules |
 | deny_domain_suffixes | `tuple[str, ...]` | Deny egress to all subdomains of these suffixes. Adds `deny DomainSuffix("...")` rules; same enforcement layers as `deny_domains` |
 | dns | [`DnsConfig`](#dnsconfig) ` \| None` | DNS interception configuration |
@@ -88,6 +88,37 @@ Block private address ranges and cloud metadata endpoints. Allow everything else
 | Type | Description |
 |------|-------------|
 | [`Network`](#network) | Public-only network configuration |
+
+---
+
+## PortBinding
+
+Frozen dataclass for published ports that need an explicit host bind address or UDP.
+
+```python
+PortBinding(
+    host_port: int,
+    guest_port: int,
+    bind: str = "127.0.0.1",
+    protocol: PortProtocol = PortProtocol.TCP,
+)
+```
+
+Prefer the protocol-specific constructors:
+
+```python
+PortBinding.tcp(8001, 8001, bind="0.0.0.0")
+PortBinding.udp(5353, 5353, bind="0.0.0.0")
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| host_port | `int` | Port on the host |
+| guest_port | `int` | Port inside the sandbox |
+| bind | `str` | Host address to bind. Defaults to `127.0.0.1`; use `0.0.0.0` for all IPv4 interfaces |
+| protocol | [`PortProtocol`](#portprotocol) | Published port protocol |
+
+`PortBinding.tcp()` maps to the Rust `port_bind(...)` path; `PortBinding.udp()` maps to `port_udp_bind(...)`.
 
 ---
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -44,7 +44,7 @@ Create and boot a sandbox. The first argument is either a name (`str`) or a full
 | registry_auth | [`RegistryAuth`](#registryauth) | Private registry credentials |
 | volumes | `dict[str, dict]` | Volume mounts. See [Volumes](/sdk/python/volumes). |
 | patches | `list[PatchConfig]` | Rootfs modifications applied before boot |
-| ports | `dict[int, int]` | Port mappings (`host_port: guest_port`) |
+| ports | `dict[int, int] \| Sequence[PortBinding]` | Port mappings. Dict form is TCP and binds to `127.0.0.1`; use [`PortBinding`](/sdk/python/networking#portbinding) for explicit bind addresses or UDP |
 | network | [`Network`](/sdk/python/networking#network) | Network policy and configuration |
 | secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | Secret injection |
 | detached | `bool` | If `True`, sandbox survives after your process exits |
@@ -844,7 +844,7 @@ The keyword arguments accepted by [`Sandbox.create()`](#sandboxcreate) and [`San
 | registry_auth | [`RegistryAuth`](#registryauth) | - | Private registry credentials |
 | volumes | `dict[str, dict]` | `{}` | Volume mounts. See [Volumes](/sdk/python/volumes). |
 | patches | `list[PatchConfig]` | `[]` | Rootfs modifications applied before boot |
-| ports | `dict[int, int]` | `{}` | Port mappings (`host_port: guest_port`) |
+| ports | `dict[int, int] \| Sequence[PortBinding]` | `{}` | Port mappings. Dict form is TCP and binds to `127.0.0.1`; use [`PortBinding`](/sdk/python/networking#portbinding) for explicit bind addresses or UDP |
 | network | [`Network`](/sdk/python/networking#network) | `public_only` | Network policy and configuration |
 | secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | `[]` | Secret injection |
 | detached | `bool` | `False` | If `True`, sandbox survives after your process exits |

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -81,7 +81,7 @@ where
     F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
 ```
 
-Sugar for [`rule()`](#rule-1) with direction pre-set to `Any`. Rules committed inside apply in both directions.
+Sugar for [`rule()`](#rule) with direction pre-set to `Any`. Rules committed inside apply in both directions.
 
 ---
 
@@ -155,7 +155,7 @@ where
     F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
 ```
 
-Sugar for [`rule()`](#rule-1) with direction pre-set to `Egress`.
+Sugar for [`rule()`](#rule) with direction pre-set to `Egress`.
 
 ---
 
@@ -167,7 +167,7 @@ where
     F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
 ```
 
-Sugar for [`rule()`](#rule-1) with direction pre-set to `Ingress`.
+Sugar for [`rule()`](#rule) with direction pre-set to `Ingress`.
 
 ---
 
@@ -314,7 +314,7 @@ Add an inclusive port range.
 fn ports<I: IntoIterator<Item = u16>>(&mut self, ports: I) -> &mut Self
 ```
 
-Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
+Add multiple single ports. Equivalent to calling [`port()`](#port-setters) once per element.
 
 ---
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -384,7 +384,7 @@ Block until the sandbox exits on its own (without triggering a stop). Returns th
 
 ## SandboxBuilder
 
-Builder for configuring a sandbox before creation. Obtained via [`Sandbox::builder(name)`](#sandboxbuilder-1).
+Builder for configuring a sandbox before creation. Obtained via [`Sandbox::builder(name)`](#sandboxbuilder).
 
 ---
 
@@ -706,7 +706,7 @@ Modify the rootfs before the VM boots. Patches go into the writable layer - the 
 fn port(self, host_port: u16, guest_port: u16) -> Self
 ```
 
-Publish a TCP port from the sandbox to the host.
+Publish a TCP port from the sandbox to the host. The default host bind address is `127.0.0.1`.
 
 **Parameters**
 
@@ -717,13 +717,23 @@ Publish a TCP port from the sandbox to the host.
 
 ---
 
+#### port_bind()
+
+```rust
+fn port_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a TCP port on a specific host bind address, such as `0.0.0.0`.
+
+---
+
 #### port_udp()
 
 ```rust
 fn port_udp(self, host_port: u16, guest_port: u16) -> Self
 ```
 
-Publish a UDP port.
+Publish a UDP port. The default host bind address is `127.0.0.1`.
 
 **Parameters**
 
@@ -731,6 +741,16 @@ Publish a UDP port.
 |------|------|-------------|
 | host_port | `u16` | Port on the host |
 | guest_port | `u16` | Port inside the sandbox |
+
+---
+
+#### port_udp_bind()
+
+```rust
+fn port_udp_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a UDP port on a specific host bind address.
 
 ---
 

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -148,7 +148,7 @@ const policy = NetworkPolicy.builder()
 any(configure: (r: RuleBuilder) => RuleBuilder): this
 ```
 
-Sugar for [`rule()`](#rule-2) with direction pre-set to `Any`. Rules committed inside apply in both directions.
+Sugar for [`rule()`](#rule) with direction pre-set to `Any`. Rules committed inside apply in both directions.
 
 ---
 
@@ -158,7 +158,7 @@ Sugar for [`rule()`](#rule-2) with direction pre-set to `Any`. Rules committed i
 build(): NetworkPolicy
 ```
 
-Materialize the accumulated state into a [`NetworkPolicy`](#networkpolicy-1). Lazily parses every recorded `.ip()` / `.cidr()` / `.domain()` / `.domainSuffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a host-side warning for each shadowed rule pair.
+Materialize the accumulated state into a [`NetworkPolicy`](#networkpolicy). Lazily parses every recorded `.ip()` / `.cidr()` / `.domain()` / `.domainSuffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a host-side warning for each shadowed rule pair.
 
 ---
 
@@ -220,7 +220,7 @@ Per-direction override for the ingress default action.
 egress(configure: (r: RuleBuilder) => RuleBuilder): this
 ```
 
-Sugar for [`rule()`](#rule-2) with direction pre-set to `Egress`.
+Sugar for [`rule()`](#rule) with direction pre-set to `Egress`.
 
 ---
 
@@ -230,7 +230,7 @@ Sugar for [`rule()`](#rule-2) with direction pre-set to `Egress`.
 ingress(configure: (r: RuleBuilder) => RuleBuilder): this
 ```
 
-Sugar for [`rule()`](#rule-2) with direction pre-set to `Ingress`.
+Sugar for [`rule()`](#rule) with direction pre-set to `Ingress`.
 
 ---
 
@@ -375,7 +375,7 @@ Add an inclusive port range. `lo > hi` records an error surfaced at `.build()` t
 ports(ports: number[]): this
 ```
 
-Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
+Add multiple single ports. Equivalent to calling [`port()`](#port-setters) once per element.
 
 ---
 
@@ -696,7 +696,7 @@ Begin an explicit-destination rule with action `Deny`.
 
 ## Rule
 
-Factory for individual policy rules. Each method returns a single [`Rule`](#rule-1) value.
+Factory for individual policy rules. Each method returns a single [`Rule`](#rule) value.
 
 ---
 
@@ -712,7 +712,7 @@ Allow rule with direction `any` (matches in either direction).
 
 | Name | Type | Description |
 |------|------|-------------|
-| destination | [`Destination`](#destination-1) | Target filter |
+| destination | [`Destination`](#destination) | Target filter |
 
 ---
 
@@ -728,7 +728,7 @@ Allow rule with direction `egress`.
 
 | Name | Type | Description |
 |------|------|-------------|
-| destination | [`Destination`](#destination-1) | Target filter |
+| destination | [`Destination`](#destination) | Target filter |
 
 ---
 
@@ -744,7 +744,7 @@ Allow rule with direction `ingress`.
 
 | Name | Type | Description |
 |------|------|-------------|
-| destination | [`Destination`](#destination-1) | Target filter |
+| destination | [`Destination`](#destination) | Target filter |
 
 ---
 
@@ -760,7 +760,7 @@ Deny rule with direction `any` (matches in either direction).
 
 | Name | Type | Description |
 |------|------|-------------|
-| destination | [`Destination`](#destination-1) | Target filter |
+| destination | [`Destination`](#destination) | Target filter |
 
 ---
 
@@ -776,7 +776,7 @@ Deny rule with direction `egress`.
 
 | Name | Type | Description |
 |------|------|-------------|
-| destination | [`Destination`](#destination-1) | Target filter |
+| destination | [`Destination`](#destination) | Target filter |
 
 ---
 
@@ -792,7 +792,7 @@ Deny rule with direction `ingress`.
 
 | Name | Type | Description |
 |------|------|-------------|
-| destination | [`Destination`](#destination-1) | Target filter |
+| destination | [`Destination`](#destination) | Target filter |
 
 ---
 
@@ -1047,7 +1047,7 @@ Set the policy. Use a [`NetworkPolicy`](#networkpolicy) factory or a literal.
 port(host: number, guest: number): this
 ```
 
-Publish a TCP port from the guest to the host.
+Publish a TCP port from the guest to the host. The default host bind address is `127.0.0.1`.
 
 **Parameters**
 
@@ -1058,13 +1058,23 @@ Publish a TCP port from the guest to the host.
 
 ---
 
+#### portBind()
+
+```typescript
+portBind(bind: string, host: number, guest: number): this
+```
+
+Publish a TCP port on a specific host bind address, such as `0.0.0.0`.
+
+---
+
 #### portUdp()
 
 ```typescript
 portUdp(host: number, guest: number): this
 ```
 
-Publish a UDP port from the guest to the host.
+Publish a UDP port from the guest to the host. The default host bind address is `127.0.0.1`.
 
 **Parameters**
 
@@ -1072,6 +1082,16 @@ Publish a UDP port from the guest to the host.
 |------|------|-------------|
 | host | `number` | Port on the host |
 | guest | `number` | Port inside the sandbox |
+
+---
+
+#### portUdpBind()
+
+```typescript
+portUdpBind(bind: string, host: number, guest: number): this
+```
+
+Publish a UDP port on a specific host bind address.
 
 ---
 
@@ -1258,7 +1278,7 @@ Built network configuration produced by `NetworkBuilder.build()`.
 |-------|------|-------------|
 | enabled | `boolean` | Master enable flag |
 | ports | `readonly PublishedPort[]` | Port publishings |
-| policy | [`NetworkPolicy`](#networkpolicy-1) ` \| null` | Active policy |
+| policy | [`NetworkPolicy`](#networkpolicy) ` \| null` | Active policy |
 | dns | [`DnsConfig`](#dnsconfig) ` \| null` | DNS interception |
 | tls | [`TlsConfig`](#tlsconfig) ` \| null` | TLS interception |
 | secrets | `readonly SecretEntry[]` | Secret entries |
@@ -1389,5 +1409,6 @@ interface PublishedPort {
   readonly hostPort: number;
   readonly guestPort: number;
   readonly protocol: "tcp" | "udp";
+  readonly hostBind: string;
 }
 ```

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -912,6 +912,7 @@ type CreateOptions struct {
 	RegistryAuth       *RegistryAuthOptions `json:"registry_auth,omitempty"`
 	Ports              map[uint16]uint16    `json:"ports,omitempty"`
 	PortsUDP           map[uint16]uint16    `json:"ports_udp,omitempty"`
+	PortBindings       []PortBindingOptions `json:"port_bindings,omitempty"`
 	Network            *NetworkOptions      `json:"network,omitempty"`
 	Secrets            []SecretOptions      `json:"secrets,omitempty"`
 	Patches            []PatchOptions       `json:"patches,omitempty"`
@@ -953,11 +954,20 @@ type NetworkOptions struct {
 	DenyDomainSuffixes  []string             `json:"deny_domain_suffixes,omitempty"`
 	TLS                 *TLSOptions          `json:"tls,omitempty"`
 	Ports               map[uint16]uint16    `json:"ports,omitempty"`
+	PortBindings        []PortBindingOptions `json:"port_bindings,omitempty"`
 	IPv4Pool            string               `json:"ipv4_pool,omitempty"`
 	IPv6Pool            string               `json:"ipv6_pool,omitempty"`
 	MaxConnections      *uint                `json:"max_connections,omitempty"`
 	OnSecretViolation   string               `json:"on_secret_violation,omitempty"`
 	TrustHostCAs        *bool                `json:"trust_host_cas,omitempty"`
+}
+
+// PortBindingOptions publishes a host port on a specific host bind address.
+type PortBindingOptions struct {
+	Bind      string `json:"bind,omitempty"`
+	HostPort  uint16 `json:"host_port"`
+	GuestPort uint16 `json:"guest_port"`
+	Protocol  string `json:"protocol,omitempty"`
 }
 
 // DNSOptions configures the in-VM DNS proxy.

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -38,6 +38,7 @@
 use std::{
     collections::HashMap,
     ffi::{CStr, CString},
+    net::IpAddr,
     os::raw::{c_char, c_uchar},
     path::PathBuf,
     sync::{
@@ -580,6 +581,14 @@ fn default_egress() -> String {
     "egress".into()
 }
 
+fn default_host_bind() -> String {
+    "127.0.0.1".into()
+}
+
+fn default_port_protocol() -> String {
+    "tcp".into()
+}
+
 /// Custom policy. Parity-aligned with Node/Python: `default_egress` and
 /// `default_ingress` are the asymmetric default actions. Empty defaults to
 /// deny egress / allow ingress (matching upstream `public_only`).
@@ -632,6 +641,9 @@ struct NetworkOpts {
     /// Ports nested inside network: {host_port: guest_port}.
     #[serde(default)]
     ports: HashMap<u16, u16>,
+    /// Ports nested inside network with explicit bind addresses.
+    #[serde(default)]
+    port_bindings: Vec<PortBindingOpts>,
     /// IPv4 pool used to derive per-sandbox /30 guest subnets.
     ipv4_pool: Option<String>,
     /// IPv6 pool used to derive per-sandbox /64 guest prefixes.
@@ -739,6 +751,9 @@ struct SandboxCreateOpts {
     /// Top-level UDP ports shorthand: {host_port: guest_port}.
     #[serde(default)]
     ports_udp: HashMap<u16, u16>,
+    /// Top-level port bindings with explicit bind addresses.
+    #[serde(default)]
+    port_bindings: Vec<PortBindingOpts>,
     #[serde(default)]
     secrets: Vec<SecretOpts>,
     #[serde(default)]
@@ -746,6 +761,16 @@ struct SandboxCreateOpts {
     /// Volume mounts: guest_path → MountSpec.
     #[serde(default)]
     volumes: HashMap<String, MountSpec>,
+}
+
+#[derive(serde::Deserialize, Clone)]
+struct PortBindingOpts {
+    #[serde(default = "default_host_bind")]
+    bind: String,
+    host_port: u16,
+    guest_port: u16,
+    #[serde(default = "default_port_protocol")]
+    protocol: String,
 }
 
 #[derive(serde::Deserialize, Default)]
@@ -1009,8 +1034,34 @@ fn apply_network(
     for (host, guest) in &net.ports {
         builder = builder.port(*host, *guest);
     }
+    for port in &net.port_bindings {
+        builder = apply_port_binding(builder, port)?;
+    }
 
     Ok(builder)
+}
+
+fn apply_port_binding(
+    builder: microsandbox::sandbox::SandboxBuilder,
+    port: &PortBindingOpts,
+) -> Result<microsandbox::sandbox::SandboxBuilder, FfiError> {
+    let bind = port.bind.parse::<IpAddr>().map_err(|_| {
+        FfiError::new(
+            error_kind::INVALID_CONFIG,
+            format!("invalid bind address: {}", port.bind),
+        )
+    })?;
+
+    Ok(match port.protocol.as_str() {
+        "" | "tcp" => builder.port_bind(bind, port.host_port, port.guest_port),
+        "udp" => builder.port_udp_bind(bind, port.host_port, port.guest_port),
+        other => {
+            return Err(FfiError::new(
+                error_kind::INVALID_CONFIG,
+                format!("invalid port protocol: {other}"),
+            ));
+        }
+    })
 }
 
 /// Resolve a JSON destination string into the typed enum. Supports the
@@ -1478,6 +1529,9 @@ pub unsafe extern "C" fn msb_sandbox_create(
             }
             for (host, guest) in &opts.ports_udp {
                 builder = builder.port_udp(*host, *guest);
+            }
+            for port in &opts.port_bindings {
+                builder = apply_port_binding(builder, port)?;
             }
             // Network (policy, DNS, TLS, ports-in-network).
             if let Some(ref net) = opts.network {

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -37,6 +37,7 @@ type SandboxConfig struct {
 	RegistryAuth     *RegistryAuth
 	Ports            map[uint16]uint16 // host port → guest port (TCP)
 	PortsUDP         map[uint16]uint16 // host port → guest port (UDP)
+	PortBindings     []PortBinding     // explicit bind address host→guest ports
 	Network          *NetworkConfig
 	Secrets          []SecretEntry
 	Patches          []PatchConfig
@@ -229,6 +230,31 @@ func WithPortsUDP(ports map[uint16]uint16) SandboxOption {
 	}
 }
 
+// PortBinding publishes a host port on a specific host bind address.
+// Protocol defaults to TCP when empty. Use Bind "0.0.0.0" to expose the
+// published port on all IPv4 interfaces.
+type PortBinding struct {
+	Bind      string
+	HostPort  uint16
+	GuestPort uint16
+	Protocol  PortProtocol
+}
+
+// PortProtocol identifies the protocol for a published port binding.
+type PortProtocol string
+
+const (
+	PortProtocolTCP PortProtocol = "tcp"
+	PortProtocolUDP PortProtocol = "udp"
+)
+
+// WithPortBindings publishes explicit bind-address host ports into the sandbox.
+func WithPortBindings(bindings ...PortBinding) SandboxOption {
+	return func(o *SandboxConfig) {
+		o.PortBindings = append(o.PortBindings, bindings...)
+	}
+}
+
 // WithNetwork sets the network configuration for the sandbox.
 func WithNetwork(net *NetworkConfig) SandboxOption {
 	return func(o *SandboxConfig) { o.Network = net }
@@ -331,6 +357,9 @@ type NetworkConfig struct {
 
 	// Ports publishes host TCP ports into the sandbox (host→guest).
 	Ports map[uint16]uint16
+
+	// PortBindings publishes host ports on explicit host bind addresses.
+	PortBindings []PortBinding
 
 	// IPv4Pool is used to derive per-sandbox /30 guest subnets.
 	// Defaults to "172.16.0.0/12".

--- a/sdk/go/options_test.go
+++ b/sdk/go/options_test.go
@@ -173,6 +173,24 @@ func TestWithPortsNilInitial(t *testing.T) {
 	}
 }
 
+func TestWithPortBindings(t *testing.T) {
+	o := SandboxConfig{}
+	WithPortBindings(
+		PortBinding{Bind: "0.0.0.0", HostPort: 8080, GuestPort: 80},
+		PortBinding{Bind: "::", HostPort: 5353, GuestPort: 53, Protocol: PortProtocolUDP},
+	)(&o)
+
+	if len(o.PortBindings) != 2 {
+		t.Fatalf("PortBindings len = %d, want 2", len(o.PortBindings))
+	}
+	if o.PortBindings[0].Bind != "0.0.0.0" || o.PortBindings[0].HostPort != 8080 || o.PortBindings[0].GuestPort != 80 {
+		t.Fatalf("PortBindings[0] = %#v", o.PortBindings[0])
+	}
+	if o.PortBindings[1].Protocol != PortProtocolUDP {
+		t.Fatalf("PortBindings[1].Protocol = %q, want udp", o.PortBindings[1].Protocol)
+	}
+}
+
 func TestWithNetwork(t *testing.T) {
 	o := SandboxConfig{}
 	net := &NetworkConfig{Policy: NetworkPolicyPresetPublicOnly}

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -60,6 +60,7 @@ func buildFFICreateOptions(o SandboxConfig) ffi.CreateOptions {
 		IdleTimeoutSecs: durationSecsCeil(o.IdleTimeout),
 		Ports:           o.Ports,
 		PortsUDP:        o.PortsUDP,
+		PortBindings:    buildFFIPortBindings(o.PortBindings),
 	}
 	if o.ReplaceWithGrace != nil {
 		var ms uint64
@@ -159,6 +160,7 @@ func buildFFINetwork(n *NetworkConfig) *ffi.NetworkOptions {
 		DenyDomains:         n.DenyDomains,
 		DenyDomainSuffixes:  n.DenyDomainSuffixes,
 		Ports:               n.Ports,
+		PortBindings:        buildFFIPortBindings(n.PortBindings),
 		IPv4Pool:            n.IPv4Pool,
 		IPv6Pool:            n.IPv6Pool,
 		MaxConnections:      n.MaxConnections,
@@ -208,6 +210,19 @@ func buildFFINetwork(n *NetworkConfig) *ffi.NetworkOptions {
 		}
 	}
 
+	return out
+}
+
+func buildFFIPortBindings(bindings []PortBinding) []ffi.PortBindingOptions {
+	out := make([]ffi.PortBindingOptions, 0, len(bindings))
+	for _, b := range bindings {
+		out = append(out, ffi.PortBindingOptions{
+			Bind:      b.Bind,
+			HostPort:  b.HostPort,
+			GuestPort: b.GuestPort,
+			Protocol:  string(b.Protocol),
+		})
+	}
 	return out
 }
 

--- a/sdk/go/sandbox_options_test.go
+++ b/sdk/go/sandbox_options_test.go
@@ -144,6 +144,7 @@ func TestFFIWireShape_Ports(t *testing.T) {
 		WithImage("alpine"),
 		WithPorts(map[uint16]uint16{8080: 80}),
 		WithPortsUDP(map[uint16]uint16{5353: 53}),
+		WithPortBindings(PortBinding{Bind: "0.0.0.0", HostPort: 8081, GuestPort: 81}),
 	)
 	ports := mustField(t, got, "ports").(map[string]any)
 	if ports["8080"] != float64(80) {
@@ -152,6 +153,11 @@ func TestFFIWireShape_Ports(t *testing.T) {
 	portsUDP := mustField(t, got, "ports_udp").(map[string]any)
 	if portsUDP["5353"] != float64(53) {
 		t.Fatalf("ports_udp = %v", portsUDP)
+	}
+	bindings := mustField(t, got, "port_bindings").([]any)
+	first := bindings[0].(map[string]any)
+	if first["bind"] != "0.0.0.0" || first["host_port"] != float64(8081) || first["guest_port"] != float64(81) {
+		t.Fatalf("port_bindings = %v", bindings)
 	}
 }
 

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -312,8 +312,12 @@ export declare class NetworkBuilder {
   enabled(enabled: boolean): this
   /** Publish a TCP port. */
   port(hostPort: number, guestPort: number): this
+  /** Publish a TCP port on a specific host bind address. */
+  portBind(bind: string, hostPort: number, guestPort: number): this
   /** Publish a UDP port. */
   portUdp(hostPort: number, guestPort: number): this
+  /** Publish a UDP port on a specific host bind address. */
+  portUdpBind(bind: string, hostPort: number, guestPort: number): this
   /**
    * Set a policy. Construct via the JS-side `NetworkPolicy.publicOnly()`
    * / `.allowAll()` / `.none()` / `.nonLocal()` factories or build a
@@ -799,8 +803,12 @@ export declare class SandboxBuilder {
   network(configure: (arg: NetworkBuilder) => NetworkBuilder): this
   /** Publish a TCP port from host -> guest. */
   port(hostPort: number, guestPort: number): this
+  /** Publish a TCP port from host -> guest on a specific host bind address. */
+  portBind(bind: string, hostPort: number, guestPort: number): this
   /** Publish a UDP port from host -> guest. */
   portUdp(hostPort: number, guestPort: number): this
+  /** Publish a UDP port from host -> guest on a specific host bind address. */
+  portUdpBind(bind: string, hostPort: number, guestPort: number): this
   /** Add a secret via a callback. */
   secret(configure: (arg: JsSecretBuilder) => JsSecretBuilder): this
   /**

--- a/sdk/node-ts/native/network_builder.rs
+++ b/sdk/node-ts/native/network_builder.rs
@@ -1,3 +1,5 @@
+use std::net::IpAddr;
+
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use std::str::FromStr;
@@ -55,6 +57,19 @@ impl JsNetworkBuilder {
         Ok(self)
     }
 
+    /// Publish a TCP port on a specific host bind address.
+    #[napi(js_name = "portBind")]
+    pub fn port_bind(&mut self, bind: String, host_port: u32, guest_port: u32) -> Result<&Self> {
+        let bind = parse_bind_addr(&bind)?;
+        let h = u16::try_from(host_port)
+            .map_err(|_| napi::Error::from_reason("host port out of range"))?;
+        let g = u16::try_from(guest_port)
+            .map_err(|_| napi::Error::from_reason("guest port out of range"))?;
+        let prev = self.take_inner();
+        self.inner = Some(prev.port_bind(bind, h, g));
+        Ok(self)
+    }
+
     /// Publish a UDP port.
     #[napi(js_name = "portUdp")]
     pub fn port_udp(&mut self, host_port: u32, guest_port: u32) -> Result<&Self> {
@@ -64,6 +79,24 @@ impl JsNetworkBuilder {
             .map_err(|_| napi::Error::from_reason("guest port out of range"))?;
         let prev = self.take_inner();
         self.inner = Some(prev.port_udp(h, g));
+        Ok(self)
+    }
+
+    /// Publish a UDP port on a specific host bind address.
+    #[napi(js_name = "portUdpBind")]
+    pub fn port_udp_bind(
+        &mut self,
+        bind: String,
+        host_port: u32,
+        guest_port: u32,
+    ) -> Result<&Self> {
+        let bind = parse_bind_addr(&bind)?;
+        let h = u16::try_from(host_port)
+            .map_err(|_| napi::Error::from_reason("host port out of range"))?;
+        let g = u16::try_from(guest_port)
+            .map_err(|_| napi::Error::from_reason("guest port out of range"))?;
+        let prev = self.take_inner();
+        self.inner = Some(prev.port_udp_bind(bind, h, g));
         Ok(self)
     }
 
@@ -250,6 +283,11 @@ impl JsNetworkBuilder {
         serde_json::to_string(&cfg)
             .map_err(|e| napi::Error::from_reason(format!("network config serialize: {e}")))
     }
+}
+
+fn parse_bind_addr(bind: &str) -> Result<IpAddr> {
+    bind.parse::<IpAddr>()
+        .map_err(|_| napi::Error::from_reason(format!("invalid bind address: {bind}")))
 }
 
 impl JsNetworkBuilder {

--- a/sdk/node-ts/native/sandbox_builder.rs
+++ b/sdk/node-ts/native/sandbox_builder.rs
@@ -1,3 +1,4 @@
+use std::net::IpAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -343,6 +344,19 @@ impl JsSandboxBuilder {
         Ok(self)
     }
 
+    /// Publish a TCP port from host -> guest on a specific host bind address.
+    #[napi(js_name = "portBind")]
+    pub fn port_bind(&mut self, bind: String, host_port: u32, guest_port: u32) -> Result<&Self> {
+        let bind = parse_bind_addr(&bind)?;
+        let h = u16::try_from(host_port)
+            .map_err(|_| napi::Error::from_reason("host port out of range"))?;
+        let g = u16::try_from(guest_port)
+            .map_err(|_| napi::Error::from_reason("guest port out of range"))?;
+        let prev = self.take_inner();
+        self.inner = Some(prev.port_bind(bind, h, g));
+        Ok(self)
+    }
+
     /// Publish a UDP port from host -> guest.
     #[napi(js_name = "portUdp")]
     pub fn port_udp(&mut self, host_port: u32, guest_port: u32) -> Result<&Self> {
@@ -352,6 +366,24 @@ impl JsSandboxBuilder {
             .map_err(|_| napi::Error::from_reason("guest port out of range"))?;
         let prev = self.take_inner();
         self.inner = Some(prev.port_udp(h, g));
+        Ok(self)
+    }
+
+    /// Publish a UDP port from host -> guest on a specific host bind address.
+    #[napi(js_name = "portUdpBind")]
+    pub fn port_udp_bind(
+        &mut self,
+        bind: String,
+        host_port: u32,
+        guest_port: u32,
+    ) -> Result<&Self> {
+        let bind = parse_bind_addr(&bind)?;
+        let h = u16::try_from(host_port)
+            .map_err(|_| napi::Error::from_reason("host port out of range"))?;
+        let g = u16::try_from(guest_port)
+            .map_err(|_| napi::Error::from_reason("guest port out of range"))?;
+        let prev = self.take_inner();
+        self.inner = Some(prev.port_udp_bind(bind, h, g));
         Ok(self)
     }
 
@@ -582,6 +614,11 @@ impl JsSandboxBuilder {
             task: std::sync::Arc::new(tokio::sync::Mutex::new(Some(task))),
         })
     }
+}
+
+fn parse_bind_addr(bind: &str) -> Result<IpAddr> {
+    bind.parse::<IpAddr>()
+        .map_err(|_| napi::Error::from_reason(format!("invalid bind address: {bind}")))
 }
 
 /// Pair returned by `createWithPullProgress`: the progress event stream

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -109,7 +109,9 @@ export interface NapiSandboxBuilderSetters {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   network(configure: (b: any) => any): this;
   port(host: number, guest: number): this;
+  portBind(bind: string, host: number, guest: number): this;
   portUdp(host: number, guest: number): this;
+  portUdpBind(bind: string, host: number, guest: number): this;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   secret(configure: (b: any) => any): this;
   secretEnv(envVar: string, value: string, allowedHost: string): this;
@@ -620,7 +622,9 @@ export interface NapiSecretInjection {
 export interface NapiNetworkBuilder {
   enabled(enabled: boolean): this;
   port(host: number, guest: number): this;
+  portBind(bind: string, host: number, guest: number): this;
   portUdp(host: number, guest: number): this;
+  portUdpBind(bind: string, host: number, guest: number): this;
   policyJson(json: string): this;
   policyFromBuilder(builder: NapiNetworkPolicyBuilder): this;
   dns(configure: (b: NapiDnsBuilder) => NapiDnsBuilder): this;

--- a/sdk/node-ts/src/network-config.ts
+++ b/sdk/node-ts/src/network-config.ts
@@ -6,6 +6,7 @@ export interface PublishedPort {
   readonly hostPort: number;
   readonly guestPort: number;
   readonly protocol: "tcp" | "udp";
+  readonly hostBind: string;
 }
 
 /** DNS interception configuration. */

--- a/sdk/node-ts/tests/unit/builders.test.ts
+++ b/sdk/node-ts/tests/unit/builders.test.ts
@@ -280,6 +280,42 @@ describe("NetworkBuilder.secretEnvSimple (3-arg shorthand)", () => {
   });
 });
 
+describe("NetworkBuilder ports", () => {
+  it("keeps loopback default and supports explicit bind addresses", () => {
+    const cfg = new NetworkBuilder()
+      .port(8080, 80)
+      .portBind("0.0.0.0", 8081, 81)
+      .portUdpBind("::", 5353, 53)
+      .build() as {
+        ports: ReadonlyArray<{
+          hostBind: string;
+          hostPort: number;
+          guestPort: number;
+          protocol: "tcp" | "udp";
+        }>;
+      };
+
+    expect(cfg.ports[0]).toMatchObject({
+      hostBind: "127.0.0.1",
+      hostPort: 8080,
+      guestPort: 80,
+      protocol: "tcp",
+    });
+    expect(cfg.ports[1]).toMatchObject({
+      hostBind: "0.0.0.0",
+      hostPort: 8081,
+      guestPort: 81,
+      protocol: "tcp",
+    });
+    expect(cfg.ports[2]).toMatchObject({
+      hostBind: "::",
+      hostPort: 5353,
+      guestPort: 53,
+      protocol: "udp",
+    });
+  });
+});
+
 describe("Stdin factory", () => {
   it("emits the right discriminants", () => {
     expect(Stdin.null()).toEqual({ kind: "null" });

--- a/sdk/python/microsandbox/__init__.py
+++ b/sdk/python/microsandbox/__init__.py
@@ -90,6 +90,7 @@ from microsandbox.types import (
     NetworkPolicy,
     Patch,
     PatchConfig,
+    PortBinding,
     PortProtocol,
     Protocol,
     PullPolicy,
@@ -171,6 +172,7 @@ __all__ = [
     "Action",
     "Direction",
     "Protocol",
+    "PortBinding",
     "PortProtocol",
     "DestGroup",
     # Secrets & TLS

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -650,10 +650,35 @@ class DnsConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class PortBinding:
+    """Published host-to-guest port with an optional host bind address."""
+    host_port: int
+    guest_port: int
+    bind: str = "127.0.0.1"
+    protocol: PortProtocol = PortProtocol.TCP
+
+    @classmethod
+    def tcp(cls, host_port: int, guest_port: int, *, bind: str = "127.0.0.1") -> PortBinding:
+        return cls(host_port=host_port, guest_port=guest_port, bind=bind, protocol=PortProtocol.TCP)
+
+    @classmethod
+    def udp(cls, host_port: int, guest_port: int, *, bind: str = "127.0.0.1") -> PortBinding:
+        return cls(host_port=host_port, guest_port=guest_port, bind=bind, protocol=PortProtocol.UDP)
+
+    def _to_dict(self) -> dict:
+        return {
+            "host_port": self.host_port,
+            "guest_port": self.guest_port,
+            "bind": self.bind,
+            "protocol": self.protocol.value,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class Network:
     """Network configuration for a sandbox."""
     policy: str | NetworkPolicy | None = None
-    ports: Mapping[int, int] = field(default_factory=dict)
+    ports: Mapping[int, int] | Sequence[PortBinding] = field(default_factory=dict)
     deny_domains: tuple[str, ...] = ()
     """Deny egress to these exact domains. Each entry adds a
     `deny Domain("...")` policy rule that fires at DNS resolution
@@ -693,7 +718,10 @@ class Network:
         elif isinstance(self.policy, NetworkPolicy):
             d["custom_policy"] = self.policy._to_dict()
         if self.ports:
-            d["ports"] = dict(self.ports)
+            if isinstance(self.ports, Mapping):
+                d["ports"] = dict(self.ports)
+            else:
+                d["ports"] = [p._to_dict() for p in self.ports]
         if self.deny_domains:
             d["deny_domains"] = list(self.deny_domains)
         if self.deny_domain_suffixes:

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -266,12 +266,7 @@ pub fn sandbox_builder_from_args(
 
     // Ports.
     if let Some(ports) = kwargs.get_item("ports")? {
-        let ports_dict: &Bound<'_, PyDict> = ports.downcast()?;
-        for (host_obj, guest_obj) in ports_dict.iter() {
-            let host_port: u16 = host_obj.extract()?;
-            let guest_port: u16 = guest_obj.extract()?;
-            builder = builder.port(host_port, guest_port);
-        }
+        builder = apply_ports(builder, &ports)?;
     }
 
     // Network.
@@ -833,12 +828,50 @@ fn apply_network(
     if let Some(ports) = net.get_item("ports")?
         && !ports.is_none()
     {
-        let ports_dict: &Bound<'_, PyDict> = ports.downcast()?;
+        builder = apply_ports(builder, &ports)?;
+    }
+
+    Ok(builder)
+}
+
+fn apply_ports(
+    mut builder: microsandbox::sandbox::SandboxBuilder,
+    ports: &Bound<'_, PyAny>,
+) -> PyResult<microsandbox::sandbox::SandboxBuilder> {
+    if let Ok(ports_dict) = ports.downcast::<PyDict>() {
         for (host_obj, guest_obj) in ports_dict.iter() {
             let host_port: u16 = host_obj.extract()?;
             let guest_port: u16 = guest_obj.extract()?;
             builder = builder.port(host_port, guest_port);
         }
+        return Ok(builder);
+    }
+
+    let iter = ports.try_iter().map_err(|_| {
+        pyo3::exceptions::PyTypeError::new_err(
+            "ports must be a mapping of host_port to guest_port or a sequence of PortBinding values",
+        )
+    })?;
+
+    for item in iter {
+        let item = item?;
+        let port = as_dict(&item)?;
+        let host_port: u16 = extract_required(&port, "host_port")?;
+        let guest_port: u16 = extract_required(&port, "guest_port")?;
+        let bind: String = extract_opt(&port, "bind")?.unwrap_or_else(|| "127.0.0.1".to_string());
+        let bind = bind.parse::<std::net::IpAddr>().map_err(|_| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid bind address: {bind}"))
+        })?;
+        let protocol: Option<String> = extract_opt(&port, "protocol")?;
+        builder = match protocol.as_deref().unwrap_or("tcp") {
+            "tcp" => builder.port_bind(bind, host_port, guest_port),
+            "udp" => builder.port_udp_bind(bind, host_port, guest_port),
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "invalid port protocol: {other}"
+                )));
+            }
+        };
     }
 
     Ok(builder)


### PR DESCRIPTION
## summary

adds explicit host bind address support for published sandbox ports while preserving the existing loopback default for current callers. the CLI now accepts `BIND_ADDR:HOST:GUEST` mappings and `/udp` variants, and the Rust, Python, TypeScript, and Go SDKs expose corresponding bind-aware APIs.

## details

- keeps existing `HOST:GUEST` behavior bound to `127.0.0.1` for compatibility.
- adds Rust builder methods for TCP/UDP bind addresses.
- adds SDK support across Python, TypeScript, and Go, including UDP bind support where applicable.
- serializes port protocols as lowercase `tcp` / `udp` while accepting legacy PascalCase during deserialization.
- updates CLI and SDK docs with bind-address examples and `PortBinding` type docs.