### PR TITLE
fix(upgrade): support 0.5 upgrade path for old sandboxes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,65 @@ Do not apply them to other repositories or to general agent behavior outside thi
 - `mcp/` and `skills/` are submodules related to agent integrations.
 - `vendor/libkrunfw` is a submodule for the kernel firmware library.
 
+Repository layout:
+
+```text
+.
+|-- AGENTS.md
+|-- Cargo.lock
+|-- Cargo.toml
+|-- DEVELOPMENT.md
+|-- Dockerfile.agentd
+|-- justfile
+|-- msb-entitlements.plist
+|-- assets/
+|-- benchmarks/
+|-- crates/
+|   |-- agentd/
+|   |-- cli/
+|   |-- db/
+|   |-- filesystem/
+|   |-- image/
+|   |-- metrics/
+|   |-- microsandbox/
+|   |-- migration/
+|   |-- network/
+|   |-- protocol/
+|   |-- runtime/
+|   |-- test-init/
+|   |-- test-macros/
+|   |-- test-utils/
+|   `-- utils/
+|-- docs/
+|   |-- cli/
+|   |-- getting-started/
+|   |-- images/
+|   |-- networking/
+|   |-- recipes/
+|   |-- sandboxes/
+|   `-- sdk/
+|-- examples/
+|   |-- python/
+|   |-- rust/
+|   `-- typescript/
+|-- mcp/
+|   |-- bin/
+|   |-- src/
+|   `-- package.json
+|-- packaging/
+|   `-- docker/
+|-- scripts/
+|   `-- smoke/
+|-- sdk/
+|   |-- go/
+|   |-- node-ts/
+|   `-- python/
+|-- skills/
+|   `-- microsandbox/
+`-- vendor/
+    `-- libkrunfw/
+```
+
 ## Design Principles
 
 - microsandbox is still early software. Prefer the clean current design over compatibility layers, migration shims, deprecated paths, or version checks unless a maintainer asks for them.
@@ -110,6 +169,17 @@ path = "bin/main.rs"
 - Keep feature-gated code close to the feature it gates and use existing `#[cfg(feature = "...")]` patterns.
 - Do not add examples under `examples/` unless requested or clearly required. Prefer tests and docs for small usage coverage.
 - Run `cargo fmt` before finalizing Rust changes.
