### PR TITLE
Fix DNS UDP response delivery to guests

### DIFF
--- a/crates/network/lib/dns/interceptor.rs
+++ b/crates/network/lib/dns/interceptor.rs
@@ -1,10 +1,11 @@
 //! DNS query interception: the smoltcp ↔ channel bridge.
 //!
 //! `DnsInterceptor` owns the smoltcp UDP socket bound to `gateway:53`
-//! and a pair of channels to the async forwarder task spawned on the
-//! tokio runtime. Each poll-loop iteration, `process()` reads pending
-//! queries off the smoltcp socket and hands them to the forwarder,
-//! then writes any forwarded responses back to the socket.
+//! and a channel to the async forwarder task spawned on the tokio
+//! runtime. Each poll-loop iteration, `process()` reads pending queries
+//! off the smoltcp socket and hands them to the forwarder. Forwarded
+//! responses are injected directly into the guest RX ring by the UDP
+//! proxy.
 //!
 //! The DNS wire protocol, upstream client, block-list, and rebind-
 //! protection logic all live under sibling modules and are reached via
@@ -42,7 +43,7 @@ const DNS_MAX_SIZE: usize = 4096;
 /// Number of packet slots in the smoltcp UDP socket buffers.
 const DNS_SOCKET_PACKET_SLOTS: usize = 16;
 
-/// Capacity of the query/response channels.
+/// Capacity of the query channel.
 const CHANNEL_CAPACITY: usize = 64;
 
 //--------------------------------------------------------------------------------------------------
@@ -51,11 +52,10 @@ const CHANNEL_CAPACITY: usize = 64;
 
 /// DNS query/response interceptor.
 ///
-/// Owns the smoltcp UDP socket handle and channels to the async forwarder
+/// Owns the smoltcp UDP socket handle and channel to the async forwarder
 /// task. The poll loop calls [`process()`] each iteration to:
 ///
 /// 1. Read pending queries from the smoltcp socket → send to forwarder task.
