### PR TITLE
feat(image): add archive load and save support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -400,6 +400,7 @@ jobs:
       - name: Run CLI smoke tests
         run: |
           chmod +x build/msb
+          scripts/smoke/cli/image-archive.sh
           scripts/smoke/cli/split-irqchip-bind-net.sh
 
   # ---------------------------------------------------------------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,7 @@ dependencies = [
  "russh",
  "serde",
  "serde_json",
+ "tempfile",
  "test-utils",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -53,6 +53,7 @@ rpassword.workspace = true
 russh = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 thiserror = { workspace = true, optional = true }
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -86,6 +86,12 @@ enum Commands {
     /// Download an image from a registry.
     Pull(pull::PullArgs),
 
+    /// Load an image archive from tar.
+    Load(image::ImageLoadArgs),
+
+    /// Save one or more cached images to a tar archive.
+    Save(image::ImageSaveArgs),
+
     /// Manage registry credentials.
     Registry(registry::RegistryArgs),
 
@@ -322,6 +328,8 @@ fn run_async_command_anyhow(
             Commands::Logs(args) => logs::run(args).await,
             Commands::Image(args) => image::run(args).await,
             Commands::Pull(args) => image::run_pull(args).await,
+            Commands::Load(args) => image::run_load(args).await,
+            Commands::Save(args) => image::run_save(args).await,
             Commands::Registry(args) => registry::run(args).await,
             #[cfg(feature = "ssh")]
             Commands::Ssh(args) => microsandbox_cli::commands::ssh::run(args).await,

--- a/crates/cli/lib/commands/image.rs
+++ b/crates/cli/lib/commands/image.rs
@@ -1,12 +1,18 @@
 //! `msb image` command — manage OCI images.
 
+use std::collections::BTreeMap;
+use std::io::{self, Write};
+use std::path::PathBuf;
 use std::sync::{Arc, mpsc};
 use std::time::Instant;
 
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use console::style;
-use microsandbox::image::Image;
-use microsandbox_image::Registry;
+use microsandbox::image::{Image, ImageConfigDetail};
+use microsandbox_image::{
+    ImageArchiveFormat, ImageLoadOptions, ImageSaveConfig, ImageSaveLayer, ImageSaveRequest,
+    Registry,
+};
 
 use crate::ui;
 
@@ -37,6 +43,12 @@ pub enum ImageCommands {
     /// Show detailed image information.
     Inspect(ImageInspectArgs),
 
+    /// Load an image archive from tar.
+    Load(ImageLoadArgs),
+
+    /// Save one or more cached images to a tar archive.
+    Save(ImageSaveArgs),
+
     /// Delete one or more cached images.
     #[command(visible_alias = "rm")]
     Remove(ImageRemoveArgs),
@@ -63,6 +75,51 @@ pub struct ImageInspectArgs {
     /// Output format (json).
     #[arg(long, value_name = "FORMAT", value_parser = ["json"])]
     pub format: Option<String>,
+}
+
+/// Arguments for `msb image load`.
+#[derive(Debug, Args)]
+pub struct ImageLoadArgs {
+    /// Read archive from a tar file instead of stdin.
+    #[arg(short, long, value_name = "PATH")]
+    pub input: Option<PathBuf>,
+
+    /// Add a local image reference to the first imported image.
+    #[arg(short, long, value_name = "REF")]
+    pub tag: Vec<String>,
+
+    /// Suppress output.
+    #[arg(short, long)]
+    pub quiet: bool,
+}
+
+/// Arguments for `msb image save`.
+#[derive(Debug, Args)]
+pub struct ImageSaveArgs {
+    /// Image reference(s) to save.
+    #[arg(required = true)]
+    pub references: Vec<String>,
+
+    /// Archive format to write.
+    #[arg(long, value_enum, default_value = "docker")]
+    pub format: ImageSaveFormat,
+
+    /// Write archive to a tar file instead of stdout.
+    #[arg(short, long, value_name = "PATH")]
+    pub output: Option<PathBuf>,
+
+    /// Suppress output.
+    #[arg(short, long)]
+    pub quiet: bool,
+}
+
+/// Archive format for `msb image save`.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ImageSaveFormat {
+    /// Docker `docker save` compatible archive.
+    Docker,
+    /// OCI Image Layout archive.
+    Oci,
 }
 
 /// Arguments for `msb image remove`.
@@ -101,6 +158,8 @@ pub async fn run(args: ImageArgs) -> anyhow::Result<()> {
         }
         ImageCommands::List(args) => run_list(args).await,
         ImageCommands::Inspect(args) => run_inspect(args).await,
+        ImageCommands::Load(args) => run_load(args).await,
+        ImageCommands::Save(args) => run_save(args).await,
         ImageCommands::Remove(args) => run_remove(args).await,
     }
 }