+
+## Development Build Notes
+
+- If you build `msb` to run it locally on macOS, make sure the binary is codesigned with `msb-entitlements.plist`; otherwise VM/runtime failures may be caused by missing entitlements instead of your code change.
+- Prefer `just build` or `just build-msb` when producing a runnable local binary. The macOS recipe rebuilds `msb` and runs:
+
+```bash
+codesign --entitlements msb-entitlements.plist --force -s - build/msb
+```
+
+- If you bypass `just` and call `cargo build` directly, manually codesign the exact `msb` binary you are going to run before testing sandbox startup, protocol, networking, or filesystem behavior.
 
 ## Validation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,6 +3255,7 @@ name = "microsandbox-migration"
 version = "0.5.0"
 dependencies = [
  "sea-orm-migration",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -189,6 +189,21 @@ fn render_anyhow_error(err: &anyhow::Error) -> i32 {
         microsandbox_cli::boot_error_render::render(&name, &boot_err);
         return 1;
     }
+    if find_pre05_sandbox_restart_required_in_chain(err) {
+        // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+        // compatibility for versions before 0.5 is no longer supported.
+        microsandbox_cli::ui::error_with_lines(
+            "filesystem and SFTP features need this sandbox to be restarted",
+            &[
+                microsandbox_cli::ui::ErrorLine::Cause(
+                    "this sandbox was started before microsandbox 0.5",
+                ),
+                microsandbox_cli::ui::ErrorLine::Hint("exec and shell still work temporarily"),
+                microsandbox_cli::ui::ErrorLine::Hint("stop and start the sandbox, then retry"),
+            ],
+        );
+        return 1;
+    }
     if let Some(failed) = find_exec_failed_in_chain(err) {
         // Try the chain first (callers wrap with `failed to exec
         // "<cmd>"`); fall back to the cmd embedded in the ExecFailed
@@ -233,6 +248,22 @@ fn find_exec_failed_in_chain(
         }
     }
     None
+}
+
+/// Walk the chain looking for a pre-0.5 sandbox restart error.
+///
+/// TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+/// compatibility for versions before 0.5 is no longer supported.
+fn find_pre05_sandbox_restart_required_in_chain(err: &anyhow::Error) -> bool {
+    for cause in err.chain() {
+        if let Some(microsandbox::MicrosandboxError::AgentClient(
+            microsandbox::AgentClientError::Pre05SandboxRestartRequired,
+        )) = cause.downcast_ref::<microsandbox::MicrosandboxError>()
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Pull the first non-empty quoted token from a message. Used to

--- a/crates/cli/lib/commands/mod.rs
+++ b/crates/cli/lib/commands/mod.rs
@@ -60,7 +60,15 @@ pub async fn resolve_and_start(name: &str, quiet: bool) -> anyhow::Result<Sandbo
     match handle.status() {
         SandboxStatus::Running | SandboxStatus::Draining => {
             // Connect to the running sandbox process via the agent relay.
-            Ok(handle.connect().await?)
+            let sandbox = handle.connect().await?;
+            if sandbox.client().is_legacy_protocol() && !quiet {
+                // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+                // compatibility for versions before 0.5 is no longer supported.
+                ui::warn(&format!(
+                    "sandbox \"{name}\" was started before microsandbox 0.5; exec/shell still work temporarily, but filesystem and SFTP need stop/start"
+                ));
+            }
+            Ok(sandbox)
         }
         SandboxStatus::Stopped | SandboxStatus::Crashed => {
             if let Ok(config) = handle.config()

--- a/crates/microsandbox/lib/agent/client.rs
+++ b/crates/microsandbox/lib/agent/client.rs
@@ -25,9 +25,9 @@ use std::sync::{
 use std::time::Duration;
 
 use microsandbox_protocol::{
-    codec::{self, RawFrame},
+    codec::{self, MAX_FRAME_SIZE, RawFrame},
     core::Ready,
-    message::{FLAG_TERMINAL, Message, MessageType},
+    message::{FLAG_TERMINAL, FRAME_HEADER_SIZE, Message, MessageType, PROTOCOL_VERSION},
 };
 use serde::Serialize;
 use tokio::io::AsyncReadExt;
@@ -45,9 +45,27 @@ use super::error::{AgentClientError, AgentClientResult};
 /// Default handshake timeout used by [`AgentClient::connect`].
 const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
+// TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+// compatibility for versions before 0.5 is no longer supported.
+const LEGACY_PROTOCOL_VERSION: u8 = 1;
+const LEGACY_RELAY_ID_RANGE_STEP: u32 = u32::MAX / 16;
+
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
+
+/// Agent protocol generation spoken by a connected sandbox relay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentProtocol {
+    /// Current protocol generation.
+    Current,
+
+    /// pre-0.5 microsandbox relay handshake and agent protocol.
+    ///
+    /// TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+    /// compatibility for versions before 0.5 is no longer supported.
+    LegacyV1,
+}
 
 /// Client for communicating with agentd through the agent relay.
 ///
@@ -61,6 +79,8 @@ pub struct AgentClient {
     id_min: u32,
     /// Upper bound (exclusive) of the assigned ID range.
     id_max: u32,
+    /// Agent protocol generation for this connection.
+    protocol: AgentProtocol,
     /// Pending response channels keyed by correlation ID.
     pending: Arc<Mutex<HashMap<u32, mpsc::UnboundedSender<RawFrame>>>>,
     /// Background reader task handle.
@@ -74,6 +94,15 @@ pub struct AgentClient {
 //--------------------------------------------------------------------------------------------------
 // Methods: Connection lifecycle
 //--------------------------------------------------------------------------------------------------
+
+impl AgentProtocol {
+    fn version(self) -> u8 {
+        match self {
+            Self::Current => PROTOCOL_VERSION,
+            Self::LegacyV1 => LEGACY_PROTOCOL_VERSION,
+        }
+    }
+}
 
 impl AgentClient {
     /// Connect to the sandbox's agent relay socket using the default 10s
@@ -112,7 +141,14 @@ impl AgentClient {
 
         let (mut reader, writer) = stream.into_split();
 
-        // Handshake: [id_min: u32 BE][id_max: u32 BE][ready_frame_bytes...]
+        // Current handshake:
+        // [id_min: u32 BE][id_max: u32 BE][ready_frame_bytes...]
+        //
+        // Legacy pre-0.5 handshake:
+        // [id_offset: u32 BE][ready_frame_bytes...]
+        //
+        // Reading 8 bytes up-front lets us distinguish the two forms. For
+        // legacy relays, the second word is the ready-frame length prefix.
         let mut range_buf = [0u8; 8];
         tokio::time::timeout_at(deadline, reader.read_exact(&mut range_buf))
             .await
@@ -122,23 +158,47 @@ impl AgentClient {
                 )
             })?
             .map_err(|e| AgentClientError::Handshake(format!("read id range: {e}")))?;
-        let id_min = u32::from_be_bytes(range_buf[0..4].try_into().unwrap());
-        let id_max = u32::from_be_bytes(range_buf[4..8].try_into().unwrap());
+        let id_start_or_offset = u32::from_be_bytes(range_buf[0..4].try_into().unwrap());
+        let id_max_or_frame_len = u32::from_be_bytes(range_buf[4..8].try_into().unwrap());
 
-        if id_min >= id_max {
+        let legacy_handshake =
+            looks_like_legacy_relay_handshake(id_start_or_offset, id_max_or_frame_len);
+        let (id_min, id_max, ready_frame, protocol) = if legacy_handshake {
+            // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+            // compatibility for versions before 0.5 is no longer supported.
+            let id_offset = id_start_or_offset;
+            let ready_frame = read_raw_frame_after_len_prefix(
+                &mut reader,
+                range_buf[4..8].try_into().unwrap(),
+                deadline,
+            )
+            .await?;
+            (
+                id_offset.saturating_add(1),
+                id_offset.saturating_add(LEGACY_RELAY_ID_RANGE_STEP),
+                ready_frame,
+                AgentProtocol::LegacyV1,
+            )
+        } else if id_start_or_offset >= id_max_or_frame_len {
             return Err(AgentClientError::Handshake(format!(
-                "invalid relay id range: start={id_min}, end={id_max}"
+                "invalid relay id range: start={id_start_or_offset}, end={id_max_or_frame_len}"
             )));
-        }
-
-        let ready_frame = tokio::time::timeout_at(deadline, codec::read_raw_frame(&mut reader))
-            .await
-            .map_err(|_| {
-                AgentClientError::Handshake(
-                    "read ready frame: timed out before relay sent frame".into(),
-                )
-            })?
-            .map_err(|e| AgentClientError::Handshake(format!("read ready frame: {e}")))?;
+        } else {
+            let ready_frame = tokio::time::timeout_at(deadline, codec::read_raw_frame(&mut reader))
+                .await
+                .map_err(|_| {
+                    AgentClientError::Handshake(
+                        "read ready frame: timed out before relay sent frame".into(),
+                    )
+                })?
+                .map_err(|e| AgentClientError::Handshake(format!("read ready frame: {e}")))?;
+            (
+                id_start_or_offset,
+                id_max_or_frame_len,
+                ready_frame,
+                AgentProtocol::Current,
+            )
+        };
         let ready_msg = codec::raw_frame_to_message(ready_frame.clone())
             .map_err(|e| AgentClientError::Handshake(format!("decode ready frame: {e}")))?;
         if ready_msg.t != MessageType::Ready {
@@ -154,10 +214,18 @@ impl AgentClient {
         tracing::info!(
             id_min,
             id_max,
+            protocol = ?protocol,
             ready_bytes = ready_frame.body.len(),
             boot_time_ns = ready.boot_time_ns,
             "agent client: connected to relay"
         );
+        if protocol == AgentProtocol::LegacyV1 {
+            // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+            // compatibility for versions before 0.5 is no longer supported.
+            tracing::warn!(
+                "agent client: connected to a sandbox started before microsandbox 0.5; exec compatibility is temporary and filesystem/SFTP require stop/start"
+            );
+        }
 
         let pending: Arc<Mutex<HashMap<u32, mpsc::UnboundedSender<RawFrame>>>> =
             Arc::new(Mutex::new(HashMap::new()));
@@ -167,9 +235,10 @@ impl AgentClient {
 
         Ok(Self {
             writer,
-            next_id: AtomicU32::new(id_min),
+            next_id: AtomicU32::new(first_request_id(id_min)),
             id_min,
             id_max,
+            protocol,
             pending,
             reader_handle,
             ready_body: ready_frame.body,
@@ -270,6 +339,16 @@ impl AgentClient {
     pub fn ready_bytes(&self) -> &[u8] {
         &self.ready_body
     }
+
+    /// Agent protocol generation for this connection.
+    pub fn protocol(&self) -> AgentProtocol {
+        self.protocol
+    }
+
+    /// Returns `true` if this connection is using the legacy pre-0.5 protocol.
+    pub fn is_legacy_protocol(&self) -> bool {
+        self.protocol == AgentProtocol::LegacyV1
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -284,7 +363,7 @@ impl AgentClient {
         payload: &T,
     ) -> AgentClientResult<Message> {
         let flags = t.flags();
-        let body = encode_message_body(t, payload)?;
+        let body = encode_message_body(self.protocol.version(), t, payload)?;
         let frame = self.request_raw(flags, body).await?;
         Ok(codec::raw_frame_to_message(frame)?)
     }
@@ -297,7 +376,7 @@ impl AgentClient {
         payload: &T,
     ) -> AgentClientResult<(u32, mpsc::UnboundedReceiver<Message>)> {
         let flags = t.flags();
-        let body = encode_message_body(t, payload)?;
+        let body = encode_message_body(self.protocol.version(), t, payload)?;
         let (id, raw_rx) = self.stream_raw(flags, body).await?;
 
         let (tx, rx) = mpsc::unbounded_channel();
@@ -313,7 +392,7 @@ impl AgentClient {
         payload: &T,
     ) -> AgentClientResult<()> {
         let flags = t.flags();
-        let body = encode_message_body(t, payload)?;
+        let body = encode_message_body(self.protocol.version(), t, payload)?;
         self.write_frame(id, flags, &body).await
     }
 
@@ -334,10 +413,11 @@ impl AgentClient {
     fn alloc_id(&self) -> u32 {
         loop {
             let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-            if id >= self.id_min && id < self.id_max {
+            if id != 0 && id >= self.id_min && id < self.id_max {
                 return id;
             }
-            self.next_id.store(self.id_min, Ordering::Relaxed);
+            self.next_id
+                .store(first_request_id(self.id_min), Ordering::Relaxed);
         }
     }
 
@@ -362,6 +442,54 @@ impl AgentClient {
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
+
+fn looks_like_legacy_relay_handshake(_id_min: u32, id_max: u32) -> bool {
+    // TODO(upgrade-0.6): Remove in 0.6.x or later once pre-0.5 relay
+    // handshakes are no longer accepted.
+    // In the legacy relay handshake, the first 4 bytes are the id offset and
+    // the next 4 bytes are already the ready-frame length prefix. In the v2
+    // handshake, the second word is the exclusive upper id bound, which is far
+    // larger than any valid frame length.
+    id_max >= FRAME_HEADER_SIZE as u32 && id_max <= MAX_FRAME_SIZE
+}
+
+fn first_request_id(id_min: u32) -> u32 {
+    id_min.max(1)
+}
+
+async fn read_raw_frame_after_len_prefix<R: AsyncReadExt + Unpin>(
+    reader: &mut R,
+    len_buf: [u8; 4],
+    deadline: Instant,
+) -> AgentClientResult<RawFrame> {
+    let frame_len = u32::from_be_bytes(len_buf);
+    if frame_len > MAX_FRAME_SIZE {
+        return Err(AgentClientError::Handshake(format!(
+            "legacy ready frame too large: {frame_len} bytes (max {MAX_FRAME_SIZE})"
+        )));
+    }
+    if frame_len < FRAME_HEADER_SIZE as u32 {
+        return Err(AgentClientError::Handshake(format!(
+            "legacy ready frame too short: {frame_len} bytes"
+        )));
+    }
+
+    let mut data = vec![0u8; frame_len as usize];
+    tokio::time::timeout_at(deadline, reader.read_exact(&mut data))
+        .await
+        .map_err(|_| {
+            AgentClientError::Handshake(
+                "read legacy ready frame: timed out before relay sent frame".into(),
+            )
+        })?
+        .map_err(|e| AgentClientError::Handshake(format!("read legacy ready frame: {e}")))?;
+
+    let id = u32::from_be_bytes(data[0..4].try_into().unwrap());
+    let flags = data[4];
+    let body = data[FRAME_HEADER_SIZE..].to_vec();
+
+    Ok(RawFrame { id, flags, body })
+}
 
 /// Background task that reads frames from the relay and dispatches them to
 /// pending channels by correlation ID. Operates on raw frames — no CBOR.
@@ -421,8 +549,13 @@ async fn decode_stream_task(
 }
 
 /// Encode a typed payload to a CBOR `Message` body.
-fn encode_message_body<T: Serialize>(t: MessageType, payload: &T) -> AgentClientResult<Vec<u8>> {
-    let msg = Message::with_payload(t, 0, payload)?;
+fn encode_message_body<T: Serialize>(
+    version: u8,
+    t: MessageType,
+    payload: &T,
+) -> AgentClientResult<Vec<u8>> {
+    let mut msg = Message::with_payload(t, 0, payload)?;
+    msg.v = version;
     let mut body = Vec::new();
     ciborium::into_writer(&msg, &mut body).map_err(microsandbox_protocol::ProtocolError::from)?;
     Ok(body)
@@ -444,8 +577,10 @@ fn sandbox_socket_path(name: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use microsandbox_protocol::core::Ready;
+    use microsandbox_protocol::exec::ExecRequest;
     use tokio::io::AsyncWriteExt;
     use tokio::net::UnixListener;
+    use tokio::sync::oneshot;
 
     use super::*;
 
@@ -464,7 +599,10 @@ mod tests {
         tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
             socket.write_all(&1u32.to_be_bytes()).await.unwrap();
-            socket.write_all(&1024u32.to_be_bytes()).await.unwrap();
+            socket
+                .write_all(&microsandbox_protocol::AGENT_RELAY_ID_RANGE_STEP.to_be_bytes())
+                .await
+                .unwrap();
             codec::write_message(&mut socket, &ready_msg).await.unwrap();
         });
 
@@ -473,6 +611,7 @@ mod tests {
                 .await
                 .unwrap();
 
+        assert_eq!(client.protocol(), AgentProtocol::Current);
         let decoded = client.ready().unwrap();
         assert_eq!(decoded.boot_time_ns, ready.boot_time_ns);
         assert_eq!(decoded.init_time_ns, ready.init_time_ns);
@@ -480,6 +619,92 @@ mod tests {
 
         let raw_msg: Message = ciborium::from_reader(client.ready_bytes()).unwrap();
         assert_eq!(raw_msg.t, MessageType::Ready);
+    }
+
+    #[tokio::test]
+    async fn connect_accepts_legacy_relay_handshake() {
+        assert_accepts_legacy_relay_handshake(0).await;
+        assert_accepts_legacy_relay_handshake(268_435_455).await;
+    }
+
+    #[tokio::test]
+    async fn legacy_relay_requests_use_v1_and_legacy_id_range() {
+        let temp = tempfile::tempdir().unwrap();
+        let sock_path = temp.path().join("agent.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let ready = Ready {
+            boot_time_ns: 11,
+            init_time_ns: 22,
+            ready_time_ns: 33,
+        };
+        let ready_msg = Message::with_payload(MessageType::Ready, 0, &ready).unwrap();
+        let id_offset = 268_435_455u32;
+        let (frame_tx, frame_rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            socket.write_all(&id_offset.to_be_bytes()).await.unwrap();
+            codec::write_message(&mut socket, &ready_msg).await.unwrap();
+            let frame = codec::read_raw_frame(&mut socket).await.unwrap();
+            frame_tx.send(frame).unwrap();
+        });
+
+        let client =
+            AgentClient::connect_with_deadline(&sock_path, Instant::now() + Duration::from_secs(1))
+                .await
+                .unwrap();
+        let request = ExecRequest {
+            cmd: "/bin/true".into(),
+            args: Vec::new(),
+            env: Vec::new(),
+            cwd: None,
+            user: None,
+            tty: false,
+            rows: 24,
+            cols: 80,
+            rlimits: Vec::new(),
+        };
+        let (id, _rx) = client
+            .stream(MessageType::ExecRequest, &request)
+            .await
+            .unwrap();
+
+        let frame = frame_rx.await.unwrap();
+        let message = codec::raw_frame_to_message(frame).unwrap();
+
+        assert_eq!(id, id_offset + 1);
+        assert_eq!(message.id, id_offset + 1);
+        assert_eq!(message.v, LEGACY_PROTOCOL_VERSION);
+        assert_eq!(message.t, MessageType::ExecRequest);
+    }
+
+    async fn assert_accepts_legacy_relay_handshake(id_offset: u32) {
+        let temp = tempfile::tempdir().unwrap();
+        let sock_path = temp.path().join("agent.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let ready = Ready {
+            boot_time_ns: 11,
+            init_time_ns: 22,
+            ready_time_ns: 33,
+        };
+        let ready_msg = Message::with_payload(MessageType::Ready, 0, &ready).unwrap();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            socket.write_all(&id_offset.to_be_bytes()).await.unwrap();
+            codec::write_message(&mut socket, &ready_msg).await.unwrap();
+        });
+
+        let client =
+            AgentClient::connect_with_deadline(&sock_path, Instant::now() + Duration::from_secs(1))
+                .await
+                .unwrap();
+
+        assert_eq!(client.protocol(), AgentProtocol::LegacyV1);
+        let decoded = client.ready().unwrap();
+        assert_eq!(decoded.boot_time_ns, ready.boot_time_ns);
+        assert_eq!(decoded.init_time_ns, ready.init_time_ns);
+        assert_eq!(decoded.ready_time_ns, ready.ready_time_ns);
     }
 }
 

--- a/crates/microsandbox/lib/agent/error.rs
+++ b/crates/microsandbox/lib/agent/error.rs
@@ -26,6 +26,15 @@ pub enum AgentClientError {
     #[error("handshake: {0}")]
     Handshake(String),
 
+    /// The sandbox must be restarted before using filesystem or SFTP features.
+    ///
+    /// TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+    /// compatibility for versions before 0.5 is no longer supported.
+    #[error(
+        "filesystem and SFTP features need this sandbox to be restarted: this sandbox was started before microsandbox 0.5; stop and start it, then retry"
+    )]
+    Pre05SandboxRestartRequired,
+
     /// Sandbox name could not be resolved to an agent socket path.
     #[error("sandbox '{0}' not found")]
     SandboxNotFound(String),

--- a/crates/microsandbox/lib/agent/mod.rs
+++ b/crates/microsandbox/lib/agent/mod.rs
@@ -13,6 +13,6 @@ mod error;
 //--------------------------------------------------------------------------------------------------
 
 pub use bridge::{AgentBridge, BridgeFrame, StreamHandle};
-pub use client::AgentClient;
+pub use client::{AgentClient, AgentProtocol};
 pub use error::{AgentClientError, AgentClientResult};
 pub use microsandbox_protocol::codec::RawFrame;

--- a/crates/microsandbox/lib/db/mod.rs
+++ b/crates/microsandbox/lib/db/mod.rs
@@ -11,7 +11,15 @@
 
 pub use microsandbox_db::entity;
 
-use std::{path::Path, time::Duration};
+#[cfg(unix)]
+use std::{
+    fs::{File, OpenOptions},
+    os::fd::AsRawFd,
+};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use microsandbox_db::pool::DbPools;
 use microsandbox_migration::{Migrator, MigratorTrait};
@@ -24,6 +32,15 @@ use crate::{MicrosandboxError, MicrosandboxResult};
 //--------------------------------------------------------------------------------------------------
 
 static GLOBAL_POOL: OnceCell<DbPools> = OnceCell::const_new();
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+struct MigrationLock {
+    #[cfg(unix)]
+    file: File,
+}
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -60,6 +77,7 @@ pub fn global() -> Option<&'static DbPools> {
 /// global config.
 async fn connect_and_migrate(db_dir: &Path) -> MicrosandboxResult<DbPools> {
     tokio::fs::create_dir_all(db_dir).await?;
+    let _migration_lock = acquire_migration_lock(db_dir).await?;
 
     let database = &crate::config::config().database;
     let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
@@ -75,6 +93,62 @@ async fn connect_and_migrate(db_dir: &Path) -> MicrosandboxResult<DbPools> {
     Migrator::up(pools.write().inner(), None).await?;
 
     Ok(pools)
+}
+
+async fn acquire_migration_lock(db_dir: &Path) -> MicrosandboxResult<MigrationLock> {
+    let path = db_dir.join(format!(
+        "{}.migration.lock",
+        microsandbox_utils::DB_FILENAME
+    ));
+    tokio::task::spawn_blocking(move || MigrationLock::acquire(path))
+        .await
+        .map_err(|e| MicrosandboxError::Runtime(format!("migration lock task failed: {e}")))?
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl MigrationLock {
+    #[cfg(unix)]
+    fn acquire(path: PathBuf) -> MicrosandboxResult<Self> {
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|e| {
+                MicrosandboxError::Runtime(format!("open migration lock {}: {e}", path.display()))
+            })?;
+
+        let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        if ret != 0 {
+            return Err(MicrosandboxError::Runtime(format!(
+                "lock migration file {}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            )));
+        }
+
+        Ok(Self { file })
+    }
+
+    #[cfg(not(unix))]
+    fn acquire(_path: PathBuf) -> MicrosandboxResult<Self> {
+        Ok(Self {})
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(unix)]
+impl Drop for MigrationLock {
+    fn drop(&mut self) {
+        let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -264,5 +338,96 @@ mod tests {
             .try_get_by_index::<i64>(0)
             .unwrap();
         assert_eq!(new_index_count, 3);
+    }
+
+    #[tokio::test]
+    async fn test_connect_and_migrate_updates_legacy_oci_rootfs_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_dir = tmp.path().join("db");
+        tokio::fs::create_dir_all(&db_dir).await.unwrap();
+
+        let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+        let conn = Database::connect(&db_url).await.unwrap();
+
+        Migrator::up(&conn, Some(2)).await.unwrap();
+        conn.execute(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "INSERT INTO sandbox (name, config, status) VALUES (?, ?, ?)",
+            [
+                "legacy".into(),
+                r#"{"name":"legacy","image":{"Oci":"ubuntu"}}"#.into(),
+                "Stopped".into(),
+            ],
+        ))
+        .await
+        .unwrap();
+        drop(conn);
+
+        let pools = connect_and_migrate(&db_dir).await.unwrap();
+        let config_json = pools
+            .read()
+            .query_one(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                "SELECT config FROM sandbox WHERE name = 'legacy'",
+            ))
+            .await
+            .unwrap()
+            .unwrap()
+            .try_get_by_index::<String>(0)
+            .unwrap();
+
+        let value: serde_json::Value = serde_json::from_str(&config_json).unwrap();
+        assert_eq!(value["image"]["Oci"]["reference"], "ubuntu");
+        assert_eq!(value["image"]["Oci"]["upper_size_mib"], 4096);
+
+        let decoded: crate::sandbox::SandboxConfig = serde_json::from_str(&config_json).unwrap();
+        assert_eq!(decoded.image.oci_reference(), Some("ubuntu"));
+        assert_eq!(decoded.image.oci_upper_size_mib(), Some(4096));
+    }
+
+    #[tokio::test]
+    async fn test_connect_and_migrate_serializes_concurrent_migrations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_dir = tmp.path().join("db");
+        tokio::fs::create_dir_all(&db_dir).await.unwrap();
+
+        let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+        let conn = Database::connect(&db_url).await.unwrap();
+
+        Migrator::up(&conn, Some(2)).await.unwrap();
+        conn.execute(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "INSERT INTO sandbox (name, config, status) VALUES (?, ?, ?)",
+            [
+                "legacy".into(),
+                r#"{"name":"legacy","image":{"Oci":"ubuntu"}}"#.into(),
+                "Stopped".into(),
+            ],
+        ))
+        .await
+        .unwrap();
+        drop(conn);
+
+        let (first, second) =
+            tokio::join!(connect_and_migrate(&db_dir), connect_and_migrate(&db_dir));
+
+        first.unwrap();
+        second.unwrap();
+
+        let conn = Database::connect(&db_url).await.unwrap();
+        let migration_count = conn
+            .query_one(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                "SELECT COUNT(*) FROM seaql_migrations",
+            ))
+            .await
+            .unwrap()
+            .unwrap()
+            .try_get_by_index::<i64>(0)
+            .unwrap();
+
+        assert_eq!(migration_count, 8);
     }
 }

--- a/crates/microsandbox/lib/lib.rs
+++ b/crates/microsandbox/lib/lib.rs
@@ -22,8 +22,8 @@ pub mod snapshot;
 pub mod volume;
 
 pub use agent::{
-    AgentBridge, AgentClient, AgentClientError, AgentClientResult, BridgeFrame, RawFrame,
-    StreamHandle,
+    AgentBridge, AgentClient, AgentClientError, AgentClientResult, AgentProtocol, BridgeFrame,
+    RawFrame, StreamHandle,
 };
 pub use error::*;
 pub use image::{Image, ImageConfigDetail, ImageDetail, ImageHandle, ImageLayerDetail};

--- a/crates/microsandbox/lib/sandbox/fs.rs
+++ b/crates/microsandbox/lib/sandbox/fs.rs
@@ -13,7 +13,10 @@ use microsandbox_protocol::{
 };
 use tokio::sync::mpsc;
 
-use crate::{MicrosandboxError, MicrosandboxResult, agent::AgentClient};
+use crate::{
+    MicrosandboxError, MicrosandboxResult,
+    agent::{AgentClient, AgentClientError},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -133,6 +136,17 @@ impl SandboxFs {
         }
     }
 
+    fn ensure_current_protocol(&self) -> MicrosandboxResult<()> {
+        if self.client.is_legacy_protocol() {
+            // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+            // compatibility for versions before 0.5 is no longer supported.
+            return Err(MicrosandboxError::AgentClient(
+                AgentClientError::Pre05SandboxRestartRequired,
+            ));
+        }
+        Ok(())
+    }
+
     //----------------------------------------------------------------------------------------------
     // Read Operations
     //----------------------------------------------------------------------------------------------
@@ -201,6 +215,7 @@ impl SandboxFs {
         len: Option<u64>,
         close_handle: Option<FsHandle>,
     ) -> MicrosandboxResult<FsReadStream> {
+        self.ensure_current_protocol()?;
         let req = FsRequest {
             op: FsOp::Read {
                 handle,
@@ -286,6 +301,7 @@ impl SandboxFs {
         len: Option<u64>,
         close_handle: Option<FsHandle>,
     ) -> MicrosandboxResult<FsWriteSink> {
+        self.ensure_current_protocol()?;
         let req = FsRequest {
             op: FsOp::Write {
                 handle,
@@ -632,6 +648,7 @@ impl SandboxFs {
     }
 
     async fn request_response(&self, req: FsRequest) -> MicrosandboxResult<FsResponse> {
+        self.ensure_current_protocol()?;
         let msg = self.client.request(MessageType::FsRequest, &req).await?;
         let resp: FsResponse = msg.payload()?;
         if resp.ok {
@@ -814,5 +831,53 @@ fn read_only_open_options() -> FsOpenOptions {
     FsOpenOptions {
         read: true,
         ..Default::default()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use microsandbox_protocol::{codec, core::Ready};
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::UnixListener;
+    use tokio::time::Instant;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn filesystem_operations_reject_legacy_agent_protocol() {
+        let temp = tempfile::tempdir().unwrap();
+        let sock_path = temp.path().join("agent.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let ready = Ready {
+            boot_time_ns: 11,
+            init_time_ns: 22,
+            ready_time_ns: 33,
+        };
+        let ready_msg = Message::with_payload(MessageType::Ready, 0, &ready).unwrap();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            socket.write_all(&0u32.to_be_bytes()).await.unwrap();
+            codec::write_message(&mut socket, &ready_msg).await.unwrap();
+        });
+
+        let client = Arc::new(
+            AgentClient::connect_with_deadline(&sock_path, Instant::now() + Duration::from_secs(1))
+                .await
+                .unwrap(),
+        );
+        let fs = SandboxFs::new(&client);
+
+        match fs.stat("/").await {
+            Err(MicrosandboxError::AgentClient(AgentClientError::Pre05SandboxRestartRequired)) => {}
+            Err(error) => panic!("unexpected error: {error}"),
+            Ok(_) => panic!("legacy filesystem request unexpectedly succeeded"),
+        }
     }
 }

--- a/crates/microsandbox/lib/sandbox/ssh.rs
+++ b/crates/microsandbox/lib/sandbox/ssh.rs
@@ -20,7 +20,10 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use super::attach;
 use crate::sandbox::exec::{ExecControl, ExecEvent, ExecOptions, ExecSink, StdinMode};
-use crate::{MicrosandboxError, MicrosandboxResult, Sandbox, agent::AgentClient};
+use crate::{
+    MicrosandboxError, MicrosandboxResult, Sandbox,
+    agent::{AgentClient, AgentClientError},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -97,6 +100,9 @@ pub struct SshClient {
     handle: russh::client::Handle<SshClientHandler>,
     term: String,
     server_task: Option<tokio::task::JoinHandle<MicrosandboxResult<()>>>,
+    // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+    // compatibility for versions before 0.5 is no longer supported.
+    legacy_agent: bool,
 }
 
 /// High-level SFTP client session.
@@ -275,6 +281,7 @@ impl SandboxSsh {
             handle: client,
             term,
             server_task: Some(server_task),
+            legacy_agent: self.sandbox.client().is_legacy_protocol(),
         })
     }
 
@@ -632,6 +639,14 @@ impl SshClient {
 
     /// Open an SFTP client session over this SSH connection.
     pub async fn sftp(&self) -> MicrosandboxResult<SftpClient> {
+        if self.legacy_agent {
+            // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+            // compatibility for versions before 0.5 is no longer supported.
+            return Err(MicrosandboxError::AgentClient(
+                AgentClientError::Pre05SandboxRestartRequired,
+            ));
+        }
+
         let mut channel = self
             .handle
             .channel_open_session()
@@ -1008,6 +1023,13 @@ impl russh::server::Handler for SshSession {
         };
 
         let client = self.agent_client().await?;
+        if client.is_legacy_protocol() {
+            // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+            // compatibility for versions before 0.5 is no longer supported.
+            session.channel_failure(channel)?;
+            return Ok(());
+        }
+
         let fs = crate::sandbox::fs::SandboxFs::new(&client);
         let cwd = self
             .settings

--- a/crates/migration/Cargo.toml
+++ b/crates/migration/Cargo.toml
@@ -13,3 +13,4 @@ path = "lib/lib.rs"
 
 [dependencies]
 sea-orm-migration.workspace = true
+serde_json.workspace = true

--- a/crates/migration/lib/lib.rs
+++ b/crates/migration/lib/lib.rs
@@ -7,6 +7,7 @@ mod m20260305_000004_create_sandbox_images_table;
 mod m20260410_000001_erofs_image_schema;
 mod m20260501_000001_create_snapshot_index;
 mod m20260517_000001_drop_sandbox_metric;
+mod m20260527_000001_migrate_oci_rootfs_source;
 
 use sea_orm_migration::prelude::*;
 
@@ -38,6 +39,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260410_000001_erofs_image_schema::Migration),
             Box::new(m20260501_000001_create_snapshot_index::Migration),
             Box::new(m20260517_000001_drop_sandbox_metric::Migration),
+            Box::new(m20260527_000001_migrate_oci_rootfs_source::Migration),
         ]
     }
 }

--- a/crates/migration/lib/m20260527_000001_migrate_oci_rootfs_source.rs
+++ b/crates/migration/lib/m20260527_000001_migrate_oci_rootfs_source.rs
@@ -1,0 +1,127 @@
+//! Migration: Rewrite legacy OCI rootfs config records.
+//!
+//! microsandbox 0.5 stores OCI rootfs configuration as an object so the
+//! persisted config can carry the writable upper size. Earlier versions stored
+//! only the image reference string under `image.Oci`.
+//!
+//! TODO(upgrade-0.6): Remove in 0.6.x or later if migration history is
+//! squashed and pre-0.5 databases no longer need direct migration.
+
+use sea_orm_migration::{
+    prelude::*,
+    sea_orm::{ConnectionTrait, DatabaseBackend, Statement},
+};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const DEFAULT_OCI_UPPER_SIZE_MIB: u32 = 4 * 1024;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+pub struct Migration;
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260527_000001_migrate_oci_rootfs_source"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        let rows = conn
+            .query_all(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                "SELECT id, config FROM sandbox".to_owned(),
+            ))
+            .await?;
+
+        for row in rows {
+            let id = row.try_get_by_index::<i32>(0)?;
+            let config = row.try_get_by_index::<String>(1)?;
+            let Some(updated) = migrate_config(&config)? else {
+                continue;
+            };
+
+            conn.execute(Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                "UPDATE sandbox SET config = ? WHERE id = ?",
+                [updated.into(), id.into()],
+            ))
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // The new shape is the canonical persisted representation. Reverting
+        // would reintroduce config JSON that current code cannot read.
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn migrate_config(config: &str) -> Result<Option<String>, DbErr> {
+    let mut value = serde_json::from_str::<serde_json::Value>(config)
+        .map_err(|err| DbErr::Custom(format!("parse sandbox config JSON: {err}")))?;
+
+    let Some(oci) = value
+        .get_mut("image")
+        .and_then(|image| image.get_mut("Oci"))
+    else {
+        return Ok(None);
+    };
+
+    let Some(reference) = oci.as_str().map(str::to_owned) else {
+        return Ok(None);
+    };
+
+    *oci = serde_json::json!({
+        "reference": reference,
+        "upper_size_mib": DEFAULT_OCI_UPPER_SIZE_MIB,
+    });
+
+    serde_json::to_string(&value)
+        .map(Some)
+        .map_err(|err| DbErr::Custom(format!("serialize sandbox config JSON: {err}")))
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrate_config_rewrites_legacy_oci_source() {
+        let config = r#"{"name":"legacy","image":{"Oci":"ubuntu"}}"#;
+        let updated = migrate_config(config).unwrap().unwrap();
+        let value: serde_json::Value = serde_json::from_str(&updated).unwrap();
+
+        assert_eq!(value["image"]["Oci"]["reference"], "ubuntu");
+        assert_eq!(value["image"]["Oci"]["upper_size_mib"], 4096);
+    }
+
+    #[test]
+    fn migrate_config_ignores_new_oci_source() {
+        let config =
+            r#"{"name":"new","image":{"Oci":{"reference":"ubuntu","upper_size_mib":8192}}}"#;
+
+        assert!(migrate_config(config).unwrap().is_none());
+    }
+}

--- a/crates/protocol/lib/message.rs
+++ b/crates/protocol/lib/message.rs
@@ -9,7 +9,7 @@ use crate::error::ProtocolResult;
 //--------------------------------------------------------------------------------------------------
 
 /// Current protocol version.
-pub const PROTOCOL_VERSION: u8 = 1;
+pub const PROTOCOL_VERSION: u8 = 2;
 
 /// Frame flag: this is the last message for the given correlation ID.
 ///

--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -136,6 +136,13 @@ const (
 	// loaded. Call EnsureInstalled() before using any SDK functions.
 	ErrLibraryNotLoaded
 
+	// ErrPre05SandboxRestartRequired indicates filesystem or SFTP was requested
+	// for a sandbox that must be stopped and started first.
+	//
+	// TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+	// compatibility for versions before 0.5 is no longer supported.
+	ErrPre05SandboxRestartRequired
+
 	// ErrInternal is every other error from the runtime.
 	ErrInternal
 )
@@ -200,6 +207,8 @@ func (k ErrorKind) String() string {
 		return "Cancelled"
 	case ErrLibraryNotLoaded:
 		return "LibraryNotLoaded"
+	case ErrPre05SandboxRestartRequired:
+		return "Pre05SandboxRestartRequired"
 	case ErrInternal:
 		return "Internal"
 	default:
@@ -313,6 +322,10 @@ func kindFromFFI(kind string) ErrorKind {
 		return ErrCancelled
 	case ffi.KindLibraryNotLoaded:
 		return ErrLibraryNotLoaded
+	case ffi.KindPre05SandboxRestartRequired:
+		// TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+		// compatibility for versions before 0.5 is no longer supported.
+		return ErrPre05SandboxRestartRequired
 	default:
 		return ErrInternal
 	}

--- a/sdk/go/errors_test.go
+++ b/sdk/go/errors_test.go
@@ -24,6 +24,7 @@ func TestErrorKindString(t *testing.T) {
 		{ErrInvalidHandle, "InvalidHandle"},
 		{ErrBufferTooSmall, "BufferTooSmall"},
 		{ErrCancelled, "Cancelled"},
+		{ErrPre05SandboxRestartRequired, "Pre05SandboxRestartRequired"},
 		{ErrInternal, "Internal"},
 		{ErrorKind(9999), "Unknown"},
 	}
@@ -139,6 +140,7 @@ func TestKindFromFFIAllTags(t *testing.T) {
 		{ffi.KindInvalidHandle, ErrInvalidHandle},
 		{ffi.KindBufferTooSmall, ErrBufferTooSmall},
 		{ffi.KindCancelled, ErrCancelled},
+		{ffi.KindPre05SandboxRestartRequired, ErrPre05SandboxRestartRequired},
 		{"unrecognized_tag", ErrInternal},
 	}
 	for _, c := range cases {

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -969,7 +969,10 @@ const (
 	KindSnapshotImageMissing   = "snapshot_image_missing"
 	KindSnapshotIntegrity      = "snapshot_integrity"
 	KindPatchFailed            = "patch_failed"
-	KindIO                     = "io"
+	// TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+	// compatibility for versions before 0.5 is no longer supported.
+	KindPre05SandboxRestartRequired = "pre05_sandbox_restart_required"
+	KindIO                          = "io"
 )
 
 // Sandbox is an opaque handle to a Rust-side sandbox. Call Close to release.

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -449,6 +449,7 @@ mod error_kind {
     pub const SNAPSHOT_IMAGE_MISSING: &str = "snapshot_image_missing";
     pub const SNAPSHOT_INTEGRITY: &str = "snapshot_integrity";
     pub const PATCH_FAILED: &str = "patch_failed";
+    pub const PRE05_SANDBOX_RESTART_REQUIRED: &str = "pre05_sandbox_restart_required";
     pub const IO: &str = "io";
 }
 
@@ -506,6 +507,13 @@ impl From<MicrosandboxError> for FfiError {
             MicrosandboxError::SnapshotImageMissing(_) => error_kind::SNAPSHOT_IMAGE_MISSING,
             MicrosandboxError::SnapshotIntegrity(_) => error_kind::SNAPSHOT_INTEGRITY,
             MicrosandboxError::PatchFailed(_) => error_kind::PATCH_FAILED,
+            MicrosandboxError::AgentClient(
+                microsandbox::AgentClientError::Pre05SandboxRestartRequired,
+            ) => {
+                // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+                // compatibility for versions before 0.5 is no longer supported.
+                error_kind::PRE05_SANDBOX_RESTART_REQUIRED
+            }
             MicrosandboxError::Io(_) => error_kind::IO,
             _ => error_kind::INTERNAL,
         };

--- a/sdk/node-ts/native/error.rs
+++ b/sdk/node-ts/native/error.rs
@@ -46,6 +46,13 @@ fn error_type_str(err: &MicrosandboxError) -> &'static str {
         MicrosandboxError::MetricsDisabled(_) => "MetricsDisabled",
         MicrosandboxError::MissedRotation { .. } => "MissedRotation",
         MicrosandboxError::InvalidCursor(_) => "InvalidCursor",
+        MicrosandboxError::AgentClient(
+            microsandbox::AgentClientError::Pre05SandboxRestartRequired,
+        ) => {
+            // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+            // compatibility for versions before 0.5 is no longer supported.
+            "Pre05SandboxRestartRequired"
+        }
         MicrosandboxError::AgentClient(_) => "AgentClient",
         MicrosandboxError::Custom(_) => "Custom",
     }

--- a/sdk/node-ts/src/errors.ts
+++ b/sdk/node-ts/src/errors.ts
@@ -20,6 +20,7 @@ export type MicrosandboxErrorCode =
   | "image"
   | "patchFailed"
   | "metricsDisabled"
+  | "pre05SandboxRestartRequired"
   | "custom";
 
 export class MicrosandboxError extends Error {
@@ -158,6 +159,14 @@ export class PatchFailedError extends MicrosandboxError {
 export class MetricsDisabledError extends MicrosandboxError {
   constructor(message: string, options?: ErrorOptions) {
     super("metricsDisabled", message, options);
+  }
+}
+
+// TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+// compatibility for versions before 0.5 is no longer supported.
+export class Pre05SandboxRestartRequiredError extends MicrosandboxError {
+  constructor(message: string, options?: ErrorOptions) {
+    super("pre05SandboxRestartRequired", message, options);
   }
 }
 

--- a/sdk/node-ts/src/index.ts
+++ b/sdk/node-ts/src/index.ts
@@ -371,6 +371,7 @@ export {
   SandboxNotFoundError,
   SandboxStillRunningError,
   TerminalError,
+  Pre05SandboxRestartRequiredError,
   VolumeAlreadyExistsError,
   VolumeNotFoundError,
 } from "./errors.js";

--- a/sdk/node-ts/src/internal/error-mapping.ts
+++ b/sdk/node-ts/src/internal/error-mapping.ts
@@ -20,6 +20,7 @@ import {
   SandboxNotFoundError,
   SandboxStillRunningError,
   TerminalError,
+  Pre05SandboxRestartRequiredError,
   VolumeAlreadyExistsError,
   VolumeNotFoundError,
 } from "../errors.js";
@@ -49,6 +50,9 @@ const CTORS = new Map<string, (msg: string, raw: Error) => MicrosandboxError>([
   ["Image", (m, c) => new ImageError(m, { cause: c })],
   ["PatchFailed", (m, c) => new PatchFailedError(m, { cause: c })],
   ["MetricsDisabled", (m, c) => new MetricsDisabledError(m, { cause: c })],
+  // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+  // compatibility for versions before 0.5 is no longer supported.
+  ["Pre05SandboxRestartRequired", (m, c) => new Pre05SandboxRestartRequiredError(m, { cause: c })],
   ["Custom", (m, c) => new CustomError(m, { cause: c })],
 ]);
 

--- a/sdk/python/microsandbox/__init__.py
+++ b/sdk/python/microsandbox/__init__.py
@@ -55,6 +55,7 @@ from microsandbox.errors import (
     MicrosandboxError,
     NetworkPolicyError,
     PathNotFoundError,
+    Pre05SandboxRestartRequiredError,
     SandboxAlreadyExistsError,
     SandboxNotFoundError,
     SandboxNotRunningError,
@@ -251,6 +252,7 @@ __all__ = [
     "TlsError",
     "IoError",
     "MetricsDisabledError",
+    "Pre05SandboxRestartRequiredError",
     # Setup
     "install",
     "is_installed",

--- a/sdk/python/microsandbox/errors.py
+++ b/sdk/python/microsandbox/errors.py
@@ -95,3 +95,10 @@ class IoError(MicrosandboxError):
 class MetricsDisabledError(MicrosandboxError):
     """Metrics sampling is disabled for this sandbox."""
     code = "metrics-disabled"
+
+
+# TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+# compatibility for versions before 0.5 is no longer supported.
+class Pre05SandboxRestartRequiredError(MicrosandboxError):
+    """Filesystem and SFTP features need this sandbox to be restarted."""
+    code = "pre05-sandbox-restart-required"

--- a/sdk/python/src/error.rs
+++ b/sdk/python/src/error.rs
@@ -31,6 +31,11 @@ pub fn to_py_err(err: microsandbox::MicrosandboxError) -> PyErr {
             VolumeNotFound(_) => ("VolumeNotFoundError", err.to_string()),
             Io(_) => ("IoError", err.to_string()),
             MetricsDisabled(_) => ("MetricsDisabledError", err.to_string()),
+            AgentClient(microsandbox::AgentClientError::Pre05SandboxRestartRequired) => {
+                // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+                // compatibility for versions before 0.5 is no longer supported.
+                ("Pre05SandboxRestartRequiredError", err.to_string())
+            }
             Terminal(_) => ("MicrosandboxError", err.to_string()),
             _ => ("MicrosandboxError", err.to_string()),
         };


### PR DESCRIPTION
## TL;DR
Keep sandboxes started before microsandbox 0.5 usable for exec/shell after updating, while making new filesystem and SFTP calls fail with a clear restart message. This also migrates old OCI sandbox config rows and serializes first-run DB migrations so concurrent upgraded commands do not race.

## Description
- Detects the pre-0.5 relay handshake and marks those connections as `AgentProtocol::LegacyV1`.
- Keeps temporary exec/shell compatibility by sending protocol v1 frames with the old relay ID range, while current sandboxes use protocol v2.
- Blocks filesystem and SFTP operations on pre-0.5 live sandboxes with `Pre05SandboxRestartRequired` before sending new filesystem requests.
- Shows a CLI warning when connecting to a sandbox started before microsandbox 0.5, and renders a restart hint for unsupported filesystem and SFTP operations.
- Migrates legacy OCI config JSON from a string image reference to the current object shape with the 4096 MiB upper size default.
- Serializes DB migrations with a per-DB lock so the first post-upgrade commands cannot race SeaORM migration bookkeeping.
- Maps the pre-0.5 restart-required error through the Python, Node, and Go SDK error surfaces.

## Test Plan
- [x] `cargo test -p microsandbox legacy`
- [x] `cargo test -p microsandbox test_connect_and_migrate_serializes_concurrent_migrations`
- [x] `cargo test -p microsandbox-migration migrate_config_rewrites_legacy_oci_source`
- [x] `cargo fmt --all -- --check && git diff --check`
- [x] `go test -count=1 .` in `sdk/go`
- [x] `npm run typecheck` in `sdk/node-ts`
- [x] Reproduced released `v0.5.0` against a live `v0.4.6` sandbox: `exec` failed with `handshake: read ready frame: frame payload too short`.
- [x] Verified signed patched binary against a live `v0.4.6` sandbox: `list`/`status` worked, `exec` worked with the pre-0.5 restart warning, and SDK filesystem/SFTP returned `Pre05SandboxRestartRequired`.
- [x] Verified stop/start with the signed patched binary moves an old sandbox onto the current protocol: `exec`, SDK filesystem stat, and SFTP all succeeded after restart.
- [x] Verified three concurrent first-upgrade commands against a fresh `v0.4.6` DB all completed without the migration uniqueness race.
