### PR TITLE
feat(cli): add env-backed secret shorthand

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -299,7 +299,7 @@ pub struct SandboxOpts {
     pub tls_upstream_ca_cert: Vec<PathBuf>,
 
     // --- Secrets ---
-    /// Inject a secret that is only sent to an allowed host (ENV=VALUE@HOST).
+    /// Inject a secret that is only sent to an allowed host (ENV@HOST or ENV=VALUE@HOST).
     #[cfg(feature = "net")]
     #[arg(long)]
     pub secret: Vec<String>,
@@ -1133,24 +1133,47 @@ fn parse_port_mapping(spec: &str) -> anyhow::Result<(std::net::IpAddr, u16, u16,
     Ok((bind, host, guest, udp))
 }
 
-/// Parse a secret spec: `ENV=VALUE@HOST`.
+/// Parse a secret spec: `ENV@HOST` or `ENV=VALUE@HOST`.
 #[cfg(feature = "net")]
 fn parse_secret(spec: &str) -> anyhow::Result<(String, String, String)> {
-    let eq_pos = spec
-        .find('=')
-        .ok_or_else(|| anyhow::anyhow!("secret must be in format ENV=VALUE@HOST"))?;
-    let env_var = spec[..eq_pos].to_string();
-    let rest = &spec[eq_pos + 1..];
+    if let Some(eq_pos) = spec.find('=') {
+        let env_var = spec[..eq_pos].to_string();
+        let rest = &spec[eq_pos + 1..];
+        let at_pos = rest.rfind('@').ok_or_else(|| {
+            anyhow::anyhow!("secret must be in format ENV@HOST or ENV=VALUE@HOST")
+        })?;
+        let value = rest[..at_pos].to_string();
+        let host = rest[at_pos + 1..].to_string();
 
-    let at_pos = rest
-        .rfind('@')
-        .ok_or_else(|| anyhow::anyhow!("secret must be in format ENV=VALUE@HOST"))?;
-    let value = rest[..at_pos].to_string();
-    let host = rest[at_pos + 1..].to_string();
+        if env_var.is_empty() || value.is_empty() || host.is_empty() {
+            anyhow::bail!(
+                "secret must be in format ENV@HOST or ENV=VALUE@HOST (all parts required)"
+            );
+        }
 
-    if env_var.is_empty() || value.is_empty() || host.is_empty() {
-        anyhow::bail!("secret must be in format ENV=VALUE@HOST (all parts required)");
+        return Ok((env_var, value, host));
     }
+
+    let at_pos = spec
+        .rfind('@')
+        .ok_or_else(|| anyhow::anyhow!("secret must be in format ENV@HOST or ENV=VALUE@HOST"))?;
+    let env_var = spec[..at_pos].to_string();
+    let host = spec[at_pos + 1..].to_string();
+
+    if env_var.is_empty() || host.is_empty() {
+        anyhow::bail!("secret must be in format ENV@HOST or ENV=VALUE@HOST (all parts required)");
+    }
+
+    let value = match std::env::var(&env_var) {
+        Ok(value) if !value.is_empty() => value,
+        Ok(_) => anyhow::bail!("secret environment variable `{env_var}` is empty"),
+        Err(std::env::VarError::NotPresent) => {
+            anyhow::bail!("secret environment variable `{env_var}` is not set")
+        }
+        Err(std::env::VarError::NotUnicode(_)) => {
+            anyhow::bail!("secret environment variable `{env_var}` is not valid UTF-8")
+        }
+    };
 
     Ok((env_var, value, host))
 }
@@ -1497,6 +1520,92 @@ mod tests {
     };
 
     use super::*;
+
+    #[cfg(feature = "net")]
+    static SECRET_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[cfg(feature = "net")]
+    struct SecretEnvCleanup<'a> {
+        name: &'a str,
+    }
+
+    #[cfg(feature = "net")]
+    impl Drop for SecretEnvCleanup<'_> {
+        fn drop(&mut self) {
+            // SAFETY: these tests use unique variable names and serialize
+            // mutations within this module.
+            unsafe { std::env::remove_var(self.name) };
+        }
+    }
+
+    #[cfg(feature = "net")]
+    fn with_secret_env<R>(name: &str, value: Option<&str>, f: impl FnOnce() -> R) -> R {
+        let _lock = SECRET_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: these tests use unique variable names and serialize
+        // mutations within this module.
+        unsafe {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
+        let _cleanup = SecretEnvCleanup { name };
+        f()
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn parse_secret_reads_value_from_same_named_env() {
+        with_secret_env("MSB_PARSE_SECRET_TOKEN", Some("from-env"), || {
+            let (env_var, value, host) =
+                parse_secret("MSB_PARSE_SECRET_TOKEN@api.example.com").unwrap();
+
+            assert_eq!(env_var, "MSB_PARSE_SECRET_TOKEN");
+            assert_eq!(value, "from-env");
+            assert_eq!(host, "api.example.com");
+        });
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn parse_secret_preserves_explicit_value_syntax() {
+        let (env_var, value, host) =
+            parse_secret("API_KEY=literal@with-at@api.example.com").unwrap();
+
+        assert_eq!(env_var, "API_KEY");
+        assert_eq!(value, "literal@with-at");
+        assert_eq!(host, "api.example.com");
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn parse_secret_rejects_missing_env_source() {
+        let err = with_secret_env("MSB_PARSE_SECRET_MISSING", None, || {
+            parse_secret("MSB_PARSE_SECRET_MISSING@api.example.com")
+                .unwrap_err()
+                .to_string()
+        });
+
+        assert_eq!(
+            err,
+            "secret environment variable `MSB_PARSE_SECRET_MISSING` is not set"
+        );
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn parse_secret_rejects_empty_env_source() {
+        let err = with_secret_env("MSB_PARSE_SECRET_EMPTY", Some(""), || {
+            parse_secret("MSB_PARSE_SECRET_EMPTY@api.example.com")
+                .unwrap_err()
+                .to_string()
+        });
+
+        assert_eq!(
+            err,
+            "secret environment variable `MSB_PARSE_SECRET_EMPTY` is empty"
+        );
+    }
 
     #[cfg(feature = "net")]
     #[test]

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -82,7 +82,7 @@ msb run --name public-api -p 0.0.0.0:8000:8000 python
 | `--net-ipv6-pool` | IPv6 pool used for per-sandbox `/64` guest prefixes (default: `fd42:6d73:62::/48`) |
 | `--max-connections` | Limit the number of concurrent network connections |
 | `--trust-host-cas` | Ship the host's trusted root CAs into the guest so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, etc.) whose gateway CA is installed on the host but unknown to the guest's stock bundle. Opt-in; by default the guest validates against its stock Mozilla bundle only |
-| `--secret` | Inject a secret that is only sent to an allowed host (`ENV=VALUE@HOST`) |
+| `--secret` | Inject a secret that is only sent to an allowed host (`ENV@HOST` or `ENV=VALUE@HOST`) |
 | `--on-secret-violation` | Action when a secret is sent to a disallowed host (`block`, `block-and-log`, `block-and-terminate`, `passthrough`) |
 | `--tls-intercept` | Intercept and inspect HTTPS traffic via a built-in TLS proxy |
 | `--tls-intercept-port` | TCP port to apply TLS interception on (default: 443) |
@@ -91,6 +91,15 @@ msb run --name public-api -p 0.0.0.0:8000:8000 python
 | `--tls-intercept-ca-cert` | Use a custom CA certificate for TLS interception (PEM file) |
 | `--tls-intercept-ca-key` | Use a custom CA private key for TLS interception (PEM file) |
 | `--tls-upstream-ca-cert` | Trust an additional CA certificate for upstream server verification (PEM file). Can be specified multiple times |
+
+Secret specs support two forms:
+
+| Form | Example | Notes |
+| ---- | ------- | ----- |
+| `ENV@HOST` | `OPENAI_API_KEY@api.openai.com` | Recommended. Reads the real value from the same-named host environment variable, so the value is not placed in the command line |
+| `ENV=VALUE@HOST` | `API_KEY=$OTHER_API_KEY@api.openai.com` | Explicit value form. Use for custom mappings or literal values. Shell-expanded values are passed to `msb` as command arguments |
+
+Because shells expand `$VAR` before launching `msb`, prefer `ENV@HOST` when the guest env var and host env var have the same name.
 
 Volume options use Docker-style colon syntax: `SOURCE:DEST:ro,noexec`. Supported `-v` flags are `ro`, `rw`, `nosuid`, and `noexec`; `stat-virt=` and `host-perms=` remain key-value options for bind and named mounts. `nosuid` is always enforced for guest volume mounts, so passing it is only an explicit assertion. `ro` and `noexec` cannot be undone by user commands with a guest remount. `noexec` blocks direct execution from the mount, but interpreters can still read scripts from it, such as `sh /mnt/script.sh`.
 

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -84,10 +84,12 @@ sb, err := m.CreateSandbox(ctx, "agent",
 
 ```bash CLI
 msb create python --name agent \
-  --secret "GITHUB_TOKEN=$GITHUB_TOKEN@api.github.com" \
-  --secret "OPENAI_API_KEY=$OPENAI_API_KEY@api.openai.com"
+  --secret "GITHUB_TOKEN@api.github.com" \
+  --secret "OPENAI_API_KEY@api.openai.com"
 ```
 
 </CodeGroup>
+
+In the CLI form, `ENV@HOST` reads the real value from the same-named host environment variable. Use `ENV=VALUE@HOST` when you need to provide an explicit value, such as `GUEST_TOKEN=$HOST_TOKEN@api.example.com`; shell-expanded values are passed to `msb` as command arguments.
 
 See the SDK Reference for the full API: [Rust](/sdk/rust/secrets) | [TypeScript](/sdk/typescript/secrets) | [Python](/sdk/python/secrets) | [Go](/sdk/go/secrets).


### PR DESCRIPTION
## TL;DR
Let `msb --secret` read same-named host environment variables with `ENV@HOST`, so users do not need to put common secret values in command arguments.

## Description
- Add `ENV@HOST` parsing for CLI secrets, reading the value from the same-named host environment variable
- Keep `ENV=VALUE@HOST` for explicit values and custom mappings, including values that contain `@`
- Return clear errors when the environment source is missing, empty, or not valid UTF-8
- Update CLI docs to recommend `ENV@HOST` and explain when the explicit form still passes values through argv
- Closes #841

```bash
msb create python --name agent \
  --secret "OPENAI_API_KEY@api.openai.com"
```

## Test Plan
- [x] `cargo test -p microsandbox-cli parse_secret` exits 0
- [x] `cargo test -p microsandbox-cli` exits 0
- [x] `cargo fmt --all -- --check` exits 0
- [x] `cargo clippy -p microsandbox-cli -- -D warnings` exits 0