### PR TITLE
chore(release): bump microsandbox to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-go"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.22.1",
  "cbindgen",
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "libc",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "futures",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "dirs",
  "libc",
@@ -6211,14 +6211,14 @@ dependencies = [
 
 [[package]]
 name = "test-init"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "test-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6227,7 +6227,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.5.0"
+version = "0.5.1"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -18,7 +18,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { version = "0.5.0", path = "../protocol" }
+microsandbox-protocol = { version = "0.5.1", path = "../protocol" }
 nix = { workspace = true, features = [
     "fs",
     "hostname",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,12 +40,12 @@ futures.workspace = true
 indicatif.workspace = true
 ipnetwork = { workspace = true, optional = true }
 libc.workspace = true
-microsandbox = { version = "0.5.0", path = "../microsandbox", default-features = false }
-microsandbox-image = { version = "0.5.0", path = "../image" }
-microsandbox-network = { version = "0.5.0", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.5.0", path = "../protocol" }
-microsandbox-runtime = { version = "0.5.0", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.5.0", path = "../utils" }
+microsandbox = { version = "0.5.1", path = "../microsandbox", default-features = false }
+microsandbox-image = { version = "0.5.1", path = "../image" }
+microsandbox-network = { version = "0.5.1", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.5.1", path = "../protocol" }
+microsandbox-runtime = { version = "0.5.1", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.5.1", path = "../utils" }
 rand.workspace = true
 regex = "1"
 reqwest.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { version = "0.5.0", path = "../utils" }
+microsandbox-utils = { version = "0.5.1", path = "../utils" }
 msb_krun = "0.1.13"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,4 +23,4 @@ default = ["prebuilt"]
 prebuilt = ["microsandbox-utils/http-client"]
 
 [build-dependencies]
-microsandbox-utils = { version = "0.5.0", path = "../utils" }
+microsandbox-utils = { version = "0.5.1", path = "../utils" }

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { version = "0.5.0", path = "../utils" }
+microsandbox-utils = { version = "0.5.1", path = "../utils" }
 oci-client.workspace = true
 rustls-pemfile.workspace = true
 oci-spec.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -41,15 +41,15 @@ flate2.workspace = true
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-db = { version = "0.5.0", path = "../db" }
-microsandbox-filesystem = { version = "0.5.0", path = "../filesystem", default-features = false }
-microsandbox-image = { version = "0.5.0", path = "../image" }
-microsandbox-metrics = { version = "0.5.0", path = "../metrics" }
-microsandbox-migration = { version = "0.5.0", path = "../migration" }
-microsandbox-network = { version = "0.5.0", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.5.0", path = "../protocol" }
-microsandbox-runtime = { version = "0.5.0", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.5.0", path = "../utils" }
+microsandbox-db = { version = "0.5.1", path = "../db" }
+microsandbox-filesystem = { version = "0.5.1", path = "../filesystem", default-features = false }
+microsandbox-image = { version = "0.5.1", path = "../image" }
+microsandbox-metrics = { version = "0.5.1", path = "../metrics" }
+microsandbox-migration = { version = "0.5.1", path = "../migration" }
+microsandbox-network = { version = "0.5.1", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.5.1", path = "../protocol" }
+microsandbox-runtime = { version = "0.5.1", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.5.1", path = "../utils" }
 nix = { workspace = true, features = ["process", "signal"] }
 notify.workspace = true
 rand.workspace = true
@@ -71,7 +71,7 @@ which.workspace = true
 
 [build-dependencies]
 flate2.workspace = true
-microsandbox-utils = { version = "0.5.0", path = "../utils" }
+microsandbox-utils = { version = "0.5.1", path = "../utils" }
 tar.workspace = true
 
 [dev-dependencies]

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -24,8 +24,8 @@ hickory-proto = { workspace = true, features = ["tls-ring"] }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
-microsandbox-protocol = { version = "0.5.0", path = "../protocol" }
-microsandbox-utils = { version = "0.5.0", path = "../utils" }
+microsandbox-protocol = { version = "0.5.1", path = "../protocol" }
+microsandbox-utils = { version = "0.5.1", path = "../utils" }
 msb_krun = { version = "0.1.13", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,12 +22,12 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
-microsandbox-db = { version = "0.5.0", path = "../db" }
-microsandbox-filesystem = { version = "0.5.0", path = "../filesystem", default-features = false }
-microsandbox-metrics = { version = "0.5.0", path = "../metrics" }
-microsandbox-network = { version = "0.5.0", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.5.0", path = "../protocol" }
-microsandbox-utils = { version = "0.5.0", path = "../utils" }
+microsandbox-db = { version = "0.5.1", path = "../db" }
+microsandbox-filesystem = { version = "0.5.1", path = "../filesystem", default-features = false }
+microsandbox-metrics = { version = "0.5.1", path = "../metrics" }
+microsandbox-network = { version = "0.5.1", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.5.1", path = "../protocol" }
+microsandbox-utils = { version = "0.5.1", path = "../utils" }
 msb_krun = { version = "0.1.13", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/init-handoff/package.json
+++ b/examples/typescript/init-handoff/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/snapshot-fork/package.json
+++ b/examples/typescript/snapshot-fork/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.0"
+    "microsandbox": "0.5.1"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/sdk/go/native/Cargo.toml
+++ b/sdk/go/native/Cargo.toml
@@ -12,8 +12,8 @@ name = "microsandbox_go_ffi"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-microsandbox = { version = "0.5.0", path = "../../../crates/microsandbox", features = ["net", "ssh"] }
-microsandbox-network = { version = "0.5.0", path = "../../../crates/network" }
+microsandbox = { version = "0.5.1", path = "../../../crates/microsandbox", features = ["net", "ssh"] }
+microsandbox-network = { version = "0.5.1", path = "../../../crates/network" }
 ipnetwork.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/sdk/go/setup.go
+++ b/sdk/go/setup.go
@@ -24,7 +24,7 @@ import (
 // embedded FFI library and the downloaded msb+libkrunfw artefacts are
 // both pinned to this version. Bump when cutting a new SDK release so
 // it matches published binaries.
-const sdkVersion = "0.5.0"
+const sdkVersion = "0.5.1"
 
 // libkrunfwABI is the major SONAME version of libkrunfw that msb links
 // against.

--- a/sdk/node-ts/Cargo.toml
+++ b/sdk/node-ts/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 path = "native/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.5.0", path = "../../crates/microsandbox", features = ["ssh"] }
-microsandbox-network = { version = "0.5.0", path = "../../crates/network" }
+microsandbox = { version = "0.5.1", path = "../../crates/microsandbox", features = ["ssh"] }
+microsandbox-network = { version = "0.5.1", path = "../../crates/network" }
 ipnetwork = { workspace = true }
 napi = { version = "3", default-features = false, features = [
     "async",

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -48,9 +48,9 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.5.0",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.0",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.5.0"
+    "@superradcompany/microsandbox-darwin-arm64": "0.5.1",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.1",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.5.1"
   },
   "files": [
     "dist",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.5.0", path = "../../crates/microsandbox", features = ["ssh"] }
-microsandbox-network = { version = "0.5.0", path = "../../crates/network" }
+microsandbox = { version = "0.5.1", path = "../../crates/microsandbox", features = ["ssh"] }
+microsandbox-network = { version = "0.5.1", path = "../../crates/network" }
 chrono = { workspace = true }
 ipnetwork = { version = "0.21.0", features = ["serde"] }
 pyo3 = { version = "0.24", features = ["abi3-py310", "extension-module"] }


### PR DESCRIPTION
## TL;DR
Bump the microsandbox release train to 0.5.1 across the Rust workspace, SDK metadata, examples, and release submodule pointers.

## Description
- Move all microsandbox Rust workspace crates and internal refs from 0.5.0 to 0.5.1.
- Update Node, Go, and Python SDK package metadata and native binding version checks.
- Update TypeScript examples so they install microsandbox 0.5.1.
- Advance the MCP submodule to its 0.5.1 package and server-version bump.
- Advance the skills submodule to the 0.5.1 Rust SDK reference.
- Leave npm lockfiles for the existing release workflow to refresh after platform packages publish.
- Carry the release notes since 0.5.0: the 0.5 upgrade path, SSH-enabled release binary, agentd workspace inclusion, and Go SDK README links.

## Test Plan
- [x] `cargo fmt --all -- --check` passed.
- [x] `CI=1 MSB_HOME=/tmp/msb-bump-check cargo check --workspace`, `cargo test --workspace`, and `cargo clippy --workspace -- -D warnings` passed.
- [x] `npm run typecheck` in `sdk/node-ts`, `go test -count=1 .` in `sdk/go`, and `npm run build` in `mcp` passed.
- [x] `CI=1 MSB_HOME=/tmp/msb-bump-check uv run maturin develop --release`, `uv run pytest tests/`, and `uv run ruff check .` in `sdk/python` passed.
- [x] `npm publish --dry-run` passed in `sdk/node-ts` and `mcp`. MCP still shows npm's existing package metadata warning for the bin and repository fields.
- [ ] `cargo publish --dry-run` reaches package verification, then fails because the v0.5.1 GitHub release asset `agentd-aarch64` does not exist yet.