### PR TITLE
fix(net): harden SNI deny-domain policy evaluation

### DIFF
--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -10,6 +10,8 @@
 //! own `~/.microsandbox` so they can run in parallel without sharing
 //! the sqlite db, image cache, or sandbox namespace.
 
+use std::net::{IpAddr, ToSocketAddrs};
+
 use microsandbox::{NetworkPolicy, Sandbox};
 use microsandbox_network::policy::{Action, Destination, Direction, PortRange, Protocol, Rule};
 use test_utils::msb_test;
@@ -154,6 +156,51 @@ async fn dns_lookup(sb: &Sandbox, name: &str) -> String {
     out.stdout().unwrap_or_default().trim().to_string()
 }
 
+/// Resolve a test hostname on the host side. This gives the test a
+/// reachable IP without populating the sandbox's resolved-hostname
+/// cache for that name.
+fn host_resolved_ipv4(name: &str) -> String {
+    (name, 443)
+        .to_socket_addrs()
+        .expect("host DNS lookup")
+        .find_map(|addr| match addr.ip() {
+            IpAddr::V4(ip) => Some(ip.to_string()),
+            IpAddr::V6(_) => None,
+        })
+        .unwrap_or_else(|| panic!("host DNS lookup for {name} returned no IPv4 address"))
+}
+
+/// Like [`probe_https`], but force curl to connect to `ip` while still
+/// sending `host` as the HTTP Host header and TLS SNI.
+async fn probe_https_with_resolve(sb: &Sandbox, host: &str, ip: &str) -> String {
+    let cmd = format!(
+        "tmp=$(mktemp); \
+         code=$(curl -sS --max-time 30 -o /dev/null \
+                -w '%{{http_code}}' \
+                --resolve {host}:443:{ip} \
+                https://{host}/ 2>\"$tmp\"); \
+         exit=$?; \
+         err=$(tr '\\n' ' ' <\"$tmp\"; rm -f \"$tmp\"); \
+         case \"$code\" in \
+             000|\"\") printf 'FAIL exit=%s err=%s' \"$exit\" \"$err\" ;; \
+             *) printf '%s' \"$code\" ;; \
+         esac"
+    );
+    let out = sb.shell(&cmd).await.expect("curl --resolve shell");
+    out.stdout().unwrap_or_default().trim().to_string()
+}
+
+async fn probe_https_with_resolve_retry(sb: &Sandbox, host: &str, ip: &str) -> String {
+    let mut last = String::new();
+    for _ in 0..3 {
+        last = probe_https_with_resolve(sb, host, ip).await;
+        if reached_server(&last) {
+            return last;
+        }
+    }
+    last
+}
+
 //--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
@@ -237,6 +284,44 @@ async fn domain_policy_deny_domain_refuses_dns() {
     assert!(
         !allowed_out.is_empty(),
         "dl-cdn.alpinelinux.org DNS lookup should succeed under default-allow: got `{allowed_out}`"
+    );
+
+    sb.stop_and_wait().await.expect("stop");
+    let _ = Sandbox::remove(name).await;
+}
+
+/// Default-allow plus `deny Domain("www.rfc-editor.org")` must block a
+/// direct-IP TLS connection whose SNI is `www.rfc-editor.org`, even when
+/// the sandbox never resolved that name through the gateway DNS cache.
+#[msb_test]
+async fn domain_policy_deny_domain_blocks_sni_direct_ip_without_dns_cache() {
+    const ALLOWED_HOST: &str = "www.iana.org";
+    const DENIED_HOST: &str = "www.rfc-editor.org";
+
+    let name = "net-domain-policy-deny-sni-ip";
+    let allowed_ip = host_resolved_ipv4(ALLOWED_HOST);
+    let denied_ip = host_resolved_ipv4(DENIED_HOST);
+    let policy = NetworkPolicy {
+        default_egress: Action::Allow,
+        default_ingress: Action::Allow,
+        rules: vec![Rule::deny_egress(Destination::Domain(
+            DENIED_HOST.parse().expect("valid domain"),
+        ))],
+    };
+    let sb = setup_alpine(name, policy).await;
+
+    // Baseline the bypass shape itself: `curl --resolve` connects by IP
+    // and sends SNI without asking the sandbox DNS resolver.
+    let allowed = probe_https_with_resolve_retry(&sb, ALLOWED_HOST, &allowed_ip).await;
+    assert!(
+        reached_server(&allowed),
+        "direct-IP HTTPS to unrelated {ALLOWED_HOST} should be allowed: got `{allowed}`"
+    );
+
+    let denied = probe_https_with_resolve(&sb, DENIED_HOST, &denied_ip).await;
+    assert!(
+        curl_failed(&denied),
+        "direct-IP HTTPS with denied SNI {DENIED_HOST} should be blocked: got `{denied}`"
     );
 
     sb.stop_and_wait().await.expect("stop");

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -369,7 +369,13 @@ impl NetworkPolicy {
                     continue;
                 }
             }