@@ -495,6 +554,114 @@ pub async fn run_inspect(args: ImageInspectArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Execute `msb image load` / `msb load`.
+pub async fn run_load(args: ImageLoadArgs) -> anyhow::Result<()> {
+    let global = microsandbox::config::config();
+    let cache_dir = global.cache_dir();
+    let temp_input;
+    let input_path = if let Some(path) = args.input.as_ref() {
+        path
+    } else {
+        temp_input = tempfile::NamedTempFile::new()?;
+        let mut input = io::stdin().lock();
+        let mut output = temp_input.reopen()?;
+        io::copy(&mut input, &mut output)?;
+        output.flush()?;
+        temp_input.path()
+    };
+
+    let loaded = microsandbox_image::load_archive(
+        &cache_dir,
+        input_path,
+        ImageLoadOptions {
+            tags: args.tag.clone(),
+        },
+    )
+    .await?;
+
+    for image in &loaded {
+        Image::persist(&image.reference, image.metadata.clone()).await?;
+    }
+
+    if !args.quiet {
+        for image in &loaded {
+            eprintln!(
+                "   {} {:<12} {}",
+                style("✓").green(),
+                "Loaded",
+                image.reference
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute `msb image save` / `msb save`.
+pub async fn run_save(args: ImageSaveArgs) -> anyhow::Result<()> {
+    let global = microsandbox::config::config();
+    let cache_dir = global.cache_dir();
+    let mut requests = Vec::with_capacity(args.references.len());
+
+    for reference in &args.references {
+        let detail = Image::inspect(reference).await?;
+        let config = save_config_from_detail(
+            detail.handle.architecture().map(ToOwned::to_owned),
+            detail.handle.os().map(ToOwned::to_owned),
+            detail.config.as_ref(),
+        );
+        let layers = detail
+            .layers
+            .iter()
+            .map(|layer| ImageSaveLayer {
+                diff_id: layer.diff_id.clone(),
+            })
+            .collect();
+
+        requests.push(ImageSaveRequest {
+            reference: reference.clone(),
+            config,
+            layers,
+        });
+    }
+
+    let temp_output;
+    let output_path = if let Some(path) = args.output.as_ref() {
+        path
+    } else {
+        temp_output = tempfile::NamedTempFile::new()?;
+        temp_output.path()
+    };
+    let output_path_for_task = output_path.to_path_buf();
+    let format = match args.format {
+        ImageSaveFormat::Docker => ImageArchiveFormat::Docker,
+        ImageSaveFormat::Oci => ImageArchiveFormat::Oci,
+    };
+
+    tokio::task::spawn_blocking(move || {
+        let cache = microsandbox_image::GlobalCache::new(&cache_dir)?;
+        microsandbox_image::save_archive(&cache, &output_path_for_task, &requests, format)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("save task panicked: {e}"))??;
+
+    if args.output.is_none() {
+        let mut file = std::fs::File::open(output_path)?;
+        let mut stdout = io::stdout().lock();
+        io::copy(&mut file, &mut stdout)?;
+        stdout.flush()?;
+    } else if !args.quiet {
+        eprintln!(
+            "   {} {:<12} {}",
+            style("✓").green(),
+            "Saved",
+            output_path.display()
+        );
+    }
+
+    Ok(())
+}
+
 /// Execute `msb image rm` / `msb rmi`.
 pub async fn run_remove(args: ImageRemoveArgs) -> anyhow::Result<()> {
     let mut failed = false;
@@ -550,4 +717,46 @@ fn truncate_digest(digest: &str) -> String {
     } else {
         digest.chars().take(19).collect()
     }
+}
+
+fn save_config_from_detail(
+    architecture: Option<String>,
+    os: Option<String>,
+    config: Option<&ImageConfigDetail>,
+) -> ImageSaveConfig {
+    let Some(config) = config else {
+        return ImageSaveConfig {
+            architecture,
+            os,
+            ..Default::default()
+        };
+    };
+
+    ImageSaveConfig {
+        architecture,
+        os,
+        env: config.env.clone(),
+        entrypoint: config.entrypoint.clone(),
+        cmd: config.cmd.clone(),
+        working_dir: config.working_dir.clone(),
+        user: config.user.clone(),
+        labels: labels_to_string_map(config.labels.as_ref()),
+    }
+}
+
+fn labels_to_string_map(labels: Option<&serde_json::Value>) -> BTreeMap<String, String> {
+    let Some(serde_json::Value::Object(labels)) = labels else {
+        return BTreeMap::new();
+    };
+
+    labels
+        .iter()
+        .map(|(key, value)| {
+            let value = value
+                .as_str()
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| value.to_string());
+            (key.clone(), value)
+        })
+        .collect()
 }

--- a/crates/cli/lib/commands/image.rs
+++ b/crates/cli/lib/commands/image.rs
@@ -1,6 +1,5 @@
 //! `msb image` command — manage OCI images.
 
-use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, mpsc};
@@ -8,10 +7,10 @@ use std::time::Instant;
 
 use clap::{Args, Subcommand, ValueEnum};
 use console::style;
-use microsandbox::image::{Image, ImageConfigDetail};
+use microsandbox::image::Image;
 use microsandbox_image::{
-    ImageArchiveFormat, ImageLoadOptions, ImageSaveConfig, ImageSaveLayer, ImageSaveRequest,
-    Registry,
+    CachedImageMetadata, ImageArchiveFormat, ImageLoadOptions, ImageSaveConfig, ImageSaveLayer,
+    ImageSaveRequest, Registry,
 };
 
 use crate::ui;
@@ -601,16 +600,16 @@ pub async fn run_load(args: ImageLoadArgs) -> anyhow::Result<()> {
 pub async fn run_save(args: ImageSaveArgs) -> anyhow::Result<()> {
     let global = microsandbox::config::config();
     let cache_dir = global.cache_dir();
+    let cache = microsandbox_image::GlobalCache::new(&cache_dir)?;
     let mut requests = Vec::with_capacity(args.references.len());
 
     for reference in &args.references {
-        let detail = Image::inspect(reference).await?;
-        let config = save_config_from_detail(
-            detail.handle.architecture().map(ToOwned::to_owned),
-            detail.handle.os().map(ToOwned::to_owned),
-            detail.config.as_ref(),
-        );
-        let layers = detail
+        let parsed: microsandbox_image::Reference = reference.parse()?;
+        let metadata = cache
+            .read_image_metadata(&parsed)?
+            .ok_or_else(|| anyhow::anyhow!("image metadata not cached: {reference}"))?;
+        let config = save_config_from_metadata(&metadata);
+        let layers = metadata
             .layers
             .iter()
             .map(|layer| ImageSaveLayer {
@@ -621,6 +620,7 @@ pub async fn run_save(args: ImageSaveArgs) -> anyhow::Result<()> {
         requests.push(ImageSaveRequest {
             reference: reference.clone(),
             config,
+            raw_config_json: metadata.raw_config_json,
             layers,
         });
     }
@@ -719,44 +719,39 @@ fn truncate_digest(digest: &str) -> String {
     }
 }
 
-fn save_config_from_detail(
-    architecture: Option<String>,
-    os: Option<String>,
-    config: Option<&ImageConfigDetail>,
-) -> ImageSaveConfig {
-    let Some(config) = config else {
-        return ImageSaveConfig {
-            architecture,
-            os,
-            ..Default::default()
-        };
-    };
+fn save_config_from_metadata(metadata: &CachedImageMetadata) -> ImageSaveConfig {
+    let (architecture, os) = raw_config_platform(&metadata.raw_config_json);
 
     ImageSaveConfig {
         architecture,
         os,
-        env: config.env.clone(),
-        entrypoint: config.entrypoint.clone(),
-        cmd: config.cmd.clone(),
-        working_dir: config.working_dir.clone(),
-        user: config.user.clone(),
-        labels: labels_to_string_map(config.labels.as_ref()),
+        env: metadata.config.env.clone(),
+        entrypoint: metadata.config.entrypoint.clone(),
+        cmd: metadata.config.cmd.clone(),
+        working_dir: metadata.config.working_dir.clone(),
+        user: metadata.config.user.clone(),
+        labels: metadata
+            .config
+            .labels
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
     }
 }
 
-fn labels_to_string_map(labels: Option<&serde_json::Value>) -> BTreeMap<String, String> {
-    let Some(serde_json::Value::Object(labels)) = labels else {
-        return BTreeMap::new();
+fn raw_config_platform(raw_config_json: &str) -> (Option<String>, Option<String>) {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(raw_config_json) else {
+        return (None, None);
     };
 
-    labels
-        .iter()
-        .map(|(key, value)| {
-            let value = value
-                .as_str()
-                .map(ToOwned::to_owned)
-                .unwrap_or_else(|| value.to_string());
-            (key.clone(), value)
-        })
-        .collect()
+    let architecture = value
+        .get("architecture")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+    let os = value
+        .get("os")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+
+    (architecture, os)
 }

--- a/crates/cli/tests/ssh.rs
+++ b/crates/cli/tests/ssh.rs
@@ -154,7 +154,7 @@ async fn run_tmux_cli_session(
             "-t",
             session,
             "-o",
-            &format!("cat > {}", shell_quote(&log_path.to_string_lossy())),
+            &format!("cat > {}", shell_quote(log_path.to_string_lossy())),
         ]),
         "pipe tmux pane",
     )?;

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -24,6 +24,7 @@ scopeguard.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+tar.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "rt", "sync"] }
 tokio-util.workspace = true
@@ -32,5 +33,4 @@ xattr.workspace = true
 
 [dev-dependencies]
 rcgen.workspace = true
-tar.workspace = true
 tempfile.workspace = true

--- a/crates/image/lib/archive/docker.rs
+++ b/crates/image/lib/archive/docker.rs
@@ -1,10 +1,15 @@
 //! Container image archive import/export.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fs::File;
-use std::io::{self, Read, Write};
-use std::os::unix::ffi::OsStrExt;
+use std::ffi::OsString;
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufWriter, Read, Write};
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as Sha2Digest, Sha256};
@@ -27,6 +32,10 @@ const OCI_LAYER_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar";
 const OCI_LAYER_GZIP_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
 const OCI_LAYER_ZSTD_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar+zstd";
 const OCI_REF_NAME_ANNOTATION: &str = "org.opencontainers.image.ref.name";
+const ARCHIVE_METADATA_MAX_BYTES: u64 = 16 * 1024 * 1024;
+const ARCHIVE_LAYER_MAX_BYTES: u64 = 10 * 1024 * 1024 * 1024;
+const ARCHIVE_MAX_ENTRY_COUNT: u64 = 1_000_000;
+static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -65,6 +74,8 @@ pub struct ImageSaveRequest {
     pub reference: String,
     /// Image config fields.
     pub config: ImageSaveConfig,
+    /// Raw image config JSON to preserve non-runtime metadata on export.
+    pub raw_config_json: String,
     /// Ordered layer list, bottom-to-top.
     pub layers: Vec<ImageSaveLayer>,
 }
@@ -104,10 +115,23 @@ struct PreparedLoadedImage {
 }
 
 #[derive(Debug)]
+struct PreparedArchiveLoad {
+    images: Vec<PreparedLoadedImage>,
+    staged_layers: HashMap<String, PathBuf>,
+}
+
+#[derive(Debug)]
+struct StagedLayerGuard {
+    paths: HashMap<String, PathBuf>,
+    cleanup_on_drop: bool,
+}
+
+#[derive(Debug)]
 struct LayerBlobInfo {
     digest: String,
     media_type: String,
     size_bytes: u64,
+    path: PathBuf,
 }
 
 #[derive(Debug, Deserialize)]
@@ -166,6 +190,34 @@ impl<W> DigestingWriter<W> {
     }
 }
 
+impl StagedLayerGuard {
+    fn new() -> Self {
+        Self {
+            paths: HashMap::new(),
+            cleanup_on_drop: true,
+        }
+    }
+
+    fn track(&mut self, digest: String, path: PathBuf) -> PathBuf {
+        if let Some(existing_path) = self.paths.get(&digest) {
+            let _ = std::fs::remove_file(&path);
+            return existing_path.clone();
+        }
+
+        self.paths.insert(digest, path.clone());
+        path
+    }
+
+    fn into_inner(mut self) -> HashMap<String, PathBuf> {
+        self.cleanup_on_drop = false;
+        std::mem::take(&mut self.paths)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
 impl<W: Write> Write for DigestingWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let written = self.inner.write(buf)?;
@@ -176,6 +228,18 @@ impl<W: Write> Write for DigestingWriter<W> {
 
     fn flush(&mut self) -> io::Result<()> {
         self.inner.flush()
+    }
+}
+
+impl Drop for StagedLayerGuard {
+    fn drop(&mut self) {
+        if !self.cleanup_on_drop {
+            return;
+        }
+
+        for path in self.paths.values() {
+            let _ = std::fs::remove_file(path);
+        }
     }
 }
 
@@ -199,47 +263,50 @@ pub async fn load_archive(
 
     let cache = GlobalCache::new_async(cache_dir).await?;
     let registry = Registry::new(Platform::host_linux(), cache)?;
-    let staged_layer_digests = prepared
-        .iter()
-        .flat_map(|image| {
-            image
-                .metadata
-                .layers
-                .iter()
-                .map(|layer| layer.digest.clone())
-        })
-        .collect::<HashSet<_>>();
-    let mut loaded = Vec::with_capacity(prepared.len());
-
-    for image in prepared {
-        let reference: Reference = image
-            .reference
-            .parse()
-            .map_err(|e| ImageError::ManifestParse(format!("invalid image reference: {e}")))?;
-
-        registry
-            .materialize_cached_layers(&reference, &image.metadata, false)
-            .await?;
-
-        let cache = GlobalCache::new_async(cache_dir).await?;
-        cache
-            .write_image_metadata_async(&reference, &image.metadata)
-            .await?;
-
-        loaded.push(LoadedImage {
-            reference: image.reference,
-            metadata: image.metadata,
-        });
-    }
-
+    let PreparedArchiveLoad {
+        images,
+        staged_layers,
+    } = prepared;
+    let cleanup_paths = staged_layers.values().cloned().collect::<Vec<_>>();
+    let staged_layers = Arc::new(staged_layers);
     let cache = GlobalCache::new_async(cache_dir).await?;
-    for digest in staged_layer_digests {
-        if let Ok(digest) = digest.parse::<Digest>() {
-            let _ = tokio::fs::remove_file(cache.tar_path(&digest)).await;
+    let mut loaded = Vec::with_capacity(images.len());
+
+    let result = async {
+        for image in images {
+            let reference: Reference = image
+                .reference
+                .parse()
+                .map_err(|e| ImageError::ManifestParse(format!("invalid image reference: {e}")))?;
+
+            registry
+                .materialize_cached_layers_from_paths(
+                    &reference,
+                    &image.metadata,
+                    false,
+                    Arc::clone(&staged_layers),
+                )
+                .await?;
+
+            cache
+                .write_image_metadata_async(&reference, &image.metadata)
+                .await?;
+
+            loaded.push(LoadedImage {
+                reference: image.reference,
+                metadata: image.metadata,
+            });
         }
+
+        Ok(loaded)
+    }
+    .await;
+
+    for path in cleanup_paths {
+        let _ = tokio::fs::remove_file(path).await;
     }
 
-    Ok(loaded)
+    result
 }
 
 /// Save images as a Docker-compatible image archive.
@@ -279,10 +346,11 @@ fn save_docker_archive_inner(
         path: output.to_path_buf(),
         source: e,
     })?;
-    let mut archive = tar::Builder::new(output_file);
+    let mut archive = tar::Builder::new(BufWriter::new(output_file));
     let mut generated_layers: HashMap<String, GeneratedLayer> = HashMap::new();
     let mut appended_layers: HashSet<String> = HashSet::new();
     let mut manifest_entries = Vec::with_capacity(images.len());
+    let mut config_entries = Vec::with_capacity(images.len());
 
     for image in images {
         let mut layer_paths = Vec::with_capacity(image.layers.len());
@@ -302,20 +370,12 @@ fn save_docker_archive_inner(
             layer_paths.push(format!("{}/layer.tar", generated.hex));
         }
 
-        let config_bytes = docker_config_json(&image.config, &regenerated_diff_ids)?;
+        let config_bytes =
+            docker_config_json(&image.config, &image.raw_config_json, &regenerated_diff_ids)?;
         let config_hex = sha256_hex(&config_bytes);
         let config_name = format!("{config_hex}.json");
 
-        append_bytes(&mut archive, &config_name, &config_bytes)?;
-
-        for layer in &image.layers {
-            let generated = generated_layers.get(&layer.diff_id).ok_or_else(|| {
-                ImageError::ManifestParse(format!("missing generated layer {}", layer.diff_id))
-            })?;
-            if appended_layers.insert(generated.hex.clone()) {
-                append_layer_entries(&mut archive, generated)?;
-            }
-        }
+        config_entries.push((config_name.clone(), config_bytes));
 
         manifest_entries.push(DockerManifestOut {
             config: config_name,
@@ -327,6 +387,22 @@ fn save_docker_archive_inner(
     let manifest_bytes = serde_json::to_vec_pretty(&manifest_entries)
         .map_err(|e| ImageError::ConfigParse(format!("serialize docker manifest: {e}")))?;
     append_bytes(&mut archive, "manifest.json", &manifest_bytes)?;
+
+    for (config_name, config_bytes) in config_entries {
+        append_bytes(&mut archive, &config_name, &config_bytes)?;
+    }
+
+    for image in images {
+        for layer in &image.layers {
+            let generated = generated_layers.get(&layer.diff_id).ok_or_else(|| {
+                ImageError::ManifestParse(format!("missing generated layer {}", layer.diff_id))
+            })?;
+            if appended_layers.insert(generated.hex.clone()) {
+                append_layer_entries(&mut archive, generated)?;
+            }
+        }
+    }
+
     archive.finish().map_err(ImageError::Io)?;
 
     for layer in generated_layers.values() {
@@ -351,18 +427,13 @@ fn save_oci_archive_inner(
         path: output.to_path_buf(),
         source: e,
     })?;
-    let mut archive = tar::Builder::new(output_file);
+    let mut archive = tar::Builder::new(BufWriter::new(output_file));
     let mut generated_layers: HashMap<String, GeneratedLayer> = HashMap::new();
-    let mut appended_blobs: HashSet<String> = HashSet::new();
+    let mut appended_metadata_blobs: HashSet<String> = HashSet::new();
+    let mut appended_layer_blobs: HashSet<String> = HashSet::new();
+    let mut layer_blob_order = Vec::new();
+    let mut metadata_blobs = Vec::new();
     let mut index_manifests = Vec::with_capacity(images.len());
-
-    append_bytes(
-        &mut archive,
-        "oci-layout",
-        br#"{"imageLayoutVersion":"1.0.0"}"#,
-    )?;
-    append_directory(&mut archive, "blobs")?;
-    append_directory(&mut archive, "blobs/sha256")?;
 
     for image in images {
         let mut layer_descriptors = Vec::with_capacity(image.layers.len());
@@ -379,13 +450,8 @@ fn save_oci_archive_inner(
             };
 
             regenerated_diff_ids.push(generated.diff_id.clone());
-            if appended_blobs.insert(generated.hex.clone()) {
-                append_blob_file(
-                    &mut archive,
-                    &generated.hex,
-                    &generated.path,
-                    generated.size,
-                )?;
+            if appended_layer_blobs.insert(generated.hex.clone()) {
+                layer_blob_order.push(layer.diff_id.clone());
             }
             layer_descriptors.push(serde_json::json!({
                 "mediaType": OCI_LAYER_MEDIA_TYPE,
@@ -394,10 +460,11 @@ fn save_oci_archive_inner(
             }));
         }
 
-        let config_bytes = docker_config_json(&image.config, &regenerated_diff_ids)?;
+        let config_bytes =
+            docker_config_json(&image.config, &image.raw_config_json, &regenerated_diff_ids)?;
         let config_hex = sha256_hex(&config_bytes);
-        if appended_blobs.insert(config_hex.clone()) {
-            append_blob_bytes(&mut archive, &config_hex, &config_bytes)?;
+        if appended_metadata_blobs.insert(config_hex.clone()) {
+            metadata_blobs.push((config_hex.clone(), config_bytes.clone()));
         }
 
         let manifest_bytes = serde_json::to_vec(&serde_json::json!({
@@ -412,8 +479,8 @@ fn save_oci_archive_inner(
         }))
         .map_err(|e| ImageError::ManifestParse(format!("serialize OCI manifest: {e}")))?;
         let manifest_hex = sha256_hex(&manifest_bytes);
-        if appended_blobs.insert(manifest_hex.clone()) {
-            append_blob_bytes(&mut archive, &manifest_hex, &manifest_bytes)?;
+        if appended_metadata_blobs.insert(manifest_hex.clone()) {
+            metadata_blobs.push((manifest_hex.clone(), manifest_bytes.clone()));
         }
 
         index_manifests.push(serde_json::json!({
@@ -436,7 +503,32 @@ fn save_oci_archive_inner(
         "manifests": index_manifests,
     }))
     .map_err(|e| ImageError::ManifestParse(format!("serialize OCI index: {e}")))?;
+
+    append_bytes(
+        &mut archive,
+        "oci-layout",
+        br#"{"imageLayoutVersion":"1.0.0"}"#,
+    )?;
     append_bytes(&mut archive, "index.json", &index_bytes)?;
+    append_directory(&mut archive, "blobs")?;
+    append_directory(&mut archive, "blobs/sha256")?;
+
+    for (hex, bytes) in metadata_blobs {
+        append_blob_bytes(&mut archive, &hex, &bytes)?;
+    }
+
+    for diff_id in layer_blob_order {
+        let generated = generated_layers.get(&diff_id).ok_or_else(|| {
+            ImageError::ManifestParse(format!("missing generated layer {diff_id}"))
+        })?;
+        append_blob_file(
+            &mut archive,
+            &generated.hex,
+            &generated.path,
+            generated.size,
+        )?;
+    }
+
     archive.finish().map_err(ImageError::Io)?;
 
     for layer in generated_layers.values() {
@@ -450,7 +542,7 @@ fn load_archive_blocking(
     cache_dir: &Path,
     input: &Path,
     options: ImageLoadOptions,
-) -> ImageResult<Vec<PreparedLoadedImage>> {
+) -> ImageResult<PreparedArchiveLoad> {
     if let Some(manifest_json) = read_archive_entry(input, "manifest.json")? {
         let manifest: Vec<DockerManifestEntry> = serde_json::from_slice(&manifest_json)
             .map_err(|e| ImageError::ManifestParse(format!("docker manifest.json: {e}")))?;
@@ -471,7 +563,7 @@ fn load_docker_archive_blocking(
     input: &Path,
     options: ImageLoadOptions,
     manifest: Vec<DockerManifestEntry>,
-) -> ImageResult<Vec<PreparedLoadedImage>> {
+) -> ImageResult<PreparedArchiveLoad> {
     let cache = GlobalCache::new(cache_dir)?;
     if manifest.is_empty() {
         return Err(ImageError::ManifestParse(
@@ -494,22 +586,27 @@ fn load_docker_archive_blocking(
     let mut archive = tar::Archive::new(file);
     let mut configs: HashMap<String, Vec<u8>> = HashMap::new();
     let mut layers: HashMap<String, LayerBlobInfo> = HashMap::new();
+    let mut staged_layers = StagedLayerGuard::new();
     let mut temp_counter = 0u64;
+    let mut entry_count = 0u64;
 
     for entry in archive.entries().map_err(ImageError::Io)? {
         let mut entry = entry.map_err(ImageError::Io)?;
+        entry_count += 1;
+        enforce_archive_entry_count(entry_count)?;
         let path = normalized_archive_path(&entry)?;
 
         if required_configs.contains(&path) {
-            let mut data = Vec::new();
-            entry.read_to_end(&mut data).map_err(ImageError::Io)?;
+            let data = read_entry_to_vec(&mut entry, &path, ARCHIVE_METADATA_MAX_BYTES)?;
             configs.insert(path, data);
             continue;
         }
 
         if required_layers.contains(&path) {
-            let info = extract_layer_blob(&cache, &path, &mut entry, temp_counter)?;
+            let mut info = extract_layer_blob(&cache, &path, &mut entry, temp_counter)?;
             temp_counter += 1;
+            info.path = staged_layers.track(info.digest.clone(), info.path);
+            verify_docker_layer_path_digest(&path, &info.digest)?;
             layers.insert(path, info);
             continue;
         }
@@ -568,6 +665,8 @@ fn load_docker_archive_blocking(
         let metadata = CachedImageMetadata {
             manifest_digest,
             config_digest,
+            raw_manifest_json: json_bytes_to_string(&manifest_bytes, "docker manifest")?,
+            raw_config_json: json_bytes_to_string(config_bytes, "docker config")?,
             config,
             layers: layer_metadata,
         };
@@ -603,14 +702,17 @@ fn load_docker_archive_blocking(
         }
     }
 
-    Ok(loaded)
+    Ok(PreparedArchiveLoad {
+        images: loaded,
+        staged_layers: staged_layers.into_inner(),
+    })
 }
 
 fn load_oci_archive_blocking(
     cache_dir: &Path,
     input: &Path,
     options: ImageLoadOptions,
-) -> ImageResult<Vec<PreparedLoadedImage>> {
+) -> ImageResult<PreparedArchiveLoad> {
     let cache = GlobalCache::new(cache_dir)?;
     let layout_json = read_archive_entry(input, "oci-layout")?
         .ok_or_else(|| ImageError::ManifestParse("OCI layout missing oci-layout".into()))?;
@@ -660,22 +762,26 @@ fn load_oci_archive_blocking(
     let mut archive = tar::Archive::new(file);
     let mut configs: HashMap<String, Vec<u8>> = HashMap::new();
     let mut layers: HashMap<String, LayerBlobInfo> = HashMap::new();
+    let mut staged_layers = StagedLayerGuard::new();
     let mut temp_counter = 0u64;
+    let mut entry_count = 0u64;
 
     for entry in archive.entries().map_err(ImageError::Io)? {
         let mut entry = entry.map_err(ImageError::Io)?;
+        entry_count += 1;
+        enforce_archive_entry_count(entry_count)?;
         let path = normalized_archive_path(&entry)?;
 
         if required_configs.contains(&path) {
-            let mut data = Vec::new();
-            entry.read_to_end(&mut data).map_err(ImageError::Io)?;
+            let data = read_entry_to_vec(&mut entry, &path, ARCHIVE_METADATA_MAX_BYTES)?;
             configs.insert(path, data);
             continue;
         }
 
         if required_layers.contains(&path) {
-            let info = extract_layer_blob(&cache, &path, &mut entry, temp_counter)?;
+            let mut info = extract_layer_blob(&cache, &path, &mut entry, temp_counter)?;
             temp_counter += 1;
+            info.path = staged_layers.track(info.digest.clone(), info.path);
             layers.insert(path, info);
             continue;
         }
@@ -716,6 +822,8 @@ fn load_oci_archive_blocking(
         let metadata = CachedImageMetadata {
             manifest_digest: format!("sha256:{}", sha256_hex(&manifest_bytes)),
             config_digest: manifest.config().digest().to_string(),
+            raw_manifest_json: json_bytes_to_string(&manifest_bytes, "OCI manifest")?,
+            raw_config_json: json_bytes_to_string(config_bytes, "OCI config")?,
             config,
             layers: layer_metadata,
         };
@@ -752,7 +860,10 @@ fn load_oci_archive_blocking(
         }
     }
 
-    Ok(loaded)
+    Ok(PreparedArchiveLoad {
+        images: loaded,
+        staged_layers: staged_layers.into_inner(),
+    })
 }
 
 fn read_archive_entry(input: &Path, wanted_path: &str) -> ImageResult<Option<Vec<u8>>> {
@@ -761,16 +872,18 @@ fn read_archive_entry(input: &Path, wanted_path: &str) -> ImageResult<Option<Vec
         source: e,
     })?;
     let mut archive = tar::Archive::new(file);
+    let mut entry_count = 0u64;
 
     for entry in archive.entries().map_err(ImageError::Io)? {
         let mut entry = entry.map_err(ImageError::Io)?;
+        entry_count += 1;
+        enforce_archive_entry_count(entry_count)?;
         let path = normalized_archive_path(&entry)?;
         if path != wanted_path {
             continue;
         }
 
-        let mut data = Vec::new();
-        entry.read_to_end(&mut data).map_err(ImageError::Io)?;
+        let data = read_entry_to_vec(&mut entry, &path, ARCHIVE_METADATA_MAX_BYTES)?;
         return Ok(Some(data));
     }
 
@@ -787,17 +900,22 @@ fn read_archive_entries(
     })?;
     let mut archive = tar::Archive::new(file);
     let mut entries = HashMap::new();
+    let mut entry_count = 0u64;
 
     for entry in archive.entries().map_err(ImageError::Io)? {
         let mut entry = entry.map_err(ImageError::Io)?;
+        entry_count += 1;
+        enforce_archive_entry_count(entry_count)?;
         let path = normalized_archive_path(&entry)?;
         if !wanted_paths.contains(&path) {
             continue;
         }
 
-        let mut data = Vec::new();
-        entry.read_to_end(&mut data).map_err(ImageError::Io)?;
+        let data = read_entry_to_vec(&mut entry, &path, ARCHIVE_METADATA_MAX_BYTES)?;
         entries.insert(path, data);
+        if entries.len() == wanted_paths.len() {
+            break;
+        }
     }
 
     Ok(entries)
@@ -906,71 +1024,119 @@ fn verify_digest_bytes(digest: &str, bytes: &[u8]) -> ImageResult<()> {
     Ok(())
 }
 
+fn verify_docker_layer_path_digest(path: &str, digest: &str) -> ImageResult<()> {
+    let Some(hex) = path.strip_prefix("blobs/sha256/") else {
+        return Ok(());
+    };
+    if hex.contains('/') {
+        return Ok(());
+    }
+
+    let expected = format!("sha256:{hex}");
+    if expected != digest {
+        return Err(ImageError::ManifestParse(format!(
+            "docker archive layer path {path} digest mismatch: expected {expected}, got {digest}"
+        )));
+    }
+
+    Ok(())
+}
+
+fn create_unique_temp_file(dir: &Path, prefix: &str, suffix: &str) -> ImageResult<(File, PathBuf)> {
+    for _ in 0..128 {
+        let id = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = dir.join(format!("{prefix}-{}-{id}{suffix}", std::process::id()));
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => return Ok((file, path)),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(e) => {
+                return Err(ImageError::Cache { path, source: e });
+            }
+        }
+    }
+
+    Err(ImageError::Cache {
+        path: dir.to_path_buf(),
+        source: io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate a unique temporary image archive file",
+        ),
+    })
+}
+
 fn extract_layer_blob(
     cache: &GlobalCache,
     path: &str,
     entry: &mut tar::Entry<'_, File>,
     counter: u64,
 ) -> ImageResult<LayerBlobInfo> {
-    let temp_path = cache
-        .tmp_dir()
-        .join(format!("load-{}-{counter}.blob", std::process::id()));
-    let mut temp = File::create(&temp_path).map_err(|e| ImageError::Cache {
-        path: temp_path.clone(),
-        source: e,
-    })?;
-    let mut hasher = Sha256::new();
-    let mut size = 0u64;
-    let mut magic = Vec::with_capacity(4);
-    let mut buf = [0u8; 64 * 1024];
-
-    loop {
-        let read = entry.read(&mut buf).map_err(ImageError::Io)?;
-        if read == 0 {
-            break;
-        }
-        if magic.len() < 4 {
-            let take = (4 - magic.len()).min(read);
-            magic.extend_from_slice(&buf[..take]);
-        }
-        hasher.update(&buf[..read]);
-        temp.write_all(&buf[..read])
-            .map_err(|e| ImageError::Cache {
-                path: temp_path.clone(),
-                source: e,
-            })?;
-        size += read as u64;
+    let declared_size = entry.header().size().map_err(ImageError::Io)?;
+    if declared_size > ARCHIVE_LAYER_MAX_BYTES {
+        return Err(ImageError::ManifestParse(format!(
+            "archive layer {path} is {declared_size} bytes; max is {ARCHIVE_LAYER_MAX_BYTES}"
+        )));
     }
-    temp.flush().map_err(|e| ImageError::Cache {
-        path: temp_path.clone(),
-        source: e,
-    })?;
-    drop(temp);
 
-    let digest = Digest::new("sha256", hex::encode(hasher.finalize()));
-    let final_path = cache.tar_path(&digest);
-    if final_path.exists() {
-        let _ = std::fs::remove_file(&temp_path);
-    } else {
-        std::fs::rename(&temp_path, &final_path).map_err(|e| ImageError::Cache {
-            path: final_path,
+    let (mut temp, temp_path) =
+        create_unique_temp_file(cache.tmp_dir(), &format!("load-{counter}"), ".blob")?;
+    let result = (|| {
+        let mut hasher = Sha256::new();
+        let mut size = 0u64;
+        let mut magic = Vec::with_capacity(4);
+        let mut buf = [0u8; 64 * 1024];
+
+        loop {
+            let read = entry.read(&mut buf).map_err(ImageError::Io)?;
+            if read == 0 {
+                break;
+            }
+            if magic.len() < 4 {
+                let take = (4 - magic.len()).min(read);
+                magic.extend_from_slice(&buf[..take]);
+            }
+            hasher.update(&buf[..read]);
+            temp.write_all(&buf[..read])
+                .map_err(|e| ImageError::Cache {
+                    path: temp_path.clone(),
+                    source: e,
+                })?;
+            size += read as u64;
+            if size > ARCHIVE_LAYER_MAX_BYTES {
+                return Err(ImageError::ManifestParse(format!(
+                    "archive layer {path} exceeds {ARCHIVE_LAYER_MAX_BYTES} bytes"
+                )));
+            }
+        }
+        temp.flush().map_err(|e| ImageError::Cache {
+            path: temp_path.clone(),
             source: e,
         })?;
+        drop(temp);
+
+        let digest = Digest::new("sha256", hex::encode(hasher.finalize()));
+        let staged_path = temp_path.clone();
+
+        let media_type = match Compression::detect(&magic) {
+            Compression::None => OCI_LAYER_MEDIA_TYPE,
+            Compression::Gzip => OCI_LAYER_GZIP_MEDIA_TYPE,
+            Compression::Zstd => OCI_LAYER_ZSTD_MEDIA_TYPE,
+        };
+
+        tracing::debug!(path, digest = %digest, size, "loaded layer blob from docker archive");
+
+        Ok(LayerBlobInfo {
+            digest: digest.to_string(),
+            media_type: media_type.to_string(),
+            size_bytes: size,
+            path: staged_path,
+        })
+    })();
+
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
     }
 
-    let media_type = match Compression::detect(&magic) {
-        Compression::None => OCI_LAYER_MEDIA_TYPE,
-        Compression::Gzip => OCI_LAYER_GZIP_MEDIA_TYPE,
-        Compression::Zstd => OCI_LAYER_ZSTD_MEDIA_TYPE,
-    };
-
-    tracing::debug!(path, digest = %digest, size, "loaded layer blob from docker archive");
-
-    Ok(LayerBlobInfo {
-        digest: digest.to_string(),
-        media_type: media_type.to_string(),
-        size_bytes: size,
-    })
+    result
 }
 
 fn generate_layer_tar(cache: &GlobalCache, layer: &ImageSaveLayer) -> ImageResult<GeneratedLayer> {
@@ -981,54 +1147,54 @@ fn generate_layer_tar(cache: &GlobalCache, layer: &ImageSaveLayer) -> ImageResul
         source: e,
     })?;
     let mut reader = ErofsReader::new(file).map_err(ImageError::Io)?;
-    let temp_path = cache.tmp_dir().join(format!(
-        "save-{}-{}.layer.tar",
-        std::process::id(),
-        diff_id.to_path_safe()
-    ));
-    let temp_file = File::create(&temp_path).map_err(|e| ImageError::Cache {
-        path: temp_path.clone(),
-        source: e,
-    })?;
-    let digesting = DigestingWriter::new(temp_file);
-    let mut builder = tar::Builder::new(digesting);
-    let entries = reader.walk().map_err(ImageError::Io)?;
-    let mut hardlinks: HashMap<u32, PathBuf> = HashMap::new();
+    let (temp_file, temp_path) = create_unique_temp_file(cache.tmp_dir(), "save", ".layer.tar")?;
+    let result = (|| {
+        let digesting = DigestingWriter::new(BufWriter::new(temp_file));
+        let mut builder = tar::Builder::new(digesting);
+        let mut hardlinks: HashMap<u32, PathBuf> = HashMap::new();
 
-    for entry in entries {
-        if entry.path.as_os_str().is_empty() {
-            continue;
-        }
+        reader.walk_entries::<ImageError, _>(|reader, entry| {
+            if entry.path.as_os_str().is_empty() {
+                return Ok(());
+            }
 
-        if entry.kind == ErofsEntryKind::CharDevice && entry.rdev == Some((0, 0)) {
-            append_whiteout(&mut builder, &entry)?;
-            continue;
-        }
+            if entry.kind == ErofsEntryKind::CharDevice && entry.rdev == Some((0, 0)) {
+                append_whiteout(&mut builder, &entry)?;
+                return Ok(());
+            }
 
-        append_erofs_entry(&mut builder, &mut reader, &entry, &mut hardlinks)?;
+            append_erofs_entry(&mut builder, reader, &entry, &mut hardlinks)?;
 
-        if entry.kind == ErofsEntryKind::Directory && entry.is_opaque() {
-            append_opaque_marker(&mut builder, &entry)?;
-        }
+            if entry.kind == ErofsEntryKind::Directory && entry.is_opaque() {
+                append_opaque_marker(&mut builder, &entry)?;
+            }
+            Ok(())
+        })?;
+
+        let digesting = builder.into_inner().map_err(ImageError::Io)?;
+        let (mut file, hex, size) = digesting.finish();
+        file.flush().map_err(|e| ImageError::Cache {
+            path: temp_path.clone(),
+            source: e,
+        })?;
+
+        Ok(GeneratedLayer {
+            diff_id: format!("sha256:{hex}"),
+            hex,
+            path: temp_path.clone(),
+            size,
+        })
+    })();
+
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
     }
 
-    let digesting = builder.into_inner().map_err(ImageError::Io)?;
-    let (mut file, hex, size) = digesting.finish();
-    file.flush().map_err(|e| ImageError::Cache {
-        path: temp_path.clone(),
-        source: e,
-    })?;
-
-    Ok(GeneratedLayer {
-        diff_id: format!("sha256:{hex}"),
-        hex,
-        path: temp_path,
-        size,
-    })
+    result
 }
 
-fn append_erofs_entry(
-    builder: &mut tar::Builder<DigestingWriter<File>>,
+fn append_erofs_entry<W: Write>(
+    builder: &mut tar::Builder<DigestingWriter<W>>,
     reader: &mut ErofsReader,
     entry: &crate::erofs::ErofsTreeEntry,
     hardlinks: &mut HashMap<u32, PathBuf>,
@@ -1115,28 +1281,30 @@ fn append_erofs_entry(
     Ok(())
 }
 
-fn append_whiteout(
-    builder: &mut tar::Builder<DigestingWriter<File>>,
+fn append_whiteout<W: Write>(
+    builder: &mut tar::Builder<DigestingWriter<W>>,
     entry: &crate::erofs::ErofsTreeEntry,
 ) -> ImageResult<()> {
     let Some(file_name) = entry.path.file_name() else {
         return Ok(());
     };
     let mut path = entry.path.clone();
-    path.set_file_name(format!(".wh.{}", file_name.to_string_lossy()));
+    let mut whiteout_name = b".wh.".to_vec();
+    whiteout_name.extend_from_slice(file_name.as_bytes());
+    path.set_file_name(OsString::from_vec(whiteout_name));
     append_empty_file(builder, &path, entry)
 }
 
-fn append_opaque_marker(
-    builder: &mut tar::Builder<DigestingWriter<File>>,
+fn append_opaque_marker<W: Write>(
+    builder: &mut tar::Builder<DigestingWriter<W>>,
     entry: &crate::erofs::ErofsTreeEntry,
 ) -> ImageResult<()> {
     let path = entry.path.join(".wh..wh..opq");
     append_empty_file(builder, &path, entry)
 }
 
-fn append_empty_file(
-    builder: &mut tar::Builder<DigestingWriter<File>>,
+fn append_empty_file<W: Write>(
+    builder: &mut tar::Builder<DigestingWriter<W>>,
     path: &Path,
     entry: &crate::erofs::ErofsTreeEntry,
 ) -> ImageResult<()> {
@@ -1151,8 +1319,8 @@ fn append_empty_file(
         .map_err(ImageError::Io)
 }
 
-fn append_layer_entries(
-    archive: &mut tar::Builder<File>,
+fn append_layer_entries<W: Write>(
+    archive: &mut tar::Builder<W>,
     layer: &GeneratedLayer,
 ) -> ImageResult<()> {
     append_bytes(archive, &format!("{}/VERSION", layer.hex), b"1.0\n")?;
@@ -1175,8 +1343,8 @@ fn append_layer_entries(
         .map_err(ImageError::Io)
 }
 
-fn append_blob_file(
-    archive: &mut tar::Builder<File>,
+fn append_blob_file<W: Write>(
+    archive: &mut tar::Builder<W>,
     hex: &str,
     path: &Path,
     size: u64,
@@ -1198,11 +1366,15 @@ fn append_blob_file(
         .map_err(ImageError::Io)
 }
 
-fn append_blob_bytes(archive: &mut tar::Builder<File>, hex: &str, bytes: &[u8]) -> ImageResult<()> {
+fn append_blob_bytes<W: Write>(
+    archive: &mut tar::Builder<W>,
+    hex: &str,
+    bytes: &[u8],
+) -> ImageResult<()> {
     append_bytes(archive, &format!("blobs/sha256/{hex}"), bytes)
 }
 
-fn append_directory(archive: &mut tar::Builder<File>, path: &str) -> ImageResult<()> {
+fn append_directory<W: Write>(archive: &mut tar::Builder<W>, path: &str) -> ImageResult<()> {
     let mut header = tar::Header::new_gnu();
     header.set_entry_type(tar::EntryType::Directory);
     header.set_mode(0o755);
@@ -1216,7 +1388,11 @@ fn append_directory(archive: &mut tar::Builder<File>, path: &str) -> ImageResult
         .map_err(ImageError::Io)
 }
 
-fn append_bytes(archive: &mut tar::Builder<File>, path: &str, bytes: &[u8]) -> ImageResult<()> {
+fn append_bytes<W: Write>(
+    archive: &mut tar::Builder<W>,
+    path: &str,
+    bytes: &[u8],
+) -> ImageResult<()> {
     let mut header = tar::Header::new_gnu();
     header.set_entry_type(tar::EntryType::Regular);
     header.set_mode(0o644);
@@ -1230,7 +1406,69 @@ fn append_bytes(archive: &mut tar::Builder<File>, path: &str, bytes: &[u8]) -> I
         .map_err(ImageError::Io)
 }
 
-fn docker_config_json(config: &ImageSaveConfig, diff_ids: &[String]) -> ImageResult<Vec<u8>> {
+fn enforce_archive_entry_count(count: u64) -> ImageResult<()> {
+    if count > ARCHIVE_MAX_ENTRY_COUNT {
+        return Err(ImageError::ManifestParse(format!(
+            "archive has more than {ARCHIVE_MAX_ENTRY_COUNT} entries"
+        )));
+    }
+
+    Ok(())
+}
+
+fn read_entry_to_vec(
+    entry: &mut tar::Entry<'_, File>,
+    path: &str,
+    max_bytes: u64,
+) -> ImageResult<Vec<u8>> {
+    let declared_size = entry.header().size().map_err(ImageError::Io)?;
+    if declared_size > max_bytes {
+        return Err(ImageError::ManifestParse(format!(
+            "archive metadata entry {path} is {declared_size} bytes; max is {max_bytes}"
+        )));
+    }
+
+    let mut data = Vec::with_capacity(declared_size as usize);
+    entry.read_to_end(&mut data).map_err(ImageError::Io)?;
+    Ok(data)
+}
+
+fn json_bytes_to_string(bytes: &[u8], context: &str) -> ImageResult<String> {
+    std::str::from_utf8(bytes)
+        .map(str::to_owned)
+        .map_err(|e| ImageError::ConfigParse(format!("{context} is not UTF-8 JSON: {e}")))
+}
+
+fn docker_config_json(
+    config: &ImageSaveConfig,
+    raw_config_json: &str,
+    diff_ids: &[String],
+) -> ImageResult<Vec<u8>> {
+    if !raw_config_json.is_empty() {
+        let mut config_json: serde_json::Value = serde_json::from_str(raw_config_json)
+            .map_err(|e| ImageError::ConfigParse(format!("parse raw image config: {e}")))?;
+        let Some(object) = config_json.as_object_mut() else {
+            return Err(ImageError::ConfigParse(
+                "raw image config JSON is not an object".into(),
+            ));
+        };
+        object.insert(
+            "rootfs".into(),
+            serde_json::json!({
+                "type": "layers",
+                "diff_ids": diff_ids,
+            }),
+        );
+        object.entry("architecture").or_insert_with(|| {
+            serde_json::json!(config.architecture.as_deref().unwrap_or("amd64"))
+        });
+        object
+            .entry("os")
+            .or_insert_with(|| serde_json::json!(config.os.as_deref().unwrap_or("linux")));
+        return serde_json::to_vec(&config_json)
+            .map_err(|e| ImageError::ConfigParse(format!("serialize image config: {e}")));
+    }
+
     let config_json = serde_json::json!({
         "architecture": config.architecture.as_deref().unwrap_or("amd64"),
         "os": config.os.as_deref().unwrap_or("linux"),
@@ -1368,6 +1606,40 @@ mod tests {
     }
 
     #[test]
+    fn docker_archive_rejects_mismatched_blob_layer_path() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let temp = tempdir().unwrap();
+        let input = temp.path().join("bad-blob-path.tar");
+        let layer_bytes = simple_layer_tar();
+        let diff_id = format!("sha256:{}", sha256_hex(&layer_bytes));
+        let config_bytes = test_config_bytes(&diff_id);
+        let config_name = format!("blobs/sha256/{}", sha256_hex(&config_bytes));
+        let layer_name = format!("blobs/sha256/{:064x}", 1u8);
+
+        write_test_docker_archive_entries(
+            &input,
+            "bad-blob-path:latest",
+            config_name,
+            layer_name,
+            config_bytes,
+            layer_bytes,
+        );
+
+        let err = runtime
+            .block_on(load_archive(
+                &temp.path().join("cache"),
+                &input,
+                ImageLoadOptions::default(),
+            ))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("digest mismatch"));
+    }
+
+    #[test]
     fn oci_layout_archive_load_save_load_roundtrip() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -1500,6 +1772,71 @@ mod tests {
 
         assert_eq!(reloaded.len(), 1);
         assert_eq!(reloaded[0].reference, "complex:latest");
+    }
+
+    #[test]
+    fn docker_archive_save_preserves_raw_config_fields() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let temp = tempdir().unwrap();
+        let input = temp.path().join("config-fidelity.tar");
+        let layer_bytes = simple_layer_tar();
+        let diff_id = format!("sha256:{}", sha256_hex(&layer_bytes));
+        let config_bytes = serde_json::to_vec(&serde_json::json!({
+            "architecture": "arm64",
+            "os": "linux",
+            "author": "microsandbox-test",
+            "config": {
+                "Env": ["PATH=/usr/bin"],
+                "Cmd": ["cat", "/hello.txt"],
+            },
+            "rootfs": {
+                "type": "layers",
+                "diff_ids": [diff_id],
+            },
+            "history": [{
+                "created_by": "fixture",
+                "comment": "keep me",
+            }],
+        }))
+        .unwrap();
+        let config_name = format!("{}.json", sha256_hex(&config_bytes));
+
+        write_test_docker_archive_entries(
+            &input,
+            "config-fidelity:latest",
+            config_name,
+            "layer/layer.tar".into(),
+            config_bytes,
+            layer_bytes,
+        );
+
+        let first_cache = temp.path().join("cache-1");
+        let loaded = runtime
+            .block_on(load_archive(
+                &first_cache,
+                &input,
+                ImageLoadOptions::default(),
+            ))
+            .unwrap();
+        let saved = temp.path().join("saved-config-fidelity.tar");
+        let request = save_request_from_loaded(&loaded[0]);
+        let cache = GlobalCache::new(&first_cache).unwrap();
+        save_docker_archive(&cache, &saved, &[request]).unwrap();
+
+        let manifest_bytes = read_archive_entry(&saved, "manifest.json")
+            .unwrap()
+            .unwrap();
+        let manifest: Vec<DockerManifestEntry> = serde_json::from_slice(&manifest_bytes).unwrap();
+        let saved_config = read_archive_entry(&saved, &manifest[0].config)
+            .unwrap()
+            .unwrap();
+        let saved_config: serde_json::Value = serde_json::from_slice(&saved_config).unwrap();
+
+        assert_eq!(saved_config["author"], "microsandbox-test");
+        assert_eq!(saved_config["history"][0]["comment"], "keep me");
     }
 
     fn write_test_docker_archive(path: &Path, reference: &str) {
@@ -1855,6 +2192,7 @@ mod tests {
                     .map(|(key, value)| (key.clone(), value.clone()))
                     .collect(),
             },
+            raw_config_json: image.metadata.raw_config_json.clone(),
             layers: image
                 .metadata
                 .layers

--- a/crates/image/lib/archive/docker.rs
+++ b/crates/image/lib/archive/docker.rs
@@ -1,0 +1,1868 @@
+//! Container image archive import/export.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as Sha2Digest, Sha256};
+
+use crate::{
+    CachedImageMetadata, CachedLayerMetadata, Digest, GlobalCache, ImageConfig, ImageError,
+    ImageResult, Platform, Reference, Registry,
+    erofs::{ErofsEntryKind, ErofsReader},
+    tar::Compression,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const OCI_CONFIG_MEDIA_TYPE: &str = "application/vnd.oci.image.config.v1+json";
+const OCI_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
+const OCI_INDEX_MEDIA_TYPE: &str = "application/vnd.oci.image.index.v1+json";
+const OCI_LAYER_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar";
+const OCI_LAYER_GZIP_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
+const OCI_LAYER_ZSTD_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar+zstd";
+const OCI_REF_NAME_ANNOTATION: &str = "org.opencontainers.image.ref.name";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Options for importing image archives.
+#[derive(Debug, Clone, Default)]
+pub struct ImageLoadOptions {
+    /// Extra tags to apply to the first image in the archive.
+    pub tags: Vec<String>,
+}
+
+/// Archive format to use when saving images.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ImageArchiveFormat {
+    /// Docker `docker save` compatible archive.
+    #[default]
+    Docker,
+    /// OCI Image Layout archive.
+    Oci,
+}
+
+/// One loaded image reference and its cached metadata.
+#[derive(Debug, Clone)]
+pub struct LoadedImage {
+    /// Image reference imported into the local cache.
+    pub reference: String,
+    /// Cached image metadata to persist in the database.
+    pub metadata: CachedImageMetadata,
+}
+
+/// Image data needed to export a Docker archive.
+#[derive(Debug, Clone)]
+pub struct ImageSaveRequest {
+    /// Image reference to write as a Docker `RepoTags` entry.
+    pub reference: String,
+    /// Image config fields.
+    pub config: ImageSaveConfig,
+    /// Ordered layer list, bottom-to-top.
+    pub layers: Vec<ImageSaveLayer>,
+}
+
+/// Config fields used when synthesizing an exported Docker image config.
+#[derive(Debug, Clone, Default)]
+pub struct ImageSaveConfig {
+    /// Target architecture.
+    pub architecture: Option<String>,
+    /// Target OS.
+    pub os: Option<String>,
+    /// Environment variables.
+    pub env: Vec<String>,
+    /// Entrypoint.
+    pub entrypoint: Option<Vec<String>>,
+    /// Command.
+    pub cmd: Option<Vec<String>>,
+    /// Working directory.
+    pub working_dir: Option<String>,
+    /// User.
+    pub user: Option<String>,
+    /// Labels.
+    pub labels: BTreeMap<String, String>,
+}
+
+/// Layer data used when exporting an image.
+#[derive(Debug, Clone)]
+pub struct ImageSaveLayer {
+    /// Original cached layer diff ID.
+    pub diff_id: String,
+}
+
+#[derive(Debug)]
+struct PreparedLoadedImage {
+    reference: String,
+    metadata: CachedImageMetadata,
+}
+
+#[derive(Debug)]
+struct LayerBlobInfo {
+    digest: String,
+    media_type: String,
+    size_bytes: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct DockerManifestEntry {
+    #[serde(rename = "Config")]
+    config: String,
+    #[serde(rename = "RepoTags")]
+    repo_tags: Option<Vec<String>>,
+    #[serde(rename = "Layers")]
+    layers: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DockerManifestOut {
+    #[serde(rename = "Config")]
+    config: String,
+    #[serde(rename = "RepoTags")]
+    repo_tags: Vec<String>,
+    #[serde(rename = "Layers")]
+    layers: Vec<String>,
+}
+
+#[derive(Debug)]
+struct GeneratedLayer {
+    diff_id: String,
+    hex: String,
+    path: PathBuf,
+    size: u64,
+}
+
+struct DigestingWriter<W> {
+    inner: W,
+    hasher: Sha256,
+    written: u64,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl<W> DigestingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            hasher: Sha256::new(),
+            written: 0,
+        }
+    }
+
+    fn finish(self) -> (W, String, u64) {
+        (
+            self.inner,
+            hex::encode(self.hasher.finalize()),
+            self.written,
+        )
+    }
+}
+
+impl<W: Write> Write for DigestingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        self.hasher.update(&buf[..written]);
+        self.written += written as u64;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Load a Docker image archive into the microsandbox image cache.
+pub async fn load_archive(
+    cache_dir: &Path,
+    input: &Path,
+    options: ImageLoadOptions,
+) -> ImageResult<Vec<LoadedImage>> {
+    let cache_dir_for_blocking = cache_dir.to_path_buf();
+    let input = input.to_path_buf();
+    let prepared = tokio::task::spawn_blocking(move || {
+        load_archive_blocking(&cache_dir_for_blocking, &input, options)
+    })
+    .await
+    .map_err(|e| ImageError::Io(io::Error::other(e)))??;
+
+    let cache = GlobalCache::new_async(cache_dir).await?;
+    let registry = Registry::new(Platform::host_linux(), cache)?;
+    let staged_layer_digests = prepared
+        .iter()
+        .flat_map(|image| {
+            image
+                .metadata
+                .layers
+                .iter()
+                .map(|layer| layer.digest.clone())
+        })
+        .collect::<HashSet<_>>();
+    let mut loaded = Vec::with_capacity(prepared.len());
+
+    for image in prepared {
+        let reference: Reference = image
+            .reference
+            .parse()
+            .map_err(|e| ImageError::ManifestParse(format!("invalid image reference: {e}")))?;
+
+        registry
+            .materialize_cached_layers(&reference, &image.metadata, false)
+            .await?;
+
+        let cache = GlobalCache::new_async(cache_dir).await?;
+        cache
+            .write_image_metadata_async(&reference, &image.metadata)
+            .await?;
+
+        loaded.push(LoadedImage {
+            reference: image.reference,
+            metadata: image.metadata,
+        });
+    }
+
+    let cache = GlobalCache::new_async(cache_dir).await?;
+    for digest in staged_layer_digests {
+        if let Ok(digest) = digest.parse::<Digest>() {
+            let _ = tokio::fs::remove_file(cache.tar_path(&digest)).await;
+        }
+    }
+
+    Ok(loaded)
+}
+
+/// Save images as a Docker-compatible image archive.
+pub fn save_docker_archive(
+    cache: &GlobalCache,
+    output: &Path,
+    images: &[ImageSaveRequest],
+) -> ImageResult<()> {
+    save_archive(cache, output, images, ImageArchiveFormat::Docker)
+}
+
+/// Save images as a container image archive.
+pub fn save_archive(
+    cache: &GlobalCache,
+    output: &Path,
+    images: &[ImageSaveRequest],
+    format: ImageArchiveFormat,
+) -> ImageResult<()> {
+    match format {
+        ImageArchiveFormat::Docker => save_docker_archive_inner(cache, output, images),
+        ImageArchiveFormat::Oci => save_oci_archive_inner(cache, output, images),
+    }
+}
+
+fn save_docker_archive_inner(
+    cache: &GlobalCache,
+    output: &Path,
+    images: &[ImageSaveRequest],
+) -> ImageResult<()> {
+    if images.is_empty() {
+        return Err(ImageError::ManifestParse(
+            "at least one image reference is required".into(),
+        ));
+    }
+
+    let output_file = File::create(output).map_err(|e| ImageError::Cache {
+        path: output.to_path_buf(),
+        source: e,
+    })?;
+    let mut archive = tar::Builder::new(output_file);
+    let mut generated_layers: HashMap<String, GeneratedLayer> = HashMap::new();
+    let mut appended_layers: HashSet<String> = HashSet::new();
+    let mut manifest_entries = Vec::with_capacity(images.len());
+
+    for image in images {
+        let mut layer_paths = Vec::with_capacity(image.layers.len());
+        let mut regenerated_diff_ids = Vec::with_capacity(image.layers.len());
+
+        for layer in &image.layers {
+            let generated = match generated_layers.get(&layer.diff_id) {
+                Some(generated) => generated,
+                None => {
+                    let generated = generate_layer_tar(cache, layer)?;
+                    generated_layers.insert(layer.diff_id.clone(), generated);
+                    generated_layers.get(&layer.diff_id).unwrap()
+                }
+            };
+
+            regenerated_diff_ids.push(generated.diff_id.clone());
+            layer_paths.push(format!("{}/layer.tar", generated.hex));
+        }
+
+        let config_bytes = docker_config_json(&image.config, &regenerated_diff_ids)?;
+        let config_hex = sha256_hex(&config_bytes);
+        let config_name = format!("{config_hex}.json");
+
+        append_bytes(&mut archive, &config_name, &config_bytes)?;
+
+        for layer in &image.layers {
+            let generated = generated_layers.get(&layer.diff_id).ok_or_else(|| {
+                ImageError::ManifestParse(format!("missing generated layer {}", layer.diff_id))
+            })?;
+            if appended_layers.insert(generated.hex.clone()) {
+                append_layer_entries(&mut archive, generated)?;
+            }
+        }
+
+        manifest_entries.push(DockerManifestOut {
+            config: config_name,
+            repo_tags: vec![image.reference.clone()],
+            layers: layer_paths,
+        });
+    }
+
+    let manifest_bytes = serde_json::to_vec_pretty(&manifest_entries)
+        .map_err(|e| ImageError::ConfigParse(format!("serialize docker manifest: {e}")))?;
+    append_bytes(&mut archive, "manifest.json", &manifest_bytes)?;
+    archive.finish().map_err(ImageError::Io)?;
+
+    for layer in generated_layers.values() {
+        let _ = std::fs::remove_file(&layer.path);
+    }
+
+    Ok(())
+}
+
+fn save_oci_archive_inner(
+    cache: &GlobalCache,
+    output: &Path,
+    images: &[ImageSaveRequest],
+) -> ImageResult<()> {
+    if images.is_empty() {
+        return Err(ImageError::ManifestParse(
+            "at least one image reference is required".into(),
+        ));
+    }
+
+    let output_file = File::create(output).map_err(|e| ImageError::Cache {
+        path: output.to_path_buf(),
+        source: e,
+    })?;
+    let mut archive = tar::Builder::new(output_file);
+    let mut generated_layers: HashMap<String, GeneratedLayer> = HashMap::new();
+    let mut appended_blobs: HashSet<String> = HashSet::new();
+    let mut index_manifests = Vec::with_capacity(images.len());
+
+    append_bytes(
+        &mut archive,
+        "oci-layout",
+        br#"{"imageLayoutVersion":"1.0.0"}"#,
+    )?;
+    append_directory(&mut archive, "blobs")?;
+    append_directory(&mut archive, "blobs/sha256")?;
+
+    for image in images {
+        let mut layer_descriptors = Vec::with_capacity(image.layers.len());
+        let mut regenerated_diff_ids = Vec::with_capacity(image.layers.len());
+
+        for layer in &image.layers {
+            let generated = match generated_layers.get(&layer.diff_id) {
+                Some(generated) => generated,
+                None => {
+                    let generated = generate_layer_tar(cache, layer)?;
+                    generated_layers.insert(layer.diff_id.clone(), generated);
+                    generated_layers.get(&layer.diff_id).unwrap()
+                }
+            };
+
+            regenerated_diff_ids.push(generated.diff_id.clone());
+            if appended_blobs.insert(generated.hex.clone()) {
+                append_blob_file(
+                    &mut archive,
+                    &generated.hex,
+                    &generated.path,
+                    generated.size,
+                )?;
+            }
+            layer_descriptors.push(serde_json::json!({
+                "mediaType": OCI_LAYER_MEDIA_TYPE,
+                "digest": generated.diff_id,
+                "size": generated.size,
+            }));
+        }
+
+        let config_bytes = docker_config_json(&image.config, &regenerated_diff_ids)?;
+        let config_hex = sha256_hex(&config_bytes);
+        if appended_blobs.insert(config_hex.clone()) {
+            append_blob_bytes(&mut archive, &config_hex, &config_bytes)?;
+        }
+
+        let manifest_bytes = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_MANIFEST_MEDIA_TYPE,
+            "config": {
+                "mediaType": OCI_CONFIG_MEDIA_TYPE,
+                "digest": format!("sha256:{config_hex}"),
+                "size": config_bytes.len(),
+            },
+            "layers": layer_descriptors,
+        }))
+        .map_err(|e| ImageError::ManifestParse(format!("serialize OCI manifest: {e}")))?;
+        let manifest_hex = sha256_hex(&manifest_bytes);
+        if appended_blobs.insert(manifest_hex.clone()) {
+            append_blob_bytes(&mut archive, &manifest_hex, &manifest_bytes)?;
+        }
+
+        index_manifests.push(serde_json::json!({
+            "mediaType": OCI_MANIFEST_MEDIA_TYPE,
+            "digest": format!("sha256:{manifest_hex}"),
+            "size": manifest_bytes.len(),
+            "platform": {
+                "architecture": image.config.architecture.as_deref().unwrap_or("amd64"),
+                "os": image.config.os.as_deref().unwrap_or("linux"),
+            },
+            "annotations": {
+                (OCI_REF_NAME_ANNOTATION): image.reference.clone(),
+            },
+        }));
+    }
+
+    let index_bytes = serde_json::to_vec_pretty(&serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": OCI_INDEX_MEDIA_TYPE,
+        "manifests": index_manifests,
+    }))
+    .map_err(|e| ImageError::ManifestParse(format!("serialize OCI index: {e}")))?;
+    append_bytes(&mut archive, "index.json", &index_bytes)?;
+    archive.finish().map_err(ImageError::Io)?;
+
+    for layer in generated_layers.values() {
+        let _ = std::fs::remove_file(&layer.path);
+    }
+
+    Ok(())
+}
+
+fn load_archive_blocking(
+    cache_dir: &Path,
+    input: &Path,
+    options: ImageLoadOptions,
+) -> ImageResult<Vec<PreparedLoadedImage>> {
+    if let Some(manifest_json) = read_archive_entry(input, "manifest.json")? {
+        let manifest: Vec<DockerManifestEntry> = serde_json::from_slice(&manifest_json)
+            .map_err(|e| ImageError::ManifestParse(format!("docker manifest.json: {e}")))?;
+        return load_docker_archive_blocking(cache_dir, input, options, manifest);
+    }
+
+    if read_archive_entry(input, "oci-layout")?.is_some() {
+        return load_oci_archive_blocking(cache_dir, input, options);
+    }
+
+    Err(ImageError::ManifestParse(
+        "archive missing manifest.json or oci-layout".into(),
+    ))
+}
+
+fn load_docker_archive_blocking(
+    cache_dir: &Path,
+    input: &Path,
+    options: ImageLoadOptions,
+    manifest: Vec<DockerManifestEntry>,
+) -> ImageResult<Vec<PreparedLoadedImage>> {
+    let cache = GlobalCache::new(cache_dir)?;
+    if manifest.is_empty() {
+        return Err(ImageError::ManifestParse(
+            "docker archive manifest is empty".into(),
+        ));
+    }
+
+    let required_configs = manifest
+        .iter()
+        .map(|image| image.config.clone())
+        .collect::<HashSet<_>>();
+    let required_layers = manifest
+        .iter()
+        .flat_map(|image| image.layers.iter().cloned())
+        .collect::<HashSet<_>>();
+    let file = File::open(input).map_err(|e| ImageError::Cache {
+        path: input.to_path_buf(),
+        source: e,
+    })?;
+    let mut archive = tar::Archive::new(file);
+    let mut configs: HashMap<String, Vec<u8>> = HashMap::new();
+    let mut layers: HashMap<String, LayerBlobInfo> = HashMap::new();
+    let mut temp_counter = 0u64;
+
+    for entry in archive.entries().map_err(ImageError::Io)? {
+        let mut entry = entry.map_err(ImageError::Io)?;
+        let path = normalized_archive_path(&entry)?;
+
+        if required_configs.contains(&path) {
+            let mut data = Vec::new();
+            entry.read_to_end(&mut data).map_err(ImageError::Io)?;
+            configs.insert(path, data);
+            continue;
+        }
+
+        if required_layers.contains(&path) {
+            let info = extract_layer_blob(&cache, &path, &mut entry, temp_counter)?;
+            temp_counter += 1;
+            layers.insert(path, info);
+            continue;
+        }
+    }
+
+    let mut loaded = Vec::new();
+    for (image_index, image) in manifest.into_iter().enumerate() {
+        let config_bytes = configs.get(&image.config).ok_or_else(|| {
+            ImageError::ConfigParse(format!("docker archive missing config {}", image.config))
+        })?;
+        let (config, diff_ids) = ImageConfig::parse(config_bytes)?;
+
+        if diff_ids.len() != image.layers.len() {
+            return Err(ImageError::ManifestParse(format!(
+                "layer count mismatch: config has {} diff_ids but archive manifest has {} layers",
+                diff_ids.len(),
+                image.layers.len()
+            )));
+        }
+
+        let config_digest = format!("sha256:{}", sha256_hex(config_bytes));
+        let mut layer_metadata = Vec::with_capacity(image.layers.len());
+        let mut manifest_layers = Vec::with_capacity(image.layers.len());
+
+        for (position, layer_path) in image.layers.iter().enumerate() {
+            let layer = layers.get(layer_path).ok_or_else(|| {
+                ImageError::ManifestParse(format!("docker archive missing layer {layer_path}"))
+            })?;
+            let diff_id = diff_ids[position].clone();
+            layer_metadata.push(CachedLayerMetadata {
+                digest: layer.digest.clone(),
+                media_type: Some(layer.media_type.clone()),
+                size_bytes: Some(layer.size_bytes),
+                diff_id,
+            });
+            manifest_layers.push(serde_json::json!({
+                "mediaType": layer.media_type,
+                "digest": layer.digest,
+                "size": layer.size_bytes,
+            }));
+        }
+
+        let manifest_bytes = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_MANIFEST_MEDIA_TYPE,
+            "config": {
+                "mediaType": OCI_CONFIG_MEDIA_TYPE,
+                "digest": config_digest,
+                "size": config_bytes.len(),
+            },
+            "layers": manifest_layers,
+        }))
+        .map_err(|e| ImageError::ManifestParse(format!("serialize manifest: {e}")))?;
+        let manifest_digest = format!("sha256:{}", sha256_hex(&manifest_bytes));
+
+        let metadata = CachedImageMetadata {
+            manifest_digest,
+            config_digest,
+            config,
+            layers: layer_metadata,
+        };
+
+        let mut refs = image
+            .repo_tags
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|tag| tag != "<none>:<none>")
+            .collect::<Vec<_>>();
+
+        if image_index == 0 {
+            refs.extend(options.tags.iter().cloned());
+        }
+
+        refs.sort();
+        refs.dedup();
+
+        if refs.is_empty() {
+            return Err(ImageError::ManifestParse(
+                "docker archive image has no tags; pass --tag to name it".into(),
+            ));
+        }
+
+        for reference in refs {
+            let _: Reference = reference.parse().map_err(|e| {
+                ImageError::ManifestParse(format!("invalid image reference {reference}: {e}"))
+            })?;
+            loaded.push(PreparedLoadedImage {
+                reference,
+                metadata: metadata.clone(),
+            });
+        }
+    }
+
+    Ok(loaded)
+}
+
+fn load_oci_archive_blocking(
+    cache_dir: &Path,
+    input: &Path,
+    options: ImageLoadOptions,
+) -> ImageResult<Vec<PreparedLoadedImage>> {
+    let cache = GlobalCache::new(cache_dir)?;
+    let layout_json = read_archive_entry(input, "oci-layout")?
+        .ok_or_else(|| ImageError::ManifestParse("OCI layout missing oci-layout".into()))?;
+    serde_json::from_slice::<oci_spec::image::OciLayout>(&layout_json)
+        .map_err(|e| ImageError::ManifestParse(format!("oci-layout: {e}")))?;
+
+    let index_json = read_archive_entry(input, "index.json")?
+        .ok_or_else(|| ImageError::ManifestParse("OCI layout missing index.json".into()))?;
+    let index: oci_spec::image::ImageIndex = serde_json::from_slice(&index_json)
+        .map_err(|e| ImageError::ManifestParse(format!("OCI index.json: {e}")))?;
+    let manifest_descriptors = selectable_oci_manifests(index.manifests())?;
+    if manifest_descriptors.is_empty() {
+        return Err(ImageError::ManifestParse(
+            "OCI layout contains no image manifests for the host platform".into(),
+        ));
+    }
+
+    let manifest_paths = manifest_descriptors
+        .iter()
+        .map(|descriptor| blob_path_from_digest(descriptor.digest().as_ref()))
+        .collect::<ImageResult<HashSet<_>>>()?;
+    let manifest_blobs = read_archive_entries(input, &manifest_paths)?;
+    let mut manifests = Vec::with_capacity(manifest_descriptors.len());
+    let mut required_configs = HashSet::new();
+    let mut required_layers = HashSet::new();
+
+    for descriptor in &manifest_descriptors {
+        let manifest_path = blob_path_from_digest(descriptor.digest().as_ref())?;
+        let manifest_bytes = manifest_blobs.get(&manifest_path).ok_or_else(|| {
+            ImageError::ManifestParse(format!("OCI layout missing manifest blob {manifest_path}"))
+        })?;
+        verify_descriptor_blob(descriptor, manifest_bytes)?;
+        let manifest: oci_spec::image::ImageManifest = serde_json::from_slice(manifest_bytes)
+            .map_err(|e| ImageError::ManifestParse(format!("OCI image manifest: {e}")))?;
+
+        required_configs.insert(blob_path_from_digest(manifest.config().digest().as_ref())?);
+        for layer in manifest.layers() {
+            required_layers.insert(blob_path_from_digest(layer.digest().as_ref())?);
+        }
+        manifests.push((descriptor.clone(), manifest, manifest_bytes.clone()));
+    }
+
+    let file = File::open(input).map_err(|e| ImageError::Cache {
+        path: input.to_path_buf(),
+        source: e,
+    })?;
+    let mut archive = tar::Archive::new(file);
+    let mut configs: HashMap<String, Vec<u8>> = HashMap::new();
+    let mut layers: HashMap<String, LayerBlobInfo> = HashMap::new();
+    let mut temp_counter = 0u64;
+
+    for entry in archive.entries().map_err(ImageError::Io)? {
+        let mut entry = entry.map_err(ImageError::Io)?;
+        let path = normalized_archive_path(&entry)?;
+
+        if required_configs.contains(&path) {
+            let mut data = Vec::new();
+            entry.read_to_end(&mut data).map_err(ImageError::Io)?;
+            configs.insert(path, data);
+            continue;
+        }
+
+        if required_layers.contains(&path) {
+            let info = extract_layer_blob(&cache, &path, &mut entry, temp_counter)?;
+            temp_counter += 1;
+            layers.insert(path, info);
+            continue;
+        }
+    }
+
+    let mut loaded = Vec::new();
+    for (image_index, (descriptor, manifest, manifest_bytes)) in manifests.into_iter().enumerate() {
+        let config_path = blob_path_from_digest(manifest.config().digest().as_ref())?;
+        let config_bytes = configs.get(&config_path).ok_or_else(|| {
+            ImageError::ConfigParse(format!("OCI layout missing config blob {config_path}"))
+        })?;
+        verify_descriptor_blob(manifest.config(), config_bytes)?;
+        let (config, diff_ids) = ImageConfig::parse(config_bytes)?;
+
+        if diff_ids.len() != manifest.layers().len() {
+            return Err(ImageError::ManifestParse(format!(
+                "layer count mismatch: config has {} diff_ids but OCI manifest has {} layers",
+                diff_ids.len(),
+                manifest.layers().len()
+            )));
+        }
+
+        let mut layer_metadata = Vec::with_capacity(manifest.layers().len());
+        for (position, layer_descriptor) in manifest.layers().iter().enumerate() {
+            let layer_path = blob_path_from_digest(layer_descriptor.digest().as_ref())?;
+            let layer = layers.get(&layer_path).ok_or_else(|| {
+                ImageError::ManifestParse(format!("OCI layout missing layer blob {layer_path}"))
+            })?;
+            verify_layer_descriptor(layer_descriptor, layer)?;
+            layer_metadata.push(CachedLayerMetadata {
+                digest: layer.digest.clone(),
+                media_type: Some(layer.media_type.clone()),
+                size_bytes: Some(layer.size_bytes),
+                diff_id: diff_ids[position].clone(),
+            });
+        }
+
+        let metadata = CachedImageMetadata {
+            manifest_digest: format!("sha256:{}", sha256_hex(&manifest_bytes)),
+            config_digest: manifest.config().digest().to_string(),
+            config,
+            layers: layer_metadata,
+        };
+
+        let mut refs = descriptor
+            .annotations()
+            .as_ref()
+            .and_then(|annotations| annotations.get(OCI_REF_NAME_ANNOTATION))
+            .cloned()
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        if image_index == 0 {
+            refs.extend(options.tags.iter().cloned());
+        }
+
+        refs.sort();
+        refs.dedup();
+
+        if refs.is_empty() {
+            return Err(ImageError::ManifestParse(
+                "OCI layout image has no ref.name annotation; pass --tag to name it".into(),
+            ));
+        }
+
+        for reference in refs {
+            let _: Reference = reference.parse().map_err(|e| {
+                ImageError::ManifestParse(format!("invalid image reference {reference}: {e}"))
+            })?;
+            loaded.push(PreparedLoadedImage {
+                reference,
+                metadata: metadata.clone(),
+            });
+        }
+    }
+
+    Ok(loaded)
+}
+
+fn read_archive_entry(input: &Path, wanted_path: &str) -> ImageResult<Option<Vec<u8>>> {
+    let file = File::open(input).map_err(|e| ImageError::Cache {
+        path: input.to_path_buf(),
+        source: e,
+    })?;
+    let mut archive = tar::Archive::new(file);
+
+    for entry in archive.entries().map_err(ImageError::Io)? {
+        let mut entry = entry.map_err(ImageError::Io)?;
+        let path = normalized_archive_path(&entry)?;
+        if path != wanted_path {
+            continue;
+        }
+
+        let mut data = Vec::new();
+        entry.read_to_end(&mut data).map_err(ImageError::Io)?;
+        return Ok(Some(data));
+    }
+
+    Ok(None)
+}
+
+fn read_archive_entries(
+    input: &Path,
+    wanted_paths: &HashSet<String>,
+) -> ImageResult<HashMap<String, Vec<u8>>> {
+    let file = File::open(input).map_err(|e| ImageError::Cache {
+        path: input.to_path_buf(),
+        source: e,
+    })?;
+    let mut archive = tar::Archive::new(file);
+    let mut entries = HashMap::new();
+
+    for entry in archive.entries().map_err(ImageError::Io)? {
+        let mut entry = entry.map_err(ImageError::Io)?;
+        let path = normalized_archive_path(&entry)?;
+        if !wanted_paths.contains(&path) {
+            continue;
+        }
+
+        let mut data = Vec::new();
+        entry.read_to_end(&mut data).map_err(ImageError::Io)?;
+        entries.insert(path, data);
+    }
+
+    Ok(entries)
+}
+
+fn selectable_oci_manifests(
+    descriptors: &[oci_spec::image::Descriptor],
+) -> ImageResult<Vec<oci_spec::image::Descriptor>> {
+    let host = Platform::host_linux();
+    let selected = descriptors
+        .iter()
+        .filter(|descriptor| is_oci_image_manifest_descriptor(descriptor))
+        .filter(|descriptor| descriptor_matches_platform(descriptor, &host))
+        .cloned()
+        .collect();
+
+    Ok(selected)
+}
+
+fn is_oci_image_manifest_descriptor(descriptor: &oci_spec::image::Descriptor) -> bool {
+    matches!(
+        descriptor.media_type(),
+        oci_spec::image::MediaType::ImageManifest
+    ) || descriptor.media_type().to_string()
+        == "application/vnd.docker.distribution.manifest.v2+json"
+}
+
+fn descriptor_matches_platform(descriptor: &oci_spec::image::Descriptor, host: &Platform) -> bool {
+    let Some(platform) = descriptor.platform() else {
+        return true;
+    };
+
+    if *platform.os() != host.os || *platform.architecture() != host.arch {
+        return false;
+    }
+
+    match (&host.variant, platform.variant()) {
+        (Some(host_variant), Some(descriptor_variant)) => host_variant == descriptor_variant,
+        (Some(_), None) => false,
+        (None, _) => true,
+    }
+}
+
+fn blob_path_from_digest(digest: &str) -> ImageResult<String> {
+    let digest: Digest = digest.parse()?;
+    Ok(format!("blobs/{}/{}", digest.algorithm(), digest.hex()))
+}
+
+fn verify_descriptor_blob(
+    descriptor: &oci_spec::image::Descriptor,
+    bytes: &[u8],
+) -> ImageResult<()> {
+    if descriptor.size() != bytes.len() as u64 {
+        return Err(ImageError::ManifestParse(format!(
+            "OCI blob {} size mismatch: descriptor has {}, archive has {}",
+            descriptor.digest(),
+            descriptor.size(),
+            bytes.len()
+        )));
+    }
+
+    verify_digest_bytes(descriptor.digest().as_ref(), bytes)
+}
+
+fn verify_layer_descriptor(
+    descriptor: &oci_spec::image::Descriptor,
+    layer: &LayerBlobInfo,
+) -> ImageResult<()> {
+    if descriptor.size() != layer.size_bytes {
+        return Err(ImageError::ManifestParse(format!(
+            "OCI layer {} size mismatch: descriptor has {}, archive has {}",
+            descriptor.digest(),
+            descriptor.size(),
+            layer.size_bytes
+        )));
+    }
+
+    if descriptor.digest().to_string() != layer.digest {
+        return Err(ImageError::ManifestParse(format!(
+            "OCI layer digest mismatch: descriptor has {}, archive has {}",
+            descriptor.digest(),
+            layer.digest
+        )));
+    }
+
+    Ok(())
+}
+
+fn verify_digest_bytes(digest: &str, bytes: &[u8]) -> ImageResult<()> {
+    let digest: Digest = digest.parse()?;
+    if digest.algorithm() != "sha256" {
+        return Err(ImageError::ManifestParse(format!(
+            "unsupported OCI digest algorithm: {}",
+            digest.algorithm()
+        )));
+    }
+
+    let actual = sha256_hex(bytes);
+    if actual != digest.hex() {
+        return Err(ImageError::ManifestParse(format!(
+            "OCI blob digest mismatch: expected {}, got sha256:{actual}",
+            digest
+        )));
+    }
+
+    Ok(())
+}
+
+fn extract_layer_blob(
+    cache: &GlobalCache,
+    path: &str,
+    entry: &mut tar::Entry<'_, File>,
+    counter: u64,
+) -> ImageResult<LayerBlobInfo> {
+    let temp_path = cache
+        .tmp_dir()
+        .join(format!("load-{}-{counter}.blob", std::process::id()));
+    let mut temp = File::create(&temp_path).map_err(|e| ImageError::Cache {
+        path: temp_path.clone(),
+        source: e,
+    })?;
+    let mut hasher = Sha256::new();
+    let mut size = 0u64;
+    let mut magic = Vec::with_capacity(4);
+    let mut buf = [0u8; 64 * 1024];
+
+    loop {
+        let read = entry.read(&mut buf).map_err(ImageError::Io)?;
+        if read == 0 {
+            break;
+        }
+        if magic.len() < 4 {
+            let take = (4 - magic.len()).min(read);
+            magic.extend_from_slice(&buf[..take]);
+        }
+        hasher.update(&buf[..read]);
+        temp.write_all(&buf[..read])
+            .map_err(|e| ImageError::Cache {
+                path: temp_path.clone(),
+                source: e,
+            })?;
+        size += read as u64;
+    }
+    temp.flush().map_err(|e| ImageError::Cache {
+        path: temp_path.clone(),
+        source: e,
+    })?;
+    drop(temp);
+
+    let digest = Digest::new("sha256", hex::encode(hasher.finalize()));
+    let final_path = cache.tar_path(&digest);
+    if final_path.exists() {
+        let _ = std::fs::remove_file(&temp_path);
+    } else {
+        std::fs::rename(&temp_path, &final_path).map_err(|e| ImageError::Cache {
+            path: final_path,
+            source: e,
+        })?;
+    }
+
+    let media_type = match Compression::detect(&magic) {
+        Compression::None => OCI_LAYER_MEDIA_TYPE,
+        Compression::Gzip => OCI_LAYER_GZIP_MEDIA_TYPE,
+        Compression::Zstd => OCI_LAYER_ZSTD_MEDIA_TYPE,
+    };
+
+    tracing::debug!(path, digest = %digest, size, "loaded layer blob from docker archive");
+
+    Ok(LayerBlobInfo {
+        digest: digest.to_string(),
+        media_type: media_type.to_string(),
+        size_bytes: size,
+    })
+}
+
+fn generate_layer_tar(cache: &GlobalCache, layer: &ImageSaveLayer) -> ImageResult<GeneratedLayer> {
+    let diff_id: Digest = layer.diff_id.parse()?;
+    let erofs_path = cache.layer_erofs_path(&diff_id);
+    let file = File::open(&erofs_path).map_err(|e| ImageError::Cache {
+        path: erofs_path.clone(),
+        source: e,
+    })?;
+    let mut reader = ErofsReader::new(file).map_err(ImageError::Io)?;
+    let temp_path = cache.tmp_dir().join(format!(
+        "save-{}-{}.layer.tar",
+        std::process::id(),
+        diff_id.to_path_safe()
+    ));
+    let temp_file = File::create(&temp_path).map_err(|e| ImageError::Cache {
+        path: temp_path.clone(),
+        source: e,
+    })?;
+    let digesting = DigestingWriter::new(temp_file);
+    let mut builder = tar::Builder::new(digesting);
+    let entries = reader.walk().map_err(ImageError::Io)?;
+    let mut hardlinks: HashMap<u32, PathBuf> = HashMap::new();
+
+    for entry in entries {
+        if entry.path.as_os_str().is_empty() {
+            continue;
+        }
+
+        if entry.kind == ErofsEntryKind::CharDevice && entry.rdev == Some((0, 0)) {
+            append_whiteout(&mut builder, &entry)?;
+            continue;
+        }
+
+        append_erofs_entry(&mut builder, &mut reader, &entry, &mut hardlinks)?;
+
+        if entry.kind == ErofsEntryKind::Directory && entry.is_opaque() {
+            append_opaque_marker(&mut builder, &entry)?;
+        }
+    }
+
+    let digesting = builder.into_inner().map_err(ImageError::Io)?;
+    let (mut file, hex, size) = digesting.finish();
+    file.flush().map_err(|e| ImageError::Cache {
+        path: temp_path.clone(),
+        source: e,
+    })?;
+
+    Ok(GeneratedLayer {
+        diff_id: format!("sha256:{hex}"),
+        hex,
+        path: temp_path,
+        size,
+    })
+}
+
+fn append_erofs_entry(
+    builder: &mut tar::Builder<DigestingWriter<File>>,
+    reader: &mut ErofsReader,
+    entry: &crate::erofs::ErofsTreeEntry,
+    hardlinks: &mut HashMap<u32, PathBuf>,
+) -> ImageResult<()> {
+    let mut header = tar::Header::new_gnu();
+    apply_header_metadata(&mut header, entry);
+
+    match entry.kind {
+        ErofsEntryKind::RegularFile => {
+            if let Some(first_path) = hardlinks.get(&entry.nid) {
+                header.set_entry_type(tar::EntryType::Link);
+                header.set_size(0);
+                header.set_link_name(first_path).map_err(ImageError::Io)?;
+                header.set_cksum();
+                builder
+                    .append_data(&mut header, &entry.path, io::empty())
+                    .map_err(ImageError::Io)?;
+                return Ok(());
+            }
+
+            hardlinks.insert(entry.nid, entry.path.clone());
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_size(entry.size);
+            header.set_cksum();
+            let mut data = reader.file_data_reader(entry.nid).map_err(ImageError::Io)?;
+            builder
+                .append_data(&mut header, &entry.path, &mut data)
+                .map_err(ImageError::Io)?;
+        }
+        ErofsEntryKind::Directory => {
+            header.set_entry_type(tar::EntryType::Directory);
+            header.set_size(0);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, &entry.path, io::empty())
+                .map_err(ImageError::Io)?;
+        }
+        ErofsEntryKind::Symlink => {
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_size(0);
+            let target = reader.read_link_by_nid(entry.nid).map_err(ImageError::Io)?;
+            header
+                .set_link_name_literal(target)
+                .map_err(ImageError::Io)?;
+            header.set_cksum();
+            builder
+                .append_data(&mut header, &entry.path, io::empty())
+                .map_err(ImageError::Io)?;
+        }
+        ErofsEntryKind::CharDevice | ErofsEntryKind::BlockDevice => {
+            header.set_entry_type(if entry.kind == ErofsEntryKind::CharDevice {
+                tar::EntryType::Char
+            } else {
+                tar::EntryType::Block
+            });
+            header.set_size(0);
+            if let Some((major, minor)) = entry.rdev {
+                header.set_device_major(major).map_err(ImageError::Io)?;
+                header.set_device_minor(minor).map_err(ImageError::Io)?;
+            }
+            header.set_cksum();
+            builder
+                .append_data(&mut header, &entry.path, io::empty())
+                .map_err(ImageError::Io)?;
+        }
+        ErofsEntryKind::Fifo => {
+            header.set_entry_type(tar::EntryType::Fifo);
+            header.set_size(0);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, &entry.path, io::empty())
+                .map_err(ImageError::Io)?;
+        }
+        ErofsEntryKind::Socket => {
+            header.set_entry_type(tar::EntryType::new(0o140));
+            header.set_size(0);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, &entry.path, io::empty())
+                .map_err(ImageError::Io)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn append_whiteout(
+    builder: &mut tar::Builder<DigestingWriter<File>>,
+    entry: &crate::erofs::ErofsTreeEntry,
+) -> ImageResult<()> {
+    let Some(file_name) = entry.path.file_name() else {
+        return Ok(());
+    };
+    let mut path = entry.path.clone();
+    path.set_file_name(format!(".wh.{}", file_name.to_string_lossy()));
+    append_empty_file(builder, &path, entry)
+}
+
+fn append_opaque_marker(
+    builder: &mut tar::Builder<DigestingWriter<File>>,
+    entry: &crate::erofs::ErofsTreeEntry,
+) -> ImageResult<()> {
+    let path = entry.path.join(".wh..wh..opq");
+    append_empty_file(builder, &path, entry)
+}
+
+fn append_empty_file(
+    builder: &mut tar::Builder<DigestingWriter<File>>,
+    path: &Path,
+    entry: &crate::erofs::ErofsTreeEntry,
+) -> ImageResult<()> {
+    let mut header = tar::Header::new_gnu();
+    apply_header_metadata(&mut header, entry);
+    header.set_mode(0o000);
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_size(0);
+    header.set_cksum();
+    builder
+        .append_data(&mut header, path, io::empty())
+        .map_err(ImageError::Io)
+}
+
+fn append_layer_entries(
+    archive: &mut tar::Builder<File>,
+    layer: &GeneratedLayer,
+) -> ImageResult<()> {
+    append_bytes(archive, &format!("{}/VERSION", layer.hex), b"1.0\n")?;
+    append_bytes(archive, &format!("{}/json", layer.hex), b"{}")?;
+
+    let mut file = File::open(&layer.path).map_err(|e| ImageError::Cache {
+        path: layer.path.clone(),
+        source: e,
+    })?;
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(layer.size);
+    header.set_cksum();
+    archive
+        .append_data(&mut header, format!("{}/layer.tar", layer.hex), &mut file)
+        .map_err(ImageError::Io)
+}
+
+fn append_blob_file(
+    archive: &mut tar::Builder<File>,
+    hex: &str,
+    path: &Path,
+    size: u64,
+) -> ImageResult<()> {
+    let mut file = File::open(path).map_err(|e| ImageError::Cache {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(size);
+    header.set_cksum();
+    archive
+        .append_data(&mut header, format!("blobs/sha256/{hex}"), &mut file)
+        .map_err(ImageError::Io)
+}
+
+fn append_blob_bytes(archive: &mut tar::Builder<File>, hex: &str, bytes: &[u8]) -> ImageResult<()> {
+    append_bytes(archive, &format!("blobs/sha256/{hex}"), bytes)
+}
+
+fn append_directory(archive: &mut tar::Builder<File>, path: &str) -> ImageResult<()> {
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::Directory);
+    header.set_mode(0o755);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(0);
+    header.set_cksum();
+    archive
+        .append_data(&mut header, path, io::empty())
+        .map_err(ImageError::Io)
+}
+
+fn append_bytes(archive: &mut tar::Builder<File>, path: &str, bytes: &[u8]) -> ImageResult<()> {
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(bytes.len() as u64);
+    header.set_cksum();
+    archive
+        .append_data(&mut header, path, bytes)
+        .map_err(ImageError::Io)
+}
+
+fn docker_config_json(config: &ImageSaveConfig, diff_ids: &[String]) -> ImageResult<Vec<u8>> {
+    let config_json = serde_json::json!({
+        "architecture": config.architecture.as_deref().unwrap_or("amd64"),
+        "os": config.os.as_deref().unwrap_or("linux"),
+        "config": {
+            "Env": config.env,
+            "Entrypoint": config.entrypoint,
+            "Cmd": config.cmd,
+            "WorkingDir": config.working_dir,
+            "User": config.user,
+            "Labels": if config.labels.is_empty() {
+                serde_json::Value::Null
+            } else {
+                serde_json::to_value(&config.labels)
+                    .map_err(|e| ImageError::ConfigParse(format!("serialize labels: {e}")))?
+            },
+        },
+        "rootfs": {
+            "type": "layers",
+            "diff_ids": diff_ids,
+        },
+        "history": diff_ids
+            .iter()
+            .map(|_| serde_json::json!({"created_by": "microsandbox image save"}))
+            .collect::<Vec<_>>(),
+    });
+
+    serde_json::to_vec(&config_json)
+        .map_err(|e| ImageError::ConfigParse(format!("serialize image config: {e}")))
+}
+
+fn apply_header_metadata(header: &mut tar::Header, entry: &crate::erofs::ErofsTreeEntry) {
+    header.set_mode((entry.metadata.mode & 0o7777) as u32);
+    header.set_uid(entry.metadata.uid as u64);
+    header.set_gid(entry.metadata.gid as u64);
+    header.set_mtime(entry.metadata.mtime);
+}
+
+fn normalized_archive_path(entry: &tar::Entry<'_, File>) -> ImageResult<String> {
+    let path = entry.path().map_err(ImageError::Io)?;
+    let bytes = path.as_os_str().as_bytes();
+    let normalized = if let Some(stripped) = bytes.strip_prefix(b"./") {
+        stripped
+    } else {
+        bytes
+    };
+    String::from_utf8(normalized.to_vec())
+        .map_err(|_| ImageError::ManifestParse("archive path is not valid UTF-8".into()))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::io::Cursor;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn docker_archive_load_save_load_roundtrip() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let temp = tempdir().unwrap();
+        let input = temp.path().join("image.tar");
+        write_test_docker_archive(&input, "tiny:latest");
+
+        let first_cache = temp.path().join("cache-1");
+        let loaded = runtime
+            .block_on(load_archive(
+                &first_cache,
+                &input,
+                ImageLoadOptions::default(),
+            ))
+            .unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].reference, "tiny:latest");
+
+        let saved = temp.path().join("saved.tar");
+        let request = save_request_from_loaded(&loaded[0]);
+        let cache = GlobalCache::new(&first_cache).unwrap();
+        save_docker_archive(&cache, &saved, &[request]).unwrap();
+
+        let second_cache = temp.path().join("cache-2");
+        let reloaded = runtime
+            .block_on(load_archive(
+                &second_cache,
+                &saved,
+                ImageLoadOptions::default(),
+            ))
+            .unwrap();
+
+        assert_eq!(reloaded.len(), 1);
+        assert_eq!(reloaded[0].reference, "tiny:latest");
+        assert_eq!(
+            reloaded[0].metadata.config.cmd,
+            Some(vec!["cat".into(), "/hello.txt".into()])
+        );
+    }
+
+    #[test]
+    fn docker_archive_loads_manifest_blob_paths() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let temp = tempdir().unwrap();
+        let input = temp.path().join("blob-paths.tar");
+        write_test_docker_blob_archive_from_layer(&input, "blob-paths:latest", simple_layer_tar());
+
+        let loaded = runtime
+            .block_on(load_archive(
+                &temp.path().join("cache"),
+                &input,
+                ImageLoadOptions::default(),
+            ))
+            .unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].reference, "blob-paths:latest");
+        assert_eq!(
+            loaded[0].metadata.config.cmd,
+            Some(vec!["cat".into(), "/hello.txt".into()])
+        );
+    }
+
+    #[test]
+    fn oci_layout_archive_load_save_load_roundtrip() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let temp = tempdir().unwrap();
+        let input = temp.path().join("oci-layout.tar");
+        write_test_oci_archive_from_layer(&input, "oci-layout:latest", simple_layer_tar());
+
+        let first_cache = temp.path().join("cache-1");
+        let loaded = runtime
+            .block_on(load_archive(
+                &first_cache,
+                &input,
+                ImageLoadOptions::default(),
+            ))
+            .unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].reference, "oci-layout:latest");
+
+        let saved = temp.path().join("saved-oci-layout.tar");
+        let request = save_request_from_loaded(&loaded[0]);
+        let cache = GlobalCache::new(&first_cache).unwrap();
+        save_archive(&cache, &saved, &[request], ImageArchiveFormat::Oci).unwrap();
+
+        let index_bytes = read_archive_entry(&saved, "index.json").unwrap().unwrap();
+        let index: oci_spec::image::ImageIndex = serde_json::from_slice(&index_bytes).unwrap();
+        assert_eq!(index.manifests().len(), 1);
+        assert_eq!(
+            index.manifests()[0]
+                .annotations()
+                .as_ref()
+                .unwrap()
+                .get(OCI_REF_NAME_ANNOTATION),
+            Some(&"oci-layout:latest".to_string())
+        );
+
+        let second_cache = temp.path().join("cache-2");
+        let reloaded = runtime
+            .block_on(load_archive(
+                &second_cache,
+                &saved,
+                ImageLoadOptions::default(),
+            ))
+            .unwrap();
+
+        assert_eq!(reloaded.len(), 1);
+        assert_eq!(reloaded[0].reference, "oci-layout:latest");
+    }
+
+    #[test]
+    fn docker_archive_save_preserves_layer_semantics() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let temp = tempdir().unwrap();
+        let input = temp.path().join("complex.tar");
+        let layer_bytes = complex_layer_tar();
+        write_test_docker_archive_from_layer(&input, "complex:latest", layer_bytes);
+
+        let first_cache = temp.path().join("cache-1");
+        let loaded = runtime
+            .block_on(load_archive(
+                &first_cache,
+                &input,
+                ImageLoadOptions::default(),
+            ))
+            .unwrap();
+
+        let saved = temp.path().join("saved-complex.tar");
+        let request = save_request_from_loaded(&loaded[0]);
+        let cache = GlobalCache::new(&first_cache).unwrap();
+        save_docker_archive(&cache, &saved, &[request]).unwrap();
+
+        let entries = saved_layer_entries(&saved);
+        let config_entry = entries.get("etc/config.txt").unwrap();
+        let config_link_entry = entries.get("etc/config.link").unwrap();
+        let regular_config_paths = [
+            ("etc/config.txt", config_entry),
+            ("etc/config.link", config_link_entry),
+        ]
+        .into_iter()
+        .filter(|(_, entry)| entry.entry_type == tar::EntryType::Regular)
+        .collect::<Vec<_>>();
+        let hardlink_config_paths = [
+            ("etc/config.txt", config_entry),
+            ("etc/config.link", config_link_entry),
+        ]
+        .into_iter()
+        .filter(|(_, entry)| entry.entry_type == tar::EntryType::Link)
+        .collect::<Vec<_>>();
+
+        assert_eq!(regular_config_paths.len(), 1);
+        assert_eq!(hardlink_config_paths.len(), 1);
+        assert_eq!(regular_config_paths[0].1.data, b"shared config\n");
+        assert_eq!(
+            hardlink_config_paths[0].1.link_name.as_deref(),
+            Some(regular_config_paths[0].0)
+        );
+        assert_eq!(regular_config_paths[0].1.mode, 0o640);
+        assert_eq!(regular_config_paths[0].1.uid, 1000);
+        assert_eq!(regular_config_paths[0].1.gid, 1001);
+        assert_eq!(regular_config_paths[0].1.mtime, 42);
+
+        let symlink_entry = entries.get("bin/config").unwrap();
+        assert_eq!(symlink_entry.entry_type, tar::EntryType::Symlink);
+        assert_eq!(
+            symlink_entry.link_name.as_deref(),
+            Some("../etc/config.txt")
+        );
+
+        let whiteout_entry = entries.get("var/.wh.deleted").unwrap();
+        assert_eq!(whiteout_entry.entry_type, tar::EntryType::Regular);
+        assert!(whiteout_entry.data.is_empty());
+
+        let opaque_entry = entries.get("cache/.wh..wh..opq").unwrap();
+        assert_eq!(opaque_entry.entry_type, tar::EntryType::Regular);
+        assert!(opaque_entry.data.is_empty());
+
+        let second_cache = temp.path().join("cache-2");
+        let reloaded = runtime
+            .block_on(load_archive(
+                &second_cache,
+                &saved,
+                ImageLoadOptions::default(),
+            ))
+            .unwrap();
+
+        assert_eq!(reloaded.len(), 1);
+        assert_eq!(reloaded[0].reference, "complex:latest");
+    }
+
+    fn write_test_docker_archive(path: &Path, reference: &str) {
+        write_test_docker_archive_from_layer(path, reference, simple_layer_tar());
+    }
+
+    fn write_test_docker_archive_from_layer(path: &Path, reference: &str, layer_bytes: Vec<u8>) {
+        let diff_id = format!("sha256:{}", sha256_hex(&layer_bytes));
+        let config_bytes = test_config_bytes(&diff_id);
+        let config_name = format!("{}.json", sha256_hex(&config_bytes));
+
+        write_test_docker_archive_entries(
+            path,
+            reference,
+            config_name,
+            "layer/layer.tar".into(),
+            config_bytes,
+            layer_bytes,
+        );
+    }
+
+    fn write_test_docker_blob_archive_from_layer(
+        path: &Path,
+        reference: &str,
+        layer_bytes: Vec<u8>,
+    ) {
+        let diff_id = format!("sha256:{}", sha256_hex(&layer_bytes));
+        let config_bytes = test_config_bytes(&diff_id);
+        let config_name = format!("blobs/sha256/{}", sha256_hex(&config_bytes));
+        let layer_name = format!("blobs/sha256/{}", sha256_hex(&layer_bytes));
+
+        write_test_docker_archive_entries(
+            path,
+            reference,
+            config_name,
+            layer_name,
+            config_bytes,
+            layer_bytes,
+        );
+    }
+
+    fn write_test_oci_archive_from_layer(path: &Path, reference: &str, layer_bytes: Vec<u8>) {
+        let diff_id = format!("sha256:{}", sha256_hex(&layer_bytes));
+        let config_bytes = test_config_bytes(&diff_id);
+        let config_hex = sha256_hex(&config_bytes);
+        let layer_hex = sha256_hex(&layer_bytes);
+        let manifest_bytes = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_MANIFEST_MEDIA_TYPE,
+            "config": {
+                "mediaType": OCI_CONFIG_MEDIA_TYPE,
+                "digest": format!("sha256:{config_hex}"),
+                "size": config_bytes.len(),
+            },
+            "layers": [{
+                "mediaType": OCI_LAYER_MEDIA_TYPE,
+                "digest": format!("sha256:{layer_hex}"),
+                "size": layer_bytes.len(),
+            }],
+        }))
+        .unwrap();
+        let manifest_hex = sha256_hex(&manifest_bytes);
+        let host = Platform::host_linux();
+        let index_bytes = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_INDEX_MEDIA_TYPE,
+            "manifests": [{
+                "mediaType": OCI_MANIFEST_MEDIA_TYPE,
+                "digest": format!("sha256:{manifest_hex}"),
+                "size": manifest_bytes.len(),
+                "platform": {
+                    "architecture": host.arch.to_string(),
+                    "os": host.os.to_string(),
+                },
+                "annotations": {
+                    (OCI_REF_NAME_ANNOTATION): reference,
+                },
+            }],
+        }))
+        .unwrap();
+
+        let file = File::create(path).unwrap();
+        let mut archive = tar::Builder::new(file);
+        append_bytes(
+            &mut archive,
+            "oci-layout",
+            br#"{"imageLayoutVersion":"1.0.0"}"#,
+        )
+        .unwrap();
+        append_bytes(&mut archive, "index.json", &index_bytes).unwrap();
+        append_bytes(
+            &mut archive,
+            &format!("blobs/sha256/{config_hex}"),
+            &config_bytes,
+        )
+        .unwrap();
+        append_bytes(
+            &mut archive,
+            &format!("blobs/sha256/{manifest_hex}"),
+            &manifest_bytes,
+        )
+        .unwrap();
+        append_bytes(
+            &mut archive,
+            &format!("blobs/sha256/{layer_hex}"),
+            &layer_bytes,
+        )
+        .unwrap();
+        archive.finish().unwrap();
+    }
+
+    fn simple_layer_tar() -> Vec<u8> {
+        let mut layer_bytes = Vec::new();
+        {
+            let mut layer = tar::Builder::new(&mut layer_bytes);
+            let data = b"hello from archive\n";
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_mode(0o644);
+            header.set_uid(0);
+            header.set_gid(0);
+            header.set_mtime(0);
+            header.set_size(data.len() as u64);
+            header.set_cksum();
+            layer
+                .append_data(&mut header, "hello.txt", Cursor::new(data))
+                .unwrap();
+            layer.finish().unwrap();
+        }
+
+        layer_bytes
+    }
+
+    fn test_config_bytes(diff_id: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "architecture": "arm64",
+            "os": "linux",
+            "config": {
+                "Env": ["PATH=/usr/bin"],
+                "Cmd": ["cat", "/hello.txt"],
+            },
+            "rootfs": {
+                "type": "layers",
+                "diff_ids": [diff_id],
+            },
+        }))
+        .unwrap()
+    }
+
+    fn write_test_docker_archive_entries(
+        path: &Path,
+        reference: &str,
+        config_name: String,
+        layer_name: String,
+        config_bytes: Vec<u8>,
+        layer_bytes: Vec<u8>,
+    ) {
+        let manifest_bytes = serde_json::to_vec(&vec![DockerManifestOut {
+            config: config_name.clone(),
+            repo_tags: vec![reference.into()],
+            layers: vec![layer_name.clone()],
+        }])
+        .unwrap();
+
+        let file = File::create(path).unwrap();
+        let mut archive = tar::Builder::new(file);
+        append_bytes(&mut archive, &config_name, &config_bytes).unwrap();
+        append_bytes(&mut archive, "manifest.json", &manifest_bytes).unwrap();
+
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_mode(0o644);
+        header.set_uid(0);
+        header.set_gid(0);
+        header.set_mtime(0);
+        header.set_size(layer_bytes.len() as u64);
+        header.set_cksum();
+        archive
+            .append_data(&mut header, layer_name, Cursor::new(layer_bytes))
+            .unwrap();
+        archive.finish().unwrap();
+    }
+
+    fn complex_layer_tar() -> Vec<u8> {
+        let mut layer_bytes = Vec::new();
+        {
+            let mut layer = tar::Builder::new(&mut layer_bytes);
+            append_test_dir(&mut layer, "bin", 0o755, 0, 0, 1);
+            append_test_dir(&mut layer, "cache", 0o755, 0, 0, 1);
+            append_test_dir(&mut layer, "etc", 0o755, 0, 0, 1);
+            append_test_dir(&mut layer, "var", 0o755, 0, 0, 1);
+            append_test_file(
+                &mut layer,
+                "etc/config.txt",
+                b"shared config\n",
+                0o640,
+                1000,
+                1001,
+                42,
+            );
+            append_test_hardlink(&mut layer, "etc/config.link", "etc/config.txt");
+            append_test_symlink(&mut layer, "bin/config", "../etc/config.txt");
+            append_test_file(&mut layer, "var/.wh.deleted", b"", 0o000, 0, 0, 1);
+            append_test_file(&mut layer, "cache/.wh..wh..opq", b"", 0o000, 0, 0, 1);
+            layer.finish().unwrap();
+        }
+        layer_bytes
+    }
+
+    fn append_test_dir(
+        layer: &mut tar::Builder<&mut Vec<u8>>,
+        path: &str,
+        mode: u32,
+        uid: u64,
+        gid: u64,
+        mtime: u64,
+    ) {
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Directory);
+        header.set_mode(mode);
+        header.set_uid(uid);
+        header.set_gid(gid);
+        header.set_mtime(mtime);
+        header.set_size(0);
+        header.set_cksum();
+        layer.append_data(&mut header, path, io::empty()).unwrap();
+    }
+
+    fn append_test_file(
+        layer: &mut tar::Builder<&mut Vec<u8>>,
+        path: &str,
+        data: &[u8],
+        mode: u32,
+        uid: u64,
+        gid: u64,
+        mtime: u64,
+    ) {
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_mode(mode);
+        header.set_uid(uid);
+        header.set_gid(gid);
+        header.set_mtime(mtime);
+        header.set_size(data.len() as u64);
+        header.set_cksum();
+        layer
+            .append_data(&mut header, path, Cursor::new(data))
+            .unwrap();
+    }
+
+    fn append_test_hardlink(layer: &mut tar::Builder<&mut Vec<u8>>, path: &str, target: &str) {
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Link);
+        header.set_link_name(target).unwrap();
+        header.set_size(0);
+        header.set_cksum();
+        layer.append_data(&mut header, path, io::empty()).unwrap();
+    }
+
+    fn append_test_symlink(layer: &mut tar::Builder<&mut Vec<u8>>, path: &str, target: &str) {
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_link_name(target).unwrap();
+        header.set_mode(0o777);
+        header.set_size(0);
+        header.set_cksum();
+        layer.append_data(&mut header, path, io::empty()).unwrap();
+    }
+
+    #[derive(Debug)]
+    struct SavedLayerEntry {
+        entry_type: tar::EntryType,
+        link_name: Option<String>,
+        mode: u32,
+        uid: u64,
+        gid: u64,
+        mtime: u64,
+        data: Vec<u8>,
+    }
+
+    fn saved_layer_entries(path: &Path) -> BTreeMap<String, SavedLayerEntry> {
+        let file = File::open(path).unwrap();
+        let mut archive = tar::Archive::new(file);
+        let mut layer_bytes = None;
+
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let entry_path = entry.path().unwrap().to_string_lossy().into_owned();
+            if entry_path.ends_with("/layer.tar") {
+                assert!(layer_bytes.is_none());
+                let mut data = Vec::new();
+                entry.read_to_end(&mut data).unwrap();
+                layer_bytes = Some(data);
+            }
+        }
+
+        let layer_bytes = layer_bytes.unwrap();
+        let mut layer = tar::Archive::new(Cursor::new(layer_bytes));
+        let mut entries = BTreeMap::new();
+
+        for entry in layer.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().to_string_lossy().into_owned();
+            let header = entry.header();
+            let entry_type = header.entry_type();
+            let mode = header.mode().unwrap();
+            let uid = header.uid().unwrap();
+            let gid = header.gid().unwrap();
+            let mtime = header.mtime().unwrap();
+            let link_name = if matches!(entry_type, tar::EntryType::Link | tar::EntryType::Symlink)
+            {
+                Some(String::from_utf8_lossy(entry.link_name_bytes().unwrap().as_ref()).into())
+            } else {
+                None
+            };
+            let mut data = Vec::new();
+            entry.read_to_end(&mut data).unwrap();
+
+            entries.insert(
+                path,
+                SavedLayerEntry {
+                    entry_type,
+                    link_name,
+                    mode,
+                    uid,
+                    gid,
+                    mtime,
+                    data,
+                },
+            );
+        }
+
+        entries
+    }
+
+    fn save_request_from_loaded(image: &LoadedImage) -> ImageSaveRequest {
+        let host = Platform::host_linux();
+        ImageSaveRequest {
+            reference: image.reference.clone(),
+            config: ImageSaveConfig {
+                architecture: Some(host.arch.to_string()),
+                os: Some(host.os.to_string()),
+                env: image.metadata.config.env.clone(),
+                entrypoint: image.metadata.config.entrypoint.clone(),
+                cmd: image.metadata.config.cmd.clone(),
+                working_dir: image.metadata.config.working_dir.clone(),
+                user: image.metadata.config.user.clone(),
+                labels: image
+                    .metadata
+                    .config
+                    .labels
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect(),
+            },
+            layers: image
+                .metadata
+                .layers
+                .iter()
+                .map(|layer| ImageSaveLayer {
+                    diff_id: layer.diff_id.clone(),
+                })
+                .collect(),
+        }
+    }
+}

--- a/crates/image/lib/archive/mod.rs
+++ b/crates/image/lib/archive/mod.rs
@@ -1,0 +1,12 @@
+//! Docker archive load/save support.
+
+mod docker;
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use docker::{
+    ImageArchiveFormat, ImageLoadOptions, ImageSaveConfig, ImageSaveLayer, ImageSaveRequest,
+    LoadedImage, load_archive, save_archive, save_docker_archive,
+};

--- a/crates/image/lib/cache/store.rs
+++ b/crates/image/lib/cache/store.rs
@@ -77,6 +77,10 @@ pub struct CachedImageMetadata {
     pub manifest_digest: String,
     /// Content-addressable digest of the config blob.
     pub config_digest: String,
+    /// Raw resolved image manifest JSON.
+    pub raw_manifest_json: String,
+    /// Raw image config JSON.
+    pub raw_config_json: String,
     /// Parsed OCI image configuration.
     pub config: ImageConfig,
     /// Layer metadata in bottom-to-top order.

--- a/crates/image/lib/erofs/mod.rs
+++ b/crates/image/lib/erofs/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod writer;
 
 pub use fsmeta::write_fsmeta;
 pub use reader::{
-    ErofsEntryInfo, ErofsEntryKind, ErofsReader, entry_info_from_erofs, read_file_from_erofs,
+    ErofsEntryInfo, ErofsEntryKind, ErofsFileDataReader, ErofsReader, ErofsTreeEntry,
+    entry_info_from_erofs, read_file_from_erofs,
 };
 pub use writer::{ErofsDataMap, ErofsError, write_erofs};

--- a/crates/image/lib/erofs/reader.rs
+++ b/crates/image/lib/erofs/reader.rs
@@ -6,6 +6,7 @@
 //! - Sorted directory entries (binary search)
 //! - No shared xattrs, no compression, no chunks
 
+use std::collections::HashSet;
 use std::io::Read;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::FileExt;
@@ -158,8 +159,20 @@ impl ErofsReader {
     pub fn walk(&mut self) -> io::Result<Vec<ErofsTreeEntry>> {
         let root = self.read_inode(self.root_nid)?;
         let mut entries = Vec::new();
-        self.walk_dir(&root, PathBuf::new(), &mut entries)?;
+        let mut visited = HashSet::new();
+        self.walk_dir(&root, PathBuf::new(), &mut entries, &mut visited)?;
         Ok(entries)
+    }
+
+    /// Walk all entries in stable path order, invoking a callback for each entry.
+    pub fn walk_entries<E, F>(&mut self, mut visit: F) -> Result<(), E>
+    where
+        E: From<io::Error>,
+        F: FnMut(&mut Self, ErofsTreeEntry) -> Result<(), E>,
+    {
+        let root = self.read_inode(self.root_nid)?;
+        let mut visited = HashSet::new();
+        self.walk_dir_entries(&root, PathBuf::new(), &mut visited, &mut visit)
     }
 
     /// Create a streaming reader for a regular file inode by NID.
@@ -301,19 +314,18 @@ impl ErofsReader {
     /// same trick). Name lengths are derived from consecutive `nameoff`
     /// values; the last entry's name extends to the end of valid data.
     fn lookup_in_dir(&mut self, dir_inode: &InodeInfo, name: &str) -> io::Result<u32> {
-        let dir_data = self.read_inode_data(dir_inode)?;
         let blksiz = EROFS_BLKSIZ as usize;
         let target = name.as_bytes();
-        let block_count = dir_data.len().div_ceil(blksiz);
+        let block_count = self.checked_inode_data_len(dir_inode)?.div_ceil(blksiz);
         let mut left = 0usize;
         let mut right = block_count;
 
         while left < right {
             let mid = (left + right) / 2;
-            let block = dir_block(&dir_data, mid, blksiz);
-            let dirent_count = dir_block_dirent_count(block)?;
-            let first_name = dirent_name(block, 0, dirent_count)?;
-            let last_name = dirent_name(block, dirent_count - 1, dirent_count)?;
+            let block = self.read_inode_data_block(dir_inode, mid)?;
+            let dirent_count = dir_block_dirent_count(&block)?;
+            let first_name = dirent_name(&block, 0, dirent_count)?;
+            let last_name = dirent_name(&block, dirent_count - 1, dirent_count)?;
 
             if target < first_name {
                 right = mid;
@@ -325,7 +337,7 @@ impl ErofsReader {
                 continue;
             }
 
-            return lookup_in_dir_block(block, dirent_count, target)?.ok_or_else(|| {
+            return lookup_in_dir_block(&block, dirent_count, target)?.ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::NotFound,
                     format!("entry '{name}' not found in directory"),
@@ -344,55 +356,108 @@ impl ErofsReader {
         dir_inode: &InodeInfo,
         dir_path: PathBuf,
         entries: &mut Vec<ErofsTreeEntry>,
+        visited: &mut HashSet<u32>,
     ) -> io::Result<()> {
-        for (name, nid) in self.read_dir_entries(dir_inode)? {
+        if !visited.insert(dir_inode.nid) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "cycle detected while walking EROFS directory tree",
+            ));
+        }
+
+        self.visit_dir_entries::<io::Error, _>(dir_inode, &mut |reader, name, nid| {
             if name.as_bytes() == b"." || name.as_bytes() == b".." {
-                continue;
+                return Ok(());
             }
 
             let path = dir_path.join(&name);
-            let inode = self.read_inode(nid)?;
-            let entry = self.tree_entry(path.clone(), &inode)?;
+            let inode = reader.read_inode(nid)?;
+            let entry = reader.tree_entry(path.clone(), &inode)?;
             let is_dir = entry.kind == ErofsEntryKind::Directory;
             entries.push(entry);
 
             if is_dir {
-                self.walk_dir(&inode, path, entries)?;
+                reader.walk_dir(&inode, path, entries, visited)?;
             }
-        }
+            Ok(())
+        })?;
 
         Ok(())
     }
 
-    fn read_dir_entries(&mut self, dir_inode: &InodeInfo) -> io::Result<Vec<(OsString, u32)>> {
-        if (dir_inode.mode & S_IFMT) != S_IFDIR {
+    fn walk_dir_entries<E, F>(
+        &mut self,
+        dir_inode: &InodeInfo,
+        dir_path: PathBuf,
+        visited: &mut HashSet<u32>,
+        visit: &mut F,
+    ) -> Result<(), E>
+    where
+        E: From<io::Error>,
+        F: FnMut(&mut Self, ErofsTreeEntry) -> Result<(), E>,
+    {
+        if !visited.insert(dir_inode.nid) {
             return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "target is not a directory",
-            ));
+                io::ErrorKind::InvalidData,
+                "cycle detected while walking EROFS directory tree",
+            )
+            .into());
         }
 
-        let dir_data = self.read_inode_data(dir_inode)?;
+        self.visit_dir_entries::<E, _>(dir_inode, &mut |reader, name, nid| {
+            if name.as_bytes() == b"." || name.as_bytes() == b".." {
+                return Ok(());
+            }
+
+            let path = dir_path.join(&name);
+            let inode = reader.read_inode(nid)?;
+            let entry = reader.tree_entry(path.clone(), &inode)?;
+            let is_dir = entry.kind == ErofsEntryKind::Directory;
+            visit(reader, entry)?;
+
+            if is_dir {
+                reader.walk_dir_entries(&inode, path, visited, visit)?;
+            }
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    fn visit_dir_entries<E, F>(&mut self, dir_inode: &InodeInfo, visit: &mut F) -> Result<(), E>
+    where
+        E: From<io::Error>,
+        F: FnMut(&mut Self, OsString, u32) -> Result<(), E>,
+    {
+        if (dir_inode.mode & S_IFMT) != S_IFDIR {
+            return Err(
+                io::Error::new(io::ErrorKind::InvalidInput, "target is not a directory").into(),
+            );
+        }
+
         let blksiz = EROFS_BLKSIZ as usize;
-        let block_count = dir_data.len().div_ceil(blksiz);
-        let mut entries = Vec::new();
+        let block_count = self.checked_inode_data_len(dir_inode)?.div_ceil(blksiz);
 
         for block_index in 0..block_count {
-            let block = dir_block(&dir_data, block_index, blksiz);
+            let block = self.read_inode_data_block(dir_inode, block_index)?;
             if block.is_empty() {
                 continue;
             }
-            let dirent_count = dir_block_dirent_count(block)?;
+            let dirent_count = dir_block_dirent_count(&block)?;
             for idx in 0..dirent_count {
-                let name = dirent_name(block, idx, dirent_count)?;
+                let name = dirent_name(&block, idx, dirent_count)?;
                 if name.is_empty() {
                     continue;
                 }
-                entries.push((OsString::from_vec(name.to_vec()), dirent_nid(block, idx)?));
+                visit(
+                    self,
+                    OsString::from_vec(name.to_vec()),
+                    dirent_nid(&block, idx)?,
+                )?;
             }
         }
 
-        Ok(entries)
+        Ok(())
     }
 
     fn tree_entry(&mut self, path: PathBuf, inode: &InodeInfo) -> io::Result<ErofsTreeEntry> {
@@ -422,7 +487,7 @@ impl ErofsReader {
     }
 
     fn read_inode_data(&mut self, inode: &InodeInfo) -> io::Result<Vec<u8>> {
-        let size = inode.size as usize;
+        let size = self.checked_inode_data_len(inode)?;
         if size == 0 {
             return Ok(Vec::new());
         }
@@ -469,6 +534,99 @@ impl ErofsReader {
                 format!("unsupported data layout: {}", inode.data_layout),
             )),
         }
+    }
+
+    fn read_inode_data_block(&self, inode: &InodeInfo, block_index: usize) -> io::Result<Vec<u8>> {
+        let blksiz = EROFS_BLKSIZ as usize;
+        let size = self.checked_inode_data_len(inode)?;
+        let start = block_index.checked_mul(blksiz).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "directory block overflow")
+        })?;
+        if start >= size {
+            return Ok(Vec::new());
+        }
+
+        let remaining = size - start;
+        let len = remaining.min(blksiz);
+        self.read_inode_data_range(inode, start as u64, len)
+    }
+
+    fn read_inode_data_range(
+        &self,
+        inode: &InodeInfo,
+        start: u64,
+        len: usize,
+    ) -> io::Result<Vec<u8>> {
+        let size = self.checked_inode_data_len(inode)? as u64;
+        let end = start
+            .checked_add(len as u64)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "inode range overflow"))?;
+        if end > size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "inode data range exceeds inode size",
+            ));
+        }
+
+        let segments = self.inode_data_segments(inode)?;
+        let mut data = vec![0u8; len];
+        let mut copied = 0usize;
+        let mut logical_start = 0u64;
+
+        for (file_offset, segment_len) in segments {
+            let logical_end = logical_start.checked_add(segment_len).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "inode segment range overflow")
+            })?;
+            let overlap_start = start.max(logical_start);
+            let overlap_end = end.min(logical_end);
+
+            if overlap_start < overlap_end {
+                let dst_start = (overlap_start - start) as usize;
+                let read_len = (overlap_end - overlap_start) as usize;
+                let source_offset = file_offset
+                    .checked_add(overlap_start - logical_start)
+                    .ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::InvalidData, "inode file offset overflow")
+                    })?;
+                read_exact_at(
+                    &self.file,
+                    source_offset,
+                    &mut data[dst_start..dst_start + read_len],
+                )?;
+                copied += read_len;
+            }
+
+            logical_start = logical_end;
+            if logical_start >= end {
+                break;
+            }
+        }
+
+        if copied != len {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "inode data range is not fully backed",
+            ));
+        }
+
+        Ok(data)
+    }
+
+    fn checked_inode_data_len(&self, inode: &InodeInfo) -> io::Result<usize> {
+        let file_len = self.file.metadata()?.len();
+        if inode.size > file_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "inode data size exceeds EROFS image size",
+            ));
+        }
+
+        usize::try_from(inode.size).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "inode data size does not fit in memory",
+            )
+        })
     }
 
     fn inode_data_segments(&self, inode: &InodeInfo) -> io::Result<Vec<(u64, u64)>> {
@@ -676,12 +834,6 @@ fn read_exact_at(file: &File, offset: u64, mut buf: &mut [u8]) -> io::Result<()>
     }
 
     Ok(())
