### PR TITLE
feat(sandbox): enforce sandbox name byte limit

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -14,7 +14,7 @@ use crate::ui;
 /// Common sandbox configuration flags shared between `msb run` and `msb create`.
 #[derive(Debug, Default, Args)]
 pub struct SandboxOpts {
-    /// Name for the sandbox. Auto-generated if omitted.
+    /// Name for the sandbox. Auto-generated if omitted. Maximum 128 UTF-8 bytes.
     #[arg(short, long)]
     pub name: Option<String>,
 

--- a/crates/metrics/lib/layout.rs
+++ b/crates/metrics/lib/layout.rs
@@ -86,6 +86,8 @@ pub const REGISTRY_VERSION: u32 = 1;
 pub const DEFAULT_CAPACITY: u32 = 1024;
 
 /// Maximum bytes reserved for the sandbox name inside a slot.
+///
+/// This matches the public sandbox-name byte limit enforced by the SDK crate.
 pub const NAME_BYTES: usize = 128;
 
 /// Size of one slot in bytes. Sized at 512 bytes so a slot occupies a single
@@ -191,7 +193,8 @@ pub struct Slot {
     pub name_len: AtomicU16,
     /// Padding before the byte array so trailing atomics align cleanly.
     _pad1: [AtomicU8; 6],
-    /// UTF-8 encoded sandbox name, truncated to `NAME_BYTES`.
+    /// UTF-8 encoded sandbox name. Public SDK callers reject names longer
+    /// than `NAME_BYTES`.
     pub name_bytes: [AtomicU8; NAME_BYTES],
     /// Padding to round the struct up to `SLOT_SIZE`.
     _tail: [u8; SLOT_TAIL_PAD],

--- a/crates/metrics/lib/lib.rs
+++ b/crates/metrics/lib/lib.rs
@@ -17,6 +17,8 @@ mod snapshot;
 //--------------------------------------------------------------------------------------------------
 
 pub use error::{MetricsError, MetricsResult};
+/// Maximum bytes reserved for a sandbox name inside a fixed metrics slot.
+pub use layout::NAME_BYTES as SLOT_NAME_BYTES;
 pub use registry::{
     ActivateSlot, MetricsRegistry, MetricsSlotWriter, ReleaseMode, ReserveSlot, SampleWrite,
     SlotReservation, default_capacity,

--- a/crates/metrics/lib/registry.rs
+++ b/crates/metrics/lib/registry.rs
@@ -37,7 +37,7 @@ const INIT_POLL_INTERVAL: Duration = Duration::from_millis(5);
 pub struct ReserveSlot<'a> {
     /// Catalog sandbox id.
     pub sandbox_id: i32,
-    /// Sandbox name. Truncated to fit the slot.
+    /// Sandbox name. Must fit in the slot's fixed inline name buffer.
     pub name: &'a str,
     /// Configured guest memory limit in bytes.
     pub memory_limit_bytes: u64,
@@ -241,6 +241,13 @@ impl MetricsRegistry {
 
     /// Reserve a slot for an upcoming sandbox spawn.
     pub fn reserve(&self, spec: ReserveSlot<'_>) -> MetricsResult<SlotReservation> {
+        if spec.name.len() > NAME_BYTES {
+            return Err(MetricsError::Custom(format!(
+                "sandbox name is too long for metrics slot: {} bytes (max {NAME_BYTES})",
+                spec.name.len()
+            )));
+        }
+
         let capacity = self.inner.capacity;
         // Scan slots once for a Free entry; fall back to a second pass that
         // also reclaims Stale entries. Two passes keep Stale samples visible
@@ -1054,6 +1061,26 @@ mod tests {
 
         writer.release(ReleaseMode::Free).unwrap();
         assert!(reg.snapshot().unwrap().is_empty());
+        cleanup(&name);
+    }
+
+    #[test]
+    fn reserve_rejects_name_that_exceeds_inline_slot_capacity() {
+        let name = unique_name("long");
+        let reg = MetricsRegistry::open_or_create(&name, 16).unwrap();
+
+        let err = reg
+            .reserve(ReserveSlot {
+                sandbox_id: 7,
+                name: &"x".repeat(NAME_BYTES + 1),
+                memory_limit_bytes: 1,
+            })
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "sandbox name is too long for metrics slot: 129 bytes (max 128)"
+        );
         cleanup(&name);
     }
 

--- a/crates/metrics/lib/snapshot.rs
+++ b/crates/metrics/lib/snapshot.rs
@@ -15,7 +15,7 @@ pub struct LiveMetric {
     pub run_id: i32,
     /// PID of the runtime process that owns the slot.
     pub pid: i32,
-    /// UTF-8 sandbox name (truncated to the slot capacity).
+    /// UTF-8 sandbox name stored inline in the slot.
     pub name: String,
     /// Wall-clock time at which the most recent sample was written.
     pub timestamp: chrono::DateTime<chrono::Utc>,

--- a/crates/microsandbox/lib/agent/bridge.rs
+++ b/crates/microsandbox/lib/agent/bridge.rs
@@ -61,12 +61,16 @@ pub struct AgentBridge {
 
 impl AgentBridge {
     /// Connect to a sandbox by name (resolves the socket path from SDK config).
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     pub async fn connect_sandbox(name: &str) -> AgentClientResult<Self> {
         let client = AgentClient::connect_sandbox(name).await?;
         Ok(Self::from_client(client))
     }
 
     /// Connect to a sandbox by name with an explicit handshake timeout.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     pub async fn connect_sandbox_with_timeout(
         name: &str,
         timeout: Duration,

--- a/crates/microsandbox/lib/agent/client.rs
+++ b/crates/microsandbox/lib/agent/client.rs
@@ -249,17 +249,23 @@ impl AgentClient {
     /// Resolve a sandbox name to its agent socket path and connect.
     ///
     /// The socket lives under the SDK's configured runtime directory at a
-    /// short, name-derived path.
+    /// short, name-derived path. Sandbox names are limited to 128 UTF-8 bytes.
     pub async fn connect_sandbox(name: &str) -> AgentClientResult<Self> {
         Self::connect_sandbox_with_timeout(name, DEFAULT_HANDSHAKE_TIMEOUT).await
     }
 
     /// Resolve a sandbox name to its agent socket path and connect with an
     /// explicit handshake timeout.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     pub async fn connect_sandbox_with_timeout(
         name: &str,
         timeout: Duration,
     ) -> AgentClientResult<Self> {
+        if let Some(message) = crate::sandbox::sandbox_name_validation_message(name) {
+            return Err(AgentClientError::InvalidSandboxName(message));
+        }
+
         let mut last_error = None;
         for sock_path in crate::runtime::sandbox_agent_socket_path_candidates(name) {
             if !sock_path.exists() {

--- a/crates/microsandbox/lib/agent/error.rs
+++ b/crates/microsandbox/lib/agent/error.rs
@@ -39,6 +39,10 @@ pub enum AgentClientError {
     #[error("sandbox '{0}' not found")]
     SandboxNotFound(String),
 
+    /// Sandbox name failed SDK validation before socket resolution.
+    #[error("invalid sandbox name: {0}")]
+    InvalidSandboxName(String),
+
     /// An I/O error occurred on the socket after connect.
     #[error("io: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/microsandbox/lib/lib.rs
+++ b/crates/microsandbox/lib/lib.rs
@@ -40,7 +40,9 @@ pub use sandbox::ssh::{
     SshClientOptionsBuilder, SshExecOptionsBuilder, SshOutput, SshServer, SshServerOptionsBuilder,
     SshStdioStream,
 };
-pub use sandbox::{ExecOutput, Sandbox, SandboxConfig};
+pub use sandbox::{
+    ExecOutput, MAX_SANDBOX_NAME_BYTES, Sandbox, SandboxConfig, validate_sandbox_name,
+};
 pub use snapshot::{
     Snapshot, SnapshotBuilder, SnapshotConfig, SnapshotDestination, SnapshotFormat, SnapshotHandle,
     SnapshotVerifyReport, UpperIntegrity, UpperVerifyStatus,

--- a/crates/microsandbox/lib/logs/mod.rs
+++ b/crates/microsandbox/lib/logs/mod.rs
@@ -132,6 +132,8 @@ pub fn log_dir_for(name: &str) -> PathBuf {
 
 /// Read all matching log entries for the named sandbox.
 ///
+/// Sandbox names are limited to 128 UTF-8 bytes.
+///
 /// Returns entries sorted by timestamp (strict chronological order
 /// across all sources). Returns
 /// [`MicrosandboxError::SandboxNotFound`] if the sandbox's log
@@ -151,6 +153,7 @@ pub async fn read_logs(name: &str, opts: &LogOptions) -> MicrosandboxResult<Vec<
 /// [`log_stream`] with [`LogStreamStart::From`] without losing log
 /// lines written between the snapshot drain and follow startup.
 pub async fn read_logs_snapshot(name: &str, opts: &LogOptions) -> MicrosandboxResult<LogSnapshot> {
+    crate::sandbox::validate_sandbox_name(name)?;
     let stream_opts = LogStreamOptions {
         sources: opts.sources.clone(),
         // Push `since` into the parser when possible so early
@@ -180,6 +183,8 @@ pub async fn read_logs_snapshot(name: &str, opts: &LogOptions) -> MicrosandboxRe
 
 /// Stream log entries for the named sandbox.
 ///
+/// Sandbox names are limited to 128 UTF-8 bytes.
+///
 /// Returns [`MicrosandboxError::SandboxNotFound`] if the sandbox's
 /// log directory doesn't exist. Within each source, entries are
 /// chronological; across sources, ordering is "as parsed."
@@ -187,6 +192,7 @@ pub async fn log_stream(
     name: &str,
     opts: &LogStreamOptions,
 ) -> MicrosandboxResult<impl Stream<Item = MicrosandboxResult<LogEntry>> + Send + 'static + use<>> {
+    crate::sandbox::validate_sandbox_name(name)?;
     let log_dir = log_dir_for(name);
     if !tokio::fs::try_exists(&log_dir).await.unwrap_or(false) {
         return Err(MicrosandboxError::SandboxNotFound(name.to_string()));

--- a/crates/microsandbox/lib/runtime/handle.rs
+++ b/crates/microsandbox/lib/runtime/handle.rs
@@ -63,7 +63,7 @@ impl ProcessHandle {
         self.pid
     }
 
-    /// Get the sandbox name.
+    /// Get the sandbox name. Names are limited to 128 UTF-8 bytes.
     pub fn sandbox_name(&self) -> &str {
         &self.sandbox_name
     }

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -1156,7 +1156,8 @@ mod tests {
     #[test]
     fn test_sandbox_agent_socket_path_is_independent_of_sandbox_name_length() {
         let short = sandbox_agent_socket_path("test");
-        let long = sandbox_agent_socket_path(&format!("testing-{}", "x".repeat(256)));
+        let max_len =
+            sandbox_agent_socket_path(&"x".repeat(crate::sandbox::MAX_SANDBOX_NAME_BYTES));
 
         let expected_len = "0123456789abcdef0123456789abcdef.sock".len();
         assert_eq!(
@@ -1164,11 +1165,11 @@ mod tests {
             expected_len
         );
         assert_eq!(
-            long.file_name().unwrap().to_string_lossy().len(),
+            max_len.file_name().unwrap().to_string_lossy().len(),
             expected_len
         );
-        assert_eq!(short.parent(), long.parent());
-        assert_ne!(short.file_name(), long.file_name());
+        assert_eq!(short.parent(), max_len.parent());
+        assert_ne!(short.file_name(), max_len.file_name());
     }
 
     #[test]

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -67,8 +67,10 @@ impl RegistryConfigBuilder {
 //--------------------------------------------------------------------------------------------------
 
 impl SandboxBuilder {
-    /// Start building a sandbox configuration. The name must be unique
-    /// among existing sandboxes (unless [`replace`](Self::replace) is set).
+    /// Start building a sandbox configuration.
+    ///
+    /// The name must be unique among existing sandboxes (unless
+    /// [`replace`](Self::replace) is set) and no longer than 128 UTF-8 bytes.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             config: SandboxConfig {
@@ -908,7 +910,7 @@ impl From<SandboxConfig> for SandboxBuilder {
 mod tests {
     use super::SandboxBuilder;
     use crate::LogLevel;
-    use crate::sandbox::RlimitResource;
+    use crate::sandbox::{MAX_SANDBOX_NAME_BYTES, RlimitResource};
     #[cfg(feature = "net")]
     use microsandbox_network::config::PortProtocol;
     #[cfg(feature = "net")]
@@ -928,8 +930,8 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_builder_accepts_long_sandbox_name() {
-        let name = format!("testing-{}", "x".repeat(256));
+    async fn test_builder_accepts_128_byte_sandbox_name() {
+        let name = "x".repeat(MAX_SANDBOX_NAME_BYTES);
         let config = SandboxBuilder::new(name.clone())
             .image("alpine")
             .build()
@@ -937,6 +939,21 @@ mod tests {
             .unwrap();
 
         assert_eq!(config.name, name);
+    }
+
+    #[tokio::test]
+    async fn test_builder_rejects_over_128_byte_sandbox_name() {
+        let name = "x".repeat(MAX_SANDBOX_NAME_BYTES + 1);
+        let err = SandboxBuilder::new(name)
+            .image("alpine")
+            .build()
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "invalid config: sandbox name is too long: 129 bytes (max 128)"
+        );
     }
 
     #[tokio::test]

--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -69,7 +69,7 @@ fn default_disable_metrics_sample() -> bool {
 /// `Serialize`/`Deserialize` for file-based configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SandboxConfig {
-    /// Unique sandbox name (required).
+    /// Unique sandbox name (required, maximum 128 UTF-8 bytes).
     pub name: String,
 
     /// Root filesystem source (required).

--- a/crates/microsandbox/lib/sandbox/handle.rs
+++ b/crates/microsandbox/lib/sandbox/handle.rs
@@ -75,6 +75,8 @@ impl SandboxHandle {
     }
 
     /// Unique name identifying this sandbox.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -55,6 +55,17 @@ use self::attach::AttachOptions;
 use self::exec::{ExecEvent, ExecHandle, ExecOptions, ExecSink, StdinMode};
 
 //--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Maximum UTF-8 byte length for a sandbox name.
+///
+/// The limit matches the fixed inline name storage in the shared-memory
+/// metrics slot, so SDK names can be copied into live metrics without
+/// truncation.
+pub const MAX_SANDBOX_NAME_BYTES: usize = microsandbox_metrics::SLOT_NAME_BYTES;
+
+//--------------------------------------------------------------------------------------------------
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
 
@@ -118,6 +129,8 @@ pub struct Sandbox {
 
 impl Sandbox {
     /// Start building a new sandbox configuration.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     pub fn builder(name: impl Into<String>) -> SandboxBuilder {
         SandboxBuilder::new(name)
     }
@@ -181,6 +194,8 @@ impl Sandbox {
 
     /// Start an existing stopped sandbox from persisted state.
     ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
+    ///
     /// Reuses the serialized sandbox config and pinned rootfs state without
     /// re-resolving the original OCI reference.
     pub async fn start(name: &str) -> MicrosandboxResult<Self> {
@@ -188,6 +203,8 @@ impl Sandbox {
     }
 
     /// Start an existing sandbox in detached/background mode.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     pub async fn start_detached(name: &str) -> MicrosandboxResult<Self> {
         Self::start_with_mode(name, SpawnMode::Detached).await
     }
@@ -408,6 +425,7 @@ impl Sandbox {
     }
 
     pub(super) async fn start_with_mode(name: &str, mode: SpawnMode) -> MicrosandboxResult<Self> {
+        validate_sandbox_name(name)?;
         tracing::debug!(sandbox = name, ?mode, "start_with_mode: loading record");
         let pools = db::init_global().await?;
         let write_db = pools.write();
@@ -472,7 +490,10 @@ impl Sandbox {
     }
 
     /// Get a sandbox handle by name from the database.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     pub async fn get(name: &str) -> MicrosandboxResult<SandboxHandle> {
+        validate_sandbox_name(name)?;
         let pools = db::init_global().await?;
 
         let model = sandbox_entity::Entity::find()
@@ -516,6 +537,7 @@ impl Sandbox {
     /// Remove a stopped sandbox from the database.
     ///
     /// Convenience method equivalent to `Sandbox::get(name).await?.remove().await`.
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     pub async fn remove(name: &str) -> MicrosandboxResult<()> {
         Self::get(name).await?.remove().await
     }
@@ -544,6 +566,8 @@ impl Sandbox {
     }
 
     /// Unique name identifying this sandbox.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     pub fn name(&self) -> &str {
         &self.config.name
     }
@@ -1729,15 +1753,39 @@ fn digest_pinned_reference(reference: &str, manifest_digest: &str) -> Microsandb
     Ok(pinned)
 }
 
+/// Validate a sandbox name used by CLI and SDK APIs.
+///
+/// Names are UTF-8 strings and must be non-empty and no longer than
+/// [`MAX_SANDBOX_NAME_BYTES`] bytes. The limit is measured in bytes, not
+/// Unicode scalar values, because names are stored in fixed-size shared-memory
+/// metrics slots.
+pub fn validate_sandbox_name(name: &str) -> MicrosandboxResult<()> {
+    if let Some(message) = sandbox_name_validation_message(name) {
+        return Err(MicrosandboxError::InvalidConfig(message));
+    }
+
+    Ok(())
+}
+
 /// Validate sandbox-name-derived runtime paths before the sandbox process starts.
 pub(super) fn validate_sandbox_name_for_runtime(name: &str) -> MicrosandboxResult<()> {
+    validate_sandbox_name(name)?;
+    runtime::resolve_sandbox_agent_socket_path(name).map(|_| ())
+}
+
+pub(crate) fn sandbox_name_validation_message(name: &str) -> Option<String> {
     if name.is_empty() {
-        return Err(MicrosandboxError::InvalidConfig(
-            "sandbox name is required".into(),
+        return Some("sandbox name is required".into());
+    }
+
+    let len = name.len();
+    if len > MAX_SANDBOX_NAME_BYTES {
+        return Some(format!(
+            "sandbox name is too long: {len} bytes (max {MAX_SANDBOX_NAME_BYTES})"
         ));
     }
 
-    runtime::resolve_sandbox_agent_socket_path(name).map(|_| ())
+    None
 }
 
 /// Pull an OCI image and return the pull result.
@@ -2233,9 +2281,10 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        RootfsSource, SandboxConfig, SandboxStatus, digest_pinned_reference, insert_sandbox_record,
-        persist_oci_manifest_pin, prepare_create_target, reconcile_sandbox_runtime_state,
-        remove_dir_if_exists, validate_rootfs_source, validate_sandbox_name_for_runtime,
+        MAX_SANDBOX_NAME_BYTES, RootfsSource, SandboxConfig, SandboxStatus,
+        digest_pinned_reference, insert_sandbox_record, persist_oci_manifest_pin,
+        prepare_create_target, reconcile_sandbox_runtime_state, remove_dir_if_exists,
+        validate_rootfs_source, validate_sandbox_name_for_runtime,
     };
 
     /// Open both pools at `db_path` for tests, with migrations applied.
@@ -2402,8 +2451,30 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_sandbox_name_accepts_long_name() {
-        validate_sandbox_name_for_runtime(&"x".repeat(256)).unwrap();
+    fn test_validate_sandbox_name_accepts_128_byte_name() {
+        validate_sandbox_name_for_runtime(&"x".repeat(MAX_SANDBOX_NAME_BYTES)).unwrap();
+    }
+
+    #[test]
+    fn test_validate_sandbox_name_rejects_over_128_bytes() {
+        let err =
+            validate_sandbox_name_for_runtime(&"x".repeat(MAX_SANDBOX_NAME_BYTES + 1)).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "invalid config: sandbox name is too long: 129 bytes (max 128)"
+        );
+    }
+
+    #[test]
+    fn test_validate_sandbox_name_limit_is_utf8_bytes() {
+        validate_sandbox_name_for_runtime(&"é".repeat(64)).unwrap();
+
+        let err = validate_sandbox_name_for_runtime(&"é".repeat(65)).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid config: sandbox name is too long: 130 bytes (max 128)"
+        );
     }
 
     #[test]

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -70,7 +70,7 @@ msb self uninstall       # Remove msb
 ```
 
 <Tip>
-  Unnamed sandboxes (no `--name` flag) are ephemeral. They're automatically removed when the command finishes. Named sandboxes persist and can be stopped, restarted, and inspected later.
+  Unnamed sandboxes (no `--name` flag) are ephemeral. They're automatically removed when the command finishes. Named sandboxes persist and can be stopped, restarted, and inspected later. Names must be non-empty and no longer than 128 UTF-8 bytes.
 </Tip>
 
 ## Global options

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -33,7 +33,7 @@ msb run --name public-api -p 0.0.0.0:8000:8000 python
 
 | Flag | Description |
 |------|-------------|
-| `-n`, `--name` | Sandbox name (if omitted, sandbox is ephemeral) |
+| `-n`, `--name` | Sandbox name, up to 128 UTF-8 bytes (if omitted, sandbox is ephemeral) |
 | `-c`, `--cpus` | Number of virtual CPUs to allocate |
 | `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
 | `--oci-upper-size` | Writable overlay upper size for OCI images (e.g. `4G`, `8192M`) |

--- a/docs/cli/ssh-commands.mdx
+++ b/docs/cli/ssh-commands.mdx
@@ -18,8 +18,8 @@ msb ssh --name serve -- uptime
 
 | Argument | Description |
 |----------|-------------|
-| `sandbox` | Sandbox name |
-| `--name NAME` | Explicit sandbox name, useful when the name collides with `serve`, `authorize`, or `help` |
+| `sandbox` | Sandbox name, up to 128 UTF-8 bytes |
+| `--name NAME` | Explicit sandbox name, up to 128 UTF-8 bytes; useful when the name collides with `serve`, `authorize`, or `help` |
 | `-- COMMAND...` | Remote command to run through the sandbox shell |
 
 ## msb ssh authorize
@@ -82,8 +82,8 @@ msb ssh connect devbox -- uname -a
 
 | Argument | Description |
 |----------|-------------|
-| `sandbox` | Sandbox name |
-| `--name NAME` | Explicit sandbox name |
+| `sandbox` | Sandbox name, up to 128 UTF-8 bytes |
+| `--name NAME` | Explicit sandbox name, up to 128 UTF-8 bytes |
 | `-- COMMAND...` | Remote command to run through the sandbox shell |
 
 ## SSH state

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -36,7 +36,7 @@ stateDiagram-v2
 
 ## Create a sandbox
 
-Creating a sandbox boots the microVM, mounts the filesystem, initializes the guest agent, and waits until it's ready to accept commands.
+Creating a sandbox boots the microVM, mounts the filesystem, initializes the guest agent, and waits until it's ready to accept commands. Names must be non-empty and no longer than 128 UTF-8 bytes.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -10,7 +10,7 @@ The security boundary here is hardware virtualization, not Linux namespaces. Con
 
 ## Creating a sandbox
 
-At minimum, a sandbox needs a name and an image. Everything else has sensible defaults: 1 vCPU, 512 MiB memory, public-only networking, `/bin/sh` as the shell.
+At minimum, a sandbox needs a name and an image. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes. Everything else has sensible defaults: 1 vCPU, 512 MiB memory, public-only networking, `/bin/sh` as the shell.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sandboxes/ssh/native-sessions.mdx
+++ b/docs/sandboxes/ssh/native-sessions.mdx
@@ -21,7 +21,7 @@ msb ssh devbox -- uname -a
 msb ssh devbox -- sh -lc "cd /app && npm test"
 ```
 
-If a sandbox name collides with an SSH subcommand such as `serve` or `authorize`, use `--name`:
+If a sandbox name collides with an SSH subcommand such as `serve` or `authorize`, use `--name`. Sandbox names are limited to 128 UTF-8 bytes:
 
 ```bash
 msb ssh --name serve

--- a/docs/sdk/go/agent-client.mdx
+++ b/docs/sdk/go/agent-client.mdx
@@ -46,7 +46,7 @@ _ = ready
 func ConnectAgentSandbox(ctx context.Context, name string) (*AgentClient, error)
 ```
 
-Connect to a running sandbox by name.
+Connect to a running sandbox by name. Sandbox names are limited to 128 UTF-8 bytes.
 
 ---
 

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -91,14 +91,14 @@ func CreateSandbox(
 ) (*Sandbox, error)
 ```
 
-Create and boot a new sandbox. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands. The returned [`*Sandbox`](#instance-methods) owns the VM process — call `Close` (or `StopAndWait` + `Close`) when done.
+Create and boot a new sandbox. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes. The returned [`*Sandbox`](#instance-methods) owns the VM process — call `Close` (or `StopAndWait` + `Close`) when done.
 
 **Parameters**
 
 | Name | Type               | Description                                                                                             |
 | ---- | ------------------ | ------------------------------------------------------------------------------------------------------- |
 | ctx  | `context.Context`  | Cancels the boot operation. Cancelling after this function returns has no effect on the running sandbox |
-| name | `string`           | Sandbox name                                                                                            |
+| name | `string`           | Sandbox name, up to 128 UTF-8 bytes                                                                    |
 | opts | `...SandboxOption` | Functional options — see [Options](#options)                                                            |
 
 **Returns**
@@ -136,7 +136,7 @@ func CreateSandboxDetached(
 ) (*Sandbox, error)
 ```
 
-Same as [`CreateSandbox`](#createsandbox) with [`WithDetached`](#withdetached) automatically applied. The VM continues running after the returned handle is released or the Go process exits. Reattach via [`GetSandbox`](#getsandbox).
+Same as [`CreateSandbox`](#createsandbox) with [`WithDetached`](#withdetached) automatically applied. The VM continues running after the returned handle is released or the Go process exits. Reattach via [`GetSandbox`](#getsandbox). Sandbox names are limited to 128 UTF-8 bytes.
 
 ---
 
@@ -153,7 +153,7 @@ Restart a previously stopped sandbox. The VM reboots using the persisted configu
 | Name | Type              | Description                |
 | ---- | ----------------- | -------------------------- |
 | ctx  | `context.Context` | Cancels the boot operation |
-| name | `string`          | Name of a stopped sandbox  |
+| name | `string`          | Name of a stopped sandbox, up to 128 UTF-8 bytes |
 
 **Returns**
 
@@ -179,7 +179,7 @@ Boot a stopped sandbox in detached mode.
 func GetSandbox(ctx context.Context, name string) (*SandboxHandle, error)
 ```
 
-Look up a sandbox by name and return a metadata handle without connecting to it. Returns `ErrSandboxNotFound` if no such sandbox exists. The returned [`*SandboxHandle`](#sandboxhandle) exposes `Connect`, `Start`, `Stop`, `Kill`, `Remove`, `Metrics`, and `Logs`.
+Look up a sandbox by name and return a metadata handle without connecting to it. Sandbox names are limited to 128 UTF-8 bytes. Returns `ErrSandboxNotFound` if no such sandbox exists. The returned [`*SandboxHandle`](#sandboxhandle) exposes `Connect`, `Start`, `Stop`, `Kill`, `Remove`, `Metrics`, and `Logs`.
 
 ---
 
@@ -940,7 +940,7 @@ A lightweight metadata reference to a sandbox returned by [`GetSandbox`](#getsan
 
 | Method                  | Returns                           | Description                                       |
 | ----------------------- | --------------------------------- | ------------------------------------------------- |
-| `Name()`                | `string`                          | Sandbox name                                      |
+| `Name()`                | `string`                          | Sandbox name, up to 128 UTF-8 bytes              |
 | `Status()`              | [`SandboxStatus`](#sandboxstatus) | Last-known lifecycle status                       |
 | `ConfigJSON()`          | `string`                          | Raw JSON configuration                            |
 | `CreatedAt()`           | `time.Time`                       | Creation time, zero value if unknown              |

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -4,7 +4,7 @@ description: Install the SDK and create your first sandbox
 icon: "play"
 ---
 
-The SDK embeds the microsandbox runtime directly into whatever application uses it. `Sandbox.builder(name).create()` spawns the VM as a child process. No daemon to install, no server to connect to.
+The SDK embeds the microsandbox runtime directly into whatever application uses it. `Sandbox.builder(name).create()` spawns the VM as a child process. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes. No daemon to install, no server to connect to.
 
 ## Installation
 

--- a/docs/sdk/python/agent-client.mdx
+++ b/docs/sdk/python/agent-client.mdx
@@ -37,7 +37,7 @@ await client.close()
 async def connect_sandbox(cls, name: str) -> AgentClient
 ```
 
-Connect to a running sandbox by name.
+Connect to a running sandbox by name. Sandbox names are limited to 128 UTF-8 bytes.
 
 ---
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -17,13 +17,13 @@ See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/
 async def create(name: str, **kwargs) -> Sandbox
 ```
 
-Create and boot a sandbox. Keyword arguments provide individual config fields. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands.
+Create and boot a sandbox. Keyword arguments provide individual config fields. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes.
 
 **Parameters**
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `str` | Sandbox name |
+| name | `str` | Sandbox name, up to 128 UTF-8 bytes |
 | image | `str \| ImageSource` | OCI image, local path, or disk image. Required unless `snapshot=` is passed. Use `Image.oci("python:3.12", upper_size_mib=8192)` to set an OCI upper size |
 | snapshot | `str \| os.PathLike` | Snapshot artifact to boot from instead of `image=`. Mutually exclusive with `image=` |
 | cpus | `int` | Virtual CPUs (default `1`) |
@@ -101,7 +101,7 @@ Restart a previously stopped sandbox. The VM reboots using the persisted configu
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `str` | Name of a stopped sandbox |
+| name | `str` | Name of a stopped sandbox, up to 128 UTF-8 bytes |
 | detached | `bool` | If `True`, sandbox survives after your process exits (default `False`) |
 
 **Returns**
@@ -125,7 +125,7 @@ Get a handle to an existing sandbox (running or stopped). The handle provides st
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `str` | Sandbox name |
+| name | `str` | Sandbox name, up to 128 UTF-8 bytes |
 
 **Returns**
 
@@ -165,7 +165,7 @@ Delete a stopped sandbox and all its state from disk. Fails if the sandbox is st
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `str` | Sandbox name |
+| name | `str` | Sandbox name, up to 128 UTF-8 bytes |
 
 ---
 
@@ -180,7 +180,7 @@ Delete a stopped sandbox and all its state from disk. Fails if the sandbox is st
 async def name(self) -> str
 ```
 
-Sandbox name. This is an async property -- use `await sb.name`.
+Sandbox name. Names are limited to 128 UTF-8 bytes. This is an async property -- use `await sb.name`.
 
 ---
 
@@ -995,7 +995,7 @@ A lightweight handle to an existing sandbox (running or stopped). Obtained via [
 
 | Property / Method | Type | Description |
 |-------------------|------|-------------|
-| name | `str` | Sandbox name |
+| name | `str` | Sandbox name, up to 128 UTF-8 bytes |
 | status | `str` | Current status (`"running"`, `"stopped"`, `"crashed"`, `"draining"`, `"paused"`) |
 | config_json | `str` | Raw JSON configuration |
 | created_at | `float \| None` | Creation timestamp (ms since epoch) |

--- a/docs/sdk/rust/agent-client.mdx
+++ b/docs/sdk/rust/agent-client.mdx
@@ -54,7 +54,7 @@ Connect to an agent relay socket by path. The connection performs the relay hand
 async fn connect_sandbox(name: &str) -> AgentClientResult<AgentClient>
 ```
 
-Resolve a sandbox name to its relay socket path and connect to it.
+Resolve a sandbox name to its relay socket path and connect to it. Sandbox names are limited to 128 UTF-8 bytes.
 
 ---
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -16,13 +16,13 @@ See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/
 fn builder(name: impl Into<String>) -> SandboxBuilder
 ```
 
-Create a builder for configuring a new sandbox. The builder lets you set the image, resources, volumes, networking, secrets, and other options before booting the VM. See [`SandboxBuilder`](#sandboxbuilder) for all available options.
+Create a builder for configuring a new sandbox. The builder lets you set the image, resources, volumes, networking, secrets, and other options before booting the VM. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes. See [`SandboxBuilder`](#sandboxbuilder) for all available options.
 
 **Parameters**
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `impl Into<String>` | Sandbox name - must be unique among running sandboxes |
+| name | `impl Into<String>` | Sandbox name - must be unique and no longer than 128 UTF-8 bytes |
 
 **Returns**
 
@@ -44,7 +44,7 @@ Get a handle to an existing sandbox (running or stopped). The handle provides st
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `&str` | Sandbox name |
+| name | `&str` | Sandbox name, up to 128 UTF-8 bytes |
 
 **Returns**
 
@@ -82,7 +82,7 @@ Delete a stopped sandbox and all its state from disk (configuration, logs, runti
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `&str` | Sandbox name |
+| name | `&str` | Sandbox name, up to 128 UTF-8 bytes |
 
 ---
 
@@ -98,7 +98,7 @@ Restart a previously stopped sandbox. The VM reboots using the persisted configu
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `&str` | Name of a stopped sandbox |
+| name | `&str` | Name of a stopped sandbox, up to 128 UTF-8 bytes |
 
 **Returns**
 
@@ -120,7 +120,7 @@ Restart a stopped sandbox in detached mode. The sandbox survives after your proc
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `&str` | Name of a stopped sandbox |
+| name | `&str` | Name of a stopped sandbox, up to 128 UTF-8 bytes |
 
 **Returns**
 
@@ -315,7 +315,7 @@ Get the sandbox name.
 
 | Type | Description |
 |------|-------------|
-| `&str` | Sandbox name |
+| `&str` | Sandbox name, up to 128 UTF-8 bytes |
 
 ---
 
@@ -1176,7 +1176,7 @@ The full configuration of a sandbox. Obtained via [`config()`](#config) or built
 | image | `RootfsSource` | Root filesystem source (OCI, bind, or disk image) |
 | max_duration_secs | `Option<u64>` | Maximum lifetime |
 | memory_mib | `u32` | Guest memory in MiB |
-| name | `String` | Sandbox name |
+| name | `String` | Sandbox name, up to 128 UTF-8 bytes |
 | patches | `Vec<Patch>` | Rootfs patches |
 | scripts | `Vec<(String, String)>` | Named scripts |
 | shell | `Option<String>` | Shell for `shell()` calls |
@@ -1197,7 +1197,7 @@ A lightweight handle to an existing sandbox (running or stopped). Obtained via [
 | kill() | `Result<()>` | Force terminate immediately. Pending writes may be lost |
 | logs() | `Result<Vec<`[`LogEntry`](#logentry)`>>` | Read captured `exec.log` (works without starting) |
 | metrics() | `Result<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
-| name() | `&str` | Sandbox name |
+| name() | `&str` | Sandbox name, up to 128 UTF-8 bytes |
 | remove() | `Result<()>` | Delete sandbox and state |
 | start() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
 | start_detached() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |

--- a/docs/sdk/typescript/agent-client.mdx
+++ b/docs/sdk/typescript/agent-client.mdx
@@ -36,7 +36,7 @@ await client.close();
 static connectSandbox(name: string): Promise<AgentClient>
 ```
 
-Connect to a running sandbox by name.
+Connect to a running sandbox by name. Sandbox names are limited to 128 UTF-8 bytes.
 
 ---
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -6,7 +6,7 @@ icon: "cube"
 
 See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
 
-The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox from `Sandbox.builder(name)` and chain configuration calls before terminating with `.create()` or `.createDetached()`.
+The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox from `Sandbox.builder(name)` and chain configuration calls before terminating with `.create()` or `.createDetached()`. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes.
 
 ```typescript
 import { Sandbox } from "microsandbox";
@@ -34,7 +34,7 @@ Begin building a new sandbox. Configure it with chainable setters, then call `.c
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `string` | Sandbox name |
+| name | `string` | Sandbox name, up to 128 UTF-8 bytes |
 
 **Returns**
 
@@ -54,7 +54,7 @@ Get a handle to an existing sandbox (running or stopped). The handle provides st
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `string` | Sandbox name |
+| name | `string` | Sandbox name, up to 128 UTF-8 bytes |
 
 **Returns**
 
@@ -92,7 +92,7 @@ Delete a stopped sandbox and all its state from disk. Fails if the sandbox is st
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `string` | Sandbox name |
+| name | `string` | Sandbox name, up to 128 UTF-8 bytes |
 
 ---
 
@@ -108,7 +108,7 @@ Restart a previously stopped sandbox. The VM reboots using the persisted configu
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `string` | Name of a stopped sandbox |
+| name | `string` | Name of a stopped sandbox, up to 128 UTF-8 bytes |
 
 **Returns**
 
@@ -130,7 +130,7 @@ Restart a stopped sandbox in detached mode.
 
 | Name | Type | Description |
 |------|------|-------------|
-| name | `string` | Name of a stopped sandbox |
+| name | `string` | Name of a stopped sandbox, up to 128 UTF-8 bytes |
 
 **Returns**
 
@@ -150,7 +150,7 @@ Restart a stopped sandbox in detached mode.
 readonly name: string
 ```
 
-Sandbox name.
+Sandbox name. Names are limited to 128 UTF-8 bytes.
 
 ---
 
@@ -717,7 +717,7 @@ Frozen configuration object — produced by `SandboxBuilder.build()` and exposed
 
 | Field | Type | Description |
 |-------|------|-------------|
-| name | `string` | Sandbox name |
+| name | `string` | Sandbox name, up to 128 UTF-8 bytes |
 | image | `RootfsSource` | OCI / bind / disk discriminated union |
 | cpus | `number \| null` | Virtual CPUs |
 | memoryMib | `number \| null` | Guest memory in MiB |
@@ -754,7 +754,7 @@ Handles from `Sandbox.get(name)` are **live** — they expose lifecycle methods 
 
 | Property / Method | Type | Description |
 |-------------------|------|-------------|
-| name | `string` | Sandbox name |
+| name | `string` | Sandbox name, up to 128 UTF-8 bytes |
 | status | [`SandboxStatus`](#sandboxstatus) | Current status |
 | configJson | `string` | Raw JSON configuration |
 | createdAt | `Date \| null` | Creation timestamp |

--- a/sdk/go/agent.go
+++ b/sdk/go/agent.go
@@ -43,6 +43,7 @@ type AgentStream struct {
 }
 
 // ConnectAgentSandbox connects to a running sandbox by name.
+// Sandbox names are limited to 128 UTF-8 bytes.
 // Use context.WithTimeout to override the default 10s handshake timeout.
 func ConnectAgentSandbox(ctx context.Context, name string) (*AgentClient, error) {
 	inner, err := ffi.OpenAgentSandbox(ctx, name)

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -18,6 +18,8 @@ type Sandbox struct {
 // CreateSandbox creates and boots a new sandbox. The returned Sandbox owns the
 // VM process — call Close (or StopAndWait + Close) when done.
 //
+// Sandbox names are limited to 128 UTF-8 bytes.
+//
 // ctx controls the boot operation only; cancelling ctx after this function
 // returns has no effect on the running sandbox.
 func CreateSandbox(ctx context.Context, name string, opts ...SandboxOption) (*Sandbox, error) {
@@ -151,7 +153,7 @@ func durationSecsCeil(d time.Duration) uint64 {
 
 // CreateSandboxDetached creates and boots a sandbox in detached mode. The VM
 // continues running after the returned handle is released or the Go process
-// exits. Reattach via GetSandbox.
+// exits. Reattach via GetSandbox. Sandbox names are limited to 128 UTF-8 bytes.
 func CreateSandboxDetached(ctx context.Context, name string, opts ...SandboxOption) (*Sandbox, error) {
 	opts = append(opts, WithDetached())
 	return CreateSandbox(ctx, name, opts...)
@@ -232,6 +234,7 @@ func buildFFIPortBindings(bindings []PortBinding) []ffi.PortBindingOptions {
 }
 
 // GetSandbox returns metadata for a sandbox by name without connecting to it.
+// Sandbox names are limited to 128 UTF-8 bytes.
 // Returns ErrSandboxNotFound if no such sandbox exists. The returned
 // SandboxHandle exposes Connect/Start/Stop/Kill/Remove to operate on the sandbox.
 func GetSandbox(ctx context.Context, name string) (*SandboxHandle, error) {
@@ -243,6 +246,7 @@ func GetSandbox(ctx context.Context, name string) (*SandboxHandle, error) {
 }
 
 // StartSandbox boots a stopped sandbox by name and returns a live Sandbox.
+// Sandbox names are limited to 128 UTF-8 bytes.
 func StartSandbox(ctx context.Context, name string) (*Sandbox, error) {
 	inner, err := ffi.StartSandbox(ctx, name, false)
 	if err != nil {
@@ -252,7 +256,8 @@ func StartSandbox(ctx context.Context, name string) (*Sandbox, error) {
 }
 
 // StartSandboxDetached boots a stopped sandbox in detached mode. The VM keeps
-// running after the returned handle is released.
+// running after the returned handle is released. Sandbox names are limited to
+// 128 UTF-8 bytes.
 func StartSandboxDetached(ctx context.Context, name string) (*Sandbox, error) {
 	inner, err := ffi.StartSandbox(ctx, name, true)
 	if err != nil {
@@ -299,6 +304,7 @@ func ListSandboxes(ctx context.Context) ([]*SandboxHandle, error) {
 }
 
 // RemoveSandbox removes a stopped sandbox's persisted state by name.
+// Sandbox names are limited to 128 UTF-8 bytes.
 func RemoveSandbox(ctx context.Context, name string) error {
 	return wrapFFI(ffi.RemoveSandbox(ctx, name))
 }
@@ -328,7 +334,7 @@ func newSandboxHandle(info *ffi.SandboxHandleInfo) *SandboxHandle {
 	}
 }
 
-// Name returns the sandbox name.
+// Name returns the sandbox name. Names are limited to 128 UTF-8 bytes.
 func (h *SandboxHandle) Name() string { return h.name }
 
 // Status returns the sandbox's last-known lifecycle status.
@@ -429,7 +435,7 @@ func (h *SandboxHandle) SnapshotTo(ctx context.Context, path string) (*SnapshotA
 // Live sandbox methods
 // ---------------------------------------------------------------------------
 
-// Name returns the sandbox's name.
+// Name returns the sandbox's name. Names are limited to 128 UTF-8 bytes.
 func (s *Sandbox) Name() string { return s.inner.Name() }
 
 // Stop gracefully stops the sandbox. It does not wait for the VM process

--- a/sdk/node-ts/native/agent.rs
+++ b/sdk/node-ts/native/agent.rs
@@ -59,7 +59,8 @@ pub struct AgentClient {
 #[napi]
 impl AgentClient {
     /// Connect to a sandbox by name. Resolves the agent socket from the
-    /// SDK's configured runtime directory.
+    /// SDK's configured runtime directory. Sandbox names are limited to
+    /// 128 UTF-8 bytes.
     #[napi(factory, js_name = "connectSandbox")]
     pub async fn connect_sandbox(
         name: String,

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -10,7 +10,8 @@
 export declare class AgentClient {
   /**
    * Connect to a sandbox by name. Resolves the agent socket from the
-   * SDK's configured sandboxes directory.
+   * SDK's configured sandboxes directory. Sandbox names are limited to
+   * 128 UTF-8 bytes.
    */
   static connectSandbox(name: string, opts?: AgentConnectOptions | undefined | null): Promise<AgentClient>
   /** Connect to an agentd relay socket by path. */
@@ -729,17 +730,33 @@ export type JsRuleDestinationBuilder = RuleDestinationBuilder
  * to the guest VM and can execute commands, access the filesystem, and query metrics.
  */
 export declare class Sandbox {
-  /** Start an existing stopped sandbox (attached mode). */
+  /**
+   * Start an existing stopped sandbox (attached mode).
+   *
+   * Sandbox names are limited to 128 UTF-8 bytes.
+   */
   static start(name: string): Promise<Sandbox>
-  /** Start an existing stopped sandbox (detached mode). */
+  /**
+   * Start an existing stopped sandbox (detached mode).
+   *
+   * Sandbox names are limited to 128 UTF-8 bytes.
+   */
   static startDetached(name: string): Promise<Sandbox>
-  /** Get a lightweight handle to an existing sandbox. */
+  /**
+   * Get a lightweight handle to an existing sandbox.
+   *
+   * Sandbox names are limited to 128 UTF-8 bytes.
+   */
   static get(name: string): Promise<JsSandboxHandle>
   /** List all sandboxes. */
   static list(): Promise<Array<SandboxInfo>>
-  /** Remove a stopped sandbox from the database. */
+  /**
+   * Remove a stopped sandbox from the database.
+   *
+   * Sandbox names are limited to 128 UTF-8 bytes.
+   */
   static remove(name: string): Promise<void>
-  /** Sandbox name. */
+  /** Sandbox name. Names are limited to 128 UTF-8 bytes. */
   get name(): Promise<string>
   /** Whether this handle owns the sandbox lifecycle (attached mode). */
   get ownsLifecycle(): Promise<boolean>
@@ -830,9 +847,11 @@ export declare class Sandbox {
  * 1:1; setters mutate in place and return `this`. Closure-style
  * sub-builders (volume / patch / network / secret / registry / imageWith)
  * receive a fresh napi-wrapped builder, let JS chain on it, and route
- * the result back through the core SDK's closure callback.
+ * the result back through the core SDK's closure callback. Sandbox names are
+ * limited to 128 UTF-8 bytes.
  */
 export declare class SandboxBuilder {
+  /** Start building a sandbox. Names are limited to 128 UTF-8 bytes. */
   constructor(name: string)
   /**
    * Set the rootfs image source. Accepts an OCI reference or a host
@@ -1041,7 +1060,7 @@ export type JsSandboxFs = SandboxFs
  * Does NOT hold a live connection — use `connect()` or `start()` to get a live `Sandbox`.
  */
 export declare class SandboxHandle {
-  /** Sandbox name. */
+  /** Sandbox name. Names are limited to 128 UTF-8 bytes. */
   get name(): string
   /** Status at time of query: "running", "stopped", "crashed", or "draining". */
   get status(): string
@@ -1796,6 +1815,7 @@ export interface Rlimit {
 
 /** Lightweight handle info for a sandbox from the database. */
 export interface SandboxInfo {
+  /** Sandbox name. Names are limited to 128 UTF-8 bytes. */
   name: string
   /** "running", "stopped", "crashed", or "draining". */
   status: string

--- a/sdk/node-ts/native/sandbox.rs
+++ b/sdk/node-ts/native/sandbox.rs
@@ -75,6 +75,8 @@ impl Sandbox {
     //----------------------------------------------------------------------------------------------
 
     /// Start an existing stopped sandbox (attached mode).
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     #[napi(factory)]
     pub async fn start(name: String) -> Result<Sandbox> {
         let inner = microsandbox::sandbox::Sandbox::start(&name)
@@ -86,6 +88,8 @@ impl Sandbox {
     }
 
     /// Start an existing stopped sandbox (detached mode).
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     #[napi(factory)]
     pub async fn start_detached(name: String) -> Result<Sandbox> {
         let inner = microsandbox::sandbox::Sandbox::start_detached(&name)
@@ -101,6 +105,8 @@ impl Sandbox {
     //----------------------------------------------------------------------------------------------
 
     /// Get a lightweight handle to an existing sandbox.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     #[napi]
     pub async fn get(name: String) -> Result<JsSandboxHandle> {
         let handle = microsandbox::sandbox::Sandbox::get(&name)
@@ -119,6 +125,8 @@ impl Sandbox {
     }
 
     /// Remove a stopped sandbox from the database.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     #[napi(js_name = "remove")]
     pub async fn remove_static(name: String) -> Result<()> {
         microsandbox::sandbox::Sandbox::remove(&name)
@@ -130,7 +138,7 @@ impl Sandbox {
     // Properties
     //----------------------------------------------------------------------------------------------
 
-    /// Sandbox name.
+    /// Sandbox name. Names are limited to 128 UTF-8 bytes.
     #[napi(getter)]
     pub async fn name(&self) -> Result<String> {
         let guard = self.inner.lock().await;

--- a/sdk/node-ts/native/sandbox_builder.rs
+++ b/sdk/node-ts/native/sandbox_builder.rs
@@ -39,7 +39,8 @@ type _NapiHints = (JsDnsBuilder, JsTlsBuilder, JsSecretBuilder);
 /// 1:1; setters mutate in place and return `this`. Closure-style
 /// sub-builders (volume / patch / network / secret / registry / imageWith)
 /// receive a fresh napi-wrapped builder, let JS chain on it, and route
-/// the result back through the core SDK's closure callback.
+/// the result back through the core SDK's closure callback. Sandbox names are
+/// limited to 128 UTF-8 bytes.
 #[napi(js_name = "SandboxBuilder")]
 pub struct JsSandboxBuilder {
     inner: Option<RustSandboxBuilder>,
@@ -51,6 +52,7 @@ pub struct JsSandboxBuilder {
 
 #[napi]
 impl JsSandboxBuilder {
+    /// Start building a sandbox. Names are limited to 128 UTF-8 bytes.
     #[napi(constructor)]
     pub fn new(name: String) -> Self {
         Self {

--- a/sdk/node-ts/native/sandbox_handle.rs
+++ b/sdk/node-ts/native/sandbox_handle.rs
@@ -30,7 +30,7 @@ impl JsSandboxHandle {
 
 #[napi]
 impl JsSandboxHandle {
-    /// Sandbox name.
+    /// Sandbox name. Names are limited to 128 UTF-8 bytes.
     #[napi(getter)]
     pub fn name(&self) -> String {
         self.inner.name().to_string()

--- a/sdk/node-ts/native/types.rs
+++ b/sdk/node-ts/native/types.rs
@@ -182,6 +182,7 @@ pub struct ExecEvent {
 /// Lightweight handle info for a sandbox from the database.
 #[napi(object)]
 pub struct SandboxInfo {
+    /// Sandbox name. Names are limited to 128 UTF-8 bytes.
     pub name: String,
     /// "running", "stopped", "crashed", or "draining".
     pub status: String,

--- a/sdk/node-ts/src/agent.ts
+++ b/sdk/node-ts/src/agent.ts
@@ -52,7 +52,10 @@ export interface AgentConnectOptions {
 export class AgentClient {
   private constructor(private readonly native: NapiAgentClient) {}
 
-  /** Connect to a running sandbox by name. */
+  /**
+   * Connect to a running sandbox by name.
+   * Names are limited to 128 UTF-8 bytes.
+   */
   static async connectSandbox(
     name: string,
     opts?: AgentConnectOptions,

--- a/sdk/node-ts/src/index.ts
+++ b/sdk/node-ts/src/index.ts
@@ -18,7 +18,8 @@ import { Sandbox as _Sandbox, type SandboxBuilder as _SBT } from "./sandbox.js";
 /**
  * Native fluent builder for a sandbox. `new SandboxBuilder(name)` is
  * equivalent to `Sandbox.builder(name)` — both return the same shape
- * with `.create()` resolving to a TS `Sandbox`.
+ * with `.create()` resolving to a TS `Sandbox`. Names are limited to
+ * 128 UTF-8 bytes.
  */
 export const SandboxBuilder = function SandboxBuilder(
   this: unknown,

--- a/sdk/node-ts/src/sandbox-handle.ts
+++ b/sdk/node-ts/src/sandbox-handle.ts
@@ -23,6 +23,7 @@ const READ_ONLY_MSG =
 
 export class SandboxHandle {
   private readonly inner: NapiSandboxHandle | NapiSandboxInfo;
+  /** Sandbox name. Names are limited to 128 UTF-8 bytes. */
   readonly name: string;
   readonly status: SandboxStatus;
   readonly configJson: string;

--- a/sdk/node-ts/src/sandbox.ts
+++ b/sdk/node-ts/src/sandbox.ts
@@ -29,6 +29,7 @@ import { SandboxSsh } from "./ssh.js";
 
 /**
  * Fluent builder for a sandbox. Returned by `Sandbox.builder(name)`.
+ * Sandbox names are limited to 128 UTF-8 bytes.
  *
  * The instance IS the napi-rs `SandboxBuilder` class — every setter is a
  * native call, no TS-side reimplementation. Only the terminal `create()`
@@ -98,6 +99,7 @@ export class PullProgressCreate {
 export class Sandbox implements AsyncDisposable {
   /** @internal */
   readonly inner: NapiSandbox;
+  /** Sandbox name. Names are limited to 128 UTF-8 bytes. */
   readonly name: string;
   readonly ownsLifecycle: boolean;
 
@@ -110,7 +112,7 @@ export class Sandbox implements AsyncDisposable {
 
   // -- statics ------------------------------------------------------------
 
-  /** Begin building a new sandbox. */
+  /** Begin building a new sandbox. Names are limited to 128 UTF-8 bytes. */
   static builder(name: string): SandboxBuilder {
     const nb = new napi.SandboxBuilder(name);
     const origCreate = nb.create.bind(nb);
@@ -148,13 +150,19 @@ export class Sandbox implements AsyncDisposable {
     return nb as unknown as SandboxBuilder;
   }
 
-  /** Resume an existing stopped sandbox in attached mode. */
+  /**
+   * Resume an existing stopped sandbox in attached mode.
+   * Names are limited to 128 UTF-8 bytes.
+   */
   static async start(name: string): Promise<Sandbox> {
     const inner = await withMappedErrors(() => napi.Sandbox.start(name));
     return new Sandbox(inner, name, /*ownsLifecycle*/ true);
   }
 
-  /** Resume an existing stopped sandbox in detached mode. */
+  /**
+   * Resume an existing stopped sandbox in detached mode.
+   * Names are limited to 128 UTF-8 bytes.
+   */
   static async startDetached(name: string): Promise<Sandbox> {
     const inner = await withMappedErrors(() =>
       napi.Sandbox.startDetached(name),
@@ -162,7 +170,10 @@ export class Sandbox implements AsyncDisposable {
     return new Sandbox(inner, name, /*ownsLifecycle*/ false);
   }
 
-  /** Look up a database handle for an existing sandbox. */
+  /**
+   * Look up a database handle for an existing sandbox.
+   * Names are limited to 128 UTF-8 bytes.
+   */
   static async get(name: string): Promise<SandboxHandle> {
     const h = await withMappedErrors(() => napi.Sandbox.get(name));
     return new SandboxHandle(h);
@@ -174,7 +185,10 @@ export class Sandbox implements AsyncDisposable {
     return infos.map(sandboxInfoToHandle);
   }
 
-  /** Remove a stopped sandbox from the database. */
+  /**
+   * Remove a stopped sandbox from the database.
+   * Names are limited to 128 UTF-8 bytes.
+   */
   static async remove(name: string): Promise<void> {
     await withMappedErrors(() => napi.Sandbox.remove(name));
   }

--- a/sdk/python/microsandbox/_microsandbox.pyi
+++ b/sdk/python/microsandbox/_microsandbox.pyi
@@ -9,6 +9,11 @@ from typing import Any
 from microsandbox.types import LogReadSource, LogSource, MountConfig, Rlimit, Stdin
 
 class PyAgentClient:
+    """Raw agent client.
+
+    Sandbox names passed to connect_sandbox are limited to 128 UTF-8 bytes.
+    """
+
     @staticmethod
     async def connect_sandbox(
         name: str,
@@ -30,6 +35,11 @@ class PyAgentClient:
     async def close(self) -> None: ...
 
 class Sandbox:
+    """Sandbox lifecycle API.
+
+    Sandbox names are limited to 128 UTF-8 bytes.
+    """
+
     @staticmethod
     async def create(name: str, **kwargs: Any) -> Sandbox: ...
     @staticmethod
@@ -142,6 +152,11 @@ class Sandbox:
     ) -> bool: ...
 
 class SandboxHandle:
+    """Lightweight sandbox metadata handle.
+
+    Sandbox names are limited to 128 UTF-8 bytes.
+    """
+
     @property
     def name(self) -> str: ...
     @property

--- a/sdk/python/microsandbox/agent.py
+++ b/sdk/python/microsandbox/agent.py
@@ -83,6 +83,10 @@ class AgentClient:
         *,
         timeout: float | None = None,
     ) -> AgentClient:
+        """Connect to a running sandbox by name.
+
+        Sandbox names are limited to 128 UTF-8 bytes.
+        """
         return cls(await _PyAgentClient.connect_sandbox(name, timeout=timeout))
 
     @classmethod

--- a/sdk/python/src/agent.rs
+++ b/sdk/python/src/agent.rs
@@ -25,6 +25,8 @@ pub struct PyAgentClient {
 #[pymethods]
 impl PyAgentClient {
     /// Connect to a running sandbox by name.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     #[staticmethod]
     #[pyo3(signature = (name, *, timeout = None))]
     fn connect_sandbox<'py>(

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -11,6 +11,8 @@ use pyo3::types::{PyDict, PyList};
 /// Build a `SandboxBuilder` from the `(name, **kwargs)` form of
 /// `Sandbox.create`.
 ///
+/// Sandbox names are limited to 128 UTF-8 bytes by the core builder.
+///
 /// Returns the builder so the async caller can drive `build().await` or
 /// `create().await` itself — the kwarg-extraction phase has to stay sync
 /// (PyO3 dict access needs the GIL), but the config materialization step

--- a/sdk/python/src/sandbox.rs
+++ b/sdk/python/src/sandbox.rs
@@ -21,6 +21,8 @@ use crate::ssh::PySandboxSsh;
 //--------------------------------------------------------------------------------------------------
 
 /// A running sandbox instance.
+///
+/// Sandbox names are limited to 128 UTF-8 bytes.
 #[pyclass(name = "Sandbox")]
 pub struct PySandbox {
     inner: Arc<Mutex<Option<microsandbox::sandbox::Sandbox>>>,
@@ -65,6 +67,8 @@ impl PySandbox {
     //----------------------------------------------------------------------------------------------
 
     /// Create a sandbox from a name and keyword-only configuration.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     #[staticmethod]
     #[pyo3(signature = (name, **kwargs))]
     fn create<'py>(
@@ -89,6 +93,8 @@ impl PySandbox {
     }
 
     /// Start an existing stopped sandbox.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     #[staticmethod]
     #[pyo3(signature = (name, *, detached = false))]
     fn start<'py>(py: Python<'py>, name: String, detached: bool) -> PyResult<Bound<'py, PyAny>> {
@@ -107,6 +113,8 @@ impl PySandbox {
     }
 
     /// Create a sandbox with pull progress reporting.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     /// Returns a PullSession async context manager.
     #[staticmethod]
     #[pyo3(signature = (name, **kwargs))]
@@ -144,6 +152,8 @@ impl PySandbox {
     //----------------------------------------------------------------------------------------------
 
     /// Get a lightweight handle to an existing sandbox.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     #[staticmethod]
     fn get<'py>(py: Python<'py>, name: String) -> PyResult<Bound<'py, PyAny>> {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
@@ -170,6 +180,8 @@ impl PySandbox {
     }
 
     /// Remove a stopped sandbox.
+    ///
+    /// Sandbox names are limited to 128 UTF-8 bytes.
     #[staticmethod]
     fn remove<'py>(py: Python<'py>, name: String) -> PyResult<Bound<'py, PyAny>> {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
@@ -184,7 +196,7 @@ impl PySandbox {
     // Properties
     //----------------------------------------------------------------------------------------------
 
-    /// Sandbox name.
+    /// Sandbox name. Names are limited to 128 UTF-8 bytes.
     #[getter]
     fn name<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();

--- a/sdk/python/src/sandbox_handle.rs
+++ b/sdk/python/src/sandbox_handle.rs
@@ -31,7 +31,7 @@ impl PySandboxHandle {
 
 #[pymethods]
 impl PySandboxHandle {
-    /// Sandbox name.
+    /// Sandbox name. Names are limited to 128 UTF-8 bytes.
     #[getter]
     fn name(&self) -> PyResult<String> {
         let guard = self


### PR DESCRIPTION
## TL;DR
Reject sandbox names over 128 UTF-8 bytes and document the limit across the CLI, SDKs, and docs.

## Description
- Add shared Rust validation for non-empty sandbox names up to 128 UTF-8 bytes and export `MAX_SANDBOX_NAME_BYTES` plus `validate_sandbox_name`.
- Apply validation before create, start, get, log, and agent-connect paths use sandbox names.
- Make metrics slot reservation reject overlong names instead of truncating them.
- Update Rust, TypeScript, Python, and Go SDK comments plus public docs to describe the limit.
- Add boundary tests for 128-byte ASCII names and multibyte UTF-8 names.
- This is a breaking behavior change for sandbox names longer than 128 UTF-8 bytes.

```rust
use microsandbox::{MAX_SANDBOX_NAME_BYTES, validate_sandbox_name};

assert_eq!(MAX_SANDBOX_NAME_BYTES, 128);
validate_sandbox_name("worker-a")?;
```

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p microsandbox-metrics reserve_rejects_name_that_exceeds_inline_slot_capacity`
- [x] `cargo test -p microsandbox test_validate_sandbox_name`
- [x] `cargo test -p microsandbox --lib`
- [x] `cargo test --workspace --exclude microsandbox-agentd`
- [x] `cargo check -p microsandbox-cli -p microsandbox-node -p microsandbox-py -p microsandbox-go`
- [x] `go test -count=1 .` in `sdk/go`
- [x] `npm run typecheck` in `sdk/node-ts`
- [x] `uv run ruff check .` in `sdk/python`
