### PR TITLE
ci: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,21 +5,26 @@
 
 version: 2
 
+multi-ecosystem-groups:
+  dependencies:
+    schedule:
+      interval: "weekly"
+
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependencies"
     commit-message:
       prefix: "chore"
       include: "scope"
     target-branch: "main"
-    schedule:
-      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependencies"
     commit-message:
       prefix: "chore(ci)"
       include: "scope"
     target-branch: "main"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
## TL;DR
Group Dependabot version updates so Cargo and GitHub Actions updates arrive in one weekly PR instead of separate PRs.

## Description
- Adds a Dependabot multi-ecosystem group named `dependencies`.
- Assigns the Cargo and GitHub Actions update jobs to that group with `patterns: ["*"]`.
- Keeps the existing weekly cadence and `main` target branch.

## Test Plan
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "ok"'
- `git diff --check`
- `go run github.com/stacklok/frizbee@v0.1.10 actions .github/workflows --dry-run --error`