-}
-
-fn dir_block(dir_data: &[u8], block_idx: usize, blksiz: usize) -> &[u8] {
-    let offset = block_idx * blksiz;
-    let end = (offset + blksiz).min(dir_data.len());
-    &dir_data[offset..end]
 }
 
 fn dir_block_dirent_count(block: &[u8]) -> io::Result<usize> {

--- a/crates/image/lib/erofs/reader.rs
+++ b/crates/image/lib/erofs/reader.rs
@@ -6,9 +6,11 @@
 //! - Sorted directory entries (binary search)
 //! - No shared xattrs, no compression, no chunks
 
+use std::io::Read;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::FileExt;
 use std::path::Path;
-use std::{fs::File, io};
+use std::{ffi::OsString, fs::File, io, path::PathBuf};
 
 use super::format::{
     EROFS_BLKSIZ, EROFS_DIRENT_SIZE, EROFS_INODE_EXTENDED_SIZE, EROFS_INODE_FLAT_INLINE,
@@ -16,6 +18,7 @@ use super::format::{
     EROFS_XATTR_INDEX_SECURITY, EROFS_XATTR_INDEX_TRUSTED, EROFS_XATTR_INDEX_USER, S_IFBLK,
     S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK, erofs_xattr_align,
 };
+use crate::tree::{InodeMetadata, Xattr};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -44,6 +47,33 @@ pub struct ErofsEntryInfo {
     pub kind: ErofsEntryKind,
     pub opaque: bool,
     pub whiteout: bool,
+}
+
+/// A filesystem entry discovered while walking an EROFS image.
+#[derive(Clone)]
+pub struct ErofsTreeEntry {
+    /// Path relative to the image root.
+    pub path: PathBuf,
+    /// Stable EROFS inode identifier.
+    pub nid: u32,
+    /// Entry kind.
+    pub kind: ErofsEntryKind,
+    /// POSIX inode metadata.
+    pub metadata: InodeMetadata,
+    /// Inline xattrs stored on the inode.
+    pub xattrs: Vec<Xattr>,
+    /// File or symlink data size.
+    pub size: u64,
+    /// Device major/minor for device nodes.
+    pub rdev: Option<(u32, u32)>,
+}
+
+/// Streaming reader for a regular file stored inside an EROFS image.
+pub struct ErofsFileDataReader {
+    file: File,
+    segments: Vec<(u64, u64)>,
+    segment_index: usize,
+    segment_offset: u64,
 }
 
 #[cfg(test)]
@@ -124,6 +154,44 @@ impl ErofsReader {
         })
     }
 
