### PR TITLE
fix(runtime): support long sandbox names for agent sockets

### DIFF
--- a/crates/microsandbox/lib/agent/client.rs
+++ b/crates/microsandbox/lib/agent/client.rs
@@ -17,7 +17,7 @@
 //!   primitives over [`Message`]; the SDK serializes payloads with CBOR.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{
     Arc,
     atomic::{AtomicU32, Ordering},
@@ -248,8 +248,8 @@ impl AgentClient {
 
     /// Resolve a sandbox name to its agent socket path and connect.
     ///
-    /// The socket lives under the SDK's configured sandboxes directory at
-    /// `<sandboxes_dir>/<name>/runtime/agent.sock`.
+    /// The socket lives under the SDK's configured runtime directory at a
+    /// short, name-derived path.
     pub async fn connect_sandbox(name: &str) -> AgentClientResult<Self> {
         Self::connect_sandbox_with_timeout(name, DEFAULT_HANDSHAKE_TIMEOUT).await
     }
@@ -260,11 +260,22 @@ impl AgentClient {
         name: &str,
         timeout: Duration,
     ) -> AgentClientResult<Self> {
-        let sock_path = sandbox_socket_path(name);
-        if !sock_path.exists() {
-            return Err(AgentClientError::SandboxNotFound(name.to_string()));
+        let mut last_error = None;
+        for sock_path in crate::runtime::sandbox_agent_socket_path_candidates(name) {
+            if !sock_path.exists() {
+                continue;
+            }
+
+            match Self::connect_with_timeout(&sock_path, timeout).await {
+                Ok(client) => return Ok(client),
+                Err(error) => last_error = Some(error),
+            }
         }
-        Self::connect_with_timeout(&sock_path, timeout).await
+
+        match last_error {
+            Some(error) => Err(error),
+            None => Err(AgentClientError::SandboxNotFound(name.to_string())),
+        }
     }
 
     /// Close the connection. Drops the writer and aborts the reader task;
@@ -559,15 +570,6 @@ fn encode_message_body<T: Serialize>(
     let mut body = Vec::new();
     ciborium::into_writer(&msg, &mut body).map_err(microsandbox_protocol::ProtocolError::from)?;
     Ok(body)
-}
-
-/// Build the standard agent socket path for a sandbox name.
-fn sandbox_socket_path(name: &str) -> PathBuf {
-    crate::config::config()
-        .sandboxes_dir()
-        .join(name)
-        .join("runtime")
-        .join("agent.sock")
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/crates/microsandbox/lib/runtime/mod.rs
+++ b/crates/microsandbox/lib/runtime/mod.rs
@@ -13,3 +13,4 @@ pub(crate) mod spawn;
 
 pub use handle::ProcessHandle;
 pub use spawn::{SpawnMode, spawn_sandbox};
+pub(crate) use spawn::{resolve_sandbox_agent_socket_path, sandbox_agent_socket_path_candidates};

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -6,10 +6,13 @@
 //! internally.
 
 #[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::{
     collections::HashMap,
     ffi::OsString,
+    fmt::Write,
     path::{Path, PathBuf},
     process::Stdio,
 };
@@ -30,7 +33,7 @@ use microsandbox_protocol::{
 use microsandbox_utils::{DB_FILENAME, DB_SUBDIR};
 
 use crate::{
-    MicrosandboxResult, config,
+    MicrosandboxError, MicrosandboxResult, config,
     runtime::handle::ProcessHandle,
     sandbox::{
         DiskImageFormat, HostPermissions, Rlimit, RootfsSource, SandboxConfig, StatVirtualization,
@@ -44,6 +47,8 @@ use crate::{
 
 #[cfg(target_os = "linux")]
 static SIGCHLD_ALT_STACK_INIT: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+
+const AGENT_SOCKET_HASH_HEX_LEN: usize = 32;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -119,7 +124,7 @@ pub async fn spawn_sandbox(
     for (name, content) in &config.scripts {
         // Prevent path traversal: only use the filename component.
         let safe_name = Path::new(name).file_name().ok_or_else(|| {
-            crate::MicrosandboxError::InvalidConfig(format!("invalid script name: {name}"))
+            MicrosandboxError::InvalidConfig(format!("invalid script name: {name}"))
         })?;
         let script_path = scripts_dir.join(safe_name);
         tokio::fs::write(&script_path, content).await?;
@@ -127,8 +132,10 @@ pub async fn spawn_sandbox(
         tokio::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).await?;
     }
 
-    // Compute the agent relay socket path.
-    let agent_sock_path = runtime_dir.join("agent.sock");
+    // Compute the agent relay socket path. This intentionally lives outside
+    // the name-derived sandbox tree so long sandbox names do not exceed the
+    // platform Unix-domain socket path limit.
+    let agent_sock_path = resolve_sandbox_agent_socket_path(&config.name)?;
 
     // Stage file bind mounts: each file gets its own isolated directory so
     // that virtio-fs (which requires directories) can share it without
@@ -192,7 +199,7 @@ pub async fn spawn_sandbox(
         Some(pid) => pid,
         None => {
             release_metrics_reservation(config, metrics_reservation.as_ref(), ReleaseMode::Free);
-            return Err(crate::MicrosandboxError::Runtime(
+            return Err(MicrosandboxError::Runtime(
                 "sandbox process exited immediately".into(),
             ));
         }
@@ -204,7 +211,7 @@ pub async fn spawn_sandbox(
         Some(stdout) => stdout,
         None => {
             release_metrics_reservation(config, metrics_reservation.as_ref(), ReleaseMode::Free);
-            return Err(crate::MicrosandboxError::Runtime(
+            return Err(MicrosandboxError::Runtime(
                 "failed to capture sandbox stdout".into(),
             ));
         }
@@ -227,7 +234,7 @@ pub async fn spawn_sandbox(
         Err(_) => {
             terminate_startup_process(&mut child).await;
             release_metrics_reservation(config, metrics_reservation.as_ref(), ReleaseMode::Free);
-            return Err(crate::MicrosandboxError::Runtime(
+            return Err(MicrosandboxError::Runtime(
                 "sandbox startup timeout: no JSON received within 30 seconds".into(),
             ));
         }
@@ -243,7 +250,7 @@ pub async fn spawn_sandbox(
                 exit_status = ?status,
                 "spawn_sandbox: failed to parse startup JSON"
             );
-            return Err(crate::MicrosandboxError::Runtime(format!(
+            return Err(MicrosandboxError::Runtime(format!(
                 "sandbox process exited ({status:?}) before sending startup info \
                  (line: {line:?}, check stderr above for details)"
             )));
@@ -309,6 +316,93 @@ fn reserve_metrics_slot(config: &SandboxConfig, sandbox_id: i32) -> Option<Metri
     }
 }
 
+/// Build the host-side agent relay socket path for a sandbox name.
+fn sandbox_agent_socket_path(name: &str) -> PathBuf {
+    let mut hasher = Sha256::new();
+    hasher.update(name.as_bytes());
+    let digest = hasher.finalize();
+
+    let mut filename = String::with_capacity(AGENT_SOCKET_HASH_HEX_LEN + ".sock".len());
+    for byte in digest.iter().take(AGENT_SOCKET_HASH_HEX_LEN / 2) {
+        let _ = Write::write_fmt(&mut filename, format_args!("{byte:02x}"));
+    }
+    filename.push_str(".sock");
+
+    config::config().run_dir().join("agent").join(filename)
+}
+
+/// Build the legacy name-derived agent relay socket path.
+fn legacy_sandbox_agent_socket_path(name: &str) -> PathBuf {
+    config::config()
+        .sandboxes_dir()
+        .join(name)
+        .join("runtime")
+        .join("agent.sock")
+}
+
+/// Return agent relay socket paths in preferred connection order.
+pub(crate) fn sandbox_agent_socket_path_candidates(name: &str) -> [PathBuf; 2] {
+    [
+        sandbox_agent_socket_path(name),
+        legacy_sandbox_agent_socket_path(name),
+    ]
+}
+
+/// Pick the first socket path usable on this platform.
+pub(crate) fn resolve_sandbox_agent_socket_path(name: &str) -> MicrosandboxResult<PathBuf> {
+    let candidates = sandbox_agent_socket_path_candidates(name);
+    for path in &candidates {
+        if sandbox_agent_socket_path_fits(path) {
+            return Ok(path.clone());
+        }
+    }
+
+    let shortest = candidates
+        .iter()
+        .map(|path| sandbox_agent_socket_path_len(path))
+        .min()
+        .unwrap_or(0);
+    Err(MicrosandboxError::InvalidConfig(format!(
+        "agent relay socket path is too long: shortest derived path is {shortest} bytes, \
+         but Unix socket paths on this platform must be shorter than {} bytes; set \
+         MSB_HOME or paths.sandboxes to a shorter directory",
+        unix_socket_path_capacity()
+    )))
+}
+
+#[cfg(unix)]
+fn sandbox_agent_socket_path_fits(path: &Path) -> bool {
+    sandbox_agent_socket_path_len(path) < unix_socket_path_capacity()
+}
+
+#[cfg(not(unix))]
+fn sandbox_agent_socket_path_fits(_path: &Path) -> bool {
+    true
+}
+
+#[cfg(unix)]
+fn sandbox_agent_socket_path_len(path: &Path) -> usize {
+    path.as_os_str().as_bytes().len()
+}
+
+#[cfg(not(unix))]
+fn sandbox_agent_socket_path_len(_path: &Path) -> usize {
+    0
+}
+
+#[cfg(unix)]
+fn unix_socket_path_capacity() -> usize {
+    // SAFETY: a zeroed sockaddr_un is valid, and we only inspect the fixed-size
+    // sun_path array length to mirror the UnixListener/socket2 precondition.
+    let storage = unsafe { std::mem::zeroed::<libc::sockaddr_un>() };
+    storage.sun_path.len()
+}
+
+#[cfg(not(unix))]
+fn unix_socket_path_capacity() -> usize {
+    usize::MAX
+}
+
 /// Best-effort release of a reservation when spawn cannot continue.
 fn release_metrics_reservation(
     config: &SandboxConfig,
@@ -336,7 +430,7 @@ async fn ensure_sigchld_handler_uses_alt_stack_before_spawn() -> MicrosandboxRes
         .get_or_try_init(|| async {
             install_tokio_sigchld_handler()?;
             patch_sigchld_handler_uses_alt_stack();
-            Ok::<(), crate::MicrosandboxError>(())
+            Ok::<(), MicrosandboxError>(())
         })
         .await?;
     Ok(())
@@ -447,14 +541,14 @@ async fn stage_file_mounts(
         tokio::fs::create_dir_all(&file_mount_dir).await?;
 
         let filename_os = host.file_name().ok_or_else(|| {
-            crate::MicrosandboxError::InvalidConfig(format!(
+            MicrosandboxError::InvalidConfig(format!(
                 "file mount has no filename: {}",
                 host.display()
             ))
         })?;
 
         let filename = filename_os.to_str().ok_or_else(|| {
-            crate::MicrosandboxError::InvalidConfig(format!(
+            MicrosandboxError::InvalidConfig(format!(
                 "file mount filename is not valid UTF-8: {}",
                 host.display()
             ))
@@ -462,7 +556,7 @@ async fn stage_file_mounts(
 
         // The MSB_FILE_MOUNTS protocol uses `:` and `;` as delimiters.
         if filename.contains(':') || filename.contains(';') {
-            return Err(crate::MicrosandboxError::InvalidConfig(format!(
+            return Err(MicrosandboxError::InvalidConfig(format!(
                 "file mount filename must not contain ':' or ';': {filename}"
             )));
         }
@@ -1026,7 +1120,10 @@ mod tests {
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
 
-    use super::sandbox_cli_args;
+    use super::{
+        legacy_sandbox_agent_socket_path, resolve_sandbox_agent_socket_path,
+        sandbox_agent_socket_path, sandbox_agent_socket_path_candidates, sandbox_cli_args,
+    };
     use crate::{
         LogLevel,
         sandbox::{
@@ -1054,6 +1151,41 @@ mod tests {
         .iter()
         .map(|arg| arg.to_string_lossy().into_owned())
         .collect()
+    }
+
+    #[test]
+    fn test_sandbox_agent_socket_path_is_independent_of_sandbox_name_length() {
+        let short = sandbox_agent_socket_path("test");
+        let long = sandbox_agent_socket_path(&format!("testing-{}", "x".repeat(256)));
+
+        let expected_len = "0123456789abcdef0123456789abcdef.sock".len();
+        assert_eq!(
+            short.file_name().unwrap().to_string_lossy().len(),
+            expected_len
+        );
+        assert_eq!(
+            long.file_name().unwrap().to_string_lossy().len(),
+            expected_len
+        );
+        assert_eq!(short.parent(), long.parent());
+        assert_ne!(short.file_name(), long.file_name());
+    }
+
+    #[test]
+    fn test_sandbox_agent_socket_path_candidates_include_legacy_fallback() {
+        let candidates = sandbox_agent_socket_path_candidates("test");
+
+        assert_eq!(candidates[0], sandbox_agent_socket_path("test"));
+        assert_eq!(candidates[1], legacy_sandbox_agent_socket_path("test"));
+        assert!(candidates[1].ends_with("sandboxes/test/runtime/agent.sock"));
+    }
+
+    #[test]
+    fn test_resolve_sandbox_agent_socket_path_prefers_hashed_path() {
+        assert_eq!(
+            resolve_sandbox_agent_socket_path("test").unwrap(),
+            sandbox_agent_socket_path("test")
+        );
     }
 
     fn render_args_with_file_mounts(

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -809,6 +809,7 @@ impl SandboxBuilder {
                 "sandbox name is required".into(),
             ));
         }
+        super::validate_sandbox_name_for_runtime(&self.config.name)?;
 
         // Check that image is set (non-empty OCI string or Bind path).
         match &self.config.image {
@@ -923,6 +924,19 @@ mod tests {
             .unwrap();
 
         assert_eq!(config.log_level, Some(LogLevel::Debug));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_builder_accepts_long_sandbox_name() {
+        let name = format!("testing-{}", "x".repeat(256));
+        let config = SandboxBuilder::new(name.clone())
+            .image("alpine")
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(config.name, name);
     }
 
     #[tokio::test]

--- a/crates/microsandbox/lib/sandbox/handle.rs
+++ b/crates/microsandbox/lib/sandbox/handle.rs
@@ -187,14 +187,7 @@ impl SandboxHandle {
             )));
         }
 
-        let global = crate::config::config();
-        let sock_path = global
-            .sandboxes_dir()
-            .join(&self.name)
-            .join("runtime")
-            .join("agent.sock");
-
-        let client = AgentClient::connect_with_timeout(&sock_path, timeout).await?;
+        let client = AgentClient::connect_sandbox_with_timeout(&self.name, timeout).await?;
         let config: SandboxConfig = serde_json::from_str(&self.config_json)?;
 
         Ok(Sandbox {

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -38,6 +38,7 @@ use microsandbox_image::{
     progress_channel, tree,
 };
 
+use crate::{MicrosandboxError, runtime};
 use crate::{
     MicrosandboxResult,
     agent::AgentClient,
@@ -210,6 +211,7 @@ impl Sandbox {
 
         config.apply_rootfs_defaults();
         config.apply_runtime_defaults();
+        validate_sandbox_name_for_runtime(&config.name)?;
         validate_rootfs_source(&config.image)?;
 
         // Initialize the database before any expensive image pull so we can
@@ -224,7 +226,7 @@ impl Sandbox {
             let upper_size_mib = oci.upper_size_mib;
             let snapshot_manifest_digest = if config.snapshot_upper_source.is_some() {
                 Some(config.manifest_digest.clone().ok_or_else(|| {
-                    crate::MicrosandboxError::InvalidConfig(
+                    MicrosandboxError::InvalidConfig(
                         "from_snapshot requires a pinned OCI manifest digest".into(),
                     )
                 })?)
@@ -246,7 +248,7 @@ impl Sandbox {
             if let Some(expected) = snapshot_manifest_digest.as_deref()
                 && resolved_manifest_digest != expected
             {
-                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                return Err(MicrosandboxError::InvalidConfig(format!(
                     "from_snapshot pinned OCI manifest digest '{expected}', but '{reference}' resolved to '{resolved_manifest_digest}'"
                 )));
             }
@@ -263,7 +265,7 @@ impl Sandbox {
 
             let vmdk_path = cache.vmdk_path(&pull_result.manifest_digest);
             if tokio::fs::metadata(&vmdk_path).await.is_err() {
-                return Err(crate::MicrosandboxError::Custom(format!(
+                return Err(MicrosandboxError::Custom(format!(
                     "VMDK not materialized: {}",
                     vmdk_path.display()
                 )));
@@ -291,7 +293,7 @@ impl Sandbox {
                 // compatible with this path because they'd need to be
                 // re-baked into the snapshot's upper, which we don't do.
                 if upper_tree.is_some() {
-                    return Err(crate::MicrosandboxError::InvalidConfig(
+                    return Err(MicrosandboxError::InvalidConfig(
                         "patches cannot be combined with from_snapshot".into(),
                     ));
                 }
@@ -300,12 +302,10 @@ impl Sandbox {
                     microsandbox_utils::copy::fast_copy(&snap_upper, &dst)
                 })
                 .await
-                .map_err(|e| {
-                    crate::MicrosandboxError::Custom(format!("snapshot copy task: {e}"))
-                })??;
+                .map_err(|e| MicrosandboxError::Custom(format!("snapshot copy task: {e}")))??;
             } else if !upper_path.exists() || upper_tree.is_some() {
                 let upper_size_mib = upper_size_mib.ok_or_else(|| {
-                    crate::MicrosandboxError::InvalidConfig(
+                    MicrosandboxError::InvalidConfig(
                         "OCI upper size was not resolved before create".into(),
                     )
                 })?;
@@ -384,7 +384,7 @@ impl Sandbox {
                         None,
                         microsandbox_metrics::ReleaseMode::Free,
                     );
-                    return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    return Err(MicrosandboxError::InvalidConfig(format!(
                         "workdir is not a directory in guest: {workdir}"
                     )));
                 }
@@ -397,7 +397,7 @@ impl Sandbox {
                         None,
                         microsandbox_metrics::ReleaseMode::Free,
                     );
-                    return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    return Err(MicrosandboxError::InvalidConfig(format!(
                         "workdir does not exist in guest: {workdir}: {error}"
                     )));
                 }
@@ -415,13 +415,13 @@ impl Sandbox {
         tracing::debug!(sandbox = name, status = ?model.status, "start_with_mode: current status");
 
         if model.status == SandboxStatus::Running || model.status == SandboxStatus::Draining {
-            return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+            return Err(MicrosandboxError::SandboxStillRunning(format!(
                 "cannot start sandbox '{name}': already running"
             )));
         }
 
         if model.status != SandboxStatus::Stopped && model.status != SandboxStatus::Crashed {
-            return Err(crate::MicrosandboxError::Custom(format!(
+            return Err(MicrosandboxError::Custom(format!(
                 "cannot start sandbox '{name}': status is {:?} (expected Stopped or Crashed)",
                 model.status
             )));
@@ -429,6 +429,7 @@ impl Sandbox {
 
         let mut config: SandboxConfig = serde_json::from_str(&model.config)?;
         config.apply_runtime_defaults();
+        validate_sandbox_name_for_runtime(&config.name)?;
         validate_rootfs_source(&config.image)?;
         validate_start_state(&config, &crate::config::config().sandboxes_dir().join(name))?;
         update_sandbox_status(write_db, model.id, SandboxStatus::Running).await?;
@@ -478,7 +479,7 @@ impl Sandbox {
             .filter(sandbox_entity::Column::Name.eq(name))
             .one(pools.read())
             .await?
-            .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(name.into()))?;
+            .ok_or_else(|| MicrosandboxError::SandboxNotFound(name.into()))?;
 
         let model = reconcile_sandbox_runtime_state(pools, model).await?;
         build_handle(pools.read(), model).await
@@ -645,7 +646,7 @@ impl Sandbox {
     pub async fn kill(&self) -> MicrosandboxResult<()> {
         match &self.handle {
             Some(h) => h.lock().await.kill(),
-            None => Err(crate::MicrosandboxError::Runtime(
+            None => Err(MicrosandboxError::Runtime(
                 "cannot kill: not the lifecycle owner".into(),
             )),
         }
@@ -655,7 +656,7 @@ impl Sandbox {
     pub async fn drain(&self) -> MicrosandboxResult<()> {
         match &self.handle {
             Some(h) => h.lock().await.drain(),
-            None => Err(crate::MicrosandboxError::Runtime(
+            None => Err(MicrosandboxError::Runtime(
                 "cannot drain: not the lifecycle owner".into(),
             )),
         }
@@ -665,7 +666,7 @@ impl Sandbox {
     pub async fn wait(&self) -> MicrosandboxResult<ExitStatus> {
         match &self.handle {
             Some(h) => h.lock().await.wait().await,
-            None => Err(crate::MicrosandboxError::Runtime(
+            None => Err(MicrosandboxError::Runtime(
                 "cannot wait: not the lifecycle owner".into(),
             )),
         }
@@ -850,7 +851,7 @@ impl Sandbox {
                             handle.collect(),
                         )
                         .await;
-                        Err(crate::MicrosandboxError::ExecTimeout(duration))
+                        Err(MicrosandboxError::ExecTimeout(duration))
                     }
                 }
             }
@@ -988,7 +989,7 @@ impl Sandbox {
 
         // Enter raw mode.
         crossterm::terminal::enable_raw_mode()
-            .map_err(|e| crate::MicrosandboxError::Terminal(e.to_string()))?;
+            .map_err(|e| MicrosandboxError::Terminal(e.to_string()))?;
         let _raw_guard = scopeguard::guard((), |_| {
             let _ = crossterm::terminal::disable_raw_mode();
         });
@@ -998,17 +999,17 @@ impl Sandbox {
         // stdout/stderr when all three stdio fds share the same TTY open file
         // description, which truncates large terminal writes.
         let tty_input_path = terminal_path_for_fd(std::io::stdin().as_raw_fd())
-            .map_err(|e| crate::MicrosandboxError::Terminal(format!("resolve tty path: {e}")))?;
+            .map_err(|e| MicrosandboxError::Terminal(format!("resolve tty path: {e}")))?;
         let tty_input = open_nonblocking_terminal_input(&tty_input_path)
-            .map_err(|e| crate::MicrosandboxError::Terminal(format!("open tty input: {e}")))?;
+            .map_err(|e| MicrosandboxError::Terminal(format!("open tty input: {e}")))?;
         let stdin_async = AsyncFd::new(tty_input)
-            .map_err(|e| crate::MicrosandboxError::Terminal(format!("async tty input: {e}")))?;
+            .map_err(|e| MicrosandboxError::Terminal(format!("async tty input: {e}")))?;
 
         // Set up async I/O.
         let mut stdout = tokio::io::stdout();
         let mut sigwinch =
             tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
-                .map_err(|e| crate::MicrosandboxError::Runtime(format!("sigwinch: {e}")))?;
+                .map_err(|e| MicrosandboxError::Runtime(format!("sigwinch: {e}")))?;
 
         let mut exit_code: i32 = -1;
         let mut spawn_failure: Option<microsandbox_protocol::exec::ExecFailed> = None;
@@ -1151,7 +1152,7 @@ impl Sandbox {
 
         // Guards restore: non-blocking → blocking, raw mode → cooked.
         if let Some(failure) = spawn_failure {
-            return Err(crate::MicrosandboxError::ExecFailed(failure));
+            return Err(MicrosandboxError::ExecFailed(failure));
         }
         Ok(exit_code)
     }
@@ -1217,7 +1218,7 @@ async fn wait_for_relay(
                     // Prefer the structured boot-error record if the
                     // sandbox got far enough to write one.
                     if let Some(boot_err) = read_boot_error(log_dir.as_deref()) {
-                        return Err(crate::MicrosandboxError::BootStart {
+                        return Err(MicrosandboxError::BootStart {
                             name: sandbox_name.to_string(),
                             err: boot_err,
                         });
@@ -1237,7 +1238,7 @@ async fn wait_for_relay(
                             "sandbox process exited ({status}) before agent relay became available"
                         ),
                     };
-                    return Err(crate::MicrosandboxError::BootStart {
+                    return Err(MicrosandboxError::BootStart {
                         name: sandbox_name.to_string(),
                         err: synthetic,
                     });
@@ -1261,7 +1262,7 @@ async fn wait_for_relay(
                 // typed record over the raw IO/timeout error so the CLI
                 // can render the styled boot-error block.
                 if let Some(boot_err) = read_boot_error(log_dir.as_deref()) {
-                    return Err(crate::MicrosandboxError::BootStart {
+                    return Err(MicrosandboxError::BootStart {
                         name: sandbox_name.to_string(),
                         err: boot_err,
                     });
@@ -1572,7 +1573,7 @@ pub(super) async fn reconcile_sandbox_runtime_state(
     sandbox_entity::Entity::find_by_id(sandbox.id)
         .one(pools.read())
         .await?
-        .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(sandbox.name))
+        .ok_or_else(|| MicrosandboxError::SandboxNotFound(sandbox.name))
 }
 
 pub(super) async fn load_active_run(
@@ -1716,18 +1717,27 @@ pub(super) fn pid_is_alive(pid: i32) -> bool {
 }
 
 fn digest_pinned_reference(reference: &str, manifest_digest: &str) -> MicrosandboxResult<String> {
-    let image_ref: Reference = reference.parse().map_err(|e| {
-        crate::MicrosandboxError::InvalidConfig(format!("invalid image reference: {e}"))
-    })?;
+    let image_ref: Reference = reference
+        .parse()
+        .map_err(|e| MicrosandboxError::InvalidConfig(format!("invalid image reference: {e}")))?;
     let pinned = image_ref
         .clone_with_digest(manifest_digest.to_string())
         .to_string();
     pinned.parse::<Reference>().map_err(|e| {
-        crate::MicrosandboxError::InvalidConfig(format!(
-            "invalid pinned image reference '{pinned}': {e}"
-        ))
+        MicrosandboxError::InvalidConfig(format!("invalid pinned image reference '{pinned}': {e}"))
     })?;
     Ok(pinned)
+}
+
+/// Validate sandbox-name-derived runtime paths before the sandbox process starts.
+pub(super) fn validate_sandbox_name_for_runtime(name: &str) -> MicrosandboxResult<()> {
+    if name.is_empty() {
+        return Err(MicrosandboxError::InvalidConfig(
+            "sandbox name is required".into(),
+        ));
+    }
+
+    runtime::resolve_sandbox_agent_socket_path(name).map(|_| ())
 }
 
 /// Pull an OCI image and return the pull result.
@@ -1750,9 +1760,9 @@ async fn pull_oci_image(
     let global = crate::config::config();
     let cache = GlobalCache::new(&global.cache_dir())?;
     let platform = microsandbox_image::Platform::host_linux();
-    let image_ref: Reference = reference.parse().map_err(|e| {
-        crate::MicrosandboxError::InvalidConfig(format!("invalid image reference: {e}"))
-    })?;
+    let image_ref: Reference = reference
+        .parse()
+        .map_err(|e| MicrosandboxError::InvalidConfig(format!("invalid image reference: {e}")))?;
     let options = PullOptions {
         pull_policy,
         ..Default::default()
@@ -1810,7 +1820,7 @@ async fn pull_oci_image(
         let task = registry.pull_with_sender(&image_ref, &options, sender);
         let result = task
             .await
-            .map_err(|e| crate::MicrosandboxError::Custom(format!("pull task panicked: {e}")))??;
+            .map_err(|e| MicrosandboxError::Custom(format!("pull task panicked: {e}")))??;
         Ok(result)
     } else {
         let result = registry.pull(&image_ref, &options).await?;
@@ -1823,14 +1833,14 @@ fn validate_rootfs_source(rootfs: &RootfsSource) -> MicrosandboxResult<()> {
     match rootfs {
         RootfsSource::Bind(path) => {
             if !path.exists() {
-                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                return Err(MicrosandboxError::InvalidConfig(format!(
                     "rootfs bind path does not exist: {}",
                     path.display()
                 )));
             }
 
             if !path.is_dir() {
-                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                return Err(MicrosandboxError::InvalidConfig(format!(
                     "rootfs bind path is not a directory: {}",
                     path.display()
                 )));
@@ -1838,26 +1848,26 @@ fn validate_rootfs_source(rootfs: &RootfsSource) -> MicrosandboxResult<()> {
         }
         RootfsSource::Oci(oci) => {
             if oci.reference.is_empty() {
-                return Err(crate::MicrosandboxError::InvalidConfig(
+                return Err(MicrosandboxError::InvalidConfig(
                     "image source is required".into(),
                 ));
             }
             if oci.upper_size_mib == Some(0) {
-                return Err(crate::MicrosandboxError::InvalidConfig(
+                return Err(MicrosandboxError::InvalidConfig(
                     "oci upper_size must be greater than 0".into(),
                 ));
             }
         }
         RootfsSource::DiskImage { path, .. } => {
             if !path.exists() {
-                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                return Err(MicrosandboxError::InvalidConfig(format!(
                     "disk image does not exist: {}",
                     path.display()
                 )));
             }
 
             if !path.is_file() {
-                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                return Err(MicrosandboxError::InvalidConfig(format!(
                     "disk image is not a regular file: {}",
                     path.display()
                 )));
@@ -1885,7 +1895,7 @@ pub(super) async fn load_sandbox_record(
         .filter(sandbox_entity::Column::Name.eq(name))
         .one(db)
         .await?
-        .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(name.into()))
+        .ok_or_else(|| MicrosandboxError::SandboxNotFound(name.into()))
 }
 
 async fn prepare_create_target(
@@ -1902,7 +1912,7 @@ async fn prepare_create_target(
 
     if !config.replace_existing {
         if existing.is_some() || dir_exists {
-            return Err(crate::MicrosandboxError::SandboxAlreadyExists(format!(
+            return Err(MicrosandboxError::SandboxAlreadyExists(format!(
                 "sandbox '{}' already exists; remove it, start the stopped sandbox, or recreate with .replace()",
                 config.name
             )));
@@ -2052,7 +2062,7 @@ async fn wait_for_pids_to_exit(pids: &[i32], timeout: std::time::Duration) {
 
 fn validate_start_state(config: &SandboxConfig, sandbox_dir: &Path) -> MicrosandboxResult<()> {
     if !sandbox_dir.exists() {
-        return Err(crate::MicrosandboxError::Custom(format!(
+        return Err(MicrosandboxError::Custom(format!(
             "sandbox state missing for '{}': {}",
             config.name,
             sandbox_dir.display()
@@ -2068,7 +2078,7 @@ fn validate_start_state(config: &SandboxConfig, sandbox_dir: &Path) -> Microsand
         {
             let vmdk_path = cache.vmdk_path(&digest);
             if !vmdk_path.exists() {
-                return Err(crate::MicrosandboxError::Custom(format!(
+                return Err(MicrosandboxError::Custom(format!(
                     "sandbox '{}' cannot start: VMDK missing: {}",
                     config.name,
                     vmdk_path.display()
@@ -2172,8 +2182,8 @@ async fn create_upper_ext4(
         ext4::format_ext4_with_tree(&path, &ext4_options, overlay_tree)
     })
     .await
-    .map_err(|e| crate::MicrosandboxError::Custom(format!("ext4 format task failed: {e}")))?
-    .map_err(|e| crate::MicrosandboxError::Custom(format!("failed to create upper.ext4: {e}")))?;
+    .map_err(|e| MicrosandboxError::Custom(format!("ext4 format task failed: {e}")))?
+    .map_err(|e| MicrosandboxError::Custom(format!("failed to create upper.ext4: {e}")))?;
 
     Ok(())
 }
@@ -2225,7 +2235,7 @@ mod tests {
     use super::{
         RootfsSource, SandboxConfig, SandboxStatus, digest_pinned_reference, insert_sandbox_record,
         persist_oci_manifest_pin, prepare_create_target, reconcile_sandbox_runtime_state,
-        remove_dir_if_exists, validate_rootfs_source,
+        remove_dir_if_exists, validate_rootfs_source, validate_sandbox_name_for_runtime,
     };
 
     /// Open both pools at `db_path` for tests, with migrations applied.
@@ -2382,6 +2392,18 @@ mod tests {
         validate_rootfs_source(&RootfsSource::Bind(path.clone())).unwrap();
 
         fs::remove_dir(path).unwrap();
+    }
+
+    #[test]
+    fn test_validate_sandbox_name_rejects_empty_name() {
+        let err = validate_sandbox_name_for_runtime("").unwrap_err();
+
+        assert_eq!(err.to_string(), "invalid config: sandbox name is required");
+    }
+
+    #[test]
+    fn test_validate_sandbox_name_accepts_long_name() {
+        validate_sandbox_name_for_runtime(&"x".repeat(256)).unwrap();
     }
 
     #[test]

--- a/sdk/node-ts/native/agent.rs
+++ b/sdk/node-ts/native/agent.rs
@@ -59,7 +59,7 @@ pub struct AgentClient {
 #[napi]
 impl AgentClient {
     /// Connect to a sandbox by name. Resolves the agent socket from the
-    /// SDK's configured sandboxes directory.
+    /// SDK's configured runtime directory.
     #[napi(factory, js_name = "connectSandbox")]
     pub async fn connect_sandbox(
         name: String,


### PR DESCRIPTION
## TL;DR
support long sandbox names by moving the agent relay socket to a short runtime path while keeping the legacy socket path as a fallback.

fixes #731

## Description
- derive the primary agent relay socket from a fixed-length hash under `~/.microsandbox/run/agent/`
- fall back to the legacy `<sandboxes>/<name>/runtime/agent.sock` path for compatibility
- validate derived socket path lengths before spawning so `SUN_LEN` failures return a clearer config error
- update builder, create, start, and connect paths to use the shared socket resolution flow
- update the node native doc comment to describe the runtime directory socket

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test -p microsandbox --lib`
- `cargo clippy -p microsandbox --lib -- -D warnings -A dead-code`
- pre-commit hook: workspace fmt, workspace clippy, agentd fmt, agentd clippy, workspace docs, and `cargo build -p microsandbox-cli`