### PR TITLE
feat(runtime): stop attached sandboxes when creator process exits

### DIFF
--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -5,6 +5,7 @@
 //! — the VMM calls `_exit()` on guest shutdown.
 
 use std::path::PathBuf;
+use std::{os::fd::FromRawFd, os::fd::OwnedFd};
 
 use clap::Args;
 use microsandbox_runtime::{
@@ -46,6 +47,10 @@ pub struct SandboxArgs {
     /// Path to the Unix domain socket for the agent relay.
     #[arg(long)]
     pub agent_sock: PathBuf,
+
+    /// Read end of the attached-parent watchdog pipe.
+    #[arg(long = "parent-watch-fd", hide = true)]
+    pub parent_watch_fd: Option<i32>,
 
     /// Forward VM console output to stdout.
     #[arg(long = "forward")]
@@ -214,6 +219,9 @@ pub fn run(args: SandboxArgs, log_level: Option<LogLevel>) -> ! {
         log_dir: args.log_dir,
         runtime_dir: args.runtime_dir,
         agent_sock_path: args.agent_sock,
+        parent_watchdog: args
+            .parent_watch_fd
+            .map(|fd| unsafe { OwnedFd::from_raw_fd(fd) }),
         forward_output: args.forward_output,
         idle_timeout_secs: args.idle_timeout,
         max_duration_secs: args.max_duration,

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -4,6 +4,7 @@
 //! [`microsandbox_runtime::vm::enter()`]. This command **never returns**
 //! — the VMM calls `_exit()` on guest shutdown.
 
+use std::mem::MaybeUninit;
 use std::path::PathBuf;
 use std::{os::fd::FromRawFd, os::fd::OwnedFd};
 
@@ -162,6 +163,17 @@ pub struct SandboxArgs {
 
 /// Run the sandbox process. This function **never returns**.
 pub fn run(args: SandboxArgs, log_level: Option<LogLevel>) -> ! {
+    let parent_watchdog = match args
+        .parent_watch_fd
+        .map(parent_watchdog_from_fd)
+        .transpose()
+    {
+        Ok(fd) => fd,
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(2);
+        }
+    };
     let is_vmdk = args.rootfs_disk_format.as_deref() == Some("vmdk");
     let disks = match parse_disk_args(&args.disk) {
         Ok(disks) => disks,
@@ -219,9 +231,7 @@ pub fn run(args: SandboxArgs, log_level: Option<LogLevel>) -> ! {
         log_dir: args.log_dir,
         runtime_dir: args.runtime_dir,
         agent_sock_path: args.agent_sock,
-        parent_watchdog: args
-            .parent_watch_fd
-            .map(|fd| unsafe { OwnedFd::from_raw_fd(fd) }),
+        parent_watchdog,
         forward_output: args.forward_output,
         idle_timeout_secs: args.idle_timeout,
         max_duration_secs: args.max_duration,
@@ -246,6 +256,47 @@ pub fn run(args: SandboxArgs, log_level: Option<LogLevel>) -> ! {
     };
 
     microsandbox_runtime::vm::enter(config)
+}
+
+fn parent_watchdog_from_fd(fd: i32) -> Result<OwnedFd, String> {
+    validate_parent_watchdog_fd(fd, microsandbox_runtime::vm::PARENT_WATCH_FD)?;
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+fn validate_parent_watchdog_fd(fd: i32, expected_fd: i32) -> Result<(), String> {
+    if fd < 0 {
+        return Err(format!(
+            "invalid --parent-watch-fd: fd must be non-negative, got {fd}"
+        ));
+    }
+    if fd != expected_fd {
+        return Err(format!(
+            "invalid --parent-watch-fd: expected {expected_fd}, got {fd}",
+        ));
+    }
+
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(format!(
+            "invalid --parent-watch-fd {fd}: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } != 0 {
+        return Err(format!(
+            "invalid --parent-watch-fd {fd}: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    let stat = unsafe { stat.assume_init() };
+    let file_type = stat.st_mode & libc::S_IFMT as libc::mode_t;
+    if file_type != libc::S_IFIFO as libc::mode_t {
+        return Err(format!("invalid --parent-watch-fd {fd}: fd is not a pipe"));
+    }
+
+    Ok(())
 }
 
 /// Parse `--disk id:host_path:format[:ro]` entries into typed specs.
@@ -313,6 +364,8 @@ fn parse_one_disk_arg(entry: &str) -> Result<DiskMountSpec, String> {
 
 #[cfg(test)]
 mod tests {
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
     use super::*;
 
     fn fmt(s: &str) -> String {
@@ -394,5 +447,41 @@ mod tests {
         assert_eq!(specs[0].id, "good");
         assert_eq!(specs[1].id, "another");
         assert!(specs[1].readonly);
+    }
+
+    #[test]
+    fn test_validate_parent_watchdog_fd_rejects_negative_fd() {
+        let err =
+            validate_parent_watchdog_fd(-1, microsandbox_runtime::vm::PARENT_WATCH_FD).unwrap_err();
+
+        assert!(err.contains("non-negative"));
+    }
+
+    #[test]
+    fn test_validate_parent_watchdog_fd_rejects_wrong_fd_number() {
+        let err =
+            validate_parent_watchdog_fd(0, microsandbox_runtime::vm::PARENT_WATCH_FD).unwrap_err();
+
+        assert!(err.contains("expected 97"));
+    }
+
+    #[test]
+    fn test_validate_parent_watchdog_fd_rejects_regular_file() {
+        let file = tempfile::tempfile().unwrap();
+        let fd = file.as_raw_fd();
+
+        let err = validate_parent_watchdog_fd(fd, fd).unwrap_err();
+
+        assert!(err.contains("not a pipe"));
+    }
+
+    #[test]
+    fn test_validate_parent_watchdog_fd_accepts_pipe() {
+        let mut fds = [0; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let read_fd = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        let _write_fd = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+
+        validate_parent_watchdog_fd(read_fd.as_raw_fd(), read_fd.as_raw_fd()).unwrap();
     }
 }

--- a/crates/microsandbox/lib/runtime/handle.rs
+++ b/crates/microsandbox/lib/runtime/handle.rs
@@ -32,6 +32,10 @@ pub struct ProcessHandle {
     /// When true, the Drop impl will NOT send SIGTERM.
     detached: bool,
 
+    /// Writer side of the attached-parent watchdog pipe. Keeping this open
+    /// lets the child detect when the owner process disappears.
+    _parent_watchdog: Option<std::os::fd::OwnedFd>,
+
     /// Ephemeral staging directory for file mounts. Dropped when the
     /// process handle is dropped, which auto-removes all staged files.
     _file_mounts_staging: Option<TempDir>,
@@ -48,6 +52,7 @@ impl ProcessHandle {
         sandbox_name: String,
         child: Child,
         file_mounts_staging: Option<TempDir>,
+        parent_watchdog: Option<std::os::fd::OwnedFd>,
     ) -> Self {
         Self {
             pid,
@@ -55,6 +60,7 @@ impl ProcessHandle {
             child,
             detached: false,
             _file_mounts_staging: file_mounts_staging,
+            _parent_watchdog: parent_watchdog,
         }
     }
 
@@ -124,8 +130,19 @@ impl Drop for ProcessHandle {
             return;
         }
 
-        // Safety net: send SIGTERM so the sandbox process is cleaned up
-        // if the handle is dropped without an explicit stop.
+        // Attached sandboxes are coupled to the owner through the parent
+        // watchdog pipe. Dropping the last writer is enough to trigger guest
+        // shutdown and lets the runtime distinguish owner-exit cleanup from a
+        // normal explicit stop. Keep SIGTERM only for legacy/non-watchdog
+        // cases.
+        if self._parent_watchdog.is_some() {
+            tracing::debug!(
+                sandbox = %self.sandbox_name,
+                "drop: closing parent watchdog writer for attached sandbox cleanup"
+            );
+            return;
+        }
+
         if let Ok(None) = self.child.try_wait()
             && let Some(pid) = self.child.id()
         {

--- a/crates/microsandbox/lib/runtime/handle.rs
+++ b/crates/microsandbox/lib/runtime/handle.rs
@@ -3,6 +3,7 @@
 //! [`ProcessHandle`] holds the PID of the sandbox process and provides
 //! methods for lifecycle management (signals, wait).
 
+use std::os::fd::{AsRawFd, OwnedFd};
 use std::process::ExitStatus;
 
 use nix::{
@@ -34,7 +35,7 @@ pub struct ProcessHandle {
 
     /// Writer side of the attached-parent watchdog pipe. Keeping this open
     /// lets the child detect when the owner process disappears.
-    _parent_watchdog: Option<std::os::fd::OwnedFd>,
+    parent_watchdog: Option<OwnedFd>,
 
     /// Ephemeral staging directory for file mounts. Dropped when the
     /// process handle is dropped, which auto-removes all staged files.
@@ -52,7 +53,7 @@ impl ProcessHandle {
         sandbox_name: String,
         child: Child,
         file_mounts_staging: Option<TempDir>,
-        parent_watchdog: Option<std::os::fd::OwnedFd>,
+        parent_watchdog: Option<OwnedFd>,
     ) -> Self {
         Self {
             pid,
@@ -60,7 +61,7 @@ impl ProcessHandle {
             child,
             detached: false,
             _file_mounts_staging: file_mounts_staging,
-            _parent_watchdog: parent_watchdog,
+            parent_watchdog,
         }
     }
 
@@ -112,6 +113,16 @@ impl ProcessHandle {
     pub fn disarm(&mut self) {
         self.detached = true;
 
+        if let Some(parent_watchdog) = &self.parent_watchdog
+            && let Err(err) = send_parent_watchdog_detach(parent_watchdog)
+        {
+            tracing::debug!(
+                error = %err,
+                sandbox = %self.sandbox_name,
+                "failed to send parent-watch detach"
+            );
+        }
+
         // Consume the TempDir without deleting its contents — the detached
         // VM process still reads from it via virtiofs.
         if let Some(td) = self._file_mounts_staging.take() {
@@ -135,7 +146,7 @@ impl Drop for ProcessHandle {
         // shutdown and lets the runtime distinguish owner-exit cleanup from a
         // normal explicit stop. Keep SIGTERM only for legacy/non-watchdog
         // cases.
-        if self._parent_watchdog.is_some() {
+        if self.parent_watchdog.is_some() {
             tracing::debug!(
                 sandbox = %self.sandbox_name,
                 "drop: closing parent watchdog writer for attached sandbox cleanup"
@@ -149,5 +160,64 @@ impl Drop for ProcessHandle {
             tracing::debug!(pid, sandbox = %self.sandbox_name, "drop: sending SIGTERM safety net");
             let _ = signal::kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn send_parent_watchdog_detach(fd: &OwnedFd) -> std::io::Result<()> {
+    let byte = [microsandbox_runtime::vm::PARENT_WATCH_DETACH];
+
+    loop {
+        let written = unsafe {
+            libc::write(
+                fd.as_raw_fd(),
+                byte.as_ptr().cast::<libc::c_void>(),
+                byte.len(),
+            )
+        };
+        if written == byte.len() as isize {
+            return Ok(());
+        }
+        if written < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::WriteZero,
+            "failed to write parent-watch detach byte",
+        ));
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+    use std::os::fd::FromRawFd;
+
+    use super::*;
+
+    #[test]
+    fn test_send_parent_watchdog_detach_writes_detach_byte() {
+        let mut fds = [0; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let read_fd = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        let write_fd = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+
+        send_parent_watchdog_detach(&write_fd).unwrap();
+
+        let mut reader = std::fs::File::from(read_fd);
+        let mut byte = [0_u8; 1];
+        reader.read_exact(&mut byte).unwrap();
+        assert_eq!(byte[0], microsandbox_runtime::vm::PARENT_WATCH_DETACH);
     }
 }

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -52,7 +52,6 @@ use crate::{
 static SIGCHLD_ALT_STACK_INIT: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
 
 const AGENT_SOCKET_HASH_HEX_LEN: usize = 32;
-const PARENT_WATCH_FD: i32 = 97;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -93,11 +92,6 @@ pub async fn spawn_sandbox(
     sandbox_id: i32,
     mode: SpawnMode,
 ) -> MicrosandboxResult<(ProcessHandle, PathBuf)> {
-    let parent_watchdog = match mode {
-        SpawnMode::Attached => Some(create_parent_watchdog_pipe()?),
-        SpawnMode::Detached => None,
-    };
-
     // Resolve paths. Per-sandbox `libkrunfw_path` takes precedence over the
     // global resolver so SDK callers can point at a custom firmware bundle.
     let msb_path = config::resolve_msb_path()?;
@@ -162,6 +156,21 @@ pub async fn spawn_sandbox(
         None
     };
 
+    let parent_watchdog = match mode {
+        SpawnMode::Attached => match create_parent_watchdog_pipe() {
+            Ok(pipe) => Some(pipe),
+            Err(err) => {
+                release_metrics_reservation(
+                    config,
+                    metrics_reservation.as_ref(),
+                    ReleaseMode::Free,
+                );
+                return Err(err);
+            }
+        },
+        SpawnMode::Detached => None,
+    };
+
     // Build the command.
     let mut cmd = Command::new(&msb_path);
     cmd.args(sandbox_cli_args(
@@ -175,7 +184,9 @@ pub async fn spawn_sandbox(
         &libkrunfw_path,
         &staged_file_mounts,
         metrics_reservation.as_ref(),
-        parent_watchdog.as_ref().map(|_| PARENT_WATCH_FD),
+        parent_watchdog
+            .as_ref()
+            .map(|_| microsandbox_runtime::vm::PARENT_WATCH_FD),
     ));
 
     // Prevent the sandbox process from inheriting the parent's terminal on
@@ -187,14 +198,23 @@ pub async fn spawn_sandbox(
         let read_fd = pipe.read_fd.as_raw_fd();
         unsafe {
             cmd.pre_exec(move || {
-                if libc::dup2(read_fd, PARENT_WATCH_FD) < 0 {
+                if libc::dup2(read_fd, microsandbox_runtime::vm::PARENT_WATCH_FD) < 0 {
                     return Err(std::io::Error::last_os_error());
                 }
-                let flags = libc::fcntl(PARENT_WATCH_FD, libc::F_GETFD);
+                if read_fd != microsandbox_runtime::vm::PARENT_WATCH_FD && libc::close(read_fd) < 0
+                {
+                    return Err(std::io::Error::last_os_error());
+                }
+                let flags = libc::fcntl(microsandbox_runtime::vm::PARENT_WATCH_FD, libc::F_GETFD);
                 if flags < 0 {
                     return Err(std::io::Error::last_os_error());
                 }
-                if libc::fcntl(PARENT_WATCH_FD, libc::F_SETFD, flags & !libc::FD_CLOEXEC) < 0 {
+                if libc::fcntl(
+                    microsandbox_runtime::vm::PARENT_WATCH_FD,
+                    libc::F_SETFD,
+                    flags & !libc::FD_CLOEXEC,
+                ) < 0
+                {
                     return Err(std::io::Error::last_os_error());
                 }
                 Ok(())
@@ -358,7 +378,7 @@ fn reserve_metrics_slot(config: &SandboxConfig, sandbox_id: i32) -> Option<Metri
 
 fn create_parent_watchdog_pipe() -> MicrosandboxResult<ParentWatchdogPipe> {
     let mut fds = [0; 2];
-    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    let rc = create_cloexec_pipe(&mut fds);
     if rc != 0 {
         return Err(std::io::Error::last_os_error().into());
     }
@@ -366,12 +386,26 @@ fn create_parent_watchdog_pipe() -> MicrosandboxResult<ParentWatchdogPipe> {
     let read_fd = unsafe { OwnedFd::from_raw_fd(fds[0]) };
     let write_fd = unsafe { OwnedFd::from_raw_fd(fds[1]) };
 
-    set_cloexec(&read_fd, false)?;
-    set_cloexec(&write_fd, true)?;
+    #[cfg(not(target_os = "linux"))]
+    {
+        set_cloexec(&read_fd, true)?;
+        set_cloexec(&write_fd, true)?;
+    }
 
     Ok(ParentWatchdogPipe { read_fd, write_fd })
 }
 
+#[cfg(target_os = "linux")]
+fn create_cloexec_pipe(fds: &mut [i32; 2]) -> i32 {
+    unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn create_cloexec_pipe(fds: &mut [i32; 2]) -> i32 {
+    unsafe { libc::pipe(fds.as_mut_ptr()) }
+}
+
+#[cfg(not(target_os = "linux"))]
 fn set_cloexec(fd: &OwnedFd, enabled: bool) -> MicrosandboxResult<()> {
     let current = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GETFD) };
     if current < 0 {
@@ -1506,7 +1540,7 @@ mod tests {
             Path::new("/tmp/libkrunfw.dylib"),
             &HashMap::new(),
             None,
-            Some(super::PARENT_WATCH_FD),
+            Some(microsandbox_runtime::vm::PARENT_WATCH_FD),
         )
         .iter()
         .map(|arg| arg.to_string_lossy().into_owned())

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -6,6 +6,8 @@
 //! internally.
 
 #[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -13,6 +15,7 @@ use std::{
     collections::HashMap,
     ffi::OsString,
     fmt::Write,
+    os::fd::{FromRawFd, OwnedFd},
     path::{Path, PathBuf},
     process::Stdio,
 };
@@ -49,6 +52,7 @@ use crate::{
 static SIGCHLD_ALT_STACK_INIT: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
 
 const AGENT_SOCKET_HASH_HEX_LEN: usize = 32;
+const PARENT_WATCH_FD: i32 = 97;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -89,6 +93,11 @@ pub async fn spawn_sandbox(
     sandbox_id: i32,
     mode: SpawnMode,
 ) -> MicrosandboxResult<(ProcessHandle, PathBuf)> {
+    let parent_watchdog = match mode {
+        SpawnMode::Attached => Some(create_parent_watchdog_pipe()?),
+        SpawnMode::Detached => None,
+    };
+
     // Resolve paths. Per-sandbox `libkrunfw_path` takes precedence over the
     // global resolver so SDK callers can point at a custom firmware bundle.
     let msb_path = config::resolve_msb_path()?;
@@ -166,12 +175,32 @@ pub async fn spawn_sandbox(
         &libkrunfw_path,
         &staged_file_mounts,
         metrics_reservation.as_ref(),
+        parent_watchdog.as_ref().map(|_| PARENT_WATCH_FD),
     ));
 
     // Prevent the sandbox process from inheriting the parent's terminal on
     // stdin — the VMM's implicit console auto-detects terminals and sets raw
     // mode, which corrupts the parent's terminal output (\n without \r).
     cmd.stdin(Stdio::null());
+
+    if let Some(pipe) = parent_watchdog.as_ref() {
+        let read_fd = pipe.read_fd.as_raw_fd();
+        unsafe {
+            cmd.pre_exec(move || {
+                if libc::dup2(read_fd, PARENT_WATCH_FD) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                let flags = libc::fcntl(PARENT_WATCH_FD, libc::F_GETFD);
+                if flags < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::fcntl(PARENT_WATCH_FD, libc::F_SETFD, flags & !libc::FD_CLOEXEC) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
 
     if mode == SpawnMode::Detached {
         // Detached sandboxes outlive the creating CLI process, so the
@@ -263,7 +292,13 @@ pub async fn spawn_sandbox(
         "spawn_sandbox: startup JSON received"
     );
 
-    let handle = ProcessHandle::new(startup.pid, config.name.clone(), child, file_mounts_staging);
+    let handle = ProcessHandle::new(
+        startup.pid,
+        config.name.clone(),
+        child,
+        file_mounts_staging,
+        parent_watchdog.map(|pipe| pipe.write_fd),
+    );
 
     Ok((handle, agent_sock_path))
 }
@@ -277,6 +312,11 @@ struct MetricsReservation {
     shm_name: String,
     slot: u32,
     generation: u64,
+}
+
+struct ParentWatchdogPipe {
+    read_fd: OwnedFd,
+    write_fd: OwnedFd,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -314,6 +354,42 @@ fn reserve_metrics_slot(config: &SandboxConfig, sandbox_id: i32) -> Option<Metri
             None
         }
     }
+}
+
+fn create_parent_watchdog_pipe() -> MicrosandboxResult<ParentWatchdogPipe> {
+    let mut fds = [0; 2];
+    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let read_fd = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+    let write_fd = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+
+    set_cloexec(&read_fd, false)?;
+    set_cloexec(&write_fd, true)?;
+
+    Ok(ParentWatchdogPipe { read_fd, write_fd })
+}
+
+fn set_cloexec(fd: &OwnedFd, enabled: bool) -> MicrosandboxResult<()> {
+    let current = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GETFD) };
+    if current < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let mut next = current;
+    if enabled {
+        next |= libc::FD_CLOEXEC;
+    } else {
+        next &= !libc::FD_CLOEXEC;
+    }
+
+    if unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_SETFD, next) } < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    Ok(())
 }
 
 /// Build the host-side agent relay socket path for a sandbox name.
@@ -815,6 +891,7 @@ fn sandbox_cli_args(
     libkrunfw_path: &Path,
     staged_file_mounts: &HashMap<String, (PathBuf, String, String)>,
     metrics_reservation: Option<&MetricsReservation>,
+    parent_watch_fd: Option<i32>,
 ) -> Vec<OsString> {
     let mut args = vec![OsString::from("sandbox")];
 
@@ -836,6 +913,10 @@ fn sandbox_cli_args(
     args.push(runtime_dir.as_os_str().to_os_string());
     args.push(OsString::from("--agent-sock"));
     args.push(agent_sock_path.as_os_str().to_os_string());
+    if let Some(fd) = parent_watch_fd {
+        args.push(OsString::from("--parent-watch-fd"));
+        args.push(OsString::from(fd.to_string()));
+    }
 
     let sp = &config.policy;
     if let Some(max_dur) = sp.max_duration_secs {
@@ -1159,6 +1240,7 @@ mod tests {
             Path::new("/tmp/libkrunfw.dylib"),
             &HashMap::new(),
             None,
+            None,
         )
         .iter()
         .map(|arg| arg.to_string_lossy().into_owned())
@@ -1215,6 +1297,7 @@ mod tests {
             Path::new("/tmp/agent.sock"),
             Path::new("/tmp/libkrunfw.dylib"),
             staged_file_mounts,
+            None,
             None,
         )
         .iter()
@@ -1405,6 +1488,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_sandbox_cli_args_include_parent_watch_fd_when_present() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .build()
+            .await
+            .unwrap();
+
+        let rendered = sandbox_cli_args(
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            30,
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/agent.sock"),
+            Path::new("/tmp/libkrunfw.dylib"),
+            &HashMap::new(),
+            None,
+            Some(super::PARENT_WATCH_FD),
+        )
+        .iter()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+
+        assert!(
+            rendered
+                .windows(2)
+                .any(|pair| pair == ["--parent-watch-fd", "97"])
+        );
+    }
+
+    #[tokio::test]
     async fn test_sandbox_cli_args_include_rlimits_env() {
         let config = SandboxBuilder::new("test")
             .image("/tmp/rootfs")
@@ -1423,6 +1538,7 @@ mod tests {
             Path::new("/tmp/agent.sock"),
             Path::new("/tmp/libkrunfw.dylib"),
             &HashMap::new(),
+            None,
             None,
         );
 
@@ -1556,6 +1672,7 @@ mod tests {
             Path::new("/tmp/libkrunfw.dylib"),
             &HashMap::new(),
             Some(&reservation),
+            None,
         )
         .iter()
         .map(|a| a.to_string_lossy().into_owned())

--- a/crates/microsandbox/tests/parent_watchdog.rs
+++ b/crates/microsandbox/tests/parent_watchdog.rs
@@ -169,6 +169,10 @@ async fn parent_exit_stops_but_preserves_named_sandbox() {
         .arg("--nocapture")
         .env(CHILD_NAME_ENV, name)
         .env(CHILD_READY_ENV, &ready_path)
+        // This helper process must observe the same sandbox database as the
+        // parent test. CI sets MSB_TEST_ISOLATE_HOME=1, and the #[msb_test]
+        // wrapper would otherwise create a fresh MSB_HOME in the child.
+        .env_remove(test_utils::ISOLATE_HOME_ENV)
         .stdin(Stdio::null())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())

--- a/crates/microsandbox/tests/parent_watchdog.rs
+++ b/crates/microsandbox/tests/parent_watchdog.rs
@@ -1,0 +1,189 @@
+//! Integration tests for the parent-watchdog lifecycle.
+//!
+//! These tests require KVM (or libkrun on macOS). The `#[msb_test]`
+//! attribute marks them `#[ignore]`, so plain `cargo test --workspace`
+//! skips them. Run them via:
+//!
+//!     cargo nextest run -p microsandbox --test parent_watchdog --run-ignored=only
+
+use std::{
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::{Duration, Instant},
+};
+
+use microsandbox::{
+    Sandbox,
+    sandbox::{SandboxHandle, SandboxStatus},
+};
+use test_utils::msb_test;
+use tokio::time::sleep;
+
+const CHILD_NAME_ENV: &str = "MSB_PARENT_WATCHDOG_CHILD_NAME";
+const CHILD_READY_ENV: &str = "MSB_PARENT_WATCHDOG_CHILD_READY";
+const IMAGE: &str = "mirror.gcr.io/library/alpine";
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+async fn cleanup(name: &str) {
+    if let Ok(mut h) = Sandbox::get(name).await {
+        let _ = h.kill().await;
+        let _ = h.remove().await;
+    }
+}
+
+async fn assert_shell_ok(sandbox: &Sandbox, command: &str, expected: &str) {
+    let output = sandbox.shell(command).await.expect("shell command");
+    let stdout = output.stdout().unwrap_or_default();
+    let stderr = output.stderr().unwrap_or_default();
+
+    assert!(
+        output.status().success,
+        "shell command failed: stdout=`{stdout}` stderr=`{stderr}`"
+    );
+    assert_eq!(stdout.trim(), expected);
+}
+
+async fn wait_for_status(name: &str, expected: SandboxStatus, timeout: Duration) -> SandboxHandle {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        match Sandbox::get(name).await {
+            Ok(handle) if handle.status() == expected => return handle,
+            Ok(handle) => {
+                assert!(
+                    Instant::now() < deadline,
+                    "sandbox `{name}` stayed {:?}; expected {expected:?}",
+                    handle.status()
+                );
+            }
+            Err(err) => {
+                assert!(
+                    Instant::now() < deadline,
+                    "sandbox `{name}` disappeared before reaching {expected:?}: {err}"
+                );
+            }
+        }
+
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+fn wait_for_ready_file(path: &Path, timeout: Duration, child: &mut std::process::Child) {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        if path.exists() {
+            return;
+        }
+
+        if let Some(status) = child.try_wait().expect("poll child process") {
+            panic!("child test process exited before creating ready file: {status}");
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "child test process did not create ready file at {}",
+            path.display()
+        );
+
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Detach explicitly disarms the parent watchdog by sending the runtime
+/// a control byte before closing the writer. The sandbox should keep
+/// running after the owning SDK handle is dropped.
+#[msb_test]
+async fn detach_disarms_parent_watchdog_for_attached_sandbox() {
+    let name = "parent-watchdog-detach";
+    cleanup(name).await;
+
+    let sandbox = Sandbox::builder(name)
+        .image(IMAGE)
+        .cpus(1)
+        .memory(256)
+        .replace()
+        .create()
+        .await
+        .expect("create sandbox");
+
+    sandbox.detach().await;
+
+    sleep(Duration::from_secs(2)).await;
+
+    let handle = wait_for_status(name, SandboxStatus::Running, Duration::from_secs(30)).await;
+    let connected = handle.connect().await.expect("connect after detach");
+    assert_shell_ok(&connected, "echo detached-ok", "detached-ok").await;
+
+    let _ = connected.stop_and_wait().await;
+    cleanup(name).await;
+}
+
+/// Child entrypoint used by `parent_exit_stops_but_preserves_named_sandbox`.
+/// The parent kills this test process after the ready file appears so the
+/// runtime observes real parent-watchdog EOF, not an SDK-level shutdown.
+#[msb_test]
+async fn parent_watchdog_child_process() {
+    let Some(name) = std::env::var_os(CHILD_NAME_ENV) else {
+        return;
+    };
+    let Some(ready_path) = std::env::var_os(CHILD_READY_ENV) else {
+        return;
+    };
+
+    let name = name.to_string_lossy().into_owned();
+    let ready_path = PathBuf::from(ready_path);
+
+    cleanup(&name).await;
+
+    let sandbox = Sandbox::builder(&name)
+        .image(IMAGE)
+        .cpus(1)
+        .memory(256)
+        .replace()
+        .create()
+        .await
+        .expect("create child-owned sandbox");
+
+    assert_shell_ok(&sandbox, "echo child-ready", "child-ready").await;
+    std::fs::write(&ready_path, b"ready").expect("write ready file");
+
+    std::future::pending::<()>().await;
+}
+
+/// When an attached SDK creator dies, the runtime should stop the VM but
+/// preserve the named sandbox record and filesystem so it can be started
+/// again later.
+#[msb_test]
+async fn parent_exit_stops_but_preserves_named_sandbox() {
+    let name = "parent-watchdog-parent-exit";
+    cleanup(name).await;
+
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let ready_path = tempdir.path().join("ready");
+
+    let mut child = Command::new(std::env::current_exe().expect("current test binary"))
+        .arg("--ignored")
+        .arg("--exact")
+        .arg("parent_watchdog_child_process")
+        .arg("--nocapture")
+        .env(CHILD_NAME_ENV, name)
+        .env(CHILD_READY_ENV, &ready_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn child test process");
+
+    wait_for_ready_file(&ready_path, Duration::from_secs(180), &mut child);
+
+    child.kill().expect("kill child test process");
+    let _ = child.wait().expect("wait child test process");
+
+    let handle = wait_for_status(name, SandboxStatus::Stopped, Duration::from_secs(90)).await;
+    let restarted = handle.start().await.expect("restart stopped sandbox");
+    assert_shell_ok(&restarted, "echo restarted-ok", "restarted-ok").await;
+
+    let _ = restarted.stop_and_wait().await;
+    cleanup(name).await;
+}

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -43,6 +43,7 @@ const EXIT_REASON_COMPLETED: u8 = 0;
 const EXIT_REASON_IDLE_TIMEOUT: u8 = 1;
 const EXIT_REASON_MAX_DURATION: u8 = 2;
 const EXIT_REASON_SIGNAL: u8 = 3;
+const EXIT_REASON_PARENT_EXIT: u8 = 4;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -77,6 +78,9 @@ pub struct Config {
 
     /// Path to the Unix domain socket for the agent relay.
     pub agent_sock_path: PathBuf,
+
+    /// Read end of the attached-parent watchdog pipe.
+    pub parent_watchdog: Option<OwnedFd>,
 
     /// Whether to forward VM console output to stdout.
     pub forward_output: bool,
@@ -417,6 +421,10 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     let exit_run_id = run_db_id;
     let exit_reason_for_observer = Arc::clone(&exit_reason);
     let exit_sock_path = config.agent_sock_path.clone();
+    let exit_sandbox_root = config
+        .runtime_dir
+        .parent()
+        .map(std::path::Path::to_path_buf);
     let exit_log_writer = exec_log_writer.clone();
     // Capture the activated writer so the exit observer can release the slot
     // without re-opening the registry (saving two mmap syscalls and a
@@ -435,6 +443,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
             let reason = match reason_tag {
                 EXIT_REASON_IDLE_TIMEOUT => run_entity::TerminationReason::IdleTimeout,
                 EXIT_REASON_MAX_DURATION => run_entity::TerminationReason::MaxDurationExceeded,
+                EXIT_REASON_PARENT_EXIT => run_entity::TerminationReason::Signal,
                 EXIT_REASON_SIGNAL => run_entity::TerminationReason::Signal,
                 _ if exit_code == 0 => run_entity::TerminationReason::Completed,
                 _ => run_entity::TerminationReason::Failed,
@@ -466,6 +475,15 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                     .filter(sandbox_entity::Column::Id.eq(exit_sandbox_id))
                     .exec(&exit_db)
                     .await;
+
+                if reason_tag == EXIT_REASON_PARENT_EXIT {
+                    if let Some(path) = exit_sandbox_root.as_ref() {
+                        let _ = std::fs::remove_dir_all(path);
+                    }
+                    let _ = sandbox_entity::Entity::delete_by_id(exit_sandbox_id)
+                        .exec(&exit_db)
+                        .await;
+                }
             });
 
             // Inject the exec.log lifecycle-stop marker before _exit().
@@ -512,6 +530,16 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         };
     relay = relay.with_bind_identity_map(bind_identity_map.handle, bind_identity_map.mount_count);
     let exit_handle = vm.exit_handle();
+
+    if let Some(parent_watchdog) = config.parent_watchdog {
+        spawn_parent_watchdog(
+            parent_watchdog,
+            Arc::clone(&shared),
+            Arc::clone(&exit_reason),
+            exit_handle.clone(),
+            config.sandbox_name.clone(),
+        );
+    }
 
     #[cfg(feature = "net")]
     if let Some(network_termination_handle) = _network_termination_handle {
@@ -1110,6 +1138,47 @@ fn request_guest_shutdown(shared: &ConsoleSharedState) -> RuntimeResult<()> {
     codec::encode_to_buf(&msg, &mut frame)
         .map_err(|e| RuntimeError::Custom(format!("encode idle shutdown frame: {e}")))?;
     relay::push_guest_frame_blocking(shared, frame)
+}
+
+fn spawn_parent_watchdog(
+    parent_watchdog: OwnedFd,
+    shared: Arc<ConsoleSharedState>,
+    exit_reason: Arc<std::sync::atomic::AtomicU8>,
+    exit_handle: msb_krun::ExitHandle,
+    sandbox_name: String,
+) {
+    std::thread::Builder::new()
+        .name(format!("msb-parent-watch-{sandbox_name}"))
+        .spawn(move || {
+            let mut file = std::fs::File::from(parent_watchdog);
+            let mut buf = [0_u8; 1];
+
+            loop {
+                match std::io::Read::read(&mut file, &mut buf) {
+                    Ok(0) => {
+                        tracing::info!("creator process exited; stopping attached sandbox");
+                        exit_reason
+                            .store(EXIT_REASON_PARENT_EXIT, std::sync::atomic::Ordering::SeqCst);
+                        if let Err(err) = request_guest_shutdown(&shared) {
+                            tracing::warn!(error = %err, "parent-watch shutdown request failed");
+                        } else {
+                            std::thread::sleep(microsandbox_protocol::SHUTDOWN_FLUSH_TIMEOUT);
+                        }
+                        exit_handle.trigger();
+                        break;
+                    }
+                    Ok(_) => {}
+                    Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+                    Err(err) => {
+                        tracing::warn!(error = %err, "parent-watch read failed; stopping sandbox");
+                        exit_reason.store(EXIT_REASON_SIGNAL, std::sync::atomic::Ordering::SeqCst);
+                        exit_handle.trigger();
+                        break;
+                    }
+                }
+            }
+        })
+        .expect("spawn parent watchdog thread");
 }
 
 /// Create a pipe pair, returning `(read_end, write_end)` as `OwnedFd`.

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -45,6 +45,12 @@ const EXIT_REASON_MAX_DURATION: u8 = 2;
 const EXIT_REASON_SIGNAL: u8 = 3;
 const EXIT_REASON_PARENT_EXIT: u8 = 4;
 
+/// Fixed fd used to pass the attached-parent watchdog pipe into `msb sandbox`.
+pub const PARENT_WATCH_FD: i32 = 97;
+
+/// Control byte sent by the owner to stop parent-watch monitoring without stopping the sandbox.
+pub const PARENT_WATCH_DETACH: u8 = 1;
+
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
@@ -114,6 +120,12 @@ pub struct MetricsSlotHandoff {
     pub slot: u32,
     /// Generation paired with the reservation.
     pub generation: u64,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum ParentWatchdogSignal {
+    ParentExited,
+    Detached,
 }
 
 /// Specification for the writable upper layer attached as virtio-blk.
@@ -421,10 +433,6 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     let exit_run_id = run_db_id;
     let exit_reason_for_observer = Arc::clone(&exit_reason);
     let exit_sock_path = config.agent_sock_path.clone();
-    let exit_sandbox_root = config
-        .runtime_dir
-        .parent()
-        .map(std::path::Path::to_path_buf);
     let exit_log_writer = exec_log_writer.clone();
     // Capture the activated writer so the exit observer can release the slot
     // without re-opening the registry (saving two mmap syscalls and a
@@ -475,15 +483,6 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                     .filter(sandbox_entity::Column::Id.eq(exit_sandbox_id))
                     .exec(&exit_db)
                     .await;
-
-                if reason_tag == EXIT_REASON_PARENT_EXIT {
-                    if let Some(path) = exit_sandbox_root.as_ref() {
-                        let _ = std::fs::remove_dir_all(path);
-                    }
-                    let _ = sandbox_entity::Entity::delete_by_id(exit_sandbox_id)
-                        .exec(&exit_db)
-                        .await;
-                }
             });
 
             // Inject the exec.log lifecycle-stop marker before _exit().
@@ -531,14 +530,23 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     relay = relay.with_bind_identity_map(bind_identity_map.handle, bind_identity_map.mount_count);
     let exit_handle = vm.exit_handle();
 
-    if let Some(parent_watchdog) = config.parent_watchdog {
-        spawn_parent_watchdog(
+    if let Some(parent_watchdog) = config.parent_watchdog
+        && let Err(e) = spawn_parent_watchdog(
             parent_watchdog,
             Arc::clone(&shared),
             Arc::clone(&exit_reason),
             exit_handle.clone(),
             config.sandbox_name.clone(),
-        );
+        )
+    {
+        let _ = tokio_rt.block_on(mark_run_failed(&db, run_db_id));
+        if let Some(writer) = metrics_writer.clone() {
+            let _ = writer.release(ReleaseMode::Free);
+        } else {
+            release_metrics_slot(config.metrics_slot.as_ref(), ReleaseMode::Free);
+        }
+        let _ = std::fs::remove_file(&config.agent_sock_path);
+        return Err(e);
     }
 
     #[cfg(feature = "net")]
@@ -1146,39 +1154,50 @@ fn spawn_parent_watchdog(
     exit_reason: Arc<std::sync::atomic::AtomicU8>,
     exit_handle: msb_krun::ExitHandle,
     sandbox_name: String,
-) {
+) -> RuntimeResult<()> {
     std::thread::Builder::new()
         .name(format!("msb-parent-watch-{sandbox_name}"))
         .spawn(move || {
             let mut file = std::fs::File::from(parent_watchdog);
-            let mut buf = [0_u8; 1];
 
-            loop {
-                match std::io::Read::read(&mut file, &mut buf) {
-                    Ok(0) => {
-                        tracing::info!("creator process exited; stopping attached sandbox");
-                        exit_reason
-                            .store(EXIT_REASON_PARENT_EXIT, std::sync::atomic::Ordering::SeqCst);
-                        if let Err(err) = request_guest_shutdown(&shared) {
-                            tracing::warn!(error = %err, "parent-watch shutdown request failed");
-                        } else {
-                            std::thread::sleep(microsandbox_protocol::SHUTDOWN_FLUSH_TIMEOUT);
-                        }
-                        exit_handle.trigger();
-                        break;
+            match read_parent_watchdog_signal(&mut file) {
+                Ok(ParentWatchdogSignal::ParentExited) => {
+                    tracing::info!("creator process exited; stopping attached sandbox");
+                    exit_reason.store(EXIT_REASON_PARENT_EXIT, std::sync::atomic::Ordering::SeqCst);
+                    if let Err(err) = request_guest_shutdown(&shared) {
+                        tracing::warn!(error = %err, "parent-watch shutdown request failed");
+                    } else {
+                        std::thread::sleep(microsandbox_protocol::SHUTDOWN_FLUSH_TIMEOUT);
                     }
-                    Ok(_) => {}
-                    Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
-                    Err(err) => {
-                        tracing::warn!(error = %err, "parent-watch read failed; stopping sandbox");
-                        exit_reason.store(EXIT_REASON_SIGNAL, std::sync::atomic::Ordering::SeqCst);
-                        exit_handle.trigger();
-                        break;
-                    }
+                    exit_handle.trigger();
+                }
+                Ok(ParentWatchdogSignal::Detached) => {
+                    tracing::debug!("attached-parent watchdog detached; leaving sandbox running");
+                }
+                Err(err) => {
+                    tracing::warn!(error = %err, "parent-watch read failed; stopping sandbox");
+                    exit_reason.store(EXIT_REASON_SIGNAL, std::sync::atomic::Ordering::SeqCst);
+                    exit_handle.trigger();
                 }
             }
         })
-        .expect("spawn parent watchdog thread");
+        .map_err(RuntimeError::Io)?;
+
+    Ok(())
+}
+
+fn read_parent_watchdog_signal(file: &mut std::fs::File) -> std::io::Result<ParentWatchdogSignal> {
+    let mut buf = [0_u8; 1];
+
+    loop {
+        match std::io::Read::read(file, &mut buf) {
+            Ok(0) => return Ok(ParentWatchdogSignal::ParentExited),
+            Ok(_) if buf[0] == PARENT_WATCH_DETACH => return Ok(ParentWatchdogSignal::Detached),
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(err) => return Err(err),
+        }
+    }
 }
 
 /// Create a pipe pair, returning `(read_end, write_end)` as `OwnedFd`.
@@ -1424,12 +1443,14 @@ pub fn prepend_scripts_path(env: &mut Vec<String>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        BindIdentityMapRegistration, ConsoleSharedState, HostPermissions, StatVirtualization,
-        append_block_root_env, bind_identity_map_for_mount, parse_mount_spec, prepend_scripts_path,
-        request_guest_shutdown, validate_disk_format,
+        BindIdentityMapRegistration, ConsoleSharedState, HostPermissions, PARENT_WATCH_DETACH,
+        ParentWatchdogSignal, StatVirtualization, append_block_root_env,
+        bind_identity_map_for_mount, parse_mount_spec, prepend_scripts_path,
+        read_parent_watchdog_signal, request_guest_shutdown, validate_disk_format,
     };
 
     use microsandbox_protocol::{codec, message::MessageType};
+    use std::io::Write;
     use std::sync::Arc;
 
     #[test]
@@ -1548,6 +1569,29 @@ mod tests {
         let msg = codec::try_decode_from_buf(&mut frame).unwrap().unwrap();
         assert_eq!(msg.t, MessageType::Shutdown);
         assert_eq!(msg.id, 0);
+    }
+
+    #[test]
+    fn test_parent_watchdog_signal_reports_parent_exit_on_eof() {
+        let (read_fd, write_fd) = super::create_pipe().unwrap();
+        drop(write_fd);
+        let mut reader = std::fs::File::from(read_fd);
+
+        let signal = read_parent_watchdog_signal(&mut reader).unwrap();
+
+        assert_eq!(signal, ParentWatchdogSignal::ParentExited);
+    }
+
+    #[test]
+    fn test_parent_watchdog_signal_reports_detach_byte() {
+        let (read_fd, write_fd) = super::create_pipe().unwrap();
+        let mut writer = std::fs::File::from(write_fd);
+        writer.write_all(&[PARENT_WATCH_DETACH]).unwrap();
+        let mut reader = std::fs::File::from(read_fd);
+
+        let signal = read_parent_watchdog_signal(&mut reader).unwrap();
+
+        assert_eq!(signal, ParentWatchdogSignal::Detached);
     }
 
     #[test]


### PR DESCRIPTION
Closes #861.

Attached sandboxes previously depended on the host handle being dropped cleanly. This change adds a parent-watch pipe so the sandbox process can detect creator exit directly and shut itself down.

Tested with the Go SDK and works nicely.