### PR TITLE
refactor(cli)!: consolidate network policy flags around --net-default and *.foo.com suffix

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -153,19 +153,6 @@ pub struct SandboxOpts {
     )]
     pub no_net: bool,
 
-    /// Deny egress to a domain. Equivalent to a `deny Domain("...")`
-    /// policy rule appended after any `--net-rule` entries.
-    #[cfg(feature = "net")]
-    #[arg(long = "deny-domain", value_name = "NAME")]
-    pub deny_domain: Vec<String>,
-
-    /// Deny egress to all subdomains of a suffix (e.g. `.ads.example`).
-    /// Equivalent to a `deny DomainSuffix("...")` rule appended after
-    /// any `--net-rule` entries.
-    #[cfg(feature = "net")]
-    #[arg(long = "deny-domain-suffix", value_name = "SUFFIX")]
-    pub deny_domain_suffix: Vec<String>,
-
     /// Allow DNS responses pointing to private/internal IP addresses.
     #[cfg(feature = "net")]
     #[arg(long)]
@@ -330,8 +317,6 @@ impl SandboxOpts {
         #[cfg(feature = "net")]
         let net = !self.port.is_empty()
             || self.no_net
-            || !self.deny_domain.is_empty()
-            || !self.deny_domain_suffix.is_empty()
             || self.no_dns_rebind_protection
             || !self.dns_nameserver.is_empty()
             || self.dns_query_timeout_ms.is_some()
@@ -609,9 +594,7 @@ fn apply_network_opts(
     }
 
     // DNS, TLS, and other network configuration.
-    let has_network_config = !opts.deny_domain.is_empty()
-        || !opts.deny_domain_suffix.is_empty()
-        || opts.no_dns_rebind_protection
+    let has_network_config = opts.no_dns_rebind_protection
         || !opts.dns_nameserver.is_empty()
         || opts.dns_query_timeout_ms.is_some()
         || !opts.net_rule.is_empty()
@@ -646,8 +629,6 @@ fn apply_network_opts(
             opts.net_default.as_deref(),
             opts.net_default_egress.as_deref(),
             opts.net_default_ingress.as_deref(),
-            &opts.deny_domain,
-            &opts.deny_domain_suffix,
         )?;
         let max_conn = opts.max_connections;
         let ipv4_pool = opts
@@ -793,9 +774,9 @@ pub fn parse_duration(s: &str) -> anyhow::Result<std::time::Duration> {
     }
 }
 
-/// Assemble a [`NetworkPolicy`] from `--net-rule` / `--net-default*` /
-/// `--no-net` and the bulk-deny flags. Returns `None` when no flag is
-/// set. Multiple `--net-rule` invocations concatenate in argv order.
+/// Assemble a [`NetworkPolicy`] from `--net-rule`, `--net-default*`,
+/// and `--no-net`. Returns `None` when no flag is set. Multiple
+/// `--net-rule` invocations concatenate in argv order.
 ///
 /// `--no-net` desugars to `--net-default deny`; clap rejects combining
 /// it with the explicit defaults, so the four default-source params are
