### PR TITLE
fix(sdk): refresh stale docs and node typings

### DIFF
--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -24,8 +24,9 @@ msb run --name api \
   -w /app \
   python
 
-# Detached (runs in background)
-msb run -d --name worker python -- python worker.py
+# Detached (boots in background; run work later with exec)
+msb run -d --name worker python
+msb exec worker -- python worker.py
 
 # Publish on all IPv4 host interfaces instead of the default 127.0.0.1
 msb run --name public-api -p 0.0.0.0:8000:8000 python
@@ -43,7 +44,7 @@ msb run --name public-api -p 0.0.0.0:8000:8000 python
 | `-w`, `--workdir` | Working directory inside the sandbox |
 | `--shell` | Default shell for interactive sessions |
 | `-t`, `--tty` | Allocate a pseudo-terminal (enables colors, line editing) |
-| `-d`, `--detach` | Run in background and print the sandbox name |
+| `-d`, `--detach` | Boot in the background and print the sandbox name. Commands after `--` are not run in detached mode; use `msb exec` afterward |
 | `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`). Per-command; the sandbox stays alive |
 | `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`, `as=1073741824`) |
 | `--detach-keys` | Key sequence to detach from interactive session (default: `ctrl-]`) |

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -144,7 +144,7 @@ sb, err := m.CreateSandbox(ctx, "sandbox",
 
 </CodeGroup>
 
-### Programmable network layer <sup><sup>coming soon</sup></sup>
+### Programmable network layer
 
 Every packet leaving a sandbox passes through a networking stack controlled entirely from the host side, where policy is enforced at the IP, DNS, or HTTP level. From inside the sandbox it looks like a normal network interface, but on the host side you decide what gets through.
 
@@ -153,11 +153,14 @@ There's no underlying host network to bridge to, no rules to circumvent, and no 
 <CodeGroup>
 
 ```rust Rust
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.allow_domains(["api.openai.com", "pypi.org"]))
+    .build()?;
+
 let sb = Sandbox::builder("sandbox")
     .image("python")
-    .network(|n| n
-        .policy(NetworkPolicy::allowlist(["api.openai.com", "pypi.org"]))
-    )
+    .network(|n| n.policy(policy))
     .create()
     .await?;
 ```
@@ -347,7 +350,7 @@ for i := range workers {
 ```
 
 ```bash CLI
-msb run --name baseline --detach python -- sleep 3600
+msb run --name baseline --detach python
 msb exec baseline -- pip install -r requirements.txt
 msb stop baseline
 
@@ -355,7 +358,7 @@ msb snapshot create after-pip-install --from baseline
 
 # Boot 10 workers from the snapshot
 for i in $(seq 1 10); do
-    msb run --name worker-$i --detach --snapshot after-pip-install -- sleep 3600
+    msb run --name worker-$i --detach --snapshot after-pip-install
 done
 ```
 

--- a/docs/images/disk-images.mdx
+++ b/docs/images/disk-images.mdx
@@ -20,7 +20,7 @@ Use disk images when you need a pre-built VM template, a custom kernel configura
 
 ## Usage
 
-When you pass a file path ending in `.qcow2`, `.raw`, or `.vmdk`, microsandbox auto-detects the format. For ambiguous cases, specify the format and filesystem type explicitly.
+When you pass a file path ending in `.qcow2`, `.raw`, or `.vmdk`, microsandbox auto-detects the format. For disk-image roots, rename ambiguous files with one of those extensions and set the filesystem type when auto-detection needs a hint.
 
 <CodeGroup>
 ```rust Rust
@@ -34,7 +34,7 @@ let sb = Sandbox::builder("custom-vm")
     .create()
     .await?;
 
-// Explicit
+// Explicit filesystem type
 let sb2 = Sandbox::builder("custom-vm")
     .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
     .cpus(1)
@@ -53,14 +53,9 @@ await using sb = await Sandbox.builder("custom-vm")
     .memory(2048)
     .create();
 
-// Explicit format / fstype via a RootfsSource literal
+// Explicit filesystem type via the ImageBuilder
 await using sb2 = await Sandbox.builder("custom-vm")
-    .image({
-        kind: "disk",
-        path: "./alpine.raw",
-        format: "raw",
-        fstype: "ext4",
-    })
+    .imageWith((i) => i.disk("./alpine.raw").fstype("ext4"))
     .cpus(1)
     .memory(512)
     .create();

--- a/docs/recipes/docker-in-sandbox.mdx
+++ b/docs/recipes/docker-in-sandbox.mdx
@@ -118,5 +118,5 @@ msb rm -f docker-demo
 
 - **Tmpfs sizing.** `/tmp` is 1 GiB here. Increase `--tmpfs /tmp:N` if you plan to pull larger images.
 - **Named volumes don't fix this.** They are virtiofs-backed host directories, and Docker's overlay snapshotter can't use those for `upperdir` / `workdir`.
-- **Future work: disk-image-backed volumes.** microsandbox already supports virtio-blk-mounted disk images at the runtime layer. Once that is exposed through `msb volume`, Docker's data root can sit on a real block device and survive sandbox removal.
+- **Disk-image-backed volumes.** The SDKs can already mount host disk images as virtio-blk devices. Once the CLI has a first-class `msb volume` flow for disk images, Docker's data root can sit on a real block device and survive sandbox removal.
 - **Not the same as [Sandbox in Docker](/recipes/docker).** That recipe covers the opposite direction.

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -417,39 +417,46 @@ msb create private.registry.io/org/app:v1 \
 
 ## Config inspection
 
-Build or inspect a sandbox configuration. Rust, TypeScript, and Python can build a config before boot; Go exposes the persisted config after creation through `SandboxHandle.ConfigJSON()`.
+Build or inspect a sandbox configuration. Rust and TypeScript can build a config before boot; Python and Go expose the persisted config after creation.
 
 <CodeGroup>
 ```rust Rust
 let config = Sandbox::builder("preview")
     .image("python")
     .memory(1024)
-    .build()?;
+    .build()
+    .await?;
 
 println!("{}", serde_json::to_string_pretty(&config)?);
 let sb = Sandbox::create(config).await?;
 ```
 
 ```typescript TypeScript
-const builder = Sandbox.builder("preview").image("python").memory(1024);
-const config = builder.build();
+const config = await Sandbox.builder("preview")
+    .image("python")
+    .memory(1024)
+    .build();
 
 console.log(JSON.stringify(config, null, 2));
-const sb = await builder.create();
+const sb = await Sandbox.builder("preview")
+    .image("python")
+    .memory(1024)
+    .create();
 ```
 
 ```python Python
 import json
 from microsandbox import Sandbox
 
-config = Sandbox.build_config(
+sb = await Sandbox.create(
     "preview",
     image="python",
     memory=1024,
 )
+handle = await Sandbox.get("preview")
+config = json.loads(handle.config_json)
 
 print(json.dumps(config, indent=2))
-sb = await Sandbox.create(**config)
 ```
 
 ```go Go

--- a/docs/sandboxes/snapshots.mdx
+++ b/docs/sandboxes/snapshots.mdx
@@ -26,8 +26,8 @@ Booting from a snapshot is a cold boot of a fresh VM that reuses the captured up
 You'll usually reach for the CLI first:
 
 ```bash
-# 1. Run something, install state, then stop it
-msb run --name baseline --detach python:3.12 -- sleep 3600
+# 1. Boot a sandbox, install state, then stop it
+msb run --name baseline --detach python:3.12
 msb exec baseline -- pip install requests
 msb stop baseline
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -154,16 +154,6 @@ Sandbox name. Names are limited to 128 UTF-8 bytes.
 
 ---
 
-#### config
-
-```typescript
-readonly config: Readonly<SandboxConfig>
-```
-
-The frozen configuration the sandbox was built with.
-
----
-
 #### ownsLifecycle
 
 ```typescript
@@ -241,6 +231,16 @@ Get a point-in-time snapshot of the sandbox's resource usage.
 | Type | Description |
 |------|-------------|
 | [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network metrics |
+
+---
+
+#### config()
+
+```typescript
+config(): Promise<SandboxConfig>
+```
+
+Get the configuration the sandbox was built with.
 
 ---
 
@@ -588,7 +588,7 @@ Fluent configuration builder returned by `Sandbox.builder(name)`. Every setter r
 | `network(n => ...)` | Configure DNS / TLS / policy / secrets — see [Networking](/sdk/typescript/networking) |
 | `secret(s => ...)` | Add a secret via [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder) |
 | `secretEnv(envVar, value, allowedHost)` | Auto-placeholder shorthand. Generates `$MSB_<ENV_VAR>`. |
-| `build(): Promise<SandboxConfig>` | Materialize without booting |
+| `build(): Promise<SandboxConfig>` | Materialize without booting. Consumes the builder |
 | `create(): Promise<Sandbox>` | Build and boot in attached mode |
 | `createDetached(): Promise<Sandbox>` | Build and boot in detached mode |
 | `createWithPullProgress(): Promise<PullProgressCreate>` | Build and boot in attached mode while streaming image pull progress |
@@ -713,7 +713,7 @@ Async iterable creation handle returned by `Sandbox.builder(name).createWithPull
 
 ### SandboxConfig
 
-Frozen configuration object — produced by `SandboxBuilder.build()` and exposed as the `config` property on a `Sandbox`. You generally should not construct this by hand; use the builder.
+Configuration object produced by `SandboxBuilder.build()` and returned by `sandbox.config()`. You generally should not construct this by hand; use the builder.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/sdk/node-ts/src/index.ts
+++ b/sdk/node-ts/src/index.ts
@@ -28,6 +28,7 @@ export const SandboxBuilder = function SandboxBuilder(
   return _Sandbox.builder(name);
 } as unknown as new (name: string) => _SBT;
 export type SandboxBuilder = _SBT;
+export type { SandboxConfig } from "./sandbox.js";
 export { SandboxHandle } from "./sandbox-handle.js";
 export { ExecHandle, ExecOutput, ExecSink } from "./exec.js";
 

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -1,4 +1,6 @@
 import { createRequire } from "node:module";
+import type { NetworkConfig } from "../network-config.js";
+import type { NetworkPolicy } from "../policy/types.js";
 import { msbPath } from "./resolve-binary.js";
 
 // Resolve the bundled runtime binary once and push it into the Rust
@@ -90,6 +92,7 @@ export interface NapiAgentClient {
 }
 
 export type NapiBuilderCtor<T> = new () => T;
+export type NapiSandboxConfig = Record<string, unknown>;
 
 export interface NapiSandboxStatic {
   start(name: string): Promise<NapiSandbox>;
@@ -159,7 +162,7 @@ export interface NapiSandboxBuilderSetters {
   volume(guest: string, configure: (b: any) => any): this;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   patch(configure: (b: any) => any): this;
-  build(): Promise<string>;
+  build(): Promise<NapiSandboxConfig>;
 }
 
 export interface NapiSandboxBuilder extends NapiSandboxBuilderSetters {
@@ -734,6 +737,7 @@ export interface NapiNetworkBuilder {
   portBind(bind: string, host: number, guest: number): this;
   portUdp(host: number, guest: number): this;
   portUdpBind(bind: string, host: number, guest: number): this;
+  policy(policy: NetworkPolicy | NapiNetworkPolicyBuilder): this;
   policyJson(json: string): this;
   policyFromBuilder(builder: NapiNetworkPolicyBuilder): this;
   dns(configure: (b: NapiDnsBuilder) => NapiDnsBuilder): this;
@@ -751,6 +755,7 @@ export interface NapiNetworkBuilder {
   ipv4Pool(pool: string): this;
   ipv6Pool(pool: string): this;
   trustHostCAs(enabled: boolean): this;
+  build(): NetworkConfig;
 }
 
 export interface NapiInterfaceOverridesBuilder {

--- a/sdk/node-ts/src/sandbox.ts
+++ b/sdk/node-ts/src/sandbox.ts
@@ -8,6 +8,7 @@ import {
   type NapiPullProgressStream,
   type NapiSandbox,
   type NapiSandboxBuilderSetters,
+  type NapiSandboxConfig,
 } from "./internal/napi.js";
 import { ExecHandle, ExecOutput } from "./exec.js";
 import { SandboxFs } from "./fs.js";
@@ -46,6 +47,8 @@ import { SandboxSsh } from "./ssh.js";
 // {...}` type alias would lose the override on every chained `this`
 // return, leaving `b.image(...).create()` inferred as
 // `Promise<NapiSandbox>`.
+export type SandboxConfig = NapiSandboxConfig;
+
 export interface SandboxBuilder extends NapiSandboxBuilderSetters {
   create(): Promise<Sandbox>;
   createDetached(): Promise<Sandbox>;
@@ -280,9 +283,9 @@ export class Sandbox implements AsyncDisposable {
    * The full configuration this sandbox was created with — image, cpus,
    * memory, env, mounts, etc. The shape mirrors `SandboxBuilder.build()`.
    */
-  async config(): Promise<unknown> {
+  async config(): Promise<SandboxConfig> {
     const json = await withMappedErrors(() => this.inner.configJson());
-    return remapKeysToCamel(JSON.parse(json));
+    return remapKeysToCamel(JSON.parse(json)) as SandboxConfig;
   }
 
   // -- logs ---------------------------------------------------------------


### PR DESCRIPTION
## TL;DR
Fix stale SDK and CLI docs examples so they match current microsandbox behavior, and update Node SDK typings for the runtime-wrapped builder APIs.

## Description
- Replace the invalid TypeScript disk-image rootfs example with `imageWith`, since rootfs disk format is inferred from the file extension.
- Update detached CLI examples so they do not pass commands that `msb run --detach` ignores.
- Refresh config inspection docs for Rust, TypeScript, Python, and Go based on the APIs that exist today.
- Use the current Rust network policy builder in the getting-started guide.
- Document `Sandbox.config()` as a method and note that `SandboxBuilder.build()` consumes the builder.
- Export `SandboxConfig` and type the Node SDK builder methods that runtime wrappers already expose.

```ts
const config = await Sandbox.builder("preview")
  .image("python")
  .memory(1024)
  .build();
```

## Test Plan
- [x] `npm run build:ts` exits 0 in `sdk/node-ts`
- [x] `npm run typecheck` exits 0 in `sdk/node-ts`
- [x] `npm run test:unit -- tests/unit/builders.test.ts tests/unit/policy.test.ts` passes in `sdk/node-ts`
- [x] `git diff --check` exits 0