### PR TITLE
fix(cli): show timestamps in local time

### DIFF
--- a/crates/cli/lib/commands/image.rs
+++ b/crates/cli/lib/commands/image.rs
@@ -329,7 +329,7 @@ pub async fn run_list(args: ImageListArgs) -> anyhow::Result<()> {
                     "architecture": img.architecture(),
                     "os": img.os(),
                     "layer_count": img.layer_count(),
-                    "created_at": img.created_at().map(|dt| ui::format_datetime(&dt)),
+                    "created_at": img.created_at().map(|dt| ui::format_json_datetime(&dt)),
                 })
             })
             .collect();
@@ -413,7 +413,7 @@ pub async fn run_inspect(args: ImageInspectArgs) -> anyhow::Result<()> {
             "architecture": detail.handle.architecture(),
             "os": detail.handle.os(),
             "layer_count": detail.handle.layer_count(),
-            "created_at": detail.handle.created_at().map(|dt| ui::format_datetime(&dt)),
+            "created_at": detail.handle.created_at().map(|dt| ui::format_json_datetime(&dt)),
             "config": config_json,
             "layers": layers_json,
         });

--- a/crates/cli/lib/commands/inspect.rs
+++ b/crates/cli/lib/commands/inspect.rs
@@ -69,8 +69,8 @@ pub async fn run(args: InspectArgs) -> anyhow::Result<()> {
             "name": handle.name(),
             "status": format!("{:?}", handle.status()),
             "config": config,
-            "created_at": handle.created_at().map(|dt| ui::format_datetime(&dt)),
-            "updated_at": handle.updated_at().map(|dt| ui::format_datetime(&dt)),
+            "created_at": handle.created_at().map(|dt| ui::format_json_datetime(&dt)),
+            "updated_at": handle.updated_at().map(|dt| ui::format_json_datetime(&dt)),
         });
         println!("{}", serde_json::to_string_pretty(&json)?);
         return Ok(());

--- a/crates/cli/lib/commands/list.rs
+++ b/crates/cli/lib/commands/list.rs
@@ -111,7 +111,7 @@ fn print_json(sandboxes: &[SandboxHandle]) -> anyhow::Result<()> {
             serde_json::json!({
                 "name": s.name(),
                 "status": format!("{:?}", s.status()),
-                "created_at": s.created_at().map(|dt| ui::format_datetime(&dt)),
+                "created_at": s.created_at().map(|dt| ui::format_json_datetime(&dt)),
                 "image": extract_image(s.config_json()),
             })
         })

--- a/crates/cli/lib/commands/snapshot.rs
+++ b/crates/cli/lib/commands/snapshot.rs
@@ -233,7 +233,7 @@ async fn list(args: SnapshotListArgs) -> anyhow::Result<()> {
                     "parent_digest": s.parent_digest(),
                     "format": format_str(s.format()),
                     "size_bytes": s.size_bytes(),
-                    "created_at": ui::format_datetime(&s.created_at().and_utc()),
+                    "created_at": ui::format_json_datetime(&s.created_at().and_utc()),
                     "artifact_path": s.path().display().to_string(),
                 })
             })
@@ -280,7 +280,7 @@ async fn inspect(args: SnapshotInspectArgs) -> anyhow::Result<()> {
     ui::detail_kv("Format", format_str(snap.manifest().format));
     ui::detail_kv("Filesystem", &m.fstype);
     ui::detail_kv("Parent", m.parent.as_deref().unwrap_or("-"));
-    ui::detail_kv("Created", &m.created_at);
+    ui::detail_kv("Created", &ui::format_rfc3339_datetime(&m.created_at)?);
     ui::detail_kv("Upper File", &m.upper.file);
     ui::detail_kv("Upper Size", &format_size(m.upper.size_bytes));
     ui::detail_kv("Integrity", &format_integrity(m.upper.integrity.as_ref()));

--- a/crates/cli/lib/commands/volume.rs
+++ b/crates/cli/lib/commands/volume.rs
@@ -123,7 +123,7 @@ async fn list(args: VolumeListArgs) -> anyhow::Result<()> {
                     "name": v.name(),
                     "quota_mib": v.quota_mib(),
                     "used_bytes": v.used_bytes(),
-                    "created_at": v.created_at().map(|dt| ui::format_datetime(&dt)),
+                    "created_at": v.created_at().map(|dt| ui::format_json_datetime(&dt)),
                 })
             })
             .collect();

--- a/crates/cli/lib/ui.rs
+++ b/crates/cli/lib/ui.rs
@@ -395,9 +395,61 @@ pub fn generate_name() -> String {
     format!("msb-{id:08x}")
 }
 
-/// Format a chrono DateTime for display.
+/// Format a UTC timestamp for human display in the system's local timezone.
 pub fn format_datetime(dt: &chrono::DateTime<chrono::Utc>) -> String {
-    dt.format("%Y-%m-%d %H:%M:%S").to_string()
+    dt.with_timezone(&chrono::Local)
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
+}
+
+/// Format a UTC timestamp for machine-readable JSON output.
+pub fn format_json_datetime(dt: &chrono::DateTime<chrono::Utc>) -> String {
+    dt.to_rfc3339()
+}
+
+/// Format an RFC 3339 timestamp for human display in the system's local timezone.
+pub fn format_rfc3339_datetime(s: &str) -> Result<String, chrono::ParseError> {
+    chrono::DateTime::parse_from_rfc3339(s).map(|dt| {
+        dt.with_timezone(&chrono::Local)
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string()
+    })
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn json_datetime_uses_rfc3339_utc() {
+        let dt = chrono::DateTime::parse_from_rfc3339("2026-05-31T09:09:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        assert_eq!(
+            super::format_json_datetime(&dt),
+            "2026-05-31T09:09:00+00:00"
+        );
+    }
+
+    #[test]
+    fn display_datetime_uses_local_timezone() {
+        let dt = chrono::DateTime::parse_from_rfc3339("2026-05-31T09:09:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let expected = dt
+            .with_timezone(&chrono::Local)
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+
+        assert_eq!(super::format_datetime(&dt), expected);
+        assert_eq!(
+            super::format_rfc3339_datetime("2026-05-31T09:09:00Z").unwrap(),
+            expected
+        );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## TL;DR
Show human-facing CLI timestamps in the system local timezone while keeping JSON output explicit and machine-readable.

## Description
- Convert shared human timestamp formatting to use the system local timezone.
- Add a separate JSON timestamp formatter that keeps RFC 3339 output with an explicit UTC offset.
- Route sandbox, image, volume, and snapshot JSON fields through the JSON formatter.
- Format snapshot inspect manifest timestamps through the same local display path as other detail views.
- Add focused tests for local display formatting and JSON timestamp formatting.
- Closes #860

## Test Plan
- [x] `cargo fmt --all -- --check` exits 0
- [x] `cargo test -p microsandbox-cli ui::tests` passes
- [x] `cargo build -p microsandbox-cli` exits 0
- [x] `./target/debug/msb list` shows local `CREATED` timestamps
- [x] `./target/debug/msb list --format json` shows RFC 3339 `created_at` values