+    /// Walk all entries in the image in stable path order.
+    pub fn walk(&mut self) -> io::Result<Vec<ErofsTreeEntry>> {
+        let root = self.read_inode(self.root_nid)?;
+        let mut entries = Vec::new();
+        self.walk_dir(&root, PathBuf::new(), &mut entries)?;
+        Ok(entries)
+    }
+
+    /// Create a streaming reader for a regular file inode by NID.
+    pub fn file_data_reader(&mut self, nid: u32) -> io::Result<ErofsFileDataReader> {
+        let inode = self.read_inode(nid)?;
+        if (inode.mode & S_IFMT) != S_IFREG {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "target is not a regular file",
+            ));
+        }
+
+        Ok(ErofsFileDataReader {
+            file: self.file.try_clone()?,
+            segments: self.inode_data_segments(&inode)?,
+            segment_index: 0,
+            segment_offset: 0,
+        })
+    }
+
+    /// Read a symlink target by NID.
+    pub fn read_link_by_nid(&mut self, nid: u32) -> io::Result<Vec<u8>> {
+        let inode = self.read_inode(nid)?;
+        if (inode.mode & S_IFMT) != S_IFLNK {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "target is not a symlink",
+            ));
+        }
+        self.read_inode_data(&inode)
+    }
+
     #[cfg(test)]
     pub(crate) fn inode_debug_info(&mut self, path: &str) -> io::Result<ErofsInodeDebugInfo> {
         let inode = self.lookup_path(path)?;
@@ -152,8 +220,13 @@ impl ErofsReader {
             buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15],
         ]);
         let i_u = u32::from_le_bytes([buf[16], buf[17], buf[18], buf[19]]);
