### PR TITLE
fix(image): preserve OCI hardlinks in EROFS output

### DIFF
--- a/crates/image/lib/erofs/fsmeta.rs
+++ b/crates/image/lib/erofs/fsmeta.rs
@@ -4,7 +4,7 @@
 //! (EROFS_INODE_CHUNK_BASED) referencing data in external layer blobs via
 //! device table entries. Directories and symlinks use standard flat layout.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsString;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -21,9 +21,10 @@ use super::format::{
 };
 use super::writer::ErofsDataMap;
 use super::writer::{
-    ErofsError, clone_dir_shell, compute_dir_data_size, compute_xattr_ibody_size,
-    compute_xattr_icount, decide_data_layout, node_data_size, node_metadata, node_nlink,
-    node_xattrs, serialize_dir_blocks, write_xattr_ibody,
+    CursorTrackingWriter, ErofsError, clone_dir_shell, compute_dir_data_size,
+    compute_xattr_ibody_size, compute_xattr_icount, decide_data_layout, node_data_size,
+    node_metadata, node_nlink, node_xattrs, serialize_dir_blocks, write_xattr_ibody,
+    write_zero_padding_to,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -70,11 +71,11 @@ struct FsmetaLayoutState {
 //--------------------------------------------------------------------------------------------------
 
 impl FsmetaLayoutState {
-    fn new(meta_blkaddr: u32, merged_tree: &FileTree) -> Self {
+    fn new(meta_blkaddr: u32) -> Self {
         Self {
             plans: Vec::new(),
             regular_file_plans: HashMap::new(),
-            regular_file_link_counts: merged_tree.regular_file_link_counts(),
+            regular_file_link_counts: HashMap::new(),
             current_meta_offset: meta_blkaddr as u64 * EROFS_BLKSIZ as u64,
             current_data_block: 0,
             meta_blkaddr,
@@ -99,8 +100,6 @@ pub fn write_fsmeta(
     layer_maps: &[ErofsDataMap],
     output: &Path,
 ) -> Result<(), ErofsError> {
-    // Iterative convergence: fsmeta_blocks depends on metadata size which depends
-    // on mapped_blkaddr which depends on fsmeta_blocks. Start with an estimate.
     let num_devices = layer_maps.len();
 
     // Device table starts right after superblock block.
@@ -118,46 +117,7 @@ pub fn write_fsmeta(
     let meta_start_byte = align_up(devt_byte_offset + devt_size, EROFS_BLKSIZ as u64);
     let meta_blkaddr = (meta_start_byte / EROFS_BLKSIZ as u64) as u32;
 
-    // Estimate fsmeta_blocks (iterate to converge).
-    let mut fsmeta_blocks: u32 = meta_blkaddr + 1; // initial guess
-
-    for _iteration in 0..4 {
-        let mut state = FsmetaLayoutState::new(meta_blkaddr, merged_tree);
-        plan_fsmeta_directory(
-            &merged_tree.root,
-            0,
-            &mut state,
-            true,
-            provenance,
-            layer_maps,
-            &PathBuf::new(),
-        )?;
-        state.root_nid = state.plans[0].nid;
-
-        // Compute actual fsmeta_blocks: metadata + directory data blocks.
-        let meta_end = align_up(state.current_meta_offset, EROFS_BLKSIZ as u64);
-        let data_start_block = (meta_end / EROFS_BLKSIZ as u64) as u32;
-        let computed_blocks = data_start_block + state.current_data_block;
-
-        if computed_blocks == fsmeta_blocks {
-            // Converged — write the image.
-            return write_fsmeta_image(
-                output,
-                &state,
-                merged_tree,
-                provenance,
-                layer_maps,
-                fsmeta_blocks,
-                num_devices,
-                devt_slotoff,
-                meta_blkaddr,
-            );
-        }
-        fsmeta_blocks = computed_blocks;
-    }
-
-    // Final pass with the last estimate.
-    let mut state = FsmetaLayoutState::new(meta_blkaddr, merged_tree);
+    let mut state = FsmetaLayoutState::new(meta_blkaddr);
     plan_fsmeta_directory(
         &merged_tree.root,
         0,
@@ -168,6 +128,10 @@ pub fn write_fsmeta(
         &PathBuf::new(),
     )?;
     state.root_nid = state.plans[0].nid;
+
+    let meta_end = align_up(state.current_meta_offset, EROFS_BLKSIZ as u64);
+    let data_start_block = (meta_end / EROFS_BLKSIZ as u64) as u32;
+    let fsmeta_blocks = data_start_block + state.current_data_block;
 
     write_fsmeta_image(
         output,
@@ -353,6 +317,7 @@ fn plan_fsmeta_directory(
                 &child_path,
             )?,
             TreeNode::RegularFile(file) => {
+                *state.regular_file_link_counts.entry(file.id).or_insert(0) += 1;
                 if let Some(plan_idx) = state.regular_file_plans.get(&file.id) {
                     state.plans[*plan_idx].nid
                 } else {
@@ -527,14 +492,16 @@ fn write_fsmeta_dir_data(
     data_start_block: u32,
     plan_idx: &mut usize,
 ) -> Result<(), ErofsError> {
-    let mut seen_regular_files = HashSet::new();
+    let mut data_cursor = data_start_block as u64 * EROFS_BLKSIZ as u64;
+    file.seek(SeekFrom::Start(data_cursor))?;
+
     write_fsmeta_dir_data_inner(
         file,
         state,
         dir,
         data_start_block,
         plan_idx,
-        &mut seen_regular_files,
+        &mut data_cursor,
     )
 }
 
@@ -544,7 +511,7 @@ fn write_fsmeta_dir_data_inner(
     dir: &DirectoryNode,
     data_start_block: u32,
     plan_idx: &mut usize,
-    seen_regular_files: &mut HashSet<RegularFileId>,
+    data_cursor: &mut u64,
 ) -> Result<(), ErofsError> {
     let blksiz = EROFS_BLKSIZ as u64;
     let plan = &state.plans[*plan_idx];
@@ -555,15 +522,16 @@ fn write_fsmeta_dir_data_inner(
     {
         let abs_block = data_start_block + plan.data_block_start;
         let offset = abs_block as u64 * blksiz;
-        file.seek(SeekFrom::Start(offset))?;
+        write_zero_padding_to(file, data_cursor, offset)?;
+        let mut tracked = CursorTrackingWriter::new(file, data_cursor);
 
         let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
         let data_to_write = &dir_data[..std::cmp::min(full_block_bytes, dir_data.len())];
-        file.write_all(data_to_write)?;
+        tracked.write_all(data_to_write)?;
 
         if data_to_write.len() < full_block_bytes {
             let pad = full_block_bytes - data_to_write.len();
-            file.write_all(&ZEROS[..pad])?;
+            tracked.write_all(&ZEROS[..pad])?;
         }
     }
 
@@ -576,15 +544,11 @@ fn write_fsmeta_dir_data_inner(
                     child_dir,
                     data_start_block,
                     plan_idx,
-                    seen_regular_files,
+                    data_cursor,
                 )?;
             }
             TreeNode::RegularFile(file) => {
-                if seen_regular_files.insert(file.id) {
-                    debug_assert_eq!(
-                        state.regular_file_plans.get(&file.id).copied(),
-                        Some(*plan_idx)
-                    );
+                if state.regular_file_plans.get(&file.id).copied() == Some(*plan_idx) {
                     *plan_idx += 1;
                 }
             }
@@ -595,19 +559,20 @@ fn write_fsmeta_dir_data_inner(
                 if child_plan.data_block_count > 0 {
                     let abs_block = data_start_block + child_plan.data_block_start;
                     let offset = abs_block as u64 * blksiz;
-                    file.seek(SeekFrom::Start(offset))?;
+                    write_zero_padding_to(file, data_cursor, offset)?;
+                    let mut tracked = CursorTrackingWriter::new(file, data_cursor);
 
                     let full_block_bytes =
                         child_plan.data_block_count as usize * EROFS_BLKSIZ as usize;
                     let data_to_write =
                         &s.target[..std::cmp::min(full_block_bytes, s.target.len())];
-                    file.write_all(data_to_write)?;
+                    tracked.write_all(data_to_write)?;
 
                     if child_plan.data_layout == EROFS_INODE_FLAT_PLAIN
                         && data_to_write.len() < full_block_bytes
                     {
                         let pad = full_block_bytes - data_to_write.len();
-                        file.write_all(&ZEROS[..pad])?;
+                        tracked.write_all(&ZEROS[..pad])?;
                     }
                 }
             }
@@ -630,6 +595,9 @@ fn write_fsmeta_metadata(
     layer_maps: &[ErofsDataMap],
     data_start_block: u32,
 ) -> Result<(), ErofsError> {
+    let mut meta_cursor = state.meta_blkaddr as u64 * EROFS_BLKSIZ as u64;
+    file.seek(SeekFrom::Start(meta_cursor))?;
+
     write_fsmeta_inode(
         file,
         state,
@@ -640,6 +608,7 @@ fn write_fsmeta_metadata(
         data_start_block,
         &mut 0,
         &PathBuf::new(),
+        &mut meta_cursor,
     )
 }
 
@@ -654,6 +623,7 @@ fn write_fsmeta_inode(
     data_start_block: u32,
     plan_idx: &mut usize,
     current_path: &Path,
+    meta_cursor: &mut u64,
 ) -> Result<(), ErofsError> {
     let blksiz = EROFS_BLKSIZ as u64;
     let meta_base = state.meta_blkaddr as u64 * blksiz;
@@ -661,7 +631,7 @@ fn write_fsmeta_inode(
     *plan_idx += 1;
 
     let inode_offset = meta_base + plan.nid as u64 * EROFS_ISLOT_SIZE as u64;
-    file.seek(SeekFrom::Start(inode_offset))?;
+    write_zero_padding_to(file, meta_cursor, inode_offset)?;
 
     // Build 64-byte extended inode.
     let mut inode = [0u8; 64];
@@ -728,38 +698,48 @@ fn write_fsmeta_inode(
     let nlink = node_nlink(node, &state.regular_file_link_counts);
     inode[44..48].copy_from_slice(&nlink.to_le_bytes());
 
-    file.write_all(&inode)?;
-
-    // Write xattr ibody.
-    let xattrs = node_xattrs(node);
-    if plan.xattr_ibody_size > 0 {
-        write_xattr_ibody(file, xattrs)?;
-    }
-
-    // For chunk-based regular files: write chunk index array.
-    if plan.data_layout == EROFS_INODE_CHUNK_BASED
-        && plan.chunk_count > 0
-        && let TreeNode::RegularFile(_) = node
     {
-        write_chunk_indexes(file, current_path, provenance, layer_maps, plan.chunk_count)?;
-    }
+        let mut tracked = CursorTrackingWriter::new(file, meta_cursor);
+        tracked.write_all(&inode)?;
 
-    // For non-chunk inodes: write inline tail data.
-    if plan.data_layout != EROFS_INODE_CHUNK_BASED && plan.inline_tail_size > 0 {
-        match node {
-            TreeNode::Directory(_) => {
-                if let Some(ref dir_data) = plan.dir_data {
-                    let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
-                    let tail = &dir_data[full_block_bytes..];
-                    file.write_all(tail)?;
+        // Write xattr ibody.
+        let xattrs = node_xattrs(node);
+        if plan.xattr_ibody_size > 0 {
+            write_xattr_ibody(&mut tracked, xattrs)?;
+        }
+
+        // For chunk-based regular files: write chunk index array.
+        if plan.data_layout == EROFS_INODE_CHUNK_BASED
+            && plan.chunk_count > 0
+            && let TreeNode::RegularFile(_) = node
+        {
+            write_chunk_indexes(
+                &mut tracked,
+                current_path,
+                provenance,
+                layer_maps,
+                plan.chunk_count,
+            )?;
+        }
+
+        // For non-chunk inodes: write inline tail data.
+        if plan.data_layout != EROFS_INODE_CHUNK_BASED && plan.inline_tail_size > 0 {
+            match node {
+                TreeNode::Directory(_) => {
+                    if let Some(ref dir_data) = plan.dir_data {
+                        let full_block_bytes =
+                            plan.data_block_count as usize * EROFS_BLKSIZ as usize;
+                        let tail = &dir_data[full_block_bytes..];
+                        tracked.write_all(tail)?;
+                    }
                 }
+                TreeNode::Symlink(s) => {
+                    let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
+                    let tail = &s.target[full_block_bytes..];
+                    tracked.write_all(tail)?;
+                }
+                _ => {}
             }
-            TreeNode::Symlink(s) => {
-                let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
-                let tail = &s.target[full_block_bytes..];
-                file.write_all(tail)?;
-            }
-            _ => {}
         }
     }
 
@@ -779,6 +759,7 @@ fn write_fsmeta_inode(
                         data_start_block,
                         plan_idx,
                         &child_path,
+                        meta_cursor,
                     )?;
                 }
                 _ => {
@@ -791,6 +772,7 @@ fn write_fsmeta_inode(
                         data_start_block,
                         plan_idx,
                         &child_path,
+                        meta_cursor,
                     )?;
                 }
             }
@@ -810,6 +792,7 @@ fn write_fsmeta_leaf(
     data_start_block: u32,
     plan_idx: &mut usize,
     current_path: &Path,
+    meta_cursor: &mut u64,
 ) -> Result<(), ErofsError> {
     let blksiz = EROFS_BLKSIZ as u64;
     let meta_base = state.meta_blkaddr as u64 * blksiz;
@@ -837,7 +820,7 @@ fn write_fsmeta_leaf(
     }
 
     let inode_offset = meta_base + plan.nid as u64 * EROFS_ISLOT_SIZE as u64;
-    file.seek(SeekFrom::Start(inode_offset))?;
+    write_zero_padding_to(file, meta_cursor, inode_offset)?;
 
     let mut inode = [0u8; 64];
 
@@ -891,26 +874,35 @@ fn write_fsmeta_leaf(
     let nlink = node_nlink(node, &state.regular_file_link_counts);
     inode[44..48].copy_from_slice(&nlink.to_le_bytes());
 
-    file.write_all(&inode)?;
-
-    let xattrs = node_xattrs(node);
-    if plan.xattr_ibody_size > 0 {
-        write_xattr_ibody(file, xattrs)?;
-    }
-
-    // For chunk-based regular files: write chunk index array.
-    if plan.data_layout == EROFS_INODE_CHUNK_BASED && plan.chunk_count > 0 {
-        write_chunk_indexes(file, current_path, provenance, layer_maps, plan.chunk_count)?;
-    }
-
-    // For non-chunk inodes with inline tail.
-    if plan.data_layout != EROFS_INODE_CHUNK_BASED
-        && plan.inline_tail_size > 0
-        && let TreeNode::Symlink(s) = node
     {
-        let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
-        let tail = &s.target[full_block_bytes..];
-        file.write_all(tail)?;
+        let mut tracked = CursorTrackingWriter::new(file, meta_cursor);
+        tracked.write_all(&inode)?;
+
+        let xattrs = node_xattrs(node);
+        if plan.xattr_ibody_size > 0 {
+            write_xattr_ibody(&mut tracked, xattrs)?;
+        }
+
+        // For chunk-based regular files: write chunk index array.
+        if plan.data_layout == EROFS_INODE_CHUNK_BASED && plan.chunk_count > 0 {
+            write_chunk_indexes(
+                &mut tracked,
+                current_path,
+                provenance,
+                layer_maps,
+                plan.chunk_count,
+            )?;
+        }
+
+        // For non-chunk inodes with inline tail.
+        if plan.data_layout != EROFS_INODE_CHUNK_BASED
+            && plan.inline_tail_size > 0
+            && let TreeNode::Symlink(s) = node
+        {
+            let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
+            let tail = &s.target[full_block_bytes..];
+            tracked.write_all(tail)?;
+        }
     }
 
     Ok(())
@@ -918,36 +910,31 @@ fn write_fsmeta_leaf(
 
 /// Write chunk index entries for a regular file.
 fn write_chunk_indexes(
-    file: &mut (impl Write + Seek),
+    file: &mut impl Write,
     file_path: &Path,
     provenance: &HashMap<PathBuf, usize>,
     layer_maps: &[ErofsDataMap],
     chunk_count: u32,
 ) -> Result<(), ErofsError> {
-    let source_layer = provenance.get(file_path).copied();
+    let source = provenance.get(file_path).and_then(|&layer_idx| {
+        let device_id = (layer_idx + 1) as u16;
+        layer_maps[layer_idx]
+            .file_blocks
+            .get(file_path)
+            .map(|&(start_block, _size)| (device_id, start_block))
+    });
 
     for chunk_idx in 0..chunk_count {
         let mut entry = [0u8; EROFS_CHUNK_INDEX_SIZE as usize];
 
-        if let Some(layer_idx) = source_layer {
-            let device_id = (layer_idx + 1) as u16; // 1-based
-            if let Some(&(start_block, _size)) = layer_maps[layer_idx].file_blocks.get(file_path) {
-                if start_block == EROFS_NULL_ADDR {
-                    // Empty file in layer — should not happen with chunk_count > 0.
-                    entry[2..4].copy_from_slice(&0u16.to_le_bytes()); // device_id = 0
-                    entry[4..8].copy_from_slice(&EROFS_NULL_ADDR.to_le_bytes());
-                } else {
-                    // advise: u16 = 0
-                    entry[2..4].copy_from_slice(&device_id.to_le_bytes());
-                    let blkaddr = start_block + chunk_idx;
-                    entry[4..8].copy_from_slice(&blkaddr.to_le_bytes());
-                }
-            } else {
-                // File not found in layer data map — emit hole.
+        if let Some((device_id, start_block)) = source {
+            if start_block == EROFS_NULL_ADDR {
                 entry[4..8].copy_from_slice(&EROFS_NULL_ADDR.to_le_bytes());
+            } else {
+                entry[2..4].copy_from_slice(&device_id.to_le_bytes());
+                entry[4..8].copy_from_slice(&(start_block + chunk_idx).to_le_bytes());
             }
         } else {
-            // No provenance — emit hole.
             entry[4..8].copy_from_slice(&EROFS_NULL_ADDR.to_le_bytes());
         }
 

--- a/crates/image/lib/erofs/fsmeta.rs
+++ b/crates/image/lib/erofs/fsmeta.rs
@@ -4,13 +4,13 @@
 //! (EROFS_INODE_CHUNK_BASED) referencing data in external layer blobs via
 //! device table entries. Directories and symlinks use standard flat layout.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::OsString;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use crate::crc32c;
-use crate::tree::{DirectoryNode, FileTree, TreeNode};
+use crate::tree::{DirectoryNode, FileTree, RegularFileId, TreeNode};
 
 use super::format::{
     EROFS_BLKSIZ, EROFS_BLKSIZ_BITS, EROFS_CHUNK_FORMAT_INDEXES, EROFS_CHUNK_INDEX_SIZE,
@@ -55,6 +55,8 @@ struct FsmetaInodePlan {
 
 struct FsmetaLayoutState {
     plans: Vec<FsmetaInodePlan>,
+    regular_file_plans: HashMap<RegularFileId, usize>,
+    regular_file_link_counts: HashMap<RegularFileId, u32>,
     current_meta_offset: u64,
     /// Only used for directory data blocks (fsmeta has no file data blocks).
     current_data_block: u32,
@@ -68,9 +70,11 @@ struct FsmetaLayoutState {
 //--------------------------------------------------------------------------------------------------
 
 impl FsmetaLayoutState {
-    fn new(meta_blkaddr: u32) -> Self {
+    fn new(meta_blkaddr: u32, merged_tree: &FileTree) -> Self {
         Self {
             plans: Vec::new(),
+            regular_file_plans: HashMap::new(),
+            regular_file_link_counts: merged_tree.regular_file_link_counts(),
             current_meta_offset: meta_blkaddr as u64 * EROFS_BLKSIZ as u64,
             current_data_block: 0,
             meta_blkaddr,
@@ -118,7 +122,7 @@ pub fn write_fsmeta(
     let mut fsmeta_blocks: u32 = meta_blkaddr + 1; // initial guess
 
     for _iteration in 0..4 {
-        let mut state = FsmetaLayoutState::new(meta_blkaddr);
+        let mut state = FsmetaLayoutState::new(meta_blkaddr, merged_tree);
         plan_fsmeta_directory(
             &merged_tree.root,
             0,
@@ -153,7 +157,7 @@ pub fn write_fsmeta(
     }
 
     // Final pass with the last estimate.
-    let mut state = FsmetaLayoutState::new(meta_blkaddr);
+    let mut state = FsmetaLayoutState::new(meta_blkaddr, merged_tree);
     plan_fsmeta_directory(
         &merged_tree.root,
         0,
@@ -348,8 +352,12 @@ fn plan_fsmeta_directory(
                 layer_maps,
                 &child_path,
             )?,
-            TreeNode::RegularFile(_) => {
-                plan_fsmeta_regular_file(child, state, provenance, layer_maps, &child_path)?
+            TreeNode::RegularFile(file) => {
+                if let Some(plan_idx) = state.regular_file_plans.get(&file.id) {
+                    state.plans[*plan_idx].nid
+                } else {
+                    plan_fsmeta_regular_file(child, state, provenance, layer_maps, &child_path)?
+                }
             }
             _ => plan_fsmeta_leaf_node(child, state)?,
         };
@@ -441,6 +449,9 @@ fn plan_fsmeta_regular_file(
         parent_nid: 0,
         chunk_count,
     };
+    if let TreeNode::RegularFile(file) = node {
+        state.regular_file_plans.insert(file.id, plan_idx);
+    }
 
     Ok(nid)
 }
@@ -516,6 +527,25 @@ fn write_fsmeta_dir_data(
     data_start_block: u32,
     plan_idx: &mut usize,
 ) -> Result<(), ErofsError> {
+    let mut seen_regular_files = HashSet::new();
+    write_fsmeta_dir_data_inner(
+        file,
+        state,
+        dir,
+        data_start_block,
+        plan_idx,
+        &mut seen_regular_files,
+    )
+}
+
+fn write_fsmeta_dir_data_inner(
+    file: &mut (impl Write + Seek),
+    state: &FsmetaLayoutState,
+    dir: &DirectoryNode,
+    data_start_block: u32,
+    plan_idx: &mut usize,
+    seen_regular_files: &mut HashSet<RegularFileId>,
+) -> Result<(), ErofsError> {
     let blksiz = EROFS_BLKSIZ as u64;
     let plan = &state.plans[*plan_idx];
     *plan_idx += 1;
@@ -540,7 +570,23 @@ fn write_fsmeta_dir_data(
     for child in dir.entries.values() {
         match child {
             TreeNode::Directory(child_dir) => {
-                write_fsmeta_dir_data(file, state, child_dir, data_start_block, plan_idx)?;
+                write_fsmeta_dir_data_inner(
+                    file,
+                    state,
+                    child_dir,
+                    data_start_block,
+                    plan_idx,
+                    seen_regular_files,
+                )?;
+            }
+            TreeNode::RegularFile(file) => {
+                if seen_regular_files.insert(file.id) {
+                    debug_assert_eq!(
+                        state.regular_file_plans.get(&file.id).copied(),
+                        Some(*plan_idx)
+                    );
+                    *plan_idx += 1;
+                }
             }
             TreeNode::Symlink(s) => {
                 let child_plan = &state.plans[*plan_idx];
@@ -679,7 +725,7 @@ fn write_fsmeta_inode(
     inode[32..40].copy_from_slice(&meta.mtime.to_le_bytes());
     inode[40..44].copy_from_slice(&meta.mtime_nsec.to_le_bytes());
 
-    let nlink = node_nlink(node);
+    let nlink = node_nlink(node, &state.regular_file_link_counts);
     inode[44..48].copy_from_slice(&nlink.to_le_bytes());
 
     file.write_all(&inode)?;
@@ -767,8 +813,28 @@ fn write_fsmeta_leaf(
 ) -> Result<(), ErofsError> {
     let blksiz = EROFS_BLKSIZ as u64;
     let meta_base = state.meta_blkaddr as u64 * blksiz;
-    let plan = &state.plans[*plan_idx];
-    *plan_idx += 1;
+    let (plan, first_regular_visit) = match node {
+        TreeNode::RegularFile(file) => {
+            let child_plan_idx = *state
+                .regular_file_plans
+                .get(&file.id)
+                .expect("regular file plan missing");
+            let first_visit = child_plan_idx == *plan_idx;
+            if first_visit {
+                *plan_idx += 1;
+            }
+            (&state.plans[child_plan_idx], first_visit)
+        }
+        _ => {
+            let plan = &state.plans[*plan_idx];
+            *plan_idx += 1;
+            (plan, true)
+        }
+    };
+
+    if !first_regular_visit {
+        return Ok(());
+    }
 
     let inode_offset = meta_base + plan.nid as u64 * EROFS_ISLOT_SIZE as u64;
     file.seek(SeekFrom::Start(inode_offset))?;
@@ -822,7 +888,7 @@ fn write_fsmeta_leaf(
     inode[32..40].copy_from_slice(&meta.mtime.to_le_bytes());
     inode[40..44].copy_from_slice(&meta.mtime_nsec.to_le_bytes());
 
-    let nlink = node_nlink(node);
+    let nlink = node_nlink(node, &state.regular_file_link_counts);
     inode[44..48].copy_from_slice(&nlink.to_le_bytes());
 
     file.write_all(&inode)?;
@@ -1013,13 +1079,29 @@ fn align_up(value: u64, alignment: u64) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, fs::File};
+    use std::{collections::HashMap, fs::File, path::PathBuf};
 
     use tempfile::tempdir;
 
-    use crate::tree::{FileTree, InodeMetadata, SymlinkNode, TreeNode};
+    use crate::{
+        erofs::write_erofs,
+        tree::{
+            FileData, FileTree, InodeMetadata, RegularFileId, RegularFileNode, SymlinkNode,
+            TreeNode,
+        },
+    };
 
     use super::{super::reader::ErofsReader, super::writer::ErofsDataMap, write_fsmeta};
+
+    fn regular_file_with_id(data: &[u8], id: RegularFileId) -> TreeNode {
+        TreeNode::RegularFile(RegularFileNode {
+            id,
+            metadata: InodeMetadata::default(),
+            xattrs: Vec::new(),
+            data: FileData::Memory(data.to_vec()),
+            nlink: 1,
+        })
+    }
 
     #[test]
     fn write_fsmeta_persists_plain_symlink_data_blocks() {
@@ -1051,5 +1133,61 @@ mod tests {
         let mut reader =
             ErofsReader::new(File::open(&output).expect("open fsmeta")).expect("create reader");
         assert_eq!(reader.read_link("/link").expect("read link"), target);
+    }
+
+    #[test]
+    fn write_fsmeta_preserves_hardlink_inode_identity() {
+        let content = b"shared layer data";
+        let file_id = RegularFileId::new();
+
+        let mut layer_tree = FileTree::new();
+        layer_tree
+            .insert(b"alpha", regular_file_with_id(content, file_id))
+            .expect("insert alpha layer file");
+        layer_tree
+            .insert(b"beta", regular_file_with_id(content, file_id))
+            .expect("insert beta layer file");
+
+        let output_dir = tempdir().expect("tempdir");
+        let layer_output = output_dir.path().join("layer.erofs");
+        let data_map = write_erofs(&layer_tree, &layer_output).expect("write layer erofs");
+        let alpha_path = PathBuf::from("alpha");
+        let beta_path = PathBuf::from("beta");
+
+        assert_eq!(
+            data_map
+                .file_blocks
+                .get(&alpha_path)
+                .copied()
+                .expect("alpha data map"),
+            data_map
+                .file_blocks
+                .get(&beta_path)
+                .copied()
+                .expect("beta data map")
+        );
+
+        let mut merged_tree = FileTree::new();
+        merged_tree
+            .insert(b"alpha", regular_file_with_id(b"", file_id))
+            .expect("insert alpha fsmeta file");
+        merged_tree
+            .insert(b"beta", regular_file_with_id(b"", file_id))
+            .expect("insert beta fsmeta file");
+
+        let provenance = HashMap::from([(alpha_path, 0usize), (beta_path, 0usize)]);
+        let fsmeta_output = output_dir.path().join("fsmeta.erofs");
+        write_fsmeta(&merged_tree, &provenance, &[data_map], &fsmeta_output).expect("write fsmeta");
+
+        let mut reader =
+            ErofsReader::new(File::open(&fsmeta_output).expect("open fsmeta")).expect("reader");
+        let alpha = reader.inode_debug_info("/alpha").expect("alpha inode");
+        let beta = reader.inode_debug_info("/beta").expect("beta inode");
+
+        assert_eq!(alpha.nid, beta.nid);
+        assert_eq!(alpha.nlink, 2);
+        assert_eq!(beta.nlink, 2);
+        assert_eq!(alpha.size, content.len() as u64);
+        assert_eq!(alpha.data_layout, super::EROFS_INODE_CHUNK_BASED);
     }
 }

--- a/crates/image/lib/erofs/reader.rs
+++ b/crates/image/lib/erofs/reader.rs
@@ -46,6 +46,15 @@ pub struct ErofsEntryInfo {
     pub whiteout: bool,
 }
 
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ErofsInodeDebugInfo {
+    pub nid: u32,
+    pub nlink: u32,
+    pub size: u64,
+    pub data_layout: u8,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
@@ -115,6 +124,17 @@ impl ErofsReader {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn inode_debug_info(&mut self, path: &str) -> io::Result<ErofsInodeDebugInfo> {
+        let inode = self.lookup_path(path)?;
+        Ok(ErofsInodeDebugInfo {
+            nid: inode.nid,
+            nlink: inode.nlink,
+            size: inode.size,
+            data_layout: inode.data_layout,
+        })
+    }
+
     fn inode_offset(&self, nid: u32) -> u64 {
         (self.meta_blkaddr as u64) * (EROFS_BLKSIZ as u64) + (nid as u64) * 32
     }
@@ -132,6 +152,8 @@ impl ErofsReader {
             buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15],
         ]);
         let i_u = u32::from_le_bytes([buf[16], buf[17], buf[18], buf[19]]);
+        #[cfg(test)]
+        let nlink = u32::from_le_bytes([buf[44], buf[45], buf[46], buf[47]]);
 
         let data_layout = ((i_format >> 1) & 0x07) as u8;
 
@@ -148,6 +170,8 @@ impl ErofsReader {
             nid,
             mode,
             size,
+            #[cfg(test)]
+            nlink,
             data_layout,
             startblk_lo: i_u,
             rdev: i_u,
@@ -376,6 +400,8 @@ struct InodeInfo {
     nid: u32,
     mode: u16,
     size: u64,
+    #[cfg(test)]
+    nlink: u32,
     data_layout: u8,
     startblk_lo: u32,
     rdev: u32,
@@ -548,18 +574,23 @@ pub fn entry_info_from_erofs(image_path: &Path, file_path: &str) -> io::Result<E
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::File, io};
+    use std::{fs::File, io, path::PathBuf};
 
     use tempfile::tempdir;
 
     use super::ErofsReader;
     use crate::{
         erofs::write_erofs,
-        tree::{FileData, FileTree, InodeMetadata, RegularFileNode, TreeNode},
+        tree::{FileData, FileTree, InodeMetadata, RegularFileId, RegularFileNode, TreeNode},
     };
 
     fn make_regular_file(data: &[u8]) -> TreeNode {
+        make_regular_file_with_id(data, RegularFileId::new())
+    }
+
+    fn make_regular_file_with_id(data: &[u8], id: RegularFileId) -> TreeNode {
         TreeNode::RegularFile(RegularFileNode {
+            id,
             metadata: InodeMetadata::default(),
             xattrs: Vec::new(),
             data: FileData::Memory(data.to_vec()),
@@ -594,5 +625,47 @@ mod tests {
             .entry_info("/dir/file-9999.txt")
             .expect_err("missing entry should fail");
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn hardlinked_regular_files_share_inode_and_data_blocks() {
+        let mut tree = FileTree::new();
+        let file_id = RegularFileId::new();
+
+        tree.insert(b"alpha", make_regular_file_with_id(b"shared", file_id))
+            .expect("insert alpha");
+        tree.insert(b"beta", make_regular_file_with_id(b"shared", file_id))
+            .expect("insert beta");
+
+        let output_dir = tempdir().expect("tempdir");
+        let output = output_dir.path().join("hardlinks.erofs");
+        let data_map = write_erofs(&tree, &output).expect("write erofs");
+        let alpha_path = PathBuf::from("alpha");
+        let beta_path = PathBuf::from("beta");
+
+        assert_eq!(
+            data_map
+                .file_blocks
+                .get(&alpha_path)
+                .copied()
+                .expect("alpha data map"),
+            data_map
+                .file_blocks
+                .get(&beta_path)
+                .copied()
+                .expect("beta data map")
+        );
+
+        let file = File::open(&output).expect("open erofs");
+        let mut reader = ErofsReader::new(file).expect("reader");
+        let alpha = reader.inode_debug_info("/alpha").expect("alpha inode");
+        let beta = reader.inode_debug_info("/beta").expect("beta inode");
+
+        assert_eq!(alpha.nid, beta.nid);
+        assert_eq!(alpha.nlink, 2);
+        assert_eq!(beta.nlink, 2);
+        assert_eq!(alpha.size, b"shared".len() as u64);
+        assert_eq!(reader.read_file("/alpha").expect("read alpha"), b"shared");
+        assert_eq!(reader.read_file("/beta").expect("read beta"), b"shared");
     }
 }

--- a/crates/image/lib/erofs/writer.rs
+++ b/crates/image/lib/erofs/writer.rs
@@ -1,11 +1,11 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::OsString;
 use std::io::{self, BufWriter, Seek, SeekFrom, Write};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
 use crate::crc32c;
-use crate::tree::{DirectoryNode, FileTree, InodeMetadata, TreeNode, Xattr};
+use crate::tree::{DirectoryNode, FileTree, InodeMetadata, RegularFileId, TreeNode, Xattr};
 
 use super::format::{
     self, EROFS_BLKSIZ, EROFS_BLKSIZ_BITS, EROFS_DIRENT_SIZE, EROFS_FEATURE_COMPAT_SB_CHKSUM,
@@ -62,6 +62,8 @@ struct InodePlan {
 #[allow(dead_code)]
 struct LayoutState {
     plans: Vec<InodePlan>,
+    regular_file_plans: HashMap<RegularFileId, usize>,
+    regular_file_link_counts: HashMap<RegularFileId, u32>,
     current_meta_offset: u64,
     current_data_block: u32,
     meta_blkaddr: u32,
@@ -74,9 +76,11 @@ struct LayoutState {
 //--------------------------------------------------------------------------------------------------
 
 impl LayoutState {
-    fn new() -> Self {
+    fn new(tree: &FileTree) -> Self {
         Self {
             plans: Vec::new(),
+            regular_file_plans: HashMap::new(),
+            regular_file_link_counts: tree.regular_file_link_counts(),
             current_meta_offset: EROFS_BLKSIZ as u64,
             current_data_block: 0,
             meta_blkaddr: 1,
@@ -121,7 +125,7 @@ impl From<io::Error> for ErofsError {
 
 pub fn write_erofs(tree: &FileTree, output: &Path) -> Result<ErofsDataMap, ErofsError> {
     let mut file = BufWriter::new(std::fs::File::create(output)?);
-    let mut state = LayoutState::new();
+    let mut state = LayoutState::new(tree);
 
     // Phase 1+2: Plan layout and assign NIDs.
     plan_directory(&tree.root, 0, &mut state, true)?;
@@ -479,9 +483,15 @@ pub(super) fn node_metadata(node: &TreeNode) -> &InodeMetadata {
     }
 }
 
-pub(super) fn node_nlink(node: &TreeNode) -> u32 {
+pub(super) fn node_nlink(
+    node: &TreeNode,
+    regular_file_link_counts: &HashMap<RegularFileId, u32>,
+) -> u32 {
     match node {
-        TreeNode::RegularFile(f) => f.nlink,
+        TreeNode::RegularFile(f) => regular_file_link_counts
+            .get(&f.id)
+            .copied()
+            .unwrap_or(f.nlink.max(1)),
         TreeNode::Directory(d) => {
             // nlink for directory = 2 + number of child directories
             let child_dirs = d
@@ -579,6 +589,7 @@ fn plan_directory(
     for (name, child) in &dir.entries {
         let child_nid = match child {
             TreeNode::Directory(child_dir) => plan_directory(child_dir, dir_nid, state, false)?,
+            TreeNode::RegularFile(file) => plan_regular_file(child, file.id, state)?,
             _ => plan_leaf_node(child, state)?,
         };
         child_nids.insert(name.clone(), child_nid);
@@ -594,6 +605,21 @@ fn plan_directory(
     state.plans[dir_plan_idx].dir_data = Some(dir_data);
 
     Ok(dir_nid)
+}
+
+fn plan_regular_file(
+    node: &TreeNode,
+    file_id: RegularFileId,
+    state: &mut LayoutState,
+) -> Result<u32, ErofsError> {
+    if let Some(plan_idx) = state.regular_file_plans.get(&file_id) {
+        return Ok(state.plans[*plan_idx].nid);
+    }
+
+    let plan_idx = state.plans.len();
+    let nid = plan_leaf_node(node, state)?;
+    state.regular_file_plans.insert(file_id, plan_idx);
+    Ok(nid)
 }
 
 fn plan_leaf_node(node: &TreeNode, state: &mut LayoutState) -> Result<u32, ErofsError> {
@@ -687,6 +713,7 @@ fn write_data_blocks(
 
     // Write data blocks for each plan that has data blocks
     let current_path = PathBuf::new();
+    let mut written_regular_files = HashSet::new();
     write_data_for_tree(
         file,
         state,
@@ -695,11 +722,13 @@ fn write_data_blocks(
         &mut 0,
         &current_path,
         data_map,
+        &mut written_regular_files,
     )?;
 
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_data_for_tree(
     file: &mut (impl Write + Seek),
     state: &LayoutState,
@@ -708,6 +737,7 @@ fn write_data_for_tree(
     plan_idx: &mut usize,
     current_path: &Path,
     data_map: &mut HashMap<PathBuf, (u32, u64)>,
+    written_regular_files: &mut HashSet<RegularFileId>,
 ) -> Result<(), ErofsError> {
     let blksiz = EROFS_BLKSIZ as u64;
     let plan = &state.plans[*plan_idx];
@@ -745,11 +775,20 @@ fn write_data_for_tree(
                     plan_idx,
                     &child_path,
                     data_map,
+                    written_regular_files,
                 )?;
             }
             TreeNode::RegularFile(f) => {
-                let child_plan = &state.plans[*plan_idx];
-                *plan_idx += 1;
+                let child_plan_idx = *state
+                    .regular_file_plans
+                    .get(&f.id)
+                    .expect("regular file plan missing");
+                let child_plan = &state.plans[child_plan_idx];
+                let first_visit = written_regular_files.insert(f.id);
+                if first_visit {
+                    debug_assert_eq!(child_plan_idx, *plan_idx);
+                    *plan_idx += 1;
+                }
 
                 // Record block address for this file in the data map.
                 if child_plan.data_block_start != EROFS_NULL_ADDR {
@@ -760,7 +799,7 @@ fn write_data_for_tree(
                     data_map.insert(child_path, (EROFS_NULL_ADDR, 0));
                 }
 
-                if child_plan.data_block_count > 0 {
+                if first_visit && child_plan.data_block_count > 0 {
                     let abs_block = data_start_block + child_plan.data_block_start;
                     let offset = abs_block as u64 * blksiz;
                     file.seek(SeekFrom::Start(offset))?;
@@ -943,7 +982,7 @@ fn write_metadata_for_tree(
     inode[40..44].copy_from_slice(&meta.mtime_nsec.to_le_bytes());
 
     // i_nlink
-    let nlink = node_nlink(node);
+    let nlink = node_nlink(node, &state.regular_file_link_counts);
     inode[44..48].copy_from_slice(&nlink.to_le_bytes());
 
     // reserved[16] already zeroed
@@ -1013,8 +1052,28 @@ fn write_metadata_for_leaf(
 ) -> Result<(), ErofsError> {
     let blksiz = EROFS_BLKSIZ as u64;
     let meta_base = state.meta_blkaddr as u64 * blksiz;
-    let plan = &state.plans[*plan_idx];
-    *plan_idx += 1;
+    let (plan, first_regular_visit) = match node {
+        TreeNode::RegularFile(file) => {
+            let child_plan_idx = *state
+                .regular_file_plans
+                .get(&file.id)
+                .expect("regular file plan missing");
+            let first_visit = child_plan_idx == *plan_idx;
+            if first_visit {
+                *plan_idx += 1;
+            }
+            (&state.plans[child_plan_idx], first_visit)
+        }
+        _ => {
+            let plan = &state.plans[*plan_idx];
+            *plan_idx += 1;
+            (plan, true)
+        }
+    };
+
+    if !first_regular_visit {
+        return Ok(());
+    }
 
     let inode_offset = meta_base + plan.nid as u64 * EROFS_ISLOT_SIZE as u64;
     file.seek(SeekFrom::Start(inode_offset))?;
@@ -1056,7 +1115,7 @@ fn write_metadata_for_leaf(
     inode[32..40].copy_from_slice(&meta.mtime.to_le_bytes());
     inode[40..44].copy_from_slice(&meta.mtime_nsec.to_le_bytes());
 
-    let nlink = node_nlink(node);
+    let nlink = node_nlink(node, &state.regular_file_link_counts);
     inode[44..48].copy_from_slice(&nlink.to_le_bytes());
 
     file.write_all(&inode)?;

--- a/crates/image/lib/erofs/writer.rs
+++ b/crates/image/lib/erofs/writer.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsString;
 use std::io::{self, BufWriter, Seek, SeekFrom, Write};
 use std::os::unix::ffi::OsStrExt;
@@ -71,22 +71,33 @@ struct LayoutState {
     inode_count: u64,
 }
 
+pub(super) struct CursorTrackingWriter<'a, W> {
+    inner: &'a mut W,
+    cursor: &'a mut u64,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
 
 impl LayoutState {
-    fn new(tree: &FileTree) -> Self {
+    fn new() -> Self {
         Self {
             plans: Vec::new(),
             regular_file_plans: HashMap::new(),
-            regular_file_link_counts: tree.regular_file_link_counts(),
+            regular_file_link_counts: HashMap::new(),
             current_meta_offset: EROFS_BLKSIZ as u64,
             current_data_block: 0,
             meta_blkaddr: 1,
             root_nid: 0,
             inode_count: 0,
         }
+    }
+}
+
+impl<'a, W> CursorTrackingWriter<'a, W> {
+    pub(super) fn new(inner: &'a mut W, cursor: &'a mut u64) -> Self {
+        Self { inner, cursor }
     }
 }
 
@@ -119,20 +130,37 @@ impl From<io::Error> for ErofsError {
     }
 }
 
+impl<W: Write> Write for CursorTrackingWriter<'_, W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        *self.cursor += written as u64;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
 
 pub fn write_erofs(tree: &FileTree, output: &Path) -> Result<ErofsDataMap, ErofsError> {
     let mut file = BufWriter::new(std::fs::File::create(output)?);
-    let mut state = LayoutState::new(tree);
+    let mut state = LayoutState::new();
 
     // Phase 1+2: Plan layout and assign NIDs.
     plan_directory(&tree.root, 0, &mut state, true)?;
     state.root_nid = state.plans[0].nid;
 
     // Phase 3: Write data blocks and collect data map.
-    let mut data_map = HashMap::new();
+    let regular_file_paths = state
+        .regular_file_link_counts
+        .values()
+        .map(|count| *count as usize)
+        .sum();
+    let mut data_map = HashMap::with_capacity(regular_file_paths);
     write_data_blocks(&mut file, &state, tree, &mut data_map)?;
 
     // Phase 4: Write metadata.
@@ -612,6 +640,8 @@ fn plan_regular_file(
     file_id: RegularFileId,
     state: &mut LayoutState,
 ) -> Result<u32, ErofsError> {
+    *state.regular_file_link_counts.entry(file_id).or_insert(0) += 1;
+
     if let Some(plan_idx) = state.regular_file_plans.get(&file_id) {
         return Ok(state.plans[*plan_idx].nid);
     }
@@ -688,6 +718,27 @@ fn plan_leaf_node(node: &TreeNode, state: &mut LayoutState) -> Result<u32, Erofs
     Ok(nid)
 }
 
+pub(super) fn write_zero_padding_to(
+    file: &mut impl Write,
+    cursor: &mut u64,
+    target: u64,
+) -> Result<(), ErofsError> {
+    if target < *cursor {
+        return Err(ErofsError::Io(io::Error::other(
+            "EROFS layout cursor moved backwards",
+        )));
+    }
+
+    while *cursor < target {
+        let remaining = (target - *cursor) as usize;
+        let to_write = remaining.min(ZEROS.len());
+        file.write_all(&ZEROS[..to_write])?;
+        *cursor += to_write as u64;
+    }
+
+    Ok(())
+}
+
 fn write_data_blocks(
     file: &mut (impl Write + Seek),
     state: &LayoutState,
@@ -711,9 +762,10 @@ fn write_data_blocks(
     // During planning, we started current_data_block at 0, which means they're
     // relative to the data area. We need to add the data_start_block offset.
 
-    // Write data blocks for each plan that has data blocks
+    file.seek(SeekFrom::Start(data_area_start))?;
+    let mut data_cursor = data_area_start;
+
     let current_path = PathBuf::new();
-    let mut written_regular_files = HashSet::new();
     write_data_for_tree(
         file,
         state,
@@ -722,7 +774,7 @@ fn write_data_blocks(
         &mut 0,
         &current_path,
         data_map,
-        &mut written_regular_files,
+        &mut data_cursor,
     )?;
 
     Ok(())
@@ -737,7 +789,7 @@ fn write_data_for_tree(
     plan_idx: &mut usize,
     current_path: &Path,
     data_map: &mut HashMap<PathBuf, (u32, u64)>,
-    written_regular_files: &mut HashSet<RegularFileId>,
+    data_cursor: &mut u64,
 ) -> Result<(), ErofsError> {
     let blksiz = EROFS_BLKSIZ as u64;
     let plan = &state.plans[*plan_idx];
@@ -749,16 +801,17 @@ fn write_data_for_tree(
     {
         let abs_block = data_start_block + plan.data_block_start;
         let offset = abs_block as u64 * blksiz;
-        file.seek(SeekFrom::Start(offset))?;
+        write_zero_padding_to(file, data_cursor, offset)?;
+        let mut tracked = CursorTrackingWriter::new(file, data_cursor);
 
         let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
         let data_to_write = &dir_data[..std::cmp::min(full_block_bytes, dir_data.len())];
-        file.write_all(data_to_write)?;
+        tracked.write_all(data_to_write)?;
 
         // Pad remaining space in last full block if needed
         if data_to_write.len() < full_block_bytes {
             let pad = full_block_bytes - data_to_write.len();
-            file.write_all(&ZEROS[..pad])?;
+            tracked.write_all(&ZEROS[..pad])?;
         }
     }
 
@@ -775,7 +828,7 @@ fn write_data_for_tree(
                     plan_idx,
                     &child_path,
                     data_map,
-                    written_regular_files,
+                    data_cursor,
                 )?;
             }
             TreeNode::RegularFile(f) => {
@@ -784,9 +837,8 @@ fn write_data_for_tree(
                     .get(&f.id)
                     .expect("regular file plan missing");
                 let child_plan = &state.plans[child_plan_idx];
-                let first_visit = written_regular_files.insert(f.id);
+                let first_visit = child_plan_idx == *plan_idx;
                 if first_visit {
-                    debug_assert_eq!(child_plan_idx, *plan_idx);
                     *plan_idx += 1;
                 }
 
@@ -802,7 +854,8 @@ fn write_data_for_tree(
                 if first_visit && child_plan.data_block_count > 0 {
                     let abs_block = data_start_block + child_plan.data_block_start;
                     let offset = abs_block as u64 * blksiz;
-                    file.seek(SeekFrom::Start(offset))?;
+                    write_zero_padding_to(file, data_cursor, offset)?;
+                    let mut tracked = CursorTrackingWriter::new(file, data_cursor);
 
                     let full_block_bytes =
                         child_plan.data_block_count as usize * EROFS_BLKSIZ as usize;
@@ -812,13 +865,13 @@ fn write_data_for_tree(
                         std::cmp::min(f.data.len(), full_block_bytes)
                     };
 
-                    f.data.write_range(0, data_end, file)?;
+                    f.data.write_range(0, data_end, &mut tracked)?;
 
                     if child_plan.data_layout == EROFS_INODE_FLAT_PLAIN
                         && data_end < full_block_bytes
                     {
                         let pad = full_block_bytes - data_end;
-                        file.write_all(&ZEROS[..pad])?;
+                        tracked.write_all(&ZEROS[..pad])?;
                     }
                 }
             }
@@ -829,7 +882,8 @@ fn write_data_for_tree(
                 if child_plan.data_block_count > 0 {
                     let abs_block = data_start_block + child_plan.data_block_start;
                     let offset = abs_block as u64 * blksiz;
-                    file.seek(SeekFrom::Start(offset))?;
+                    write_zero_padding_to(file, data_cursor, offset)?;
+                    let mut tracked = CursorTrackingWriter::new(file, data_cursor);
 
                     let full_block_bytes =
                         child_plan.data_block_count as usize * EROFS_BLKSIZ as usize;
@@ -839,13 +893,13 @@ fn write_data_for_tree(
                         std::cmp::min(s.target.len(), full_block_bytes)
                     };
 
-                    file.write_all(&s.target[..data_end])?;
+                    tracked.write_all(&s.target[..data_end])?;
 
                     if child_plan.data_layout == EROFS_INODE_FLAT_PLAIN
                         && data_end < full_block_bytes
                     {
                         let pad = full_block_bytes - data_end;
-                        file.write_all(&ZEROS[..pad])?;
+                        tracked.write_all(&ZEROS[..pad])?;
                     }
                 }
             }
@@ -866,6 +920,9 @@ fn write_metadata(
 ) -> Result<(), ErofsError> {
     let meta_end = align_to_block(state.current_meta_offset);
     let data_start_block = (meta_end / EROFS_BLKSIZ as u64) as u32;
+    let mut meta_cursor = state.meta_blkaddr as u64 * EROFS_BLKSIZ as u64;
+
+    file.seek(SeekFrom::Start(meta_cursor))?;
 
     write_metadata_for_tree(
         file,
@@ -874,6 +931,7 @@ fn write_metadata(
         &tree.root,
         data_start_block,
         &mut 0,
+        &mut meta_cursor,
     )?;
 
     Ok(())
@@ -907,6 +965,7 @@ fn write_metadata_for_tree(
     real_dir: &DirectoryNode,
     data_start_block: u32,
     plan_idx: &mut usize,
+    meta_cursor: &mut u64,
 ) -> Result<(), ErofsError> {
     let blksiz = EROFS_BLKSIZ as u64;
     let meta_base = state.meta_blkaddr as u64 * blksiz;
@@ -916,8 +975,7 @@ fn write_metadata_for_tree(
     // Compute the byte offset of this inode
     let inode_offset = meta_base + plan.nid as u64 * EROFS_ISLOT_SIZE as u64;
 
-    // Seek to inode position
-    file.seek(SeekFrom::Start(inode_offset))?;
+    write_zero_padding_to(file, meta_cursor, inode_offset)?;
 
     // Build the 64-byte extended inode
     let mut inode = [0u8; 64];
@@ -987,35 +1045,40 @@ fn write_metadata_for_tree(
 
     // reserved[16] already zeroed
 
-    file.write_all(&inode)?;
+    {
+        let mut tracked = CursorTrackingWriter::new(file, meta_cursor);
+        tracked.write_all(&inode)?;
 
-    // Write xattr ibody if present
-    let xattrs = node_xattrs(node);
-    if plan.xattr_ibody_size > 0 {
-        write_xattr_ibody(file, xattrs)?;
-    }
+        // Write xattr ibody if present
+        let xattrs = node_xattrs(node);
+        if plan.xattr_ibody_size > 0 {
+            write_xattr_ibody(&mut tracked, xattrs)?;
+        }
 
-    // Write inline tail data
-    if plan.inline_tail_size > 0 {
-        match node {
-            TreeNode::Directory(_) => {
-                if let Some(ref dir_data) = plan.dir_data {
-                    let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
-                    let tail = &dir_data[full_block_bytes..];
-                    file.write_all(tail)?;
+        // Write inline tail data
+        if plan.inline_tail_size > 0 {
+            match node {
+                TreeNode::Directory(_) => {
+                    if let Some(ref dir_data) = plan.dir_data {
+                        let full_block_bytes =
+                            plan.data_block_count as usize * EROFS_BLKSIZ as usize;
+                        let tail = &dir_data[full_block_bytes..];
+                        tracked.write_all(tail)?;
+                    }
                 }
+                TreeNode::RegularFile(f) => {
+                    let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
+                    let tail_len = f.data.len() - full_block_bytes;
+                    f.data
+                        .write_range(full_block_bytes, tail_len, &mut tracked)?;
+                }
+                TreeNode::Symlink(s) => {
+                    let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
+                    let tail = &s.target[full_block_bytes..];
+                    tracked.write_all(tail)?;
+                }
+                _ => {}
             }
-            TreeNode::RegularFile(f) => {
-                let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
-                let tail_len = f.data.len() - full_block_bytes;
-                f.data.write_range(full_block_bytes, tail_len, file)?;
-            }
-            TreeNode::Symlink(s) => {
-                let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
-                let tail = &s.target[full_block_bytes..];
-                file.write_all(tail)?;
-            }
-            _ => {}
         }
     }
 
@@ -1031,10 +1094,18 @@ fn write_metadata_for_tree(
                         child_dir,
                         data_start_block,
                         plan_idx,
+                        meta_cursor,
                     )?;
                 }
                 _ => {
-                    write_metadata_for_leaf(file, state, child, data_start_block, plan_idx)?;
+                    write_metadata_for_leaf(
+                        file,
+                        state,
+                        child,
+                        data_start_block,
+                        plan_idx,
+                        meta_cursor,
+                    )?;
                 }
             }
         }
@@ -1049,6 +1120,7 @@ fn write_metadata_for_leaf(
     node: &TreeNode,
     data_start_block: u32,
     plan_idx: &mut usize,
+    meta_cursor: &mut u64,
 ) -> Result<(), ErofsError> {
     let blksiz = EROFS_BLKSIZ as u64;
     let meta_base = state.meta_blkaddr as u64 * blksiz;
@@ -1076,7 +1148,7 @@ fn write_metadata_for_leaf(
     }
 
     let inode_offset = meta_base + plan.nid as u64 * EROFS_ISLOT_SIZE as u64;
-    file.seek(SeekFrom::Start(inode_offset))?;
+    write_zero_padding_to(file, meta_cursor, inode_offset)?;
 
     let mut inode = [0u8; 64];
 
@@ -1118,36 +1190,37 @@ fn write_metadata_for_leaf(
     let nlink = node_nlink(node, &state.regular_file_link_counts);
     inode[44..48].copy_from_slice(&nlink.to_le_bytes());
 
-    file.write_all(&inode)?;
+    {
+        let mut tracked = CursorTrackingWriter::new(file, meta_cursor);
+        tracked.write_all(&inode)?;
 
-    let xattrs = node_xattrs(node);
-    if plan.xattr_ibody_size > 0 {
-        write_xattr_ibody(file, xattrs)?;
-    }
+        let xattrs = node_xattrs(node);
+        if plan.xattr_ibody_size > 0 {
+            write_xattr_ibody(&mut tracked, xattrs)?;
+        }
 
-    if plan.inline_tail_size > 0 {
-        match node {
-            TreeNode::RegularFile(f) => {
-                let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
-                let tail_len = f.data.len() - full_block_bytes;
-                f.data.write_range(full_block_bytes, tail_len, file)?;
+        if plan.inline_tail_size > 0 {
+            match node {
+                TreeNode::RegularFile(f) => {
+                    let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
+                    let tail_len = f.data.len() - full_block_bytes;
+                    f.data
+                        .write_range(full_block_bytes, tail_len, &mut tracked)?;
+                }
+                TreeNode::Symlink(s) => {
+                    let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
+                    let tail = &s.target[full_block_bytes..];
+                    tracked.write_all(tail)?;
+                }
+                _ => {}
             }
-            TreeNode::Symlink(s) => {
-                let full_block_bytes = plan.data_block_count as usize * EROFS_BLKSIZ as usize;
-                let tail = &s.target[full_block_bytes..];
-                file.write_all(tail)?;
-            }
-            _ => {}
         }
     }
 
     Ok(())
 }
 
-pub(super) fn write_xattr_ibody(
-    file: &mut (impl Write + Seek),
-    xattrs: &[Xattr],
-) -> Result<(), ErofsError> {
+pub(super) fn write_xattr_ibody(file: &mut impl Write, xattrs: &[Xattr]) -> Result<(), ErofsError> {
     // Write the ibody header (12 bytes)
     // h_name_filter: u32 = 0, h_shared_count: u8 = 0, reserved: [u8; 7] = 0
     let header = [0u8; EROFS_XATTR_IBODY_HEADER_SIZE as usize];

--- a/crates/image/lib/tar/ingest.rs
+++ b/crates/image/lib/tar/ingest.rs
@@ -312,15 +312,13 @@ pub async fn ingest_tar<R: AsyncRead + Unpin>(
                         tree.insert(&whiteout_path, node)?;
                     }
                     WhiteoutKind::None => {
-                        let mut buf = Vec::with_capacity(size as usize);
-                        entry.read_to_end(&mut buf).await.map_err(IngestError::Io)?;
-
-                        // Spool large files to disk to bound memory usage.
-                        let file_data = if buf.len() as u64 >= SPOOL_THRESHOLD
+                        let file_data = if size >= SPOOL_THRESHOLD
                             && let Some(spool) = spool.as_mut()
                         {
-                            spool.write_data(&buf).map_err(IngestError::Io)?
+                            stream_entry_to_spool(&mut entry, size, spool).await?
                         } else {
+                            let mut buf = Vec::with_capacity(size as usize);
+                            entry.read_to_end(&mut buf).await.map_err(IngestError::Io)?;
                             FileData::Memory(buf)
                         };
 
@@ -687,58 +685,58 @@ fn handle_hardlink(
     link_path: &[u8],
     target_path: &[u8],
 ) -> Result<(), IngestError> {
-    let target_path_str = String::from_utf8_lossy(target_path).into_owned();
-
-    // Look up the target node and clone it.
-    let cloned_node = match tree.get(target_path) {
+    let node = match tree.get_mut(target_path) {
         Some(TreeNode::RegularFile(f)) => {
-            let cloned = RegularFileNode {
+            let new_nlink = f.nlink + 1;
+            f.nlink = new_nlink;
+            TreeNode::RegularFile(RegularFileNode {
                 id: f.id,
-                metadata: InodeMetadata {
-                    uid: f.metadata.uid,
-                    gid: f.metadata.gid,
-                    mode: f.metadata.mode,
-                    mtime: f.metadata.mtime,
-                    mtime_nsec: f.metadata.mtime_nsec,
-                },
-                xattrs: f
-                    .xattrs
-                    .iter()
-                    .map(|x| Xattr {
-                        name: x.name.clone(),
-                        value: x.value.clone(),
-                    })
-                    .collect(),
-                data: DataSpool::clone_ref(&f.data),
-                nlink: f.nlink + 1,
-            };
-            // The new copy also gets incremented nlink.
-            let new_nlink = cloned.nlink;
-            (TreeNode::RegularFile(cloned), new_nlink)
+                metadata: f.metadata.clone(),
+                xattrs: f.xattrs.clone(),
+                data: f.data.clone_ref(),
+                nlink: new_nlink,
+            })
         }
         Some(_) => {
-            // Hardlinks to non-regular files: clone metadata only.
             return Err(IngestError::HardlinkTarget(format!(
-                "hardlink target is not a regular file: \"{target_path_str}\""
+                "hardlink target is not a regular file: \"{}\"",
+                String::from_utf8_lossy(target_path)
             )));
         }
         None => {
-            return Err(IngestError::HardlinkTarget(target_path_str));
+            return Err(IngestError::HardlinkTarget(
+                String::from_utf8_lossy(target_path).into_owned(),
+            ));
         }
     };
 
-    let (node, new_nlink) = cloned_node;
-
-    // Update the nlink on the original target.
-    if let Some(TreeNode::RegularFile(target)) = tree.get_mut(target_path) {
-        target.nlink = new_nlink;
-    }
-
-    // Insert the cloned node at the link path.
     tree.insert(link_path, node)?;
-    tree.refresh_regular_nlinks();
 
     Ok(())
+}
+
+async fn stream_entry_to_spool<R: AsyncRead + Unpin>(
+    entry: &mut tar::Entry<R>,
+    size: u64,
+    spool: &mut DataSpool,
+) -> Result<FileData, IngestError> {
+    let offset = spool.current_offset();
+    let mut remaining = size;
+    let mut buf = vec![0u8; 1024 * 1024];
+
+    while remaining > 0 {
+        let to_read = remaining.min(buf.len() as u64) as usize;
+        entry
+            .read_exact(&mut buf[..to_read])
+            .await
+            .map_err(IngestError::Io)?;
+        spool
+            .write_chunk(&buf[..to_read])
+            .map_err(IngestError::Io)?;
+        remaining -= to_read as u64;
+    }
+
+    Ok(spool.data_ref(offset, size))
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1153,12 +1151,15 @@ mod tests {
             header.set_cksum();
             b.append(&header, &content[..]).unwrap();
 
-            for link_name in ["hardlink-a.txt", "hardlink-b.txt"] {
+            for (link_name, target_name) in [
+                ("hardlink-a.txt", "original.txt"),
+                ("hardlink-b.txt", "hardlink-a.txt"),
+            ] {
                 let mut header = sync_tar::Header::new_gnu();
                 header.set_path(link_name).unwrap();
                 header.set_size(0);
                 header.set_entry_type(sync_tar::EntryType::Link);
-                header.set_link_name("original.txt").unwrap();
+                header.set_link_name(target_name).unwrap();
                 header.set_cksum();
                 b.append(&header, &[] as &[u8]).unwrap();
             }

--- a/crates/image/lib/tar/ingest.rs
+++ b/crates/image/lib/tar/ingest.rs
@@ -16,7 +16,7 @@ use tokio_tar as tar;
 
 use crate::tree::{
     DataSpool, DeviceNode, DirectoryNode, FileData, FileTree, FileTreeError, InodeMetadata,
-    RegularFileNode, ResourceLimits, SPOOL_THRESHOLD, SymlinkNode, TreeNode, Xattr,
+    RegularFileId, RegularFileNode, ResourceLimits, SPOOL_THRESHOLD, SymlinkNode, TreeNode, Xattr,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -325,6 +325,7 @@ pub async fn ingest_tar<R: AsyncRead + Unpin>(
                         };
 
                         let node = TreeNode::RegularFile(RegularFileNode {
+                            id: RegularFileId::new(),
                             metadata,
                             xattrs: Vec::new(),
                             data: file_data,
@@ -376,6 +377,8 @@ pub async fn ingest_tar<R: AsyncRead + Unpin>(
             tokio::task::yield_now().await;
         }
     }
+
+    tree.refresh_regular_nlinks();
 
     Ok(tree)
 }
@@ -690,6 +693,7 @@ fn handle_hardlink(
     let cloned_node = match tree.get(target_path) {
         Some(TreeNode::RegularFile(f)) => {
             let cloned = RegularFileNode {
+                id: f.id,
                 metadata: InodeMetadata {
                     uid: f.metadata.uid,
                     gid: f.metadata.gid,
@@ -732,6 +736,7 @@ fn handle_hardlink(
 
     // Insert the cloned node at the link path.
     tree.insert(link_path, node)?;
+    tree.refresh_regular_nlinks();
 
     Ok(())
 }
@@ -1118,21 +1123,65 @@ mod tests {
             .await
             .unwrap();
 
-        // Both should exist with the same data and nlink=2.
-        match tree.get(b"original.txt").unwrap() {
-            TreeNode::RegularFile(f) => {
-                assert_eq!(f.data, FileData::Memory(b"shared data".to_vec()));
-                assert_eq!(f.nlink, 2);
-            }
+        // Both should exist with the same data, inode identity, and nlink=2.
+        let original = match tree.get(b"original.txt").unwrap() {
+            TreeNode::RegularFile(f) => f,
             _ => panic!("expected regular file"),
-        }
-        match tree.get(b"hardlink.txt").unwrap() {
-            TreeNode::RegularFile(f) => {
-                assert_eq!(f.data, FileData::Memory(b"shared data".to_vec()));
-                assert_eq!(f.nlink, 2);
-            }
+        };
+        let hardlink = match tree.get(b"hardlink.txt").unwrap() {
+            TreeNode::RegularFile(f) => f,
             _ => panic!("expected regular file"),
-        }
+        };
+
+        assert_eq!(original.data, FileData::Memory(b"shared data".to_vec()));
+        assert_eq!(hardlink.data, FileData::Memory(b"shared data".to_vec()));
+        assert_eq!(original.id, hardlink.id);
+        assert_eq!(original.nlink, 2);
+        assert_eq!(hardlink.nlink, 2);
+        assert_eq!(tree.total_data_size(), b"shared data".len() as u64);
+    }
+
+    #[tokio::test]
+    async fn ingest_hardlink_chain_refreshes_link_counts() {
+        let data = build_tar(|b| {
+            let content = b"shared data";
+            let mut header = sync_tar::Header::new_gnu();
+            header.set_path("original.txt").unwrap();
+            header.set_size(content.len() as u64);
+            header.set_entry_type(sync_tar::EntryType::Regular);
+            header.set_mode(0o644);
+            header.set_cksum();
+            b.append(&header, &content[..]).unwrap();
+
+            for link_name in ["hardlink-a.txt", "hardlink-b.txt"] {
+                let mut header = sync_tar::Header::new_gnu();
+                header.set_path(link_name).unwrap();
+                header.set_size(0);
+                header.set_entry_type(sync_tar::EntryType::Link);
+                header.set_link_name("original.txt").unwrap();
+                header.set_cksum();
+                b.append(&header, &[] as &[u8]).unwrap();
+            }
+        });
+
+        let limits = ResourceLimits::default();
+        let tree = ingest_tar(std::io::Cursor::new(data), &limits, None)
+            .await
+            .unwrap();
+
+        let ids = ["original.txt", "hardlink-a.txt", "hardlink-b.txt"].map(|path| {
+            match tree.get(path.as_bytes()).unwrap() {
+                TreeNode::RegularFile(f) => {
+                    assert_eq!(f.nlink, 3);
+                    f.id
+                }
+                _ => panic!("expected regular file"),
+            }
+        });
+
+        assert_eq!(ids[0], ids[1]);
+        assert_eq!(ids[0], ids[2]);
+        assert_eq!(tree.total_data_size(), b"shared data".len() as u64);
     }
 
     #[tokio::test]

--- a/crates/image/lib/tree/model.rs
+++ b/crates/image/lib/tree/model.rs
@@ -38,6 +38,8 @@ pub(crate) const OPAQUE_XATTR_VALUE: &[u8] = b"y";
 pub enum FileData {
     /// Small file content held in memory.
     Memory(Vec<u8>),
+    /// In-memory content shared by hardlinked regular-file aliases.
+    SharedMemory(Arc<[u8]>),
     /// Large file content written to a shared spool file on disk.
     /// Multiple `FileData::Spool` entries can reference different regions
     /// of the same underlying spool file via `Arc`.
@@ -52,6 +54,9 @@ impl std::fmt::Debug for FileData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FileData::Memory(data) => f.debug_tuple("Memory").field(&data.len()).finish(),
+            FileData::SharedMemory(data) => {
+                f.debug_tuple("SharedMemory").field(&data.len()).finish()
+            }
             FileData::Spool { offset, len, .. } => f
                 .debug_struct("Spool")
                 .field("offset", offset)
@@ -65,6 +70,9 @@ impl PartialEq for FileData {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (FileData::Memory(a), FileData::Memory(b)) => a == b,
+            (FileData::Memory(a), FileData::SharedMemory(b))
+            | (FileData::SharedMemory(b), FileData::Memory(a)) => a.as_slice() == b.as_ref(),
+            (FileData::SharedMemory(a), FileData::SharedMemory(b)) => a.as_ref() == b.as_ref(),
             _ => false,
         }
     }
@@ -170,6 +178,7 @@ impl FileData {
     pub fn len(&self) -> usize {
         match self {
             FileData::Memory(v) => v.len(),
+            FileData::SharedMemory(v) => v.len(),
             FileData::Spool { len, .. } => *len as usize,
         }
     }
@@ -183,6 +192,7 @@ impl FileData {
     pub fn read_all(&self) -> std::io::Result<Vec<u8>> {
         match self {
             FileData::Memory(v) => Ok(v.clone()),
+            FileData::SharedMemory(v) => Ok(v.to_vec()),
             FileData::Spool { spool, offset, len } => {
                 let mut buf = vec![0u8; *len as usize];
                 let mut file = spool
@@ -199,6 +209,7 @@ impl FileData {
     pub fn as_bytes(&self) -> Option<&[u8]> {
         match self {
             FileData::Memory(v) => Some(v),
+            FileData::SharedMemory(v) => Some(v),
             FileData::Spool { .. } => None,
         }
     }
@@ -218,6 +229,7 @@ impl FileData {
     ) -> std::io::Result<()> {
         match self {
             FileData::Memory(v) => out.write_all(&v[start..start + len]),
+            FileData::SharedMemory(v) => out.write_all(&v[start..start + len]),
             FileData::Spool { spool, offset, .. } => {
                 let mut file = spool
                     .lock()
@@ -233,6 +245,23 @@ impl FileData {
                 }
                 Ok(())
             }
+        }
+    }
+
+    /// Return a shared reference suitable for a hardlinked alias.
+    pub fn clone_ref(&mut self) -> FileData {
+        match self {
+            FileData::Memory(data) => {
+                let shared: Arc<[u8]> = std::mem::take(data).into();
+                *self = FileData::SharedMemory(Arc::clone(&shared));
+                FileData::SharedMemory(shared)
+            }
+            FileData::SharedMemory(data) => FileData::SharedMemory(Arc::clone(data)),
+            FileData::Spool { spool, offset, len } => FileData::Spool {
+                spool: Arc::clone(spool),
+                offset: *offset,
+                len: *len,
+            },
         }
     }
 }
@@ -280,15 +309,22 @@ impl DataSpool {
         })
     }
 
-    /// Clone a spool reference for a hardlinked file.
-    pub fn clone_ref(data: &FileData) -> FileData {
-        match data {
-            FileData::Memory(v) => FileData::Memory(v.clone()),
-            FileData::Spool { spool, offset, len } => FileData::Spool {
-                spool: Arc::clone(spool),
-                offset: *offset,
-                len: *len,
-            },
+    pub fn current_offset(&self) -> u64 {
+        self.offset
+    }
+
+    pub fn write_chunk(&mut self, data: &[u8]) -> std::io::Result<()> {
+        use std::io::Write;
+        self.file.write_all(data)?;
+        self.offset += data.len() as u64;
+        Ok(())
+    }
+
+    pub fn data_ref(&self, offset: u64, len: u64) -> FileData {
+        FileData::Spool {
+            spool: Arc::clone(&self.shared),
+            offset,
+            len,
         }
     }
 }

--- a/crates/image/lib/tree/model.rs
+++ b/crates/image/lib/tree/model.rs
@@ -1,10 +1,11 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::io::{Read, Seek, SeekFrom};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -104,6 +105,9 @@ pub struct Xattr {
     pub value: Vec<u8>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RegularFileId(u64);
+
 #[derive(Clone)]
 pub enum TreeNode {
     RegularFile(RegularFileNode),
@@ -117,6 +121,7 @@ pub enum TreeNode {
 
 #[derive(Clone)]
 pub struct RegularFileNode {
+    pub id: RegularFileId,
     pub metadata: InodeMetadata,
     pub xattrs: Vec<Xattr>,
     pub data: FileData,
@@ -229,6 +234,19 @@ impl FileData {
                 Ok(())
             }
         }
+    }
+}
+
+impl RegularFileId {
+    pub fn new() -> Self {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        Self(NEXT_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+impl Default for RegularFileId {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -439,8 +457,20 @@ impl FileTree {
         data_size_in_dir(&self.root)
     }
 
+    pub(crate) fn regular_file_link_counts(&self) -> HashMap<RegularFileId, u32> {
+        let mut counts = HashMap::new();
+        count_regular_links_in_dir(&self.root, &mut counts);
+        counts
+    }
+
+    pub(crate) fn refresh_regular_nlinks(&mut self) {
+        let counts = self.regular_file_link_counts();
+        refresh_regular_nlinks_in_dir(&mut self.root, &counts);
+    }
+
     pub fn merge_layer(&mut self, layer: FileTree) {
         merge_directory(&mut self.root, layer.root);
+        self.refresh_regular_nlinks();
     }
 
     /// Strip file data from this tree, keeping only directory structure and metadata.
@@ -537,19 +567,52 @@ fn count_nodes_in_dir(dir: &DirectoryNode) -> u64 {
 }
 
 fn data_size_in_dir(dir: &DirectoryNode) -> u64 {
+    let mut seen = HashSet::new();
+    data_size_in_dir_once(dir, &mut seen)
+}
+
+fn data_size_in_dir_once(dir: &DirectoryNode, seen: &mut HashSet<RegularFileId>) -> u64 {
     let mut size = 0u64;
     for node in dir.entries.values() {
         match node {
-            TreeNode::RegularFile(file) => {
+            TreeNode::RegularFile(file) if seen.insert(file.id) => {
                 size += file.data.len() as u64;
             }
             TreeNode::Directory(child_dir) => {
-                size += data_size_in_dir(child_dir);
+                size += data_size_in_dir_once(child_dir, seen);
             }
             _ => {}
         }
     }
     size
+}
+
+fn count_regular_links_in_dir(dir: &DirectoryNode, counts: &mut HashMap<RegularFileId, u32>) {
+    for node in dir.entries.values() {
+        match node {
+            TreeNode::RegularFile(file) => {
+                *counts.entry(file.id).or_insert(0) += 1;
+            }
+            TreeNode::Directory(child_dir) => {
+                count_regular_links_in_dir(child_dir, counts);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn refresh_regular_nlinks_in_dir(dir: &mut DirectoryNode, counts: &HashMap<RegularFileId, u32>) {
+    for node in dir.entries.values_mut() {
+        match node {
+            TreeNode::RegularFile(file) => {
+                file.nlink = counts.get(&file.id).copied().unwrap_or(1);
+            }
+            TreeNode::Directory(child_dir) => {
+                refresh_regular_nlinks_in_dir(child_dir, counts);
+            }
+            _ => {}
+        }
+    }
 }
 
 fn strip_data_in_dir(dir: &mut DirectoryNode) {
@@ -592,6 +655,7 @@ pub fn merge_layers_with_provenance(layers: Vec<FileTree>) -> (FileTree, HashMap
     // Strip opaque xattrs from the final merged tree — they are overlayfs
     // directives consumed by the merge, not meaningful in fsmeta.
     strip_opaque_xattrs(&mut merged.root);
+    merged.refresh_regular_nlinks();
 
     (merged, provenance)
 }
@@ -744,7 +808,12 @@ mod tests {
     use super::*;
 
     fn make_regular_file(data: &[u8]) -> TreeNode {
+        make_regular_file_with_id(data, RegularFileId::new())
+    }
+
+    fn make_regular_file_with_id(data: &[u8], id: RegularFileId) -> TreeNode {
         TreeNode::RegularFile(RegularFileNode {
+            id,
             metadata: InodeMetadata::default(),
             xattrs: Vec::new(),
             data: FileData::Memory(data.to_vec()),
@@ -895,6 +964,27 @@ mod tests {
         assert_eq!(tree.node_count(), 6);
         // 5 + 6 + 1 = 12
         assert_eq!(tree.total_data_size(), 12);
+    }
+
+    #[test]
+    fn data_size_counts_hardlinked_regular_file_once() {
+        let mut tree = FileTree::new();
+        let file_id = RegularFileId::new();
+
+        tree.insert(b"a.txt", make_regular_file_with_id(b"shared", file_id))
+            .unwrap();
+        tree.insert(b"b.txt", make_regular_file_with_id(b"shared", file_id))
+            .unwrap();
+
+        tree.refresh_regular_nlinks();
+
+        assert_eq!(tree.total_data_size(), b"shared".len() as u64);
+        for path in [b"a.txt".as_slice(), b"b.txt".as_slice()] {
+            match tree.get(path).unwrap() {
+                TreeNode::RegularFile(file) => assert_eq!(file.nlink, 2),
+                _ => panic!("expected regular file"),
+            }
+        }
     }
 
     #[test]

--- a/crates/microsandbox/lib/sandbox/patch.rs
+++ b/crates/microsandbox/lib/sandbox/patch.rs
@@ -9,8 +9,8 @@ use std::path::{Path, PathBuf};
 
 use microsandbox_image::erofs::{ErofsEntryInfo, ErofsEntryKind, ErofsReader};
 use microsandbox_image::tree::{
-    DeviceNode, DirectoryNode, FileData, FileTree, FileTreeError, InodeMetadata, RegularFileNode,
-    SymlinkNode, TreeNode,
+    DeviceNode, DirectoryNode, FileData, FileTree, FileTreeError, InodeMetadata, RegularFileId,
+    RegularFileNode, SymlinkNode, TreeNode,
 };
 use tokio::fs;
 
@@ -153,6 +153,7 @@ async fn apply_one_to_tree(
                 tree,
                 &rel,
                 TreeNode::RegularFile(RegularFileNode {
+                    id: RegularFileId::new(),
                     metadata: metadata_with_mode(mode.unwrap_or(0o644) as u16),
                     xattrs: Vec::new(),
                     data: FileData::Memory(content.as_bytes().to_vec()),
@@ -173,6 +174,7 @@ async fn apply_one_to_tree(
                 tree,
                 &rel,
                 TreeNode::RegularFile(RegularFileNode {
+                    id: RegularFileId::new(),
                     metadata: metadata_with_mode(mode.unwrap_or(0o644) as u16),
                     xattrs: Vec::new(),
                     data: FileData::Memory(content.clone()),
@@ -199,6 +201,7 @@ async fn apply_one_to_tree(
                 tree,
                 &rel,
                 TreeNode::RegularFile(RegularFileNode {
+                    id: RegularFileId::new(),
                     metadata: metadata_with_mode(file_mode),
                     xattrs: Vec::new(),
                     data: FileData::Memory(data),
@@ -302,6 +305,7 @@ async fn apply_one_to_tree(
                         tree,
                         &rel,
                         TreeNode::RegularFile(RegularFileNode {
+                            id: RegularFileId::new(),
                             metadata: metadata_with_mode(0o644),
                             xattrs: Vec::new(),
                             data: FileData::Memory(data),
@@ -609,6 +613,7 @@ async fn copy_dir_into_tree(
                 tree,
                 &child_relative,
                 TreeNode::RegularFile(RegularFileNode {
+                    id: RegularFileId::new(),
                     metadata: metadata_with_mode(mode),
                     xattrs: Vec::new(),
                     data: FileData::Memory(data),
@@ -999,6 +1004,7 @@ mod tests {
 
     fn make_regular_file(data: &[u8]) -> TreeNode {
         TreeNode::RegularFile(RegularFileNode {
+            id: RegularFileId::new(),
             metadata: metadata_with_mode(0o644),
             xattrs: Vec::new(),
             data: FileData::Memory(data.to_vec()),


### PR DESCRIPTION
## TL;DR
Preserve hardlink identity when converting OCI layers into EROFS. This keeps hardlinked files on the same inode, avoids huge duplicated layer output, and fixes the corruption from #727.

## Description
- Adds a regular-file identity to the image tree so hardlink aliases can stay connected after tar ingest and layer merge.
- Derives regular file link counts from shared identity, so replacements, whiteouts, and merges do not leave stale `nlink` values behind.
- Reuses one EROFS inode and one data write per shared regular file in per-layer images, which avoids duplicating large hardlink groups.
- Reuses one chunk-based fsmeta inode for hardlink aliases, so fsmerge sees one final inode with the right link count.
- Updates patch-created regular files to assign fresh file identities.
- Adds regression coverage for tar ingest hardlinks, tree data sizing, per-layer EROFS hardlinks, and fsmeta hardlinks.

Closes https://github.com/superradcompany/microsandbox/issues/727

## Test Plan
- [x] `cargo test -p microsandbox-image`
- [x] `cargo check -p microsandbox`
- [x] `cargo clippy -p microsandbox-image --lib -- -D warnings`
- [x] `git diff --check`
- [x] Run the #727 repro image against 0.4.6 and fixed artifacts, confirming 0.4.6 corrupts `git-remote-https` while the fixed artifacts preserve shared inodes, shared hashes, and ELF magic.