### PR TITLE
refactor(sdk/go)!: remove CreateSandboxDetached

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -481,7 +481,6 @@ sb, err := h.Connect(ctx)
 |----------|-------------|
 | `EnsureInstalled(ctx, opts...)` | Optional — download msb + libkrunfw to `~/.microsandbox/` up front (idempotent) |
 | `CreateSandbox(ctx, name, ...opts)` | Create and start a sandbox |
-| `CreateSandboxDetached(ctx, name, ...opts)` | Create a sandbox in detached mode |
 | `StartSandbox(ctx, name)` | Boot a stopped sandbox by name |
 | `StartSandboxDetached(ctx, name)` | Boot a stopped sandbox in detached mode |
 | `GetSandbox(ctx, name)` | Fetch sandbox metadata; returns `*SandboxHandle` |

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -169,7 +169,7 @@ func WithReplaceWithTimeout(timeout time.Duration) SandboxOption {
 }
 
 // WithDetached creates the sandbox in detached mode. The sandbox continues
-// running after the Go process exits. Reattach via GetSandbox or CreateSandboxDetached.
+// running after the Go process exits. Reattach via GetSandbox.
 func WithDetached() SandboxOption {
 	return func(o *SandboxConfig) { o.Detached = true }
 }

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -153,14 +153,6 @@ func durationSecsCeil(d time.Duration) uint64 {
 	return uint64((d + time.Second - 1) / time.Second)
 }
 
-// CreateSandboxDetached creates and boots a sandbox in detached mode. The VM
-// continues running after the returned handle is released or the Go process
-// exits. Reattach via GetSandbox. Sandbox names are limited to 128 UTF-8 bytes.
-func CreateSandboxDetached(ctx context.Context, name string, opts ...SandboxOption) (*Sandbox, error) {
-	opts = append(opts, WithDetached())
-	return CreateSandbox(ctx, name, opts...)
-}
-
 // buildFFINetwork converts a public NetworkConfig into its ffi counterpart.
 func buildFFINetwork(n *NetworkConfig) *ffi.NetworkOptions {
 	out := &ffi.NetworkOptions{


### PR DESCRIPTION
The justification for removing this is that it's a simple wrapper around CreateSandbox that appends the WithDetached() functional option, increasing the API surface for little benefit.