### PR TITLE
Refresh cached TLS intercept certs before expiry

### DIFF
--- a/crates/network/lib/tls/certgen.rs
+++ b/crates/network/lib/tls/certgen.rs
@@ -18,7 +18,7 @@ pub struct DomainCert {
     /// Leaf certificate private key.
     pub key: PrivateKeyDer<'static>,
     /// Expiry time for the generated leaf certificate.
-    pub not_after: OffsetDateTime,
+    pub expires_at: OffsetDateTime,
     /// Pre-built `ServerConfig` for this domain (avoids per-connection rebuild).
     pub server_config: std::sync::Arc<rustls::ServerConfig>,
 }
@@ -29,11 +29,11 @@ pub struct DomainCert {
 
 /// Generate a certificate for `domain` signed by the given CA.
 pub fn generate_domain_cert(domain: &str, ca: &CertAuthority, validity_hours: u64) -> DomainCert {
-    let now = OffsetDateTime::now_utc();
-    let params = build_domain_cert_params(domain, validity_hours, now);
-    let not_after = params.not_after;
+    let now: OffsetDateTime = OffsetDateTime::now_utc();
+    let params: CertificateParams = build_domain_cert_params(domain, validity_hours, now);
+    let expires_at: OffsetDateTime = params.not_after;
 
-    let key_pair = rcgen::KeyPair::generate().expect("failed to generate domain key pair");
+    let key_pair: rcgen::KeyPair = rcgen::KeyPair::generate().expect("failed to generate domain key pair");
 
     let cert_der = params
         .signed_by(&key_pair, &ca.cert, &ca.key_pair)
@@ -54,7 +54,7 @@ pub fn generate_domain_cert(domain: &str, ca: &CertAuthority, validity_hours: u6
     DomainCert {
         chain,
         key,
-        not_after,
+        expires_at,
         server_config: std::sync::Arc::new(server_config),
     }
 }

--- a/crates/network/lib/tls/certgen.rs
+++ b/crates/network/lib/tls/certgen.rs
@@ -33,7 +33,8 @@ pub fn generate_domain_cert(domain: &str, ca: &CertAuthority, validity_hours: u6
     let params: CertificateParams = build_domain_cert_params(domain, validity_hours, now);
     let expires_at: OffsetDateTime = params.not_after;
 
-    let key_pair: rcgen::KeyPair = rcgen::KeyPair::generate().expect("failed to generate domain key pair");
+    let key_pair: rcgen::KeyPair =
+        rcgen::KeyPair::generate().expect("failed to generate domain key pair");
 
     let cert_der = params
         .signed_by(&key_pair, &ca.cert, &ca.key_pair)

--- a/crates/network/lib/tls/certgen.rs
+++ b/crates/network/lib/tls/certgen.rs
@@ -17,6 +17,8 @@ pub struct DomainCert {
     pub chain: Vec<CertificateDer<'static>>,
     /// Leaf certificate private key.
     pub key: PrivateKeyDer<'static>,
+    /// Expiry time for the generated leaf certificate.
+    pub not_after: OffsetDateTime,
     /// Pre-built `ServerConfig` for this domain (avoids per-connection rebuild).
     pub server_config: std::sync::Arc<rustls::ServerConfig>,
 }
@@ -29,6 +31,7 @@ pub struct DomainCert {
 pub fn generate_domain_cert(domain: &str, ca: &CertAuthority, validity_hours: u64) -> DomainCert {
     let now = OffsetDateTime::now_utc();
     let params = build_domain_cert_params(domain, validity_hours, now);
+    let not_after = params.not_after;
 
     let key_pair = rcgen::KeyPair::generate().expect("failed to generate domain key pair");
 
@@ -51,6 +54,7 @@ pub fn generate_domain_cert(domain: &str, ca: &CertAuthority, validity_hours: u6
     DomainCert {
         chain,
         key,
+        not_after,
         server_config: std::sync::Arc::new(server_config),
     }
 }

--- a/crates/network/lib/tls/state.rs
+++ b/crates/network/lib/tls/state.rs
@@ -108,7 +108,7 @@ impl TlsState {
     pub fn get_or_generate_cert(&self, domain: &str) -> Arc<DomainCert> {
         let mut cache = self.cert_cache.lock().unwrap();
         if let Some(cert) = cache.get(domain) {
-            if cert.not_after > OffsetDateTime::now_utc() + CERT_REFRESH_WINDOW {
+            if cert.expires_at > OffsetDateTime::now_utc() + CERT_REFRESH_WINDOW {
                 return cert.clone();
             }
         }
@@ -149,22 +149,22 @@ mod tests {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let state = TlsState::new(TlsConfig::default(), SecretsConfig::default());
         let first = state.get_or_generate_cert("openrouter.ai");
-        let original_not_after = first.not_after;
+        let original_expires_at = first.expires_at;
 
         {
             let mut cache = state.cert_cache.lock().unwrap();
             let stale = Arc::new(DomainCert {
                 chain: first.chain.clone(),
                 key: first.key.clone_key(),
-                not_after: OffsetDateTime::now_utc() + Duration::seconds(30),
+                expires_at: OffsetDateTime::now_utc() + Duration::seconds(30),
                 server_config: first.server_config.clone(),
             });
             cache.put("openrouter.ai".to_string(), stale);
         }
 
         let refreshed = state.get_or_generate_cert("openrouter.ai");
-        assert!(refreshed.not_after > OffsetDateTime::now_utc() + Duration::hours(23));
-        assert!(refreshed.not_after > original_not_after - Duration::minutes(10));
+        assert!(refreshed.expires_at > OffsetDateTime::now_utc() + Duration::hours(23));
+        assert!(refreshed.expires_at > original_expires_at - Duration::minutes(10));
     }
 }
 

--- a/crates/network/lib/tls/state.rs
+++ b/crates/network/lib/tls/state.rs
@@ -107,10 +107,10 @@ impl TlsState {
     /// Get or generate a certificate for the given domain.
     pub fn get_or_generate_cert(&self, domain: &str) -> Arc<DomainCert> {
         let mut cache = self.cert_cache.lock().unwrap();
-        if let Some(cert) = cache.get(domain) {
-            if cert.expires_at > OffsetDateTime::now_utc() + CERT_REFRESH_WINDOW {
-                return cert.clone();
-            }
+        if let Some(cert) = cache.get(domain)
+            && cert.expires_at > OffsetDateTime::now_utc() + CERT_REFRESH_WINDOW
+        {
+            return cert.clone();
         }
 
         let cert = Arc::new(certgen::generate_domain_cert(

--- a/crates/network/lib/tls/state.rs
+++ b/crates/network/lib/tls/state.rs
@@ -7,6 +7,7 @@ use lru::LruCache;
 use rustls::DigitallySignedStruct;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use time::{Duration, OffsetDateTime};
 use tokio_rustls::TlsConnector;
 
 use super::ca::CertAuthority;
@@ -50,6 +51,10 @@ enum BypassPattern {
 /// validation. Used when `verify_upstream` is `false`.
 #[derive(Debug)]
 struct NoVerify;
+
+/// Refresh cached leaf certs shortly before expiry so long-lived sandboxes
+/// do not start serving an already-expired intercept certificate.
+const CERT_REFRESH_WINDOW: Duration = Duration::minutes(5);
 
 //--------------------------------------------------------------------------------------------------
 // Methods
@@ -103,7 +108,9 @@ impl TlsState {
     pub fn get_or_generate_cert(&self, domain: &str) -> Arc<DomainCert> {
         let mut cache = self.cert_cache.lock().unwrap();
         if let Some(cert) = cache.get(domain) {
-            return cert.clone();
+            if cert.not_after > OffsetDateTime::now_utc() + CERT_REFRESH_WINDOW {
+                return cert.clone();
+            }
         }
 
         let cert = Arc::new(certgen::generate_domain_cert(
@@ -129,6 +136,35 @@ impl TlsState {
     /// Get the CA certificate PEM bytes for guest installation.
     pub fn ca_cert_pem(&self) -> Vec<u8> {
         self.intercept_ca.cert_pem()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secrets::config::SecretsConfig;
+
+    #[test]
+    fn regenerates_cached_domain_cert_when_near_expiry() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let state = TlsState::new(TlsConfig::default(), SecretsConfig::default());
+        let first = state.get_or_generate_cert("openrouter.ai");
+        let original_not_after = first.not_after;
+
+        {
+            let mut cache = state.cert_cache.lock().unwrap();
+            let stale = Arc::new(DomainCert {
+                chain: first.chain.clone(),
+                key: first.key.clone_key(),
+                not_after: OffsetDateTime::now_utc() + Duration::seconds(30),
+                server_config: first.server_config.clone(),
+            });
+            cache.put("openrouter.ai".to_string(), stale);
+        }
+
+        let refreshed = state.get_or_generate_cert("openrouter.ai");
+        assert!(refreshed.not_after > OffsetDateTime::now_utc() + Duration::hours(23));
+        assert!(refreshed.not_after > original_not_after - Duration::minutes(10));
     }
 }
 


### PR DESCRIPTION
## Summary
We run Microsandbox for long-lived user runtimes in production, and this surfaced there as older sandboxes began failing TLS interception for intercepted hosts.

Fix TLS interception for long-lived sandboxes by refreshing cached per-domain leaf certificates when they are expired or near expiry.

## Problem

Microsandbox caches generated intercept certs in `TlsState.cert_cache`, but cached entries were reused without checking whether the leaf cert had already expired.

In practice this caused older sandboxes to start failing TLS for intercepted hosts with errors like:

- `certificate has expired`
- `SSL certificate problem: certificate has expired`

## Fix

- store `not_after` on `DomainCert`
- check cached cert expiry in `TlsState::get_or_generate_cert()`
- regenerate and replace the cached cert when it is expired or within a small refresh window

## Files changed

- `crates/network/lib/tls/certgen.rs`
- `crates/network/lib/tls/state.rs`

## Testing

Passed:

```bash
cargo test -p microsandbox-network tls::certgen
cargo test -p microsandbox-network tls::state
cargo test -p microsandbox-network --lib
```

Happy to adjust this if there’s a preferred place to handle cert rotation or expiry checks.
