### PR TITLE
fix(sandbox): reject zero resource limits in builder

### DIFF
--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -841,6 +841,18 @@ impl SandboxBuilder {
         }
         super::validate_sandbox_name_for_runtime(&self.config.name)?;
 
+        if self.config.cpus == 0 {
+            return Err(crate::MicrosandboxError::InvalidConfig(
+                "cpus must be greater than 0".into(),
+            ));
+        }
+
+        if self.config.memory_mib == 0 {
+            return Err(crate::MicrosandboxError::InvalidConfig(
+                "memory must be greater than 0".into(),
+            ));
+        }
+
         // Check that image is set (non-empty OCI string or Bind path).
         match &self.config.image {
             RootfsSource::Oci(oci) if oci.reference.is_empty() => {
@@ -990,6 +1002,36 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "invalid config: sandbox name is too long: 129 bytes (max 128)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_builder_rejects_zero_cpus() {
+        let err = SandboxBuilder::new("test")
+            .image("alpine")
+            .cpus(0)
+            .build()
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "invalid config: cpus must be greater than 0"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_builder_rejects_zero_memory() {
+        let err = SandboxBuilder::new("test")
+            .image("alpine")
+            .memory(0u32)
+            .build()
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "invalid config: memory must be greater than 0"
         );
     }
 


### PR DESCRIPTION
## TL;DR

Reject invalid zero CPU and zero-memory sandbox builder configs before runtime startup.

## Description

- Add builder validation for `cpus == 0`.
- Add builder validation for `memory_mib == 0`.
- Add regression tests for both invalid inputs.

## Test Plan

- `cargo test -p microsandbox test_builder_rejects_zero_ -- --nocapture`
- `cargo test -p microsandbox sandbox::builder::tests -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo test -p microsandbox --lib`
- `cargo clippy -p microsandbox --lib -- -D warnings`
