### PR TITLE
fix(runtime): use raised boot argument limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,8 +3459,7 @@ dependencies = [
 [[package]]
 name = "msb_krun"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1204f9be84d1d6a7522745f2ca8c1daaad10b6974c31491b23fbfba8948ea436"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3479,8 +3478,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_arch"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f3fb3872287fbe2f9022da8e4b99bd7e2d56bffa225dc8e76ff5f8bea207c0"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3495,14 +3493,12 @@ dependencies = [
 [[package]]
 name = "msb_krun_arch_gen"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e9b644799f042ecd9ff8e1083548b069bfe5c055fb30a2ee5488d32d532305"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
 
 [[package]]
 name = "msb_krun_cpuid"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80daaaa5c82e40b410813655552dae003273439dd4f663fdf8c0d482daa81690"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3512,8 +3508,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_devices"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60168afa59b23513902fca621af0ae2e34b7c1eb6778c4dfdbcbf639d90e9d88"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3540,8 +3535,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_hvf"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff58dae8f64ded015362c7cf34fc6d3137e21ac67a2a2d9266c930d74de515c2"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -3552,8 +3546,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_kernel"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c276f8c223cfef11a20777ceebf11452cbdbec0753f4f530490600abfd54e6c"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -3562,8 +3555,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_polly"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cc89c4d634828d4487321dc1ad27440d5b610b51a313572b5b41e5ad810c0"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3572,8 +3564,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_smbios"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2da7cdc57310229e8edfe559df924ae7deb747dacac65dc42898aeec44c62f"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
 dependencies = [
  "vm-memory 0.16.2",
 ]
@@ -3581,8 +3572,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_utils"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68805ba9921de9794b2c5a5e4e2efc6f0dbe5206e5c3bcc602d072823373a068"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3596,8 +3586,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_vmm"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6042a24c047faba9b2c033db72257d765cb7dde393d61943d45cccac6e1fa12"
+source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,8 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.13"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb6bc3f86b45ed69cc1e5b8707d4be00e31c5938527d8cebd3859c8a05b3941"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3477,8 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.13"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633af99c56b526465e537f339c7ed37c803007e112315d136aa1a775bf325f0b"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3492,13 +3494,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.13"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a76f5f78825cadb17d0fff6bf66d6ee9bea1c42f0564e428b968cf05feb9f23"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.13"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77f96769b10d84263a996813cb79e058d9b2d59ef95f46a7d1c5ab47fb2de35"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3507,8 +3511,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.13"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da8cd67781a32a03deaee0739e9695009ac3088d1770c75bca72c8105be09f8c"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3534,8 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.13"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213559ed39c57e2141871912c3f19f0659e2e9ebb50e6e43c831942c7a32b0d5"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -3545,8 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.13"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8b9a530e42f59c2548b8c435463b55e9b6aa3c6e2835f30052170ea473ea42"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -3554,8 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.13"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "018aadd9c3bbc1e588201df5574a886ba9b929b44335cdd48f151254b4e0bc04"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3563,16 +3571,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.13"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d45211addb08a5865a37e5f983a0014a75f8a878914cb7c06c18fd51bb68b8f"
 dependencies = [
  "vm-memory 0.16.2",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.13"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31628b7fbebb78d4390ac325c2f1dd127c50266b966af5f2fe40a9522a40d92"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3585,8 +3595,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.13"
-source = "git+https://github.com/superradcompany/libkrun.git?branch=appcypher%2Fraise-boot-cmdline-limits#ade6cf649a2c49c9c3abf375e118b8529e2dcc08"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f12d282559e4ca29a22d2c83e5bde2f80f6ac387b62ee27002dd05b83c98bf5"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib/lib.rs"
 [dependencies]
 libc.workspace = true
 microsandbox-utils = { version = "0.5.3", path = "../utils" }
-msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "appcypher/raise-boot-cmdline-limits" }
+msb_krun = "0.1.14"
 scopeguard.workspace = true
 tempfile.workspace = true
 tracing.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib/lib.rs"
 [dependencies]
 libc.workspace = true
 microsandbox-utils = { version = "0.5.3", path = "../utils" }
-msb_krun = "0.1.13"
+msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "appcypher/raise-boot-cmdline-limits" }
 scopeguard.workspace = true
 tempfile.workspace = true
 tracing.workspace = true

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -27,7 +27,7 @@ libc = { workspace = true }
 lru = { workspace = true }
 microsandbox-protocol = { version = "0.5.3", path = "../protocol" }
 microsandbox-utils = { version = "0.5.3", path = "../utils" }
-msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "appcypher/raise-boot-cmdline-limits", features = ["net"] }
+msb_krun = { version = "0.1.14", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"
 percent-encoding = "2"

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -27,7 +27,7 @@ libc = { workspace = true }
 lru = { workspace = true }
 microsandbox-protocol = { version = "0.5.3", path = "../protocol" }
 microsandbox-utils = { version = "0.5.3", path = "../utils" }
-msb_krun = { version = "0.1.13", features = ["net"] }
+msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "appcypher/raise-boot-cmdline-limits", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"
 percent-encoding = "2"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -28,7 +28,7 @@ microsandbox-metrics = { version = "0.5.3", path = "../metrics" }
 microsandbox-network = { version = "0.5.3", path = "../network", optional = true }
 microsandbox-protocol = { version = "0.5.3", path = "../protocol" }
 microsandbox-utils = { version = "0.5.3", path = "../utils" }
-msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "appcypher/raise-boot-cmdline-limits", features = ["blk"] }
+msb_krun = { version = "0.1.14", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }
 sea-orm.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -28,7 +28,7 @@ microsandbox-metrics = { version = "0.5.3", path = "../metrics" }
 microsandbox-network = { version = "0.5.3", path = "../network", optional = true }
 microsandbox-protocol = { version = "0.5.3", path = "../protocol" }
 microsandbox-utils = { version = "0.5.3", path = "../utils" }
-msb_krun = { version = "0.1.13", features = ["blk"] }
+msb_krun = { git = "https://github.com/superradcompany/libkrun.git", branch = "appcypher/raise-boot-cmdline-limits", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }
 sea-orm.workspace = true


### PR DESCRIPTION
## TL;DR
Use the released libkrun and merged libkrunfw boot-argument limit fixes in microsandbox, so larger startup env payloads can boot reliably.

## Description
- Point microsandbox at crates.io `msb_krun` 0.1.14 instead of the temporary libkrun fix branch.
- Update `vendor/libkrunfw` to the merged firmware fix commit from [superradcompany/libkrunfw#8](https://github.com/superradcompany/libkrunfw/pull/8).
- Pull in the VMM command-line limit fix from [superradcompany/libkrun#57](https://github.com/superradcompany/libkrun/pull/57) through the published 0.1.14 crate release from [superradcompany/libkrun#58](https://github.com/superradcompany/libkrun/pull/58).
- Keep the VMM byte limit, guest kernel command-line limit, and guest init env/arg limit aligned while microsandbox boot config still travels through the kernel command line.
- Closes #844.

## Test Plan
- [x] `cargo build --no-default-features --features net,ssh -p microsandbox-cli` exits 0 with crates.io `msb_krun` 0.1.14.
- [x] Commit hook passes workspace `cargo fmt`, workspace `cargo clippy`, agentd `cargo fmt`, agentd `cargo clippy`, workspace `cargo doc`, and `cargo build (msb)`.
- [x] Rebuilt the patched arm64 libkrunfw kernel in Docker and linked the macOS `libkrunfw.5.dylib`.
- [x] Signed `build/msb`, copied the corrected `libkrunfw.5.dylib` into `build/`, and confirmed a 5 KB env value VM run prints `5000`.
- [x] Confirmed a 64 env entry VM run prints `64`.
