### PR TITLE
fix(runtime): re-enable split irqchip on x86 Linux

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -372,6 +372,37 @@ jobs:
           npm run build
 
   # ---------------------------------------------------------------------------
+  # CLI smoke tests (requires KVM)
+  #
+  # Runs black-box CLI user flows against the freshly-built msb artifact.
+  # Keep these below the SDK layer so runtime/libkrun regressions fail with a
+  # direct signal before SDK packaging enters the picture.
+  # ---------------------------------------------------------------------------
+  cli-smoke-test:
+    name: CLI Smoke Tests
+    needs: [check, changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: self-hosted-ubuntu-2404-x64
+    steps:
+      - name: Clean workspace
+        run: |
+          rm -rf "${{ github.workspace }}"/build
+          rm -rf ~/.microsandbox
+
+      - uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: msb-linux-x86_64
+          path: build/
+
+      - name: Run CLI smoke tests
+        run: |
+          chmod +x build/msb
+          scripts/smoke/cli/split-irqchip-bind-net.sh
+
+  # ---------------------------------------------------------------------------
   # Integration tests (requires KVM)
   # ---------------------------------------------------------------------------
   integration-test:
@@ -665,6 +696,7 @@ jobs:
       - build-kernel
       - build-agentd-aarch64
       - check
+      - cli-smoke-test
       - integration-test
       - node-sdk-test
       - python-sdk-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c29ba9c9c8a38cd001c0c9af16bd3c75be328ab8c95a3aa933b125c1d93f41c"
+checksum = "1204f9be84d1d6a7522745f2ca8c1daaad10b6974c31491b23fbfba8948ea436"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3443,9 +3443,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb4327e3efe423f3bcdca0390589193834b9f73eb54bb13b90f48f1755b499e"
+checksum = "99f3fb3872287fbe2f9022da8e4b99bd7e2d56bffa225dc8e76ff5f8bea207c0"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3459,15 +3459,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc7dbc08509138172ccd3b40df5c1501ad498ba12f2643eb013320205f9c987"
+checksum = "81e9b644799f042ecd9ff8e1083548b069bfe5c055fb30a2ee5488d32d532305"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d88b81a52ae5b3fe1afb1692b0785a4fe946c77bbc9e43a030e84e90627819"
+checksum = "80daaaa5c82e40b410813655552dae003273439dd4f663fdf8c0d482daa81690"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3476,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6d808b3c4d5a7c24fba02a64f2f704da973cf6820deedd2811c2ec795b9fc"
+checksum = "60168afa59b23513902fca621af0ae2e34b7c1eb6778c4dfdbcbf639d90e9d88"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3504,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce2de785e2cceda28ce03f20a9eeb895ac947ab66b09db31077a070bd6dda86"
+checksum = "ff58dae8f64ded015362c7cf34fc6d3137e21ac67a2a2d9266c930d74de515c2"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -3516,9 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047a3f886330138dd6a681ef96b0b2257b494f295535bdd641841068f5847bc"
+checksum = "8c276f8c223cfef11a20777ceebf11452cbdbec0753f4f530490600abfd54e6c"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -3526,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db57f147c6e1aca9a14d137ada76b6df78b538a0673d86b33652be78e9784499"
+checksum = "5c1cc89c4d634828d4487321dc1ad27440d5b610b51a313572b5b41e5ad810c0"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3536,18 +3536,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0c3a0923f194852028fd0e809a8d26c5465bc550f59c08b25bae5dd9885457"
+checksum = "3d2da7cdc57310229e8edfe559df924ae7deb747dacac65dc42898aeec44c62f"
 dependencies = [
  "vm-memory 0.16.2",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbae5590c539ee8b9ed0e2d4c50c6ee5b546f03f9eb2408b885628514ddb9a6"
+checksum = "68805ba9921de9794b2c5a5e4e2efc6f0dbe5206e5c3bcc602d072823373a068"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3560,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd62153e5ffe89a76b775c89b9c01b65d38c67a32ca8d516a910d4cb497d367"
+checksum = "d6042a24c047faba9b2c033db72257d765cb7dde393d61943d45cccac6e1fa12"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib/lib.rs"
 [dependencies]
 libc.workspace = true
 microsandbox-utils = { version = "0.4.6", path = "../utils" }
-msb_krun = "0.1.12"
+msb_krun = "0.1.13"
 scopeguard.workspace = true
 tempfile.workspace = true
 tracing.workspace = true

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -26,7 +26,7 @@ libc = { workspace = true }
 lru = { workspace = true }
 microsandbox-protocol = { version = "0.4.6", path = "../protocol" }
 microsandbox-utils = { version = "0.4.6", path = "../utils" }
-msb_krun = { version = "0.1.12", features = ["net"] }
+msb_krun = { version = "0.1.13", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"
 percent-encoding = "2"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -28,7 +28,7 @@ microsandbox-metrics = { version = "0.4.6", path = "../metrics" }
 microsandbox-network = { version = "0.4.6", path = "../network", optional = true }
 microsandbox-protocol = { version = "0.4.6", path = "../protocol" }
 microsandbox-utils = { version = "0.4.6", path = "../utils" }
-msb_krun = { version = "0.1.12", features = ["blk"] }
+msb_krun = { version = "0.1.13", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }
 sea-orm.workspace = true

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -647,7 +647,17 @@ fn build_vm(
     let vm = &config.vm;
 
     let mut builder = VmBuilder::new()
-        .machine(|m| m.vcpus(vm.vcpus).memory_mib(vm.memory_mib as usize))
+        .machine(|m| {
+            let m = m.vcpus(vm.vcpus).memory_mib(vm.memory_mib as usize);
+            #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+            {
+                m.split_irqchip(true)
+            }
+            #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+            {
+                m
+            }
+        })
         .kernel(|k| {
             let k = k.krunfw_path(&vm.libkrunfw_path);
             if let Some(ref init_path) = vm.init_path {

--- a/scripts/smoke/cli/split-irqchip-bind-net.sh
+++ b/scripts/smoke/cli/split-irqchip-bind-net.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MSB_BIN="${MSB_BIN:-${ROOT_DIR}/build/msb}"
+IMAGE="${MSB_CLI_SMOKE_IMAGE:-mirror.gcr.io/library/alpine}"
+SANDBOX_NAME="${MSB_CLI_SMOKE_NAME:-ci-splitirq-bind-net}"
+TIMEOUT="${MSB_CLI_SMOKE_TIMEOUT:-60s}"
+
+if [[ ! -x "$MSB_BIN" ]]; then
+  echo "msb binary is not executable: $MSB_BIN" >&2
+  exit 1
+fi
+
+if [[ ! -r /dev/kvm || ! -w /dev/kvm ]]; then
+  echo "/dev/kvm must be readable and writable for CLI smoke tests" >&2
+  exit 1
+fi
+
+smoke_root="$(mktemp -d "${TMPDIR:-/tmp}/msb-cli-smoke.XXXXXX")"
+created_home=0
+
+if [[ -z "${MSB_HOME:-}" ]]; then
+  MSB_HOME="$(mktemp -d "${TMPDIR:-/tmp}/msb-cli-home.XXXXXX")"
+  export MSB_HOME
+  created_home=1
+fi
+
+cleanup() {
+  rm -rf "$smoke_root"
+  if [[ "$created_home" -eq 1 ]]; then
+    rm -rf "$MSB_HOME"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$smoke_root"/bind-{a,b,c}
+
+export LD_LIBRARY_PATH="$ROOT_DIR/build${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+"$MSB_BIN" run \
+  --name "$SANDBOX_NAME" \
+  --replace \
+  --timeout "$TIMEOUT" \
+  -v "$smoke_root/bind-a:/a" \
+  -v "$smoke_root/bind-b:/b" \
+  -v "$smoke_root/bind-c:/c" \
+  "$IMAGE" -- sh -lc 'ip link show eth0 >/dev/null && mountpoint -q /a && mountpoint -q /b && mountpoint -q /c'


### PR DESCRIPTION
## TL;DR

Re-enable split irqchip for x86 Linux VMs now that libkrun 0.1.13 fixes the high IOAPIC pin path. Add a CLI smoke test that covers bind mounts with networking.

## Description

- Updates microsandbox's `msb_krun` dependencies to 0.1.13 from crates.io and refreshes the lockfile.
- Enables `split_irqchip(true)` only for Linux x86_64 VM builds, keeping other platforms on the existing builder path.
- Adds a CLI smoke script that starts Alpine with three bind mounts and verifies both networking and mountpoints.
- Runs that smoke script in CI on the self-hosted Linux x86_64 runner after the `msb-linux-x86_64` artifact is built.
- Closes #567.

## Sibling PRs

- superradcompany/libkrun#55 fixes high IOAPIC pin support in libkrun.
- superradcompany/libkrun#56 publishes the `msb_krun` 0.1.13 crates consumed here.

## Test Plan

- [x] `cargo metadata --locked --format-version 1`
- [x] `cargo fmt --check`
- [x] `bash -n scripts/smoke/cli/split-irqchip-bind-net.sh`
- [x] `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/check.yml'); puts 'ok'"`
- [x] local `build/agentd` placeholder plus `cargo check --no-default-features --features net -p microsandbox-runtime`
- [x] x86 KVM E2E on `ci-runner-ubuntu-2404-x64`: fresh PR checkout, build `agentd`, build `libkrunfw`, build release `msb`, run `scripts/smoke/cli/split-irqchip-bind-net.sh`
- [x] CI `CLI Smoke Tests` runs `scripts/smoke/cli/split-irqchip-bind-net.sh` on the self-hosted Linux x86_64 runner
