### PR TITLE
[codex] Expose custom libkrunfw path in Go SDK

### DIFF
--- a/docs/changelog/2026-04-03.mdx
+++ b/docs/changelog/2026-04-03.mdx
@@ -1,0 +1,35 @@
+---
+title: "Week of April 3, 2026"
+description: "The microsandbox rewrite around an embeddable SDK, smoltcp networking, and a composable filesystem."
+icon: "bolt"
+---
+
+<Tip>
+  **Released this week:** [v0.3.3](https://github.com/superradcompany/microsandbox/releases/tag/v0.3.3) through [v0.3.10](https://github.com/superradcompany/microsandbox/releases/tag/v0.3.10)
+</Tip>
+
+## New features
+
+**Microsandbox rewrite**
+
+Rewritten around an embeddable SDK, smoltcp-based networking, and a composable filesystem:
+
+- First-class Rust SDK that the CLI is built on.
+- User-space network stack (smoltcp) with an in-sandbox DNS resolver and TLS proxy.
+- Composable filesystem layering OCI images, host volumes, and writable overlays through one VFS.
+- Redesigned policy and config model shared across CLI, SDK, and `Sandboxfile`.
+
+Breaking change.
+
+**Other features**
+
+- **Per-command exec flags for `msb run`.** Pass `--env`, `--workdir`, `--tty`, `--timeout`, etc. directly without a `Sandboxfile`.
+
+## Bug fixes
+
+- VM logs split into `guest.log` and `host.log` instead of interleaving.
+- Reopening inodes via `/.vol` on macOS no longer fails under `O_RESOLVE_BENEATH`.
+- Overlay `readdir` resolves real inode numbers instead of surfacing `0`.
+- `ExecTimeout` is returned consistently when an exec call hits its timeout.
+- Sandbox creation validates `workdir` up front and defaults `cwd` to `/` when unset.
+- `msb self update` resolves the latest version before downloading the bundle.

--- a/docs/changelog/2026-04-10.mdx
+++ b/docs/changelog/2026-04-10.mdx
@@ -1,0 +1,22 @@
+---
+title: "Week of April 10, 2026"
+description: "File-level volume mounts, TypeScript SDK streams, and `msb shell` removal."
+icon: "bolt"
+---
+
+<Tip>
+  **Released this week:** [v0.3.11](https://github.com/superradcompany/microsandbox/releases/tag/v0.3.11) · [v0.3.12](https://github.com/superradcompany/microsandbox/releases/tag/v0.3.12)
+</Tip>
+
+## New features
+
+- **File-level volume mounts.** Mounts now target individual files, not just directories. See [Sandbox volumes](/sandboxes/volumes).
+- **`fs.readStream` in the TypeScript SDK.** Async-iterable file reads instead of buffering whole files in memory.
+- **`sandbox.metricsStream()` in the TypeScript SDK.** Async iterable of CPU, memory, and I/O samples, mirroring the Rust SDK.
+- **`msb shell` removed.** Use `msb exec --tty <sandbox> -- bash` instead.
+
+## Bug fixes
+
+- The network proxy now recomputes `Content-Length` after substituting secrets into request bodies.
+- `msb run` execution options (env, cwd, signal handling) only apply when `--tty` is set.
+- Extended attributes on symlinks and `listxattr` initialization now match the underlying VFS.

--- a/docs/changelog/2026-04-17.mdx
+++ b/docs/changelog/2026-04-17.mdx
@@ -1,0 +1,37 @@
+---
+title: "Week of April 17, 2026"
+description: "New Python SDK, Docker image publishing, and TLS proxy fixes."
+icon: "bolt"
+---
+
+<Tip>
+  **Released this week:** [v0.3.13](https://github.com/superradcompany/microsandbox/releases/tag/v0.3.13)
+</Tip>
+
+## New features
+
+**Python SDK**
+
+PyO3 bindings exposing the same sandbox, exec, networking, and filesystem APIs as the Rust and TypeScript SDKs.
+
+```python
+async with await Sandbox.create("my-sandbox", image="alpine") as sb:
+    out = await sb.shell("echo hello")
+    print(out.stdout_text)
+```
+
+Install with `pip install microsandbox`. See the [Python SDK reference](/sdk/python/sandbox).
+
+**Other features**
+
+- **Docker image publishing.** Releases now publish a `microsandbox` Docker image alongside the binary artifacts.
+- **Interactive `msb self uninstall`** with a multi-select prompt over CLI, SDK shims, cached images, and state directory.
+- **Interactive `msb exec`.** Running without a command opens a picker over registered scripts and recent exec history.
+- **Upstream CA trust config.** Point the TLS proxy at a custom upstream CA bundle; the old `--tls-ca` flag names are deprecated but still resolve.
+- **`--allow-private-ips`** opts permissive policies into RFC1918 ranges without disabling policy entirely.
+
+## Bug fixes
+
+- Concurrent TLS connections through the in-sandbox MITM proxy no longer interleave plaintext between sessions.
+- TLS 1.3 connections no longer drop bytes that arrived in the same TCP segment as the final handshake message.
+- Sandboxes that boot faster than host clock convergence no longer reject internal TLS traffic with `CERT_NOT_YET_VALID`.

--- a/docs/changelog/2026-04-24.mdx
+++ b/docs/changelog/2026-04-24.mdx
@@ -1,0 +1,25 @@
+---
+title: "Week of April 24, 2026"
+description: "Block-backed OCI rootfs, guest rlimits, and TypeScript SDK improvements."
+icon: "bolt"
+---
+
+<Tip>
+  **Released this week:** [v0.3.14](https://github.com/superradcompany/microsandbox/releases/tag/v0.3.14)
+</Tip>
+
+## New features
+
+**Block-backed OCI rootfs**
+
+Image rootfs now ships as a packed VMDK with EROFS metadata and copy-on-write overlays instead of an extracted directory, cutting boot time and host disk usage. See the [images overview](/images/overview).
+
+**Other features**
+
+- **Sandbox-wide guest rlimits.** Apply default `RLIMIT_*` values to every process inside the guest.
+- **`execStreamWithConfig` in the TypeScript SDK.** Stream stdout/stderr while passing the same per-exec options as `execWithConfig`.
+- **Run microsandbox via cargo, npx, and pipx.** `cargo install microsandbox`, `npx microsandbox`, and `pipx run microsandbox` all bring up a working CLI.
+
+## Bug fixes
+
+- The SDK now self-heals when the bundled `msb` binary is missing, re-downloading it on demand.

--- a/docs/changelog/2026-05-01.mdx
+++ b/docs/changelog/2026-05-01.mdx
@@ -1,0 +1,56 @@
+---
+title: "Week of May 1, 2026"
+description: "TypeScript SDK redesign, network policy redesign, disk-image volumes, and more."
+icon: "bolt"
+---
+
+<Tip>
+  **Released this week:** [v0.4.0](https://github.com/superradcompany/microsandbox/releases/tag/v0.4.0) · [v0.4.1](https://github.com/superradcompany/microsandbox/releases/tag/v0.4.1) · [v0.4.2](https://github.com/superradcompany/microsandbox/releases/tag/v0.4.2) · [v0.4.3](https://github.com/superradcompany/microsandbox/releases/tag/v0.4.3)
+</Tip>
+
+## New features
+
+**Redesigned TypeScript SDK**
+
+Builder API matching the Rust SDK, with `await using`, typed errors, async iterables, and bundled native binaries (no postinstall download).
+
+```ts
+await using sandbox = await Sandbox.builder("my-sandbox")
+  .image("alpine:latest")
+  .cpus(2)
+  .create();
+```
+
+See the [TypeScript SDK reference](/sdk/typescript/sandbox).
+
+**Redesigned network policy**
+
+`--network-policy` is gone. Rules now carry their own direction, action, target, protocol, and ports through a single grammar: `<action>[:<direction>]@<target>[:<proto>[:<ports>]]`.
+
+```bash
+msb run alpine --name agent \
+  --net-default-egress deny \
+  --net-rule "allow@public,allow@host" \
+  --net-rule "deny@private:tcp:445"
+```
+
+See the [networking overview](/networking/overview).
+
+**Other features**
+
+- **Disk-image volume mounts.** Attach qcow2, raw, or vmdk images as virtio-blk devices at any guest path; `readonly` is now consistent across volume types. See [Sandbox volumes](/sandboxes/volumes).
+- **Inline `--script` flag.** Register scripts on the command line with `--script NAME=BODY`; the file form is now `--script-path NAME:PATH`. See the [CLI reference](/cli/sandbox-commands).
+- **`msb` alias.** Installs from npm, pip, and cargo now put both `microsandbox` and `msb` on PATH.
+- **`host.microsandbox.internal`.** Sandboxes can reach the host through this well-known DNS name.
+- **Trust host CAs (opt-in).** Sandboxes can trust the host's CA bundle for internal TLS endpoints. See [Networking TLS](/networking/tls).
+- **DNS interception over TCP/53 and DoT/853.** Closes gaps where apps bypassed policy by switching transports. See [Networking DNS](/networking/dns).
+- **Custom TLS certs and insecure registries** for self-hosted image registries. See the [images overview](/images/overview).
+- **Per-sandbox `libkrunfw` override** for SDK callers developing against unreleased firmware.
+- **Installer rejects unsupported glibc** up front, instead of producing confusing runtime errors.
+
+## Bug fixes
+
+- Domain and `suffix=` rules now enforce consistently across DNS, SNI, and policy layers.
+- The Node/TypeScript SDK supports the same secret injection options as the Rust SDK.
+- macOS reads system nameservers via `SCDynamicStore`, matching what the OS actually uses.
+- The npm platform package ships `libkrunfw` under its canonical name, fixing load failures on some Linux distros.

--- a/docs/changelog/2026-05-15.mdx
+++ b/docs/changelog/2026-05-15.mdx
@@ -1,0 +1,85 @@
+---
+title: "Week of May 15, 2026"
+description: "Go SDK, file-first disk snapshots, guest init handoff, exec and boot logs, and DNS egress policy."
+icon: "bolt"
+---
+
+<Tip>
+  **Released this week:** [v0.4.4](https://github.com/superradcompany/microsandbox/releases/tag/v0.4.4) · [v0.4.5](https://github.com/superradcompany/microsandbox/releases/tag/v0.4.5) · [v0.4.6](https://github.com/superradcompany/microsandbox/releases/tag/v0.4.6)
+</Tip>
+
+## New features
+
+**Go SDK**
+
+A first-class Go SDK with full parity to the Rust, TypeScript, and Python SDKs: sandbox lifecycle, exec and PTY, filesystem, networking, secrets, snapshots, volumes, images, and event streams. The library uses CGO over a runtime-loaded FFI bundle, so `go get` works without a Rust toolchain.
+
+```go
+ctx := context.Background()
+sb, err := microsandbox.CreateSandbox(ctx, "my-sandbox",
+    microsandbox.WithImage("alpine:latest"),
+    microsandbox.WithCPUs(2),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer sb.Close()
+```
+
+See the [Go SDK reference](/sdk/go/sandbox).
+
+**File-first disk snapshots**
+
+Stopped sandboxes can be snapshotted to a content-addressed directory and used to boot fresh sandboxes on any compatible host. Snapshots stay sparse via reflink and `SEEK_DATA`/`SEEK_HOLE` copying, so create and inspect stay fast. The CLI ships `msb snapshot create | open | list | list-dir | remove | reindex | export | import | verify`, and `msb run --from <name|path>` boots a fork. The same surface is available in all four SDKs.
+
+```bash
+msb snapshot create my-sandbox --name baseline
+msb run alpine --from baseline --name fork
+```
+
+See [Sandbox snapshots](/sandboxes/snapshots).
+
+**Guest init handoff**
+
+`--init` hands PID 1 inside the guest off to systemd, OpenRC, s6, or any other init binary while the agent continues serving the host channel from a child process. Shutdown adapts to the new PID 1 (for example, `SIGRTMIN+4` for systemd) with a `SIGTERM` fallback. All three SDKs gained matching `init` / `initWith` surfaces.
+
+```bash
+msb run debian:12 \
+  --init /lib/systemd/systemd \
+  --init-arg --unit=multi-user.target \
+  --init-env container=microsandbox
+```
+
+See the [systemd services recipe](/recipes/systemd-services).
+
+**Exec logs and structured boot errors**
+
+Each sandbox now writes a per-session `exec.log` (JSON Lines) capturing stdout, stderr, and PTY output, readable via the new `msb logs` command and `logs()` SDK methods. Sandboxes that fail before the agent is ready now emit a structured `boot-error.json` that the CLI renders as a typed error block instead of a generic "process exited" message. Spawn-time exec failures are now reported through a typed `ExecFailed` message with kinds such as `NotFound`, `PermissionDenied`, `NotExecutable`, and `OutOfMemory`. The CLI exits 127, 126, or 1 per POSIX convention.
+
+See [Sandbox logs](/sandboxes/logs).
+
+**DNS queries are subject to egress policy**
+
+DNS lookups are now treated as a regular egress action rather than an exception. Under a deny-by-default policy with no rules, DNS is blocked; `allow DomainSuffix(".good.com")` only permits lookups for `*.good.com`; `allow host udp/53 + tcp/53` grants resolution wholesale. The `public_only` and `non_local` presets prepend a DNS-allow rule so default sandboxes still resolve names, and `Rule.allowDns()` / `Rule.allow_dns()` is available across SDKs.
+
+See [Networking DNS](/networking/dns).
+
+**Other features**
+
+- **Ingress policy gate on published ports.** Inbound TCP connections on published ports are now evaluated against the network policy before the listener accepts them; denied peers receive a TCP RST instead of a graceful close. See the [networking overview](/networking/overview).
+- **`MSB_HOME` env override.** Point a sandbox at an isolated state directory without touching `$HOME`, useful for CI jobs that share a runner. The build script honors the same variable, so build-time and runtime paths agree.
+- **Secret injection for Basic auth.** Placeholders inside `Authorization: Basic <base64>` headers are now decoded, substituted, and re-encoded. The proxy also detects bypass attempts via URL percent-encoding, JSON unicode escapes, and placeholders split across TCP writes. The Python SDK gained the same `SecretInjection` options (`headers`, `basic_auth`, `query_params`, `body`) as the Node SDK.
+- **`createWithProgress` in the Node TS SDK.** Stream image pull events (layer downloads, extraction) while creating a sandbox; the returned `PullSession` resolves to the live sandbox. See the [TypeScript SDK reference](/sdk/typescript/sandbox).
+- **`--replace-grace` flag.** Configure how long `replace()` waits for the previous sandbox to shut down before escalating, exposed in the CLI and all SDKs.
+
+## Bug fixes
+
+- `replace()` no longer hangs for 30 seconds when the previous sandbox is mid-shutdown; it now escalates from `SIGTERM` to `SIGKILL` after the grace period.
+- Stdin payloads larger than the kernel pipe buffer (about 64 KiB on Linux) are delivered correctly, and broken-pipe errors surface as a new `stdin_error` exec event instead of being silently dropped.
+- Address families are gated on host route availability, so v4-only hosts no longer advertise an IPv6 address into the guest and v6-only hosts can publish ports.
+- Connection timeouts during the relay handshake now respect the 30-second deadline and prefer `boot-error.json` over a raw IO error when available.
+- Prebuilt runtime downloads use the platform certificate store, so builds behind enterprise TLS proxies with custom CAs succeed instead of failing with `UnknownIssuer`.
+- OCI digests with path traversal components are rejected, keeping cache filenames safe.
+- The Node SDK accepts kebab-case `link-local` in plain-object network policies, matching the documented public form.
+- The Node SDK's `msb` path resolution works under Bun, which does not propagate JS-side `process.env` mutations to native code.
+- Bind-mounting host directories the caller does not own (for example `/tmp`, `/var`, mounted USB drives) no longer fails with `Operation not permitted` before the VM boots.

--- a/docs/changelog/2026-05-22.mdx
+++ b/docs/changelog/2026-05-22.mdx
@@ -1,0 +1,91 @@
+---
+title: "Week of May 22, 2026"
+description: "Rotation-aware log streaming, raw agent client across SDKs, per-mount passthroughfs policies, network policy CLI cleanup, configurable port bind addresses, and ergonomic --script."
+icon: "bolt"
+---
+
+## New features
+
+**Rotation-aware log streaming**
+
+`Sandbox.log_stream` / `logStream` / `LogStream` lands in the Rust, Node, Python, and Go SDKs, alongside `read_logs` for sorted snapshots. The engine merges `exec.log`, `runtime.log`, and `kernel.log` including their rotated siblings, and each entry carries an opaque `cursor` so consumers can resume after a disconnect. `msb logs` and `msb logs -f` now ride the same engine; if a follower falls behind retention it receives a typed `MissedRotation` error with a hint to restart instead of silently skipping records.
+
+```python
+async for entry in sandbox.log_stream(follow=True):
+    print(entry.timestamp, entry.source, entry.data)
+```
+
+See [Sandbox logs](/sandboxes/logs).
+
+**Raw agent client in every SDK**
+
+A new `AgentClient` surface lets SDK callers talk to a sandbox's `agentd` directly through the relay, sending and receiving framed CBOR without going through the typed sandbox API. Rust ships both a typed tier (with a validated `core.ready` handshake and cached ready bytes) and a raw tier; Node, Python, and Go expose the raw tier and keep CBOR encoding in userland. Useful for experimenting with new agent operations or building higher-level tooling on top of the protocol.
+
+```ts
+const client = await AgentClient.connectSandbox("dev");
+const ready = client.ready();
+const response = await client.request(frame);
+```
+
+See the [TypeScript SDK reference](/sdk/typescript/sandbox).
+
+**Per-mount passthroughfs policies**
+
+Two explicit knobs replace the previous boolean flags on every mount. `stat_virtualization` chooses between `Strict`, `Relaxed`, and `Off`, and `host_permissions` chooses between `Private` and `Mirror`. Defaults stay `Strict + Private`, so existing sandboxes are unchanged. The new combinations make it possible to bind-mount foreign-owned read-only paths like `/tmp`, mirror guest `chmod` bits to the host inode, and create real host-visible symlinks from inside the guest. The `--mount` flag gains `tag:host[:ro][,stat-virt=...][,host-perms=...]` for opting in.
+
+See [Sandbox filesystem](/sandboxes/filesystem).
+
+**Network policy CLI consolidation**
+
+The egress and ingress flags collapse into one consistent surface. `--net-default <allow|deny>` sets both directions at once, `*.foo.com` is now accepted as a suffix shorthand inside `--net-rule` targets, and `--no-net` is sugar for `--net-default deny` (it now also blocks ingress, matching its name). TLD-broad patterns like `*.com` are rejected at parse time so they cannot widen blast radius by accident. `--deny-domain` and `--deny-domain-suffix` are removed; express the same intent with `--net-rule "deny@..."` plus `--net-default allow`.
+
+```bash
+msb run alpine \
+  --net-default deny \
+  --net-rule "allow@*.good.com,allow@host"
+```
+
+See the [networking overview](/networking/overview).
+
+**Configurable port bind addresses**
+
+Published ports can now bind to a specific host address rather than the implicit loopback. The CLI accepts `BIND_ADDR:HOST:GUEST` and `/udp` variants, and the Rust, Python, TypeScript, and Go SDKs gained matching bind-aware port APIs. Existing `HOST:GUEST` mappings continue to bind to `127.0.0.1`.
+
+```bash
+msb run nginx --port 0.0.0.0:8080:80 --port 127.0.0.1:9000:9000/udp
+```
+
+See the [networking overview](/networking/overview).
+
+**Ergonomic `--script` flag**
+
+`msb create --script NAME=BODY` now produces a runnable script: the body is wrapped with a shebang derived from `--shell` (default `/bin/sh`), and the escapes `\n`, `\t`, `\r`, `\\`, `\"`, `\'` are decoded so multiline scripts survive normal shell quoting. A new `--script-raw NAME=BODY` writes the body byte-for-byte for callers that bring their own shebang. `--shell` rejects empty, whitespace, and NUL values at parse time so a stray newline cannot inject lines into every generated script.
+
+```bash
+msb create --replace alpine --name py \
+  --script start='echo hello\npython3 -c "print(123)"'
+msb exec py -- start
+```
+
+See the [CLI reference](/cli/sandbox-commands).
+
+**Other features**
+
+- **Passthrough secret violation action.** A new `Passthrough` violation policy forwards requests containing secret placeholders without substituting the real value, scoped to a configurable list of host patterns. Useful for letting non-sensitive traffic flow to hosts that happen to share placeholder syntax. See [Sandbox secrets](/sandboxes/secrets).
+- **Python exec keyword arguments.** `sandbox.exec("python3", ["script.py"], cwd="/app", env={...}, timeout=30.0)` now works directly, instead of requiring an `ExecOptions` dict. See the [Python SDK reference](/sdk/python/execution).
+- **Configurable guest IP pools.** Deployments can override the default IPv4 and IPv6 guest pools, and the default IPv4 pool changes from `100.96.0.0/11` to `172.16.0.0/12` to avoid colliding with Tailscale.
+- **`msb start` accepts variadic sandbox names.** Start more than one sandbox in a single command.
+- **Agent relay supports up to 128 concurrent clients.** Raised from 16. The relay also reports its correlation-ID range size to each SDK during the handshake, so a future bump will not silently misroute frames on older clients.
+- **Configurable shared-memory metrics registry.** Live per-sandbox metrics now live in a POSIX shared-memory segment instead of SQLite, removing steady-state writes to the catalog database. Capacity is tunable via `metrics.capacity` in `~/.microsandbox/config.json`; the public metrics API is unchanged. See [Sandbox metrics](/sandboxes/metrics).
+
+## Bug fixes
+
+- TLS interception no longer fails on long-lived sandboxes; cached per-domain leaf certificates are now refreshed before they expire.
+- Sandbox writes are flushed to disk on `msb stop` and `sandbox.stop()`; previously the host could tear down the VM before the guest synced ext4, occasionally losing in-flight writes across stop and start. As part of this fix, `replace_with_grace` is renamed to `replace_with_timeout` across the CLI, Rust, Python, Node, and Go SDKs, and `stop_with_timeout` / `connect_with_timeout` are now available on `SandboxHandle`.
+- The microsandbox CA is now installed into guest trust directories with mode `0755`, creating those directories first when they are missing, so distro trust-store refreshes pick it up.
+- `msb logs --follow --json` emits JSON Lines for the follow records, not just the initial snapshot, so streaming consumers no longer hit a parse error mid-stream.
+- Request bodies that arrive already content-encoded (gzip, brotli, deflate) are preserved verbatim during secret substitution instead of being silently rewritten.
+- `msb run ./path` and other dot-prefixed inputs are now recognized as local image inputs instead of being interpreted as registry references.
+- Sandboxes with large environment-variable payloads no longer overflow at startup.
+- `AllSandboxMetrics` in the Go SDK reports the real uptime instead of zero.
+- Several `--net-rule` suffix entry points now reject TLD-broad patterns like `*.com` at parse time, with a clear `SuffixTooBroad` error.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -186,6 +186,7 @@
       {
         "tab": "Changelog",
         "pages": [
+          "changelog/2026-05-22",
           "changelog/2026-05-15",
           "changelog/2026-05-01",
           "changelog/2026-04-24",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -186,6 +186,7 @@
       {
         "tab": "Changelog",
         "pages": [
+          "changelog/2026-05-15",
           "changelog/2026-05-01",
           "changelog/2026-04-24",
           "changelog/2026-04-17",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -182,6 +182,16 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Changelog",
+        "pages": [
+          "changelog/2026-05-01",
+          "changelog/2026-04-24",
+          "changelog/2026-04-17",
+          "changelog/2026-04-10",
+          "changelog/2026-04-03"
+        ]
       }
     ]
   },

--- a/docs/getting-started/agents.mdx
+++ b/docs/getting-started/agents.mdx
@@ -6,7 +6,7 @@ icon: "robot"
 
 microsandbox is built for AI agents. The SDK and CLI give you full programmatic control, but there are two additional ways to connect agents directly: **Agent Skills** for coding assistants and an **MCP server** for any MCP-compatible client.
 
-## Agent Skills
+## Agent skills
 
 [Agent Skills](https://github.com/superradcompany/skills) teach AI coding agents how to use microsandbox without any custom integration code. Once installed, the agent can create sandboxes, run commands, manage files, and control the full sandbox lifecycle through natural language.
 

--- a/docs/getting-started/agents.mdx
+++ b/docs/getting-started/agents.mdx
@@ -18,7 +18,7 @@ npx skills add superradcompany/skills
 
 This installs a set of skill files into your project that the agent reads as context. No server process, no configuration, just files that describe how to use microsandbox.
 
-## MCP Server
+## MCP server
 
 The [microsandbox MCP server](https://github.com/superradcompany/microsandbox-mcp) exposes microsandbox as a set of structured tool calls over the [Model Context Protocol](https://modelcontextprotocol.io). Any MCP-compatible client can use it to manage sandbox lifecycle, execute commands, access the filesystem, work with volumes, and monitor sandbox state.
 

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -4,7 +4,7 @@ description: HTTPS inspection with an auto-generated CA
 icon: "lock"
 ---
 
-Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server. That's how features like per-host secret injection and URL-level policy checks can see inside what would otherwise be an opaque stream.
+Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server. That's how features like per-host secret injection and URL-level policy checks can see inside an otherwise opaque stream.
 
 ## How it works
 
@@ -12,7 +12,7 @@ When you enable TLS interception:
 
 1. A CA key and certificate are generated for the sandbox at creation time. The CA is scoped to that sandbox: it's not shared across sandboxes or with the host.
 2. The guest's trust store is updated to trust this CA.
-3. When the guest opens an HTTPS connection, the host-side proxy intercepts the handshake, generates a leaf certificate for the target domain on the fly, and signs it with the per-sandbox CA.
+3. When the guest opens an HTTPS connection, the host-side proxy intercepts the handshake. It then generates a leaf certificate for the target domain on the fly and signs it with the per-sandbox CA.
 4. The proxy opens its own TLS connection to the upstream server and bridges the two.
 
 Because the CA lives only for the sandbox's lifetime, nothing signed by it is trusted anywhere else.
@@ -94,7 +94,7 @@ Bypass patterns accept exact matches (`api.example.com`) and wildcards (`*.gov`,
 
 Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, ...) terminate outbound HTTPS at the host and re-sign it with a gateway CA. That CA is installed in your macOS Keychain or Linux trust store as part of the corporate rollout, so HTTPS works silently on the host. Inside a sandbox it doesn't. The guest's stock Mozilla bundle has never seen the gateway CA, so `apk update`, `pip install`, `curl`, and any SDK fetch fail with `server certificate not trusted`.
 
-By default the sandbox does not extend host trust into the guest, so the guest validates TLS strictly against its stock Mozilla bundle. Opt in when you need the guest to trust whatever the host trusts: at sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle.
+By default the sandbox does not extend host trust into the guest, so the guest validates TLS strictly against its stock Mozilla bundle. Opt in when you need the guest to trust whatever the host trusts: at sandbox boot, microsandbox copies the host's trusted root CAs into the guest and appends them to the system CA bundle.
 
 <Note>
 **Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox.
@@ -145,7 +145,7 @@ msb run alpine --trust-host-cas -- apk update
 
 ### Interaction with TLS interception
 
-TLS interception also covers the corporate-proxy case, but only on the ports it's configured for (default `[443]`), and only for non-bypassed domains. It doesn't touch QUIC / HTTP/3 flows. Everything outside that scope (gRPC, Postgres / Redis / Mongo TLS, custom 8443, non-intercepted ports, bypassed domains) goes over raw TLS from the guest, where host-CA trust is what makes certificate validation succeed.
+TLS interception also covers the corporate-proxy case, but only on the ports it's configured for (default `[443]`), and only for non-bypassed domains. It doesn't touch QUIC / HTTP/3 flows. Everything outside that scope (gRPC, Postgres / Redis / Mongo TLS, custom 8443, non-intercepted ports, bypassed domains) goes over raw TLS from the guest. Host-CA trust is what makes certificate validation succeed in those cases.
 
 The two features compose. Turn on host-CA trust alongside TLS interception when you need both: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Leave it off to keep the guest's TLS stack validating strictly against its stock Mozilla bundle.
 

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -4,7 +4,7 @@ description: HTTPS inspection with an auto-generated CA
 icon: "lock"
 ---
 
-Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server, which is how features like per-host secret injection and URL-level policy checks are able to see inside what would otherwise be an opaque stream.
+Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server. That's how features like per-host secret injection and URL-level policy checks can see inside what would otherwise be an opaque stream.
 
 ## How it works
 
@@ -80,7 +80,7 @@ msb create python --name agent \
 
 ## Bypass patterns
 
-Some domains don't play well with interception, typically ones whose clients pin a specific certificate or public key instead of trusting the system CA store. Software update channels (browser autoupdate, macOS `softwareupdate`, package-manager mirrors that ship a pinned signing CA) and vendor SDKs that bundle their own pinned CA are the usual suspects. Add them to the bypass list and their traffic flows through as-is, encrypted end-to-end between the guest and the upstream server.
+Some domains don't play well with interception, typically ones whose clients pin a specific certificate or public key instead of trusting the system CA store. The usual suspects are software update channels (browser autoupdate, macOS `softwareupdate`, package-manager mirrors with a pinned signing CA) and vendor SDKs that bundle their own pinned CA. Add them to the bypass list and their traffic flows through as-is, encrypted end-to-end between the guest and the upstream server.
 
 Bypass patterns accept exact matches (`api.example.com`) and wildcards (`*.gov`, `*.apple.com`).
 
@@ -92,7 +92,7 @@ Bypass patterns accept exact matches (`api.example.com`) and wildcards (`*.gov`,
 
 ## Trusting host CAs
 
-Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, ...) terminate outbound HTTPS at the host and re-sign it with a gateway CA. That CA is installed in your macOS Keychain or Linux trust store as part of the corporate rollout, so HTTPS works silently on the host. Inside a sandbox it doesn't: the guest's stock Mozilla bundle has never seen the gateway CA, so `apk update`, `pip install`, `curl`, and any SDK fetch fail with `server certificate not trusted`.
+Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, ...) terminate outbound HTTPS at the host and re-sign it with a gateway CA. That CA is installed in your macOS Keychain or Linux trust store as part of the corporate rollout, so HTTPS works silently on the host. Inside a sandbox it doesn't. The guest's stock Mozilla bundle has never seen the gateway CA, so `apk update`, `pip install`, `curl`, and any SDK fetch fail with `server certificate not trusted`.
 
 By default the sandbox does not extend host trust into the guest, so the guest validates TLS strictly against its stock Mozilla bundle. Opt in when you need the guest to trust whatever the host trusts: at sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle.
 

--- a/docs/recipes/systemd-services.mdx
+++ b/docs/recipes/systemd-services.mdx
@@ -56,7 +56,7 @@ root@msb:/# curl -s localhost | head -1
 <!DOCTYPE html>
 ```
 
-Microsandbox is detected as a container, so packages with `policy-rc.d` deferral install but don't auto-start. `systemctl enable --now <unit>` starts them in one step.
+microsandbox is detected as a container, so packages with `policy-rc.d` deferral install but don't auto-start. `systemctl enable --now <unit>` starts them in one step.
 
 ## Notes
 

--- a/docs/sandboxes/customize.mdx
+++ b/docs/sandboxes/customize.mdx
@@ -181,13 +181,6 @@ The handoff sequence:
 
 Common reasons to opt in: long-lived daemons, system service tests, anything that talks to dbus or expects `systemctl` to work.
 
-The simplest entry point is `auto`, which probes a small list of well-known paths inside the guest rootfs and picks the first one that exists:
-
-- `/sbin/init`
-- `/lib/systemd/systemd`
-- `/usr/lib/systemd/systemd`
-
-Pass an absolute path instead when you need pinning (e.g. for reproducible CI).
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -519,6 +519,12 @@ fn idle_timeout(self, secs: u64) -> Self
 
 Auto-drain the sandbox after this many seconds of inactivity (no active exec sessions). Enforced on the host side.
 
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `u64` | Idle timeout in seconds |
+
 ---
 
 #### init()
@@ -579,12 +585,6 @@ let sb = Sandbox::builder("worker")
 ```
 
 Calling `init` or `init_with` more than once overwrites — different from `env`, which appends. The init is one-shot pre-boot.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| secs | `u64` | Idle timeout in seconds |
 
 ---
 


### PR DESCRIPTION
## Summary

- Exposes a Go SDK `WithLibkrunfwPath(path)` option and `SandboxConfig.LibkrunfwPath` field for per-sandbox custom `libkrunfw` usage.
- Wires the option through the Go FFI JSON payload into the native Rust bridge as `libkrunfw_path`.
- Documents custom `libkrunfw` usage across Go, Rust, Python, and TypeScript SDK docs.
- Promotes TypeScript builder sections so `SandboxBuilder`, `VolumeBuilder`, and `MountBuilder` match the rest of the SDK docs structure.

## Why

Rust, TypeScript, and Python already had per-sandbox custom `libkrunfw` support either in API or bindings, but the docs were incomplete and Go had no public option. This makes custom kernel/firmware development available consistently from Go and clearer in the docs.

## Validation

- `go test .` in `sdk/go`
- `cargo check --manifest-path sdk/go/native/Cargo.toml`
- Commit hook suite passed, including workspace fmt, clippy, docs, and msb build checks.