@@ -807,41 +788,21 @@ fn build_network_policy(
     default_both: Option<&str>,
     default_egress: Option<&str>,
     default_ingress: Option<&str>,
-    deny_domains: &[String],
-    deny_domain_suffixes: &[String],
 ) -> anyhow::Result<Option<microsandbox_network::policy::NetworkPolicy>> {
-    use anyhow::Context;
-    use microsandbox_network::policy::{Action, Destination, DomainName, NetworkPolicy, Rule};
+    use microsandbox_network::policy::{Action, NetworkPolicy};
 
     use crate::net_rule::parse_rule_list;
 
-    let no_rule_flags = rule_args.is_empty()
+    let no_flags = rule_args.is_empty()
         && !no_net
         && default_both.is_none()
         && default_egress.is_none()
         && default_ingress.is_none();
-    let no_block_flags = deny_domains.is_empty() && deny_domain_suffixes.is_empty();
-    if no_rule_flags && no_block_flags {
+    if no_flags {
         return Ok(None);
     }
 
     let mut rules = Vec::new();
-
-    // Prepend bulk-deny flags so they outrank later allow rules.
-    for d in deny_domains {
-        let domain: DomainName = d.parse().with_context(|| format!("--deny-domain {d:?}"))?;
-        rules.push(Rule::deny_egress(Destination::Domain(domain)));
-    }
-    for s in deny_domain_suffixes {
-        let suffix: DomainName = s
-            .parse()
-            .with_context(|| format!("--deny-domain-suffix {s:?}"))?;
-        let suffix = suffix
-            .try_into_suffix()
-            .with_context(|| format!("--deny-domain-suffix {s:?}"))?;
-        rules.push(Rule::deny_egress(Destination::DomainSuffix(suffix)));
-    }
-
     for arg in rule_args {
         let parsed = parse_rule_list(arg).map_err(anyhow::Error::from)?;
         rules.extend(parsed);
@@ -870,16 +831,10 @@ fn build_network_policy(
     // When the user sets no defaults explicitly, fall through to
     // NetworkPolicy::public_only's defaults so behaviour stays in sync
     // with the preset.
-    //
-    // Exception: if only --deny-domain / --deny-domain-suffix were set
-    // (no --net-rule, no --net-default*, no --no-net), default egress
-    // flips to Allow so the rest of the network keeps working — these
-    // flags add deny entries on top of permissive defaults.
     let preset = NetworkPolicy::public_only();
     let default_egress = match (symmetric, default_egress) {
         (_, Some(raw)) => parse_action("--net-default-egress", raw)?,
         (Some(action), None) => action,
-        (None, None) if no_rule_flags => Action::Allow,
         (None, None) => preset.default_egress,
     };
     let default_ingress = match (symmetric, default_ingress) {
@@ -1861,14 +1816,14 @@ mod tests {
     #[cfg(feature = "net")]
     #[test]
     fn build_policy_no_flags_returns_none() {
-        let p = build_network_policy(&[], false, None, None, None, &[], &[]).unwrap();
+        let p = build_network_policy(&[], false, None, None, None).unwrap();
         assert!(p.is_none());
     }
 
     #[cfg(feature = "net")]
     #[test]
     fn build_policy_net_default_deny_sets_both_directions() {
-        let p = build_network_policy(&[], false, Some("deny"), None, None, &[], &[])
+        let p = build_network_policy(&[], false, Some("deny"), None, None)
             .unwrap()
             .expect("policy");
         assert_eq!(p.default_egress, Action::Deny);
@@ -1879,7 +1834,7 @@ mod tests {
     #[cfg(feature = "net")]
     #[test]
     fn build_policy_net_default_allow_sets_both_directions() {
-        let p = build_network_policy(&[], false, Some("allow"), None, None, &[], &[])
+        let p = build_network_policy(&[], false, Some("allow"), None, None)
             .unwrap()
             .expect("policy");
         assert_eq!(p.default_egress, Action::Allow);
@@ -1889,7 +1844,7 @@ mod tests {
     #[cfg(feature = "net")]
     #[test]
     fn build_policy_no_net_desugars_to_deny_both() {
-        let p = build_network_policy(&[], true, None, None, None, &[], &[])
+        let p = build_network_policy(&[], true, None, None, None)
             .unwrap()
             .expect("policy");
         assert_eq!(p.default_egress, Action::Deny);
@@ -1900,7 +1855,7 @@ mod tests {
     #[test]
     fn build_policy_no_net_with_allow_rule_yields_allowlist() {
         let rules = vec!["allow@example.com".to_string()];
-        let p = build_network_policy(&rules, true, None, None, None, &[], &[])
+        let p = build_network_policy(&rules, true, None, None, None)
             .unwrap()
             .expect("policy");
         assert_eq!(p.default_egress, Action::Deny);
@@ -1912,11 +1867,26 @@ mod tests {
     #[cfg(feature = "net")]
     #[test]
     fn build_policy_net_default_rejects_unknown_action() {
-        let err =
-            build_network_policy(&[], false, Some("maybe"), None, None, &[], &[]).unwrap_err();
+        let err = build_network_policy(&[], false, Some("maybe"), None, None).unwrap_err();
         assert!(
             err.to_string().contains("--net-default"),
             "expected --net-default in error, got: {err}"
         );
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn build_policy_rule_only_uses_preset_defaults() {
+        // Without any --net-default* flag, rules apply on top of the
+        // public_only preset (deny egress, allow ingress). Verifies the
+        // "rules alone keep the preset's defaults" path now that the
+        // --deny-domain* flip-to-allow exception is gone.
+        let rules = vec!["allow@example.com".to_string()];
+        let p = build_network_policy(&rules, false, None, None, None)
+            .unwrap()
+            .expect("policy");
+        let preset = microsandbox_network::policy::NetworkPolicy::public_only();
+        assert_eq!(p.default_egress, preset.default_egress);
+        assert_eq!(p.default_ingress, preset.default_ingress);
     }
 }

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -197,11 +197,16 @@ pub struct SandboxOpts {
     /// rule tokens. Token grammar:
     /// `<action>[:<direction>]@<target>[:<proto>[:<ports>]]`.
     ///
-    /// Examples:
-    ///   --net-rule "allow@public"
-    ///   --net-rule "deny@198.51.100.5,allow@public"
-    ///   --net-rule "allow:ingress@private"
-    ///   --net-rule "allow@example.com:tcp:443"
+    /// Target kinds: IPs/CIDRs, domains (`example.com`), domain suffixes
+    /// (`*.example.com` shorthand or `suffix=example.com`), and groups
+    /// (`public`, `private`, `multicast`, ...). Suffixes must be at
+    /// least two labels (e.g. `*.example.com`, not `*.com`).
+    ///
+    /// Examples: --net-rule "allow@public"
+    /// --net-rule "deny@198.51.100.5,allow@public"
+    /// --net-rule "allow:ingress@private"
+    /// --net-rule "allow@example.com:tcp:443"
+    /// --net-rule "deny@*.ads.example.com"
     #[cfg(feature = "net")]
     #[arg(long = "net-rule", value_name = "TOKENS")]
     pub net_rule: Vec<String>,
@@ -830,6 +835,9 @@ fn build_network_policy(
     for s in deny_domain_suffixes {
         let suffix: DomainName = s
             .parse()
+            .with_context(|| format!("--deny-domain-suffix {s:?}"))?;
+        let suffix = suffix
+            .try_into_suffix()
             .with_context(|| format!("--deny-domain-suffix {s:?}"))?;
         rules.push(Rule::deny_egress(Destination::DomainSuffix(suffix)));
     }

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -143,10 +143,14 @@ pub struct SandboxOpts {
     #[arg(short, long)]
     pub port: Vec<String>,
 
-    /// Disable all network access. Sugar for `--net-default-egress deny`
-    /// with no rules.
+    /// Disable all network access by default. Sugar for `--net-default deny`.
+    /// Combine with `--net-rule allow@<target>` entries to build an
+    /// allowlist; without rules, the guest has no network reachability.
     #[cfg(feature = "net")]
-    #[arg(long = "no-net")]
+    #[arg(
+        long = "no-net",
+        conflicts_with_all = ["net_default", "net_default_egress", "net_default_ingress"]
+    )]
     pub no_net: bool,
 
     /// Deny egress to a domain. Equivalent to a `deny Domain("...")`
@@ -201,6 +205,18 @@ pub struct SandboxOpts {
     #[cfg(feature = "net")]
     #[arg(long = "net-rule", value_name = "TOKENS")]
     pub net_rule: Vec<String>,
+
+    /// Default action for traffic in both directions that doesn't match
+    /// any `--net-rule`. Sets egress and ingress symmetrically; use
+    /// `--net-default-egress` / `--net-default-ingress` to set them
+    /// independently.
+    #[cfg(feature = "net")]
+    #[arg(
+        long = "net-default",
+        value_name = "ACTION",
+        conflicts_with_all = ["net_default_egress", "net_default_ingress"],
+    )]
+    pub net_default: Option<String>,
 
     /// Default action for egress traffic that doesn't match any
     /// `--net-rule`. Default: deny (with an implicit allow@public rule
@@ -315,6 +331,7 @@ impl SandboxOpts {
             || !self.dns_nameserver.is_empty()
             || self.dns_query_timeout_ms.is_some()
             || !self.net_rule.is_empty()
+            || self.net_default.is_some()
             || self.net_default_egress.is_some()
             || self.net_default_ingress.is_some()
             || self.max_connections.is_some()
@@ -580,39 +597,6 @@ fn apply_network_opts(
         };
     }
 
-    // Disable networking. `--no-net` is mutually exclusive with the
-    // policy-shaping flags: it kills the guest's network interface
-    // entirely, so any rule or default action would be dead code and
-    // is almost certainly a user mistake. Reject the combination at
-    // parse time with a helpful migration hint.
-    if opts.no_net {
-        let mut conflicts: Vec<&'static str> = Vec::new();
-        if !opts.net_rule.is_empty() {
-            conflicts.push("--net-rule");
-        }
-        if opts.net_default_egress.is_some() {
-            conflicts.push("--net-default-egress");
-        }
-        if opts.net_default_ingress.is_some() {
-            conflicts.push("--net-default-ingress");
-        }
-        if opts.net_ipv4_pool.is_some() {
-            conflicts.push("--net-ipv4-pool");
-        }
-        if opts.net_ipv6_pool.is_some() {
-            conflicts.push("--net-ipv6-pool");
-        }
-        if !conflicts.is_empty() {
-            anyhow::bail!(
-                "--no-net cannot be combined with {}; \
-                 --no-net disables the guest network entirely, so rules and defaults are dead code. \
-                 Drop --no-net to apply rules, or drop the rule flags to keep the network off.",
-                conflicts.join(" / "),
-            );
-        }
-        builder = builder.disable_network();
-    }
-
     // Secrets.
     for secret_str in &opts.secret {
         let (env_var, value, host) = parse_secret(secret_str)?;
@@ -626,6 +610,8 @@ fn apply_network_opts(
         || !opts.dns_nameserver.is_empty()
         || opts.dns_query_timeout_ms.is_some()
         || !opts.net_rule.is_empty()
+        || opts.no_net
+        || opts.net_default.is_some()
         || opts.net_default_egress.is_some()
         || opts.net_default_ingress.is_some()
         || opts.net_ipv4_pool.is_some()
@@ -651,6 +637,8 @@ fn apply_network_opts(
         let dns_query_timeout_ms = opts.dns_query_timeout_ms;
         let network_policy = build_network_policy(
             &opts.net_rule,
+            opts.no_net,
+            opts.net_default.as_deref(),
             opts.net_default_egress.as_deref(),
             opts.net_default_ingress.as_deref(),
             &opts.deny_domain,
@@ -800,12 +788,18 @@ pub fn parse_duration(s: &str) -> anyhow::Result<std::time::Duration> {
     }
 }
 
-/// Assemble a [`NetworkPolicy`] from `--net-rule` / `--net-default-*`
-/// and the bulk-deny flags. Returns `None` when no flag is set.
-/// Multiple `--net-rule` invocations concatenate in argv order.
+/// Assemble a [`NetworkPolicy`] from `--net-rule` / `--net-default*` /
+/// `--no-net` and the bulk-deny flags. Returns `None` when no flag is
+/// set. Multiple `--net-rule` invocations concatenate in argv order.
+///
+/// `--no-net` desugars to `--net-default deny`; clap rejects combining
+/// it with the explicit defaults, so the four default-source params are
+/// mutually exclusive on the caller side.
 #[cfg(feature = "net")]
 fn build_network_policy(
     rule_args: &[String],
+    no_net: bool,
+    default_both: Option<&str>,
     default_egress: Option<&str>,
     default_ingress: Option<&str>,
     deny_domains: &[String],
@@ -816,8 +810,11 @@ fn build_network_policy(
 
     use crate::net_rule::parse_rule_list;
 
-    let no_rule_flags =
-        rule_args.is_empty() && default_egress.is_none() && default_ingress.is_none();
+    let no_rule_flags = rule_args.is_empty()
+        && !no_net
+        && default_both.is_none()
+        && default_egress.is_none()
+        && default_ingress.is_none();
     let no_block_flags = deny_domains.is_empty() && deny_domain_suffixes.is_empty();
     if no_rule_flags && no_block_flags {
         return Ok(None);
@@ -850,23 +847,37 @@ fn build_network_policy(
         }
     };
 
+    // `--no-net` and `--net-default` are siblings: both set egress and
+    // ingress symmetrically. clap enforces they're mutex with each
+    // other and with `--net-default-{egress,ingress}`, so at most one
+    // source resolves here.
+    let symmetric = if no_net {
+        Some(Action::Deny)
+    } else if let Some(raw) = default_both {
+        Some(parse_action("--net-default", raw)?)
+    } else {
+        None
+    };
+
     // When the user sets no defaults explicitly, fall through to
     // NetworkPolicy::public_only's defaults so behaviour stays in sync
     // with the preset.
     //
     // Exception: if only --deny-domain / --deny-domain-suffix were set
-    // (no --net-rule, no --net-default-*), default egress flips to
-    // Allow so the rest of the network keeps working — these flags
-    // add deny entries on top of permissive defaults.
+    // (no --net-rule, no --net-default*, no --no-net), default egress
+    // flips to Allow so the rest of the network keeps working — these
+    // flags add deny entries on top of permissive defaults.
     let preset = NetworkPolicy::public_only();
-    let default_egress = match default_egress {
-        Some(raw) => parse_action("--net-default-egress", raw)?,
-        None if no_rule_flags => Action::Allow,
-        None => preset.default_egress,
+    let default_egress = match (symmetric, default_egress) {
+        (_, Some(raw)) => parse_action("--net-default-egress", raw)?,
+        (Some(action), None) => action,
+        (None, None) if no_rule_flags => Action::Allow,
+        (None, None) => preset.default_egress,
     };
-    let default_ingress = match default_ingress {
-        Some(raw) => parse_action("--net-default-ingress", raw)?,
-        None => preset.default_ingress,
+    let default_ingress = match (symmetric, default_ingress) {
+        (_, Some(raw)) => parse_action("--net-default-ingress", raw)?,
+        (Some(action), None) => action,
+        (None, None) => preset.default_ingress,
     };
 
     Ok(Some(NetworkPolicy {
@@ -1832,5 +1843,72 @@ mod tests {
     fn collect_empty_inputs_ok() {
         let out = collect_scripts(None, &[], &[], &[]).unwrap();
         assert!(out.is_empty());
+    }
+
+    // --- build_network_policy: --net-default / --no-net ---
+
+    #[cfg(feature = "net")]
+    use microsandbox_network::policy::Action;
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn build_policy_no_flags_returns_none() {
+        let p = build_network_policy(&[], false, None, None, None, &[], &[]).unwrap();
+        assert!(p.is_none());
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn build_policy_net_default_deny_sets_both_directions() {
+        let p = build_network_policy(&[], false, Some("deny"), None, None, &[], &[])
+            .unwrap()
+            .expect("policy");
+        assert_eq!(p.default_egress, Action::Deny);
+        assert_eq!(p.default_ingress, Action::Deny);
+        assert!(p.rules.is_empty());
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn build_policy_net_default_allow_sets_both_directions() {
+        let p = build_network_policy(&[], false, Some("allow"), None, None, &[], &[])
+            .unwrap()
+            .expect("policy");
+        assert_eq!(p.default_egress, Action::Allow);
+        assert_eq!(p.default_ingress, Action::Allow);
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn build_policy_no_net_desugars_to_deny_both() {
+        let p = build_network_policy(&[], true, None, None, None, &[], &[])
+            .unwrap()
+            .expect("policy");
+        assert_eq!(p.default_egress, Action::Deny);
+        assert_eq!(p.default_ingress, Action::Deny);
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn build_policy_no_net_with_allow_rule_yields_allowlist() {
+        let rules = vec!["allow@example.com".to_string()];
+        let p = build_network_policy(&rules, true, None, None, None, &[], &[])
+            .unwrap()
+            .expect("policy");
+        assert_eq!(p.default_egress, Action::Deny);
+        assert_eq!(p.default_ingress, Action::Deny);
+        assert_eq!(p.rules.len(), 1);
+        assert_eq!(p.rules[0].action, Action::Allow);
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn build_policy_net_default_rejects_unknown_action() {
+        let err =
+            build_network_policy(&[], false, Some("maybe"), None, None, &[], &[]).unwrap_err();
+        assert!(
+            err.to_string().contains("--net-default"),
+            "expected --net-default in error, got: {err}"
+        );
     }
 }

--- a/crates/cli/lib/net_rule.rs
+++ b/crates/cli/lib/net_rule.rs
@@ -375,16 +375,21 @@ fn parse_target(raw: &str) -> Result<Destination, RuleParseError> {
         return Ok(Destination::Group(group));
     }
 
-    // 5. `suffix=<name>`
-    if let Some(rest) = raw.strip_prefix("suffix=") {
-        let name = DomainName::from_str(rest).map_err(|source| RuleParseError::InvalidDomain {
-            raw: rest.to_string(),
-            source,
-        })?;
+    // 5. `*.<name>` (suffix shorthand). Mirrors the syntax already used
+    // by `--tls-bypass` and `--secret` so users see one wildcard
+    // convention across the CLI. Equivalent to `suffix=<name>`.
+    if let Some(rest) = raw.strip_prefix("*.") {
+        let name = parse_domain_suffix(rest)?;
         return Ok(Destination::DomainSuffix(name));
     }
 
-    // 6. `domain=<name>` (escape hatch)
+    // 6. `suffix=<name>` (explicit form, parallels `domain=`).
+    if let Some(rest) = raw.strip_prefix("suffix=") {
+        let name = parse_domain_suffix(rest)?;
+        return Ok(Destination::DomainSuffix(name));
+    }
+
+    // 7. `domain=<name>` (escape hatch)
     if let Some(rest) = raw.strip_prefix("domain=") {
         let name = DomainName::from_str(rest).map_err(|source| RuleParseError::InvalidDomain {
             raw: rest.to_string(),
@@ -428,6 +433,22 @@ fn parse_target(raw: &str) -> Result<Destination, RuleParseError> {
         raw: raw.to_string(),
         suggestion: SuggestionDisplay(suggestion),
     })
+}
+
+/// Parse a string as a [`DomainName`] and validate it for use as a
+/// [`Destination::DomainSuffix`] target. Shared by the `*.<name>` and
+/// `suffix=<name>` arms of [`parse_target`] so the TLD-broad guard
+/// (single-label suffix rejection) is enforced uniformly.
+fn parse_domain_suffix(raw: &str) -> Result<DomainName, RuleParseError> {
+    let name = DomainName::from_str(raw).map_err(|source| RuleParseError::InvalidDomain {
+        raw: raw.to_string(),
+        source,
+    })?;
+    name.try_into_suffix()
+        .map_err(|source| RuleParseError::InvalidDomain {
+            raw: raw.to_string(),
+            source,
+        })
 }
 
 fn parse_bracketed_target(inner: &str) -> Result<Destination, RuleParseError> {
@@ -647,11 +668,73 @@ mod tests {
 
     #[test]
     fn suffix_prefix_explicit() {
-        let r = parse_rule_token("allow@suffix=.local").unwrap();
+        let r = parse_rule_token("allow@suffix=corp.internal").unwrap();
         match r.destination {
-            Destination::DomainSuffix(name) => assert_eq!(name.as_str(), "local"),
+            Destination::DomainSuffix(name) => assert_eq!(name.as_str(), "corp.internal"),
             other => panic!("expected DomainSuffix, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn asterisk_suffix_shorthand_parses_as_domain_suffix() {
+        let r = parse_rule_token("deny@*.ads.example.com").unwrap();
+        match r.destination {
+            Destination::DomainSuffix(name) => assert_eq!(name.as_str(), "ads.example.com"),
+            other => panic!("expected DomainSuffix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn asterisk_suffix_shorthand_with_two_labels_is_accepted() {
+        // Two-label suffixes pass the TLD-broad guard. The PSL
+        // shortcoming (`*.co.uk`, `*.github.io` etc) is documented; the
+        // guard intentionally stops at the dot heuristic.
+        let r = parse_rule_token("allow@*.example.com").unwrap();
+        match r.destination {
+            Destination::DomainSuffix(name) => assert_eq!(name.as_str(), "example.com"),
+            other => panic!("expected DomainSuffix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn asterisk_suffix_rejects_single_label_tld() {
+        let err = parse_rule_token("deny@*.com").unwrap_err();
+        match &err {
+            RuleParseError::InvalidDomain { raw, source } => {
+                assert_eq!(raw, "com");
+                assert!(
+                    matches!(
+                        source,
+                        microsandbox_network::policy::DomainNameError::SuffixTooBroad { .. }
+                    ),
+                    "expected SuffixTooBroad, got {source:?}"
+                );
+            }
+            other => panic!("expected InvalidDomain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn suffix_keyword_rejects_single_label_tld() {
+        let err = parse_rule_token("deny@suffix=local").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("match every domain"),
+            "expected guard message in error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn bare_asterisk_is_ambiguous() {
+        // `*` alone is not a suffix shorthand. The shorthand requires
+        // the `*.` prefix; bare `*` would conflict semantically with
+        // the `any` keyword and falls through to the ambiguous-token
+        // path so the user sees a hint.
+        let err = parse_rule_token("allow@*").unwrap_err();
+        assert!(
+            matches!(err, RuleParseError::AmbiguousBareToken { .. }),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/network/lib/policy/builder.rs
+++ b/crates/network/lib/policy/builder.rs
@@ -722,6 +722,13 @@ impl PendingDestination {
                         raw: raw.clone(),
                         source,
                     })?;
+                let name = name
+                    .try_into_suffix()
+                    .map_err(|source| BuildError::InvalidDomain {
+                        rule_index: idx,
+                        raw: raw.clone(),
+                        source,
+                    })?;
                 Ok(Destination::DomainSuffix(name))
             }
         }

--- a/crates/network/lib/policy/name.rs
+++ b/crates/network/lib/policy/name.rs
@@ -61,6 +61,17 @@ pub enum DomainNameError {
     /// chars, invalid UTF-8 for an ASCII name, etc.).
     #[error("invalid domain name: {0}")]
     Invalid(#[from] ProtoError),
+
+    /// Suffix pattern resolves to a single DNS label (e.g. `com`,
+    /// `local`, `internal`). A label-aware suffix matcher treats this
+    /// as "match every subdomain under that TLD," which is almost
+    /// never the operator's intent. Add at least one parent label
+    /// (e.g. `corp.internal`, `myco.com`).
+    #[error(
+        "suffix `{raw}` is a single DNS label and would match every domain under that TLD; \
+         add at least one parent label to scope it (e.g. `myco.{raw}`)"
+    )]
+    SuffixTooBroad { raw: String },
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -72,6 +83,30 @@ impl DomainName {
     /// trailing dot and is lowercased ASCII.
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Validate this name for use as a [`Destination::DomainSuffix`]
+    /// target and return it unchanged on success.
+    ///
+    /// Returns [`DomainNameError::SuffixTooBroad`] when the name is a
+    /// single DNS label (e.g. `com`, `local`, `internal`). The
+    /// label-aware suffix matcher would otherwise treat such a name
+    /// as "match every host under that TLD" which is almost certainly
+    /// not what the operator meant. Use a multi-label suffix
+    /// (`myco.com`, `corp.internal`) instead.
+    ///
+    /// Domains intended for exact-match rules are unaffected: use
+    /// `Destination::Domain` for those.
+    ///
+    /// [`Destination::DomainSuffix`]: super::Destination::DomainSuffix
+    pub fn try_into_suffix(self) -> Result<Self, DomainNameError> {
+        if self.0.contains('.') {
+            Ok(self)
+        } else {
+            Err(DomainNameError::SuffixTooBroad {
+                raw: self.0.clone(),
+            })
+        }
     }
 }
 
@@ -194,6 +229,34 @@ mod tests {
     fn serde_deserialize_validates() {
         assert!(serde_json::from_str::<DomainName>(r#""foo bar.example""#).is_err());
         assert!(serde_json::from_str::<DomainName>(r#""""#).is_err());
+    }
+
+    #[test]
+    fn try_into_suffix_accepts_multilabel_names() {
+        let name: DomainName = "example.com".parse().unwrap();
+        let suffix = name.try_into_suffix().unwrap();
+        assert_eq!(suffix.as_str(), "example.com");
+
+        let deep: DomainName = "api.staging.example.com".parse().unwrap();
+        let suffix = deep.try_into_suffix().unwrap();
+        assert_eq!(suffix.as_str(), "api.staging.example.com");
+    }
+
+    #[test]
+    fn try_into_suffix_rejects_single_label_tlds() {
+        for raw in ["com", "local", "internal", "intranet", "lan"] {
+            let name: DomainName = raw.parse().unwrap();
+            let err = name.try_into_suffix().unwrap_err();
+            assert!(
+                matches!(&err, DomainNameError::SuffixTooBroad { raw: r } if r == raw),
+                "expected SuffixTooBroad for `{raw}`, got {err:?}"
+            );
+            let msg = err.to_string();
+            assert!(
+                msg.contains("match every domain"),
+                "error message should explain blast radius, got: {msg}"
+            );
+        }
     }
 
     #[test]

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -63,10 +63,11 @@ msb run --name public-api -p 0.0.0.0:8000:8000 python
 | `--script-path` | Register a script from a host file (`NAME:PATH`). File contents are read verbatim |
 | `--max-duration` | Kill the entire sandbox after this duration (e.g. `30s`, `5m`, `1h`). Sandbox-level lifetime limit |
 | `--idle-timeout` | Stop the sandbox after this period of inactivity (e.g. `30s`, `5m`, `1h`) |
-| `--no-network` | Disable all network access |
-| `--network-policy` | Control which destinations are reachable from the sandbox. Accepted values: `none` (no network), `public-only` (default — public internet only), `nonlocal` (public + private/LAN; blocks loopback, link-local, and metadata), `allow-all` (unrestricted) |
-| `--deny-domain` | Deny egress to a domain. Repeatable. Adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback) |
-| `--deny-domain-suffix` | Deny egress to all subdomains of a suffix (e.g. `.ads.com`). Repeatable. Adds a `deny DomainSuffix("...")` policy rule |
+| `--no-net` | Disable all network access by default. Sugar for `--net-default deny`. Combine with `--net-rule allow@<target>` entries to build an allowlist |
+| `--net-rule` | Network rule. Repeatable; each value is a comma-separated list of rule tokens (see [Network rule syntax](#network-rule-syntax) below). Adds entries to the policy in argv order |
+| `--net-default` | Default action (`allow` or `deny`) for traffic in both directions that doesn't match any `--net-rule`. Mutually exclusive with `--net-default-egress` / `--net-default-ingress` |
+| `--net-default-egress` | Default action for unmatched egress traffic. Mutually exclusive with `--net-default` |
+| `--net-default-ingress` | Default action for unmatched ingress traffic. Mutually exclusive with `--net-default` |
 | `--no-dns-rebind-protection` | Allow DNS responses pointing to private/internal IP addresses |
 | `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
 | `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |
@@ -85,6 +86,49 @@ msb run --name public-api -p 0.0.0.0:8000:8000 python
 | `--tls-upstream-ca-cert` | Trust an additional CA certificate for upstream server verification (PEM file). Can be specified multiple times |
 
 When no `--` command is given, the image's `entrypoint` and `cmd` are used as the default process. If the image has neither, an interactive shell is started. When a command is given via `--`, it replaces the image `cmd` but the `entrypoint` is preserved. See [Image config inheritance](/images/overview#image-config-inheritance) for details.
+
+### Network rule syntax
+
+`--net-rule` takes one or more comma-separated rule tokens. The token grammar is:
+
+```
+<action>[:<direction>]@<target>[:<proto>[:<ports>]]
+```
+
+| Field | Values |
+| ----- | ------ |
+| `action` | `allow`, `deny` |
+| `direction` | `egress` (default), `ingress`, `any` |
+| `target` | See *Targets* below |
+| `proto` | `tcp`, `udp`, `icmpv4`, `icmpv6`, `any` (default) |
+| `ports` | `<port>`, `<lo>-<hi>`, or `any` (default) |
+
+**Targets**
+
+| Form | Example | Notes |
+| ---- | ------- | ----- |
+| IP / CIDR | `198.51.100.5`, `10.0.0.0/8`, `[2001:db8::]/32` | IPv6 must be bracketed |
+| Domain (exact) | `example.com` | Use `domain=public` to disambiguate from the `public` group |
+| Domain suffix | `*.example.com`, `suffix=example.com` | Matches the apex and any subdomain at any depth. Suffixes must be at least two labels: `*.com` and `suffix=local` are rejected to prevent accidental blast radius |
+| Group | `public`, `private`, `multicast`, `loopback`, `link_local`, `metadata`, `any` | Pre-defined IP groups |
+
+Wildcard quoting: the rule grammar uses `@`, `:`, and `,` which are shell-significant, so always quote `--net-rule` values. The `*.` in suffix shorthand mirrors the syntax already used by `--tls-bypass` and `--secret`.
+
+**Common compositions**
+
+```bash
+# Allowlist: deny by default, allow specific destinations
+msb run alpine --net-default deny --net-rule "allow@github.com,allow@*.githubusercontent.com"
+
+# Blocklist: allow by default, deny specific destinations
+msb run alpine --net-default allow --net-rule "deny@*.tracking.com,deny@*.ads.example"
+
+# Airgapped: equivalent to `--net-default deny`
+msb run alpine --no-net
+
+# Airgapped except one host (allowlist with --no-net sugar)
+msb run alpine --no-net --net-rule "allow@api.internal.corp"
+```
 
 ## msb create
 

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -87,9 +87,8 @@ sb, err := m.CreateSandbox(ctx, "safe-agent",
 ```
 
 ```bash CLI
-msb create python --name safe-agent \
-  --deny-domain malware.example.com \
-  --deny-domain-suffix .tracking.com
+msb create python --name safe-agent --net-default allow \
+  --net-rule "deny@malware.example.com,deny@*.tracking.com"
 ```
 
 </CodeGroup>


### PR DESCRIPTION
## TL;DR
Collapse the network policy CLI surface: add `--net-default <allow|deny>` as a symmetric default, add `*.foo.com` as a suffix shorthand for `--net-rule`, drop `--deny-domain` and `--deny-domain-suffix` since they overlap with `--net-rule`, and reject TLD-broad suffix patterns like `*.com` to prevent accidental blast radius.

## Description
- `--net-default <allow|deny>` sets egress and ingress defaults together. Mutex with `--net-default-egress` and `--net-default-ingress` at the clap level.
- `--no-net` is now sugar for `--net-default deny`. Today it only denied egress and silently left ingress allowed, contradicting the flag's name. It also accepts `--net-rule "allow@..."` now so you can express deny-by-default allowlists in one extra flag.
- `--net-rule` target syntax gains `*.foo.com` as the suffix shorthand. Mirrors the wildcard convention already used by `--tls-bypass` and `--secret`. `suffix=foo.com` stays as the explicit form.
- `DomainName::try_into_suffix` rejects single-label suffixes (`com`, `local`, `internal`) with a clear `SuffixTooBroad` error. Applied at every user-input suffix construction site so `--net-rule "deny@*.com"` fails fast at parse time.
- `--deny-domain` and `--deny-domain-suffix` are removed. They overlapped with `--net-rule "deny@..."` plus `--net-default allow` and the choice between them was confusing.
- Docs updated: `docs/cli/sandbox-commands.mdx` gains a Network rule syntax section with the target grammar, suffix shorthand, and allowlist/blocklist/airgap compositions. `docs/networking/dns.mdx` CLI example migrated to the new syntax.
- SDK builder methods (`deny_domains`, `deny_domain_suffixes` and their allow counterparts) on the library API are intentionally untouched. SDK surface alignment is a follow-up.

Migration:

```bash
# before
msb run alpine --deny-domain malware.example.com
msb run alpine --deny-domain-suffix .ads.example.com

# after
msb run alpine --net-default allow --net-rule "deny@malware.example.com"
msb run alpine --net-default allow --net-rule "deny@*.ads.example.com"

# new compositions enabled
msb run alpine --net-default deny --net-rule "allow@github.com,allow@*.githubusercontent.com"
msb run alpine --no-net --net-rule "allow@api.internal.corp"
```

## Test Plan
- [ ] `cargo test -p microsandbox-cli --lib` passes (138 tests, includes 7 new tests for `build_network_policy` and the suffix parser arms)
- [ ] `cargo test -p microsandbox-network --lib` passes (includes 2 new tests for `DomainName::try_into_suffix`)
- [ ] `cargo clippy -p microsandbox-cli -p microsandbox-network -- -D warnings` is clean
- [ ] `msb run alpine --net-default deny --net-rule "allow@example.com" -- nslookup example.com` resolves
- [ ] `msb run alpine --net-default deny --net-rule "allow@example.com" -- nslookup github.com` returns REFUSED
- [ ] `msb run alpine --net-rule "deny@*.com" -- true` fails at parse time with `SuffixTooBroad`
- [ ] `msb run alpine --no-net --net-default deny -- true` fails at parse time with clap mutex error