-            match matches_destination_with_source(&rule.destination, addr, shared, source) {
+            match matches_egress_destination_with_source(
+                &rule.destination,
+                rule.action,
+                addr,
+                shared,
+                source,
+            ) {
                 DestinationMatch::Match => return rule.action.into(),
                 DestinationMatch::Defer => return EgressEvaluation::DeferUntilHostname,
                 DestinationMatch::NoMatch => continue,
@@ -741,7 +747,7 @@ fn rule_matches(
     matches_destination(&rule.destination, addr, shared)
 }
 
-/// Internal three-state result for [`matches_destination_with_source`].
+/// Internal three-state result for [`matches_egress_destination_with_source`].
 /// `Defer` is reachable only when the source is
 /// [`HostnameSource::Deferred`] and the destination is `Domain` or
 /// `DomainSuffix`.
@@ -761,25 +767,28 @@ impl From<bool> for DestinationMatch {
     }
 }
 
-/// Check if an IP / hostname source matches a destination specification.
+/// Check if an egress IP / hostname source matches a destination specification.
 ///
 /// IP-based destinations (`Any`, `Cidr`, `Group`) ignore `source` since
 /// they decide on the address alone. `Domain` / `DomainSuffix` consult
 /// `source`:
 ///
 /// - [`HostnameSource::Sni`]: byte-equality against the canonicalized
-///   SNI string (or label-aware suffix match) AND a resolved-hostname
-///   cache binding tying the claimed name to `addr`. The cache check
-///   stops a guest from declaring an arbitrary SNI on an unresolved
-///   IP to pass a `Domain`-allow rule (lax-SNI server spoof). Genuine
-///   shared-CDN traffic still passes because the guest resolves the
-///   name before connecting, populating the cache.
+///   SNI string (or label-aware suffix match). Allow rules also require
+///   a resolved-hostname cache binding tying the claimed name to `addr`;
+///   deny rules match on the SNI alone so a direct-to-IP connection
+///   cannot bypass a domain blocklist. The allow-side cache check stops
+///   a guest from declaring an arbitrary SNI on an unresolved IP to pass
+///   a `Domain`-allow rule (lax-SNI server spoof). Genuine shared-CDN
+///   traffic still passes because the guest resolves the name before
+///   connecting, populating the cache.
 /// - [`HostnameSource::CacheOnly`]: query the resolved-hostname cache
 ///   on `shared` for any prior resolution of `addr` that matches.
 /// - [`HostnameSource::Deferred`]: short-circuits to
 ///   [`DestinationMatch::Defer`].
-fn matches_destination_with_source(
+fn matches_egress_destination_with_source(
     dest: &Destination,
+    action: Action,
     addr: IpAddr,
     shared: &SharedState,
     source: HostnameSource<'_>,
@@ -789,20 +798,27 @@ fn matches_destination_with_source(
         Destination::Cidr(network) => matches_cidr(network, addr).into(),
         Destination::Group(group) => matches_group(*group, addr, shared).into(),
         Destination::Domain(domain) => match source {
-            HostnameSource::Sni(name) => (name == domain.as_str()
-                && shared.any_resolved_hostname(addr, |hostname| hostname == domain.as_str()))
-            .into(),
+            HostnameSource::Sni(name) => {
+                let name_matches = name == domain.as_str();
+                let cache_matches =
+                    || shared.any_resolved_hostname(addr, |hostname| hostname == domain.as_str());
+                (name_matches && (action.is_deny() || cache_matches())).into()
+            }
             HostnameSource::CacheOnly => shared
                 .any_resolved_hostname(addr, |hostname| hostname == domain.as_str())
                 .into(),
             HostnameSource::Deferred => DestinationMatch::Defer,
         },
         Destination::DomainSuffix(suffix) => match source {
-            HostnameSource::Sni(name) => (matches_suffix(name, suffix.as_str())
-                && shared.any_resolved_hostname(addr, |hostname| {
-                    matches_suffix(hostname, suffix.as_str())
-                }))
-            .into(),
+            HostnameSource::Sni(name) => {
+                let name_matches = matches_suffix(name, suffix.as_str());
+                let cache_matches = || {
+                    shared.any_resolved_hostname(addr, |hostname| {
+                        matches_suffix(hostname, suffix.as_str())
+                    })
+                };
+                (name_matches && (action.is_deny() || cache_matches())).into()
+            }
             HostnameSource::CacheOnly => shared
                 .any_resolved_hostname(addr, |hostname| matches_suffix(hostname, suffix.as_str()))
                 .into(),
@@ -811,12 +827,18 @@ fn matches_destination_with_source(
     }
 }
 
-/// Cache-only destination match used by the ingress evaluator. Wraps
-/// [`matches_destination_with_source`] with [`HostnameSource::CacheOnly`]
-/// since ingress has no SNI concept.
+/// Cache-only destination match used by the ingress evaluator. Ingress
+/// has no SNI concept, so the action-specific egress SNI behavior is
+/// irrelevant here.
 fn matches_destination(dest: &Destination, addr: IpAddr, shared: &SharedState) -> bool {
     matches!(
-        matches_destination_with_source(dest, addr, shared, HostnameSource::CacheOnly),
+        matches_egress_destination_with_source(
+            dest,
+            Action::Allow,
+            addr,
+            shared,
+            HostnameSource::CacheOnly,
+        ),
         DestinationMatch::Match,
     )
 }
@@ -1778,6 +1800,45 @@ mod tests {
             Protocol::Tcp,
             &shared,
             HostnameSource::Sni("pypi.org"),
+        );
+        assert_eq!(eval, EgressEvaluation::Deny);
+    }
+
+    #[test]
+    fn deny_rule_sni_matches_exact_domain_without_cache_binding() {
+        let shared = SharedState::new(4);
+        let policy = deny_domain_policy(Destination::Domain(name("evil.com")));
+        let eval = policy.evaluate_egress_with_source(
+            sock(PYPI_V4, 443),
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Sni("evil.com"),
+        );
+        assert_eq!(eval, EgressEvaluation::Deny);
+    }
+
+    #[test]
+    fn deny_rule_sni_matches_domain_suffix_without_cache_binding() {
+        let shared = SharedState::new(4);
+        let policy = deny_domain_policy(Destination::DomainSuffix(name(".evil.com")));
+        let eval = policy.evaluate_egress_with_source(
+            sock(PYPI_V4, 443),
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Sni("api.evil.com"),
+        );
+        assert_eq!(eval, EgressEvaluation::Deny);
+    }
+
+    #[test]
+    fn deny_rule_sni_matches_exact_domain_with_cache_binding() {
+        let shared = shared_with_host("evil.com", PYPI_V4);
+        let policy = deny_domain_policy(Destination::Domain(name("evil.com")));
+        let eval = policy.evaluate_egress_with_source(
+            sock(PYPI_V4, 443),
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Sni("evil.com"),
         );
         assert_eq!(eval, EgressEvaluation::Deny);
     }


### PR DESCRIPTION
## Summary
- Make SNI domain matching action-aware.
- Keep DNS-cache binding required for allow rules.
- Deny matching domain/suffix SNI without requiring a DNS-cache binding.
- Add integration coverage for direct-IP HTTPS with denied SNI and no sandbox DNS cache binding.

## Tests
- `cargo test -p microsandbox-network deny_rule_sni_matches -- --nocapture`
- `cargo test -p microsandbox-network hostname_source_sni -- --nocapture`
- `cargo test -p microsandbox-network`
- `cargo test -p microsandbox --test domain_policy domain_policy_deny_domain_blocks_sni_direct_ip_without_dns_cache --no-run`