### PR TITLE
chore(ci): add python sdk integration ci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -511,6 +511,70 @@ jobs:
         run: bunx --bun vitest run
 
   # ---------------------------------------------------------------------------
+  # Python SDK integration tests (requires KVM)
+  #
+  # Downloads the pre-built msb + libkrunfw from the `check` job, then builds
+  # the Python extension locally and runs the integration suite against those
+  # fresh runtime binaries.
+  # ---------------------------------------------------------------------------
+  python-sdk-test:
+    name: Python SDK Tests
+    needs: [check, changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: self-hosted-ubuntu-2404-x64
+    steps:
+      - name: Clean workspace
+        run: |
+          rm -rf "${{ github.workspace }}"/{build}
+          rm -rf ~/.microsandbox
+
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "sdk/python/uv.lock"
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: msb-linux-x86_64
+          path: build/
+
+      - name: Stage runtime bundle
+        run: |
+          chmod +x build/msb
+          mkdir -p sdk/python/microsandbox/_bundled/bin
+          mkdir -p sdk/python/microsandbox/_bundled/lib
+          cp build/msb sdk/python/microsandbox/_bundled/bin/
+          cp build/libkrunfw.so.${{ env.LIBKRUNFW_VERSION }} sdk/python/microsandbox/_bundled/lib/
+          cd sdk/python/microsandbox/_bundled/lib
+          ln -sf libkrunfw.so.${{ env.LIBKRUNFW_VERSION }} libkrunfw.so.${{ env.LIBKRUNFW_ABI }}
+          ln -sf libkrunfw.so.${{ env.LIBKRUNFW_ABI }} libkrunfw.so
+
+      - name: Sync Python dev environment
+        working-directory: sdk/python
+        run: uv sync --group dev
+
+      - name: Build Python SDK (editable)
+        working-directory: sdk/python
+        run: uv run maturin develop --release
+
+      - name: Run Python integration tests
+        working-directory: sdk/python
+        env:
+          MSB_HOME: ${{ runner.temp }}/msb-home-${{ github.run_id }}-python
+          MSB_PATH: ${{ github.workspace }}/build/msb
+          LD_LIBRARY_PATH: ${{ github.workspace }}/build:${{ github.workspace }}/sdk/python/microsandbox/_bundled/lib
+        run: uv run pytest integration
+
+  # ---------------------------------------------------------------------------
   # Go SDK integration tests (requires KVM)
   #
   # Downloads the pre-built msb + libkrunfw + libmicrosandbox_go_ffi.so from
@@ -590,6 +654,7 @@ jobs:
       - check
       - integration-test
       - node-sdk-test
+      - python-sdk-test
       - go-sdk-test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -569,10 +569,13 @@ jobs:
       - name: Run Python integration tests
         working-directory: sdk/python
         env:
-          MSB_HOME: ${{ runner.temp }}/msb-home-${{ github.run_id }}-python
           MSB_PATH: ${{ github.workspace }}/build/msb
           LD_LIBRARY_PATH: ${{ github.workspace }}/build:${{ github.workspace }}/sdk/python/microsandbox/_bundled/lib
-        run: uv run pytest integration
+        run: |
+          MSB_HOME=$(mktemp -d -p /tmp XXX)
+          trap "rm -rf '$MSB_HOME'" EXIT
+          export MSB_HOME
+          uv run pytest integration
 
   # ---------------------------------------------------------------------------
   # Go SDK integration tests (requires KVM)

--- a/sdk/python/integration/test_smoke.py
+++ b/sdk/python/integration/test_smoke.py
@@ -37,7 +37,7 @@ async def test_python_sdk_end_to_end_smoke():
     )
 
     try:
-        assert await sandbox.name() == name
+        assert await sandbox.name == name
 
         output = await sandbox.exec("echo", ["hello"])
         assert output.success is True

