### PR TITLE
refactor(deps): inherit internal crates via [workspace.dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,24 @@ strip = true
 panic = "abort"
 
 [workspace.dependencies]
+# Internal crates. Versioned here so a release bumps one place, not every
+# manifest; members reference them via `{ workspace = true }`.
+# `default-features = false` on crates whose consumers opt into features
+# explicitly (see each member manifest); other consumers re-enable defaults.
+microsandbox = { version = "0.5.4", path = "crates/microsandbox", default-features = false }
+microsandbox-db = { version = "0.5.4", path = "crates/db" }
+microsandbox-filesystem = { version = "0.5.4", path = "crates/filesystem", default-features = false }
+microsandbox-image = { version = "0.5.4", path = "crates/image" }
+microsandbox-metrics = { version = "0.5.4", path = "crates/metrics" }
+microsandbox-migration = { version = "0.5.4", path = "crates/migration" }
+microsandbox-network = { version = "0.5.4", path = "crates/network" }
+microsandbox-protocol = { version = "0.5.4", path = "crates/protocol" }
+microsandbox-runtime = { version = "0.5.4", path = "crates/runtime", default-features = false }
+microsandbox-utils = { version = "0.5.4", path = "crates/utils" }
+test-macros = { path = "crates/test-macros" }
+test-utils = { path = "crates/test-utils" }
+
+# External crates.
 anyhow = "1.0"
 astral-tokio-tar = "0.6"
 base64 = "0.22"

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -18,7 +18,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { version = "0.5.4", path = "../protocol" }
+microsandbox-protocol = { workspace = true }
 nix = { workspace = true, features = [
     "fs",
     "hostname",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -18,7 +18,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { workspace = true }
+microsandbox-protocol.workspace = true
 nix = { workspace = true, features = [
     "fs",
     "hostname",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,12 +40,12 @@ futures.workspace = true
 indicatif.workspace = true
 ipnetwork = { workspace = true, optional = true }
 libc.workspace = true
-microsandbox = { workspace = true }
-microsandbox-image = { workspace = true }
+microsandbox.workspace = true
+microsandbox-image.workspace = true
 microsandbox-network = { workspace = true, optional = true }
-microsandbox-protocol = { workspace = true }
-microsandbox-runtime = { workspace = true }
-microsandbox-utils = { workspace = true }
+microsandbox-protocol.workspace = true
+microsandbox-runtime.workspace = true
+microsandbox-utils.workspace = true
 rand.workspace = true
 regex = "1"
 reqwest.workspace = true
@@ -60,4 +60,4 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
-test-utils = { workspace = true }
+test-utils.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,12 +40,12 @@ futures.workspace = true
 indicatif.workspace = true
 ipnetwork = { workspace = true, optional = true }
 libc.workspace = true
-microsandbox = { version = "0.5.4", path = "../microsandbox", default-features = false }
-microsandbox-image = { version = "0.5.4", path = "../image" }
-microsandbox-network = { version = "0.5.4", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.5.4", path = "../protocol" }
-microsandbox-runtime = { version = "0.5.4", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.5.4", path = "../utils" }
+microsandbox = { workspace = true }
+microsandbox-image = { workspace = true }
+microsandbox-network = { workspace = true, optional = true }
+microsandbox-protocol = { workspace = true }
+microsandbox-runtime = { workspace = true }
+microsandbox-utils = { workspace = true }
 rand.workspace = true
 regex = "1"
 reqwest.workspace = true
@@ -60,4 +60,4 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
-test-utils = { path = "../test-utils" }
+test-utils = { workspace = true }

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { workspace = true }
+microsandbox-utils.workspace = true
 msb_krun = "0.1.14"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,4 +23,4 @@ default = ["prebuilt"]
 prebuilt = ["microsandbox-utils/http-client"]
 
 [build-dependencies]
-microsandbox-utils = { workspace = true }
+microsandbox-utils.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { version = "0.5.4", path = "../utils" }
+microsandbox-utils = { workspace = true }
 msb_krun = "0.1.14"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,4 +23,4 @@ default = ["prebuilt"]
 prebuilt = ["microsandbox-utils/http-client"]
 
 [build-dependencies]
-microsandbox-utils = { version = "0.5.4", path = "../utils" }
+microsandbox-utils = { workspace = true }

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { workspace = true }
+microsandbox-utils.workspace = true
 oci-client.workspace = true
 rustls-pemfile.workspace = true
 oci-spec.workspace = true

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { version = "0.5.4", path = "../utils" }
+microsandbox-utils = { workspace = true }
 oci-client.workspace = true
 rustls-pemfile.workspace = true
 oci-spec.workspace = true

--- a/crates/metrics-collector/Cargo.toml
+++ b/crates/metrics-collector/Cargo.toml
@@ -17,7 +17,7 @@ path = "bin/main.rs"
 
 [dependencies]
 # Shared-memory primitives — the read source for every tick.
-microsandbox-metrics = { version = "0.5.4", path = "../metrics" }
+microsandbox-metrics = { workspace = true }
 # ENOENT detection on shm_open failures.
 libc.workspace = true
 # Async runtime + primitives (broadcast, mpsc, JoinSet, time).
@@ -38,11 +38,11 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 
 # Catalog access for per-sandbox labels (read-only connection + entity).
-microsandbox-db = { version = "0.5.4", path = "../db" }
+microsandbox-db = { workspace = true }
 # Query traits (EntityTrait, ColumnTrait, QueryFilter) for the label lookup.
 sea-orm = { workspace = true }
 # Used by the binary to derive the shm registry name from `$MSB_HOME`.
-microsandbox-utils = { version = "0.5.4", path = "../utils" }
+microsandbox-utils = { workspace = true }
 # CLI duration parsing (e.g. "1s", "500ms").
 humantime = "2"
 # Resolving the default `~/.microsandbox` path when --msb-home is omitted.
@@ -75,7 +75,7 @@ tonic = { version = "0.14", default-features = false, features = [
 [dev-dependencies]
 tempfile.workspace = true
 # Apply the catalog schema to a temp DB in LabelCache tests.
-microsandbox-migration = { version = "0.5.4", path = "../migration" }
+microsandbox-migration = { workspace = true }
 tokio = { workspace = true, features = [
     "macros",
     "rt-multi-thread",

--- a/crates/metrics-collector/Cargo.toml
+++ b/crates/metrics-collector/Cargo.toml
@@ -17,7 +17,7 @@ path = "bin/main.rs"
 
 [dependencies]
 # Shared-memory primitives — the read source for every tick.
-microsandbox-metrics = { workspace = true }
+microsandbox-metrics.workspace = true
 # ENOENT detection on shm_open failures.
 libc.workspace = true
 # Async runtime + primitives (broadcast, mpsc, JoinSet, time).
@@ -38,11 +38,11 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 
 # Catalog access for per-sandbox labels (read-only connection + entity).
-microsandbox-db = { workspace = true }
+microsandbox-db.workspace = true
 # Query traits (EntityTrait, ColumnTrait, QueryFilter) for the label lookup.
 sea-orm = { workspace = true }
 # Used by the binary to derive the shm registry name from `$MSB_HOME`.
-microsandbox-utils = { workspace = true }
+microsandbox-utils.workspace = true
 # CLI duration parsing (e.g. "1s", "500ms").
 humantime = "2"
 # Resolving the default `~/.microsandbox` path when --msb-home is omitted.
@@ -75,7 +75,7 @@ tonic = { version = "0.14", default-features = false, features = [
 [dev-dependencies]
 tempfile.workspace = true
 # Apply the catalog schema to a temp DB in LabelCache tests.
-microsandbox-migration = { workspace = true }
+microsandbox-migration.workspace = true
 tokio = { workspace = true, features = [
     "macros",
     "rt-multi-thread",

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -41,15 +41,15 @@ flate2.workspace = true
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-db = { workspace = true }
-microsandbox-filesystem = { workspace = true }
-microsandbox-image = { workspace = true }
-microsandbox-metrics = { workspace = true }
-microsandbox-migration = { workspace = true }
+microsandbox-db.workspace = true
+microsandbox-filesystem.workspace = true
+microsandbox-image.workspace = true
+microsandbox-metrics.workspace = true
+microsandbox-migration.workspace = true
 microsandbox-network = { workspace = true, optional = true }
-microsandbox-protocol = { workspace = true }
-microsandbox-runtime = { workspace = true }
-microsandbox-utils = { workspace = true }
+microsandbox-protocol.workspace = true
+microsandbox-runtime.workspace = true
+microsandbox-utils.workspace = true
 nix = { workspace = true, features = ["process", "signal"] }
 notify.workspace = true
 rand.workspace = true
@@ -71,16 +71,16 @@ which.workspace = true
 
 [build-dependencies]
 flate2.workspace = true
-microsandbox-utils = { workspace = true }
+microsandbox-utils.workspace = true
 tar.workspace = true
 
 [dev-dependencies]
 ipnetwork.workspace = true
-microsandbox-network = { workspace = true }
+microsandbox-network.workspace = true
 rcgen.workspace = true
 rustls.workspace = true
 tempfile.workspace = true
-test-utils = { workspace = true }
+test-utils.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-rustls.workspace = true
 

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -41,15 +41,15 @@ flate2.workspace = true
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-db = { version = "0.5.4", path = "../db" }
-microsandbox-filesystem = { version = "0.5.4", path = "../filesystem", default-features = false }
-microsandbox-image = { version = "0.5.4", path = "../image" }
-microsandbox-metrics = { version = "0.5.4", path = "../metrics" }
-microsandbox-migration = { version = "0.5.4", path = "../migration" }
-microsandbox-network = { version = "0.5.4", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.5.4", path = "../protocol" }
-microsandbox-runtime = { version = "0.5.4", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.5.4", path = "../utils" }
+microsandbox-db = { workspace = true }
+microsandbox-filesystem = { workspace = true }
+microsandbox-image = { workspace = true }
+microsandbox-metrics = { workspace = true }
+microsandbox-migration = { workspace = true }
+microsandbox-network = { workspace = true, optional = true }
+microsandbox-protocol = { workspace = true }
+microsandbox-runtime = { workspace = true }
+microsandbox-utils = { workspace = true }
 nix = { workspace = true, features = ["process", "signal"] }
 notify.workspace = true
 rand.workspace = true
@@ -71,16 +71,16 @@ which.workspace = true
 
 [build-dependencies]
 flate2.workspace = true
-microsandbox-utils = { version = "0.5.4", path = "../utils" }
+microsandbox-utils = { workspace = true }
 tar.workspace = true
 
 [dev-dependencies]
 ipnetwork.workspace = true
-microsandbox-network = { version = "0.5.4", path = "../network" }
+microsandbox-network = { workspace = true }
 rcgen.workspace = true
 rustls.workspace = true
 tempfile.workspace = true
-test-utils = { path = "../test-utils" }
+test-utils = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-rustls.workspace = true
 

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -25,8 +25,8 @@ httlib-hpack = { workspace = true }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
-microsandbox-protocol = { version = "0.5.4", path = "../protocol" }
-microsandbox-utils = { version = "0.5.4", path = "../utils" }
+microsandbox-protocol = { workspace = true }
+microsandbox-utils = { workspace = true }
 msb_krun = { version = "0.1.14", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -25,8 +25,8 @@ httlib-hpack = { workspace = true }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
-microsandbox-protocol = { workspace = true }
-microsandbox-utils = { workspace = true }
+microsandbox-protocol.workspace = true
+microsandbox-utils.workspace = true
 msb_krun = { version = "0.1.14", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,12 +22,12 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
-microsandbox-db = { version = "0.5.4", path = "../db" }
-microsandbox-filesystem = { version = "0.5.4", path = "../filesystem", default-features = false }
-microsandbox-metrics = { version = "0.5.4", path = "../metrics" }
-microsandbox-network = { version = "0.5.4", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.5.4", path = "../protocol" }
-microsandbox-utils = { version = "0.5.4", path = "../utils" }
+microsandbox-db = { workspace = true }
+microsandbox-filesystem = { workspace = true }
+microsandbox-metrics = { workspace = true }
+microsandbox-network = { workspace = true, optional = true }
+microsandbox-protocol = { workspace = true }
+microsandbox-utils = { workspace = true }
 msb_krun = { version = "0.1.14", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,12 +22,12 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
-microsandbox-db = { workspace = true }
-microsandbox-filesystem = { workspace = true }
-microsandbox-metrics = { workspace = true }
+microsandbox-db.workspace = true
+microsandbox-filesystem.workspace = true
+microsandbox-metrics.workspace = true
 microsandbox-network = { workspace = true, optional = true }
-microsandbox-protocol = { workspace = true }
-microsandbox-utils = { workspace = true }
+microsandbox-protocol.workspace = true
+microsandbox-utils.workspace = true
 msb_krun = { version = "0.1.14", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -12,5 +12,5 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
-test-macros = { workspace = true }
+test-macros.workspace = true
 tempfile.workspace = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -12,5 +12,5 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
-test-macros = { path = "../test-macros" }
+test-macros = { workspace = true }
 tempfile.workspace = true

--- a/sdk/go/native/Cargo.toml
+++ b/sdk/go/native/Cargo.toml
@@ -12,8 +12,8 @@ name = "microsandbox_go_ffi"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-microsandbox = { version = "0.5.4", path = "../../../crates/microsandbox", features = ["net", "ssh"] }
-microsandbox-network = { version = "0.5.4", path = "../../../crates/network" }
+microsandbox = { workspace = true, default-features = true, features = ["net", "ssh"] }
+microsandbox-network = { workspace = true }
 ipnetwork.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/sdk/go/native/Cargo.toml
+++ b/sdk/go/native/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 microsandbox = { workspace = true, default-features = true, features = ["net", "ssh"] }
-microsandbox-network = { workspace = true }
+microsandbox-network.workspace = true
 ipnetwork.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/sdk/node-ts/Cargo.toml
+++ b/sdk/node-ts/Cargo.toml
@@ -12,7 +12,7 @@ path = "native/lib.rs"
 
 [dependencies]
 microsandbox = { workspace = true, default-features = true, features = ["ssh"] }
-microsandbox-network = { workspace = true }
+microsandbox-network.workspace = true
 ipnetwork = { workspace = true }
 napi = { version = "3", default-features = false, features = [
     "async",

--- a/sdk/node-ts/Cargo.toml
+++ b/sdk/node-ts/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 path = "native/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.5.4", path = "../../crates/microsandbox", features = ["ssh"] }
-microsandbox-network = { version = "0.5.4", path = "../../crates/network" }
+microsandbox = { workspace = true, default-features = true, features = ["ssh"] }
+microsandbox-network = { workspace = true }
 ipnetwork = { workspace = true }
 napi = { version = "3", default-features = false, features = [
     "async",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 microsandbox = { workspace = true, default-features = true, features = ["ssh"] }
-microsandbox-network = { workspace = true }
+microsandbox-network.workspace = true
 chrono = { workspace = true }
 ipnetwork = { version = "0.21.0", features = ["serde"] }
 pyo3 = { version = "0.24", features = ["abi3-py310", "extension-module"] }

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.5.4", path = "../../crates/microsandbox", features = ["ssh"] }
-microsandbox-network = { version = "0.5.4", path = "../../crates/network" }
+microsandbox = { workspace = true, default-features = true, features = ["ssh"] }
+microsandbox-network = { workspace = true }
 chrono = { workspace = true }
 ipnetwork = { version = "0.21.0", features = ["serde"] }
 pyo3 = { version = "0.24", features = ["abi3-py310", "extension-module"] }


### PR DESCRIPTION
internal crate versions were pinned in every manifest, so each release bumped them in N places and a missing version broke `cargo package`.

declares the internal crates once in `[workspace.dependencies]` and references them with `{ workspace = true }` everywhere. a release now bumps a single place; published crates still carry version requirements.

verified: `cargo check --workspace` clean, `cargo package` succeeds for the published crates, clippy + doc green.