### PR TITLE
feat(sandbox): atomically create per-sandbox named volumes via MountBuilder::create_named

### DIFF
--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -672,14 +672,28 @@ impl SandboxBuilder {
     /// .volume("/data", |m| m.bind("/host/data"))
     /// .volume("/config", |m| m.bind("/host/config").readonly())
     /// .volume("/cache", |m| m.named("my-cache"))
-    /// .volume("/tmp", |m| m.tmpfs().size(100))
+    /// .volume("/tmp", |m| m.create_named("my-sandbox-tmp"))
+    /// .volume("/scratch", |m| m
+    ///     .create_named_with("my-sandbox-scratch", |v| v.quota(1024).label("owner", "team"))
+    ///     .readonly())
+    /// .volume("/tmpfs", |m| m.tmpfs().size(100))
     /// ```
     pub fn volume(
         mut self,
         guest_path: impl Into<String>,
         f: impl FnOnce(MountBuilder) -> MountBuilder,
     ) -> Self {
-        match f(MountBuilder::new(guest_path)).build() {
+        let mut mb = f(MountBuilder::new(guest_path));
+        if let Some(intent) = mb.take_create_intent() {
+            if let Err(e) = crate::volume::validate_volume_name(&intent.name)
+                && self.build_error.is_none()
+            {
+                self.build_error = Some(e);
+                return self;
+            }
+            self.config.auto_volumes.push(intent);
+        }
+        match mb.build() {
             Ok(mount) => self.config.mounts.push(mount),
             Err(e) => {
                 if self.build_error.is_none() {
@@ -1452,5 +1466,68 @@ mod tests {
             err.to_string()
                 .contains("disk image host path does not exist")
         );
+    }
+
+    #[tokio::test]
+    async fn test_create_named_registers_intent_and_mount() {
+        let config = SandboxBuilder::new("sb")
+            .image("alpine")
+            .volume("/tmp", |m| m.create_named("sb-tmp"))
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(config.auto_volumes.len(), 1);
+        assert_eq!(config.auto_volumes[0].name, "sb-tmp");
+        assert_eq!(config.mounts.len(), 1);
+        match &config.mounts[0] {
+            super::VolumeMount::Named { name, guest, .. } => {
+                assert_eq!(name, "sb-tmp");
+                assert_eq!(guest, "/tmp");
+            }
+            _ => panic!("expected Named mount"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_named_with_carries_quota_and_labels() {
+        let config = SandboxBuilder::new("sb")
+            .image("alpine")
+            .volume("/scratch", |m| {
+                m.create_named_with("sb-scratch", |v| v.quota(1024u32).label("owner", "my-team"))
+                    .readonly()
+            })
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(config.auto_volumes[0].name, "sb-scratch");
+        assert_eq!(config.auto_volumes[0].quota_mib, Some(1024));
+        assert_eq!(
+            config.auto_volumes[0].labels,
+            vec![("owner".to_string(), "my-team".to_string())]
+        );
+        match &config.mounts[0] {
+            super::VolumeMount::Named { options, .. } => assert!(options.readonly),
+            _ => panic!("expected Named mount"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_named_with_name_override() {
+        let config = SandboxBuilder::new("sb")
+            .image("alpine")
+            .volume("/tmp", |m| {
+                m.create_named_with("initial", |v| v.name("overridden"))
+            })
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(config.auto_volumes[0].name, "overridden");
+        match &config.mounts[0] {
+            super::VolumeMount::Named { name, .. } => assert_eq!(name, "overridden"),
+            _ => panic!("expected Named mount"),
+        }
     }
 }

--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -254,6 +254,26 @@ pub struct SandboxConfig {
     /// during `create_with_mode`. Never persisted.
     #[serde(skip)]
     pub(crate) snapshot_upper_source: Option<PathBuf>,
+
+    /// Volumes to provision atomically alongside this sandbox.
+    ///
+    /// Each entry is registered in the same DB transaction that inserts
+    /// the sandbox row, so `Volume::list` cannot observe one of these
+    /// before the owning sandbox exists. Set by
+    /// [`SandboxBuilder::auto_volume`] and friends. The matching
+    /// [`VolumeMount::Named`] entries are appended to `mounts`.
+    #[serde(skip)]
+    pub(crate) auto_volumes: Vec<AutoVolumeIntent>,
+}
+
+/// Intent to atomically create a named volume alongside the sandbox.
+#[derive(Debug, Clone)]
+pub(crate) struct AutoVolumeIntent {
+    pub name: String,
+    pub kind: crate::volume::VolumeKind,
+    pub quota_mib: Option<u32>,
+    pub capacity_mib: Option<u32>,
+    pub labels: Vec<(String, String)>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -460,6 +480,7 @@ impl Default for SandboxConfig {
             replace_with_timeout: DEFAULT_REPLACE_TIMEOUT,
             manifest_digest: None,
             snapshot_upper_source: None,
+            auto_volumes: Vec::new(),
         }
     }
 }

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -377,9 +377,27 @@ impl Sandbox {
         }
 
         // Insert the sandbox record and keep its stable database ID.
+        // Auto-volumes (from `SandboxBuilder::auto_volume`) are inserted
+        // in the same transaction so a concurrent `Volume::list` can't
+        // see them without the owning sandbox.
         let write_db = db.write();
         let sandbox_id = insert_sandbox_record(write_db, &config).await?;
         tracing::debug!(sandbox_id, sandbox = %config.name, "create_with_mode: db record inserted");
+
+        // Materialise the on-disk directory for each auto-volume after
+        // the transaction commits. On failure, remove any directories
+        // we already created plus the sandbox row so the partial state
+        // doesn't leak.
+        if !config.auto_volumes.is_empty()
+            && let Err(e) = materialise_auto_volume_dirs(&config.auto_volumes).await
+        {
+            rollback_auto_volume_dirs(&config.auto_volumes).await;
+            let _ = remove_sandbox_row(write_db, sandbox_id).await;
+            for intent in &config.auto_volumes {
+                let _ = remove_volume_row(write_db, &intent.name).await;
+            }
+            return Err(e);
+        }
 
         // Spawn the sandbox process and create the bridge. On failure, mark the sandbox
         // as stopped so it doesn't appear as a phantom "Running" entry. Also
@@ -387,11 +405,18 @@ impl Sandbox {
         // exit observer cannot be relied upon if the child was SIGKILL'd
         // before activation, and `reconcile_sandbox_runtime_state` will not
         // run reaper cleanup for a Stopped sandbox.
+        // Move auto_volumes out so we can use them after the config
+        // is consumed by create_inner.
+        let auto_volumes = std::mem::take(&mut config.auto_volumes);
         let sandbox = match Self::create_inner(config, sandbox_id, mode).await {
             Ok(sandbox) => sandbox,
             Err(e) => {
                 let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
                 free_metrics_slot_for(sandbox_id, None, microsandbox_metrics::ReleaseMode::Free);
+                rollback_auto_volume_dirs(&auto_volumes).await;
+                for intent in &auto_volumes {
+                    let _ = remove_volume_row(write_db, &intent.name).await;
+                }
                 return Err(e);
             }
         };
@@ -2286,9 +2311,13 @@ async fn insert_sandbox_record(
     config: &SandboxConfig,
 ) -> MicrosandboxResult<i32> {
     let config_json = serde_json::to_string(config)?;
+    // `auto_volumes` is `#[serde(skip)]` so the cloned config carries
+    // no record of these intents — capture them before the move.
+    let auto_volumes = config.auto_volumes.clone();
 
     db.transaction(|txn| {
         let config_json = config_json.clone();
+        let auto_volumes = auto_volumes.clone();
         async move {
             let now = chrono::Utc::now().naive_utc();
             let model = sandbox_entity::ActiveModel {
@@ -2302,8 +2331,6 @@ async fn insert_sandbox_record(
             let result = sandbox_entity::Entity::insert(model).exec(&txn).await?;
             let sandbox_id = result.last_insert_id;
 
-            // Persist labels in the same transaction so the catalog record is
-            // all-or-nothing — a failed label write rolls back the sandbox row.
             let label_rows: Vec<sandbox_label_entity::ActiveModel> = config
                 .labels
                 .iter()
@@ -2319,7 +2346,67 @@ async fn insert_sandbox_record(
                     .await?;
             }
 
+            for intent in &auto_volumes {
+                let vol_config = crate::volume::VolumeConfig {
+                    name: intent.name.clone(),
+                    kind: intent.kind,
+                    quota_mib: intent.quota_mib,
+                    capacity_mib: intent.capacity_mib,
+                    labels: intent.labels.clone(),
+                };
+                crate::volume::Volume::create_in_transaction(&txn, &vol_config).await?;
+            }
+
             Ok((txn, sandbox_id))
+        }
+    })
+    .await
+}
+
+async fn materialise_auto_volume_dirs(
+    intents: &[crate::sandbox::config::AutoVolumeIntent],
+) -> MicrosandboxResult<()> {
+    for intent in intents {
+        let vol_config = crate::volume::VolumeConfig {
+            name: intent.name.clone(),
+            kind: intent.kind,
+            quota_mib: intent.quota_mib,
+            capacity_mib: intent.capacity_mib,
+            labels: intent.labels.clone(),
+        };
+        crate::volume::Volume::materialise_for(&vol_config).await?;
+    }
+    Ok(())
+}
+
+async fn rollback_auto_volume_dirs(intents: &[crate::sandbox::config::AutoVolumeIntent]) {
+    for intent in intents {
+        let path = crate::volume::Volume::path_for(&intent.name);
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+}
+
+async fn remove_sandbox_row(db: &DbWriteConnection, sandbox_id: i32) -> MicrosandboxResult<()> {
+    db.transaction(|txn| async move {
+        sandbox_entity::Entity::delete_by_id(sandbox_id)
+            .exec(&txn)
+            .await?;
+        Ok((txn, ()))
+    })
+    .await
+}
+
+async fn remove_volume_row(db: &DbWriteConnection, name: &str) -> MicrosandboxResult<()> {
+    use crate::db::entity::volume as volume_entity;
+    let name = name.to_string();
+    db.transaction(|txn| {
+        let name = name.clone();
+        async move {
+            volume_entity::Entity::delete_many()
+                .filter(volume_entity::Column::Name.eq(name))
+                .exec(&txn)
+                .await?;
+            Ok((txn, ()))
         }
     })
     .await
@@ -2914,6 +3001,99 @@ mod tests {
             by(&pools, &[("user.id", "alice"), ("user.id", "bob")])
                 .await
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_sandbox_record_atomic_with_auto_volumes() {
+        use crate::db::entity::volume as volume_entity;
+        use crate::sandbox::config::AutoVolumeIntent;
+
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let pools = open_test_pools(&db_path).await;
+
+        let mut config = SandboxConfig {
+            name: "atomic-host".into(),
+            image: RootfsSource::oci("docker.io/library/alpine"),
+            ..Default::default()
+        };
+        config.auto_volumes.push(AutoVolumeIntent {
+            name: "atomic-host-tmp".into(),
+            kind: crate::volume::VolumeKind::Directory,
+            quota_mib: None,
+            capacity_mib: None,
+            labels: vec![("owner".into(), "atomic-host".into())],
+        });
+
+        let _sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
+
+        // Both rows visible after the same transaction commits.
+        let vol = volume_entity::Entity::find()
+            .filter(volume_entity::Column::Name.eq("atomic-host-tmp"))
+            .one(pools.read())
+            .await
+            .unwrap();
+        assert!(
+            vol.is_some(),
+            "auto-volume row must exist alongside sandbox"
+        );
+        let vol = vol.unwrap();
+        let labels: Vec<(String, String)> =
+            serde_json::from_str(vol.labels.as_deref().unwrap_or("[]")).unwrap();
+        assert!(labels.contains(&("owner".to_string(), "atomic-host".to_string())));
+    }
+
+    #[tokio::test]
+    async fn test_insert_sandbox_record_rolls_back_when_volume_name_collides() {
+        use crate::db::entity::volume as volume_entity;
+        use crate::sandbox::config::AutoVolumeIntent;
+
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let pools = open_test_pools(&db_path).await;
+
+        // Pre-seed a volume that collides with the auto-volume name.
+        let now = chrono::Utc::now().naive_utc();
+        volume_entity::Entity::insert(volume_entity::ActiveModel {
+            name: Set("collision".into()),
+            kind: Set(crate::volume::VolumeKind::Directory.as_str().to_string()),
+            created_at: Set(Some(now)),
+            updated_at: Set(Some(now)),
+            ..Default::default()
+        })
+        .exec(pools.write())
+        .await
+        .unwrap();
+
+        let mut config = SandboxConfig {
+            name: "rollback-host".into(),
+            image: RootfsSource::oci("docker.io/library/alpine"),
+            ..Default::default()
+        };
+        config.auto_volumes.push(AutoVolumeIntent {
+            name: "collision".into(),
+            kind: crate::volume::VolumeKind::Directory,
+            quota_mib: None,
+            capacity_mib: None,
+            labels: Vec::new(),
+        });
+
+        let result = insert_sandbox_record(pools.write(), &config).await;
+        assert!(
+            result.is_err(),
+            "duplicate volume name must fail the insert"
+        );
+
+        // Sandbox row must NOT exist — transaction rolled back.
+        let sb = super::sandbox_entity::Entity::find()
+            .filter(super::sandbox_entity::Column::Name.eq("rollback-host"))
+            .one(pools.read())
+            .await
+            .unwrap();
+        assert!(
+            sb.is_none(),
+            "transaction must roll back the sandbox row when volume insert fails"
         );
     }
 

--- a/crates/microsandbox/lib/sandbox/types.rs
+++ b/crates/microsandbox/lib/sandbox/types.rs
@@ -252,6 +252,7 @@ pub struct MountBuilder {
     disk_fstype: Option<String>,
     stat_virtualization: Option<StatVirtualization>,
     host_permissions: Option<HostPermissions>,
+    create_intent: Option<super::config::AutoVolumeIntent>,
     error: Option<crate::MicrosandboxError>,
 }
 
@@ -355,6 +356,47 @@ pub enum Patch {
     },
 }
 
+/// Sub-builder for [`MountBuilder::create_named_with`].
+pub struct VolumeBuilder {
+    intent: super::config::AutoVolumeIntent,
+}
+
+impl VolumeBuilder {
+    pub(crate) fn new(name: String) -> Self {
+        Self {
+            intent: super::config::AutoVolumeIntent {
+                name,
+                kind: crate::volume::VolumeKind::Directory,
+                quota_mib: None,
+                capacity_mib: None,
+                labels: Vec::new(),
+            },
+        }
+    }
+
+    /// Override the volume name.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.intent.name = name.into();
+        self
+    }
+
+    /// Set a storage quota for the volume.
+    pub fn quota(mut self, size: impl Into<Mebibytes>) -> Self {
+        self.intent.quota_mib = Some(size.into().as_u32());
+        self
+    }
+
+    /// Attach a label to the volume. Can be called multiple times.
+    pub fn label(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.intent.labels.push((key.into(), value.into()));
+        self
+    }
+
+    pub(crate) fn build(self) -> super::config::AutoVolumeIntent {
+        self.intent
+    }
+}
+
 /// Builder for constructing a list of [`Patch`] operations.
 pub struct PatchBuilder {
     patches: Vec<Patch>,
@@ -376,6 +418,7 @@ impl MountBuilder {
             disk_fstype: None,
             stat_virtualization: None,
             host_permissions: None,
+            create_intent: None,
             error: None,
         }
     }
@@ -391,6 +434,39 @@ impl MountBuilder {
     pub fn named(mut self, name: impl Into<String>) -> Self {
         self.mount = MountKind::Named(name.into());
         self
+    }
+
+    /// Provision a fresh named volume atomically with the sandbox and
+    /// mount it. The volume row is inserted in the same DB transaction
+    /// as the sandbox row.
+    pub fn create_named(mut self, name: impl Into<String>) -> Self {
+        let name = name.into();
+        self.mount = MountKind::Named(name.clone());
+        self.create_intent = Some(super::config::AutoVolumeIntent {
+            name,
+            kind: crate::volume::VolumeKind::Directory,
+            quota_mib: None,
+            capacity_mib: None,
+            labels: Vec::new(),
+        });
+        self
+    }
+
+    /// Same as [`create_named`](Self::create_named) but with builder-driven
+    /// volume metadata (quota, labels, name override).
+    pub fn create_named_with(
+        mut self,
+        name: impl Into<String>,
+        f: impl FnOnce(VolumeBuilder) -> VolumeBuilder,
+    ) -> Self {
+        let intent = f(VolumeBuilder::new(name.into())).build();
+        self.mount = MountKind::Named(intent.name.clone());
+        self.create_intent = Some(intent);
+        self
+    }
+
+    pub(crate) fn take_create_intent(&mut self) -> Option<super::config::AutoVolumeIntent> {
+        self.create_intent.take()
     }
 
     /// Use tmpfs (memory-backed).

--- a/crates/microsandbox/lib/volume/mod.rs
+++ b/crates/microsandbox/lib/volume/mod.rs
@@ -299,6 +299,79 @@ impl Volume {
         })
     }
 
+    /// Insert the volume DB record inside the caller's transaction.
+    ///
+    /// Lets `SandboxBuilder::auto_volume` create the volume and the
+    /// sandbox in one atomic write so a concurrent `Volume::list`
+    /// cannot observe the volume before the owning sandbox exists.
+    /// Returns [`MicrosandboxError::VolumeAlreadyExists`] if the name
+    /// is already in the table.
+    ///
+    /// The caller is responsible for creating the on-disk directory
+    /// after the transaction commits (or rolling back via
+    /// `Volume::remove` if the directory step fails).
+    pub(crate) async fn create_in_transaction<C: ConnectionTrait>(
+        txn: &C,
+        config: &VolumeConfig,
+    ) -> MicrosandboxResult<()> {
+        validate_volume_name(&config.name)?;
+        validate_volume_config(config)?;
+
+        let existing = volume_entity::Entity::find()
+            .filter(volume_entity::Column::Name.eq(&config.name))
+            .one(txn)
+            .await?;
+        if existing.is_some() {
+            return Err(MicrosandboxError::VolumeAlreadyExists(config.name.clone()));
+        }
+
+        let labels_json = if config.labels.is_empty() {
+            None
+        } else {
+            Some(serde_json::to_string(&config.labels)?)
+        };
+        let now = chrono::Utc::now().naive_utc();
+        let capacity_bytes = config.capacity_mib.map(|mib| i64::from(mib) * 1024 * 1024);
+        let model = volume_entity::ActiveModel {
+            name: Set(config.name.clone()),
+            kind: Set(config.kind.as_str().to_string()),
+            quota_mib: Set(config.quota_mib.map(|v| v as i32)),
+            size_bytes: Set(None),
+            capacity_bytes: Set(capacity_bytes),
+            disk_format: Set((config.kind == VolumeKind::Disk).then(|| "raw".to_string())),
+            disk_fstype: Set((config.kind == VolumeKind::Disk).then(|| "ext4".to_string())),
+            labels: Set(labels_json),
+            created_at: Set(Some(now)),
+            updated_at: Set(Some(now)),
+            ..Default::default()
+        };
+        volume_entity::Entity::insert(model).exec(txn).await?;
+        Ok(())
+    }
+
+    /// Resolve the on-disk path for a named volume.
+    pub(crate) fn path_for(name: &str) -> PathBuf {
+        crate::config::config().volumes_dir().join(name)
+    }
+
+    /// Provision the on-disk artifact for a volume registered via
+    /// [`create_in_transaction`].
+    pub(crate) async fn materialise_for(config: &VolumeConfig) -> MicrosandboxResult<()> {
+        let volumes_dir = crate::config::config().volumes_dir();
+        tokio::fs::create_dir_all(&volumes_dir).await?;
+        let path = volumes_dir.join(&config.name);
+        if path.exists() {
+            return Err(MicrosandboxError::VolumeAlreadyExists(config.name.clone()));
+        }
+        let temp = tempfile::Builder::new()
+            .prefix(&format!(".{}.", config.name))
+            .tempdir_in(&volumes_dir)?;
+        provision_volume_path(config, temp.path()).await?;
+        tokio::fs::rename(temp.path(), &path).await?;
+        let _ = temp.keep();
+        Ok(())
+    }
+
     /// Get a volume handle by name from the database.
     ///
     /// Returns a lightweight handle for metadata and management operations.


### PR DESCRIPTION
## Summary

Adds `m.create_named(name)` and `m.create_named_with(name, |v| ...)` to the existing `MountBuilder`, following @appcypher's suggestion to express the behavior through the mount builder instead of a parallel `auto_volume*` surface. The volume row is inserted in the same DB transaction as the sandbox row, so a concurrent `Volume::list` cannot observe the volume before the owning sandbox exists.

```rust
SandboxBuilder::new("my-sandbox")
    .image("alpine")
    .volume("/tmp", |m| m.create_named("my-sandbox-tmp"))
    .volume("/scratch", |m| m
        .create_named_with("my-sandbox-scratch", |v| v
            .quota(1.gib())
            .label("owner", "my-team"))
        .readonly())
    .create_detached().await?;
```

## Motivation

Callers who want a per-sandbox dedicated volume call `Volume::create` and then list it in `SandboxConfig::mounts`. Those are two independent DB writes; another process scanning `Volume::list` between them sees an orphan-shaped row. Anyone scanning `Volume::list` for owner-less volumes (a startup sweep for orphan cleanup, a quota auditor, a metrics collector) hits the same window — no way to tell an in-flight `Volume::create` apart from a real orphan without a `created_at`-keyed grace window. Closing the window at the source removes the need for that grace window entirely.

## API

* `MountBuilder::create_named(name)` — sibling of `named()`. Same mount semantics, plus atomic provisioning of the named volume.
* `MountBuilder::create_named_with(name, |v| ...)` — `VolumeBuilder` sub-builder for `quota`, `label`, `name` override. Mount-side options (`readonly`, `noexec`, ...) stay on `MountBuilder`.
* Existing `m.named(...)` continues to mean "mount existing named volume" and is unchanged.

## Implementation

* `Volume::create_in_transaction(&txn, &VolumeConfig)` — new `pub(crate)` helper that inserts the volume row using the caller's connection. Shares validation, label serialisation, and the `kind` / `capacity_bytes` / `disk_format` / `disk_fstype` columns with `Volume::create`.
* `Volume::materialise_for(&VolumeConfig)` — provisions the on-disk artifact (directory or `disk.raw`) via the same tempdir → rename pattern as `Volume::create`. Disk volumes get ext4 formatting for free.
* `MountBuilder::create_intent: Option<AutoVolumeIntent>` — `SandboxBuilder::volume()` calls `take_create_intent()` after the closure runs and pushes any intent to `config.auto_volumes`.
* `SandboxConfig::auto_volumes: Vec<AutoVolumeIntent>` — new `#[serde(skip)] pub(crate)` transient field.
* `insert_sandbox_record` inserts every auto-volume row inside the same transaction as the sandbox row. Any error rolls both back atomically.
* `Sandbox::create_with_mode` materialises on-disk artifacts after the transaction commits. Directory failure or sandbox-spawn failure removes the volume rows and rolls back the artifacts.

## Tests

* `test_insert_sandbox_record_atomic_with_auto_volumes` — sandbox row and labelled volume row both visible after one transaction.
* `test_insert_sandbox_record_rolls_back_when_volume_name_collides` — pre-seeded duplicate volume name fails the transaction; the sandbox row never lands.
* `test_create_named_registers_intent_and_mount` — `create_named` registers the intent and emits a matching `VolumeMount::Named`.
* `test_create_named_with_carries_quota_and_labels` — sub-builder carries quota and labels, and outer `readonly()` reaches the mount.
* `test_create_named_with_name_override` — `v.name(...)` wins over the initial argument.

## Test plan

- [x] `cargo build -p microsandbox`
- [x] `cargo test -p microsandbox --lib` — 269 passed, 0 failed (264 pre-existing + 5 new related)
- [x] `cargo fmt --check -p microsandbox`

## Reference

- brekkylab/ailoy#416