### PR TITLE
Enable nested virtualization for Linux x86_64 VMs

### DIFF
--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -651,7 +651,7 @@ fn build_vm(
             let m = m.vcpus(vm.vcpus).memory_mib(vm.memory_mib as usize);
             #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
             {
-                m.split_irqchip(true)
+                m.nested_virt(true).split_irqchip(true)
             }
             #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
             {


### PR DESCRIPTION
## Summary

- Enable libkrun nested virtualization for Linux x86_64 VMs by calling `nested_virt(true)` in the runtime machine builder.
- Keep the existing split irqchip setup on the same platform-specific path.

## Notes

This exposes nested virtualization support from the outer VMM configuration. A fully usable nested KVM setup still depends on the host having nested virtualization enabled and the guest firmware/kernel including KVM support.

## Testing

Not run, per request.
