### PR TITLE
fix(filesystem): map bind mount ownership for guest users

### DIFF
--- a/crates/agentd/bin/main.rs
+++ b/crates/agentd/bin/main.rs
@@ -47,8 +47,14 @@ fn main() {
     let handoff_spec = boot.take_handoff_init();
 
     // Phase 1: Synchronous init (mount filesystems, prepare runtime directories).
+    let mut port_file = None;
     let init_start = clock::boottime_ns();
-    if let Err(e) = init::init(boot) {
+    if let Err(e) = init::init(boot, || {
+        let port = agent::open_serial_port()?;
+        agent::report_init_context(&port, config.user())?;
+        port_file = Some(port);
+        Ok(())
+    }) {
         eprintln!("agentd: init failed: {e}");
         process::exit(1);
     }
@@ -70,7 +76,14 @@ fn main() {
         .expect("agentd: failed to build tokio runtime");
 
     rt.block_on(async {
-        match agent::run(boot_time_ns, init_time_ns, &config).await {
+        match agent::run(
+            boot_time_ns,
+            init_time_ns,
+            &config,
+            port_file.expect("serial port opened during init"),
+        )
+        .await
+        {
             Ok(()) => {}
             Err(AgentdError::Shutdown) => {}
             Err(e) => {

--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -1,8 +1,9 @@
 //! Main agent loop: serial I/O, session management, heartbeat.
 
 use std::collections::HashMap;
-use std::fs::OpenOptions;
+use std::fs::{File, OpenOptions};
 use std::os::fd::AsRawFd;
+use std::time::Instant;
 use std::{env, ptr};
 
 use chrono::Utc;
@@ -12,7 +13,9 @@ use tokio::time::{self, Duration};
 
 use microsandbox_protocol::HANDOFF_POWEROFF_TIMEOUT;
 use microsandbox_protocol::codec::{self, MAX_FRAME_SIZE};
-use microsandbox_protocol::core::{ClockSync, Ready, RelayClientDisconnected};
+use microsandbox_protocol::core::{
+    ClockSync, InitAck, InitResolved, Ready, RelayClientDisconnected, ResolvedUser,
+};
 use microsandbox_protocol::exec::{
     ExecExited, ExecFailed, ExecFailureKind, ExecRequest, ExecResize, ExecSignal, ExecStarted,
     ExecStderr, ExecStdin, ExecStdinError, ExecStdout,
@@ -24,7 +27,7 @@ use crate::config::AgentdConfig;
 use crate::error::{AgentdError, AgentdResult};
 use crate::fs::{FsReadSession, FsState, FsStreamSession, FsWriteSession};
 use crate::serial::AGENT_PORT_NAME;
-use crate::session::{ExecSession, SessionOutput};
+use crate::session::{ExecSession, SessionOutput, resolve_default_user};
 use crate::{clock, fs, heartbeat, serial};
 
 //--------------------------------------------------------------------------------------------------
@@ -42,6 +45,9 @@ const SERIAL_READ_BUF_SIZE: usize = 64 * 1024;
 
 /// Maximum allowed input buffer size (frame size limit + 4 bytes for length prefix).
 const MAX_INPUT_BUF_SIZE: usize = MAX_FRAME_SIZE as usize + 4;
+
+/// Maximum time to wait for the host to acknowledge the init context.
+const INIT_ACK_TIMEOUT_SECS: u64 = 60;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -61,20 +67,19 @@ struct AgentState {
 
 /// Runs the main agent loop.
 ///
-/// Discovers the virtio serial port, sends `core.ready` with boot timing data,
+/// Reuses the already-open virtio serial port, sends `core.ready` with boot timing data,
 /// then enters the main select loop handling serial I/O, process output, and heartbeat.
 ///
 /// - `boot_time_ns`: `CLOCK_BOOTTIME` at `main()` start (kernel boot duration).
 /// - `init_time_ns`: nanoseconds spent in `init::init()`.
-pub async fn run(boot_time_ns: u64, init_time_ns: u64, config: &AgentdConfig) -> AgentdResult<()> {
-    // Discover serial port.
-    let port_path = serial::find_serial_port(AGENT_PORT_NAME)?;
-
-    // Open the port once with read+write. Virtio-console multiport devices
-    // only allow a single open; a second open returns EBUSY.
-    let port_file = OpenOptions::new().read(true).write(true).open(&port_path)?;
-
-    // Set non-blocking for async I/O.
+pub async fn run(
+    boot_time_ns: u64,
+    init_time_ns: u64,
+    config: &AgentdConfig,
+    port_file: File,
+) -> AgentdResult<()> {
+    // Set non-blocking for async I/O. Early boot handshakes use the same fd
+    // in blocking mode before it is moved into the async loop.
     let port_fd = port_file.as_raw_fd();
     set_nonblocking(port_fd)?;
 
@@ -212,6 +217,39 @@ pub async fn run(boot_time_ns: u64, init_time_ns: u64, config: &AgentdConfig) ->
     }
 
     Ok(())
+}
+
+/// Opens the agent virtio-serial port once for early boot handshakes and the agent loop.
+pub fn open_serial_port() -> AgentdResult<File> {
+    // Discover serial port.
+    let port_path = serial::find_serial_port(AGENT_PORT_NAME)?;
+
+    // Open the port once with read+write. Virtio-console multiport devices
+    // only allow a single open; a second open returns EBUSY.
+    Ok(OpenOptions::new().read(true).write(true).open(&port_path)?)
+}
+
+/// Reports init-time guest context to the host and waits for an acknowledgement.
+pub fn report_init_context(port_file: &File, default_user: Option<&str>) -> AgentdResult<()> {
+    let (uid, gid) = resolve_default_user(default_user)?;
+    let deadline = init_ack_deadline();
+    let fd = port_file.as_raw_fd();
+    set_nonblocking(fd)?;
+
+    let msg = Message::with_payload(
+        MessageType::InitResolved,
+        0,
+        &InitResolved {
+            default_user: ResolvedUser { uid, gid },
+        },
+    )
+    .map_err(|e| AgentdError::ExecSession(format!("encode init context: {e}")))?;
+
+    let mut out = Vec::new();
+    codec::encode_to_buf(&msg, &mut out)
+        .map_err(|e| AgentdError::ExecSession(format!("encode init context frame: {e}")))?;
+    write_all_to_fd(fd, &out, deadline)?;
+    wait_for_init_ack(fd, deadline)
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -508,6 +546,95 @@ fn set_nonblocking(fd: i32) -> AgentdResult<()> {
     Ok(())
 }
 
+fn init_ack_deadline() -> Instant {
+    Instant::now() + std::time::Duration::from_secs(INIT_ACK_TIMEOUT_SECS)
+}
+
+fn init_ack_timeout() -> AgentdError {
+    AgentdError::ExecSession("timed out waiting for init ack".into())
+}
+
+fn wait_for_init_ack(fd: i32, deadline: Instant) -> AgentdResult<()> {
+    let mut serial_in_buf = Vec::new();
+    let mut read_buf = [0u8; 4096];
+
+    loop {
+        if let Some(msg) = codec::try_decode_from_buf(&mut serial_in_buf)
+            .map_err(|e| AgentdError::ExecSession(format!("decode init ack: {e}")))?
+        {
+            if msg.t == MessageType::InitAck {
+                let _: InitAck = msg.payload().map_err(|e| {
+                    AgentdError::ExecSession(format!("decode init ack payload: {e}"))
+                })?;
+                return Ok(());
+            }
+
+            return Err(AgentdError::ExecSession(format!(
+                "expected core.init.ack, got {}",
+                msg.t.as_str()
+            )));
+        }
+
+        if serial_in_buf.len() > MAX_INPUT_BUF_SIZE {
+            return Err(AgentdError::ExecSession(
+                "serial input buffer exceeded maximum size while waiting for init ack".into(),
+            ));
+        }
+
+        if !poll_fd_until(fd, libc::POLLIN, deadline)? {
+            return Err(init_ack_timeout());
+        }
+
+        let n = match read_from_fd(fd, &mut read_buf) {
+            Ok(n) => n,
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock
+                ) =>
+            {
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        };
+        if n == 0 {
+            return Err(AgentdError::ExecSession(
+                "serial port closed while waiting for init ack".into(),
+            ));
+        }
+        serial_in_buf.extend_from_slice(&read_buf[..n]);
+    }
+}
+
+fn poll_fd_until(fd: i32, events: i16, deadline: Instant) -> AgentdResult<bool> {
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Ok(false);
+        }
+
+        let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
+        let timeout_ms = if timeout_ms == 0 { 1 } else { timeout_ms };
+        let mut pfd = libc::pollfd {
+            fd,
+            events,
+            revents: 0,
+        };
+        let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
+        if ret > 0 {
+            return Ok(true);
+        }
+        if ret == 0 {
+            return Ok(false);
+        }
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EINTR) {
+            continue;
+        }
+        return Err(err.into());
+    }
+}
+
 /// Reads from a raw fd (non-blocking).
 fn read_from_fd(fd: i32, buf: &mut [u8]) -> std::io::Result<usize> {
     let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
@@ -516,6 +643,24 @@ fn read_from_fd(fd: i32, buf: &mut [u8]) -> std::io::Result<usize> {
     } else {
         Ok(n as usize)
     }
+}
+
+fn write_all_to_fd(fd: i32, mut buf: &[u8], deadline: Instant) -> AgentdResult<()> {
+    while !buf.is_empty() {
+        match write_to_fd(fd, buf) {
+            Ok(0) => return Err(std::io::Error::from(std::io::ErrorKind::WriteZero).into()),
+            Ok(n) => buf = &buf[n..],
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                if !poll_fd_until(fd, libc::POLLOUT, deadline)? {
+                    return Err(init_ack_timeout());
+                }
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    Ok(())
 }
 
 /// Flushes the write buffer to the async fd.

--- a/crates/agentd/lib/config.rs
+++ b/crates/agentd/lib/config.rs
@@ -296,6 +296,11 @@ impl BootParams {
 }
 
 impl AgentdConfig {
+    /// Returns the configured default guest user, if any.
+    pub fn user(&self) -> Option<&str> {
+        self.user.as_deref()
+    }
+
     /// Reads the runtime-config `MSB_*` environment variables.
     ///
     /// Empty or whitespace-only values are treated as absent (`None`).

--- a/crates/agentd/lib/init.rs
+++ b/crates/agentd/lib/init.rs
@@ -17,13 +17,17 @@ use crate::{network, rlimit, tls};
 ///
 /// Consumes the [`BootParams`] by value — the data is one-shot and not
 /// needed after init returns.
-pub fn init(params: BootParams) -> AgentdResult<()> {
+pub fn init(
+    params: BootParams,
+    before_user_mounts: impl FnOnce() -> AgentdResult<()>,
+) -> AgentdResult<()> {
     rlimit::apply_baseline(&params.rlimits)?;
     linux::mount_filesystems()?;
     linux::mount_runtime()?;
     if let Some(spec) = &params.block_root {
         linux::mount_block_root(spec)?;
     }
+    before_user_mounts()?;
     linux::apply_dir_mounts(&params.dir_mounts)?;
     linux::apply_file_mounts(&params.file_mounts)?;
     linux::apply_disk_mounts(&params.disk_mounts)?;

--- a/crates/agentd/lib/session.rs
+++ b/crates/agentd/lib/session.rs
@@ -623,6 +623,18 @@ fn drop_mount_admin_privileges() -> AgentdResult<()> {
     Ok(())
 }
 
+pub(crate) fn resolve_default_user(default_user: Option<&str>) -> AgentdResult<(u32, u32)> {
+    let Some(spec) = default_user
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok((0, 0));
+    };
+
+    let resolved = resolve_user_spec(spec)?;
+    Ok((resolved.uid, resolved.gid))
+}
+
 fn resolve_requested_user(
     req: &ExecRequest,
     default_user: Option<&str>,
@@ -1178,6 +1190,12 @@ mod tests {
         let resolved = resolved.expect("should resolve to a user");
         assert_eq!(resolved.uid, uid);
         assert_eq!(resolved.gid, gid);
+    }
+
+    #[test]
+    fn test_default_user_absent_resolves_to_root() {
+        let resolved = resolve_default_user(None).expect("resolve absent default user");
+        assert_eq!(resolved, (0, 0));
     }
 
     #[test]

--- a/crates/filesystem/lib/backends/passthroughfs/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/builder.rs
@@ -23,7 +23,9 @@ use std::{
     time::Duration,
 };
 
-use super::{CachePolicy, HostPermissions, PassthroughFs, StatVirtualization};
+use super::{
+    BindIdentityMapHandle, CachePolicy, HostPermissions, PassthroughFs, StatVirtualization,
+};
 use crate::backends::shared::{
     init_binary, inode_table::MultikeyBTreeMap, platform, stat_override,
 };
@@ -43,6 +45,7 @@ pub struct PassthroughFsBuilder {
     cache_policy: CachePolicy,
     writeback: bool,
     inject_init: bool,
+    bind_identity_map: Option<BindIdentityMapHandle>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -62,6 +65,7 @@ impl PassthroughFsBuilder {
             cache_policy: CachePolicy::Auto,
             writeback: false,
             inject_init: true,
+            bind_identity_map: None,
         }
     }
 
@@ -86,6 +90,12 @@ impl PassthroughFsBuilder {
     /// Set whether mutating guest operations should be rejected.
     pub fn readonly(mut self, readonly: bool) -> Self {
         self.readonly = readonly;
+        self
+    }
+
+    /// Set the optional bind identity map handle.
+    pub fn bind_identity_map(mut self, handle: BindIdentityMapHandle) -> Self {
+        self.bind_identity_map = Some(handle);
         self
     }
 
@@ -152,6 +162,7 @@ impl PassthroughFsBuilder {
             cache_policy: self.cache_policy,
             writeback: self.writeback,
             inject_init: self.inject_init,
+            bind_identity_map: self.bind_identity_map,
         };
         if cfg_probe.strict_enabled() && cfg_probe.xattr_enabled() {
             let supported = stat_override::probe_xattr_support(root_fd.as_raw_fd())?;

--- a/crates/filesystem/lib/backends/passthroughfs/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/inode.rs
@@ -283,6 +283,7 @@ fn do_lookup_linux(
         st,
         fs.cfg.xattr_enabled(),
         fs.cfg.strict_enabled(),
+        fs.cfg.bind_identity_map.as_ref(),
     )?;
 
     let mut inodes = fs.inodes.write().unwrap();
@@ -345,6 +346,7 @@ fn do_lookup_macos(fs: &PassthroughFs, parent_fd: i32, name: &CStr) -> io::Resul
         st,
         fs.cfg.xattr_enabled(),
         fs.cfg.strict_enabled(),
+        fs.cfg.bind_identity_map.as_ref(),
     )?;
 
     // Fast path: most lookups hit an already-tracked inode and only need a
@@ -414,6 +416,7 @@ fn open_and_patch_stat_macos(
     st: stat64,
     xattr_enabled: bool,
     strict: bool,
+    bind_identity_map: Option<&crate::backends::shared::stat_override::BindIdentityMapHandle>,
 ) -> io::Result<stat64> {
     let path = vol_path(dev, ino);
 
@@ -421,13 +424,22 @@ fn open_and_patch_stat_macos(
     // O_SYMLINK so we can read override metadata from the link itself without
     // following it.
     if let Ok(fd) = open_macos_path_for_stat(path.as_ptr()) {
-        let result =
-            crate::backends::shared::stat_override::patched_stat(fd, st, xattr_enabled, strict);
+        let result = crate::backends::shared::stat_override::patched_stat(
+            fd,
+            st,
+            xattr_enabled,
+            strict,
+            bind_identity_map,
+        );
         unsafe { libc::close(fd) };
         return result;
     }
 
-    // Can't open — return unpatched stat.
+    // Can't open — return the safe mapped fallback when stat virtualization is on.
+    let mut st = st;
+    if xattr_enabled {
+        crate::backends::shared::stat_override::apply_bind_identity_map(&mut st, bind_identity_map);
+    }
     Ok(st)
 }
 
@@ -973,6 +985,7 @@ pub(crate) fn stat_inode(fs: &PassthroughFs, inode: u64) -> io::Result<stat64> {
             st,
             fs.cfg.xattr_enabled(),
             fs.cfg.strict_enabled(),
+            fs.cfg.bind_identity_map.as_ref(),
         )
     }
 
@@ -990,6 +1003,7 @@ pub(crate) fn stat_inode(fs: &PassthroughFs, inode: u64) -> io::Result<stat64> {
                 st,
                 fs.cfg.xattr_enabled(),
                 fs.cfg.strict_enabled(),
+                fs.cfg.bind_identity_map.as_ref(),
             );
         }
 
@@ -1000,6 +1014,7 @@ pub(crate) fn stat_inode(fs: &PassthroughFs, inode: u64) -> io::Result<stat64> {
                     st,
                     fs.cfg.xattr_enabled(),
                     fs.cfg.strict_enabled(),
+                    fs.cfg.bind_identity_map.as_ref(),
                 )
             });
             unsafe { libc::close(fd) };
@@ -1018,6 +1033,7 @@ pub(crate) fn stat_inode(fs: &PassthroughFs, inode: u64) -> io::Result<stat64> {
             st,
             fs.cfg.xattr_enabled(),
             fs.cfg.strict_enabled(),
+            fs.cfg.bind_identity_map.as_ref(),
         )
     }
 }

--- a/crates/filesystem/lib/backends/passthroughfs/metadata.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/metadata.rs
@@ -115,7 +115,11 @@ pub(crate) fn do_setattr(
             let (cur_uid, cur_gid, cur_mode, cur_rdev) = match current {
                 Some(ovr) => (ovr.uid, ovr.gid, ovr.mode, ovr.rdev),
                 None => {
-                    let st = platform::fstat(*close_fd)?;
+                    let mut st = platform::fstat(*close_fd)?;
+                    stat_override::apply_bind_identity_map(
+                        &mut st,
+                        fs.cfg.bind_identity_map.as_ref(),
+                    );
                     let mode = platform::mode_u32(st.st_mode);
                     (st.st_uid, st.st_gid, mode, 0)
                 }
@@ -287,7 +291,13 @@ fn stat_handle(fs: &PassthroughFs, handle: u64) -> io::Result<stat64> {
     let fd = file.as_raw_fd();
     let st = platform::fstat(fd)?;
 
-    stat_override::patched_stat(fd, st, fs.cfg.xattr_enabled(), fs.cfg.strict_enabled())
+    stat_override::patched_stat(
+        fd,
+        st,
+        fs.cfg.xattr_enabled(),
+        fs.cfg.strict_enabled(),
+        fs.cfg.bind_identity_map.as_ref(),
+    )
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/filesystem/lib/backends/passthroughfs/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/mod.rs
@@ -146,6 +146,9 @@ pub struct PassthroughConfig {
 
     /// Whether to expose the synthetic `init.krun` entry at the mount root.
     pub inject_init: bool,
+
+    /// Optional user-volume identity map for host metadata fallback.
+    pub bind_identity_map: Option<stat_override::BindIdentityMapHandle>,
 }
 
 /// Passthrough filesystem backend.
@@ -440,9 +443,16 @@ impl Default for PassthroughConfig {
             cache_policy: CachePolicy::Auto,
             writeback: false,
             inject_init: true,
+            bind_identity_map: None,
         }
     }
 }
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use stat_override::{BindIdentityMap, BindIdentityMapHandle};
 
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations

--- a/crates/filesystem/lib/backends/passthroughfs/tests/test_stat_virt.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/tests/test_stat_virt.rs
@@ -1,9 +1,11 @@
 //! Tests for the `StatVirtualization` policy: Strict / Relaxed / Off semantics.
 
 use std::os::fd::AsRawFd;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::sync::{Arc, OnceLock};
 
 use super::*;
-use crate::backends::passthroughfs::{HostPermissions, StatVirtualization};
+use crate::backends::passthroughfs::{BindIdentityMap, HostPermissions, StatVirtualization};
 use crate::backends::shared::stat_override::OVERRIDE_XATTR_KEY;
 
 fn host_set_raw_xattr(path: &std::path::Path, data: &[u8]) {
@@ -49,6 +51,189 @@ fn override_blob(uid: u32, gid: u32, mode: u32, rdev: u32) -> [u8; 20] {
     buf[12..16].copy_from_slice(&mode.to_ne_bytes());
     buf[16..20].copy_from_slice(&rdev.to_ne_bytes());
     buf
+}
+
+fn current_host_uid() -> u32 {
+    unsafe { libc::getuid() as u32 }
+}
+
+fn distinct_uid(uid: u32) -> u32 {
+    if uid == 1234 { 4321 } else { 1234 }
+}
+
+fn identity_handle(map: BindIdentityMap) -> crate::backends::passthroughfs::BindIdentityMapHandle {
+    let handle = Arc::new(OnceLock::new());
+    handle.set(map).unwrap();
+    handle
+}
+
+#[test]
+fn test_identity_map_applies_to_no_xattr_host_owner() {
+    let host_uid = current_host_uid();
+    let guest_uid = distinct_uid(host_uid);
+    let guest_gid = 5678;
+    let sb = TestSandbox::with_config(|mut cfg| {
+        cfg.bind_identity_map = Some(identity_handle(BindIdentityMap::new(
+            host_uid, guest_uid, guest_gid,
+        )));
+        cfg
+    });
+
+    sb.host_create_file("mapped.txt", b"data");
+
+    let entry = sb.lookup_root("mapped.txt").unwrap();
+    assert_eq!(entry.attr.st_uid, guest_uid);
+    assert_eq!(entry.attr.st_gid, guest_gid);
+
+    let (st, _) = sb.fs.getattr(sb.ctx(), entry.inode, None).unwrap();
+    assert_eq!(st.st_uid, guest_uid);
+    assert_eq!(st.st_gid, guest_gid);
+}
+
+#[test]
+fn test_identity_map_preserves_xattr_precedence() {
+    let host_uid = current_host_uid();
+    let sb = TestSandbox::with_config(|mut cfg| {
+        cfg.bind_identity_map = Some(identity_handle(BindIdentityMap::new(host_uid, 1234, 5678)));
+        cfg
+    });
+
+    let host_path = sb.host_create_file("override-wins.txt", b"data");
+    host_set_raw_xattr(&host_path, &override_blob(4242, 4243, 0o100644, 0));
+
+    let entry = sb.lookup_root("override-wins.txt").unwrap();
+    assert_eq!(entry.attr.st_uid, 4242);
+    assert_eq!(entry.attr.st_gid, 4243);
+}
+
+#[test]
+fn test_identity_map_uses_overflow_for_other_host_owners() {
+    let host_uid = current_host_uid();
+    let non_matching_uid = if host_uid == 0 { 1 } else { 0 };
+    let sb = TestSandbox::with_config(|mut cfg| {
+        cfg.bind_identity_map = Some(identity_handle(BindIdentityMap::new(
+            non_matching_uid,
+            1234,
+            5678,
+        )));
+        cfg
+    });
+
+    let host_path = sb.host_create_file("overflow.txt", b"data");
+    assert_ne!(host_path.metadata().unwrap().uid(), non_matching_uid);
+
+    let entry = sb.lookup_root("overflow.txt").unwrap();
+    assert_eq!(entry.attr.st_uid, 65534);
+    assert_eq!(entry.attr.st_gid, 65534);
+}
+
+#[test]
+fn test_identity_map_is_ignored_when_stat_virtualization_is_off() {
+    let host_uid = current_host_uid();
+    let guest_uid = distinct_uid(host_uid);
+    let sb = TestSandbox::with_config(|mut cfg| {
+        cfg.stat_virtualization = StatVirtualization::Off;
+        cfg.bind_identity_map = Some(identity_handle(BindIdentityMap::new(
+            host_uid, guest_uid, 5678,
+        )));
+        cfg
+    });
+
+    let host_path = sb.host_create_file("off-raw.txt", b"data");
+    let host_meta = host_path.metadata().unwrap();
+
+    let entry = sb.lookup_root("off-raw.txt").unwrap();
+    assert_eq!(entry.attr.st_uid, host_meta.uid());
+    assert_eq!(entry.attr.st_gid, host_meta.gid());
+}
+
+#[test]
+fn test_identity_map_participates_in_access_checks() {
+    let host_uid = current_host_uid();
+    let guest_uid = distinct_uid(host_uid);
+    let guest_gid = 5678;
+    let sb = TestSandbox::with_config(|mut cfg| {
+        cfg.bind_identity_map = Some(identity_handle(BindIdentityMap::new(
+            host_uid, guest_uid, guest_gid,
+        )));
+        cfg
+    });
+
+    let host_path = sb.host_create_file("writeable-for-mapped-owner.txt", b"data");
+    let mut perms = host_path.metadata().unwrap().permissions();
+    perms.set_mode(0o644);
+    std::fs::set_permissions(&host_path, perms).unwrap();
+
+    let entry = sb.lookup_root("writeable-for-mapped-owner.txt").unwrap();
+    sb.fs
+        .access(
+            sb.ctx_as(guest_uid, guest_gid),
+            entry.inode,
+            libc::W_OK as u32,
+        )
+        .unwrap();
+}
+
+#[test]
+fn test_identity_map_preserves_owner_on_mode_setattr_without_xattr() {
+    let host_uid = current_host_uid();
+    let guest_uid = distinct_uid(host_uid);
+    let guest_gid = 5678;
+    let sb = TestSandbox::with_config(|mut cfg| {
+        cfg.bind_identity_map = Some(identity_handle(BindIdentityMap::new(
+            host_uid, guest_uid, guest_gid,
+        )));
+        cfg
+    });
+
+    sb.host_create_file("chmod-preserves-owner.txt", b"data");
+    let entry = sb.lookup_root("chmod-preserves-owner.txt").unwrap();
+
+    let mut attr: stat64 = unsafe { std::mem::zeroed() };
+    attr.st_mode = 0o600;
+    let (st, _) = sb
+        .fs
+        .setattr(sb.ctx(), entry.inode, attr, None, SetattrValid::MODE)
+        .unwrap();
+
+    assert_eq!(st.st_uid, guest_uid);
+    assert_eq!(st.st_gid, guest_gid);
+    assert_eq!(st.st_mode as u32 & 0o777, 0o600);
+
+    let (st, _) = sb.fs.getattr(sb.ctx(), entry.inode, None).unwrap();
+    assert_eq!(st.st_uid, guest_uid);
+    assert_eq!(st.st_gid, guest_gid);
+}
+
+#[test]
+fn test_identity_map_preserves_gid_on_partial_chown_without_xattr() {
+    let host_uid = current_host_uid();
+    let guest_uid = distinct_uid(host_uid);
+    let guest_gid = 5678;
+    let new_uid = 2468;
+    let sb = TestSandbox::with_config(|mut cfg| {
+        cfg.bind_identity_map = Some(identity_handle(BindIdentityMap::new(
+            host_uid, guest_uid, guest_gid,
+        )));
+        cfg
+    });
+
+    sb.host_create_file("partial-chown-preserves-gid.txt", b"data");
+    let entry = sb.lookup_root("partial-chown-preserves-gid.txt").unwrap();
+
+    let mut attr: stat64 = unsafe { std::mem::zeroed() };
+    attr.st_uid = new_uid;
+    let (st, _) = sb
+        .fs
+        .setattr(sb.ctx(), entry.inode, attr, None, SetattrValid::UID)
+        .unwrap();
+
+    assert_eq!(st.st_uid, new_uid);
+    assert_eq!(st.st_gid, guest_gid);
+
+    let (st, _) = sb.fs.getattr(sb.ctx(), entry.inode, None).unwrap();
+    assert_eq!(st.st_uid, new_uid);
+    assert_eq!(st.st_gid, guest_gid);
 }
 
 #[test]

--- a/crates/filesystem/lib/backends/shared/stat_override.rs
+++ b/crates/filesystem/lib/backends/shared/stat_override.rs
@@ -17,7 +17,12 @@
 //! skips the xattr read for real host symlinks (detected via `S_IFLNK` in the unpatched stat).
 //! File-backed symlinks (regular files with S_IFLNK in xattr) are handled normally.
 
-use std::{ffi::CStr, io, os::fd::RawFd};
+use std::{
+    ffi::CStr,
+    io,
+    os::fd::RawFd,
+    sync::{Arc, OnceLock},
+};
 
 use crate::stat64;
 
@@ -36,6 +41,10 @@ const OVERRIDE_VERSION: u8 = 1;
 /// Size of the binary override struct.
 const OVERRIDE_SIZE: usize = std::mem::size_of::<OverrideStat>();
 
+/// Maximum length of `/proc/self/fd/{fd}\0` for any non-negative i32 fd.
+#[cfg(target_os = "linux")]
+const PROC_SELF_FD_PATH_BUF_LEN: usize = 32;
+
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
@@ -52,6 +61,61 @@ pub(crate) struct OverrideStat {
     pub rdev: u32,
 }
 
+/// Guest-visible ownership mapping for host-backed user volume files.
+///
+/// The map is applied only when stat virtualization is enabled and no
+/// per-file override xattr exists. Files owned by the host user running
+/// microsandbox appear as the sandbox's effective guest user; files owned by
+/// other host users appear as the overflow identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BindIdentityMap {
+    /// Host uid that owns ordinary caller-created files.
+    pub host_owner_uid: u32,
+
+    /// Guest uid to show for host-owner files.
+    pub guest_uid: u32,
+
+    /// Guest gid to show for host-owner files.
+    pub guest_gid: u32,
+
+    /// Guest uid to show for files not owned by [`host_owner_uid`](Self::host_owner_uid).
+    pub overflow_uid: u32,
+
+    /// Guest gid to show for files not owned by [`host_owner_uid`](Self::host_owner_uid).
+    pub overflow_gid: u32,
+}
+
+/// Shared bind identity map that can be installed after guest user resolution.
+pub type BindIdentityMapHandle = Arc<OnceLock<BindIdentityMap>>;
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl BindIdentityMap {
+    /// Create a map from one host owner uid to one guest uid/gid pair.
+    pub fn new(host_owner_uid: u32, guest_uid: u32, guest_gid: u32) -> Self {
+        Self {
+            host_owner_uid,
+            guest_uid,
+            guest_gid,
+            overflow_uid: 65534,
+            overflow_gid: 65534,
+        }
+    }
+
+    /// Apply this map to a stat result in place.
+    pub fn apply(&self, st: &mut stat64) {
+        if st.st_uid == self.host_owner_uid {
+            st.st_uid = self.guest_uid;
+            st.st_gid = self.guest_gid;
+        } else {
+            st.st_uid = self.overflow_uid;
+            st.st_gid = self.overflow_gid;
+        }
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
@@ -65,6 +129,7 @@ pub(crate) fn patched_stat(
     mut st: stat64,
     xattr_enabled: bool,
     strict: bool,
+    bind_identity_map: Option<&BindIdentityMapHandle>,
 ) -> io::Result<stat64> {
     if !xattr_enabled {
         return Ok(st);
@@ -73,6 +138,7 @@ pub(crate) fn patched_stat(
     // Real symlinks on host cannot have user xattrs on Linux.
     #[cfg(target_os = "linux")]
     if st.st_mode & libc::S_IFMT == libc::S_IFLNK {
+        apply_bind_identity_map(&mut st, bind_identity_map);
         return Ok(st);
     }
 
@@ -104,7 +170,10 @@ pub(crate) fn patched_stat(
             }
             Ok(st)
         }
-        Ok(None) => Ok(st), // No override xattr
+        Ok(None) => {
+            apply_bind_identity_map(&mut st, bind_identity_map);
+            Ok(st)
+        } // No override xattr
         Err(e) => Err(e),
     }
 }
@@ -117,15 +186,15 @@ fn read_override(fd: RawFd, strict: bool) -> io::Result<Option<OverrideStat>> {
     let mut buf = [0u8; OVERRIDE_SIZE];
 
     #[cfg(target_os = "linux")]
-    let path = format!("/proc/self/fd/{fd}");
+    let mut path_buf = [0u8; PROC_SELF_FD_PATH_BUF_LEN];
 
     #[cfg(target_os = "linux")]
-    let path_cstr = std::ffi::CString::new(path).map_err(|_| platform::eio())?;
+    let path = format_proc_self_fd_path(fd, &mut path_buf)?;
 
     #[cfg(target_os = "linux")]
     let ret = unsafe {
         libc::getxattr(
-            path_cstr.as_ptr(),
+            path,
             OVERRIDE_XATTR_KEY.as_ptr(),
             buf.as_mut_ptr() as *mut libc::c_void,
             OVERRIDE_SIZE,
@@ -190,6 +259,50 @@ fn handle_unsupported_xattr(strict: bool) -> io::Result<Option<OverrideStat>> {
     Ok(None)
 }
 
+#[cfg(target_os = "linux")]
+fn format_proc_self_fd_path(
+    fd: RawFd,
+    buf: &mut [u8; PROC_SELF_FD_PATH_BUF_LEN],
+) -> io::Result<*const libc::c_char> {
+    if fd < 0 {
+        return Err(platform::eio());
+    }
+
+    let prefix = b"/proc/self/fd/";
+    buf[..prefix.len()].copy_from_slice(prefix);
+
+    let mut digits = [0u8; 10];
+    let mut value = fd as u32;
+    let mut start = digits.len();
+    loop {
+        start -= 1;
+        digits[start] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 {
+            break;
+        }
+    }
+
+    let digits = &digits[start..];
+    let end = prefix.len() + digits.len();
+    if end + 1 > buf.len() {
+        return Err(platform::eio());
+    }
+
+    buf[prefix.len()..end].copy_from_slice(digits);
+    buf[end] = 0;
+    Ok(buf.as_ptr().cast())
+}
+
+pub(crate) fn apply_bind_identity_map(
+    st: &mut stat64,
+    bind_identity_map: Option<&BindIdentityMapHandle>,
+) {
+    if let Some(map) = bind_identity_map.and_then(|handle| handle.get().copied()) {
+        map.apply(st);
+    }
+}
+
 /// Set the override xattr on a file descriptor.
 pub(crate) fn set_override(fd: RawFd, uid: u32, gid: u32, mode: u32, rdev: u32) -> io::Result<()> {
     let ovr = OverrideStat {
@@ -207,11 +320,11 @@ pub(crate) fn set_override(fd: RawFd, uid: u32, gid: u32, mode: u32, rdev: u32) 
 
     #[cfg(target_os = "linux")]
     {
-        let path = format!("/proc/self/fd/{fd}");
-        let path_cstr = std::ffi::CString::new(path).map_err(|_| platform::eio())?;
+        let mut path_buf = [0u8; PROC_SELF_FD_PATH_BUF_LEN];
+        let path = format_proc_self_fd_path(fd, &mut path_buf)?;
         let ret = unsafe {
             libc::setxattr(
-                path_cstr.as_ptr(),
+                path,
                 OVERRIDE_XATTR_KEY.as_ptr(),
                 buf.as_ptr() as *const libc::c_void,
                 OVERRIDE_SIZE,
@@ -305,11 +418,11 @@ pub(crate) fn probe_xattr_support(dirfd: RawFd) -> io::Result<bool> {
 
     #[cfg(target_os = "linux")]
     {
-        let path = format!("/proc/self/fd/{dirfd}");
-        let path_cstr = std::ffi::CString::new(path).map_err(|_| platform::eio())?;
+        let mut path_buf = [0u8; PROC_SELF_FD_PATH_BUF_LEN];
+        let path = format_proc_self_fd_path(dirfd, &mut path_buf)?;
         let ret = unsafe {
             libc::setxattr(
-                path_cstr.as_ptr(),
+                path,
                 probe_key.as_ptr(),
                 probe_val.as_ptr() as *const libc::c_void,
                 1,
@@ -326,7 +439,7 @@ pub(crate) fn probe_xattr_support(dirfd: RawFd) -> io::Result<bool> {
         }
         // Clean up the probe xattr.
         unsafe {
-            libc::removexattr(path_cstr.as_ptr(), probe_key.as_ptr());
+            libc::removexattr(path, probe_key.as_ptr());
         }
     }
 

--- a/crates/filesystem/lib/lib.rs
+++ b/crates/filesystem/lib/lib.rs
@@ -29,8 +29,8 @@ pub use backends::{
     },
     memfs::{CachePolicy as MemCachePolicy, MemFs, MemFsConfig},
     passthroughfs::{
-        CachePolicy, HostPermissions, PassthroughConfig, PassthroughFs, PassthroughFsBuilder,
-        StatVirtualization,
+        BindIdentityMap, BindIdentityMapHandle, CachePolicy, HostPermissions, PassthroughConfig,
+        PassthroughFs, PassthroughFsBuilder, StatVirtualization,
     },
 };
 pub use microsandbox_utils::size::{ByteSize, Bytes, Mebibytes, SizeExt};

--- a/crates/protocol/lib/codec.rs
+++ b/crates/protocol/lib/codec.rs
@@ -197,10 +197,29 @@ pub fn encode_to_buf(msg: &Message, buf: &mut Vec<u8>) -> ProtocolResult<()> {
 ///
 /// Frame format: `[len: u32 BE][id: u32 BE][flags: u8][CBOR(v, t, p)]`
 pub fn try_decode_from_buf(buf: &mut Vec<u8>) -> ProtocolResult<Option<Message>> {
-    match try_decode_raw_from_buf(buf)? {
-        Some(frame) => Ok(Some(raw_frame_to_message(frame)?)),
-        None => Ok(None),
+    if buf.len() < 4 {
+        return Ok(None);
     }
+
+    let frame_len = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
+
+    if frame_len > MAX_FRAME_SIZE {
+        return Err(ProtocolError::FrameTooLarge {
+            size: frame_len,
+            max: MAX_FRAME_SIZE,
+        });
+    }
+
+    let frame_len = frame_len as usize;
+    let total = 4 + frame_len;
+
+    if buf.len() < total {
+        return Ok(None);
+    }
+
+    let msg = decode_message_frame(&buf[..total])?;
+    buf.drain(..total);
+    Ok(Some(msg))
 }
 
 /// Reads a length-prefixed message from the given reader.
@@ -230,6 +249,42 @@ pub fn raw_frame_to_message(frame: RawFrame) -> ProtocolResult<Message> {
     let mut msg: Message = ciborium::from_reader(&frame.body[..])?;
     msg.id = frame.id;
     msg.flags = frame.flags;
+    Ok(msg)
+}
+
+/// Decodes one complete length-prefixed frame from a borrowed byte slice.
+///
+/// The input must include the 4-byte length prefix, frame header, and CBOR body.
+/// The slice is not consumed or copied.
+pub fn decode_message_frame(frame: &[u8]) -> ProtocolResult<Message> {
+    if frame.len() < 4 {
+        return Err(ProtocolError::UnexpectedEof);
+    }
+
+    let frame_len = u32::from_be_bytes([frame[0], frame[1], frame[2], frame[3]]);
+    if frame_len > MAX_FRAME_SIZE {
+        return Err(ProtocolError::FrameTooLarge {
+            size: frame_len,
+            max: MAX_FRAME_SIZE,
+        });
+    }
+
+    let frame_len = frame_len as usize;
+    let total = 4 + frame_len;
+    if frame.len() < total {
+        return Err(ProtocolError::UnexpectedEof);
+    }
+
+    if frame_len < FRAME_HEADER_SIZE {
+        return Err(ProtocolError::FrameTooShort {
+            size: frame_len as u32,
+            min: FRAME_HEADER_SIZE as u32,
+        });
+    }
+
+    let mut msg: Message = ciborium::from_reader(&frame[4 + FRAME_HEADER_SIZE..total])?;
+    msg.id = u32::from_be_bytes([frame[4], frame[5], frame[6], frame[7]]);
+    msg.flags = frame[8];
     Ok(msg)
 }
 
@@ -327,6 +382,35 @@ mod tests {
         let payload: ExecExited = decoded.payload().unwrap();
         assert_eq!(payload.code, 0);
         assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_borrowed_decode_message_frame_roundtrip() {
+        use crate::exec::ExecExited;
+
+        let msg =
+            Message::with_payload(MessageType::ExecExited, 5, &ExecExited { code: 0 }).unwrap();
+
+        let mut buf = Vec::new();
+        encode_to_buf(&msg, &mut buf).unwrap();
+
+        let decoded = decode_message_frame(&buf).unwrap();
+        assert_eq!(decoded.t, MessageType::ExecExited);
+        assert_eq!(decoded.id, 5);
+        assert_eq!(decoded.flags, FLAG_TERMINAL);
+
+        let payload: ExecExited = decoded.payload().unwrap();
+        assert_eq!(payload.code, 0);
+        assert!(!buf.is_empty(), "borrowed decode must not consume input");
+    }
+
+    #[test]
+    fn test_borrowed_decode_message_frame_rejects_incomplete() {
+        let buf = vec![0, 0, 0, 10];
+        assert!(matches!(
+            decode_message_frame(&buf),
+            Err(ProtocolError::UnexpectedEof)
+        ));
     }
 
     #[test]

--- a/crates/protocol/lib/core.rs
+++ b/crates/protocol/lib/core.rs
@@ -37,6 +37,34 @@ pub struct ClockSync {
     pub unix_time_nanos: u64,
 }
 
+/// Payload for `core.init.resolved` messages.
+///
+/// Sent by agentd after the guest rootfs is ready to resolve init-time facts,
+/// but before user volume mounts are attached. The host uses this to install
+/// early runtime state that depends on guest-resolved values.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitResolved {
+    /// Default guest user for sandbox commands.
+    pub default_user: ResolvedUser,
+}
+
+/// A guest user and group resolved by agentd.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ResolvedUser {
+    /// Effective default guest user id for sandbox commands.
+    pub uid: u32,
+
+    /// Effective default guest group id for sandbox commands.
+    pub gid: u32,
+}
+
+/// Payload for `core.init.ack` messages.
+///
+/// Sent by the host after it has consumed the init context and completed any
+/// dependent setup.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitAck {}
+
 /// Payload for `core.relay.client.disconnected` messages.
 ///
 /// Sent by the host relay when one SDK client socket disconnects. The

--- a/crates/protocol/lib/message.rs
+++ b/crates/protocol/lib/message.rs
@@ -9,7 +9,7 @@ use crate::error::ProtocolResult;
 //--------------------------------------------------------------------------------------------------
 
 /// Current protocol version.
-pub const PROTOCOL_VERSION: u8 = 2;
+pub const PROTOCOL_VERSION: u8 = 3;
 
 /// Frame flag: this is the last message for the given correlation ID.
 ///
@@ -74,6 +74,12 @@ pub struct Message {
 pub enum MessageType {
     /// Guest agent is ready.
     Ready,
+
+    /// Guest reports init context before user mounts.
+    InitResolved,
+
+    /// Host acknowledges init-context setup.
+    InitAck,
 
     /// Host requests shutdown.
     Shutdown,
@@ -185,6 +191,8 @@ impl MessageType {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Ready => "core.ready",
+            Self::InitResolved => "core.init.resolved",
+            Self::InitAck => "core.init.ack",
             Self::Shutdown => "core.shutdown",
             Self::RelayClientDisconnected => "core.relay.client.disconnected",
             Self::ClockSync => "core.clock.sync",
@@ -208,6 +216,8 @@ impl MessageType {
     pub fn from_wire_str(s: &str) -> Option<Self> {
         match s {
             "core.ready" => Some(Self::Ready),
+            "core.init.resolved" => Some(Self::InitResolved),
+            "core.init.ack" => Some(Self::InitAck),
             "core.shutdown" => Some(Self::Shutdown),
             "core.relay.client.disconnected" => Some(Self::RelayClientDisconnected),
             "core.clock.sync" => Some(Self::ClockSync),
@@ -265,6 +275,8 @@ mod tests {
     fn test_message_type_roundtrip() {
         let types = [
             (MessageType::Ready, "core.ready"),
+            (MessageType::InitResolved, "core.init.resolved"),
+            (MessageType::InitAck, "core.init.ack"),
             (MessageType::Shutdown, "core.shutdown"),
             (
                 MessageType::RelayClientDisconnected,
@@ -296,6 +308,8 @@ mod tests {
     fn test_message_type_serde_roundtrip() {
         let types = [
             MessageType::Ready,
+            MessageType::InitResolved,
+            MessageType::InitAck,
             MessageType::Shutdown,
             MessageType::RelayClientDisconnected,
             MessageType::ClockSync,
@@ -350,6 +364,8 @@ mod tests {
         assert_eq!(MessageType::ExecRequest.flags(), FLAG_SESSION_START);
         assert_eq!(MessageType::FsRequest.flags(), FLAG_SESSION_START);
         assert_eq!(MessageType::Ready.flags(), 0);
+        assert_eq!(MessageType::InitResolved.flags(), 0);
+        assert_eq!(MessageType::InitAck.flags(), 0);
         assert_eq!(MessageType::Shutdown.flags(), FLAG_SHUTDOWN);
         assert_eq!(MessageType::ClockSync.flags(), 0);
         assert_eq!(MessageType::ExecStarted.flags(), 0);

--- a/crates/runtime/lib/relay.rs
+++ b/crates/runtime/lib/relay.rs
@@ -16,8 +16,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use bytes::{Bytes, BytesMut};
+use microsandbox_filesystem::{BindIdentityMap, BindIdentityMapHandle};
 use microsandbox_protocol::codec::{self, MAX_FRAME_SIZE};
-use microsandbox_protocol::core::RelayClientDisconnected;
+use microsandbox_protocol::core::{InitAck, InitResolved, RelayClientDisconnected};
 use microsandbox_protocol::exec::{ExecRequest, ExecSignal, ExecStderr, ExecStdout};
 use microsandbox_protocol::message::{
     FLAG_SESSION_START, FLAG_SHUTDOWN, FLAG_TERMINAL, FRAME_HEADER_SIZE, Message, MessageType,
@@ -101,6 +102,8 @@ pub struct AgentRelay {
     /// Optional `exec.log` writer. When set, the ring reader task
     /// captures the primary session's stdout/stderr to JSON Lines.
     log_writer: Option<Arc<LogWriter>>,
+    /// User-volume bind identity maps to install before `core.ready`.
+    bind_identity_maps: Vec<BindIdentityMapHandle>,
 }
 
 /// A frame extracted from the byte stream, kept as raw bytes for transparent
@@ -147,6 +150,7 @@ impl AgentRelay {
             sock_path: agent_sock_path.to_path_buf(),
             ready_frame: None,
             log_writer: None,
+            bind_identity_maps: Vec::new(),
         })
     }
 
@@ -165,6 +169,46 @@ impl AgentRelay {
         self
     }
 
+    /// Attach pending bind identity maps for the early init handshake.
+    pub fn with_bind_identity_maps(mut self, maps: Vec<BindIdentityMapHandle>) -> Self {
+        self.bind_identity_maps = maps;
+        self
+    }
+
+    fn install_bind_identity_maps(&self, resolved: InitResolved) -> RuntimeResult<()> {
+        let host_owner_uid = unsafe { libc::getuid() as u32 };
+        let map = BindIdentityMap::new(
+            host_owner_uid,
+            resolved.default_user.uid,
+            resolved.default_user.gid,
+        );
+
+        for handle in &self.bind_identity_maps {
+            handle
+                .set(map)
+                .map_err(|_| RuntimeError::Custom("bind identity map already installed".into()))?;
+        }
+
+        tracing::info!(
+            host_owner_uid,
+            guest_uid = resolved.default_user.uid,
+            guest_gid = resolved.default_user.gid,
+            mounts = self.bind_identity_maps.len(),
+            "agent relay: installed bind identity maps"
+        );
+
+        Ok(())
+    }
+
+    fn send_init_ack(&self) -> RuntimeResult<()> {
+        let msg = Message::with_payload(MessageType::InitAck, 0, &InitAck {})
+            .map_err(|e| RuntimeError::Custom(format!("encode init ack: {e}")))?;
+        let mut frame = Vec::new();
+        codec::encode_to_buf(&msg, &mut frame)
+            .map_err(|e| RuntimeError::Custom(format!("encode init ack frame: {e}")))?;
+        push_guest_frame_blocking(&self.shared, frame)
+    }
+
     /// Read frames from the console ring buffer until `core.ready` is
     /// received.
     ///
@@ -175,6 +219,7 @@ impl AgentRelay {
         const READY_TIMEOUT_SECS: i32 = 60;
 
         let mut buf = BytesMut::new();
+        let mut init_resolved = false;
         let deadline =
             std::time::Instant::now() + std::time::Duration::from_secs(READY_TIMEOUT_SECS as u64);
 
@@ -191,6 +236,12 @@ impl AgentRelay {
                 let msg = decode_frame(raw_data.clone())?;
 
                 if msg.t == MessageType::Ready {
+                    if !self.bind_identity_maps.is_empty() && !init_resolved {
+                        return Err(RuntimeError::Custom(
+                            "agent relay: received core.ready before init context resolution"
+                                .into(),
+                        ));
+                    }
                     tracing::info!("agent relay: received core.ready from agentd");
                     self.ready_frame = Some(raw_data);
                     // Now that agentd has signalled readiness, mark the
@@ -203,6 +254,16 @@ impl AgentRelay {
                         writer.write_system("--- sandbox started ---");
                     }
                     return Ok(());
+                }
+
+                if msg.t == MessageType::InitResolved {
+                    let resolved: InitResolved = msg.payload().map_err(|e| {
+                        RuntimeError::Custom(format!("decode init context payload: {e}"))
+                    })?;
+                    self.install_bind_identity_maps(resolved)?;
+                    init_resolved = true;
+                    self.send_init_ack()?;
+                    continue;
                 }
 
                 tracing::debug!(
@@ -443,6 +504,28 @@ fn poll_fd_readable_timeout(fd: RawFd, timeout_ms: i32) {
             return;
         }
         // EINTR — retry.
+    }
+}
+
+fn push_guest_frame_blocking(shared: &ConsoleSharedState, mut frame: Vec<u8>) -> RuntimeResult<()> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+
+    loop {
+        match shared.rx_ring.push(frame) {
+            Ok(()) => {
+                shared.rx_wake.wake();
+                return Ok(());
+            }
+            Err(returned) => {
+                frame = returned;
+                if std::time::Instant::now() >= deadline {
+                    return Err(RuntimeError::Custom(
+                        "timed out sending init ack to agentd".into(),
+                    ));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+        }
     }
 }
 
@@ -933,6 +1016,15 @@ fn is_client_frame_allowed(id: u32, flags: u8, id_start: u32, id_end_exclusive: 
 mod tests {
     use super::*;
 
+    use microsandbox_protocol::core::Ready;
+
+    fn encoded_message<T: serde::Serialize>(t: MessageType, payload: &T) -> Vec<u8> {
+        let msg = Message::with_payload(t, 0, payload).unwrap();
+        let mut frame = Vec::new();
+        codec::encode_to_buf(&msg, &mut frame).unwrap();
+        frame
+    }
+
     #[test]
     fn client_frame_validation_allows_ids_in_assigned_range() {
         assert!(is_client_frame_allowed(10, 0, 10, 20));
@@ -949,5 +1041,86 @@ mod tests {
     #[test]
     fn client_frame_validation_allows_shutdown_control_id_zero() {
         assert!(is_client_frame_allowed(0, FLAG_SHUTDOWN, 10, 20));
+    }
+
+    #[tokio::test]
+    async fn wait_ready_rejects_ready_before_init_when_maps_are_pending() {
+        let shared = Arc::new(ConsoleSharedState::with_capacity(8));
+        let handle = Arc::new(std::sync::OnceLock::new());
+        let sock_dir = tempfile::tempdir().unwrap();
+        let sock_path = sock_dir.path().join("agent.sock");
+        let mut relay = AgentRelay::new(&sock_path, Arc::clone(&shared))
+            .await
+            .unwrap()
+            .with_bind_identity_maps(vec![Arc::clone(&handle)]);
+
+        shared
+            .tx_ring
+            .push(encoded_message(
+                MessageType::Ready,
+                &Ready {
+                    boot_time_ns: 0,
+                    init_time_ns: 0,
+                    ready_time_ns: 0,
+                },
+            ))
+            .unwrap();
+        shared.tx_wake.wake();
+
+        let err = relay.wait_ready().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("received core.ready before init context resolution")
+        );
+        assert!(handle.get().is_none());
+    }
+
+    #[tokio::test]
+    async fn wait_ready_installs_init_map_before_ready() {
+        let shared = Arc::new(ConsoleSharedState::with_capacity(8));
+        let handle = Arc::new(std::sync::OnceLock::new());
+        let sock_dir = tempfile::tempdir().unwrap();
+        let sock_path = sock_dir.path().join("agent.sock");
+        let mut relay = AgentRelay::new(&sock_path, Arc::clone(&shared))
+            .await
+            .unwrap()
+            .with_bind_identity_maps(vec![Arc::clone(&handle)]);
+
+        shared
+            .tx_ring
+            .push(encoded_message(
+                MessageType::InitResolved,
+                &InitResolved {
+                    default_user: microsandbox_protocol::core::ResolvedUser {
+                        uid: 1000,
+                        gid: 1001,
+                    },
+                },
+            ))
+            .unwrap();
+        shared
+            .tx_ring
+            .push(encoded_message(
+                MessageType::Ready,
+                &Ready {
+                    boot_time_ns: 0,
+                    init_time_ns: 0,
+                    ready_time_ns: 0,
+                },
+            ))
+            .unwrap();
+        shared.tx_wake.wake();
+
+        relay.wait_ready().unwrap();
+
+        assert_eq!(
+            handle.get().copied(),
+            Some(BindIdentityMap::new(
+                unsafe { libc::getuid() as u32 },
+                1000,
+                1001
+            ))
+        );
+        assert!(shared.rx_ring.pop().is_some(), "host should ack agentd");
     }
 }

--- a/crates/runtime/lib/relay.rs
+++ b/crates/runtime/lib/relay.rs
@@ -102,8 +102,10 @@ pub struct AgentRelay {
     /// Optional `exec.log` writer. When set, the ring reader task
     /// captures the primary session's stdout/stderr to JSON Lines.
     log_writer: Option<Arc<LogWriter>>,
-    /// User-volume bind identity maps to install before `core.ready`.
-    bind_identity_maps: Vec<BindIdentityMapHandle>,
+    /// Shared user-volume bind identity map to install before `core.ready`.
+    bind_identity_map: Option<BindIdentityMapHandle>,
+    /// Number of user-volume mounts that use the shared bind identity map.
+    bind_identity_map_mount_count: usize,
 }
 
 /// A frame extracted from the byte stream, kept as raw bytes for transparent
@@ -150,7 +152,8 @@ impl AgentRelay {
             sock_path: agent_sock_path.to_path_buf(),
             ready_frame: None,
             log_writer: None,
-            bind_identity_maps: Vec::new(),
+            bind_identity_map: None,
+            bind_identity_map_mount_count: 0,
         })
     }
 
@@ -169,13 +172,22 @@ impl AgentRelay {
         self
     }
 
-    /// Attach pending bind identity maps for the early init handshake.
-    pub fn with_bind_identity_maps(mut self, maps: Vec<BindIdentityMapHandle>) -> Self {
-        self.bind_identity_maps = maps;
+    /// Attach a pending bind identity map for the early init handshake.
+    pub fn with_bind_identity_map(
+        mut self,
+        handle: Option<BindIdentityMapHandle>,
+        mount_count: usize,
+    ) -> Self {
+        self.bind_identity_map = handle;
+        self.bind_identity_map_mount_count = mount_count;
         self
     }
 
-    fn install_bind_identity_maps(&self, resolved: InitResolved) -> RuntimeResult<()> {
+    fn install_bind_identity_map(&self, resolved: InitResolved) -> RuntimeResult<()> {
+        let Some(handle) = &self.bind_identity_map else {
+            return Ok(());
+        };
+
         let host_owner_uid = unsafe { libc::getuid() as u32 };
         let map = BindIdentityMap::new(
             host_owner_uid,
@@ -183,17 +195,15 @@ impl AgentRelay {
             resolved.default_user.gid,
         );
 
-        for handle in &self.bind_identity_maps {
-            handle
-                .set(map)
-                .map_err(|_| RuntimeError::Custom("bind identity map already installed".into()))?;
-        }
+        handle
+            .set(map)
+            .map_err(|_| RuntimeError::Custom("bind identity map already installed".into()))?;
 
         tracing::info!(
             host_owner_uid,
             guest_uid = resolved.default_user.uid,
             guest_gid = resolved.default_user.gid,
-            mounts = self.bind_identity_maps.len(),
+            mounts = self.bind_identity_map_mount_count,
             "agent relay: installed bind identity maps"
         );
 
@@ -232,18 +242,17 @@ impl AgentRelay {
 
             // Try to extract complete frames.
             while let Some(frame) = try_extract_frame(&mut buf) {
-                let raw_data = frame.data.to_vec();
-                let msg = decode_frame(raw_data.clone())?;
+                let msg = decode_frame(frame.data.as_ref())?;
 
                 if msg.t == MessageType::Ready {
-                    if !self.bind_identity_maps.is_empty() && !init_resolved {
+                    if self.bind_identity_map.is_some() && !init_resolved {
                         return Err(RuntimeError::Custom(
                             "agent relay: received core.ready before init context resolution"
                                 .into(),
                         ));
                     }
                     tracing::info!("agent relay: received core.ready from agentd");
-                    self.ready_frame = Some(raw_data);
+                    self.ready_frame = Some(frame.data.to_vec());
                     // Now that agentd has signalled readiness, mark the
                     // exec.log lifecycle. Doing this here (rather than
                     // in `with_log_writer`) means the marker only shows
@@ -260,7 +269,7 @@ impl AgentRelay {
                     let resolved: InitResolved = msg.payload().map_err(|e| {
                         RuntimeError::Custom(format!("decode init context payload: {e}"))
                     })?;
-                    self.install_bind_identity_maps(resolved)?;
+                    self.install_bind_identity_map(resolved)?;
                     init_resolved = true;
                     self.send_init_ack()?;
                     continue;
@@ -573,10 +582,8 @@ fn try_extract_frame(buf: &mut BytesMut) -> Option<RawFrame> {
 }
 
 /// Decode raw frame bytes into a protocol `Message`.
-fn decode_frame(mut buf: Vec<u8>) -> RuntimeResult<Message> {
-    codec::try_decode_from_buf(&mut buf)
-        .map_err(|e| RuntimeError::Custom(format!("decode frame: {e}")))?
-        .ok_or_else(|| RuntimeError::Custom("decode frame: incomplete frame".into()))
+fn decode_frame(buf: &[u8]) -> RuntimeResult<Message> {
+    codec::decode_message_frame(buf).map_err(|e| RuntimeError::Custom(format!("decode frame: {e}")))
 }
 
 /// Tap a guest-originated frame into `exec.log` if it belongs to the
@@ -586,7 +593,7 @@ fn tap_frame_into_log(frame: &RawFrame, writer: &LogWriter, session_registry: &S
     // Decode the message envelope to learn the type. The full CBOR
     // decode is small (the envelope is a 3-field map; the heavy
     // payload is left as opaque bytes in `Message::p`).
-    let msg = match decode_frame(frame.data.to_vec()) {
+    let msg = match decode_frame(frame.data.as_ref()) {
         Ok(m) => m,
         Err(err) => {
             tracing::debug!(error = %err, "exec_log: skipping frame with decode error");
@@ -882,7 +889,7 @@ async fn client_reader_task(
         // so we decode the type to disambiguate.
         let mut is_exec_session_start = false;
         if is_session_start
-            && let Ok(msg) = decode_frame(frame.data.to_vec())
+            && let Ok(msg) = decode_frame(frame.data.as_ref())
             && msg.t == MessageType::ExecRequest
         {
             is_exec_session_start = true;
@@ -1052,7 +1059,7 @@ mod tests {
         let mut relay = AgentRelay::new(&sock_path, Arc::clone(&shared))
             .await
             .unwrap()
-            .with_bind_identity_maps(vec![Arc::clone(&handle)]);
+            .with_bind_identity_map(Some(Arc::clone(&handle)), 1);
 
         shared
             .tx_ring
@@ -1084,7 +1091,7 @@ mod tests {
         let mut relay = AgentRelay::new(&sock_path, Arc::clone(&shared))
             .await
             .unwrap()
-            .with_bind_identity_maps(vec![Arc::clone(&handle)]);
+            .with_bind_identity_map(Some(Arc::clone(&handle)), 2);
 
         shared
             .tx_ring
@@ -1122,5 +1129,35 @@ mod tests {
             ))
         );
         assert!(shared.rx_ring.pop().is_some(), "host should ack agentd");
+    }
+
+    #[tokio::test]
+    async fn wait_ready_skips_init_requirement_when_no_bind_map_pending() {
+        let shared = Arc::new(ConsoleSharedState::with_capacity(8));
+        let sock_dir = tempfile::tempdir().unwrap();
+        let sock_path = sock_dir.path().join("agent.sock");
+        let mut relay = AgentRelay::new(&sock_path, Arc::clone(&shared))
+            .await
+            .unwrap()
+            .with_bind_identity_map(None, 0);
+
+        let ready = encoded_message(
+            MessageType::Ready,
+            &Ready {
+                boot_time_ns: 0,
+                init_time_ns: 0,
+                ready_time_ns: 0,
+            },
+        );
+        shared.tx_ring.push(ready.clone()).unwrap();
+        shared.tx_wake.wake();
+
+        relay.wait_ready().unwrap();
+
+        assert_eq!(relay.ready_frame, Some(ready));
+        assert!(
+            shared.rx_ring.pop().is_none(),
+            "no init context means no ack should be sent"
+        );
     }
 }

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -15,7 +15,8 @@ use std::time::Duration;
 use microsandbox_db::DbWriteConnection;
 use microsandbox_db::entity::run as run_entity;
 use microsandbox_filesystem::{
-    DynFileSystem, HostPermissions, PassthroughConfig, PassthroughFs, StatVirtualization,
+    BindIdentityMapHandle, DynFileSystem, HostPermissions, PassthroughConfig, PassthroughFs,
+    StatVirtualization,
 };
 use microsandbox_metrics::{ActivateSlot, MetricsRegistry, ReleaseMode};
 use msb_krun::VmBuilder;
@@ -247,6 +248,13 @@ type NetworkMetricsHandle = microsandbox_network::network::MetricsHandle;
 #[cfg(not(feature = "net"))]
 type NetworkMetricsHandle = ();
 
+type VmBuildOutput = (
+    msb_krun::Vm,
+    Option<NetworkTerminationHandle>,
+    Option<NetworkMetricsHandle>,
+    Vec<BindIdentityMapHandle>,
+);
+
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
@@ -402,7 +410,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     // without re-opening the registry (saving two mmap syscalls and a
     // potential `wait_for_ready` round-trip on the VMM's exit path).
     let exit_metrics_writer = metrics_writer.clone();
-    let (vm, _network_termination_handle, network_metrics_handle) = match build_vm(
+    let build_result = build_vm(
         &config,
         console_backend,
         move |exit_code: i32| {
@@ -472,22 +480,25 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
             let _ = std::fs::remove_file(&exit_sock_path);
         },
         tokio_rt.handle().clone(),
-    ) {
-        Ok(vm) => vm,
-        Err(e) => {
-            let _ = tokio_rt.block_on(mark_run_failed(&db, run_db_id));
-            // Free the slot: build_vm never started the sampler, so no live
-            // sample is worth preserving. Prefer the writer (already holds
-            // the registry handle) when activation succeeded; otherwise
-            // open the registry once via the handoff fields.
-            if let Some(writer) = metrics_writer.clone() {
-                let _ = writer.release(ReleaseMode::Free);
-            } else {
-                release_metrics_slot(config.metrics_slot.as_ref(), ReleaseMode::Free);
+    );
+    let (vm, _network_termination_handle, network_metrics_handle, bind_identity_maps) =
+        match build_result {
+            Ok(vm) => vm,
+            Err(e) => {
+                let _ = tokio_rt.block_on(mark_run_failed(&db, run_db_id));
+                // Free the slot: build_vm never started the sampler, so no live
+                // sample is worth preserving. Prefer the writer (already holds
+                // the registry handle) when activation succeeded; otherwise
+                // open the registry once via the handoff fields.
+                if let Some(writer) = metrics_writer.clone() {
+                    let _ = writer.release(ReleaseMode::Free);
+                } else {
+                    release_metrics_slot(config.metrics_slot.as_ref(), ReleaseMode::Free);
+                }
+                return Err(e);
             }
-            return Err(e);
-        }
-    };
+        };
+    relay = relay.with_bind_identity_maps(bind_identity_maps);
     let exit_handle = vm.exit_handle();
 
     #[cfg(feature = "net")]
@@ -638,13 +649,10 @@ fn build_vm(
     console_backend: AgentConsoleBackend,
     on_exit: impl Fn(i32) + Send + 'static,
     tokio_handle: tokio::runtime::Handle,
-) -> RuntimeResult<(
-    msb_krun::Vm,
-    Option<NetworkTerminationHandle>,
-    Option<NetworkMetricsHandle>,
-)> {
+) -> RuntimeResult<VmBuildOutput> {
     let mut exec_env = config.vm.env.clone();
     let vm = &config.vm;
+    let mut bind_identity_maps = Vec::new();
 
     let mut builder = VmBuilder::new()
         .machine(|m| {
@@ -762,12 +770,20 @@ fn build_vm(
             .map_err(|e| RuntimeError::Custom(format!("--mount {mount_spec:?}: {e}")))?;
 
         let tag = parsed.tag;
+        let bind_identity_map = if matches!(parsed.stat_virtualization, StatVirtualization::Off) {
+            None
+        } else {
+            let handle = Arc::new(std::sync::OnceLock::new());
+            bind_identity_maps.push(Arc::clone(&handle));
+            Some(handle)
+        };
         let cfg = PassthroughConfig {
             root_dir: PathBuf::from(parsed.host_path),
             inject_init: false,
             stat_virtualization: parsed.stat_virtualization,
             host_permissions: parsed.host_permissions,
             readonly: parsed.readonly,
+            bind_identity_map,
             ..Default::default()
         };
         let backend = PassthroughFs::new(cfg)
@@ -885,7 +901,12 @@ fn build_vm(
         .build()
         .map_err(|e| RuntimeError::Custom(format!("build VM: {e}")))?;
 
-    Ok((vm, network_termination_handle, network_metrics_handle))
+    Ok((
+        vm,
+        network_termination_handle,
+        network_metrics_handle,
+        bind_identity_maps,
+    ))
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 use std::num::NonZero;
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use microsandbox_db::DbWriteConnection;
@@ -236,6 +236,12 @@ struct StartupInfo {
     pid: u32,
 }
 
+/// Shared bind identity map registration for user-volume passthrough mounts.
+struct BindIdentityMapRegistration {
+    handle: Option<BindIdentityMapHandle>,
+    mount_count: usize,
+}
+
 #[cfg(feature = "net")]
 type NetworkTerminationHandle = microsandbox_network::network::TerminationHandle;
 
@@ -252,7 +258,7 @@ type VmBuildOutput = (
     msb_krun::Vm,
     Option<NetworkTerminationHandle>,
     Option<NetworkMetricsHandle>,
-    Vec<BindIdentityMapHandle>,
+    BindIdentityMapRegistration,
 );
 
 //--------------------------------------------------------------------------------------------------
@@ -481,7 +487,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         },
         tokio_rt.handle().clone(),
     );
-    let (vm, _network_termination_handle, network_metrics_handle, bind_identity_maps) =
+    let (vm, _network_termination_handle, network_metrics_handle, bind_identity_map) =
         match build_result {
             Ok(vm) => vm,
             Err(e) => {
@@ -498,7 +504,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                 return Err(e);
             }
         };
-    relay = relay.with_bind_identity_maps(bind_identity_maps);
+    relay = relay.with_bind_identity_map(bind_identity_map.handle, bind_identity_map.mount_count);
     let exit_handle = vm.exit_handle();
 
     #[cfg(feature = "net")]
@@ -652,7 +658,10 @@ fn build_vm(
 ) -> RuntimeResult<VmBuildOutput> {
     let mut exec_env = config.vm.env.clone();
     let vm = &config.vm;
-    let mut bind_identity_maps = Vec::new();
+    let mut bind_identity_map = BindIdentityMapRegistration {
+        handle: None,
+        mount_count: 0,
+    };
 
     let mut builder = VmBuilder::new()
         .machine(|m| {
@@ -770,20 +779,15 @@ fn build_vm(
             .map_err(|e| RuntimeError::Custom(format!("--mount {mount_spec:?}: {e}")))?;
 
         let tag = parsed.tag;
-        let bind_identity_map = if matches!(parsed.stat_virtualization, StatVirtualization::Off) {
-            None
-        } else {
-            let handle = Arc::new(std::sync::OnceLock::new());
-            bind_identity_maps.push(Arc::clone(&handle));
-            Some(handle)
-        };
+        let mount_bind_identity_map =
+            bind_identity_map_for_mount(&mut bind_identity_map, parsed.stat_virtualization);
         let cfg = PassthroughConfig {
             root_dir: PathBuf::from(parsed.host_path),
             inject_init: false,
             stat_virtualization: parsed.stat_virtualization,
             host_permissions: parsed.host_permissions,
             readonly: parsed.readonly,
-            bind_identity_map,
+            bind_identity_map: mount_bind_identity_map,
             ..Default::default()
         };
         let backend = PassthroughFs::new(cfg)
@@ -905,7 +909,7 @@ fn build_vm(
         vm,
         network_termination_handle,
         network_metrics_handle,
-        bind_identity_maps,
+        bind_identity_map,
     ))
 }
 
@@ -953,6 +957,21 @@ fn release_metrics_slot(handoff: Option<&MetricsSlotHandoff>, mode: ReleaseMode)
     if let Ok(reg) = MetricsRegistry::open(&handoff.shm_name) {
         let _ = reg.release(handoff.slot, handoff.generation, mode);
     }
+}
+
+fn bind_identity_map_for_mount(
+    registration: &mut BindIdentityMapRegistration,
+    stat_virtualization: StatVirtualization,
+) -> Option<BindIdentityMapHandle> {
+    if matches!(stat_virtualization, StatVirtualization::Off) {
+        return None;
+    }
+
+    registration.mount_count += 1;
+    let handle = registration
+        .handle
+        .get_or_insert_with(|| Arc::new(OnceLock::new()));
+    Some(Arc::clone(handle))
 }
 
 /// Set up host log capture.
@@ -1301,9 +1320,11 @@ pub fn prepend_scripts_path(env: &mut Vec<String>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        HostPermissions, StatVirtualization, append_block_root_env, parse_mount_spec,
-        prepend_scripts_path, validate_disk_format,
+        BindIdentityMapRegistration, HostPermissions, StatVirtualization, append_block_root_env,
+        bind_identity_map_for_mount, parse_mount_spec, prepend_scripts_path, validate_disk_format,
     };
+
+    use std::sync::Arc;
 
     #[test]
     fn test_parse_mount_spec_minimal() {
@@ -1391,6 +1412,24 @@ mod tests {
     fn test_parse_mount_spec_rejects_unsupported_flags() {
         let err = parse_mount_spec("foo:/host:exec").unwrap_err();
         assert!(err.contains("unsupported mount option"), "got: {err}");
+    }
+
+    #[test]
+    fn test_bind_identity_map_registration_shares_handle_for_virtualized_mounts() {
+        let mut registration = BindIdentityMapRegistration {
+            handle: None,
+            mount_count: 0,
+        };
+
+        let first =
+            bind_identity_map_for_mount(&mut registration, StatVirtualization::Strict).unwrap();
+        let second =
+            bind_identity_map_for_mount(&mut registration, StatVirtualization::Relaxed).unwrap();
+        let off = bind_identity_map_for_mount(&mut registration, StatVirtualization::Off);
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(off.is_none());
+        assert_eq!(registration.mount_count, 2);
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR
Map host-owned bind mount files to the sandbox's resolved guest user so non-root guests can work with mounted project files. The runtime now installs that mapping before user mounts are exposed.

## Description
- Add a bind identity map for user passthrough mounts, with host-owner files shown as the guest default user and other host owners shown as `65534:65534`.
- Preserve xattr stat overrides ahead of the identity map and keep `stat-virt=off` as raw host metadata.
- Add an early `core.init.resolved` and `core.init.ack` host-agent handshake so the runtime can install maps before `core.ready`.
- Bump the internal protocol version to 3 for the new host-agent boot contract.
- Keep rootfs and `/.msb` runtime passthrough mounts out of the user-volume identity mapping.
- Add focused filesystem and relay tests for mapping behavior, xattr precedence, access checks, partial metadata updates, and pre-ready ordering.
- Closes #741

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p microsandbox-protocol`
- [x] `cargo test -p microsandbox-runtime --lib`
- [x] `cargo test -p microsandbox-filesystem test_identity_map`
- [x] `cargo test --manifest-path crates/agentd/Cargo.toml && cargo check --manifest-path crates/agentd/Cargo.toml --target x86_64-unknown-linux-gnu`
- [x] `cargo clippy -p microsandbox-protocol -p microsandbox-filesystem -p microsandbox-runtime -- -D warnings && cargo clippy --manifest-path crates/agentd/Cargo.toml --target x86_64-unknown-linux-gnu -- -D warnings`