### PR TITLE
ci: fix dependabot multi-ecosystem settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,22 +9,18 @@ multi-ecosystem-groups:
   dependencies:
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    target-branch: "main"
 
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    target-branch: "main"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
-    commit-message:
-      prefix: "chore(ci)"
-      include: "scope"
-    target-branch: "main"


### PR DESCRIPTION
## TL;DR
Fix the Dependabot multi-ecosystem config so Cargo and GitHub Actions updates are grouped into one PR instead of being opened separately.

## Description
- Moves `commit-message` from grouped update entries onto the `dependencies` multi-ecosystem group.
- Moves `target-branch` from grouped update entries onto the `dependencies` multi-ecosystem group.
- Leaves each ecosystem update entry scoped to its package ecosystem, root directory, patterns, and group membership.

## Test Plan
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "ok"'`\n- `git diff --check`\n- pre-commit hooks from `git commit -S`