### PR TITLE
fix(runtime): prevent idle timeout restart races

### DIFF
--- a/crates/runtime/lib/heartbeat.rs
+++ b/crates/runtime/lib/heartbeat.rs
@@ -10,6 +10,13 @@ use chrono::Utc;
 use microsandbox_protocol::heartbeat::Heartbeat;
 
 //--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const HEARTBEAT_FILE: &str = "heartbeat.json";
+const HEARTBEAT_TMP_FILE: &str = "heartbeat.tmp";
+
+//--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
 
@@ -27,7 +34,7 @@ impl HeartbeatReader {
     /// Create a new heartbeat reader for the given runtime directory.
     pub fn new(runtime_dir: &Path) -> Self {
         Self {
-            path: runtime_dir.join("heartbeat.json"),
+            path: runtime_dir.join(HEARTBEAT_FILE),
         }
     }
 
@@ -55,5 +62,61 @@ impl HeartbeatReader {
             .num_seconds();
 
         elapsed >= 0 && elapsed as u64 >= timeout_secs
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Clear heartbeat files from a previous sandbox run.
+pub fn clear_stale(runtime_dir: &Path) -> std::io::Result<()> {
+    remove_file_if_exists(&runtime_dir.join(HEARTBEAT_FILE))?;
+    remove_file_if_exists(&runtime_dir.join(HEARTBEAT_TMP_FILE))?;
+    Ok(())
+}
+
+fn remove_file_if_exists(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Duration, Utc};
+    use microsandbox_protocol::heartbeat::Heartbeat;
+
+    use super::*;
+
+    #[test]
+    fn clear_stale_removes_previous_run_heartbeat_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let heartbeat_path = dir.path().join(HEARTBEAT_FILE);
+        let tmp_path = dir.path().join(HEARTBEAT_TMP_FILE);
+        let stale_time = Utc::now() - Duration::seconds(120);
+        let heartbeat = Heartbeat {
+            timestamp: stale_time,
+            active_sessions: 0,
+            last_activity: stale_time,
+        };
+
+        std::fs::write(&heartbeat_path, serde_json::to_vec(&heartbeat).unwrap()).unwrap();
+        std::fs::write(&tmp_path, b"stale").unwrap();
+
+        let reader = HeartbeatReader::new(dir.path());
+        assert!(reader.is_idle(60));
+
+        clear_stale(dir.path()).unwrap();
+
+        assert!(!heartbeat_path.exists());
+        assert!(!tmp_path.exists());
+        assert!(!reader.is_idle(60));
     }
 }

--- a/crates/runtime/lib/relay.rs
+++ b/crates/runtime/lib/relay.rs
@@ -516,7 +516,10 @@ fn poll_fd_readable_timeout(fd: RawFd, timeout_ms: i32) {
     }
 }
 
