### PR TITLE
fix(db): read connections must not create the catalog db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,6 +3225,7 @@ dependencies = [
  "async-trait",
  "sea-orm",
  "sqlx",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -17,3 +17,6 @@ sea-orm.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/db/lib/connection.rs
+++ b/crates/db/lib/connection.rs
@@ -51,14 +51,23 @@ impl DbReadConnection {
     }
 
     /// Open a stand-alone read pool at `db_path` with shared PRAGMAs.
+    ///
+    /// Read-only: opening a non-existent DB fails rather than creating it, so a
+    /// read consumer never authors or pre-empts the catalog owned by `msb`.
     pub async fn open(
         db_path: &Path,
         max_connections: u32,
         connect_timeout: Duration,
         busy_timeout: Duration,
     ) -> Result<Self, sqlx::Error> {
-        let conn =
-            pool::build_pool(db_path, max_connections, connect_timeout, busy_timeout).await?;
+        let conn = pool::build_pool(
+            db_path,
+            max_connections,
+            connect_timeout,
+            busy_timeout,
+            false,
+        )
+        .await?;
         Ok(Self(conn))
     }
 
@@ -83,7 +92,7 @@ impl DbWriteConnection {
         connect_timeout: Duration,
         busy_timeout: Duration,
     ) -> Result<Self, sqlx::Error> {
-        let conn = pool::build_pool(db_path, 1, connect_timeout, busy_timeout).await?;
+        let conn = pool::build_pool(db_path, 1, connect_timeout, busy_timeout, true).await?;
         Ok(Self(conn))
     }
 
@@ -194,5 +203,45 @@ impl ConnectionTrait for DbWriteConnection {
 
     fn is_mock_connection(&self) -> bool {
         self.0.is_mock_connection()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[tokio::test]
+    async fn read_open_does_not_create_db() {
+        // Existing directory, missing DB file.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("catalog.db");
+
+        let result = DbReadConnection::open(&db_path, 1, TIMEOUT, TIMEOUT).await;
+
+        assert!(result.is_err(), "read open should fail on a missing db");
+        assert!(
+            !db_path.exists(),
+            "read open must not create the catalog db file"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_open_creates_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("catalog.db");
+
+        let conn = DbWriteConnection::open(&db_path, TIMEOUT, TIMEOUT).await;
+
+        assert!(conn.is_ok(), "write open should succeed");
+        assert!(
+            db_path.exists(),
+            "write open should create the catalog db file"
+        );
     }
 }

--- a/crates/db/lib/pool.rs
+++ b/crates/db/lib/pool.rs
@@ -71,15 +71,20 @@ impl DbPools {
 /// lock before returning `SQLITE_BUSY`. It interacts with the
 /// application-level retry policy: a longer busy timeout reduces retry
 /// volume at the cost of higher tail latency on contention.
+///
+/// `create_if_missing` controls whether opening a non-existent DB file creates
+/// it. The write side (owned by `msb`) creates the catalog; read-only consumers
+/// (e.g. `msb-metrics`) pass `false` so they never author or pre-empt it.
 pub(crate) async fn build_pool(
     db_path: &Path,
     max_connections: u32,
     connect_timeout: Duration,
     busy_timeout: Duration,
+    create_if_missing: bool,
 ) -> Result<DatabaseConnection, sqlx::Error> {
     let connect_options = SqliteConnectOptions::new()
         .filename(db_path)
-        .create_if_missing(true)
+        .create_if_missing(create_if_missing)
         .journal_mode(SqliteJournalMode::Wal)
         .busy_timeout(busy_timeout)
         .foreign_keys(true)


### PR DESCRIPTION
the shared pool builder hardcoded `create_if_missing(true)`, so a read-only consumer (msb-metrics) could create an empty `msb.db` before msb did, pre-empting the catalog's owner and leaving a schema-less file.

threads `create_if_missing` through `build_pool`: read connections pass `false` (open fails on a missing db), write connections keep `true`. in `DbPools` the write pool opens before the read pool, so the file always exists by the time the read pool opens. paired with the existing msb-metrics lazy-connect retry, a not-yet-present catalog just means no labels that tick, then enrichment switches on once msb creates it.

tests: read open fails + creates nothing; write open creates; existing connect/migrate path unaffected.