--- a/sdk/python/integration/test_smoke.py
+++ b/sdk/python/integration/test_smoke.py
@@ -1,0 +1,86 @@
+"""End-to-end smoke tests for the Python SDK integration CI lane."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from contextlib import suppress
+
+import pytest
+
+from microsandbox import Sandbox
+
+IMAGE = os.environ.get("MICROSANDBOX_PYTHON_INTEGRATION_IMAGE", "mirror.gcr.io/library/alpine")
+
+
+def _sandbox_name() -> str:
+    run_id = os.environ.get("GITHUB_RUN_ID") or str(os.getpid())
+    return f"py-sdk-smoke-{run_id}-{uuid.uuid4().hex[:8]}"
+
+
+async def _remove_sandbox(name: str) -> None:
+    with suppress(Exception):
+        await Sandbox.remove(name)
+
+
+@pytest.mark.asyncio
+async def test_python_sdk_end_to_end_smoke():
+    name = _sandbox_name()
+    await _remove_sandbox(name)
+
+    sandbox = await Sandbox.create(
+        name,
+        image=IMAGE,
+        cpus=1,
+        memory=512,
+        replace=True,
+    )
+
+    try:
+        assert await sandbox.name() == name
+
+        output = await sandbox.exec("echo", ["hello"])
+        assert output.success is True
+        assert output.exit_code == 0
+        assert output.stdout_text == "hello\n"
+        assert output.stderr_text == ""
+
+        configured = await sandbox.exec(
+            "sh",
+            {
+                "args": ["-c", 'printf "%s:%s\\n" "$(pwd)" "$PYTHON_SMOKE"'],
+                "cwd": "/tmp",
+                "env": {"PYTHON_SMOKE": "ok"},
+                "timeout": 30.0,
+            },
+        )
+        assert configured.success is True
+        assert configured.stdout_text == "/tmp:ok\n"
+
+        shell = await sandbox.shell("printf 'shell:%s\\n' ok")
+        assert shell.success is True
+        assert shell.stdout_text == "shell:ok\n"
+
+        streamed = await sandbox.exec_stream("sh", ["-c", "echo stream; echo err >&2"])
+        streamed_output = await streamed.collect()
+        assert streamed_output.success is True
+        assert streamed_output.stdout_text == "stream\n"
+        assert streamed_output.stderr_text == "err\n"
+
+        fs = sandbox.fs
+        await fs.write("/tmp/python-sdk-smoke.txt", b"data\n")
+        assert await fs.exists("/tmp/python-sdk-smoke.txt") is True
+        assert await fs.exists("/tmp/python-sdk-missing.txt") is False
+        assert await fs.read_text("/tmp/python-sdk-smoke.txt") == "data\n"
+
+        metadata = await fs.stat("/tmp/python-sdk-smoke.txt")
+        assert metadata.kind == "file"
+        assert metadata.size == len(b"data\n")
+
+        metrics = await sandbox.metrics()
+        assert isinstance(metrics.cpu_percent, float)
+        assert metrics.memory_limit_bytes > 0
+    finally:
+        with suppress(Exception):
+            await sandbox.stop_and_wait()
+        await _remove_sandbox(name)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -67,3 +67,4 @@ ignore = ["RUF022"]  # __all__ organized by category, not alphabetically
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/sdk/python/src/sandbox.rs
+++ b/sdk/python/src/sandbox.rs
@@ -248,7 +248,7 @@ impl PySandbox {
 
             let output = if let Some(opts) = options {
                 sandbox
-                    .exec_with(&cmd, |e| apply_exec_options(e, opts))
+                    .exec_with(&cmd, |e| apply_exec_options(e, args, opts))
                     .await
                     .map_err(to_py_err)?
             } else {
@@ -275,7 +275,7 @@ impl PySandbox {
 
             let handle = if let Some(opts) = options {
                 sandbox
-                    .exec_stream_with(&cmd, |e| apply_exec_options(e, opts))
+                    .exec_stream_with(&cmd, |e| apply_exec_options(e, args, opts))
                     .await
                     .map_err(to_py_err)?
             } else {
@@ -681,6 +681,7 @@ fn parse_exec_args(
 
 fn apply_exec_options(
     mut builder: microsandbox::sandbox::exec::ExecOptionsBuilder,
+    args: Vec<String>,
     opts: ExecOpts,
 ) -> microsandbox::sandbox::exec::ExecOptionsBuilder {
     if !opts.env.is_empty() {
@@ -731,7 +732,7 @@ fn apply_exec_options(
         };
         builder = builder.rlimit_range(res, *soft, *hard);
     }
-    builder
+    builder.args(args)
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a dedicated Python SDK integration-test lane to the Check workflow, running on the existing self-hosted KVM runner. The job downloads the `msb-linux-x86_64` artifact from the build matrix, stages the runtime bundle for the Python SDK, builds the extension with `maturin develop`, and runs `uv run pytest integration`.

The first integration test is a modest end-to-end smoke test that boots Alpine and exercises sandbox creation, `exec`, options-dict execution, shell execution, streaming collection, basic filesystem access, and metrics.

## Notes

Normal Python pytest discovery is scoped to `sdk/python/tests` so hosted checks do not accidentally collect KVM-dependent integration tests.

## Validation

- `uv run ruff check integration`
- `uv run pytest integration --collect-only -q`
- `uv run pytest --collect-only -q`
- `git diff --check`
- workflow YAML parse
- pre-commit hook on commit: cargo fmt/clippy/doc/build, ruff, Python SDK cargo check