### PR TITLE
fix(metrics): improve msb-metrics reporting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,13 @@ jobs:
           mkdir -p build
           cp target/release/msb build/msb
 
+      # -- msb-metrics --
+      - name: Build msb-metrics
+        run: |
+          cargo build --release -p microsandbox-metrics-collector
+          mkdir -p build
+          cp target/release/msb-metrics build/msb-metrics
+
       # -- Go FFI cdylib --
       - name: Build microsandbox-go
         run: |
@@ -288,6 +295,9 @@ jobs:
 
           # Standalone msb
           cp build/msb artifacts/msb-${{ matrix.target }}
+
+          # Standalone msb-metrics
+          cp build/msb-metrics artifacts/msb-metrics-${{ matrix.target }}
 
           # Standalone libkrunfw
           cp build/${{ matrix.libkrunfw_file }} artifacts/${{ matrix.libkrunfw_asset }}
@@ -579,6 +589,7 @@ jobs:
             microsandbox-filesystem \
             microsandbox-network \
             microsandbox-metrics \
+            microsandbox-metrics-collector \
             microsandbox-runtime \
             microsandbox \
             microsandbox-cli; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics-collector"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/metrics-collector/lib/exporters/otel.rs
+++ b/crates/metrics-collector/lib/exporters/otel.rs
@@ -94,9 +94,8 @@ pub enum OtlpProtocol {
 /// Optional payload compression for OTLP exports.
 ///
 /// Compression is only wired through on the gRPC transport in
-/// `opentelemetry-otlp` 0.27; HTTP/Protobuf currently has no
-/// `with_compression` hook. Selecting [`OtlpCompression::Gzip`] together
-/// with [`OtlpProtocol::HttpProtobuf`] returns a build-time error.
+/// the current HTTP/Protobuf build. Selecting [`OtlpCompression::Gzip`]
+/// together with [`OtlpProtocol::HttpProtobuf`] returns a build-time error.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum OtlpCompression {
     /// No compression. Default; preserves prior behavior.
@@ -251,9 +250,8 @@ impl OtelExporterBuilder {
     /// OTLP endpoint. Added on top of webpki roots, so a corporate gateway
     /// signed by a private CA works without disabling system trust.
     ///
-    /// gRPC only — the `opentelemetry-otlp` 0.27 HTTP transport does not
-    /// expose a TLS configuration hook. Passing this with `--protocol=http`
-    /// is rejected at build time.
+    /// gRPC only — the HTTP transport does not expose a TLS configuration
+    /// hook. Passing this with `--protocol=http` is rejected at build time.
     pub fn ca_cert_pem(mut self, pem: impl Into<Vec<u8>>) -> Self {
         self.ca_cert_pem = Some(pem.into());
         self
@@ -374,46 +372,27 @@ impl MetricsExporter for OtelExporter {
                     .add(batch.dropped_collection_count, &[]);
             }
 
+            if batch.collections.is_empty() {
+                let result = export_recorded_metrics(&reader, &otlp).await;
+                record_export_outcome(&self_instruments, &result);
+                return result;
+            }
+
+            // Synchronous OTel gauges use LastValue aggregation. Record and
+            // export one collection at a time so a buffered flush preserves
+            // every collected sample instead of collapsing to the final value.
             for collection in &batch.collections {
                 for snapshot in &collection.sandboxes {
                     let attrs = build_attributes(snapshot, &identity);
                     record_snapshot(&instruments, snapshot, &attrs);
                 }
+
+                let result = export_recorded_metrics(&reader, &otlp).await;
+                record_export_outcome(&self_instruments, &result);
+                result?;
             }
 
-            // Pull what we just recorded out of the SDK pipeline and ship it.
-            // `ManualReader::collect` populates resource + scope_metrics
-            // synchronously (cheap memory copy); `PushMetricExporter::export`
-            // is genuinely async on the OTLP transport.
-            let mut rm = ResourceMetrics::default();
-            let collect_result = reader.collect(&mut rm).map_err(|e| {
-                MetricsCollectorError::Custom(format!("otel reader.collect failed: {e}"))
-            });
-            let result = match collect_result {
-                Ok(()) => otlp.export(&rm).await.map_err(|e| {
-                    MetricsCollectorError::Custom(format!("otel exporter.export failed: {e}"))
-                }),
-                Err(e) => Err(e),
-            };
-
-            // Record outcome after the transport call; the values ship on
-            // the next successful export. Cumulative counters preserve
-            // the total even if the current export failed.
-            match &result {
-                Ok(()) => {
-                    self_instruments.exports_success.add(1, &[]);
-                    if let Ok(now) =
-                        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)
-                    {
-                        self_instruments
-                            .last_success_timestamp
-                            .record(now.as_secs_f64(), &[]);
-                    }
-                }
-                Err(_) => self_instruments.exports_failure.add(1, &[]),
-            }
-
-            result
+            Ok(())
         })
     }
 