-fn push_guest_frame_blocking(shared: &ConsoleSharedState, mut frame: Vec<u8>) -> RuntimeResult<()> {
+pub(crate) fn push_guest_frame_blocking(
+    shared: &ConsoleSharedState,
+    mut frame: Vec<u8>,
+) -> RuntimeResult<()> {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
 
     loop {
@@ -529,7 +532,7 @@ fn push_guest_frame_blocking(shared: &ConsoleSharedState, mut frame: Vec<u8>) ->
                 frame = returned;
                 if std::time::Instant::now() >= deadline {
                     return Err(RuntimeError::Custom(
-                        "timed out sending init ack to agentd".into(),
+                        "timed out sending frame to agentd".into(),
                     ));
                 }
                 std::thread::sleep(std::time::Duration::from_millis(1));

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -19,15 +19,19 @@ use microsandbox_filesystem::{
     StatVirtualization,
 };
 use microsandbox_metrics::{ActivateSlot, MetricsRegistry, ReleaseMode};
+use microsandbox_protocol::{
+    codec,
+    message::{Message, MessageType},
+};
 use msb_krun::VmBuilder;
 use sea_orm::{ColumnTrait, EntityTrait, Set};
 use serde::Serialize;
 
 use crate::console::{AgentConsoleBackend, ConsoleSharedState};
-use crate::heartbeat::HeartbeatReader;
+use crate::heartbeat::{self, HeartbeatReader};
 use crate::logging::LogLevel;
 use crate::metrics::run_metrics_sampler;
-use crate::relay::AgentRelay;
+use crate::relay::{self, AgentRelay};
 use crate::{RuntimeError, RuntimeResult};
 
 //--------------------------------------------------------------------------------------------------
@@ -348,6 +352,8 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     // Set up runtime directory.
     std::fs::create_dir_all(&config.runtime_dir)?;
     std::fs::create_dir_all(config.runtime_dir.join("scripts"))?;
+    // Heartbeats are per boot, while the runtime directory persists across starts.
+    heartbeat::clear_stale(&config.runtime_dir)?;
 
     // Create the relay and persist the run record with a single runtime hop.
     let (mut relay, db, run_db_id) = tokio_rt.block_on(async {
@@ -604,16 +610,31 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         let heartbeat_reader = HeartbeatReader::new(&config.runtime_dir);
         let idle_exit_handle = exit_handle.clone();
         let idle_reason = Arc::clone(&exit_reason);
+        let idle_shared = Arc::clone(&shared);
         tokio_rt.spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(1));
             loop {
                 interval.tick().await;
                 if heartbeat_reader.is_idle(idle_secs) {
-                    tracing::info!("sandbox idle for {idle_secs}s, triggering exit");
+                    tracing::info!("sandbox idle for {idle_secs}s, requesting guest shutdown");
                     idle_reason.store(
                         EXIT_REASON_IDLE_TIMEOUT,
                         std::sync::atomic::Ordering::SeqCst,
                     );
+                    match request_guest_shutdown(&idle_shared) {
+                        Ok(()) => {
+                            tokio::time::sleep(microsandbox_protocol::SHUTDOWN_FLUSH_TIMEOUT).await;
+                            tracing::info!(
+                                "idle shutdown flush window elapsed, triggering host exit"
+                            );
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                error = %err,
+                                "idle shutdown request failed, triggering host exit"
+                            );
+                        }
+                    }
                     idle_exit_handle.trigger();
                     break;
                 }
@@ -1081,6 +1102,16 @@ async fn mark_run_failed(db: &DbWriteConnection, run_id: i32) -> RuntimeResult<(
     Ok(())
 }
 
+/// Request guest poweroff through agentd without requiring a client connection.
+fn request_guest_shutdown(shared: &ConsoleSharedState) -> RuntimeResult<()> {
+    let msg = Message::with_payload(MessageType::Shutdown, 0, &())
+        .map_err(|e| RuntimeError::Custom(format!("encode idle shutdown: {e}")))?;
+    let mut frame = Vec::new();
+    codec::encode_to_buf(&msg, &mut frame)
+        .map_err(|e| RuntimeError::Custom(format!("encode idle shutdown frame: {e}")))?;
+    relay::push_guest_frame_blocking(shared, frame)
+}
+
 /// Create a pipe pair, returning `(read_end, write_end)` as `OwnedFd`.
 fn create_pipe() -> RuntimeResult<(OwnedFd, OwnedFd)> {
     let mut fds = [0i32; 2];
@@ -1324,10 +1355,12 @@ pub fn prepend_scripts_path(env: &mut Vec<String>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        BindIdentityMapRegistration, HostPermissions, StatVirtualization, append_block_root_env,
-        bind_identity_map_for_mount, parse_mount_spec, prepend_scripts_path, validate_disk_format,
+        BindIdentityMapRegistration, ConsoleSharedState, HostPermissions, StatVirtualization,
+        append_block_root_env, bind_identity_map_for_mount, parse_mount_spec, prepend_scripts_path,
+        request_guest_shutdown, validate_disk_format,
     };
 
+    use microsandbox_protocol::{codec, message::MessageType};
     use std::sync::Arc;
 
     #[test]
@@ -1434,6 +1467,18 @@ mod tests {
         assert!(Arc::ptr_eq(&first, &second));
         assert!(off.is_none());
         assert_eq!(registration.mount_count, 2);
+    }
+
+    #[test]
+    fn test_request_guest_shutdown_enqueues_shutdown_frame() {
+        let shared = ConsoleSharedState::new();
+
+        request_guest_shutdown(&shared).unwrap();
+
+        let mut frame = shared.rx_ring.pop().unwrap();
+        let msg = codec::try_decode_from_buf(&mut frame).unwrap().unwrap();
+        assert_eq!(msg.t, MessageType::Shutdown);
+        assert_eq!(msg.id, 0);
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR
Fix idle-timeout restarts so a stale heartbeat from the previous run cannot stop the next VM before agentd reports `core.ready`.

## Description
- Clear per-boot heartbeat files before each sandbox start, since the runtime directory persists across starts.
- Send idle-timeout shutdown through agentd first, so the guest can flush state before the host exit fallback runs.
- Reuse the relay frame enqueue path for runtime-originated shutdown frames without requiring an attached client.
- Add unit coverage for stale heartbeat cleanup and idle shutdown frame enqueueing.
- Closes #837.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p microsandbox-runtime --lib`
- [x] `cargo clippy -p microsandbox-runtime --lib -- -D warnings`
- [x] `git diff --check`
- [x] Delayed-ready repro with the pre-fix binary exits before the agent relay receives `core.ready`.
- [x] Delayed-ready repro with the fixed binary restarts successfully and receives `core.ready`.