### PR TITLE
feat(sandbox): import oci image labels as sandbox labels

### DIFF
--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -265,9 +265,11 @@ impl SandboxConfig {
     /// Apply OCI image config as defaults. User-provided values take precedence.
     ///
     /// - `env`: image env vars form the base; user env vars override by key, otherwise append.
+    /// - `labels`: image labels form the base; user labels override by key.
     /// - `cmd`, `entrypoint`, `workdir`, `user`: image value used only if user did not set one.
     pub fn merge_image_defaults(&mut self, image: &ImageConfig) {
         self.env = merge_env(&image.env, &self.env);
+        self.labels = merge_image_labels(&image.labels, &self.labels);
 
         if self.cmd.is_none() {
             self.cmd = image.cmd.clone();
@@ -366,6 +368,28 @@ fn merge_env(image_env: &[String], user_env: &[(String, String)]) -> Vec<(String
         .collect();
 
     merge_env_pairs(&base, user_env)
+}
+
+/// Merge OCI image labels (base) with user labels (override on key collision).
+///
+/// Image labels carrying a reserved prefix or an empty key are skipped: they
+/// cannot become metric attributes and would otherwise bypass user-label
+/// validation (which already ran before the image was pulled).
+fn merge_image_labels(
+    image_labels: &HashMap<String, String>,
+    user_labels: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut merged: HashMap<String, String> = image_labels
+        .iter()
+        .filter(|(key, _)| !key.is_empty() && super::reserved_label_prefix(key).is_none())
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+
+    // User labels win on collision.
+    for (key, value) in user_labels {
+        merged.insert(key.clone(), value.clone());
+    }
+    merged
 }
 
 fn default_oci_tmpfs_size_mib(memory_mib: u32) -> u32 {
@@ -531,6 +555,53 @@ mod tests {
         assert_eq!(config.entrypoint, Some(vec!["/entrypoint.sh".to_string()]));
         assert_eq!(config.workdir, Some("/workspace".to_string()));
         assert_eq!(config.user, Some("root".to_string()));
+    }
+
+    #[test]
+    fn test_merge_image_defaults_imports_labels() {
+        use std::collections::HashMap;
+
+        let image = ImageConfig {
+            labels: HashMap::from([
+                (
+                    "org.opencontainers.image.source".to_string(),
+                    "https://example.com/repo".to_string(),
+                ),
+                ("vendor".to_string(), "image-vendor".to_string()),
+                // Reserved prefix and empty key must be skipped.
+                ("sandbox.id".to_string(), "spoofed".to_string()),
+                (String::new(), "x".to_string()),
+            ]),
+            ..Default::default()
+        };
+
+        let mut config = SandboxConfig {
+            labels: HashMap::from([
+                ("user.id".to_string(), "alice".to_string()),
+                // Collides with an image label; the user value must win.
+                ("vendor".to_string(), "user-vendor".to_string()),
+            ]),
+            ..Default::default()
+        };
+        config.merge_image_defaults(&image);
+
+        assert_eq!(
+            config
+                .labels
+                .get("org.opencontainers.image.source")
+                .map(String::as_str),
+            Some("https://example.com/repo")
+        );
+        assert_eq!(
+            config.labels.get("user.id").map(String::as_str),
+            Some("alice")
+        );
+        assert_eq!(
+            config.labels.get("vendor").map(String::as_str),
+            Some("user-vendor")
+        );
+        assert!(!config.labels.contains_key("sandbox.id"));
+        assert!(!config.labels.contains_key(""));
     }
 
     #[test]

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -2007,26 +2007,30 @@ async fn pull_oci_image(
     }
 }
 
+/// Prefixes reserved for the built-in identity/resource attributes the metrics
+/// exporter emits. User labels must not use them or they would shadow the
+/// `sandbox.*` / `microsandbox.*` / `service.*` attributes downstream.
+pub(crate) const RESERVED_LABEL_PREFIXES: [&str; 3] = ["sandbox.", "microsandbox.", "service."];
+
+/// Return the reserved prefix a label key starts with, if any.
+pub(crate) fn reserved_label_prefix(key: &str) -> Option<&'static str> {
+    RESERVED_LABEL_PREFIXES
+        .iter()
+        .copied()
+        .find(|prefix| key.starts_with(prefix))
+}
+
 /// Validate user-defined sandbox labels. Keys must be non-empty and must not
 /// use a reserved prefix. Values may be empty: a valueless label is a plain
 /// marker (e.g. `gpu`), matching Docker's label semantics.
 fn validate_labels(labels: &HashMap<String, String>) -> MicrosandboxResult<()> {
-    /// Prefixes reserved for the built-in identity/resource attributes the
-    /// metrics exporter emits. User labels must not use them or they would
-    /// shadow the `sandbox.*` / `microsandbox.*` / `service.*` attributes
-    /// downstream.
-    const RESERVED_LABEL_PREFIXES: [&str; 3] = ["sandbox.", "microsandbox.", "service."];
-
     for key in labels.keys() {
         if key.is_empty() {
             return Err(MicrosandboxError::InvalidConfig(
                 "label key must not be empty".into(),
             ));
         }
-        if let Some(prefix) = RESERVED_LABEL_PREFIXES
-            .iter()
-            .find(|p| key.starts_with(**p))
-        {
+        if let Some(prefix) = reserved_label_prefix(key) {
             return Err(MicrosandboxError::InvalidConfig(format!(
                 "label key '{key}' uses reserved prefix '{prefix}'"
             )));

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -127,6 +127,13 @@ in Python). On the CLI, repeat `--label` once per entry. Values may be empty: a
 valueless label such as `--label gpu` is a plain marker (it stores `gpu=""`),
 matching Docker's label semantics.
 
+The OCI image's own labels (`LABEL` instructions, `org.opencontainers.image.*`,
+etc.) are imported automatically as sandbox labels at create time; a label you
+set yourself overrides the image's value on a key collision. Image labels using
+a reserved prefix are skipped. Note this can add series cardinality if an image
+carries high-cardinality labels (a commit SHA, a build timestamp); set
+`--no-labels` on `msb-metrics` if that is a concern.
+
 ### Selecting sandboxes by label
 
 Labels double as selectors. `list_with` returns sandboxes carrying **all** of


### PR DESCRIPTION
## what

an oci image's own labels (`LABEL` instructions, `org.opencontainers.image.*`) are now merged into the sandbox's labels at create time, so they flow through to metric attributes and `inspect` without having to re-declare them on every sandbox.

## behaviour

- image labels are imported as the base set; a user `--label` overrides the image's value on a key collision.
- image labels using a reserved prefix (`sandbox.`, `microsandbox.`, `service.`) or an empty key are skipped. they cannot become metric attributes, and the merge runs after user-label validation so they would otherwise bypass it.
- merge happens in `merge_image_defaults`, before the sandbox record is persisted, so imported labels are stored alongside user labels.

## cardinality note

auto-import is unconditional, so an image carrying high-cardinality labels (a commit sha, a build timestamp) will add metric series. documented in the labels section of the sandbox overview, with a pointer to `--no-labels` on `msb-metrics` as the kill switch.

addresses part of #748.

## test plan

- `cargo test -p microsandbox` — added `test_merge_image_defaults_imports_labels` (import, user override, reserved-prefix skip, empty-key skip); existing merge + `validate_labels` tests still pass.