-/// 2. Read forwarded responses from the channel → write to smoltcp socket.
 ///
 /// [`process()`]: DnsInterceptor::process
 pub(crate) struct DnsInterceptor {
@@ -63,8 +63,6 @@ pub(crate) struct DnsInterceptor {
     socket_handle: smoltcp::iface::SocketHandle,
     /// Sends queries to the background forwarder task.
     query_tx: mpsc::Sender<DnsQuery>,
-    /// Receives responses from the background forwarder task.
-    response_rx: mpsc::Receiver<DnsResponse>,
 }
 
 /// A DNS query extracted from the smoltcp socket.
@@ -79,17 +77,6 @@ pub(crate) struct DnsQuery {
     /// preserving the original destination we'd reply from the gateway
     /// IP and the guest's resolver would drop the response.
     pub(super) original_dst: Option<IpAddress>,
-}
-
-/// A forwarded DNS response ready to send back to the guest.
-pub(crate) struct DnsResponse {
-    /// Raw DNS response bytes.
-    pub(crate) data: Bytes,
-    /// Destination endpoint (guest IP:port).
-    pub(super) dest: IpEndpoint,
-    /// Source IP to stamp on the outgoing packet. Echoes the query's
-    /// original destination so replies match what the guest asked.
-    pub(super) source_addr: Option<IpAddress>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -111,6 +98,8 @@ impl DnsInterceptor {
         gateway_ips: Arc<HashSet<IpAddr>>,
         network_policy: Arc<NetworkPolicy>,
         gateway: GatewayIps,
+        gateway_mac: [u8; 6],
+        guest_mac: [u8; 6],
     ) -> (Self, DnsForwarderHandle) {
         // Create and bind the smoltcp UDP socket.
         let rx_meta = vec![PacketMetadata::EMPTY; DNS_SOCKET_PACKET_SLOTS];
@@ -131,9 +120,8 @@ impl DnsInterceptor {
 
         let socket_handle = sockets.add(socket);
 
-        // Create channels.
+        // Create channel.
         let (query_tx, query_rx) = mpsc::channel(CHANNEL_CAPACITY);
-        let (response_tx, response_rx) = mpsc::channel(CHANNEL_CAPACITY);
 
         let normalized = Arc::new(NormalizedDnsConfig::from_config(dns_config));
 
@@ -155,16 +143,16 @@ impl DnsInterceptor {
         UdpProxy::spawn(
             tokio_handle,
             query_rx,
-            response_tx,
             forwarder_handle.clone(),
             shared,
+            gateway_mac,
+            guest_mac,
         );
 
         (
             Self {
                 socket_handle,
                 query_tx,
-                response_rx,
             },
             forwarder_handle,
         )
@@ -174,7 +162,6 @@ impl DnsInterceptor {
     ///
     /// Called by the poll loop each iteration:
     /// 1. Reads queries from the smoltcp socket → sends to forwarder task.
-    /// 2. Reads responses from the forwarder → writes to smoltcp socket.
     pub(crate) fn process(&mut self, sockets: &mut SocketSet<'_>) {
         let socket = sockets.get_mut::<udp::Socket>(self.socket_handle);
 
@@ -192,23 +179,6 @@ impl DnsInterceptor {
                         // Channel full — drop query. Guest will retry.
                         tracing::debug!("DNS query channel full, dropping query");
                     }
-                }
-                Err(_) => break,
-            }
-        }
-
-        // Write responses to the smoltcp socket.
-        // Check can_send() BEFORE consuming from the channel so
-        // undeliverable responses remain for the next poll iteration.
-        while socket.can_send() {
-            match self.response_rx.try_recv() {
-                Ok(response) => {
-                    let mut meta = udp::UdpMetadata::from(response.dest);
-                    // Stamp the reply with the IP the guest originally
-                    // aimed at; smoltcp uses this as the source IP when
-                    // it dispatches the packet.
-                    meta.local_address = response.source_addr;
-                    let _ = socket.send_slice(&response.data, meta);
                 }
                 Err(_) => break,
             }
@@ -259,10 +229,9 @@ mod tests {
             })
             .expect("bind addr:None succeeds");
 
-        // Construct outgoing metadata with a v6 source: this is what
-        // the interceptor does when it stamps responses for guests that
-        // aimed at a v6 resolver. If the bind didn't accept v6, the
-        // send_slice path below would fail.
+        // Construct outgoing metadata with a v6 source. The production
+        // response path injects raw frames now, but this keeps the
+        // addr:None socket metadata behavior covered.
         let v6: Ipv6Address = "fd42::1".parse().unwrap();
         let v6_dest = IpEndpoint {
             addr: IpAddress::Ipv6(v6),

--- a/crates/network/lib/dns/proxies/udp.rs
+++ b/crates/network/lib/dns/proxies/udp.rs
@@ -1,6 +1,6 @@
 //! DNS-over-UDP proxy: drain queries from the interceptor channel,
-//! route each through the shared [`DnsForwarder`], and send responses
-//! back via the response channel.
+//! route each through the shared [`DnsForwarder`], and inject responses
+//! back into the guest RX ring.
 //!
 //! Mirrors [`super::tcp`] for the connectionless side. The interceptor
 //! ([`crate::dns::interceptor::DnsInterceptor`]) handles smoltcp UDP
@@ -10,15 +10,24 @@
 //!
 //! [`DnsForwarder`]: super::super::forwarder::DnsForwarder
 
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
+use smoltcp::wire::{EthernetAddress, IpEndpoint};
 use tokio::sync::mpsc;
 
 use super::super::common::transport::Transport;
 use super::super::forwarder::{DnsForwarder, DnsForwarderHandle};
-use super::super::interceptor::{DnsQuery, DnsResponse};
+use super::super::interceptor::DnsQuery;
 use crate::shared::SharedState;
+use crate::udp_relay::construct_udp_response;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// DNS port.
+const DNS_PORT: u16 = 53;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -26,17 +35,18 @@ use crate::shared::SharedState;
 
 /// DNS-over-UDP proxy. Drains [`DnsQuery`] records the interceptor
 /// pushed onto `query_rx`, dispatches each through the shared
-/// forwarder, and sends [`DnsResponse`]s back on `response_tx` for the
-/// interceptor to write to the smoltcp socket.
+/// forwarder, and injects response frames directly into the guest RX ring.
 pub(crate) struct UdpProxy {
     /// Queries pushed by the interceptor's smoltcp read loop.
     query_rx: mpsc::Receiver<DnsQuery>,
-    /// Responses the interceptor will pop and write back to the socket.
-    response_tx: mpsc::Sender<DnsResponse>,
     /// Shared forwarder handle used by every inner query.
     forwarder: Arc<DnsForwarder>,
-    /// Shared wake handle for poking the smoltcp poll loop after send.
+    /// Shared rings and wake handles for guest delivery.
     shared: Arc<SharedState>,
+    /// Source MAC on synthesized response frames.
+    gateway_mac: EthernetAddress,
+    /// Destination MAC on synthesized response frames.
+    guest_mac: EthernetAddress,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -49,9 +59,10 @@ impl UdpProxy {
     pub(crate) fn spawn(
         handle: &tokio::runtime::Handle,
         query_rx: mpsc::Receiver<DnsQuery>,
-        response_tx: mpsc::Sender<DnsResponse>,
         forwarder: DnsForwarderHandle,
         shared: Arc<SharedState>,
+        gateway_mac: [u8; 6],
+        guest_mac: [u8; 6],
     ) {
         handle.spawn(async move {
             let Some(forwarder) = DnsForwarder::wait(forwarder).await else {
@@ -60,7 +71,7 @@ impl UdpProxy {
                 );
                 return;
             };
-            Self::new(query_rx, response_tx, forwarder, shared)
+            Self::new(query_rx, forwarder, shared, gateway_mac, guest_mac)
                 .run()
                 .await;
         });
@@ -69,15 +80,17 @@ impl UdpProxy {
     /// Build a UDP proxy bound to the interceptor's channel pair.
     fn new(
         query_rx: mpsc::Receiver<DnsQuery>,
-        response_tx: mpsc::Sender<DnsResponse>,
         forwarder: Arc<DnsForwarder>,
         shared: Arc<SharedState>,
+        gateway_mac: [u8; 6],
+        guest_mac: [u8; 6],
     ) -> Self {
         Self {
             query_rx,
-            response_tx,
             forwarder,
             shared,
+            gateway_mac: EthernetAddress(gateway_mac),
+            guest_mac: EthernetAddress(guest_mac),
         }
     }
 
@@ -85,9 +98,10 @@ impl UdpProxy {
     /// are owned by this task for its lifetime.
     async fn run(mut self) {
         while let Some(query) = self.query_rx.recv().await {
-            let response_tx = self.response_tx.clone();
             let shared = self.shared.clone();
             let forwarder = self.forwarder.clone();
+            let gateway_mac = self.gateway_mac;
+            let guest_mac = self.guest_mac;
             // Two views of the same address: smoltcp's IpAddress for
             // the outgoing source-IP stamp on the response, and std's
             // IpAddr for the forwarder's policy lookup.
@@ -101,14 +115,14 @@ impl UdpProxy {
                 else {
                     return;
                 };
-                let response = DnsResponse {
-                    data,
-                    dest: query.source,
-                    source_addr: original_dst_smoltcp,
-                };
-                if response_tx.send(response).await.is_ok() {
-                    shared.proxy_wake.wake();
-                }
+                inject_dns_response(
+                    query.source,
+                    original_dst_smoltcp,
+                    &data,
+                    shared,
+                    gateway_mac,
+                    guest_mac,
+                );
             });
         }
     }
@@ -125,6 +139,44 @@ fn smoltcp_ip_to_std(addr: smoltcp::wire::IpAddress) -> IpAddr {
     match addr {
         smoltcp::wire::IpAddress::Ipv4(a) => IpAddr::V4(a),
         smoltcp::wire::IpAddress::Ipv6(a) => IpAddr::V6(a),
+    }
+}
+
+fn smoltcp_endpoint_to_std(endpoint: IpEndpoint) -> SocketAddr {
+    SocketAddr::new(smoltcp_ip_to_std(endpoint.addr), endpoint.port)
+}
+
+fn inject_dns_response(
+    response_dest: IpEndpoint,
+    response_source: Option<smoltcp::wire::IpAddress>,
+    payload: &[u8],
+    shared: Arc<SharedState>,
+    gateway_mac: EthernetAddress,
+    guest_mac: EthernetAddress,
+) {
+    let Some(response_source) = response_source else {
+        tracing::debug!("dns/udp: response dropped because original destination is missing");
+        return;
+    };
+
+    let response_source = SocketAddr::new(smoltcp_ip_to_std(response_source), DNS_PORT);
+    let response_dest = smoltcp_endpoint_to_std(response_dest);
+
+    let Some(frame) = construct_udp_response(
+        response_source,
+        response_dest,
+        payload,
+        gateway_mac,
+        guest_mac,
+    ) else {
+        tracing::debug!("dns/udp: response dropped because address families differ");
+        return;
+    };
+
+    if shared.rx_ring.push(frame).is_ok() {
+        shared.rx_wake.wake();
+    } else {
+        tracing::debug!("dns/udp: response dropped because rx_ring is full");
     }
 }
 
@@ -152,6 +204,19 @@ mod tests {
         assert_eq!(
             smoltcp_ip_to_std(smoltcp),
             IpAddr::V6("fd42::1".parse::<Ipv6Addr>().unwrap())
+        );
+    }
+
+    #[test]
+    fn smoltcp_endpoint_to_std_preserves_port() {
+        let endpoint = IpEndpoint {
+            addr: smoltcp::wire::IpAddress::Ipv4(Ipv4Addr::new(10, 0, 0, 2)),
+            port: 4242,
+        };
+
+        assert_eq!(
+            smoltcp_endpoint_to_std(endpoint),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 4242)
         );
     }
 }

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -232,6 +232,8 @@ pub fn smoltcp_poll_loop(
         gateway_ips,
         network_policy.clone(),
         config.gateway,
+        config.gateway_mac,
+        config.guest_mac,
     );
     let mut port_publisher = PortPublisher::new(
         &published_ports,

--- a/crates/network/lib/udp_relay.rs
+++ b/crates/network/lib/udp_relay.rs
@@ -299,7 +299,7 @@ async fn udp_relay_task(
 /// Construct an ethernet frame containing a UDP response for the guest.
 ///
 /// Builds Ethernet + IPv4/IPv6 + UDP headers using smoltcp's wire module.
-fn construct_udp_response(
+pub(crate) fn construct_udp_response(
     src: SocketAddr,
     dst: SocketAddr,
     payload: &[u8],


### PR DESCRIPTION
## Summary

- Inject forwarded DNS-over-UDP responses directly into the guest RX ring.
- Remove the DNS interceptor response channel that tried to write forwarded responses back through the smoltcp UDP socket.
- Reuse the UDP response frame construction path so DNS replies are delivered to the guest as actual Ethernet frames.

## Problem

The DNS interceptor reads guest UDP/53 packets from the smoltcp socket and forwards them asynchronously to the DNS forwarder. Before this change, the async UDP proxy sent successful upstream responses back over an internal response channel, and the interceptor then called `socket.send_slice(...)` on the smoltcp UDP socket.

That means DNS responses were re-entered through smoltcp as socket output after the original guest packet had already been consumed by the interception path. In practice, this can leave the guest resolver waiting even though the upstream query succeeded: the response is not injected into the guest-facing RX ring as a packet arriving from the gateway/resolver, so the guest can time out DNS lookups.

This is different from the generic UDP relay path, which already constructs a UDP response packet and enqueues the frame into the guest RX ring.

## Fix

This changes DNS-over-UDP forwarding to use the same guest-delivery model as the UDP relay:

- preserve the guest source endpoint from the intercepted DNS query,
- preserve the original destination address so the response appears to come from the resolver address the guest queried,
- construct a UDP response frame with the gateway and guest MAC addresses,
- enqueue that frame into `SharedState`'s RX ring and notify the libkrun network worker.

With this, forwarded DNS answers are delivered to the guest as incoming network frames instead of being written back through the interceptor's smoltcp socket.

## Testing

Not run, per request.
