### PR TITLE
feat(python-sdk)!: simplify sandbox execution API

### DIFF
--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -802,6 +802,19 @@ impl Sandbox {
         handle.collect().await
     }
 
+    /// Run a shell command with full execution options and wait for completion.
+    ///
+    /// The shell invocation itself supplies `-c <script>`, so any args configured
+    /// through the builder are ignored.
+    pub async fn shell_with(
+        &self,
+        script: impl Into<String>,
+        f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder,
+    ) -> MicrosandboxResult<ExecOutput> {
+        let mut handle = self.shell_stream_with(script, f).await?;
+        handle.collect().await
+    }
+
     /// Run a shell command with streaming I/O.
     ///
     /// Like [`shell`](Self::shell) but returns a streaming [`ExecHandle`]
@@ -812,6 +825,21 @@ impl Sandbox {
             args: vec!["-c".to_string(), script.into()],
             ..Default::default()
         };
+        self.exec_stream_inner(shell.to_string(), opts).await
+    }
+
+    /// Run a shell command with full execution options and streaming I/O.
+    ///
+    /// Like [`shell_with`](Self::shell_with) but returns a streaming
+    /// [`ExecHandle`] instead of waiting for completion.
+    pub async fn shell_stream_with(
+        &self,
+        script: impl Into<String>,
+        f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder,
+    ) -> MicrosandboxResult<ExecHandle> {
+        let shell = self.config.shell.as_deref().unwrap_or("/bin/sh");
+        let mut opts = f(ExecOptionsBuilder::default()).build()?;
+        opts.args = vec!["-c".to_string(), script.into()];
         self.exec_stream_inner(shell.to_string(), opts).await
     }
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,14 +93,14 @@
             "icon": "rust",
             "pages": [
               "sdk/rust/sandbox",
-              "sdk/rust/agent-client",
               "sdk/rust/execution",
               "sdk/rust/filesystem",
               "sdk/rust/volumes",
               "sdk/rust/networking",
               "sdk/rust/secrets",
               "sdk/rust/snapshots",
-              "sdk/rust/events"
+              "sdk/rust/events",
+              "sdk/rust/agent-client"
             ]
           },
           {
@@ -108,14 +108,14 @@
             "icon": "js",
             "pages": [
               "sdk/typescript/sandbox",
-              "sdk/typescript/agent-client",
               "sdk/typescript/execution",
               "sdk/typescript/filesystem",
               "sdk/typescript/volumes",
               "sdk/typescript/networking",
               "sdk/typescript/secrets",
               "sdk/typescript/snapshots",
-              "sdk/typescript/events"
+              "sdk/typescript/events",
+              "sdk/typescript/agent-client"
             ]
           },
           {
@@ -123,14 +123,14 @@
             "icon": "python",
             "pages": [
               "sdk/python/sandbox",
-              "sdk/python/agent-client",
               "sdk/python/execution",
               "sdk/python/filesystem",
               "sdk/python/volumes",
               "sdk/python/networking",
               "sdk/python/secrets",
               "sdk/python/snapshots",
-              "sdk/python/events"
+              "sdk/python/events",
+              "sdk/python/agent-client"
             ]
           },
           {
@@ -138,7 +138,6 @@
             "icon": "golang",
             "pages": [
               "sdk/go/sandbox",
-              "sdk/go/agent-client",
               "sdk/go/execution",
               "sdk/go/filesystem",
               "sdk/go/volumes",
@@ -146,7 +145,8 @@
               "sdk/go/networking",
               "sdk/go/secrets",
               "sdk/go/snapshots",
-              "sdk/go/events"
+              "sdk/go/events",
+              "sdk/go/agent-client"
             ]
           }
         ]