@@ -444,7 +423,7 @@ fn build_otlp_exporter(
     if matches!(protocol, OtlpProtocol::HttpProtobuf) && ca_cert_pem.is_some() {
         return Err(MetricsCollectorError::InvalidConfig(
             "custom CA certificate is currently supported only with --protocol=grpc; \
-             opentelemetry-otlp 0.27 has no TLS configuration hook on the HTTP transport"
+             opentelemetry-otlp has no TLS configuration hook on the HTTP transport"
                 .into(),
         ));
     }
@@ -453,7 +432,7 @@ fn build_otlp_exporter(
     {
         return Err(MetricsCollectorError::InvalidConfig(
             "gzip compression is currently supported only with --protocol=grpc; \
-             opentelemetry-otlp 0.27 has no with_compression hook on the HTTP transport"
+             the HTTP transport was not built with gzip support"
                 .into(),
         ));
     }
@@ -482,6 +461,39 @@ fn build_otlp_exporter(
             .build(),
     };
     result.map_err(|e| MetricsCollectorError::Custom(format!("otel exporter build failed: {e}")))
+}
+
+/// Pull recorded points out of the SDK pipeline and ship them. `collect`
+/// populates resource + scope metrics synchronously; the OTLP transport export
+/// is async.
+async fn export_recorded_metrics(
+    reader: &SharedManualReader,
+    otlp: &OtlpMetricExporter,
+) -> MetricsCollectorResult<()> {
+    let mut rm = ResourceMetrics::default();
+    reader
+        .collect(&mut rm)
+        .map_err(|e| MetricsCollectorError::Custom(format!("otel reader.collect failed: {e}")))?;
+    otlp.export(&rm)
+        .await
+        .map_err(|e| MetricsCollectorError::Custom(format!("otel exporter.export failed: {e}")))?;
+    Ok(())
+}
+
+/// Record exporter self-observability after the transport returns. These
+/// cumulative points ship on the next successful OTLP request.
+fn record_export_outcome(instruments: &SelfInstruments, result: &MetricsCollectorResult<()>) {
+    match result {
+        Ok(()) => {
+            instruments.exports_success.add(1, &[]);
+            if let Ok(now) = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+                instruments
+                    .last_success_timestamp
+                    .record(now.as_secs_f64(), &[]);
+            }
+        }
+        Err(_) => instruments.exports_failure.add(1, &[]),
+    }
 }
 
 /// Apply caller-supplied `--header k=v` pairs by writing them into the

--- a/crates/metrics-collector/lib/lib.rs
+++ b/crates/metrics-collector/lib/lib.rs
@@ -2,8 +2,8 @@
 //! metrics registry, buffers per-exporter, and fans batches out to
 //! registered exporters.
 //!
-//! See `docs/msb-metrics-binary-plan.md` for the architecture and the
-//! `msb-metrics` binary that ships in this crate's `bin/main.rs`.
+//! See `docs/observability/msb-metrics.mdx` for the user-facing overview and
+//! the `msb-metrics` binary that ships in this crate's `bin/main.rs`.
 //!
 //! # Lifecycle
 //!

--- a/crates/metrics-collector/tests/otel_exporter.rs
+++ b/crates/metrics-collector/tests/otel_exporter.rs
@@ -40,7 +40,7 @@ async fn grpc_gzip_builds() {
             .compression(OtlpCompression::Gzip)
             .build()
             .is_ok(),
-        "gRPC + gzip is supported in opentelemetry-otlp 0.27"
+        "gRPC + gzip is supported by the configured opentelemetry-otlp build"
     );
 }
 

--- a/docs/changelog/2026-05-15.mdx
+++ b/docs/changelog/2026-05-15.mdx
@@ -50,7 +50,7 @@ msb run debian:12 \
   --init-env container=microsandbox
 ```
 
-See the [systemd services recipe](/recipes/systemd-services).
+See the [systemd services recipe](/recipes/guest/systemd-services).
 
 **Exec logs and structured boot errors**
 

--- a/docs/observability/deep-dive.mdx
+++ b/docs/observability/deep-dive.mdx
@@ -177,9 +177,9 @@ msb-metrics otel --endpoint=<URL>
 
 | Flag | Default | Notes |
 |---|---|---|
-| `--endpoint` | (required) | OTLP endpoint URL. |
-| `--protocol` | `grpc` | `grpc` (port `4317`) or `http` (Protobuf body, port `4318`). |
-| `--compression` | `none` | `gzip` or `none`. gRPC-only in `opentelemetry-otlp` 0.27; rejected at startup with `--protocol=http`. Meaningful bandwidth saving for direct provider gateways over public internet. |
+| `--endpoint` | (required) | OTLP endpoint URL. With `--protocol=http`, pass the complete metrics signal URL (usually ending in `/v1/metrics`). |
+| `--protocol` | `grpc` | `grpc` (port `4317`) or `http` (Protobuf body, port `4318`). HTTP endpoints are used exactly as provided. |
+| `--compression` | `none` | `gzip` or `none`. gRPC-only in the current build; rejected at startup with `--protocol=http`. Meaningful bandwidth saving for direct provider gateways over public internet. |
 | `--ca-cert` | none | Path to a PEM-encoded CA certificate to trust when negotiating TLS. Added on top of webpki roots, so a corporate gateway signed by a private CA works without disabling system trust. gRPC only; rejected at startup with `--protocol=http`. |
 | `--header` | none | `KEY=VALUE`, repeatable. For auth (`Authorization`, `api-key`, etc.). Applied via `OTEL_EXPORTER_OTLP_HEADERS`. |
 | `--resource` | none | `KEY=VALUE`, repeatable. Overrides or adds OTel resource attributes. |
@@ -283,8 +283,9 @@ lands. This is normal counter-reset behavior, not a bug.
   <Accordion title="OTLP backend rejects the request (HTTP 401/403/422)">
     Auth or schema mismatch. Verify the `--header` value (especially
     `Authorization` base64 encoding) and that the endpoint URL matches
-    the protocol. gRPC endpoints typically end at `4317`, HTTP/Protobuf
-    at `4318` with an explicit `/v1/metrics` path on some backends.
+    the protocol. gRPC endpoints typically end at `4317`; HTTP/Protobuf
+    endpoints should be the full metrics URL expected by that backend
+    (often `/v1/metrics`, but deployments can route it differently).
   </Accordion>
 
   <Accordion title="Sandbox restarts produce fresh time series">

--- a/docs/observability/msb-metrics.mdx
+++ b/docs/observability/msb-metrics.mdx
@@ -78,7 +78,7 @@ and place it on your `PATH`.
         Cloud's OTLP gateway over HTTPS).
 
         ```sh