-        #[cfg(test)]
         let nlink = u32::from_le_bytes([buf[44], buf[45], buf[46], buf[47]]);
+        let uid = u32::from_le_bytes([buf[24], buf[25], buf[26], buf[27]]);
+        let gid = u32::from_le_bytes([buf[28], buf[29], buf[30], buf[31]]);
+        let mtime = u64::from_le_bytes([
+            buf[32], buf[33], buf[34], buf[35], buf[36], buf[37], buf[38], buf[39],
+        ]);
+        let mtime_nsec = u32::from_le_bytes([buf[40], buf[41], buf[42], buf[43]]);
 
         let data_layout = ((i_format >> 1) & 0x07) as u8;
 
@@ -170,8 +243,11 @@ impl ErofsReader {
             nid,
             mode,
             size,
-            #[cfg(test)]
             nlink,
+            uid,
+            gid,
+            mtime,
+            mtime_nsec,
             data_layout,
             startblk_lo: i_u,
             rdev: i_u,
@@ -263,6 +339,88 @@ impl ErofsReader {
         ))
     }
 
+    fn walk_dir(
+        &mut self,
+        dir_inode: &InodeInfo,
+        dir_path: PathBuf,
+        entries: &mut Vec<ErofsTreeEntry>,
+    ) -> io::Result<()> {
+        for (name, nid) in self.read_dir_entries(dir_inode)? {
+            if name.as_bytes() == b"." || name.as_bytes() == b".." {
+                continue;
+            }
+
+            let path = dir_path.join(&name);
+            let inode = self.read_inode(nid)?;
+            let entry = self.tree_entry(path.clone(), &inode)?;
+            let is_dir = entry.kind == ErofsEntryKind::Directory;
+            entries.push(entry);
+
+            if is_dir {
+                self.walk_dir(&inode, path, entries)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn read_dir_entries(&mut self, dir_inode: &InodeInfo) -> io::Result<Vec<(OsString, u32)>> {
+        if (dir_inode.mode & S_IFMT) != S_IFDIR {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "target is not a directory",
+            ));
+        }
+
+        let dir_data = self.read_inode_data(dir_inode)?;
+        let blksiz = EROFS_BLKSIZ as usize;
+        let block_count = dir_data.len().div_ceil(blksiz);
+        let mut entries = Vec::new();
+
+        for block_index in 0..block_count {
+            let block = dir_block(&dir_data, block_index, blksiz);
+            if block.is_empty() {
+                continue;
+            }
+            let dirent_count = dir_block_dirent_count(block)?;
+            for idx in 0..dirent_count {
+                let name = dirent_name(block, idx, dirent_count)?;
+                if name.is_empty() {
+                    continue;
+                }
+                entries.push((OsString::from_vec(name.to_vec()), dirent_nid(block, idx)?));
+            }
+        }
+
+        Ok(entries)
+    }
+
+    fn tree_entry(&mut self, path: PathBuf, inode: &InodeInfo) -> io::Result<ErofsTreeEntry> {
+        let kind = inode_kind(inode)?;
+        let rdev = if matches!(
+            kind,
+            ErofsEntryKind::CharDevice | ErofsEntryKind::BlockDevice
+        ) {
+            Some(decode_dev(inode.rdev))
+        } else {
+            None
+        };
+
+        Ok(ErofsTreeEntry {
+            path,
+            nid: inode.nid,
+            kind,
+            metadata: inode.metadata(),
+            xattrs: self
+                .read_inode_xattrs(inode)?
+                .into_iter()
+                .map(|(name, value)| Xattr { name, value })
+                .collect(),
+            size: inode.size,
+            rdev,
+        })
+    }
+
     fn read_inode_data(&mut self, inode: &InodeInfo) -> io::Result<Vec<u8>> {
         let size = inode.size as usize;
         if size == 0 {
@@ -305,6 +463,45 @@ impl ErofsReader {
                 }
 
                 Ok(data)
+            }
+            _ => Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!("unsupported data layout: {}", inode.data_layout),
+            )),
+        }
+    }
+
+    fn inode_data_segments(&self, inode: &InodeInfo) -> io::Result<Vec<(u64, u64)>> {
+        let size = inode.size;
+        if size == 0 {
+            return Ok(Vec::new());
+        }
+
+        let blksiz = EROFS_BLKSIZ as u64;
+        match inode.data_layout {
+            EROFS_INODE_FLAT_PLAIN => {
+                if inode.startblk_lo == EROFS_NULL_ADDR {
+                    Ok(Vec::new())
+                } else {
+                    Ok(vec![((inode.startblk_lo as u64) * blksiz, size)])
+                }
+            }
+            EROFS_INODE_FLAT_INLINE => {
+                let full_blocks = size / blksiz;
+                let tail_size = size % blksiz;
+                let mut segments = Vec::new();
+                if full_blocks > 0 && inode.startblk_lo != EROFS_NULL_ADDR {
+                    segments.push(((inode.startblk_lo as u64) * blksiz, full_blocks * blksiz));
+                }
+                if tail_size > 0 {
+                    segments.push((
+                        self.inode_offset(inode.nid)
+                            + EROFS_INODE_EXTENDED_SIZE as u64
+                            + inode.xattr_ibody_size as u64,
+                        tail_size,
+                    ));
+                }
+                Ok(segments)
             }
             _ => Err(io::Error::new(
                 io::ErrorKind::Unsupported,
@@ -400,12 +597,64 @@ struct InodeInfo {
     nid: u32,
     mode: u16,
     size: u64,
-    #[cfg(test)]
+    #[allow(dead_code)]
     nlink: u32,
+    uid: u32,
+    gid: u32,
+    mtime: u64,
+    mtime_nsec: u32,
     data_layout: u8,
     startblk_lo: u32,
     rdev: u32,
     xattr_ibody_size: u32,
+}
+
+impl InodeInfo {
+    fn metadata(&self) -> InodeMetadata {
+        InodeMetadata {
+            uid: self.uid,
+            gid: self.gid,
+            mode: self.mode,
+            mtime: self.mtime,
+            mtime_nsec: self.mtime_nsec,
+        }
+    }
+}
+
+impl ErofsTreeEntry {
+    /// Return true if this directory carries the overlay opaque marker.
+    pub fn is_opaque(&self) -> bool {
+        self.xattrs
+            .iter()
+            .any(|x| x.name == b"trusted.overlay.opaque" && x.value == b"y")
+    }
+}
+
+impl Read for ErofsFileDataReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        while self.segment_index < self.segments.len() {
+            let (offset, len) = self.segments[self.segment_index];
+            if self.segment_offset >= len {
+                self.segment_index += 1;
+                self.segment_offset = 0;
+                continue;
+            }
+
+            let remaining = (len - self.segment_offset) as usize;
+            let to_read = remaining.min(buf.len());
+            let read = self
+                .file
+                .read_at(&mut buf[..to_read], offset + self.segment_offset)?;
+            self.segment_offset += read as u64;
+            return Ok(read);
+        }
+
+        Ok(0)
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -553,6 +802,12 @@ fn inode_kind(inode: &InodeInfo) -> io::Result<ErofsEntryKind> {
             format!("unsupported inode mode type: {other:#o}"),
         )),
     }
+}
+
+fn decode_dev(encoded: u32) -> (u32, u32) {
+    let major = (encoded >> 8) & 0x0000_0fff;
+    let minor = (encoded & 0x0000_00ff) | ((encoded >> 12) & 0xffff_ff00);
+    (major, minor)
 }
 
 /// Read a file from an EROFS image file on disk.

--- a/crates/image/lib/lib.rs
+++ b/crates/image/lib/lib.rs
@@ -16,6 +16,7 @@
     clippy::needless_update
 )]
 