--- a/docs/sandboxes/commands.mdx
+++ b/docs/sandboxes/commands.mdx
@@ -72,15 +72,16 @@ const output = await sb.execWith("python", (e) =>
 ```
 
 ```python Python
-from microsandbox import ExecOptions, Rlimit
+from microsandbox import Rlimit
 
-output = await sb.exec("python", ExecOptions(
-    args=("compute.py",),
+output = await sb.exec(
+    "python",
+    ["compute.py"],
     cwd="/app",
     env={"PYTHONPATH": "/app/lib"},
     timeout=30.0,
-    rlimits=(Rlimit.nofile(1024),),
-))
+    rlimits=[Rlimit.nofile(1024)],
+)
 ```
 
 ```go Go
@@ -217,17 +218,16 @@ await sb.attachWith("bash", (a) =>
 ```
 
 ```python Python
-from microsandbox import AttachOptions
-
 # Attach to the default shell
 exit_code = await sb.attach_shell()
 
 # Attach to a specific command with custom detach keys
-exit_code = await sb.attach("python", AttachOptions(
+exit_code = await sb.attach(
+    "python",
     env={"DEBUG": "1"},
     cwd="/app",
     detach_keys="ctrl-q",
-))
+)
 ```
 
 ```go Go
@@ -283,9 +283,9 @@ await handle.wait();
 ```
 
 ```python Python
-from microsandbox import ExecOptions, Stdin
+from microsandbox import Stdin
 
-handle = await sb.exec_stream("python", ExecOptions(stdin=Stdin.pipe(), tty=True))
+handle = await sb.exec_stream("python", stdin=Stdin.pipe(), tty=True)
 stdin = handle.take_stdin()
 await stdin.write(b"print('hello')\n")
 await stdin.write(b"exit()\n")

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -449,7 +449,7 @@ config = Sandbox.build_config(
 )
 
 print(json.dumps(config, indent=2))
-sb = await Sandbox.create(config)
+sb = await Sandbox.create(**config)
 ```
 
 ```go Go

--- a/docs/sdk/python/execution.mdx
+++ b/docs/sdk/python/execution.mdx
@@ -89,7 +89,9 @@ ExecOptions(
 )
 ```
 
-Frozen dataclass for per-execution overrides.
+Frozen dataclass for reusable per-execution overrides. Pass it explicitly with
+`options=...`; for one-off calls, prefer keyword arguments on `exec`,
+`exec_stream`, or `shell`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -116,7 +118,9 @@ AttachOptions(
 )
 ```
 
-Frozen dataclass for interactive PTY attach configuration.
+Frozen dataclass for reusable interactive PTY attach configuration. Pass it
+explicitly with `options=...`; for one-off calls, prefer keyword arguments on
+`attach`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/docs/sdk/python/execution.mdx
+++ b/docs/sdk/python/execution.mdx
@@ -72,66 +72,6 @@ Python dataclass variants are also available for pattern matching:
 
 The union type `ExecEvent = StartedEvent | StdoutEvent | StderrEvent | ExitedEvent` is available from `events.py`.
 
----
-
-### ExecOptions
-
-```python
-ExecOptions(
-    args: tuple[str, ...] = (),
-    cwd: str | None = None,
-    user: str | None = None,
-    env: Mapping[str, str] = {},
-    timeout: float | None = None,  # seconds
-    stdin: Stdin = Stdin.null(),
-    tty: bool = False,
-    rlimits: tuple[Rlimit, ...] = (),
-)
-```
-
-Frozen dataclass for reusable per-execution overrides. Pass it explicitly with
-`options=...`; for one-off calls, prefer keyword arguments on `exec`,
-`exec_stream`, or `shell`.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| args | `tuple[str, ...]` | `()` | Command arguments |
-| cwd | `str \| None` | `None` | Working directory |
-| user | `str \| None` | `None` | Guest user |
-| env | `Mapping[str, str]` | `{}` | Environment variables |
-| timeout | `float \| None` | `None` | Kill the process after this many seconds |
-| stdin | [`Stdin`](#stdin) | `Stdin.null()` | Stdin source |
-| tty | `bool` | `False` | Allocate a pseudo-terminal |
-| rlimits | `tuple[`[`Rlimit`](#rlimit)`, ...]` | `()` | Resource limits |
-
----
-
-### AttachOptions
-
-```python
-AttachOptions(
-    args: tuple[str, ...] = (),
-    cwd: str | None = None,
-    user: str | None = None,
-    env: Mapping[str, str] = {},
-    detach_keys: str | None = None,
-)
-```
-
-Frozen dataclass for reusable interactive PTY attach configuration. Pass it
-explicitly with `options=...`; for one-off calls, prefer keyword arguments on
-`attach`.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| args | `tuple[str, ...]` | `()` | Command arguments |
-| cwd | `str \| None` | `None` | Working directory |
-| user | `str \| None` | `None` | Guest user |
-| env | `Mapping[str, str]` | `{}` | Environment variables |
-| detach_keys | `str \| None` | `None` | Key sequence to detach without stopping |
-
----
-
 ### Stdin
 
 Frozen dataclass with factory methods for configuring process stdin.

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -14,16 +14,16 @@ See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/
 
 ```python
 @staticmethod
-async def create(name_or_config: str | dict, **kwargs) -> Sandbox
+async def create(name: str, **kwargs) -> Sandbox
 ```
 
-Create and boot a sandbox. The first argument is either a name (`str`) or a full config (`dict`). Keyword arguments provide individual config fields. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands.
+Create and boot a sandbox. Keyword arguments provide individual config fields. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands.
 
 **Parameters**
 
 | Name | Type | Description |
 |------|------|-------------|
-| name_or_config | `str \| dict` | Sandbox name or full configuration dict |
+| name | `str` | Sandbox name |
 | image | `str \| ImageSource` | OCI image, local path, or disk image (required) |
 | cpus | `int` | Virtual CPUs (default `1`) |
 | memory | `int` | Guest memory in MiB (default `512`) |
@@ -42,7 +42,7 @@ Create and boot a sandbox. The first argument is either a name (`str`) or a full
 | pull_policy | `str \| PullPolicy` | Image pull behavior |
 | log_level | `str \| LogLevel` | Override log verbosity |
 | registry_auth | [`RegistryAuth`](#registryauth) | Private registry credentials |
-| volumes | `dict[str, dict]` | Volume mounts. See [Volumes](/sdk/python/volumes). |
+| volumes | `dict[str, MountConfig]` | Volume mounts. See [Volumes](/sdk/python/volumes). |
 | patches | `list[PatchConfig]` | Rootfs modifications applied before boot |
 | ports | `dict[int, int] \| Sequence[PortBinding]` | Port mappings. Dict form is TCP and binds to `127.0.0.1`; use [`PortBinding`](/sdk/python/networking#portbinding) for explicit bind addresses or UDP |
 | network | [`Network`](/sdk/python/networking#network) | Network policy and configuration |
@@ -70,7 +70,7 @@ async with await Sandbox.create("my-sandbox", image="alpine") as sb:
 
 ```python
 @staticmethod
-def create_with_progress(name_or_config: str | dict, **kwargs) -> PullSession
+def create_with_progress(name: str, **kwargs) -> PullSession
 ```
 
 Same parameters as [`Sandbox.create()`](#sandboxcreate) but returns a [`PullSession`](#pullsession) that lets you track image pull progress before the sandbox is ready. This method is synchronous (not awaitable) -- the async work happens through the `PullSession`.
@@ -218,7 +218,16 @@ Get a filesystem handle for reading and writing files inside the running sandbox
 #### attach()
 
 ```python
-async def attach(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> int
+async def attach(
+    cmd: str,
+    args: list[str] | None = None,
+    *,
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] | None = None,
+    detach_keys: str | None = None,
+    options: AttachOptions | None = None,
+) -> int
 ```
 
 Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session.
@@ -228,7 +237,12 @@ Bridge your terminal directly to a process inside the sandbox for a fully intera
 | Name | Type | Description |
 |------|------|-------------|
 | cmd | `str` | Command to run |
-| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or execution options |
+| args | `list[str] \| None` | Command arguments |
+| cwd | `str \| None` | Working directory |
+| user | `str \| None` | Guest user |
+| env | `Mapping[str, str] \| None` | Environment variables |
+| detach_keys | `str \| None` | Custom detach key sequence |
+| options | [`AttachOptions`](/sdk/python/execution#attachoptions) `\| None` | Explicit reusable options object |
 
 **Returns**
 
@@ -277,7 +291,19 @@ Start a graceful drain (SIGUSR1). Existing commands run to completion, new `exec
 #### exec()
 
 ```python
-async def exec(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecOutput
+async def exec(
+    cmd: str,
+    args: list[str] | None = None,
+    *,
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+    stdin: Stdin | bytes | str | None = None,
+    tty: bool = False,
+    rlimits: list[Rlimit] | None = None,
+    options: ExecOptions | None = None,
+) -> ExecOutput
 ```
 
 Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
@@ -287,7 +313,15 @@ Run a command inside the sandbox and wait for it to complete. Collects all stdou
 | Name | Type | Description |
 |------|------|-------------|
 | cmd | `str` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
-| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments (e.g. `["-c", "print('hello')"]`) or [`ExecOptions`](/sdk/python/execution#execoptions) |
+| args | `list[str] \| None` | Command arguments (e.g. `["-c", "print('hello')"]`) |
+| cwd | `str \| None` | Working directory |
+| user | `str \| None` | Guest user |
+| env | `Mapping[str, str] \| None` | Environment variables |
+| timeout | `float \| None` | Kill the process after this many seconds |
+| stdin | [`Stdin`](/sdk/python/execution#stdin) `\| bytes \| str \| None` | Stdin source |
+| tty | `bool` | Allocate a pseudo-terminal |
+| rlimits | `list[`[`Rlimit`](/sdk/python/execution#rlimit)`] \| None` | Resource limits |
+| options | [`ExecOptions`](/sdk/python/execution#execoptions) `\| None` | Explicit reusable options object |
 
 **Returns**
 
@@ -300,7 +334,19 @@ Run a command inside the sandbox and wait for it to complete. Collects all stdou
 #### exec_stream()
 
 ```python
-async def exec_stream(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecHandle
+async def exec_stream(
+    cmd: str,
+    args: list[str] | None = None,
+    *,
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+    stdin: Stdin | bytes | str | None = None,
+    tty: bool = False,
+    rlimits: list[Rlimit] | None = None,
+    options: ExecOptions | None = None,
+) -> ExecHandle
 ```
 
 Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
@@ -310,7 +356,8 @@ Run a command with streaming output. Returns a handle that emits stdout, stderr,
 | Name | Type | Description |
 |------|------|-------------|
 | cmd | `str` | Command to execute |
-| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or [`ExecOptions`](/sdk/python/execution#execoptions) |
+| args | `list[str] \| None` | Command arguments |
+| options | [`ExecOptions`](/sdk/python/execution#execoptions) `\| None` | Explicit reusable options object |
 
 **Returns**
 
@@ -457,7 +504,18 @@ Remove the sandbox and all its persisted state from disk.
 #### shell()
 
 ```python
-async def shell(script: str) -> ExecOutput
+async def shell(
+    script: str,
+    *,
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+    stdin: Stdin | bytes | str | None = None,
+    tty: bool = False,
+    rlimits: list[Rlimit] | None = None,
+    options: ExecOptions | None = None,
+) -> ExecOutput
 ```
 
 Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
@@ -467,6 +525,7 @@ Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Sh
 | Name | Type | Description |
 |------|------|-------------|
 | script | `str` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+| options | [`ExecOptions`](/sdk/python/execution#execoptions) `\| None` | Explicit reusable options object. `options.args` is not valid for shell commands. |
 
 **Returns**
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -226,7 +226,6 @@ async def attach(
     user: str | None = None,
     env: Mapping[str, str] | None = None,
     detach_keys: str | None = None,
-    options: AttachOptions | None = None,
 ) -> int
 ```
 
@@ -242,7 +241,6 @@ Bridge your terminal directly to a process inside the sandbox for a fully intera
 | user | `str \| None` | Guest user |
 | env | `Mapping[str, str] \| None` | Environment variables |
 | detach_keys | `str \| None` | Custom detach key sequence |
-| options | [`AttachOptions`](/sdk/python/execution#attachoptions) `\| None` | Explicit reusable options object |
 
 **Returns**
 
@@ -302,7 +300,6 @@ async def exec(
     stdin: Stdin | bytes | str | None = None,
     tty: bool = False,
     rlimits: list[Rlimit] | None = None,
-    options: ExecOptions | None = None,
 ) -> ExecOutput
 ```
 
@@ -321,7 +318,6 @@ Run a command inside the sandbox and wait for it to complete. Collects all stdou
 | stdin | [`Stdin`](/sdk/python/execution#stdin) `\| bytes \| str \| None` | Stdin source |
 | tty | `bool` | Allocate a pseudo-terminal |
 | rlimits | `list[`[`Rlimit`](/sdk/python/execution#rlimit)`] \| None` | Resource limits |
-| options | [`ExecOptions`](/sdk/python/execution#execoptions) `\| None` | Explicit reusable options object |
 
 **Returns**
 
@@ -345,7 +341,6 @@ async def exec_stream(
     stdin: Stdin | bytes | str | None = None,
     tty: bool = False,
     rlimits: list[Rlimit] | None = None,
-    options: ExecOptions | None = None,
 ) -> ExecHandle
 ```
 
@@ -357,7 +352,13 @@ Run a command with streaming output. Returns a handle that emits stdout, stderr,
 |------|------|-------------|
 | cmd | `str` | Command to execute |
 | args | `list[str] \| None` | Command arguments |
-| options | [`ExecOptions`](/sdk/python/execution#execoptions) `\| None` | Explicit reusable options object |
+| cwd | `str \| None` | Working directory |
+| user | `str \| None` | Guest user |
+| env | `Mapping[str, str] \| None` | Environment variables |
+| timeout | `float \| None` | Kill the process after this many seconds |
+| stdin | [`Stdin`](/sdk/python/execution#stdin) `\| bytes \| str \| None` | Stdin source |
+| tty | `bool` | Allocate a pseudo-terminal |
+| rlimits | `list[`[`Rlimit`](/sdk/python/execution#rlimit)`] \| None` | Resource limits |
 
 **Returns**
 
@@ -514,7 +515,6 @@ async def shell(
     stdin: Stdin | bytes | str | None = None,
     tty: bool = False,
     rlimits: list[Rlimit] | None = None,
-    options: ExecOptions | None = None,
 ) -> ExecOutput
 ```
 
@@ -525,7 +525,13 @@ Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Sh
 | Name | Type | Description |
 |------|------|-------------|
 | script | `str` | Shell command string (e.g. `"ls -la /app && echo done"`) |
-| options | [`ExecOptions`](/sdk/python/execution#execoptions) `\| None` | Explicit reusable options object. `options.args` is not valid for shell commands. |
+| cwd | `str \| None` | Working directory |
+| user | `str \| None` | Guest user |
+| env | `Mapping[str, str] \| None` | Environment variables |
+| timeout | `float \| None` | Kill the process after this many seconds |
+| stdin | [`Stdin`](/sdk/python/execution#stdin) `\| bytes \| str \| None` | Stdin source |
+| tty | `bool` | Allocate a pseudo-terminal |
+| rlimits | `list[`[`Rlimit`](/sdk/python/execution#rlimit)`] \| None` | Resource limits |
 
 **Returns**
 

--- a/docs/sdk/python/snapshots.mdx
+++ b/docs/sdk/python/snapshots.mdx
@@ -18,7 +18,7 @@ from microsandbox import Sandbox, Snapshot, SnapshotHandle
 
 ```python
 @staticmethod
-async def create(name_or_config, *, snapshot: str | os.PathLike | None = None, **kwargs) -> Sandbox
+async def create(name: str, *, snapshot: str | os.PathLike | None = None, **kwargs) -> Sandbox
 ```
 
 Boot a fresh sandbox from a snapshot artifact by passing `snapshot=` as a peer of `image=`. The two are mutually exclusive — pass exactly one.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -432,8 +432,6 @@ if not is_installed():
 
 | Type | Description |
 |------|-------------|
-| `ExecOptions` | Reusable execution options for `options=` |
-| `AttachOptions` | Reusable attach options for `options=` |
 | `ExitStatus` | Exit code and success flag |
 | `MountConfig` | Volume mount (bind, named, or tmpfs) |
 | `PatchConfig` | Pre-boot filesystem modification |

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -84,13 +84,14 @@ print(output.exit_code)      # 0
 output = await sandbox.shell("echo hello && pwd")
 print(output.stdout_text)
 
-# Full configuration via ExecOptions dict.
-output = await sandbox.exec("python3", {
-    "args": ["script.py"],
-    "cwd": "/app",
-    "env": {"PYTHONPATH": "/app/lib"},
-    "timeout": 30.0,
-})
+# Full configuration via keyword-only options.
+output = await sandbox.exec(
+    "python3",
+    ["script.py"],
+    cwd="/app",
+    env={"PYTHONPATH": "/app/lib"},
+    timeout=30.0,
+)
 
 # Streaming output.
 handle = await sandbox.exec_stream("tail", ["-f", "/var/log/app.log"])
@@ -431,8 +432,8 @@ if not is_installed():
 
 | Type | Description |
 |------|-------------|
-| `ExecOptions` | Full execution options (args, cwd, env, timeout, tty, rlimits) |
-| `AttachOptions` | Attach options (args, cwd, env, detach_keys) |
+| `ExecOptions` | Reusable execution options for `options=` |
+| `AttachOptions` | Reusable attach options for `options=` |
 | `ExitStatus` | Exit code and success flag |
 | `MountConfig` | Volume mount (bind, named, or tmpfs) |
 | `PatchConfig` | Pre-boot filesystem modification |

--- a/sdk/python/integration/test_smoke.py
+++ b/sdk/python/integration/test_smoke.py
@@ -47,12 +47,10 @@ async def test_python_sdk_end_to_end_smoke():
 
         configured = await sandbox.exec(
             "sh",
-            {
-                "args": ["-c", 'printf "%s:%s\\n" "$(pwd)" "$PYTHON_SMOKE"'],
-                "cwd": "/tmp",
-                "env": {"PYTHON_SMOKE": "ok"},
-                "timeout": 30.0,
-            },
+            ["-c", 'printf "%s:%s\\n" "$(pwd)" "$PYTHON_SMOKE"'],
+            cwd="/tmp",
+            env={"PYTHON_SMOKE": "ok"},
+            timeout=30.0,
         )
         assert configured.success is True
         assert configured.stdout_text == "/tmp:ok\n"

--- a/sdk/python/microsandbox/__init__.py
+++ b/sdk/python/microsandbox/__init__.py
@@ -78,11 +78,9 @@ from microsandbox.events import (
 )
 from microsandbox.types import (
     Action,
-    AttachOptions,
     DestGroup,
     Direction,
     DiskImageFormat,
-    ExecOptions,
     ExitStatus,
     FsEntryKind,
     GiB,
@@ -146,7 +144,6 @@ __all__ = [
     "LogEntry",
     "LogStream",
     "MetricsStream",
-    "ExecOptions",
     "ExitStatus",
     "Stdin",
     "Rlimit",
@@ -216,7 +213,6 @@ __all__ = [
     # Patches
     "Patch",
     "PatchConfig",
-    "AttachOptions",
     # Init handoff
     "InitConfig",
     # Metrics

--- a/sdk/python/microsandbox/_microsandbox.pyi
+++ b/sdk/python/microsandbox/_microsandbox.pyi
@@ -6,15 +6,7 @@ import os
 from collections.abc import AsyncIterator, Mapping
 from typing import Any
 
-from microsandbox.types import (
-    AttachOptions,
-    ExecOptions,
-    LogReadSource,
-    LogSource,
-    MountConfig,
-    Rlimit,
-    Stdin,
-)
+from microsandbox.types import LogReadSource, LogSource, MountConfig, Rlimit, Stdin
 
 class PyAgentClient:
     @staticmethod
@@ -70,7 +62,6 @@ class Sandbox:
         stdin: Stdin | bytes | str | None = None,
         tty: bool = False,
         rlimits: list[Rlimit] | None = None,
-        options: ExecOptions | None = None,
     ) -> ExecOutput: ...
     async def exec_stream(
         self,
@@ -84,7 +75,6 @@ class Sandbox:
         stdin: Stdin | bytes | str | None = None,
         tty: bool = False,
         rlimits: list[Rlimit] | None = None,
-        options: ExecOptions | None = None,
     ) -> ExecHandle: ...
     async def shell(
         self,
@@ -97,7 +87,6 @@ class Sandbox:
         stdin: Stdin | bytes | str | None = None,
         tty: bool = False,
         rlimits: list[Rlimit] | None = None,
-        options: ExecOptions | None = None,
     ) -> ExecOutput: ...
     async def shell_stream(
         self,
@@ -110,7 +99,6 @@ class Sandbox:
         stdin: Stdin | bytes | str | None = None,
         tty: bool = False,
         rlimits: list[Rlimit] | None = None,
-        options: ExecOptions | None = None,
     ) -> ExecHandle: ...
     async def attach(
         self,
@@ -121,7 +109,6 @@ class Sandbox:
         user: str | None = None,
         env: Mapping[str, str] | None = None,
         detach_keys: str | None = None,
-        options: AttachOptions | None = None,
     ) -> int: ...
     async def attach_shell(self) -> int: ...
     async def metrics(self) -> SandboxMetrics: ...

--- a/sdk/python/microsandbox/_microsandbox.pyi
+++ b/sdk/python/microsandbox/_microsandbox.pyi
@@ -3,10 +3,18 @@
 from __future__ import annotations
 
 import os
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from typing import Any
 
-from microsandbox.types import LogReadSource, LogSource
+from microsandbox.types import (
+    AttachOptions,
+    ExecOptions,
+    LogReadSource,
+    LogSource,
+    MountConfig,
+    Rlimit,
+    Stdin,
+)
 
 class PyAgentClient:
     @staticmethod
@@ -31,7 +39,7 @@ class PyAgentClient:
 
 class Sandbox:
     @staticmethod
-    async def create(name_or_config: str | dict[str, Any], **kwargs: Any) -> Sandbox: ...
+    async def create(name: str, **kwargs: Any) -> Sandbox: ...
     @staticmethod
     async def start(name: str, *, detached: bool = False) -> Sandbox: ...
     @staticmethod
@@ -42,7 +50,7 @@ class Sandbox:
     async def remove(name: str) -> None: ...
     @staticmethod
     def create_with_progress(
-        name_or_config: str | dict[str, Any], **kwargs: Any
+        name: str, **kwargs: Any
     ) -> PullSession: ...
 
     async def name(self) -> str: ...
@@ -51,15 +59,69 @@ class Sandbox:
     def fs(self) -> SandboxFs: ...
 
     async def exec(
-        self, cmd: str, args_or_options: list[str] | dict[str, Any] | None = None
+        self,
+        cmd: str,
+        args: list[str] | None = None,
+        *,
+        cwd: str | None = None,
+        user: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        stdin: Stdin | bytes | str | None = None,
+        tty: bool = False,
+        rlimits: list[Rlimit] | None = None,
+        options: ExecOptions | None = None,
     ) -> ExecOutput: ...
     async def exec_stream(
-        self, cmd: str, args_or_options: list[str] | dict[str, Any] | None = None
+        self,
+        cmd: str,
+        args: list[str] | None = None,
+        *,
+        cwd: str | None = None,
+        user: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        stdin: Stdin | bytes | str | None = None,
+        tty: bool = False,
+        rlimits: list[Rlimit] | None = None,
+        options: ExecOptions | None = None,
     ) -> ExecHandle: ...
-    async def shell(self, script: str) -> ExecOutput: ...
-    async def shell_stream(self, script: str) -> ExecHandle: ...
+    async def shell(
+        self,
+        script: str,
+        *,
+        cwd: str | None = None,
+        user: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        stdin: Stdin | bytes | str | None = None,
+        tty: bool = False,
+        rlimits: list[Rlimit] | None = None,
+        options: ExecOptions | None = None,
+    ) -> ExecOutput: ...
+    async def shell_stream(
+        self,
+        script: str,
+        *,
+        cwd: str | None = None,
+        user: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        stdin: Stdin | bytes | str | None = None,
+        tty: bool = False,
+        rlimits: list[Rlimit] | None = None,
+        options: ExecOptions | None = None,
+    ) -> ExecHandle: ...
     async def attach(
-        self, cmd: str, args_or_options: list[str] | dict[str, Any] | None = None
+        self,
+        cmd: str,
+        args: list[str] | None = None,
+        *,
+        cwd: str | None = None,
+        user: str | None = None,
+        env: Mapping[str, str] | None = None,
+        detach_keys: str | None = None,
+        options: AttachOptions | None = None,
     ) -> int: ...
     async def attach_shell(self) -> int: ...
     async def metrics(self) -> SandboxMetrics: ...
@@ -142,9 +204,8 @@ class ExecOutput:
 
 class ExecHandle:
     @property
-    async def id(self) -> str: ...
-    @property
-    def stdin(self) -> ExecSink | None: ...
+    def id(self) -> str: ...
+    def take_stdin(self) -> ExecSink | None: ...
     async def recv(self) -> ExecEvent | None: ...
     async def wait(self) -> tuple[int, bool]: ...
     async def collect(self) -> ExecOutput: ...
@@ -248,11 +309,11 @@ class Volume:
     @staticmethod
     async def remove(name: str) -> None: ...
     @staticmethod
-    def bind(path: str, *, readonly: bool = False) -> dict[str, Any]: ...
+    def bind(path: str, *, readonly: bool = False) -> MountConfig: ...
     @staticmethod
-    def named(name: str, *, readonly: bool = False) -> dict[str, Any]: ...
+    def named(name: str, *, readonly: bool = False) -> MountConfig: ...
     @staticmethod
-    def tmpfs(*, size_mib: int | None = None, readonly: bool = False) -> dict[str, Any]: ...
+    def tmpfs(*, size_mib: int | None = None, readonly: bool = False) -> MountConfig: ...
     @staticmethod
     def disk(
         path: str,
@@ -260,7 +321,7 @@ class Volume:
         format: str | None = None,
         fstype: str | None = None,
         readonly: bool = False,
-    ) -> dict[str, Any]: ...
+    ) -> MountConfig: ...
     @property
     def name(self) -> str: ...
     @property

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -240,6 +240,9 @@ class Rlimit:
     def stack(cls, limit: int) -> Rlimit:
         return cls(RlimitResource.STACK, limit, limit)
 
+    def _to_dict(self) -> dict:
+        return {"resource": str(self.resource), "soft": self.soft, "hard": self.hard}
+
 #--------------------------------------------------------------------------------------------------
 # Types: Stdin
 #--------------------------------------------------------------------------------------------------
@@ -268,7 +271,7 @@ class Stdin:
 
 @dataclass(frozen=True, slots=True)
 class ExecOptions:
-    """Full execution options (passed as second positional to exec/exec_stream)."""
+    """Reusable execution options for ``options=`` on exec/exec_stream/shell."""
     args: tuple[str, ...] = ()
     cwd: str | None = None
     user: str | None = None
@@ -335,7 +338,7 @@ class InitConfig:
 
 @dataclass(frozen=True, slots=True)
 class AttachOptions:
-    """Full options for attach (passed as second positional to attach)."""
+    """Reusable attach options for ``options=`` on attach."""
     args: tuple[str, ...] = ()
     cwd: str | None = None
     user: str | None = None
@@ -372,10 +375,10 @@ class MountConfig:
     size_mib: int | None = None
     readonly: bool = False
     disk: str | None = None
-    format: DiskImageFormat | None = None
+    format: DiskImageFormat | str | None = None
     fstype: str | None = None
-    stat_virtualization: StatVirtualization | None = None
-    host_permissions: HostPermissions | None = None
+    stat_virtualization: StatVirtualization | str | None = None
+    host_permissions: HostPermissions | str | None = None
 
     def _to_dict(self) -> dict:
         # Drive emission off `kind` exclusively so a `MountConfig` with
@@ -399,7 +402,7 @@ class MountConfig:
                 raise ValueError("MountConfig kind=DISK requires disk=...")
             d["disk"] = self.disk
             if self.format is not None:
-                d["format"] = self.format.value
+                d["format"] = _enum_value(self.format)
             if self.fstype is not None:
                 d["fstype"] = self.fstype
         else:  # pragma: no cover - StrEnum exhaustive above
@@ -408,15 +411,18 @@ class MountConfig:
         # Per-mount policies — only valid for virtiofs-backed kinds.
         if self.kind in (MountKind.BIND, MountKind.NAMED):
             if self.stat_virtualization is not None:
-                d["stat_virtualization"] = self.stat_virtualization.value
+                d["stat_virtualization"] = _enum_value(self.stat_virtualization)
             if self.host_permissions is not None:
-                d["host_permissions"] = self.host_permissions.value
+                d["host_permissions"] = _enum_value(self.host_permissions)
         elif self.stat_virtualization is not None or self.host_permissions is not None:
             raise ValueError(
                 f"stat_virtualization/host_permissions are only valid for "
                 f"BIND/NAMED mounts (got kind={self.kind.value})"
             )
         return d
+
+def _enum_value(value: enum.Enum | str) -> str:
+    return value.value if isinstance(value, enum.Enum) else value
 
 #--------------------------------------------------------------------------------------------------
 # Types: Image

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -266,45 +266,6 @@ class Stdin:
         return cls("bytes", data)
 
 #--------------------------------------------------------------------------------------------------
-# Types: Exec
-#--------------------------------------------------------------------------------------------------
-
-@dataclass(frozen=True, slots=True)
-class ExecOptions:
-    """Reusable execution options for ``options=`` on exec/exec_stream/shell."""
-    args: tuple[str, ...] = ()
-    cwd: str | None = None
-    user: str | None = None
-    env: Mapping[str, str] = field(default_factory=dict)
-    timeout: float | None = None
-    stdin: Stdin = field(default_factory=Stdin.null)
-    tty: bool = False
-    rlimits: tuple[Rlimit, ...] = ()
-
-    def _to_dict(self) -> dict:
-        d: dict = {"args": list(self.args)}
-        if self.cwd is not None:
-            d["cwd"] = self.cwd
-        if self.user is not None:
-            d["user"] = self.user
-        if self.env:
-            d["env"] = dict(self.env)
-        if self.timeout is not None:
-            d["timeout"] = self.timeout
-        if self.tty:
-            d["tty"] = True
-        if self.stdin._mode != "null":
-            d["stdin"] = self.stdin._mode
-            if self.stdin._data is not None:
-                d["stdin_data"] = self.stdin._data
-        if self.rlimits:
-            d["rlimits"] = [
-                {"resource": str(r.resource), "soft": r.soft, "hard": r.hard}
-                for r in self.rlimits
-            ]
-        return d
-
-#--------------------------------------------------------------------------------------------------
 # Types: Init Handoff
 #--------------------------------------------------------------------------------------------------
 
@@ -330,31 +291,6 @@ class InitConfig:
             d["args"] = list(self.args)
         if self.env:
             d["env"] = dict(self.env)
-        return d
-
-#--------------------------------------------------------------------------------------------------
-# Types: Attach
-#--------------------------------------------------------------------------------------------------
-
-@dataclass(frozen=True, slots=True)
-class AttachOptions:
-    """Reusable attach options for ``options=`` on attach."""
-    args: tuple[str, ...] = ()
-    cwd: str | None = None
-    user: str | None = None
-    env: Mapping[str, str] = field(default_factory=dict)
-    detach_keys: str | None = None
-
-    def _to_dict(self) -> dict:
-        d: dict = {"args": list(self.args)}
-        if self.cwd is not None:
-            d["cwd"] = self.cwd
-        if self.user is not None:
-            d["user"] = self.user
-        if self.env:
-            d["env"] = dict(self.env)
-        if self.detach_keys is not None:
-            d["detach_keys"] = self.detach_keys
         return d
 
 #--------------------------------------------------------------------------------------------------

--- a/sdk/python/src/sandbox.rs
+++ b/sdk/python/src/sandbox.rs
@@ -224,7 +224,6 @@ impl PySandbox {
         stdin = None,
         tty = false,
         rlimits = None,
-        options = None,
     ))]
     fn exec<'py>(
         &self,
@@ -238,11 +237,9 @@ impl PySandbox {
         stdin: Option<&Bound<'py, PyAny>>,
         tty: bool,
         rlimits: Option<&Bound<'py, PyAny>>,
-        options: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let (args, opts) =
-            parse_exec_call(args, cwd, user, env, timeout, stdin, tty, rlimits, options)?;
+        let (args, opts) = parse_exec_call(args, cwd, user, env, timeout, stdin, tty, rlimits)?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
@@ -267,7 +264,6 @@ impl PySandbox {
         stdin = None,
         tty = false,
         rlimits = None,
-        options = None,
     ))]
     fn exec_stream<'py>(
         &self,
@@ -281,11 +277,9 @@ impl PySandbox {
         stdin: Option<&Bound<'py, PyAny>>,
         tty: bool,
         rlimits: Option<&Bound<'py, PyAny>>,
-        options: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let (args, opts) =
-            parse_exec_call(args, cwd, user, env, timeout, stdin, tty, rlimits, options)?;
+        let (args, opts) = parse_exec_call(args, cwd, user, env, timeout, stdin, tty, rlimits)?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
@@ -309,7 +303,6 @@ impl PySandbox {
         stdin = None,
         tty = false,
         rlimits = None,
-        options = None,
     ))]
     fn shell<'py>(
         &self,
@@ -322,10 +315,9 @@ impl PySandbox {
         stdin: Option<&Bound<'py, PyAny>>,
         tty: bool,
         rlimits: Option<&Bound<'py, PyAny>>,
-        options: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let opts = parse_shell_call(cwd, user, env, timeout, stdin, tty, rlimits, options)?;
+        let opts = parse_shell_call(cwd, user, env, timeout, stdin, tty, rlimits)?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
@@ -349,7 +341,6 @@ impl PySandbox {
         stdin = None,
         tty = false,
         rlimits = None,
-        options = None,
     ))]
     fn shell_stream<'py>(
         &self,
@@ -362,10 +353,9 @@ impl PySandbox {
         stdin: Option<&Bound<'py, PyAny>>,
         tty: bool,
         rlimits: Option<&Bound<'py, PyAny>>,
-        options: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let opts = parse_shell_call(cwd, user, env, timeout, stdin, tty, rlimits, options)?;
+        let opts = parse_shell_call(cwd, user, env, timeout, stdin, tty, rlimits)?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
@@ -393,7 +383,6 @@ impl PySandbox {
         user = None,
         env = None,
         detach_keys = None,
-        options = None,
     ))]
     fn attach<'py>(
         &self,
@@ -404,10 +393,9 @@ impl PySandbox {
         user: Option<String>,
         env: Option<HashMap<String, String>>,
         detach_keys: Option<String>,
-        options: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let (args, opts) = parse_attach_call(args, cwd, user, env, detach_keys, options)?;
+        let (args, opts) = parse_attach_call(args, cwd, user, env, detach_keys)?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
@@ -668,13 +656,7 @@ fn parse_exec_call(
     stdin: Option<&Bound<'_, PyAny>>,
     tty: bool,
     rlimits: Option<&Bound<'_, PyAny>>,
-    options: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<(Vec<String>, ExecOpts)> {
-    if let Some(options) = options {
-        ensure_no_exec_keywords(args, &cwd, &user, &env, timeout_secs, stdin, tty, rlimits)?;
-        return parse_exec_options_obj(options);
-    }
-
     let args = parse_args(args)?;
     let (stdin_mode, stdin_data) = parse_stdin(stdin)?;
     validate_timeout(timeout_secs)?;
@@ -702,19 +684,7 @@ fn parse_shell_call(
     stdin: Option<&Bound<'_, PyAny>>,
     tty: bool,
     rlimits: Option<&Bound<'_, PyAny>>,
-    options: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<ExecOpts> {
-    if let Some(options) = options {
-        ensure_no_exec_keywords(None, &cwd, &user, &env, timeout_secs, stdin, tty, rlimits)?;
-        let (args, opts) = parse_exec_options_obj(options)?;
-        if !args.is_empty() {
-            return Err(PyValueError::new_err(
-                "options.args is not valid for shell(); pass the script as the first argument",
-            ));
-        }
-        return Ok(opts);
-    }
-
     let (stdin_mode, stdin_data) = parse_stdin(stdin)?;
     validate_timeout(timeout_secs)?;
     Ok(ExecOpts {
@@ -735,22 +705,7 @@ fn parse_attach_call(
     user: Option<String>,
     env: Option<HashMap<String, String>>,
     detach_keys: Option<String>,
-    options: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<(Vec<String>, AttachOpts)> {
-    if let Some(options) = options {
-        if args.is_some()
-            || cwd.is_some()
-            || user.is_some()
-            || env.is_some()
-            || detach_keys.is_some()
-        {
-            return Err(PyValueError::new_err(
-                "options= cannot be combined with args or attach keyword options",
-            ));
-        }
-        return parse_attach_options_obj(options);
-    }
-
     Ok((
         parse_args(args)?,
         AttachOpts {
@@ -762,40 +717,13 @@ fn parse_attach_call(
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
-fn ensure_no_exec_keywords(
-    args: Option<&Bound<'_, PyAny>>,
-    cwd: &Option<String>,
-    user: &Option<String>,
-    env: &Option<HashMap<String, String>>,
-    timeout_secs: Option<f64>,
-    stdin: Option<&Bound<'_, PyAny>>,
-    tty: bool,
-    rlimits: Option<&Bound<'_, PyAny>>,
-) -> PyResult<()> {
-    if args.is_some()
-        || cwd.is_some()
-        || user.is_some()
-        || env.is_some()
-        || timeout_secs.is_some()
-        || stdin.is_some()
-        || tty
-        || rlimits.is_some()
-    {
-        return Err(PyValueError::new_err(
-            "options= cannot be combined with args or execution keyword options",
-        ));
-    }
-    Ok(())
-}
-
 fn parse_args(args: Option<&Bound<'_, PyAny>>) -> PyResult<Vec<String>> {
     let Some(args) = args else {
         return Ok(Vec::new());
     };
     if args.downcast::<PyDict>().is_ok() {
         return Err(pyo3::exceptions::PyTypeError::new_err(
-            "args must be a list of strings; pass ExecOptions with options=...",
+            "args must be a list of strings",
         ));
     }
     if args.downcast::<PyBytes>().is_ok() || args.extract::<String>().is_ok() {
@@ -809,40 +737,6 @@ fn parse_args(args: Option<&Bound<'_, PyAny>>) -> PyResult<Vec<String>> {
     list.iter().map(|item| item.extract::<String>()).collect()
 }
 
-fn parse_exec_options_obj(obj: &Bound<'_, PyAny>) -> PyResult<(Vec<String>, ExecOpts)> {
-    let dict = options_dict(obj, "options")?;
-    let args = parse_args_from_dict(&dict)?;
-    let (stdin_mode, stdin_data) = parse_stdin_from_dict(&dict)?;
-    let timeout_secs = optional_from_dict::<f64>(&dict, "timeout")?;
-    validate_timeout(timeout_secs)?;
-    Ok((
-        args,
-        ExecOpts {
-            cwd: optional_from_dict(&dict, "cwd")?,
-            user: optional_from_dict(&dict, "user")?,
-            env: parse_env_from_dict(&dict)?,
-            timeout_secs,
-            tty: optional_from_dict(&dict, "tty")?.unwrap_or(false),
-            stdin_mode,
-            stdin_data,
-            rlimits: parse_rlimits_from_dict(&dict)?,
-        },
-    ))
-}
-
-fn parse_attach_options_obj(obj: &Bound<'_, PyAny>) -> PyResult<(Vec<String>, AttachOpts)> {
-    let dict = options_dict(obj, "options")?;
-    Ok((
-        parse_args_from_dict(&dict)?,
-        AttachOpts {
-            cwd: optional_from_dict(&dict, "cwd")?,
-            user: optional_from_dict(&dict, "user")?,
-            env: parse_env_from_dict(&dict)?,
-            detach_keys: optional_from_dict(&dict, "detach_keys")?,
-        },
-    ))
-}
-
 fn options_dict<'py>(obj: &Bound<'py, PyAny>, label: &str) -> PyResult<Bound<'py, PyDict>> {
     if let Ok(dict) = obj.downcast::<PyDict>() {
         return Ok(dict.clone());
@@ -854,34 +748,6 @@ fn options_dict<'py>(obj: &Bound<'py, PyAny>, label: &str) -> PyResult<Bound<'py
     Err(pyo3::exceptions::PyTypeError::new_err(format!(
         "{label} must be a dict or object with _to_dict()",
     )))
-}
-
-fn parse_args_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<Vec<String>> {
-    let Some(args) = dict.get_item("args")? else {
-        return Ok(Vec::new());
-    };
-    if args.is_none() {
-        return Ok(Vec::new());
-    }
-    let list = args.downcast::<PyList>().map_err(|_| {
-        pyo3::exceptions::PyTypeError::new_err("options.args must be a list of strings")
-    })?;
-    list.iter().map(|item| item.extract::<String>()).collect()
-}
-
-fn parse_env_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<Vec<(String, String)>> {
-    let Some(env_obj) = dict.get_item("env")? else {
-        return Ok(Vec::new());
-    };
-    if env_obj.is_none() {
-        return Ok(Vec::new());
-    }
-
-    let env_dict: &Bound<'_, PyDict> = env_obj.downcast()?;
-    env_dict
-        .iter()
-        .map(|(k, v)| Ok::<_, PyErr>((k.extract::<String>()?, v.extract::<String>()?)))
-        .collect()
 }
 
 fn env_to_pairs(env: Option<HashMap<String, String>>) -> Vec<(String, String)> {
@@ -913,18 +779,6 @@ fn parse_stdin(stdin: Option<&Bound<'_, PyAny>>) -> PyResult<(Option<String>, Op
     normalize_stdin(mode, data)
 }
 
-fn parse_stdin_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<(Option<String>, Option<Vec<u8>>)> {
-    let Some(stdin_obj) = dict.get_item("stdin")? else {
-        return Ok((None, None));
-    };
-    if stdin_obj.is_none() {
-        return Ok((None, None));
-    }
-    let mode: String = stdin_obj.extract()?;
-    let data = optional_from_dict(dict, "stdin_data")?;
-    normalize_stdin(mode, data)
-}
-
 fn normalize_stdin(
     mode: String,
     data: Option<Vec<u8>>,
@@ -944,16 +798,6 @@ fn parse_rlimits(rlimits: Option<&Bound<'_, PyAny>>) -> PyResult<Vec<(String, u6
         return Ok(Vec::new());
     };
     parse_rlimits_iter(rlimits)
-}
-
-fn parse_rlimits_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<Vec<(String, u64, u64)>> {
-    let Some(rlimits) = dict.get_item("rlimits")? else {
-        return Ok(Vec::new());
-    };
-    if rlimits.is_none() {
-        return Ok(Vec::new());
-    }
-    parse_rlimits_iter(&rlimits)
 }
 
 fn parse_rlimits_iter(obj: &Bound<'_, PyAny>) -> PyResult<Vec<(String, u64, u64)>> {
@@ -1015,16 +859,6 @@ fn validate_timeout(timeout_secs: Option<f64>) -> PyResult<()> {
         return Err(PyValueError::new_err("timeout must be non-negative"));
     }
     Ok(())
-}
-
-fn optional_from_dict<'py, T: FromPyObject<'py>>(
-    dict: &Bound<'py, PyDict>,
-    key: &str,
-) -> PyResult<Option<T>> {
-    match dict.get_item(key)? {
-        Some(val) if !val.is_none() => Ok(Some(val.extract()?)),
-        _ => Ok(None),
-    }
 }
 
 fn required_from_dict<'py, T: FromPyObject<'py>>(

--- a/sdk/python/src/sandbox.rs
+++ b/sdk/python/src/sandbox.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyBytes, PyDict, PyList};
 use tokio::sync::Mutex;
 
 use crate::error::to_py_err;
@@ -62,25 +63,14 @@ impl PySandbox {
     // Static Methods — Creation
     //----------------------------------------------------------------------------------------------
 
-    /// Create a sandbox from a name + kwargs, or from a config dict.
+    /// Create a sandbox from a name and keyword-only configuration.
     #[staticmethod]
-    #[pyo3(signature = (name_or_config, **kwargs))]
+    #[pyo3(signature = (name, **kwargs))]
     fn create<'py>(
         py: Python<'py>,
-        name_or_config: &Bound<'py, PyAny>,
+        name: String,
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let (name, kwargs) = match name_or_config.downcast::<PyDict>() {
-            Err(_) => (name_or_config.extract()?, kwargs),
-            Ok(config_dict) => (
-                config_dict
-                    .get_item("name")?
-                    .ok_or_else(|| PyValueError::new_err("config.name is required"))?
-                    .extract()?,
-                Some(config_dict),
-            ),
-        };
-
         let builder = sandbox_builder_from_args(name, kwargs)?;
         let detached = kwargs
             .and_then(|kw| kw.get_item("detached").ok().flatten())
@@ -118,21 +108,12 @@ impl PySandbox {
     /// Create a sandbox with pull progress reporting.
     /// Returns a PullSession async context manager.
     #[staticmethod]
-    #[pyo3(signature = (name_or_config, **kwargs))]
+    #[pyo3(signature = (name, **kwargs))]
     fn create_with_progress<'py>(
         _py: Python<'py>,
-        name_or_config: &Bound<'py, PyAny>,
+        name: String,
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<PyPullSession> {
-        let (name, kwargs) = if let Ok(config_dict) = name_or_config.downcast::<PyDict>() {
-            let name: String = config_dict
-                .get_item("name")?
-                .ok_or_else(|| PyValueError::new_err("config.name is required"))?
-                .extract()?;
-            (name, Some(config_dict))
-        } else {
-            (name_or_config.extract()?, kwargs)
-        };
         let builder = sandbox_builder_from_args(name, kwargs)?;
         let detached = kwargs
             .and_then(|kw| kw.get_item("detached").ok().flatten())
@@ -231,77 +212,167 @@ impl PySandbox {
     //----------------------------------------------------------------------------------------------
 
     /// Execute a command and wait for completion.
-    ///
-    /// Second positional is either a list of args (shortcut) or an ExecOptions dict.
-    #[pyo3(signature = (cmd, args_or_options=None))]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        cmd,
+        args = None,
+        *,
+        cwd = None,
+        user = None,
+        env = None,
+        timeout = None,
+        stdin = None,
+        tty = false,
+        rlimits = None,
+        options = None,
+    ))]
     fn exec<'py>(
         &self,
         py: Python<'py>,
         cmd: String,
-        args_or_options: Option<&Bound<'py, PyAny>>,
+        args: Option<&Bound<'py, PyAny>>,
+        cwd: Option<String>,
+        user: Option<String>,
+        env: Option<HashMap<String, String>>,
+        timeout: Option<f64>,
+        stdin: Option<&Bound<'py, PyAny>>,
+        tty: bool,
+        rlimits: Option<&Bound<'py, PyAny>>,
+        options: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let (args, options) = parse_exec_args(args_or_options)?;
+        let (args, opts) =
+            parse_exec_call(args, cwd, user, env, timeout, stdin, tty, rlimits, options)?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
-
-            let output = if let Some(opts) = options {
-                sandbox
-                    .exec_with(&cmd, |e| apply_exec_options(e, args, opts))
-                    .await
-                    .map_err(to_py_err)?
-            } else {
-                sandbox.exec(&cmd, args).await.map_err(to_py_err)?
-            };
-
+            let output = sandbox
+                .exec_with(&cmd, |e| apply_exec_options(e, args, opts))
+                .await
+                .map_err(to_py_err)?;
             Ok(PyExecOutput::from_rust(output))
         })
     }
 
     /// Execute a command with streaming I/O.
-    #[pyo3(signature = (cmd, args_or_options=None))]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        cmd,
+        args = None,
+        *,
+        cwd = None,
+        user = None,
+        env = None,
+        timeout = None,
+        stdin = None,
+        tty = false,
+        rlimits = None,
+        options = None,
+    ))]
     fn exec_stream<'py>(
         &self,
         py: Python<'py>,
         cmd: String,
-        args_or_options: Option<&Bound<'py, PyAny>>,
+        args: Option<&Bound<'py, PyAny>>,
+        cwd: Option<String>,
+        user: Option<String>,
+        env: Option<HashMap<String, String>>,
+        timeout: Option<f64>,
+        stdin: Option<&Bound<'py, PyAny>>,
+        tty: bool,
+        rlimits: Option<&Bound<'py, PyAny>>,
+        options: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let (args, options) = parse_exec_args(args_or_options)?;
+        let (args, opts) =
+            parse_exec_call(args, cwd, user, env, timeout, stdin, tty, rlimits, options)?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
-
-            let handle = if let Some(opts) = options {
-                sandbox
-                    .exec_stream_with(&cmd, |e| apply_exec_options(e, args, opts))
-                    .await
-                    .map_err(to_py_err)?
-            } else {
-                sandbox.exec_stream(&cmd, args).await.map_err(to_py_err)?
-            };
-
+            let handle = sandbox
+                .exec_stream_with(&cmd, |e| apply_exec_options(e, args, opts))
+                .await
+                .map_err(to_py_err)?;
             Ok(PyExecHandle::from_rust(handle))
         })
     }
 
     /// Execute a shell command.
-    fn shell<'py>(&self, py: Python<'py>, script: String) -> PyResult<Bound<'py, PyAny>> {
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        script,
+        *,
+        cwd = None,
+        user = None,
+        env = None,
+        timeout = None,
+        stdin = None,
+        tty = false,
+        rlimits = None,
+        options = None,
+    ))]
+    fn shell<'py>(
+        &self,
+        py: Python<'py>,
+        script: String,
+        cwd: Option<String>,
+        user: Option<String>,
+        env: Option<HashMap<String, String>>,
+        timeout: Option<f64>,
+        stdin: Option<&Bound<'py, PyAny>>,
+        tty: bool,
+        rlimits: Option<&Bound<'py, PyAny>>,
+        options: Option<&Bound<'py, PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
+        let opts = parse_shell_call(cwd, user, env, timeout, stdin, tty, rlimits, options)?;
+
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
-            let output = sandbox.shell(&script).await.map_err(to_py_err)?;
+            let output = sandbox
+                .shell_with(&script, |e| apply_exec_options(e, Vec::new(), opts))
+                .await
+                .map_err(to_py_err)?;
             Ok(PyExecOutput::from_rust(output))
         })
     }
 
     /// Execute a shell command with streaming I/O.
-    fn shell_stream<'py>(&self, py: Python<'py>, script: String) -> PyResult<Bound<'py, PyAny>> {
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        script,
+        *,
+        cwd = None,
+        user = None,
+        env = None,
+        timeout = None,
+        stdin = None,
+        tty = false,
+        rlimits = None,
+        options = None,
+    ))]
+    fn shell_stream<'py>(
+        &self,
+        py: Python<'py>,
+        script: String,
+        cwd: Option<String>,
+        user: Option<String>,
+        env: Option<HashMap<String, String>>,
+        timeout: Option<f64>,
+        stdin: Option<&Bound<'py, PyAny>>,
+        tty: bool,
+        rlimits: Option<&Bound<'py, PyAny>>,
+        options: Option<&Bound<'py, PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
+        let opts = parse_shell_call(cwd, user, env, timeout, stdin, tty, rlimits, options)?;
+
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
-            let handle = sandbox.shell_stream(&script).await.map_err(to_py_err)?;
+            let handle = sandbox
+                .shell_stream_with(&script, |e| apply_exec_options(e, Vec::new(), opts))
+                .await
+                .map_err(to_py_err)?;
             Ok(PyExecHandle::from_rust(handle))
         })
     }
@@ -313,41 +384,37 @@ impl PySandbox {
     /// Attach to the sandbox with an interactive terminal session.
     /// Note: attach requires a real terminal (PTY) and blocks the calling thread.
     /// This is primarily useful for CLI tools, not library usage.
-    #[pyo3(signature = (cmd, args_or_options=None))]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        cmd,
+        args = None,
+        *,
+        cwd = None,
+        user = None,
+        env = None,
+        detach_keys = None,
+        options = None,
+    ))]
     fn attach<'py>(
         &self,
         py: Python<'py>,
         cmd: String,
-        args_or_options: Option<&Bound<'py, PyAny>>,
+        args: Option<&Bound<'py, PyAny>>,
+        cwd: Option<String>,
+        user: Option<String>,
+        env: Option<HashMap<String, String>>,
+        detach_keys: Option<String>,
+        options: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let (args, options) = parse_exec_args(args_or_options)?;
+        let (args, opts) = parse_attach_call(args, cwd, user, env, detach_keys, options)?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
-            let exit_code = if let Some(opts) = options {
-                sandbox
-                    .attach_with(&cmd, |a| {
-                        let mut a = a.args(args);
-                        if !opts.env.is_empty() {
-                            a = a.envs(opts.env);
-                        }
-                        if let Some(cwd) = opts.cwd {
-                            a = a.cwd(cwd);
-                        }
-                        if let Some(user) = opts.user {
-                            a = a.user(user);
-                        }
-                        if let Some(keys) = opts.detach_keys {
-                            a = a.detach_keys(keys);
-                        }
-                        a
-                    })
-                    .await
-                    .map_err(to_py_err)?
-            } else {
-                sandbox.attach(&cmd, args).await.map_err(to_py_err)?
-            };
+            let exit_code = sandbox
+                .attach_with(&cmd, |a| apply_attach_options(a, args, opts))
+                .await
+                .map_err(to_py_err)?;
             Ok(exit_code)
         })
     }
@@ -568,10 +635,10 @@ impl PySandbox {
 }
 
 //--------------------------------------------------------------------------------------------------
-// Functions: Exec Arg Parsing
+// Functions: Execution Options
 //--------------------------------------------------------------------------------------------------
 
-/// Parsed exec arguments — either a vec of string args or a full options dict.
+#[derive(Default)]
 struct ExecOpts {
     cwd: Option<String>,
     user: Option<String>,
@@ -581,139 +648,406 @@ struct ExecOpts {
     stdin_mode: Option<String>,
     stdin_data: Option<Vec<u8>>,
     rlimits: Vec<(String, u64, u64)>,
+}
+
+#[derive(Default)]
+struct AttachOpts {
+    cwd: Option<String>,
+    user: Option<String>,
+    env: Vec<(String, String)>,
     detach_keys: Option<String>,
 }
 
-fn parse_exec_args(
-    args_or_options: Option<&Bound<'_, PyAny>>,
-) -> PyResult<(Vec<String>, Option<ExecOpts>)> {
-    let Some(val) = args_or_options else {
-        return Ok((Vec::new(), None));
-    };
-
-    // Try as list of strings first (simple args shortcut).
-    if let Ok(list) = val.downcast::<pyo3::types::PyList>() {
-        let args: Vec<String> = list
-            .iter()
-            .map(|item| item.extract())
-            .collect::<PyResult<_>>()?;
-        return Ok((args, None));
+#[allow(clippy::too_many_arguments)]
+fn parse_exec_call(
+    args: Option<&Bound<'_, PyAny>>,
+    cwd: Option<String>,
+    user: Option<String>,
+    env: Option<HashMap<String, String>>,
+    timeout_secs: Option<f64>,
+    stdin: Option<&Bound<'_, PyAny>>,
+    tty: bool,
+    rlimits: Option<&Bound<'_, PyAny>>,
+    options: Option<&Bound<'_, PyAny>>,
+) -> PyResult<(Vec<String>, ExecOpts)> {
+    if let Some(options) = options {
+        ensure_no_exec_keywords(args, &cwd, &user, &env, timeout_secs, stdin, tty, rlimits)?;
+        return parse_exec_options_obj(options);
     }
 
-    // Try as dict (ExecOptions), or object with _to_dict().
-    let dict_result = if let Ok(dict) = val.downcast::<PyDict>() {
-        Ok(dict.clone())
-    } else if let Ok(method) = val.getattr("_to_dict") {
-        let result = method.call0()?;
-        Ok(result.downcast::<PyDict>()?.clone())
-    } else {
-        Err(())
-    };
-    if let Ok(dict) = dict_result {
-        let dict = &dict;
-        let args: Vec<String> = dict
-            .get_item("args")?
-            .map(|v| v.extract())
-            .transpose()?
-            .unwrap_or_default();
-
-        let opts = ExecOpts {
-            cwd: dict
-                .get_item("cwd")?
-                .and_then(|v| if v.is_none() { None } else { Some(v) })
-                .map(|v| v.extract())
-                .transpose()?,
-            user: dict
-                .get_item("user")?
-                .and_then(|v| if v.is_none() { None } else { Some(v) })
-                .map(|v| v.extract())
-                .transpose()?,
-            env: {
-                let mut env = Vec::new();
-                if let Some(env_obj) = dict.get_item("env")?
-                    && !env_obj.is_none()
-                {
-                    let env_dict: &Bound<'_, PyDict> = env_obj.downcast()?;
-                    for (k, v) in env_dict.iter() {
-                        env.push((k.extract::<String>()?, v.extract::<String>()?));
-                    }
-                }
-                env
-            },
-            timeout_secs: dict
-                .get_item("timeout")?
-                .and_then(|v| if v.is_none() { None } else { Some(v) })
-                .map(|v| v.extract())
-                .transpose()?,
-            tty: dict
-                .get_item("tty")?
-                .and_then(|v| if v.is_none() { None } else { Some(v) })
-                .map(|v| v.extract())
-                .transpose()?
-                .unwrap_or(false),
-            stdin_mode: dict
-                .get_item("stdin")?
-                .and_then(|v| if v.is_none() { None } else { Some(v) })
-                .map(|v| v.extract())
-                .transpose()?,
-            stdin_data: dict
-                .get_item("stdin_data")?
-                .and_then(|v| if v.is_none() { None } else { Some(v) })
-                .map(|v| v.extract())
-                .transpose()?,
-            detach_keys: dict
-                .get_item("detach_keys")?
-                .and_then(|v| if v.is_none() { None } else { Some(v) })
-                .map(|v| v.extract())
-                .transpose()?,
-            rlimits: {
-                let mut rlimits = Vec::new();
-                if let Some(rl_obj) = dict.get_item("rlimits")?
-                    && !rl_obj.is_none()
-                {
-                    let rl_list: &Bound<'_, pyo3::types::PyList> = rl_obj.downcast()?;
-                    for item in rl_list.iter() {
-                        let d: &Bound<'_, PyDict> = item.downcast()?;
-                        let resource: String = d.get_item("resource")?.unwrap().extract()?;
-                        let valid = matches!(
-                            resource.as_str(),
-                            "cpu"
-                                | "fsize"
-                                | "data"
-                                | "stack"
-                                | "core"
-                                | "rss"
-                                | "nproc"
-                                | "nofile"
-                                | "memlock"
-                                | "as"
-                                | "locks"
-                                | "sigpending"
-                                | "msgqueue"
-                                | "nice"
-                                | "rtprio"
-                                | "rttime"
-                        );
-                        if !valid {
-                            return Err(PyValueError::new_err(format!(
-                                "unknown rlimit resource: {resource}"
-                            )));
-                        }
-                        let soft: u64 = d.get_item("soft")?.unwrap().extract()?;
-                        let hard: u64 = d.get_item("hard")?.unwrap().extract()?;
-                        rlimits.push((resource, soft, hard));
-                    }
-                }
-                rlimits
-            },
-        };
-
-        return Ok((args, Some(opts)));
-    }
-
-    Err(pyo3::exceptions::PyTypeError::new_err(
-        "expected list[str] (args) or dict (ExecOptions)",
+    let args = parse_args(args)?;
+    let (stdin_mode, stdin_data) = parse_stdin(stdin)?;
+    validate_timeout(timeout_secs)?;
+    Ok((
+        args,
+        ExecOpts {
+            cwd,
+            user,
+            env: env_to_pairs(env),
+            timeout_secs,
+            tty,
+            stdin_mode,
+            stdin_data,
+            rlimits: parse_rlimits(rlimits)?,
+        },
     ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn parse_shell_call(
+    cwd: Option<String>,
+    user: Option<String>,
+    env: Option<HashMap<String, String>>,
+    timeout_secs: Option<f64>,
+    stdin: Option<&Bound<'_, PyAny>>,
+    tty: bool,
+    rlimits: Option<&Bound<'_, PyAny>>,
+    options: Option<&Bound<'_, PyAny>>,
+) -> PyResult<ExecOpts> {
+    if let Some(options) = options {
+        ensure_no_exec_keywords(None, &cwd, &user, &env, timeout_secs, stdin, tty, rlimits)?;
+        let (args, opts) = parse_exec_options_obj(options)?;
+        if !args.is_empty() {
+            return Err(PyValueError::new_err(
+                "options.args is not valid for shell(); pass the script as the first argument",
+            ));
+        }
+        return Ok(opts);
+    }
+
+    let (stdin_mode, stdin_data) = parse_stdin(stdin)?;
+    validate_timeout(timeout_secs)?;
+    Ok(ExecOpts {
+        cwd,
+        user,
+        env: env_to_pairs(env),
+        timeout_secs,
+        tty,
+        stdin_mode,
+        stdin_data,
+        rlimits: parse_rlimits(rlimits)?,
+    })
+}
+
+fn parse_attach_call(
+    args: Option<&Bound<'_, PyAny>>,
+    cwd: Option<String>,
+    user: Option<String>,
+    env: Option<HashMap<String, String>>,
+    detach_keys: Option<String>,
+    options: Option<&Bound<'_, PyAny>>,
+) -> PyResult<(Vec<String>, AttachOpts)> {
+    if let Some(options) = options {
+        if args.is_some()
+            || cwd.is_some()
+            || user.is_some()
+            || env.is_some()
+            || detach_keys.is_some()
+        {
+            return Err(PyValueError::new_err(
+                "options= cannot be combined with args or attach keyword options",
+            ));
+        }
+        return parse_attach_options_obj(options);
+    }
+
+    Ok((
+        parse_args(args)?,
+        AttachOpts {
+            cwd,
+            user,
+            env: env_to_pairs(env),
+            detach_keys,
+        },
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ensure_no_exec_keywords(
+    args: Option<&Bound<'_, PyAny>>,
+    cwd: &Option<String>,
+    user: &Option<String>,
+    env: &Option<HashMap<String, String>>,
+    timeout_secs: Option<f64>,
+    stdin: Option<&Bound<'_, PyAny>>,
+    tty: bool,
+    rlimits: Option<&Bound<'_, PyAny>>,
+) -> PyResult<()> {
+    if args.is_some()
+        || cwd.is_some()
+        || user.is_some()
+        || env.is_some()
+        || timeout_secs.is_some()
+        || stdin.is_some()
+        || tty
+        || rlimits.is_some()
+    {
+        return Err(PyValueError::new_err(
+            "options= cannot be combined with args or execution keyword options",
+        ));
+    }
+    Ok(())
+}
+
+fn parse_args(args: Option<&Bound<'_, PyAny>>) -> PyResult<Vec<String>> {
+    let Some(args) = args else {
+        return Ok(Vec::new());
+    };
+    if args.downcast::<PyDict>().is_ok() {
+        return Err(pyo3::exceptions::PyTypeError::new_err(
+            "args must be a list of strings; pass ExecOptions with options=...",
+        ));
+    }
+    if args.downcast::<PyBytes>().is_ok() || args.extract::<String>().is_ok() {
+        return Err(pyo3::exceptions::PyTypeError::new_err(
+            "args must be a list of strings, not a string",
+        ));
+    }
+    let list = args
+        .downcast::<PyList>()
+        .map_err(|_| pyo3::exceptions::PyTypeError::new_err("args must be a list of strings"))?;
+    list.iter().map(|item| item.extract::<String>()).collect()
+}
+
+fn parse_exec_options_obj(obj: &Bound<'_, PyAny>) -> PyResult<(Vec<String>, ExecOpts)> {
+    let dict = options_dict(obj, "options")?;
+    let args = parse_args_from_dict(&dict)?;
+    let (stdin_mode, stdin_data) = parse_stdin_from_dict(&dict)?;
+    let timeout_secs = optional_from_dict::<f64>(&dict, "timeout")?;
+    validate_timeout(timeout_secs)?;
+    Ok((
+        args,
+        ExecOpts {
+            cwd: optional_from_dict(&dict, "cwd")?,
+            user: optional_from_dict(&dict, "user")?,
+            env: parse_env_from_dict(&dict)?,
+            timeout_secs,
+            tty: optional_from_dict(&dict, "tty")?.unwrap_or(false),
+            stdin_mode,
+            stdin_data,
+            rlimits: parse_rlimits_from_dict(&dict)?,
+        },
+    ))
+}
+
+fn parse_attach_options_obj(obj: &Bound<'_, PyAny>) -> PyResult<(Vec<String>, AttachOpts)> {
+    let dict = options_dict(obj, "options")?;
+    Ok((
+        parse_args_from_dict(&dict)?,
+        AttachOpts {
+            cwd: optional_from_dict(&dict, "cwd")?,
+            user: optional_from_dict(&dict, "user")?,
+            env: parse_env_from_dict(&dict)?,
+            detach_keys: optional_from_dict(&dict, "detach_keys")?,
+        },
+    ))
+}
+
+fn options_dict<'py>(obj: &Bound<'py, PyAny>, label: &str) -> PyResult<Bound<'py, PyDict>> {
+    if let Ok(dict) = obj.downcast::<PyDict>() {
+        return Ok(dict.clone());
+    }
+    if let Ok(method) = obj.getattr("_to_dict") {
+        let result = method.call0()?;
+        return Ok(result.downcast::<PyDict>()?.clone());
+    }
+    Err(pyo3::exceptions::PyTypeError::new_err(format!(
+        "{label} must be a dict or object with _to_dict()",
+    )))
+}
+
+fn parse_args_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<Vec<String>> {
+    let Some(args) = dict.get_item("args")? else {
+        return Ok(Vec::new());
+    };
+    if args.is_none() {
+        return Ok(Vec::new());
+    }
+    let list = args.downcast::<PyList>().map_err(|_| {
+        pyo3::exceptions::PyTypeError::new_err("options.args must be a list of strings")
+    })?;
+    list.iter().map(|item| item.extract::<String>()).collect()
+}
+
+fn parse_env_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<Vec<(String, String)>> {
+    let Some(env_obj) = dict.get_item("env")? else {
+        return Ok(Vec::new());
+    };
+    if env_obj.is_none() {
+        return Ok(Vec::new());
+    }
+
+    let env_dict: &Bound<'_, PyDict> = env_obj.downcast()?;
+    env_dict
+        .iter()
+        .map(|(k, v)| Ok::<_, PyErr>((k.extract::<String>()?, v.extract::<String>()?)))
+        .collect()
+}
+
+fn env_to_pairs(env: Option<HashMap<String, String>>) -> Vec<(String, String)> {
+    env.unwrap_or_default().into_iter().collect()
+}
+
+fn parse_stdin(stdin: Option<&Bound<'_, PyAny>>) -> PyResult<(Option<String>, Option<Vec<u8>>)> {
+    let Some(stdin) = stdin else {
+        return Ok((None, None));
+    };
+
+    if let Ok(bytes) = stdin.downcast::<PyBytes>() {
+        return Ok((Some("bytes".to_string()), Some(bytes.as_bytes().to_vec())));
+    }
+    if let Ok(mode) = stdin.extract::<String>() {
+        return normalize_stdin(mode, None);
+    }
+
+    let mode_obj = stdin.getattr("_mode").map_err(|_| {
+        pyo3::exceptions::PyTypeError::new_err("stdin must be Stdin, bytes, or a stdin mode string")
+    })?;
+    let mode: String = mode_obj.extract()?;
+    let data = stdin
+        .getattr("_data")
+        .ok()
+        .and_then(|v| if v.is_none() { None } else { Some(v) })
+        .map(|v| v.extract::<Vec<u8>>())
+        .transpose()?;
+    normalize_stdin(mode, data)
+}
+
+fn parse_stdin_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<(Option<String>, Option<Vec<u8>>)> {
+    let Some(stdin_obj) = dict.get_item("stdin")? else {
+        return Ok((None, None));
+    };
+    if stdin_obj.is_none() {
+        return Ok((None, None));
+    }
+    let mode: String = stdin_obj.extract()?;
+    let data = optional_from_dict(dict, "stdin_data")?;
+    normalize_stdin(mode, data)
+}
+
+fn normalize_stdin(
+    mode: String,
+    data: Option<Vec<u8>>,
+) -> PyResult<(Option<String>, Option<Vec<u8>>)> {
+    match mode.as_str() {
+        "null" => Ok((None, None)),
+        "pipe" => Ok((Some(mode), None)),
+        "bytes" => Ok((Some(mode), Some(data.unwrap_or_default()))),
+        _ => Err(PyValueError::new_err(format!(
+            "unknown stdin mode: {mode}. Expected: null, pipe, bytes"
+        ))),
+    }
+}
+
+fn parse_rlimits(rlimits: Option<&Bound<'_, PyAny>>) -> PyResult<Vec<(String, u64, u64)>> {
+    let Some(rlimits) = rlimits else {
+        return Ok(Vec::new());
+    };
+    parse_rlimits_iter(rlimits)
+}
+
+fn parse_rlimits_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<Vec<(String, u64, u64)>> {
+    let Some(rlimits) = dict.get_item("rlimits")? else {
+        return Ok(Vec::new());
+    };
+    if rlimits.is_none() {
+        return Ok(Vec::new());
+    }
+    parse_rlimits_iter(&rlimits)
+}
+
+fn parse_rlimits_iter(obj: &Bound<'_, PyAny>) -> PyResult<Vec<(String, u64, u64)>> {
+    obj.try_iter()
+        .map_err(|_| pyo3::exceptions::PyTypeError::new_err("rlimits must be a sequence"))?
+        .map(|item| parse_rlimit(&item?))
+        .collect()
+}
+
+fn parse_rlimit(obj: &Bound<'_, PyAny>) -> PyResult<(String, u64, u64)> {
+    let (resource, soft, hard) = if let Ok(dict) = options_dict(obj, "rlimit") {
+        (
+            required_string_from_dict(&dict, "resource")?,
+            required_from_dict(&dict, "soft")?,
+            required_from_dict(&dict, "hard")?,
+        )
+    } else {
+        (
+            py_value_to_string(&obj.getattr("resource")?)?,
+            obj.getattr("soft")?.extract()?,
+            obj.getattr("hard")?.extract()?,
+        )
+    };
+
+    validate_rlimit_resource(&resource)?;
+    Ok((resource, soft, hard))
+}
+
+fn validate_rlimit_resource(resource: &str) -> PyResult<()> {
+    if matches!(
+        resource,
+        "cpu"
+            | "fsize"
+            | "data"
+            | "stack"
+            | "core"
+            | "rss"
+            | "nproc"
+            | "nofile"
+            | "memlock"
+            | "as"
+            | "locks"
+            | "sigpending"
+            | "msgqueue"
+            | "nice"
+            | "rtprio"
+            | "rttime"
+    ) {
+        Ok(())
+    } else {
+        Err(PyValueError::new_err(format!(
+            "unknown rlimit resource: {resource}"
+        )))
+    }
+}
+
+fn validate_timeout(timeout_secs: Option<f64>) -> PyResult<()> {
+    if timeout_secs.is_some_and(|timeout| timeout < 0.0) {
+        return Err(PyValueError::new_err("timeout must be non-negative"));
+    }
+    Ok(())
+}
+
+fn optional_from_dict<'py, T: FromPyObject<'py>>(
+    dict: &Bound<'py, PyDict>,
+    key: &str,
+) -> PyResult<Option<T>> {
+    match dict.get_item(key)? {
+        Some(val) if !val.is_none() => Ok(Some(val.extract()?)),
+        _ => Ok(None),
+    }
+}
+
+fn required_from_dict<'py, T: FromPyObject<'py>>(
+    dict: &Bound<'py, PyDict>,
+    key: &str,
+) -> PyResult<T> {
+    dict.get_item(key)?
+        .ok_or_else(|| PyValueError::new_err(format!("{key} is required")))?
+        .extract()
+}
+
+fn required_string_from_dict(dict: &Bound<'_, PyDict>, key: &str) -> PyResult<String> {
+    let value = dict
+        .get_item(key)?
+        .ok_or_else(|| PyValueError::new_err(format!("{key} is required")))?;
+    py_value_to_string(&value)
+}
+
+fn py_value_to_string(value: &Bound<'_, PyAny>) -> PyResult<String> {
+    if let Ok(s) = value.extract::<String>() {
+        return Ok(s);
+    }
+    Ok(value.str()?.to_str()?.to_string())
 }
 
 fn apply_exec_options(
@@ -770,6 +1104,27 @@ fn apply_exec_options(
         builder = builder.rlimit_range(res, *soft, *hard);
     }
     builder.args(args)
+}
+
+fn apply_attach_options(
+    mut builder: microsandbox::sandbox::AttachOptionsBuilder,
+    args: Vec<String>,
+    opts: AttachOpts,
+) -> microsandbox::sandbox::AttachOptionsBuilder {
+    builder = builder.args(args);
+    if !opts.env.is_empty() {
+        builder = builder.envs(opts.env);
+    }
+    if let Some(cwd) = opts.cwd {
+        builder = builder.cwd(cwd);
+    }
+    if let Some(user) = opts.user {
+        builder = builder.user(user);
+    }
+    if let Some(keys) = opts.detach_keys {
+        builder = builder.detach_keys(keys);
+    }
+    builder
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/sdk/python/src/volume.rs
+++ b/sdk/python/src/volume.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyModule};
 
 use crate::error::to_py_err;
 
@@ -101,40 +102,42 @@ impl PyVolume {
     }
 
     //----------------------------------------------------------------------------------------------
-    // Static Factories (for mount configs — return dicts)
+    // Static Factories (for mount configs)
     //----------------------------------------------------------------------------------------------
 
     /// Create a bind mount config.
     #[staticmethod]
     #[pyo3(signature = (path, *, readonly = false))]
     fn bind(py: Python<'_>, path: String, readonly: bool) -> PyResult<PyObject> {
-        let dict = pyo3::types::PyDict::new(py);
-        dict.set_item("bind", path)?;
-        dict.set_item("readonly", readonly)?;
-        Ok(dict.into())
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("kind", mount_kind(py, "BIND")?)?;
+        kwargs.set_item("bind", path)?;
+        kwargs.set_item("readonly", readonly)?;
+        Ok(mount_config_class(py)?.call((), Some(&kwargs))?.unbind())
     }
 
     /// Create a named volume mount config.
     #[staticmethod]
     #[pyo3(signature = (name, *, readonly = false))]
     fn named(py: Python<'_>, name: String, readonly: bool) -> PyResult<PyObject> {
-        let dict = pyo3::types::PyDict::new(py);
-        dict.set_item("named", name)?;
-        dict.set_item("readonly", readonly)?;
-        Ok(dict.into())
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("kind", mount_kind(py, "NAMED")?)?;
+        kwargs.set_item("named", name)?;
+        kwargs.set_item("readonly", readonly)?;
+        Ok(mount_config_class(py)?.call((), Some(&kwargs))?.unbind())
     }
 
     /// Create a tmpfs mount config.
     #[staticmethod]
     #[pyo3(signature = (*, size_mib = None, readonly = false))]
     fn tmpfs(py: Python<'_>, size_mib: Option<u32>, readonly: bool) -> PyResult<PyObject> {
-        let dict = pyo3::types::PyDict::new(py);
-        dict.set_item("tmpfs", true)?;
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("kind", mount_kind(py, "TMPFS")?)?;
         if let Some(size) = size_mib {
-            dict.set_item("size_mib", size)?;
+            kwargs.set_item("size_mib", size)?;
         }
-        dict.set_item("readonly", readonly)?;
-        Ok(dict.into())
+        kwargs.set_item("readonly", readonly)?;
+        Ok(mount_config_class(py)?.call((), Some(&kwargs))?.unbind())
     }
 
     /// Create a disk-image volume mount config.
@@ -153,16 +156,17 @@ impl PyVolume {
         fstype: Option<String>,
         readonly: bool,
     ) -> PyResult<PyObject> {
-        let dict = pyo3::types::PyDict::new(py);
-        dict.set_item("disk", path)?;
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("kind", mount_kind(py, "DISK")?)?;
+        kwargs.set_item("disk", path)?;
         if let Some(format) = format {
-            dict.set_item("format", format)?;
+            kwargs.set_item("format", format)?;
         }
         if let Some(fstype) = fstype {
-            dict.set_item("fstype", fstype)?;
+            kwargs.set_item("fstype", fstype)?;
         }
-        dict.set_item("readonly", readonly)?;
-        Ok(dict.into())
+        kwargs.set_item("readonly", readonly)?;
+        Ok(mount_config_class(py)?.call((), Some(&kwargs))?.unbind())
     }
 }
 
@@ -310,4 +314,18 @@ impl PyVolumeFs {
             Ok(exists)
         })
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn mount_config_class<'py>(py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    let types = PyModule::import(py, "microsandbox.types")?;
+    types.getattr("MountConfig")
+}
+
+fn mount_kind<'py>(py: Python<'py>, variant: &str) -> PyResult<Bound<'py, PyAny>> {
+    let types = PyModule::import(py, "microsandbox.types")?;
+    types.getattr("MountKind")?.getattr(variant)
 }

--- a/sdk/python/tests/test_mount_policies.py
+++ b/sdk/python/tests/test_mount_policies.py
@@ -25,6 +25,22 @@ def test_bind_default_omits_policies() -> None:
     assert d["bind"] == "/host/data"
 
 
+def test_bind_accepts_policy_strings() -> None:
+    mc = MountConfig(
+        kind=MountKind.BIND,
+        bind="/host/data",
+        readonly=True,
+        stat_virtualization="relaxed",
+        host_permissions="mirror",
+    )
+    assert mc._to_dict() == {
+        "readonly": True,
+        "bind": "/host/data",
+        "stat_virtualization": "relaxed",
+        "host_permissions": "mirror",
+    }
+
+
 def test_bind_with_relaxed_and_mirror_serializes_lowercase() -> None:
     mc = MountConfig(
         kind=MountKind.BIND,


### PR DESCRIPTION
Closes https://github.com/superradcompany/microsandbox/issues/775#issuecomment-4523790540

## TL;DR
Simplifies the Python SDK so sandbox creation uses `name, **kwargs` and command execution uses `list[str]` args plus keyword options. This removes the confusing positional dict/options path and updates docs, stubs, and tests around the new shape.

## Description
- Keep `Sandbox.create` and `create_with_progress` focused on `name, **kwargs`, with config dictionaries passed through normal Python unpacking.
- Make `exec`, `exec_stream`, and `attach` take `list[str]` args positionally with keyword-only execution settings.
- Expose keyword execution fields like `cwd`, `env`, `timeout`, `stdin`, `tty`, and `rlimits` directly on Python execution methods.
- Add Rust `shell_with` and `shell_stream_with` helpers so Python shell calls can pass full execution options while keeping `-c <script>` internal.
- Return typed `MountConfig` objects from Python `Volume` mount factory helpers instead of plain dictionaries.
- Remove Python `ExecOptions`, `AttachOptions`, and `options=` so there is one clear way to configure command execution.
- Update the Python stubs, docs, smoke test, and mount policy tests for the new API.
- Move low-level AgentClient reference pages to the end of each SDK sidebar group.
- This is a breaking Python SDK API change.

```python
from microsandbox import Sandbox

async def run() -> None:
    config = {"name": "worker", "image": "python"}
    sandbox = await Sandbox.create(**config)
    output = await sandbox.exec("python", ["-c", "print('hi')"], timeout=30.0)
    print(output.stdout_text)
```

## Test Plan
- [x] `cargo fmt --check` exits 0
- [x] `cargo check -p microsandbox-py` exits 0
- [x] `cargo clippy -p microsandbox-py --all-targets --all-features -- -D warnings` exits 0
- [x] `uv run ruff check microsandbox tests integration` exits 0
- [x] `uv run pytest tests` passes the Python SDK unit tests
- [x] `uv run maturin develop` builds and installs the editable Python extension