### PR TITLE
feat(metrics): add --exclude-label-key to msb-metrics

### DIFF
--- a/crates/metrics-collector/bin/main.rs
+++ b/crates/metrics-collector/bin/main.rs
@@ -149,6 +149,14 @@ struct CollectorOpts {
     /// high-cardinality label keys (e.g. `user.id`).
     #[arg(long)]
     no_labels: bool,
+
+    /// Drop a label key from emitted metrics. Repeatable
+    /// (`--exclude-label-key user.id --exclude-label-key request.id`). The
+    /// label stays in the catalog and is still visible to `msb inspect`; it is
+    /// only withheld from metric attributes, so this trims series cardinality on
+    /// noisy keys without losing the metadata. Ignored when `--no-labels` is set.
+    #[arg(long = "exclude-label-key", value_name = "KEY")]
+    exclude_label_keys: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -254,9 +262,8 @@ async fn run_otel(args: OtelArgs) -> anyhow::Result<()> {
         .max_buffered_collections(args.collector.max_buffered)
         .export_timeout(args.collector.export_timeout)
         .register(exporter);
-    if !args.collector.no_labels {
-        let db_path = label_db_path(args.collector.msb_home.as_deref())?;
-        builder = builder.enrich_labels(Arc::new(CatalogLabelSource::new(db_path)));
+    if let Some(source) = label_source(&args.collector)? {
+        builder = builder.enrich_labels(Arc::new(source));
     }
     let collector = builder.build().context("build metrics collector")?;
 
@@ -285,9 +292,8 @@ async fn run_stdout(args: StdoutArgs) -> anyhow::Result<()> {
         .max_buffered_collections(args.collector.max_buffered)
         .export_timeout(args.collector.export_timeout)
         .register(exporter);
-    if !args.collector.no_labels {
-        let db_path = label_db_path(args.collector.msb_home.as_deref())?;
-        builder = builder.enrich_labels(Arc::new(CatalogLabelSource::new(db_path)));
+    if let Some(source) = label_source(&args.collector)? {
+        builder = builder.enrich_labels(Arc::new(source));
     }
     let collector = builder.build().context("build metrics collector")?;
 
@@ -371,6 +377,18 @@ fn label_db_path(msb_home: Option<&std::path::Path>) -> anyhow::Result<PathBuf> 
     Ok(resolve_msb_home(msb_home)?
         .join(microsandbox_utils::DB_SUBDIR)
         .join(microsandbox_utils::DB_FILENAME))
+}
+
+/// Build the catalog label source for `opts`, or `None` when `--no-labels`
+/// disables enrichment entirely. Applies the `--exclude-label-keys` denylist.
+fn label_source(opts: &CollectorOpts) -> anyhow::Result<Option<CatalogLabelSource>> {
+    if opts.no_labels {
+        return Ok(None);
+    }
+    let db_path = label_db_path(opts.msb_home.as_deref())?;
+    Ok(Some(CatalogLabelSource::new(db_path).with_excluded_keys(
+        opts.exclude_label_keys.iter().cloned(),
+    )))
 }
 
 /// Wait for SIGINT or SIGTERM (on Unix) / Ctrl+C (everywhere else).

--- a/crates/metrics-collector/lib/core/label_source.rs
+++ b/crates/metrics-collector/lib/core/label_source.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -17,7 +18,7 @@ use tracing::{info, warn};
 
 use crate::error::MetricsCollectorResult;
 
-use super::label_cache::LabelCache;
+use super::label_cache::{LabelCache, LabelSet};
 use super::types::SandboxLabels;
 
 //--------------------------------------------------------------------------------------------------
@@ -60,6 +61,12 @@ pub trait LabelSource: Send + Sync {
 /// newly-seen sandbox, presence-based eviction).
 pub struct CatalogLabelSource {
     db_path: PathBuf,
+
+    /// Label keys dropped from emitted metrics. The labels stay in the catalog
+    /// (still visible to `msb inspect`); they are only withheld from metric
+    /// attributes so an operator can cap series cardinality on noisy keys.
+    exclude_keys: HashSet<String>,
+
     state: Mutex<State>,
 }
 
@@ -83,12 +90,20 @@ impl CatalogLabelSource {
     pub fn new(db_path: PathBuf) -> Self {
         Self {
             db_path,
+            exclude_keys: HashSet::new(),
             state: Mutex::new(State {
                 db: None,
                 cache: LabelCache::new(),
                 degraded: false,
             }),
         }
+    }
+
+    /// Withhold the given label keys from emitted metrics. Cumulative with any
+    /// previously set keys.
+    pub fn with_excluded_keys(mut self, keys: impl IntoIterator<Item = String>) -> Self {
+        self.exclude_keys.extend(keys);
+        self
     }
 }
 
@@ -129,7 +144,7 @@ impl LabelSource for CatalogLabelSource {
         let resolved = {
             let State { db, cache, .. } = &mut *state;
             let db = db.as_ref().expect("connection ensured above");
-            resolve_labels(db, cache, &sandbox_ids).await
+            resolve_labels(db, cache, &sandbox_ids, &self.exclude_keys).await
         };
 
         match resolved {
@@ -163,17 +178,36 @@ async fn resolve_labels(
     db: &DbReadConnection,
     cache: &mut LabelCache,
     sandbox_ids: &HashSet<i32>,
+    exclude_keys: &HashSet<String>,
 ) -> MetricsCollectorResult<SandboxLabels> {
     cache.sync(sandbox_ids);
 
     let mut labels = SandboxLabels::with_capacity(sandbox_ids.len());
     for &sandbox_id in sandbox_ids {
-        let set = cache.get_or_fetch(sandbox_id, db).await?;
+        let set = apply_exclusions(cache.get_or_fetch(sandbox_id, db).await?, exclude_keys);
         if !set.is_empty() {
             labels.insert(sandbox_id, set);
         }
     }
     Ok(labels)
+}
+
+/// Drop excluded keys from a cached label set.
+///
+/// The cache holds the full label set; exclusion is an emit-time policy, so it
+/// is applied here rather than baked into the cache. Returns the input `Arc`
+/// untouched (no allocation) when nothing is excluded for this sandbox, which is
+/// the common case.
+fn apply_exclusions(set: Arc<LabelSet>, exclude_keys: &HashSet<String>) -> Arc<LabelSet> {
+    if exclude_keys.is_empty() || !set.iter().any(|(key, _)| exclude_keys.contains(key)) {
+        return set;
+    }
+    Arc::new(
+        set.iter()
+            .filter(|(key, _)| !exclude_keys.contains(key))
+            .cloned()
+            .collect(),
+    )
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -219,6 +253,69 @@ mod tests {
         .insert(write.inner())
         .await
         .unwrap();
+    }
+
+    #[test]
+    fn apply_exclusions_drops_only_matching_keys() {
+        let set = Arc::new(vec![
+            ("user.id".to_string(), "alice".to_string()),
+            (
+                "org.opencontainers.image.revision".to_string(),
+                "abc123".to_string(),
+            ),
+        ]);
+        let exclude = HashSet::from(["org.opencontainers.image.revision".to_string()]);
+
+        let filtered = apply_exclusions(set, &exclude);
+        assert_eq!(
+            filtered.as_slice(),
+            [("user.id".to_string(), "alice".to_string())].as_slice()
+        );
+    }
+
+    #[test]
+    fn apply_exclusions_returns_same_arc_when_nothing_matches() {
+        let set = Arc::new(vec![("user.id".to_string(), "alice".to_string())]);
+
+        // Empty exclude set and a non-matching exclude set both skip allocation.
+        let unchanged = apply_exclusions(set.clone(), &HashSet::new());
+        assert!(Arc::ptr_eq(&set, &unchanged));
+
+        let unmatched = apply_exclusions(set.clone(), &HashSet::from(["other".to_string()]));
+        assert!(Arc::ptr_eq(&set, &unmatched));
+    }
+
+    #[tokio::test]
+    async fn excluded_keys_are_withheld_from_resolved_labels() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("db").join("msb.db");
+        seed_catalog(&db_path).await;
+
+        // Add a second, noisy label to the same sandbox.
+        let write = DbWriteConnection::open(
+            &db_path,
+            CONNECT_TIMEOUT,
+            Duration::from_secs(DEFAULT_BUSY_TIMEOUT_SECS),
+        )
+        .await
+        .unwrap();
+        sandbox_label::ActiveModel {
+            sandbox_id: Set(1),
+            key: Set("org.opencontainers.image.revision".to_string()),
+            value: Set("abc123".to_string()),
+        }
+        .insert(write.inner())
+        .await
+        .unwrap();
+
+        let source = CatalogLabelSource::new(db_path)
+            .with_excluded_keys(["org.opencontainers.image.revision".to_string()]);
+
+        let labels = source.labels_for(HashSet::from([1])).await.unwrap();
+        assert_eq!(
+            labels.get(&1).map(|l| l.as_slice()),
+            Some([("user.id".to_string(), "alice".to_string())].as_slice())
+        );
     }
 
     #[tokio::test]

--- a/docs/observability/deep-dive.mdx
+++ b/docs/observability/deep-dive.mdx
@@ -138,14 +138,18 @@ cardinality-billed backends.
 creation (`msb create --label user.id=alice`). They are read from the
 catalog on first sight of each sandbox, cached, and attached to every
 datapoint as a plain attribute with the same key and value, so backends
-can group and filter by them. On by default; disable with `--no-labels`.
+can group and filter by them. On by default; disable with `--no-labels`,
+or drop individual keys with `--exclude-label-keys <key>` (repeatable).
 
 <Warning>
   Labels are emitted unconditionally and are not pre-declared, so a
   high-cardinality key like `user.id` multiplies active series far more
   than the opt-in `run_id` / `pid` do. Backends such as Grafana Cloud and
-  Prometheus bill on active series. Keep label keys low-cardinality, or
-  pass `--no-labels` where attribution is not needed.
+  Prometheus bill on active series. Keep label keys low-cardinality, pass
+  `--no-labels` where attribution is not needed, or `--exclude-label-key`
+  to drop specific noisy keys (e.g. an image's commit-SHA label) while
+  keeping the rest. Excluded keys stay in the catalog and remain visible
+  to `msb inspect`; only the metric attribute is withheld.
 </Warning>
 
 Label enrichment is best-effort and never blocks metrics. If the catalog
@@ -168,6 +172,7 @@ msb-metrics stdout [--collect-interval=<dur>]
                    [--export-timeout=<dur>]
                    [--msb-home=<path>]
                    [--no-labels]
+                   [--exclude-label-key=<key>]...
 ```
 
 The output format is not a stable contract; don't pipe it into
@@ -195,6 +200,7 @@ msb-metrics otel --endpoint=<URL>
                  [--export-timeout=<dur>]
                  [--msb-home=<path>]
                  [--no-labels]
+                 [--exclude-label-key=<key>]...
 ```
 
 | Flag | Default | Notes |
@@ -208,6 +214,7 @@ msb-metrics otel --endpoint=<URL>
 | `--emit-run-id` | off | Add `sandbox.run_id` to every datapoint. Opt-in: high cardinality. |
 | `--emit-pid` | off | Add `sandbox.pid` to every datapoint. Opt-in: high cardinality. |
 | `--no-labels` | off | Stop attaching per-sandbox labels (skips the catalog lookup). Use to cap series cardinality from high-cardinality label keys. |
+| `--exclude-label-key` | none | Label key to drop from emitted metrics, repeatable. The key stays in the catalog (visible to `msb inspect`) and is only withheld from metric attributes. Ignored when `--no-labels` is set. |
 | `--collect-interval` | `1s` | How often shm is read. `humantime` durations (`1s`, `500ms`, `2m`). |
 | `--flush-interval` | `10s` | Per-exporter scheduled flush cadence. |
 | `--max-buffered` | `60` | Per-exporter buffer cap. Oldest collection drops on overflow; drop count surfaces on the next batch. |

--- a/docs/observability/msb-metrics.mdx
+++ b/docs/observability/msb-metrics.mdx
@@ -167,8 +167,12 @@ Panels:    microsandbox_cpu_utilization{user_id="$user"}
 
 Labels are on by default. Pass `--no-labels` to turn them off, e.g. when
 a high-cardinality key like `user.id` would inflate active-series
-billing. See the [Deep dive](/observability/deep-dive#attributes) for the
-cardinality trade-offs.
+billing. To drop individual noisy keys while keeping the rest, repeat
+`--exclude-label-key <key>` (e.g.
+`--exclude-label-key org.opencontainers.image.revision`); the key stays
+in the catalog for `msb inspect` and is only withheld from metrics. See
+the [Deep dive](/observability/deep-dive#attributes) for the cardinality
+trade-offs.
 
 ## Reference
 


### PR DESCRIPTION
## what

`msb-metrics` gains a repeatable `--exclude-label-key <key>` flag that drops individual label keys from emitted metrics while keeping every other label. it's the per-key middle ground between full attribution and the all-or-nothing `--no-labels` kill switch.

```
msb-metrics otel --endpoint=... --exclude-label-key org.opencontainers.image.revision --exclude-label-key request.id
```

## why

per-sandbox labels are emitted unconditionally, so a single high-cardinality key (a commit sha auto-imported from an image, a per-request id) can inflate active series and cardinality-billed backends. previously the only lever was `--no-labels`, which throws away all attribution. this lets an operator snip just the noisy keys.

the excluded key stays in the catalog and is still visible to `msb inspect` — only the metric attribute is withheld.

## design

- exclusion lives in `CatalogLabelSource`, applied on the way out of the label cache. the cache still holds the full set, so the filter is source-agnostic (image- vs user-sourced labels are treated identically by key) and zero-allocation when nothing matches.
- a denylist, not an allowlist: chosen as the cheaper interim lever. a future `--label-keys` allowlist (hard cardinality ceiling) would supersede rather than coexist with it.
- singular flag name, repeatable, matching the existing `--header` / `--resource` / `--label` convention.
- ignored when `--no-labels` is set (no labels are emitted at all).

## test plan

- `cargo test -p microsandbox-metrics-collector` — added `apply_exclusions_drops_only_matching_keys`, `apply_exclusions_returns_same_arc_when_nothing_matches` (asserts the no-alloc path via `Arc::ptr_eq`), and `excluded_keys_are_withheld_from_resolved_labels` (end-to-end against a seeded catalog). all 36 crate tests pass.
- docs updated: `msb-metrics.mdx` labels section + `deep-dive.mdx` flag table, usage blocks, and cardinality warning.