### PR TITLE
refactor(sdk)!: use builder flag for detached creation

### DIFF
--- a/crates/cli/lib/commands/create.rs
+++ b/crates/cli/lib/commands/create.rs
@@ -33,7 +33,7 @@ pub async fn run(args: CreateArgs) -> anyhow::Result<()> {
     let builder = Sandbox::builder(&name).image(args.image.as_str());
     let builder = apply_sandbox_opts(builder, &args.sandbox)?;
 
-    let (mut progress, task) = builder.create_detached_with_pull_progress()?;
+    let (mut progress, task) = builder.detached(true).create_with_pull_progress()?;
     let mut display = if args.sandbox.quiet {
         ui::PullProgressDisplay::quiet(&args.image)
     } else {

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -162,11 +162,7 @@ async fn run_new(name: String, is_named: bool, args: RunArgs) -> anyhow::Result<
     let builder = apply_sandbox_opts(builder, &args.sandbox)?;
 
     // Create sandbox with pull progress — select attached vs detached mode.
-    let (mut progress, task) = if args.detach {
-        builder.create_detached_with_pull_progress()?
-    } else {
-        builder.create_with_pull_progress()?
-    };
+    let (mut progress, task) = builder.detached(args.detach).create_with_pull_progress()?;
 
     let display_label = args
         .snapshot

--- a/crates/microsandbox/README.md
+++ b/crates/microsandbox/README.md
@@ -228,7 +228,8 @@ Sandboxes in detached mode survive the parent process:
 // Create and detach.
 let sandbox = Sandbox::builder("background")
     .image("python")
-    .create_detached()
+    .detached(true)
+    .create()
     .await?;
 
 // Later, from another process:

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -28,6 +28,7 @@ use std::time::Duration;
 /// Builder for constructing a [`SandboxConfig`] with a fluent API.
 pub struct SandboxBuilder {
     config: SandboxConfig,
+    detached: bool,
     build_error: Option<crate::MicrosandboxError>,
     /// Pending snapshot reference (path or bare name) supplied via
     /// [`from_snapshot`]. Resolved during async `create()`.
@@ -77,6 +78,7 @@ impl SandboxBuilder {
                 name: name.into(),
                 ..Default::default()
             },
+            detached: false,
             build_error: None,
             pending_snapshot: None,
         }
@@ -185,6 +187,14 @@ impl SandboxBuilder {
     /// Disable runtime logs for this sandbox, even if a global default exists.
     pub fn quiet_logs(mut self) -> Self {
         self.config.log_level = None;
+        self
+    }
+
+    /// Configure whether the sandbox process is created in detached/background mode.
+    ///
+    /// Detached sandboxes survive the creating process. Defaults to `false`.
+    pub fn detached(mut self, detached: bool) -> Self {
+        self.detached = detached;
         self
     }
 
@@ -766,14 +776,13 @@ impl SandboxBuilder {
 
     /// Create the sandbox. Boots the VM with agentd ready.
     pub async fn create(self) -> MicrosandboxResult<super::Sandbox> {
+        let mode = if self.detached {
+            crate::runtime::SpawnMode::Detached
+        } else {
+            crate::runtime::SpawnMode::Attached
+        };
         let config = self.build().await?;
-        super::Sandbox::create(config).await
-    }
-
-    /// Create the sandbox for detached/background use.
-    pub async fn create_detached(self) -> MicrosandboxResult<super::Sandbox> {
-        let config = self.build().await?;
-        super::Sandbox::create_detached(config).await
+        super::Sandbox::create_with_mode(config, mode, None).await
     }
 
     /// Create the sandbox with pull progress reporting.
@@ -792,36 +801,15 @@ impl SandboxBuilder {
         PullProgressHandle,
         tokio::task::JoinHandle<crate::MicrosandboxResult<super::Sandbox>>,
     )> {
+        let mode = if self.detached {
+            crate::runtime::SpawnMode::Detached
+        } else {
+            crate::runtime::SpawnMode::Attached
+        };
         let (handle, sender) = microsandbox_image::progress_channel();
         let task = tokio::spawn(async move {
             let config = self.build().await?;
-            super::Sandbox::create_with_mode(
-                config,
-                crate::runtime::SpawnMode::Attached,
-                Some(sender),
-            )
-            .await
-        });
-        Ok((handle, task))
-    }
-
-    /// Like `create_with_pull_progress` but spawns the sandbox process in detached
-    /// mode so the sandbox survives after the creating process exits.
-    pub fn create_detached_with_pull_progress(
-        self,
-    ) -> crate::MicrosandboxResult<(
-        PullProgressHandle,
-        tokio::task::JoinHandle<crate::MicrosandboxResult<super::Sandbox>>,
-    )> {
-        let (handle, sender) = microsandbox_image::progress_channel();
-        let task = tokio::spawn(async move {
-            let config = self.build().await?;
-            super::Sandbox::create_with_mode(
-                config,
-                crate::runtime::SpawnMode::Detached,
-                Some(sender),
-            )
-            .await
+            super::Sandbox::create_with_mode(config, mode, Some(sender)).await
         });
         Ok((handle, task))
     }
@@ -931,6 +919,7 @@ impl From<SandboxConfig> for SandboxBuilder {
     fn from(config: SandboxConfig) -> Self {
         Self {
             config,
+            detached: false,
             build_error: None,
             pending_snapshot: None,
         }

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -189,15 +189,6 @@ impl Sandbox {
         Self::create_with_mode(config, SpawnMode::Attached, None).await
     }
 
-    /// Create a sandbox that must survive after the creating process exits.
-    ///
-    /// This is intended for detached CLI workflows such as `msb create` and
-    /// `msb run --detach`, where the sandbox should keep running in the
-    /// background after the command returns.
-    pub async fn create_detached(config: SandboxConfig) -> MicrosandboxResult<Self> {
-        Self::create_with_mode(config, SpawnMode::Detached, None).await
-    }
-
     /// Create a sandbox with pull progress reporting.
     ///
     /// Returns a progress handle for per-layer pull events and a task handle
@@ -209,32 +200,10 @@ impl Sandbox {
         PullProgressHandle,
         tokio::task::JoinHandle<MicrosandboxResult<Self>>,
     ) {
-        Self::create_with_pull_progress_and_mode(config, SpawnMode::Attached)
-    }
-
-    /// Create a detached sandbox with pull progress reporting.
-    ///
-    /// Like `create_with_pull_progress` but spawns the sandbox process in detached
-    /// mode so the sandbox survives after the creating process exits.
-    pub fn create_detached_with_pull_progress(
-        config: SandboxConfig,
-    ) -> (
-        PullProgressHandle,
-        tokio::task::JoinHandle<MicrosandboxResult<Self>>,
-    ) {
-        Self::create_with_pull_progress_and_mode(config, SpawnMode::Detached)
-    }
-
-    fn create_with_pull_progress_and_mode(
-        config: SandboxConfig,
-        mode: SpawnMode,
-    ) -> (
-        PullProgressHandle,
-        tokio::task::JoinHandle<MicrosandboxResult<Self>>,
-    ) {
         let (handle, sender) = progress_channel();
-        let task =
-            tokio::spawn(async move { Self::create_with_mode(config, mode, Some(sender)).await });
+        let task = tokio::spawn(async move {
+            Self::create_with_mode(config, SpawnMode::Attached, Some(sender)).await
+        });
         (handle, task)
     }
 

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -41,7 +41,11 @@ Creating a sandbox boots the microVM, mounts the filesystem, initializes the gue
 let sb = Sandbox::builder("worker").image("python").create().await?;
 
 // Detached: sandbox survives after your process exits
-let sb = Sandbox::builder("worker").image("python").create_detached().await?;
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .detached(true)
+    .create()
+    .await?;
 ```
 
 ```typescript TypeScript
@@ -49,7 +53,10 @@ let sb = Sandbox::builder("worker").image("python").create_detached().await?;
 await using sb = await Sandbox.builder("worker").image("python").create();
 
 // Detached: sandbox survives after your process exits
-const detached = await Sandbox.builder("worker").image("python").createDetached();
+const detached = await Sandbox.builder("worker")
+  .image("python")
+  .detached(true)
+  .create();
 ```
 
 ```python Python

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -125,20 +125,6 @@ defer func() {
 
 ---
 
-#### CreateSandboxDetached()
-
-```go
-func CreateSandboxDetached(
-    ctx context.Context,
-    name string,
-    opts ...SandboxOption,
-) (*Sandbox, error)
-```
-
-Same as [`CreateSandbox`](#createsandbox) with [`WithDetached`](#withdetached) automatically applied. The VM continues running after the returned handle is released or the Go process exits. Reattach via [`GetSandbox`](#getsandbox). Sandbox names are limited to 128 UTF-8 bytes.
-
----
-
 #### StartSandbox()
 
 ```go

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -402,7 +402,7 @@ Builder for configuring a sandbox before creation. Obtained via [`Sandbox::build
 async fn build(self) -> MicrosandboxResult<SandboxConfig>
 ```
 
-Materialize the [`SandboxConfig`](#sandboxconfig) without booting the sandbox. Validates the configuration and, if [`from_snapshot`](#from_snapshot) was called, opens the snapshot manifest to pin its image reference and upper-layer source. For booting, use [`create`](#create) or [`create_detached`](#create_detached) instead — they call `build` internally.
+Materialize the [`SandboxConfig`](#sandboxconfig) without booting the sandbox. Validates the configuration and, if [`from_snapshot`](#from_snapshot) was called, opens the snapshot manifest to pin its image reference and upper-layer source. For booting, use [`create`](#create) instead — it calls `build` internally.
 
 **Returns**
 
@@ -434,7 +434,7 @@ Set the number of virtual CPUs. This is a limit, not a reservation. Default: `1`
 async fn create(self) -> MicrosandboxResult<Sandbox>
 ```
 
-Boot the sandbox in attached mode. The sandbox stops when your process exits.
+Boot the sandbox. By default, the sandbox runs in attached mode and stops when your process exits. Use [`detached(true)`](#detached) to create it in detached mode instead.
 
 **Returns**
 
@@ -444,19 +444,33 @@ Boot the sandbox in attached mode. The sandbox stops when your process exits.
 
 ---
 
-#### create_detached()
+#### detached()
 
 ```rust
-async fn create_detached(self) -> MicrosandboxResult<Sandbox>
+fn detached(self, detached: bool) -> Self
 ```
 
-Boot the sandbox in detached mode. The sandbox survives after your process exits.
+Choose whether the sandbox process is created in detached mode. Defaults to `false`.
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .detached(true)
+    .create()
+    .await?;
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| detached | `bool` | `true` to create in detached/background mode |
 
 **Returns**
 
 | Type | Description |
 |------|-------------|
-| [`Sandbox`](#instance-methods) | Running sandbox |
+| `Self` | Builder |
 
 ---
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -5,7 +5,7 @@ description: TypeScript SDK - Sandbox API reference
 
 See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
 
-The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox from `Sandbox.builder(name)` and chain configuration calls before terminating with `.create()` or `.createDetached()`. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes.
+The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox from `Sandbox.builder(name)` and chain configuration calls before terminating with `.create()`. Use `.detached(true)` before `.create()` for detached/background mode. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes.
 
 ```typescript
 import { Sandbox } from "microsandbox";
@@ -27,7 +27,7 @@ await using sandbox = await Sandbox.builder("demo")
 static builder(name: string): SandboxBuilder
 ```
 
-Begin building a new sandbox. Configure it with chainable setters, then call `.create()` or `.createDetached()` to boot it.
+Begin building a new sandbox. Configure it with chainable setters, then call `.create()` to boot it.
 
 **Parameters**
 
@@ -587,11 +587,10 @@ Fluent configuration builder returned by `Sandbox.builder(name)`. Every setter r
 | `network(n => ...)` | Configure DNS / TLS / policy / secrets — see [Networking](/sdk/typescript/networking) |
 | `secret(s => ...)` | Add a secret via [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder) |
 | `secretEnv(envVar, value, allowedHost)` | Auto-placeholder shorthand. Generates `$MSB_<env_var>`. |
+| `detached(enabled)` | Create in detached/background mode when `true` |
 | `build(): Promise<SandboxConfig>` | Materialize without booting. Consumes the builder |
-| `create(): Promise<Sandbox>` | Build and boot in attached mode |
-| `createDetached(): Promise<Sandbox>` | Build and boot in detached mode |
-| `createWithPullProgress(): Promise<PullProgressCreate>` | Build and boot in attached mode while streaming image pull progress |
-| `createDetachedWithPullProgress(): Promise<PullProgressCreate>` | Build and boot in detached mode while streaming image pull progress |
+| `create(): Promise<Sandbox>` | Build and boot |
+| `createWithPullProgress(): Promise<PullProgressCreate>` | Build and boot while streaming image pull progress |
 
 ### LogLevel
 
@@ -702,7 +701,7 @@ const sandbox = await creation.awaitSandbox();
 
 ### PullProgressCreate
 
-Async iterable creation handle returned by `Sandbox.builder(name).createWithPullProgress()` and `Sandbox.builder(name).createDetachedWithPullProgress()`. Yields [`PullProgress`](#pullprogress) events as the image is resolved, downloaded, and materialized. Call `awaitSandbox()` after iteration to obtain the live sandbox.
+Async iterable creation handle returned by `Sandbox.builder(name).createWithPullProgress()`. Yields [`PullProgress`](#pullprogress) events as the image is resolved, downloaded, and materialized. Call `awaitSandbox()` after iteration to obtain the live sandbox.
 
 | Method | Returns | Description |
 |--------|---------|-------------|

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -1851,11 +1851,7 @@ pub unsafe extern "C" fn msb_sandbox_create(
                 builder = apply_volume(builder, guest_path, mount)?;
             }
 
-            let sandbox = if opts.detached {
-                builder.create_detached().await?
-            } else {
-                builder.create().await?
-            };
+            let sandbox = builder.detached(opts.detached).create().await?;
             let handle = register(sandbox)?;
             Ok(format!(r#"{{"handle":{handle}}}"#))
         }))

--- a/sdk/node-ts/README.md
+++ b/sdk/node-ts/README.md
@@ -308,7 +308,8 @@ Detached sandboxes survive the Node.js process:
 // Create detached — drops the lifecycle on this handle's `Symbol.asyncDispose`.
 const sb = await Sandbox.builder("background")
   .image("python")
-  .createDetached();
+  .detached(true)
+  .create();
 
 // Later, from another process:
 const handle = await Sandbox.get("background");
@@ -462,7 +463,7 @@ await setup()
 | Symbol | Description |
 |---|---|
 | `Sandbox` | Live sandbox — lifecycle, exec, fs, metrics. Implements `AsyncDisposable`. |
-| `SandboxBuilder` | Fluent builder — every Rust setter, terminal `.create()` / `.createDetached()`. |
+| `SandboxBuilder` | Fluent builder — every Rust setter, terminal `.create()`. |
 | `SandboxHandle` | Lightweight DB handle — `connect()`, `start()`, `stop()`, `kill()`. |
 | `SandboxConfig` | Built sandbox configuration (output of `SandboxBuilder.build()`). |
 | `SandboxStatus` | `"running" \| "stopped" \| "crashed" \| "draining"` |

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -879,6 +879,8 @@ export declare class SandboxBuilder {
   logLevel(level: string): this
   /** Suppress sandbox logs. */
   quietLogs(): this
+  /** Create the sandbox in detached/background mode when enabled. */
+  detached(detached: boolean): this
   /** Override the metrics sampling interval in milliseconds; pass `0` to disable. */
   metricsSampleIntervalMs(ms: number): this
   /** Force-disable metrics sampling regardless of `metricsSampleIntervalMs`. */
@@ -990,7 +992,7 @@ export declare class SandboxBuilder {
    */
   build(): Promise<string>
   /**
-   * Create and start the sandbox in attached mode.
+   * Create and start the sandbox.
    *
    * # Safety
    * `&mut self` async is required because we drain `inner`
@@ -998,14 +1000,6 @@ export declare class SandboxBuilder {
    * regardless. JS callers see `create(): Promise<Sandbox>`.
    */
   create(): Promise<JsSandbox>
-  /**
-   * Create and start the sandbox in detached mode (survives the
-   * parent process).
-   *
-   * # Safety
-   * Same justification as `create`.
-   */
-  createDetached(): Promise<JsSandbox>
   /**
    * Create the sandbox with image-pull progress reporting. Returns
    * a `PullProgressStream` of per-layer download/materialization
@@ -1017,13 +1011,6 @@ export declare class SandboxBuilder {
    * Same justification as `create`.
    */
   createWithPullProgress(): Promise<JsPullProgressCreate>
-  /**
-   * Detached variant of `createWithPullProgress`.
-   *
-   * # Safety
-   * Same justification as `create`.
-   */
-  createDetachedWithPullProgress(): Promise<JsPullProgressCreate>
 }
 export type JsSandboxBuilder = SandboxBuilder
 

--- a/sdk/node-ts/native/sandbox_builder.rs
+++ b/sdk/node-ts/native/sandbox_builder.rs
@@ -146,6 +146,14 @@ impl JsSandboxBuilder {
         self
     }
 
+    /// Create the sandbox in detached/background mode when enabled.
+    #[napi]
+    pub fn detached(&mut self, detached: bool) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.detached(detached));
+        self
+    }
+
     /// Override the metrics sampling interval in milliseconds; pass `0` to disable.
     #[napi(js_name = "metricsSampleIntervalMs")]
     pub fn metrics_sample_interval_ms(&mut self, ms: u32) -> &Self {
@@ -561,7 +569,7 @@ impl JsSandboxBuilder {
             .map_err(|e| napi::Error::from_reason(format!("failed to serialize config: {e}")))
     }
 
-    /// Create and start the sandbox in attached mode.
+    /// Create and start the sandbox.
     ///
     /// # Safety
     /// `&mut self` async is required because we drain `inner`
@@ -574,21 +582,6 @@ impl JsSandboxBuilder {
             .take()
             .ok_or_else(|| napi::Error::from_reason("SandboxBuilder already consumed"))?;
         let inner: RustSandbox = b.create().await.map_err(to_napi_error)?;
-        Ok(JsSandbox::from_rust(inner))
-    }
-
-    /// Create and start the sandbox in detached mode (survives the
-    /// parent process).
-    ///
-    /// # Safety
-    /// Same justification as `create`.
-    #[napi(js_name = "createDetached")]
-    pub async unsafe fn create_detached(&mut self) -> Result<JsSandbox> {
-        let b = self
-            .inner
-            .take()
-            .ok_or_else(|| napi::Error::from_reason("SandboxBuilder already consumed"))?;
-        let inner: RustSandbox = b.create_detached().await.map_err(to_napi_error)?;
         Ok(JsSandbox::from_rust(inner))
     }
 
@@ -607,27 +600,6 @@ impl JsSandboxBuilder {
             .take()
             .ok_or_else(|| napi::Error::from_reason("SandboxBuilder already consumed"))?;
         let (handle, task) = b.create_with_pull_progress().map_err(to_napi_error)?;
-        Ok(JsPullProgressCreate {
-            stream: JsPullProgressStream::from_handle(handle),
-            task: std::sync::Arc::new(tokio::sync::Mutex::new(Some(task))),
-        })
-    }
-
-    /// Detached variant of `createWithPullProgress`.
-    ///
-    /// # Safety
-    /// Same justification as `create`.
-    #[napi(js_name = "createDetachedWithPullProgress")]
-    pub async unsafe fn create_detached_with_pull_progress(
-        &mut self,
-    ) -> Result<JsPullProgressCreate> {
-        let b = self
-            .inner
-            .take()
-            .ok_or_else(|| napi::Error::from_reason("SandboxBuilder already consumed"))?;
-        let (handle, task) = b
-            .create_detached_with_pull_progress()
-            .map_err(to_napi_error)?;
         Ok(JsPullProgressCreate {
             stream: JsPullProgressStream::from_handle(handle),
             task: std::sync::Arc::new(tokio::sync::Mutex::new(Some(task))),

--- a/sdk/node-ts/src/index.ts
+++ b/sdk/node-ts/src/index.ts
@@ -144,7 +144,6 @@ function wrapMethodWithErrorMap(cls: any, method: string) {
 
 wrapMethodWithErrorMap(napi.MountBuilder, "build");
 wrapMethodWithErrorMap(napi.SandboxBuilder, "create");
-wrapMethodWithErrorMap(napi.SandboxBuilder, "createDetached");
 wrapMethodWithErrorMap(napi.PatchBuilder, "build");
 wrapMethodWithErrorMap(napi.DnsBuilder, "build");
 wrapMethodWithErrorMap(napi.SecretBuilder, "build");

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -129,6 +129,7 @@ export interface NapiSandboxBuilderSetters {
   memory(mib: number): this;
   logLevel(level: string): this;
   quietLogs(): this;
+  detached(enabled: boolean): this;
   metricsSampleIntervalMs(ms: number): this;
   disableMetricsSample(): this;
   workdir(path: string): this;
@@ -174,9 +175,7 @@ export interface NapiSandboxBuilderSetters {
 
 export interface NapiSandboxBuilder extends NapiSandboxBuilderSetters {
   create(): Promise<NapiSandbox>;
-  createDetached(): Promise<NapiSandbox>;
   createWithPullProgress(): Promise<NapiPullProgressCreate>;
-  createDetachedWithPullProgress(): Promise<NapiPullProgressCreate>;
 }
 
 export interface NapiSandbox {

--- a/sdk/node-ts/src/sandbox.ts
+++ b/sdk/node-ts/src/sandbox.ts
@@ -34,7 +34,7 @@ import { SandboxSsh } from "./ssh.js";
  *
  * The instance IS the napi-rs `SandboxBuilder` class — every setter is a
  * native call, no TS-side reimplementation. Only the terminal `create()`
- * / `createDetached()` methods are wrapped here so they return a TS
+ * method is wrapped here so it returns a TS
  * `Sandbox` (which adds `Symbol.asyncDispose`, error-mapping, and a few
  * sync getters on top of the native handle).
  */
@@ -51,9 +51,7 @@ export type SandboxConfig = NapiSandboxConfig;
 
 export interface SandboxBuilder extends NapiSandboxBuilderSetters {
   create(): Promise<Sandbox>;
-  createDetached(): Promise<Sandbox>;
   createWithPullProgress(): Promise<PullProgressCreate>;
-  createDetachedWithPullProgress(): Promise<PullProgressCreate>;
 }
 
 /**
@@ -118,21 +116,22 @@ export class Sandbox implements AsyncDisposable {
   /** Begin building a new sandbox. Names are limited to 128 UTF-8 bytes. */
   static builder(name: string): SandboxBuilder {
     const nb = new napi.SandboxBuilder(name);
+    let detached = false;
+    const origDetached = nb.detached.bind(nb);
     const origCreate = nb.create.bind(nb);
-    const origCreateDetached = nb.createDetached.bind(nb);
     const origCreateWithPP = nb.createWithPullProgress.bind(nb);
-    const origCreateDetachedWithPP =
-      nb.createDetachedWithPullProgress.bind(nb);
+    const wrapped = nb as unknown as {
+      detached: (enabled: boolean) => SandboxBuilder;
+    };
+    wrapped.detached = (enabled: boolean) => {
+      detached = enabled;
+      origDetached(enabled);
+      return nb as unknown as SandboxBuilder;
+    };
     // Override the terminals so they return a TS Sandbox.
     (nb as unknown as { create: () => Promise<Sandbox> }).create = async () => {
       const inner = await withMappedErrors(() => origCreate());
-      return new Sandbox(inner, name, /*ownsLifecycle*/ true);
-    };
-    (
-      nb as unknown as { createDetached: () => Promise<Sandbox> }
-    ).createDetached = async () => {
-      const inner = await withMappedErrors(() => origCreateDetached());
-      return new Sandbox(inner, name, /*ownsLifecycle*/ false);
+      return new Sandbox(inner, name, /*ownsLifecycle*/ !detached);
     };
     (
       nb as unknown as {
@@ -140,15 +139,7 @@ export class Sandbox implements AsyncDisposable {
       }
     ).createWithPullProgress = async () => {
       const raw = await withMappedErrors(() => origCreateWithPP());
-      return new PullProgressCreate(raw, name, /*attached*/ true);
-    };
-    (
-      nb as unknown as {
-        createDetachedWithPullProgress: () => Promise<PullProgressCreate>;
-      }
-    ).createDetachedWithPullProgress = async () => {
-      const raw = await withMappedErrors(() => origCreateDetachedWithPP());
-      return new PullProgressCreate(raw, name, /*attached*/ false);
+      return new PullProgressCreate(raw, name, /*attached*/ !detached);
     };
     return nb as unknown as SandboxBuilder;
   }

--- a/sdk/node-ts/tests/smoke.test.ts
+++ b/sdk/node-ts/tests/smoke.test.ts
@@ -152,13 +152,14 @@ describe("Node.js SDK Pull Progress", () => {
 		await sb.stopAndWait();
 	}, 120_000);
 
-	it("createDetachedWithPullProgress yields events and creates a detached sandbox", async () => {
+	it("detached createWithPullProgress yields events and creates a detached sandbox", async () => {
 		const session = await Sandbox.builder(NAME_DETACHED)
 			.image("mirror.gcr.io/library/alpine")
 			.cpus(1)
 			.memory(512)
 			.replace()
-			.createDetachedWithPullProgress();
+			.detached(true)
+			.createWithPullProgress();
 
 		const types: string[] = [];
 		for await (const ev of session) types.push(ev.kind);

--- a/sdk/python/integration/test_pull_progress.py
+++ b/sdk/python/integration/test_pull_progress.py
@@ -83,7 +83,7 @@ async def test_create_with_progress_result_rejects_on_second_call(sandbox_name):
 
 
 @pytest.mark.asyncio
-async def test_create_detached_with_progress_returns_detached_sandbox(sandbox_name):
+async def test_create_with_progress_detached_returns_detached_sandbox(sandbox_name):
     name = sandbox_name("py-sdk-progress-detached")
     await remove_sandbox(name)
 

--- a/sdk/python/src/sandbox.rs
+++ b/sdk/python/src/sandbox.rs
@@ -83,11 +83,11 @@ impl PySandbox {
             .unwrap_or(false);
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let sb = if detached {
-                builder.create_detached().await.map_err(to_py_err)?
-            } else {
-                builder.create().await.map_err(to_py_err)?
-            };
+            let sb = builder
+                .detached(detached)
+                .create()
+                .await
+                .map_err(to_py_err)?;
             Ok(PySandbox::from_rust(sb))
         })
     }
@@ -136,13 +136,10 @@ impl PySandbox {
         let runtime = pyo3_async_runtimes::tokio::get_runtime();
         let _runtime_guard = runtime.enter();
 
-        let (progress, task) = if detached {
-            builder
-                .create_detached_with_pull_progress()
-                .map_err(to_py_err)?
-        } else {
-            builder.create_with_pull_progress().map_err(to_py_err)?
-        };
+        let (progress, task) = builder
+            .detached(detached)
+            .create_with_pull_progress()
+            .map_err(to_py_err)?;
 
         Ok(PyPullSession::new(progress, task))
     }


### PR DESCRIPTION
## TL;DR
Remove the detached-specific create helpers and route detached sandbox creation through the normal builder or option path. This keeps Rust, TypeScript, Python, Go, and the CLI on one creation flow.

## Description
- Add `SandboxBuilder::detached(bool)` and use it to choose attached or detached spawn mode during `create()` and `create_with_pull_progress()`.
- Remove detached-specific creation helpers from Rust and TypeScript so callers use the same terminal create methods everywhere.
- Update Python and Go native bridges to forward detached creation through the Rust builder instead of branching to detached create helpers.
- Keep Go detached creation on `CreateSandbox(..., WithDetached())`, matching the recently removed `CreateSandboxDetached` wrapper.
- Update CLI creation paths, SDK docs, README examples, smoke coverage, Python integration test naming, and microsandbox skill references.

```rust
let sandbox = Sandbox::builder("worker")
    .image("python")
    .detached(true)
    .create()
    .await?;
```

## Test Plan
- [x] `cargo check -p microsandbox-cli`
- [x] `cargo check --manifest-path sdk/python/Cargo.toml`
- [x] `cargo check --manifest-path sdk/go/native/Cargo.toml`
- [x] `cargo check --manifest-path sdk/node-ts/Cargo.toml`
- [x] `npm run typecheck`
- [x] `go test -count=1 .` in `sdk/go`