### PR TITLE
fix(image): bound gzip tar entry reads

### DIFF
--- a/crates/image/lib/tar/ingest.rs
+++ b/crates/image/lib/tar/ingest.rs
@@ -40,6 +40,9 @@ const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
 /// Entry cadence for cooperative scheduler yields during tar ingestion.
 const INGEST_YIELD_EVERY_ENTRIES: u64 = 32;
 
+/// Maximum file-body read size used while ingesting tar entries.
+const ENTRY_READ_CHUNK_SIZE: usize = 64 * 1024;
+
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
@@ -317,9 +320,7 @@ pub async fn ingest_tar<R: AsyncRead + Unpin>(
                         {
                             stream_entry_to_spool(&mut entry, size, spool).await?
                         } else {
-                            let mut buf = Vec::with_capacity(size as usize);
-                            entry.read_to_end(&mut buf).await.map_err(IngestError::Io)?;
-                            FileData::Memory(buf)
+                            FileData::Memory(read_entry_to_memory(&mut entry, size).await?)
                         };
 
                         let node = TreeNode::RegularFile(RegularFileNode {
@@ -715,6 +716,36 @@ fn handle_hardlink(
     Ok(())
 }
 
+async fn read_entry_to_memory<R: AsyncRead + Unpin>(
+    entry: &mut tar::Entry<R>,
+    size: u64,
+) -> Result<Vec<u8>, IngestError> {
+    let size = usize::try_from(size)
+        .map_err(|_| IngestError::InvalidEntry("file too large to fit in memory".to_string()))?;
+
+    if size <= ENTRY_READ_CHUNK_SIZE {
+        let mut data = vec![0u8; size];
+        entry.read_exact(&mut data).await.map_err(IngestError::Io)?;
+        return Ok(data);
+    }
+
+    let mut data = Vec::with_capacity(size);
+    let mut remaining = size;
+    let mut buf = vec![0u8; ENTRY_READ_CHUNK_SIZE];
+
+    while remaining > 0 {
+        let to_read = remaining.min(buf.len());
+        entry
+            .read_exact(&mut buf[..to_read])
+            .await
+            .map_err(IngestError::Io)?;
+        data.extend_from_slice(&buf[..to_read]);
+        remaining -= to_read;
+    }
+
+    Ok(data)
+}
+
 async fn stream_entry_to_spool<R: AsyncRead + Unpin>(
     entry: &mut tar::Entry<R>,
     size: u64,
@@ -722,7 +753,7 @@ async fn stream_entry_to_spool<R: AsyncRead + Unpin>(
 ) -> Result<FileData, IngestError> {
     let offset = spool.current_offset();
     let mut remaining = size;
-    let mut buf = vec![0u8; 1024 * 1024];
+    let mut buf = vec![0u8; ENTRY_READ_CHUNK_SIZE];
 
     while remaining > 0 {
         let to_read = remaining.min(buf.len() as u64) as usize;
@@ -970,12 +1001,21 @@ mod tests {
     // The parent module aliases `tokio_tar` as `tar`, so we use the explicit
     // crate path here to avoid ambiguity.
     use ::tar as sync_tar;
+    use async_compression::tokio::write::GzipEncoder;
     use tempfile::tempdir;
+    use tokio::io::AsyncWriteExt;
 
     fn build_tar(build: impl FnOnce(&mut sync_tar::Builder<Vec<u8>>)) -> Vec<u8> {
         let mut builder = sync_tar::Builder::new(Vec::new());
         build(&mut builder);
         builder.into_inner().unwrap()
+    }
+
+    async fn gzip(data: &[u8]) -> Vec<u8> {
+        let mut encoder = GzipEncoder::new(Vec::new());
+        encoder.write_all(data).await.unwrap();
+        encoder.shutdown().await.unwrap();
+        encoder.into_inner()
     }
 
     #[tokio::test]
@@ -1007,6 +1047,36 @@ mod tests {
                 assert_eq!(f.metadata.mode, 0o644);
                 assert_eq!(f.metadata.mtime, 1234567890);
                 assert_eq!(f.nlink, 1);
+            }
+            _ => panic!("expected regular file"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ingest_gzip_large_file_without_spool() {
+        let content = (0..SPOOL_THRESHOLD as usize * 8 + 13)
+            .map(|i| (i % 251) as u8)
+            .collect::<Vec<_>>();
+        let tar_data = build_tar(|b| {
+            let mut header = sync_tar::Header::new_gnu();
+            header.set_path("large.bin").unwrap();
+            header.set_size(content.len() as u64);
+            header.set_entry_type(sync_tar::EntryType::Regular);
+            header.set_mode(0o644);
+            header.set_cksum();
+            b.append(&header, content.as_slice()).unwrap();
+        });
+        let data = gzip(&tar_data).await;
+
+        let limits = ResourceLimits::default();
+        let result =
+            ingest_compressed_tar(std::io::Cursor::new(data), Compression::Gzip, &limits, None)
+                .await
+                .unwrap();
+
+        match result.tree.get(b"large.bin").unwrap() {
+            TreeNode::RegularFile(f) => {
+                assert_eq!(f.data, FileData::Memory(content));
             }
             _ => panic!("expected regular file"),
         }

--- a/crates/image/lib/tar/ingest.rs
+++ b/crates/image/lib/tar/ingest.rs
@@ -5,6 +5,8 @@
 //! including whiteouts, hardlinks, special files, and path validation.
 
 use std::fmt;
+use std::future::poll_fn;
+use std::io::ErrorKind;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -42,6 +44,12 @@ const INGEST_YIELD_EVERY_ENTRIES: u64 = 32;
 
 /// Maximum file-body read size used while ingesting tar entries.
 const ENTRY_READ_CHUNK_SIZE: usize = 64 * 1024;
+
+/// Compressed input buffer size used before gzip/zstd decoders.
+const COMPRESSED_INPUT_BUFFER_SIZE: usize = 256 * 1024;
+
+/// Spool write batch size used after bounded decoder reads.
+const SPOOL_WRITE_BUFFER_SIZE: usize = 1024 * 1024;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -188,6 +196,9 @@ pub async fn ingest_tar<R: AsyncRead + Unpin>(
     let mut tree = FileTree::new();
     let mut entry_count: u64 = 0;
     let mut total_size: u64 = 0;
+    let mut saw_hardlink = false;
+    let mut spool_read_buf = Vec::new();
+    let mut spool_write_buf = Vec::new();
 
     let mut entries = archive.entries().map_err(IngestError::Io)?;
 
@@ -236,6 +247,7 @@ pub async fn ingest_tar<R: AsyncRead + Unpin>(
                 };
 
                 handle_hardlink(&mut tree, &path, &target_path)?;
+                saw_hardlink = true;
             }
             tar::EntryType::Directory => {
                 let node = TreeNode::Directory(DirectoryNode {
@@ -318,7 +330,14 @@ pub async fn ingest_tar<R: AsyncRead + Unpin>(
                         let file_data = if size >= SPOOL_THRESHOLD
                             && let Some(spool) = spool.as_mut()
                         {
-                            stream_entry_to_spool(&mut entry, size, spool).await?
+                            stream_entry_to_spool(
+                                &mut entry,
+                                size,
+                                spool,
+                                &mut spool_read_buf,
+                                &mut spool_write_buf,
+                            )
+                            .await?
                         } else {
                             FileData::Memory(read_entry_to_memory(&mut entry, size).await?)
                         };
@@ -377,7 +396,9 @@ pub async fn ingest_tar<R: AsyncRead + Unpin>(
         }
     }
 
-    tree.refresh_regular_nlinks();
+    if saw_hardlink {
+        tree.refresh_regular_nlinks();
+    }
 
     Ok(tree)
 }
@@ -414,7 +435,10 @@ pub async fn ingest_compressed_tar<R: AsyncRead + Unpin>(
             })
         }
         Compression::Gzip => {
-            let decoder = GzipDecoder::new(BufReader::new(reader));
+            let decoder = GzipDecoder::new(BufReader::with_capacity(
+                COMPRESSED_INPUT_BUFFER_SIZE,
+                reader,
+            ));
             let mut hashing = HashingReader::new(decoder);
             let tree = ingest_tar(&mut hashing, limits, spool.as_mut()).await?;
             // Drain any remaining bytes (tar EOF padding) to include
@@ -426,7 +450,10 @@ pub async fn ingest_compressed_tar<R: AsyncRead + Unpin>(
             })
         }
         Compression::Zstd => {
-            let decoder = ZstdDecoder::new(BufReader::new(reader));
+            let decoder = ZstdDecoder::new(BufReader::with_capacity(
+                COMPRESSED_INPUT_BUFFER_SIZE,
+                reader,
+            ));
             let mut hashing = HashingReader::new(decoder);
             let tree = ingest_tar(&mut hashing, limits, spool.as_mut()).await?;
             drain_reader(&mut hashing).await?;
@@ -442,7 +469,7 @@ pub async fn ingest_compressed_tar<R: AsyncRead + Unpin>(
 /// consumed (and hashed, if wrapped in `HashingReader`). The tar parser
 /// may stop before the EOF padding; the diff_id covers the full stream.
 async fn drain_reader<R: AsyncRead + Unpin>(reader: &mut R) -> Result<(), IngestError> {
-    let mut buf = [0u8; 8192];
+    let mut buf = vec![0u8; ENTRY_READ_CHUNK_SIZE];
     loop {
         let n = reader.read(&mut buf).await.map_err(IngestError::Io)?;
         if n == 0 {
@@ -722,25 +749,33 @@ async fn read_entry_to_memory<R: AsyncRead + Unpin>(
 ) -> Result<Vec<u8>, IngestError> {
     let size = usize::try_from(size)
         .map_err(|_| IngestError::InvalidEntry("file too large to fit in memory".to_string()))?;
-
-    if size <= ENTRY_READ_CHUNK_SIZE {
-        let mut data = vec![0u8; size];
-        entry.read_exact(&mut data).await.map_err(IngestError::Io)?;
-        return Ok(data);
-    }
-
     let mut data = Vec::with_capacity(size);
     let mut remaining = size;
-    let mut buf = vec![0u8; ENTRY_READ_CHUNK_SIZE];
 
     while remaining > 0 {
-        let to_read = remaining.min(buf.len());
-        entry
-            .read_exact(&mut buf[..to_read])
-            .await
-            .map_err(IngestError::Io)?;
-        data.extend_from_slice(&buf[..to_read]);
-        remaining -= to_read;
+        let start = data.len();
+        let to_read = remaining.min(ENTRY_READ_CHUNK_SIZE);
+        let read = {
+            let mut read_buf = ReadBuf::uninit(&mut data.spare_capacity_mut()[..to_read]);
+            poll_fn(|cx| Pin::new(&mut *entry).poll_read(cx, &mut read_buf))
+                .await
+                .map_err(IngestError::Io)?;
+            read_buf.filled().len()
+        };
+
+        if read == 0 {
+            return Err(IngestError::Io(std::io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            )));
+        }
+
+        // SAFETY: `poll_read` reported `read` initialized bytes in the spare
+        // capacity window above, and the window begins at the previous length.
+        unsafe {
+            data.set_len(start + read);
+        }
+        remaining -= read;
     }
 
     Ok(data)
@@ -750,21 +785,39 @@ async fn stream_entry_to_spool<R: AsyncRead + Unpin>(
     entry: &mut tar::Entry<R>,
     size: u64,
     spool: &mut DataSpool,
+    read_buf: &mut Vec<u8>,
+    write_buf: &mut Vec<u8>,
 ) -> Result<FileData, IngestError> {
     let offset = spool.current_offset();
     let mut remaining = size;
-    let mut buf = vec![0u8; ENTRY_READ_CHUNK_SIZE];
+
+    if read_buf.len() != ENTRY_READ_CHUNK_SIZE {
+        read_buf.resize(ENTRY_READ_CHUNK_SIZE, 0);
+    }
+    if write_buf.capacity() < SPOOL_WRITE_BUFFER_SIZE {
+        write_buf.reserve(SPOOL_WRITE_BUFFER_SIZE - write_buf.capacity());
+    }
+    write_buf.clear();
 
     while remaining > 0 {
-        let to_read = remaining.min(buf.len() as u64) as usize;
+        let to_read = remaining.min(read_buf.len() as u64) as usize;
         entry
-            .read_exact(&mut buf[..to_read])
+            .read_exact(&mut read_buf[..to_read])
             .await
             .map_err(IngestError::Io)?;
-        spool
-            .write_chunk(&buf[..to_read])
-            .map_err(IngestError::Io)?;
+
+        if write_buf.len() + to_read > SPOOL_WRITE_BUFFER_SIZE && !write_buf.is_empty() {
+            spool.write_chunk(write_buf).map_err(IngestError::Io)?;
+            write_buf.clear();
+        }
+
+        write_buf.extend_from_slice(&read_buf[..to_read]);
         remaining -= to_read as u64;
+    }
+
+    if !write_buf.is_empty() {
+        spool.write_chunk(write_buf).map_err(IngestError::Io)?;
+        write_buf.clear();
     }
 
     Ok(spool.data_ref(offset, size))
@@ -1109,6 +1162,47 @@ mod tests {
                 assert_eq!(f.data.read_all().unwrap(), content);
             }
             _ => panic!("expected regular file"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ingest_multiple_large_files_spools_to_distinct_ranges() {
+        let first = vec![b'a'; SPOOL_THRESHOLD as usize + 17];
+        let second = vec![b'b'; SPOOL_THRESHOLD as usize * 2 + 31];
+        let data = build_tar(|b| {
+            for (path, content) in [
+                ("first.bin", first.as_slice()),
+                ("second.bin", second.as_slice()),
+            ] {
+                let mut header = sync_tar::Header::new_gnu();
+                header.set_path(path).unwrap();
+                header.set_size(content.len() as u64);
+                header.set_entry_type(sync_tar::EntryType::Regular);
+                header.set_mode(0o644);
+                header.set_cksum();
+                b.append(&header, content).unwrap();
+            }
+        });
+
+        let tempdir = tempdir().unwrap();
+        let spool_path = tempdir.path().join("layer.spool");
+        let mut spool = DataSpool::new(&spool_path).unwrap();
+        let limits = ResourceLimits::default();
+        let tree = ingest_tar(std::io::Cursor::new(data), &limits, Some(&mut spool))
+            .await
+            .unwrap();
+
+        for (path, content) in [
+            (b"first.bin".as_slice(), first),
+            (b"second.bin".as_slice(), second),
+        ] {
+            match tree.get(path).unwrap() {
+                TreeNode::RegularFile(f) => {
+                    assert!(matches!(f.data, FileData::Spool { .. }));
+                    assert_eq!(f.data.read_all().unwrap(), content);
+                }
+                _ => panic!("expected regular file"),
+            }
         }
     }
 


### PR DESCRIPTION
## TL;DR
Read large tar file bodies through bounded chunks so gzip layer ingest does not repeatedly zero huge output buffers, while keeping production spool writes batched.

## Description
- Replaces large in-memory tar entry `read_to_end` with bounded 64 KiB decoder reads, which avoids exposing the final buffer's full spare capacity to gzip decompression.
- Reads no-spool file bodies directly into bounded spare-capacity windows, avoiding an extra copy from a scratch buffer into the final `Vec`.
- Uses larger compressed input buffering for gzip and zstd so the decoders do fewer source reads on large incompressible layers.
- Batches spooled writes behind a 1 MiB buffer while keeping decoder-facing reads capped at 64 KiB.
- Reuses spool scratch buffers across entries and skips regular link-count refresh when a tar stream has no hardlinks.
- Adds regression coverage for large gzip no-spool ingest and multiple spooled files sharing one spool.
- Credits @evgeny-boger for the original analysis and proposed fix in wirenboard/microsandbox#1.
- Closes https://github.com/superradcompany/microsandbox/issues/790.

## Test Plan
- [x] `cargo test -p microsandbox-image tar::ingest::tests`
- [x] `cargo test -p microsandbox-image`
- [x] `cargo clippy -p microsandbox-image --all-targets -- -D warnings`
- [x] `git diff --check`
- [x] signed commit hooks: workspace fmt, workspace clippy, workspace docs, `cargo build (msb)`