### PR TITLE
chore(install): purge libkrunfw library path setup

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -39,13 +39,7 @@ just setup
 After setup, add these to your shell profile (e.g. `~/.bashrc`, `~/.zshrc`):
 
 ```bash
-# Linux
 export PATH="$HOME/.microsandbox/bin:$PATH"
-export LD_LIBRARY_PATH="$HOME/.microsandbox/lib:$LD_LIBRARY_PATH"
-
-# macOS
-export PATH="$HOME/.microsandbox/bin:$PATH"
-export DYLD_LIBRARY_PATH="$HOME/.microsandbox/lib:$DYLD_LIBRARY_PATH"
 ```
 
 Verify the installation:

--- a/justfile
+++ b/justfile
@@ -84,7 +84,7 @@ build-agentd:
     docker cp "$id:/agentd" build/agentd
     touch build/agentd
 
-# Check for libkrunfw and build it only if not found in build/, ~/.microsandbox/lib/, or system paths.
+# Check for libkrunfw and build it only if not found in build/ or ~/.microsandbox/lib/.
 [linux]
 _ensure-libkrunfw:
     #!/usr/bin/env bash
@@ -99,15 +99,10 @@ _ensure-libkrunfw:
         echo "Found libkrunfw in ~/.microsandbox/lib/"
         exit 0
     fi
-    # Check system library paths via ldconfig.
-    if ldconfig -p 2>/dev/null | grep -q libkrunfw; then
-        echo "Found libkrunfw in system library paths"
-        exit 0
-    fi
     echo "libkrunfw not found — building from source..."
     just build-libkrunfw
 
-# Check for libkrunfw and build it only if not found in build/, ~/.microsandbox/lib/, or system paths.
+# Check for libkrunfw and build it only if not found in build/ or ~/.microsandbox/lib/.
 [macos]
 _ensure-libkrunfw:
     #!/usr/bin/env bash
@@ -197,7 +192,7 @@ install:
     echo "Installed libkrunfw → ~/.microsandbox/lib/"
 
     echo ""
-    echo "Remember to add ~/.microsandbox/bin to your PATH and ~/.microsandbox/lib to your LD_LIBRARY_PATH."
+    echo "Remember to add ~/.microsandbox/bin to your PATH."
 
 # Install msb and libkrunfw to ~/.microsandbox/{bin,lib}/. Requires: just build.
 [macos]
@@ -222,7 +217,7 @@ install:
     echo "Installed libkrunfw → ~/.microsandbox/lib/"
 
     echo ""
-    echo "Remember to add ~/.microsandbox/bin to your PATH and ~/.microsandbox/lib to your DYLD_LIBRARY_PATH."
+    echo "Remember to add ~/.microsandbox/bin to your PATH."
 
 # Remove installed binaries from ~/.microsandbox/{bin,lib}/.
 uninstall:

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -13,7 +13,5 @@ RUN apt-get update \
 COPY build/${TARGETARCH}/msb /usr/local/bin/msb
 COPY build/${TARGETARCH}/libkrunfw.so.* /usr/local/lib/
 
-ENV LD_LIBRARY_PATH="/usr/local/lib"
-
 ENTRYPOINT ["msb"]
 CMD ["--help"]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -124,32 +124,20 @@ update_shell_config() {
     fi
 }
 
-# Configure all relevant shell config files with PATH and library path.
+# Configure all relevant shell config files with PATH.
 configure_shell() {
     detect_current_shell
 
     # Build POSIX block (sh, bash, zsh)
-    if [ "$OS" = "linux" ]; then
-        _lib_line='export LD_LIBRARY_PATH="$HOME/.microsandbox/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"'
-    else
-        _lib_line='export DYLD_LIBRARY_PATH="$HOME/.microsandbox/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"'
-    fi
     _path_line='export PATH="$HOME/.microsandbox/bin:$PATH"'
     _posix_block="${MARKER_START}
 ${_path_line}
-${_lib_line}
 ${MARKER_END}"
 
     # Build fish block
-    if [ "$OS" = "linux" ]; then
-        _fish_lib='set -gx LD_LIBRARY_PATH "$HOME/.microsandbox/lib" $LD_LIBRARY_PATH'
-    else
-        _fish_lib='set -gx DYLD_LIBRARY_PATH "$HOME/.microsandbox/lib" $DYLD_LIBRARY_PATH'
-    fi
     _fish_path='set -gx PATH "$HOME/.microsandbox/bin" $PATH'
     _fish_block="${MARKER_START}
 ${_fish_path}
-${_fish_lib}
 ${MARKER_END}"
 
     _did_bashrc=false
@@ -501,10 +489,8 @@ main() {
         printf "\n"
         if [ "$OS" = "linux" ]; then
             printf "    ${DIM}export${RESET} PATH=\"%s:\$PATH\"\n" "$BIN_DIR"
-            printf "    ${DIM}export${RESET} LD_LIBRARY_PATH=\"%s\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\"\n" "$LIB_DIR"
         elif [ "$OS" = "darwin" ]; then
             printf "    ${DIM}export${RESET} PATH=\"%s:\$PATH\"\n" "$BIN_DIR"
-            printf "    ${DIM}export${RESET} DYLD_LIBRARY_PATH=\"%s\${DYLD_LIBRARY_PATH:+:\$DYLD_LIBRARY_PATH}\"\n" "$LIB_DIR"
         fi
         printf "\n"
     fi

--- a/scripts/smoke/cli/image-archive.sh
+++ b/scripts/smoke/cli/image-archive.sh
@@ -34,8 +34,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-export LD_LIBRARY_PATH="$ROOT_DIR/build${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-
 docker image inspect "$IMAGE" >/dev/null 2>&1 || docker pull "$IMAGE" >/dev/null
 docker save "$IMAGE" -o "$smoke_root/docker-input.tar"
 

--- a/scripts/smoke/cli/split-irqchip-bind-net.sh
+++ b/scripts/smoke/cli/split-irqchip-bind-net.sh
@@ -37,8 +37,6 @@ trap cleanup EXIT
 
 mkdir -p "$smoke_root"/bind-{a,b,c}
 
-export LD_LIBRARY_PATH="$ROOT_DIR/build${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-
 "$MSB_BIN" run \
   --name "$SANDBOX_NAME" \
   --replace \


### PR DESCRIPTION
## TL;DR
Remove the old `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH` setup around libkrunfw. microsandbox already resolves libkrunfw explicitly, so installs and smoke tests should not rely on dynamic loader env vars.

## Description
- Remove library-path exports from the installer shell profile block and manual install instructions.
- Trim development docs and `just install` reminders down to the only shell setup users still need: adding `msb` to `PATH`.
- Stop probing Linux system library paths for libkrunfw in the justfile, keeping discovery tied to bundled locations.
- Remove `LD_LIBRARY_PATH` assumptions from Docker packaging and CLI smoke scripts.

## Test Plan
- [x] `rg -n "DYLD_LIBRARY_PATH|LD_LIBRARY_PATH" . || true` prints no matches
- [x] `bash -n scripts/install.sh` exits 0
- [x] `bash -n scripts/smoke/cli/split-irqchip-bind-net.sh` exits 0
- [x] `bash -n scripts/smoke/cli/image-archive.sh` exits 0
- [x] `git diff --check` exits 0
