### PR TITLE
feat: wire host balloon controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,9 +3511,8 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb6bc3f86b45ed69cc1e5b8707d4be00e31c5938527d8cebd3859c8a05b3941"
+version = "0.1.15"
+source = "git+https://github.com/enricoschaaf/msb-libkrun?branch=enrico%2Fhost-balloon-control#89d9f51d322bac97bdbea0827e802a6c26e4b1be"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3531,9 +3530,8 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633af99c56b526465e537f339c7ed37c803007e112315d136aa1a775bf325f0b"
+version = "0.1.15"
+source = "git+https://github.com/enricoschaaf/msb-libkrun?branch=enrico%2Fhost-balloon-control#89d9f51d322bac97bdbea0827e802a6c26e4b1be"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3547,15 +3545,13 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a76f5f78825cadb17d0fff6bf66d6ee9bea1c42f0564e428b968cf05feb9f23"
+version = "0.1.15"
+source = "git+https://github.com/enricoschaaf/msb-libkrun?branch=enrico%2Fhost-balloon-control#89d9f51d322bac97bdbea0827e802a6c26e4b1be"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77f96769b10d84263a996813cb79e058d9b2d59ef95f46a7d1c5ab47fb2de35"
+version = "0.1.15"
+source = "git+https://github.com/enricoschaaf/msb-libkrun?branch=enrico%2Fhost-balloon-control#89d9f51d322bac97bdbea0827e802a6c26e4b1be"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3564,9 +3560,8 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da8cd67781a32a03deaee0739e9695009ac3088d1770c75bca72c8105be09f8c"
+version = "0.1.15"
+source = "git+https://github.com/enricoschaaf/msb-libkrun?branch=enrico%2Fhost-balloon-control#89d9f51d322bac97bdbea0827e802a6c26e4b1be"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3592,9 +3587,8 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213559ed39c57e2141871912c3f19f0659e2e9ebb50e6e43c831942c7a32b0d5"
+version = "0.1.15"
+source = "git+https://github.com/enricoschaaf/msb-libkrun?branch=enrico%2Fhost-balloon-control#89d9f51d322bac97bdbea0827e802a6c26e4b1be"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -3604,9 +3598,8 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8b9a530e42f59c2548b8c435463b55e9b6aa3c6e2835f30052170ea473ea42"
+version = "0.1.15"
+source = "git+https://github.com/enricoschaaf/msb-libkrun?branch=enrico%2Fhost-balloon-control#89d9f51d322bac97bdbea0827e802a6c26e4b1be"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -3614,9 +3607,8 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "018aadd9c3bbc1e588201df5574a886ba9b929b44335cdd48f151254b4e0bc04"
+version = "0.1.15"
+source = "git+https://github.com/enricoschaaf/msb-libkrun?branch=enrico%2Fhost-balloon-control#89d9f51d322bac97bdbea0827e802a6c26e4b1be"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3624,18 +3616,16 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d45211addb08a5865a37e5f983a0014a75f8a878914cb7c06c18fd51bb68b8f"
+version = "0.1.15"
+source = "git+https://github.com/enricoschaaf/msb-libkrun?branch=enrico%2Fhost-balloon-control#89d9f51d322bac97bdbea0827e802a6c26e4b1be"
 dependencies = [
  "vm-memory 0.16.2",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31628b7fbebb78d4390ac325c2f1dd127c50266b966af5f2fe40a9522a40d92"
+version = "0.1.15"
+source = "git+https://github.com/enricoschaaf/msb-libkrun?branch=enrico%2Fhost-balloon-control#89d9f51d322bac97bdbea0827e802a6c26e4b1be"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3648,9 +3638,8 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f12d282559e4ca29a22d2c83e5bde2f80f6ac387b62ee27002dd05b83c98bf5"
+version = "0.1.15"
+source = "git+https://github.com/enricoschaaf/msb-libkrun?branch=enrico%2Fhost-balloon-control#89d9f51d322bac97bdbea0827e802a6c26e4b1be"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,3 +133,6 @@ parking_lot = "0.12"
 rpassword = "7"
 russh = "0.61.1"
 russh-sftp = "2.2.2"
+
+[patch.crates-io]
+msb_krun = { git = "https://github.com/enricoschaaf/msb-libkrun", branch = "enrico/host-balloon-control" }

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -72,6 +72,18 @@ pub struct SandboxArgs {
     #[arg(long, default_value_t = 512)]
     pub memory_mib: u32,
 
+    /// Guest-visible memory at boot when ballooning is enabled, in MiB.
+    #[arg(long = "balloon-initial-mib")]
+    pub balloon_initial_mib: Option<u32>,
+
+    /// Minimum guest-visible memory accepted by the balloon controller, in MiB.
+    #[arg(long = "balloon-min-mib")]
+    pub balloon_min_mib: Option<u32>,
+
+    /// Host Unix socket for runtime balloon target updates.
+    #[arg(long = "balloon-control-socket")]
+    pub balloon_control_socket: Option<PathBuf>,
+
     /// Metrics sampling interval in milliseconds; `0` disables sampling.
     #[arg(long = "metrics-sample-interval-ms", default_value_t = 1000)]
     pub metrics_sample_interval_ms: u64,
@@ -169,6 +181,9 @@ pub fn run(args: SandboxArgs, log_level: Option<LogLevel>) -> ! {
         libkrunfw_path: args.libkrunfw_path,
         vcpus: args.vcpus,
         memory_mib: args.memory_mib,
+        balloon_initial_mib: args.balloon_initial_mib,
+        balloon_min_mib: args.balloon_min_mib,
+        balloon_control_socket: args.balloon_control_socket,
         rootfs_path: args.rootfs_path,
         rootfs_vmdk: if is_vmdk {
             args.rootfs_disk.clone()

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib/lib.rs"
 [dependencies]
 libc.workspace = true
 microsandbox-utils = { version = "0.5.4", path = "../utils" }
-msb_krun = "0.1.14"
+msb_krun = "0.1.15"
 scopeguard.workspace = true
 tempfile.workspace = true
 tracing.workspace = true

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -853,6 +853,18 @@ fn sandbox_cli_args(
     args.push(OsString::from(config.cpus.to_string()));
     args.push(OsString::from("--memory-mib"));
     args.push(OsString::from(config.memory_mib.to_string()));
+    if let Some(initial_mib) = config.balloon_initial_mib {
+        args.push(OsString::from("--balloon-initial-mib"));
+        args.push(OsString::from(initial_mib.to_string()));
+    }
+    if let Some(min_mib) = config.balloon_min_mib {
+        args.push(OsString::from("--balloon-min-mib"));
+        args.push(OsString::from(min_mib.to_string()));
+    }
+    if let Some(socket) = &config.balloon_control_socket {
+        args.push(OsString::from("--balloon-control-socket"));
+        args.push(socket.as_os_str().to_os_string());
+    }
     match config.effective_metrics_interval() {
         Some(ms) => {
             args.push(OsString::from("--metrics-sample-interval-ms"));
@@ -1708,6 +1720,35 @@ mod tests {
         let rendered = render_args(&config);
 
         assert!(rendered.contains(&"MSB_TMPFS=/tools:noexec".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_cli_args_include_balloon_config() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .memory(4096)
+            .balloon(2048, 512, "/tmp/test-balloon.sock")
+            .build()
+            .await
+            .unwrap();
+
+        let rendered = render_args(&config);
+
+        assert!(
+            rendered
+                .windows(2)
+                .any(|pair| pair == ["--balloon-initial-mib", "2048"])
+        );
+        assert!(
+            rendered
+                .windows(2)
+                .any(|pair| pair == ["--balloon-min-mib", "512"])
+        );
+        assert!(
+            rendered
+                .windows(2)
+                .any(|pair| pair == ["--balloon-control-socket", "/tmp/test-balloon.sock"])
+        );
     }
 
     #[tokio::test]

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -174,6 +174,22 @@ impl SandboxBuilder {
         self
     }
 
+    /// Enable guest memory ballooning.
+    ///
+    /// `initial` and `min` are guest-visible memory sizes in MiB. The VM still
+    /// boots with [`memory`](Self::memory) as the host-side ceiling.
+    pub fn balloon(
+        mut self,
+        initial: impl Into<Mebibytes>,
+        min: impl Into<Mebibytes>,
+        control_socket: impl Into<PathBuf>,
+    ) -> Self {
+        self.config.balloon_initial_mib = Some(initial.into().as_u32());
+        self.config.balloon_min_mib = Some(min.into().as_u32());
+        self.config.balloon_control_socket = Some(control_socket.into());
+        self
+    }
+
     /// Set the runtime log level for the sandbox process.
     ///
     /// This controls the verbosity of the `msb sandbox` process.
@@ -850,6 +866,33 @@ impl SandboxBuilder {
             )));
         }
 
+        if let Some(initial_mib) = self.config.balloon_initial_mib
+            && initial_mib > self.config.memory_mib
+        {
+            return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                "balloon initial memory ({initial_mib} MiB) exceeds configured memory ({} MiB)",
+                self.config.memory_mib
+            )));
+        }
+
+        if let Some(min_mib) = self.config.balloon_min_mib
+            && min_mib > self.config.memory_mib
+        {
+            return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                "balloon minimum memory ({min_mib} MiB) exceeds configured memory ({} MiB)",
+                self.config.memory_mib
+            )));
+        }
+
+        if let (Some(initial_mib), Some(min_mib)) =
+            (self.config.balloon_initial_mib, self.config.balloon_min_mib)
+            && min_mib > initial_mib
+        {
+            return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                "balloon minimum memory ({min_mib} MiB) exceeds initial memory ({initial_mib} MiB)"
+            )));
+        }
+
         for rlimit in &self.config.rlimits {
             if rlimit.soft > rlimit.hard {
                 return Err(crate::MicrosandboxError::InvalidConfig(format!(
@@ -943,6 +986,24 @@ mod tests {
             .unwrap();
 
         assert_eq!(config.log_level, Some(LogLevel::Debug));
+    }
+
+    #[tokio::test]
+    async fn test_builder_sets_balloon_config() {
+        let config = SandboxBuilder::new("test")
+            .image("alpine")
+            .memory(4096)
+            .balloon(2048, 512, "/tmp/test-balloon.sock")
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(config.balloon_initial_mib, Some(2048));
+        assert_eq!(config.balloon_min_mib, Some(512));
+        assert_eq!(
+            config.balloon_control_socket,
+            Some("/tmp/test-balloon.sock".into())
+        );
     }
 
     #[cfg(unix)]

--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -84,6 +84,18 @@ pub struct SandboxConfig {
     #[serde(default = "default_memory_mib")]
     pub memory_mib: u32,
 
+    /// Guest-visible memory at boot when ballooning is enabled, in MiB.
+    #[serde(default)]
+    pub balloon_initial_mib: Option<u32>,
+
+    /// Minimum guest-visible memory allowed by the balloon controller, in MiB.
+    #[serde(default)]
+    pub balloon_min_mib: Option<u32>,
+
+    /// Host Unix socket used to send runtime balloon memory targets.
+    #[serde(default)]
+    pub balloon_control_socket: Option<PathBuf>,
+
     /// Runtime log level for the sandbox process.
     ///
     /// `None` means the sandbox process stays silent.
@@ -392,6 +404,9 @@ impl Default for SandboxConfig {
             image: RootfsSource::default(),
             cpus: default_cpus(),
             memory_mib: default_memory_mib(),
+            balloon_initial_mib: None,
+            balloon_min_mib: None,
+            balloon_control_socket: None,
             log_level: default_log_level(),
             metrics_sample_interval_ms: default_metrics_sample_interval_ms(),
             disable_metrics_sample: default_disable_metrics_sample(),

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -27,7 +27,7 @@ libc = { workspace = true }
 lru = { workspace = true }
 microsandbox-protocol = { version = "0.5.4", path = "../protocol" }
 microsandbox-utils = { version = "0.5.4", path = "../utils" }
-msb_krun = { version = "0.1.14", features = ["net"] }
+msb_krun = { version = "0.1.15", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"
 percent-encoding = "2"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -28,7 +28,7 @@ microsandbox-metrics = { version = "0.5.4", path = "../metrics" }
 microsandbox-network = { version = "0.5.4", path = "../network", optional = true }
 microsandbox-protocol = { version = "0.5.4", path = "../protocol" }
 microsandbox-utils = { version = "0.5.4", path = "../utils" }
-msb_krun = { version = "0.1.14", features = ["blk"] }
+msb_krun = { version = "0.1.15", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }
 sea-orm.workspace = true

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -170,6 +170,15 @@ pub struct VmConfig {
     /// Memory in MiB.
     pub memory_mib: u32,
 
+    /// Guest-visible memory at boot when ballooning is enabled, in MiB.
+    pub balloon_initial_mib: Option<u32>,
+
+    /// Minimum guest-visible memory accepted by the balloon controller, in MiB.
+    pub balloon_min_mib: Option<u32>,
+
+    /// Host Unix socket for runtime balloon target updates.
+    pub balloon_control_socket: Option<PathBuf>,
+
     /// Root filesystem path for direct passthrough mounts.
     pub rootfs_path: Option<PathBuf>,
 
@@ -275,6 +284,9 @@ impl std::fmt::Debug for VmConfig {
             .field("libkrunfw_path", &self.libkrunfw_path)
             .field("vcpus", &self.vcpus)
             .field("memory_mib", &self.memory_mib)
+            .field("balloon_initial_mib", &self.balloon_initial_mib)
+            .field("balloon_min_mib", &self.balloon_min_mib)
+            .field("balloon_control_socket", &self.balloon_control_socket)
             .field("rootfs_path", &self.rootfs_path)
             .field("rootfs_vmdk", &self.rootfs_vmdk)
             .field("rootfs_upper", &self.rootfs_upper)
@@ -704,6 +716,23 @@ fn build_vm(
                 k
             }
         });
+
+    if vm.balloon_initial_mib.is_some()
+        || vm.balloon_min_mib.is_some()
+        || vm.balloon_control_socket.is_some()
+    {
+        let initial_mib = vm.balloon_initial_mib.unwrap_or(vm.memory_mib);
+        let min_mib = vm.balloon_min_mib.unwrap_or(0);
+        let control_socket = vm.balloon_control_socket.clone();
+        builder = builder.balloon(move |mut balloon| {
+            balloon = balloon.enable().initial_mib(initial_mib).min_mib(min_mib);
+            if let Some(socket) = control_socket {
+                balloon.control_socket_path(socket)
+            } else {
+                balloon
+            }
+        });
+    }
 
     // Root filesystem.
     if let Some(ref rootfs_path) = vm.rootfs_path {


### PR DESCRIPTION
## Summary

Wires host-driven memory balloon configuration through microsandbox and stacks it on the libkrun support in superradcompany/libkrun#59.

This adds app-level fields for the guest-visible boot target, the minimum guest-visible target, and the host Unix control socket, then carries those values through sandbox spawning into `msb_krun::VmBuilder::balloon(...)`.

## Technical implementation

- Extends `SandboxConfig` with three optional fields:
  - `balloon_initial_mib`: guest-visible memory at boot;
  - `balloon_min_mib`: minimum guest-visible memory allowed at runtime;
  - `balloon_control_socket`: Unix socket path used by the host to submit runtime memory targets.
- Adds `SandboxBuilder::balloon(initial, min, control_socket)` as the fluent API. The builder stores guest-visible MiB values instead of reclaimed pages so callers do not need to know the virtio-balloon representation.
- Adds builder validation so balloon settings cannot exceed the configured memory ceiling and the minimum cannot exceed the initial target.
- Updates the host spawn argument renderer to emit `--balloon-initial-mib`, `--balloon-min-mib`, and `--balloon-control-socket` only when the corresponding config values are present.
- Extends the internal `msb sandbox` clap args with matching fields and passes them into `microsandbox_runtime::vm::VmConfig`.
- Extends runtime `VmConfig` and its `Debug` output with the balloon fields.
- In `build_vm()`, enables `msb_krun::VmBuilder::balloon(...)` whenever any balloon field is set. Missing `initial` defaults to the configured memory ceiling, and missing `min` defaults to `0`, leaving the lower-level libkrun validation and max-page clamping as the final enforcement layer.
- Updates the `msb_krun` dependency requirements to `0.1.15` and temporarily patches `msb_krun` to the `enricoschaaf/msb-libkrun` branch used by superradcompany/libkrun#59. The lockfile resolves all internal `msb_krun*` crates from that same branch so microsandbox compiles against the new API before a crates.io release exists.

## Dependency and firmware notes

- This PR depends on superradcompany/libkrun#59.
- I did not open a libkrunfw PR. I checked the target firmware configs and they already carry the relevant virtio-balloon / compaction support, with memory hotplug enabled on the architectures where those options exist.
- Once `msb_krun 0.1.15` is published, the `[patch.crates-io]` entry can be removed and the dependency can resolve from crates.io normally.

## Validation

- `cargo check -p microsandbox-runtime -p microsandbox-cli -p microsandbox`
- `cargo test -p microsandbox balloon`

## Caviats

Main caveats in the current PRs:

- **No encrypted guest support.** `tee` builds reject ballooning. The C API returns `EOPNOTSUPP`; the Rust builder returns a config error.

- **Guest cooperation is required.** This only changes the virtio-balloon target. The guest kernel must have and load a working virtio-balloon driver. If the guest ignores the device or cannot reclaim memory, the host request may not take effect.

- **It is best-effort, not a hard memory cap.** The VM still has the configured `memory_mib` ceiling. Ballooning asks the guest to give pages back; it does not resize the guest physical address space or enforce a cgroup-like limit.

- **Runtime targets are clamped, not rejected.** If the control socket receives a target above the ceiling, it effectively becomes the ceiling. If it receives a target below `min_mib`, it clamps to `min_mib`. The response is `OK <pages>`, not the effective MiB target.

- **Dangerous default when partially configured.** In microsandbox runtime, setting only one balloon field enables ballooning. If only the socket is set, `initial` defaults to the full memory ceiling and `min` defaults to `0`, meaning the controller can request reclaiming essentially all guest memory.

- **The control socket is very simple.** It accepts one decimal MiB target per connection. No auth, no structured protocol, no status query, no actual-memory reporting. Access control is only filesystem permissions on the socket path.

- **Socket bind failure does not fail VM startup.** The listener is spawned after the VMM is built. If the parent directory does not exist, bind fails, or stale socket removal fails, it logs but the VM continues.

- **A stuck socket client can block control.** The listener handles connections serially and uses `read_line`; a client that connects and never sends a newline/EOF can block later resize commands.

- **No cleanup lifecycle for the socket.** The code removes a stale socket before binding, but does not explicitly unlink the socket on VM exit.

- **No SDK/top-level CLI exposure yet.** The internal `msb sandbox` process accepts the flags, and Rust config/builder fields exist, but I did not wire public `msb run/create` flags or update Node/Python/Go SDK APIs.

- **Metrics still use the ceiling.** Existing memory-limit metrics/reservation are based on `memory_mib`, not the current balloon target.