+mod archive;
 mod auth;
 mod cache;
 mod config;
@@ -38,6 +39,10 @@ pub mod tree;
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
 
+pub use archive::{
+    ImageArchiveFormat, ImageLoadOptions, ImageSaveConfig, ImageSaveLayer, ImageSaveRequest,
+    LoadedImage, load_archive, save_archive, save_docker_archive,
+};
 pub use auth::RegistryAuth;
 pub use cache::{CachedImageMetadata, CachedLayerMetadata, GlobalCache};
 pub use config::ImageConfig;

--- a/crates/image/lib/registry/client.rs
+++ b/crates/image/lib/registry/client.rs
@@ -6,7 +6,7 @@ use std::{
     collections::{HashMap, HashSet},
     io,
     os::fd::AsRawFd,
-    path::Path,
+    path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -76,6 +76,16 @@ struct CachedPullInfo {
 
 struct LayerPipelineFailure {
     error: ImageError,
+}
+
+struct MaterializeLayersRequest<'a> {
+    oci_ref: &'a oci_client::Reference,
+    manifest_digest: &'a Digest,
+    layer_descriptors: &'a [LayerDescriptor],
+    diff_ids: &'a [String],
+    force: bool,
+    progress: Option<PullProgressSender>,
+    staged_layers: Option<Arc<HashMap<String, PathBuf>>>,
 }
 
 /// Per-layer pipeline success: EROFS image written, data-stripped tree + data map retained.
@@ -164,6 +174,28 @@ impl Registry {
         metadata: &CachedImageMetadata,
         force: bool,
     ) -> ImageResult<PullResult> {
+        self.materialize_cached_layers_inner(reference, metadata, force, None)
+            .await
+    }
+
+    pub(crate) async fn materialize_cached_layers_from_paths(
+        &self,
+        reference: &oci_client::Reference,
+        metadata: &CachedImageMetadata,
+        force: bool,
+        staged_layers: Arc<HashMap<String, PathBuf>>,
+    ) -> ImageResult<PullResult> {
+        self.materialize_cached_layers_inner(reference, metadata, force, Some(staged_layers))
+            .await
+    }
+
+    async fn materialize_cached_layers_inner(
+        &self,
+        reference: &oci_client::Reference,
+        metadata: &CachedImageMetadata,
+        force: bool,
+        staged_layers: Option<Arc<HashMap<String, PathBuf>>>,
+    ) -> ImageResult<PullResult> {
         let manifest_digest: Digest = metadata.manifest_digest.parse()?;
         let layer_descriptors = metadata
             .layers
@@ -182,14 +214,15 @@ impl Registry {
             .map(|layer| layer.diff_id.clone())
             .collect::<Vec<_>>();
 
-        self.materialize_layers_and_fsmeta(
-            reference,
-            &manifest_digest,
-            &layer_descriptors,
-            &diff_ids,
+        self.materialize_layers_and_fsmeta(MaterializeLayersRequest {
+            oci_ref: reference,
+            manifest_digest: &manifest_digest,
+            layer_descriptors: &layer_descriptors,
+            diff_ids: &diff_ids,
             force,
-            None,
-        )
+            progress: None,
+            staged_layers,
+        })
         .await?;
 
         let layer_diff_ids = diff_ids
@@ -357,7 +390,7 @@ impl Registry {
 
         // Determine media type from manifest bytes. For multi-platform images,
         // this also fetches the platform-specific config bytes.
-        let (manifest, config_bytes) = self
+        let (manifest, config_bytes, resolved_manifest_bytes) = self
             .parse_and_resolve_manifest(&manifest_bytes, config_bytes, oci_ref)
             .await?;
 
@@ -420,14 +453,15 @@ impl Registry {
         }
 
         // Materialize per-layer EROFS images, then generate fsmeta + VMDK.
-        self.materialize_layers_and_fsmeta(
+        self.materialize_layers_and_fsmeta(MaterializeLayersRequest {
             oci_ref,
-            &manifest_digest,
-            &layer_descriptors,
-            &diff_ids,
-            options.force,
-            progress.clone(),
-        )
+            manifest_digest: &manifest_digest,
+            layer_descriptors: &layer_descriptors,
+            diff_ids: &diff_ids,
+            force: options.force,
+            progress: progress.clone(),
+            staged_layers: None,
+        })
         .await?;
 
         // Clean up compressed tarballs after all layer tasks complete.
@@ -446,6 +480,8 @@ impl Registry {
         let cached_image = CachedImageMetadata {
             manifest_digest: manifest_digest.to_string(),
             config_digest: manifest.config_digest().unwrap_or_default(),
+            raw_manifest_json: json_bytes_to_string(&resolved_manifest_bytes, "resolved manifest")?,
+            raw_config_json: json_bytes_to_string(&config_bytes, "image config")?,
             config: image_config.clone(),
             layers: layer_descriptors
                 .iter()
@@ -510,7 +546,7 @@ impl Registry {
         manifest_bytes: &[u8],
         config_bytes: Vec<u8>,
         reference: &oci_client::Reference,
-    ) -> ImageResult<(OciManifest, Vec<u8>)> {
+    ) -> ImageResult<(OciManifest, Vec<u8>, Vec<u8>)> {
         // Try to detect media type from the JSON.
         let media_type = detect_manifest_media_type(manifest_bytes);
 
@@ -521,7 +557,7 @@ impl Registry {
             self.resolve_platform_manifest(manifest_bytes, reference)
                 .await
         } else {
-            Ok((manifest, config_bytes))
+            Ok((manifest, config_bytes, manifest_bytes.to_vec()))
         }
     }
 
@@ -532,7 +568,7 @@ impl Registry {
         &self,
         index_bytes: &[u8],
         reference: &oci_client::Reference,
-    ) -> ImageResult<(OciManifest, Vec<u8>)> {
+    ) -> ImageResult<(OciManifest, Vec<u8>, Vec<u8>)> {
         let index: oci_spec::image::ImageIndex = serde_json::from_slice(index_bytes)
             .map_err(|e| ImageError::ManifestParse(format!("failed to parse index: {e}")))?;
 
@@ -604,7 +640,7 @@ impl Registry {
 
         let media_type = detect_manifest_media_type(&manifest_bytes);
         let manifest = OciManifest::parse(&manifest_bytes, &media_type)?;
-        Ok((manifest, config_bytes))
+        Ok((manifest, config_bytes, manifest_bytes))
     }
 
     /// Extract layer digests and sizes from a parsed manifest.
@@ -644,13 +680,18 @@ impl Registry {
     /// Materialize per-layer EROFS images, then generate fsmeta + VMDK.
     async fn materialize_layers_and_fsmeta(
         &self,
-        oci_ref: &oci_client::Reference,
-        manifest_digest: &Digest,
-        layer_descriptors: &[LayerDescriptor],
-        diff_ids: &[String],
-        force: bool,
-        progress: Option<PullProgressSender>,
+        request: MaterializeLayersRequest<'_>,
     ) -> ImageResult<()> {
+        let MaterializeLayersRequest {
+            oci_ref,
+            manifest_digest,
+            layer_descriptors,
+            diff_ids,
+            force,
+            progress,
+            staged_layers,
+        } = request;
+
         // Validate all diff_ids parse as digests before spawning layer tasks.
         // diff_ids come from the remote config blob (untrusted input).
         let validated_diff_ids: Vec<Digest> = diff_ids
@@ -714,6 +755,9 @@ impl Registry {
                 let progress = progress.clone();
                 let media_type = layer_desc.media_type.clone();
                 let diff_id = diff_ids[i].clone();
+                let staged_tar_path = staged_layers
+                    .as_ref()
+                    .and_then(|layers| layers.get(&layer_desc.digest.to_string()).cloned());
 
                 let diff_id_digest: Digest = validated_diff_ids[i].clone();
                 let erofs_path = self.cache.layer_erofs_path(&diff_id_digest);
@@ -755,9 +799,10 @@ impl Registry {
                         });
                     }
 
-                    if let Err(error) = layer
-                        .download(&client, &oci_ref, size, force, progress.as_ref(), i)
-                        .await
+                    if staged_tar_path.is_none()
+                        && let Err(error) = layer
+                            .download(&client, &oci_ref, size, force, progress.as_ref(), i)
+                            .await
                     {
                         return Err(LayerPipelineFailure { error });
                     }
@@ -806,7 +851,9 @@ impl Registry {
                         });
                     }
 
-                    let tar_path = layer.tar_path_ref();
+                    let tar_path = staged_tar_path
+                        .clone()
+                        .unwrap_or_else(|| layer.tar_path_ref());
                     let tar_size =
                         tokio::fs::metadata(&tar_path)
                             .await
@@ -1507,6 +1554,12 @@ fn layer_pipeline_concurrency(layer_count: usize) -> usize {
     host_limit.min(layer_count.max(1))
 }
 
+fn json_bytes_to_string(bytes: &[u8], context: &str) -> ImageResult<String> {
+    std::str::from_utf8(bytes)
+        .map(str::to_owned)
+        .map_err(|e| ImageError::ConfigParse(format!("{context} is not UTF-8 JSON: {e}")))
+}
+
 //--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
@@ -1860,6 +1913,10 @@ mod tests {
                     .to_string(),
             config_digest:
                 "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    .to_string(),
+            raw_manifest_json: r#"{"schemaVersion":2,"layers":[]}"#.to_string(),
+            raw_config_json:
+                r#"{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]}}"#
                     .to_string(),
             config: ImageConfig {
                 env: vec!["PATH=/usr/bin".into()],

--- a/crates/image/lib/registry/client.rs
+++ b/crates/image/lib/registry/client.rs
@@ -153,6 +153,58 @@ impl Registry {
         self.pull_inner(reference, options, None).await
     }
 
+    /// Materialize layers that have already been staged into the cache.
+    ///
+    /// This is used by archive import: layer blobs are written to the cache at
+    /// their descriptor digest first, then the normal EROFS/fsmeta/VMDK
+    /// materialization path can run without contacting a registry.
+    pub async fn materialize_cached_layers(
+        &self,
+        reference: &oci_client::Reference,
+        metadata: &CachedImageMetadata,
+        force: bool,
+    ) -> ImageResult<PullResult> {
+        let manifest_digest: Digest = metadata.manifest_digest.parse()?;
+        let layer_descriptors = metadata
+            .layers
+            .iter()
+            .map(|layer| {
+                Ok(LayerDescriptor {
+                    digest: layer.digest.parse()?,
+                    media_type: layer.media_type.clone(),
+                    size: layer.size_bytes,
+                })
+            })
+            .collect::<ImageResult<Vec<_>>>()?;
+        let diff_ids = metadata
+            .layers
+            .iter()
+            .map(|layer| layer.diff_id.clone())
+            .collect::<Vec<_>>();
+
+        self.materialize_layers_and_fsmeta(
+            reference,
+            &manifest_digest,
+            &layer_descriptors,
+            &diff_ids,
+            force,
+            None,
+        )
+        .await?;
+
+        let layer_diff_ids = diff_ids
+            .iter()
+            .map(|diff_id| diff_id.parse())
+            .collect::<ImageResult<Vec<Digest>>>()?;
+
+        Ok(PullResult {
+            layer_diff_ids,
+            config: metadata.config.clone(),
+            manifest_digest,
+            cached: false,
+        })
+    }
+
     /// Pull with progress reporting.
     ///
     /// Creates a progress channel internally and returns both the receiver

--- a/docs/cli/image-commands.mdx
+++ b/docs/cli/image-commands.mdx
@@ -15,6 +15,8 @@ msb pull alpine
 msb pull ghcr.io/my-org/my-image:v1
 ```
 
+Expanded form: `msb image pull`.
+
 | Flag | Description |
 |------|-------------|
 | `-f`, `--force` | Force re-download even if cached |
@@ -26,16 +28,17 @@ msb pull ghcr.io/my-org/my-image:v1
   Pre-pulling is useful when you want sandbox creation to be instant. Without a pre-pull, the first `Sandbox.create` with a new image will block on the download.
 </Tip>
 
-## msb image load
+## msb load
 
 Load a Docker image archive or OCI Image Layout archive into the local microsandbox cache.
 
 ```bash
-docker save my-image:latest | msb image load
-msb image load --input my-image.tar
-msb image load --input oci-layout.tar --tag my-image:latest
+docker save my-image:latest | msb load
 msb load --input my-image.tar
+msb load --input oci-layout.tar --tag my-image:latest
 ```
+
+Expanded form: `msb image load`.
 
 | Flag | Description |
 |------|-------------|
@@ -43,16 +46,17 @@ msb load --input my-image.tar
 | `-t`, `--tag <REF>` | Add a local image reference to the first imported image |
 | `-q`, `--quiet` | Suppress output |
 
-## msb image save
+## msb save
 
 Save one or more cached images as a Docker-compatible archive or OCI Image Layout archive.
 
 ```bash
-msb image save --output my-image.tar my-image:latest
-msb image save --format oci --output my-image.oci.tar my-image:latest
 msb save --output my-image.tar my-image:latest
-msb image save my-image:latest > my-image.tar
+msb save --format oci --output my-image.oci.tar my-image:latest
+msb save my-image:latest > my-image.tar
 ```
+
+Expanded form: `msb image save`.
 
 | Flag | Description |
 |------|-------------|
@@ -60,26 +64,24 @@ msb image save my-image:latest > my-image.tar
 | `-o`, `--output <PATH>` | Write archive to a tar file instead of stdout |
 | `-q`, `--quiet` | Suppress output |
 
-`msb image save` re-exports images from microsandbox's EROFS cache. The saved archive is semantically equivalent, but it is not a byte-for-byte copy of the originally pulled image. Manifest digest and layer digests can change because layer tar streams are regenerated.
+`msb save` re-exports images from microsandbox's EROFS cache. The saved archive is semantically equivalent, but it is not a byte-for-byte copy of the originally pulled image. Manifest digest and layer digests can change because layer tar streams are regenerated.
 
-## msb image ls
+## msb images
 
 List images in the local cache.
 
 ```bash
-msb image ls
-msb image ls --format json
-msb image ls -q               # References only
+msb images
+msb images --format json
+msb images -q               # References only
 ```
+
+Expanded form: `msb image ls`.
 
 | Flag | Description |
 |------|-------------|
 | `--format` | Output format (`json`) |
 | `-q`, `--quiet` | Show only image references |
-
-<Tip>
-  `msb images` is a shorthand alias for `msb image ls`.
-</Tip>
 
 ## msb image inspect
 
@@ -94,23 +96,21 @@ msb image inspect python --format json
 |------|-------------|
 | `--format` | Output format (`json`) |
 
-## msb image rm
+## msb rmi
 
 Remove one or more cached images and their layers (layers shared with other images are kept).
 
 ```bash
-msb image rm python
-msb image rm alpine ubuntu   # Remove multiple
+msb rmi python
+msb rmi alpine ubuntu   # Remove multiple
 ```
+
+Expanded form: `msb image rm`.
 
 | Flag | Description |
 |------|-------------|
 | `-f`, `--force` | Remove even if the image is used by existing sandboxes |
 | `-q`, `--quiet` | Suppress output |
-
-<Tip>
-  `msb rmi` is a shorthand alias for `msb image rm`.
-</Tip>
 
 ## msb registry
 

--- a/docs/cli/image-commands.mdx
+++ b/docs/cli/image-commands.mdx
@@ -26,6 +26,42 @@ msb pull ghcr.io/my-org/my-image:v1
   Pre-pulling is useful when you want sandbox creation to be instant. Without a pre-pull, the first `Sandbox.create` with a new image will block on the download.
 </Tip>
 
+## msb image load
+
+Load a Docker image archive or OCI Image Layout archive into the local microsandbox cache.
+
+```bash
+docker save my-image:latest | msb image load
+msb image load --input my-image.tar
+msb image load --input oci-layout.tar --tag my-image:latest
+msb load --input my-image.tar
+```
+
+| Flag | Description |
+|------|-------------|
+| `-i`, `--input <PATH>` | Read archive from a tar file instead of stdin |
+| `-t`, `--tag <REF>` | Add a local image reference to the first imported image |
+| `-q`, `--quiet` | Suppress output |
+
+## msb image save
+
+Save one or more cached images as a Docker-compatible archive or OCI Image Layout archive.
+
+```bash
+msb image save --output my-image.tar my-image:latest
+msb image save --format oci --output my-image.oci.tar my-image:latest
+msb save --output my-image.tar my-image:latest
+msb image save my-image:latest > my-image.tar
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format <FORMAT>` | Archive format (`docker`, `oci`; default: `docker`) |
+| `-o`, `--output <PATH>` | Write archive to a tar file instead of stdout |
+| `-q`, `--quiet` | Suppress output |
+
+`msb image save` re-exports images from microsandbox's EROFS cache. The saved archive is semantically equivalent, but it is not a byte-for-byte copy of the originally pulled image. Manifest digest and layer digests can change because layer tar streams are regenerated.
+
 ## msb image ls
 
 List images in the local cache.

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -52,9 +52,9 @@ msb ssh devbox -- uname -a
 msb ssh serve devbox --host 127.0.0.1 --port 2222
 
 # Images
-msb pull python     # Pre-pull to cache
-msb image ls             # List cached images
-msb image rm python # Remove a cached image
+msb pull python       # Pre-pull to cache
+msb images            # List cached images
+msb rmi python        # Remove a cached image
 
 # Volumes
 msb volume create data --size 10G

--- a/docs/images/overview.mdx
+++ b/docs/images/overview.mdx
@@ -192,7 +192,9 @@ Images are cached in the global microsandbox home directory:
 
 | Path | Description |
 |------|-------------|
-| `~/.microsandbox/cache/layers/` | Downloaded and extracted image layers |
+| `~/.microsandbox/cache/layers/` | Materialized EROFS image layers |
+| `~/.microsandbox/cache/fsmeta/` | Merged metadata images for cached manifests |
+| `~/.microsandbox/cache/vmdk/` | VMDK descriptors used to boot cached images |
 | `~/.microsandbox/db/` | Database tracking image metadata and digests |
 
 Layers are content-addressable and deduplicated. If `python` and `python` share a base layer, it's stored once.
@@ -200,3 +202,5 @@ Layers are content-addressable and deduplicated. If `python` and `python` share 
 <Tip>
   Use `msb pull` from the CLI to pre-pull images before creating sandboxes. This avoids blocking on a download during `Sandbox.create`.
 </Tip>
+
+`msb image load` accepts Docker image archives and OCI Image Layout archives. `msb image save` exports from the materialized EROFS cache as a Docker archive by default, or as an OCI Image Layout archive with `--format oci`. The exported image should run the same way after `msb image load`, but it is a regenerated archive: manifest digest and layer digests can differ from the original registry image.

--- a/docs/images/overview.mdx
+++ b/docs/images/overview.mdx
@@ -203,4 +203,4 @@ Layers are content-addressable and deduplicated. If `python` and `python` share 
   Use `msb pull` from the CLI to pre-pull images before creating sandboxes. This avoids blocking on a download during `Sandbox.create`.
 </Tip>
 
-`msb image load` accepts Docker image archives and OCI Image Layout archives. `msb image save` exports from the materialized EROFS cache as a Docker archive by default, or as an OCI Image Layout archive with `--format oci`. The exported image should run the same way after `msb image load`, but it is a regenerated archive: manifest digest and layer digests can differ from the original registry image.
+`msb load` accepts Docker image archives and OCI Image Layout archives. `msb save` exports from the materialized EROFS cache as a Docker archive by default, or as an OCI Image Layout archive with `--format oci`. The expanded forms are `msb image load` and `msb image save`. The exported image should run the same way after `msb load`, but it is a regenerated archive: manifest digest and layer digests can differ from the original registry image.

--- a/docs/recipes/docker/local-images.mdx
+++ b/docs/recipes/docker/local-images.mdx
@@ -1,10 +1,38 @@
 ---
 title: Using local Docker images
-description: Use locally built Docker images with microsandbox via a local registry
+description: Use locally built Docker images with microsandbox
 icon: "boxes-stacked"
 ---
 
-microsandbox pulls images from OCI-compatible registries. If you build an image locally with `docker build`, microsandbox can't access it directly from Docker's local store. The workaround is to run a local registry and push your image there.
+microsandbox cannot read Docker's private local image store directly. If you build an image locally with `docker build`, export it with `docker save` and load it into microsandbox:
+
+```bash
+docker build -t my-image:latest .
+docker save my-image:latest | msb image load
+msb run my-image:latest
+```
+
+You can also save to a file first:
+
+```bash
+docker save -o my-image.tar my-image:latest
+msb image load --input my-image.tar
+```
+
+If the archive has no useful tag, or you want a different local alias, pass one:
+
+```bash
+docker save my-image:latest | msb image load --tag app:local
+msb run app:local
+```
+
+`msb load` is a top-level alias for `msb image load`.
+
+`msb image load` can also import OCI Image Layout archives produced by tools such as BuildKit, Skopeo, or ORAS. If the OCI layout does not include an `org.opencontainers.image.ref.name` annotation, pass `--tag` to name the imported image locally.
+
+## Local registry alternative
+
+Use a local registry when you want registry-like push/pull behavior, or when multiple machines should pull the same locally built image.
 
 ## Step 1: Start a local registry
 

--- a/docs/recipes/docker/local-images.mdx
+++ b/docs/recipes/docker/local-images.mdx
@@ -8,7 +8,7 @@ microsandbox cannot read Docker's private local image store directly. If you bui
 
 ```bash
 docker build -t my-image:latest .
-docker save my-image:latest | msb image load
+docker save my-image:latest | msb load
 msb run my-image:latest
 ```
 
@@ -16,19 +16,19 @@ You can also save to a file first:
 
 ```bash
 docker save -o my-image.tar my-image:latest
-msb image load --input my-image.tar
+msb load --input my-image.tar
 ```
 
 If the archive has no useful tag, or you want a different local alias, pass one:
 
 ```bash
-docker save my-image:latest | msb image load --tag app:local
+docker save my-image:latest | msb load --tag app:local
 msb run app:local
 ```
 
-`msb load` is a top-level alias for `msb image load`.
+`msb load` is the short top-level form of `msb image load`.
 
-`msb image load` can also import OCI Image Layout archives produced by tools such as BuildKit, Skopeo, or ORAS. If the OCI layout does not include an `org.opencontainers.image.ref.name` annotation, pass `--tag` to name the imported image locally.
+`msb load` can also import OCI Image Layout archives produced by tools such as BuildKit, Skopeo, or ORAS. If the OCI layout does not include an `org.opencontainers.image.ref.name` annotation, pass `--tag` to name the imported image locally.
 
 ## Local registry alternative
 

--- a/scripts/smoke/cli/image-archive.sh
+++ b/scripts/smoke/cli/image-archive.sh
@@ -36,17 +36,21 @@ trap cleanup EXIT
 
 export LD_LIBRARY_PATH="$ROOT_DIR/build${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-docker pull "$IMAGE" >/dev/null
+docker image inspect "$IMAGE" >/dev/null 2>&1 || docker pull "$IMAGE" >/dev/null
 docker save "$IMAGE" -o "$smoke_root/docker-input.tar"
 
-"$MSB_BIN" image load --input "$smoke_root/docker-input.tar" --tag "$TAG" --quiet
-"$MSB_BIN" image save --output "$smoke_root/docker-output.tar" --quiet "$TAG"
-"$MSB_BIN" image save --format oci --output "$smoke_root/oci-output.tar" --quiet "$TAG"
+"$MSB_BIN" load -i "$smoke_root/docker-input.tar" --tag "$TAG" --quiet
+"$MSB_BIN" save -o "$smoke_root/docker-output.tar" --quiet "$TAG"
+"$MSB_BIN" save --format oci -o "$smoke_root/oci-output.tar" --quiet "$TAG"
+
+tar -tf "$smoke_root/docker-output.tar" > "$smoke_root/docker-entries.txt"
+grep -qx 'manifest.json' "$smoke_root/docker-entries.txt"
+grep -q '/layer.tar$' "$smoke_root/docker-entries.txt"
 
 tar -tf "$smoke_root/oci-output.tar" > "$smoke_root/oci-entries.txt"
 grep -qx 'oci-layout' "$smoke_root/oci-entries.txt"
 grep -qx 'index.json' "$smoke_root/oci-entries.txt"
 grep -q '^blobs/sha256/' "$smoke_root/oci-entries.txt"
 
-MSB_HOME="$smoke_root/reload-home" "$MSB_BIN" image load --input "$smoke_root/oci-output.tar" --quiet
-MSB_HOME="$smoke_root/reload-home" "$MSB_BIN" image ls -q | grep -qx "$TAG"
+MSB_HOME="$smoke_root/reload-home" "$MSB_BIN" load -i "$smoke_root/oci-output.tar" --quiet
+MSB_HOME="$smoke_root/reload-home" "$MSB_BIN" images -q | grep -qx "$TAG"

--- a/scripts/smoke/cli/image-archive.sh
+++ b/scripts/smoke/cli/image-archive.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MSB_BIN="${MSB_BIN:-${ROOT_DIR}/build/msb}"
+IMAGE="${MSB_CLI_SMOKE_DOCKER_IMAGE:-alpine:3.20}"
+TAG="${MSB_CLI_SMOKE_ARCHIVE_TAG:-msb-archive-smoke:ci}"
+
+if [[ ! -x "$MSB_BIN" ]]; then
+  echo "msb binary is not executable: $MSB_BIN" >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required for image archive smoke tests" >&2
+  exit 1
+fi
+
+smoke_root="$(mktemp -d "${TMPDIR:-/tmp}/msb-image-archive-smoke.XXXXXX")"
+created_home=0
+
+if [[ -z "${MSB_HOME:-}" ]]; then
+  MSB_HOME="$(mktemp -d "${TMPDIR:-/tmp}/msb-image-archive-home.XXXXXX")"
+  export MSB_HOME
+  created_home=1
+fi
+
+cleanup() {
+  rm -rf "$smoke_root"
+  if [[ "$created_home" -eq 1 ]]; then
+    rm -rf "$MSB_HOME"
+  fi
+}
+trap cleanup EXIT
+
+export LD_LIBRARY_PATH="$ROOT_DIR/build${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+docker pull "$IMAGE" >/dev/null
+docker save "$IMAGE" -o "$smoke_root/docker-input.tar"
+
+"$MSB_BIN" image load --input "$smoke_root/docker-input.tar" --tag "$TAG" --quiet
+"$MSB_BIN" image save --output "$smoke_root/docker-output.tar" --quiet "$TAG"
+"$MSB_BIN" image save --format oci --output "$smoke_root/oci-output.tar" --quiet "$TAG"
+
+tar -tf "$smoke_root/oci-output.tar" > "$smoke_root/oci-entries.txt"
+grep -qx 'oci-layout' "$smoke_root/oci-entries.txt"
+grep -qx 'index.json' "$smoke_root/oci-entries.txt"
+grep -q '^blobs/sha256/' "$smoke_root/oci-entries.txt"
+
+MSB_HOME="$smoke_root/reload-home" "$MSB_BIN" image load --input "$smoke_root/oci-output.tar" --quiet
+MSB_HOME="$smoke_root/reload-home" "$MSB_BIN" image ls -q | grep -qx "$TAG"


### PR DESCRIPTION
## TL;DR
Add `msb image load` and `msb image save` so users can move Docker and OCI image archives into and out of the local microsandbox cache without running a registry.

## Description
- Add `msb image load` and top-level `msb load` for Docker archives and OCI Image Layout archives, with stdin or `--input` support.
- Add `msb image save` and top-level `msb save`, with Docker output by default and OCI Image Layout output through `--format oci`.
- Materialize imported archive layers through the existing image cache path so loaded images get EROFS layers, fsmeta, and VMDK data like pulled images.
- Regenerate saved layer tar streams from cached EROFS layers while preserving whiteouts, opaque directories, symlinks, hardlinks, and POSIX metadata.
- Document that saved archives are semantically equivalent exports, not byte-for-byte copies of the original image.
- Add a Docker-backed CLI smoke test that covers Docker load/save and OCI save/load roundtrips.

```bash
docker save my-image:latest | msb image load --tag app:local
msb image save --format oci -o app.oci.tar app:local
msb image load -i app.oci.tar
```

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p microsandbox-image -p microsandbox-cli`
- [x] `cargo test -p microsandbox-image`
- [x] `cargo test -p microsandbox-cli`
- [x] `cargo clippy -p microsandbox-image -p microsandbox-cli --all-targets -- -D warnings`
- [x] `just build-msb && scripts/smoke/cli/image-archive.sh`

Closes #512