### PR TITLE
Enable ssh feature for release binary

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Build msb
         run: |
-          cargo build --release --no-default-features --features net -p microsandbox-cli
+          cargo build --release --no-default-features --features net,ssh -p microsandbox-cli
           mkdir -p build
           cp target/release/msb build/msb
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
       # -- msb --
       - name: Build msb
         run: |
-          cargo build --release --no-default-features --features net -p microsandbox-cli
+          cargo build --release --no-default-features --features net,ssh -p microsandbox-cli
           mkdir -p build
           cp target/release/msb build/msb
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
       # -- Build & Test --
       - name: Build msb
         run: |
-          cargo build --release --no-default-features --features net -p microsandbox-cli
+          cargo build --release --no-default-features --features net,ssh -p microsandbox-cli
           mkdir -p build
           cp target/release/msb build/msb
 


### PR DESCRIPTION
In released binaries at [v0.5.0](https://github.com/superradcompany/microsandbox/releases/tag/v0.5.0), SSH feature is disabled.
I'd like to enable it so added feature flag in CI settings.