### PR TITLE
Fix published-port stalls by waking smoltcp after host accepts

### DIFF
--- a/crates/network/lib/publisher.rs
+++ b/crates/network/lib/publisher.rs
@@ -353,12 +353,25 @@ async fn tcp_listener_task(
         }
 
         let conn = InboundConnection { stream, guest_port };
-        if inbound_tx.send(conn).await.is_err() {
+        if !queue_inbound_connection(&inbound_tx, conn, &shared).await {
             break; // Publisher dropped.
         }
     }
 
     Ok(())
+}
+
+async fn queue_inbound_connection<T>(
+    inbound_tx: &mpsc::Sender<T>,
+    conn: T,
+    shared: &SharedState,
+) -> bool {
+    if inbound_tx.send(conn).await.is_err() {
+        return false;
+    }
+
+    shared.proxy_wake.wake();
+    true
 }
 
 /// Relay task: bridges a host TcpStream to channels connected to smoltcp.
@@ -448,5 +461,34 @@ fn write_host_data(socket: &mut tcp::Socket<'_>, relay: &mut InboundRelay) {
             }
             Err(_) => break,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fd_is_readable(fd: std::os::fd::RawFd) -> bool {
+        let mut poll_fd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+
+        // SAFETY: poll_fd points to one valid pollfd and uses a zero timeout.
+        let n = unsafe { libc::poll(&mut poll_fd, 1, 0) };
+        n > 0 && poll_fd.revents & libc::POLLIN != 0
+    }
+
+    #[tokio::test]
+    async fn queue_inbound_connection_wakes_poll_loop() {
+        let shared = SharedState::new(4);
+        shared.proxy_wake.drain();
+
+        let (tx, mut rx) = mpsc::channel(1);
+
+        assert!(queue_inbound_connection(&tx, (), &shared).await);
+        assert!(rx.try_recv().is_ok());
+        assert!(fd_is_readable(shared.proxy_wake.as_raw_fd()));
     }
 }


### PR DESCRIPTION
## Problem

This proposed fix resolves a serious user-facing problem where sites which load instantly locally were taking 15 to 20 seconds to load when run from a sandbox.

Host-to-guest published-port traffic can stall for seconds even when the guest service is ready and responds immediately. In a local reproduction, requests from the host to a published port connected and sent successfully, but then waited in TTFB plateaus of several seconds, sometimes around 10 seconds. The same service, when requested from inside the guest, responded in low milliseconds.

A minimal diagnostic HTTP server reproduced the stall without the application stack involved, which isolated the issue to the Microsandbox published-port forwarding path.

The root cause is that the host-side TCP listener accepts a connection and sends it into `PortPublisher`'s inbound channel, but it does not wake the smoltcp poll loop. If the poll loop is asleep in `poll(2)`, the accepted connection can sit in that channel until an unrelated wake or timer causes the loop to run again.

## Proposed Fix

Wake `shared.proxy_wake` immediately after a published-port listener successfully queues an accepted host connection.

The relay task already wakes this same poll loop after reading host socket data, but that happens too late for this case: the relay task is only spawned after the poll loop drains the inbound connection queue and creates the smoltcp socket. The missing wake is therefore on the accept/queue edge.

## Testing

- `cargo fmt --check`
- `cargo check -p microsandbox-network`
- `cargo test -p microsandbox-network queue_inbound_connection_wakes_poll_loop`
- `cargo test -p microsandbox-network --lib`
- `cargo clippy -p microsandbox-network -- -D warnings`

## Local Validation

With the patch applied to a local `msb`, the diagnostic server no longer showed the multi-second TTFB plateaus. The affected application also returned to low-ms load timings through the same published-port path.