-        msb-metrics otel --endpoint=https://example.com/otlp --protocol=http
+        msb-metrics otel --endpoint=https://example.com/otlp/v1/metrics --protocol=http
         ```
       </Tab>
     </Tabs>

--- a/docs/recipes/docker/docker-in-sandbox.mdx
+++ b/docs/recipes/docker/docker-in-sandbox.mdx
@@ -119,4 +119,4 @@ msb rm -f docker-demo
 - **Tmpfs sizing.** `/tmp` is 1 GiB here. Increase `--tmpfs /tmp:N` if you plan to pull larger images.
 - **Named volumes don't fix this.** They are virtiofs-backed host directories, and Docker's overlay snapshotter can't use those for `upperdir` / `workdir`.
 - **Disk-image-backed volumes.** The SDKs can already mount host disk images as virtio-blk devices. Once the CLI has a first-class `msb volume` flow for disk images, Docker's data root can sit on a real block device and survive sandbox removal.
-- **Not the same as [Sandbox in Docker](/recipes/docker).** That recipe covers the opposite direction.
+- **Not the same as [Sandbox in Docker](/recipes/docker/docker).** That recipe covers the opposite direction.

--- a/docs/recipes/metrics-backends/grafana-cloud.mdx
+++ b/docs/recipes/metrics-backends/grafana-cloud.mdx
@@ -40,12 +40,14 @@ to it using HTTP/Protobuf and Basic auth.
   <Step title="Run msb-metrics">
     ```sh
     msb-metrics otel \
-      --endpoint=https://otlp-gateway-prod-us-east-2.grafana.net/otlp \
+      --endpoint=https://otlp-gateway-prod-us-east-2.grafana.net/otlp/v1/metrics \
       --protocol=http \
       --header="Authorization=${AUTH}"
     ```
 
-    Sub the region in the URL for yours.
+    Sub the region in the URL for yours. If Grafana shows you the base
+    OTLP URL ending in `/otlp`, append `/v1/metrics` for this HTTP
+    metrics-only exporter.
   </Step>
 
   <Step title="Verify">

--- a/docs/recipes/metrics-backends/prometheus.mdx
+++ b/docs/recipes/metrics-backends/prometheus.mdx
@@ -37,12 +37,12 @@ the OTLP endpoint at Prometheus's `/api/v1/otlp/v1/metrics` path and the
 
     ```sh
     msb-metrics otel \
-      --endpoint=http://localhost:9090/api/v1/otlp \
+      --endpoint=http://localhost:9090/api/v1/otlp/v1/metrics \
       --protocol=http
     ```
 
-    The `/v1/metrics` path is appended automatically by the OTLP HTTP
-    client.
+    Pass the full receiver path. `msb-metrics` uses HTTP endpoints
+    exactly as provided.
   </Step>
 
   <Step title="Verify">


### PR DESCRIPTION
## TL;DR
Fixes follow-ups from the merged `msb-metrics` sidecar PR so HTTP OTLP endpoints are explicit, buffered gauge samples are preserved, and releases actually ship the new binary.

## Description
- Export buffered OTLP gauge collections one collection at a time so OTel LastValue aggregation does not collapse a flush down to only the final sample.
- Keep HTTP OTLP endpoints exact as provided, and update docs/examples to show full metrics URLs such as `/v1/metrics` or Prometheus's `/api/v1/otlp/v1/metrics`.
- Build and stage `msb-metrics` in the release workflow, and include `microsandbox-metrics-collector` in the crates.io publish list.
- Fix stale docs links left behind by recipe path moves and remove stale internal doc/version references.

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test -p microsandbox-metrics-collector`
- `cargo build --release -p microsandbox-metrics-collector`
- Pre-commit hook also passed workspace clippy/docs, agentd checks, and `cargo build (msb)`.