### PR TITLE
chore(releases): auto-mark rc tags as prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,9 +350,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Auto-prerelease for rc / alpha / beta / dev tags so consumers
+          # querying /releases/latest (e.g. install.microsandbox.dev) don't
+          # accidentally promote them. Matches v0.5.0-rc-1, v1.2.3-rc1,
+          # v1.0.0-alpha.4, etc.
+          PRERELEASE=""
+          if [[ "${{ github.ref_name }}" =~ -(rc|alpha|beta|dev) ]]; then
+            PRERELEASE="--prerelease"
+          fi
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --generate-notes \
+            $PRERELEASE \
             release-artifacts/*
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- mark rc/alpha/beta/dev release tags as GitHub prereleases in `release.yml`
- keep stable releases as the only candidates for `/releases/latest` consumers

## Why
`install.microsandbox.dev` fetches GitHub's `/releases/latest`, which excludes prereleases but includes normal releases. If `v0.5.0-rc-1` is published as a normal release, fresh install-script runs would auto-install the rc. This change makes release tags like `v0.5.0-rc-1`, `v1.2.3-rc1`, and alpha/beta/dev tags pass `--prerelease` to `gh release create`, so `/releases/latest` continues to resolve to the latest stable runtime release.

## Validation
- `git diff --check`
- pre-commit hook: check yaml passed