### PR TITLE
fix(network): wake poll loop after draining inbound relay channel

### DIFF
--- a/crates/network/lib/publisher.rs
+++ b/crates/network/lib/publisher.rs
@@ -765,6 +765,8 @@ async fn inbound_relay_task(
                             tracing::debug!(error = %e, "write to host client failed");
                             break;
                         }
+                        // Wake the poll loop so it can refill the channel from smoltcp.
+                        shared.proxy_wake.wake();
                     }
                     None => break,
                 }


### PR DESCRIPTION
## Summary

- Add missing `shared.proxy_wake.wake()` call in `inbound_relay_task` after writing guest data to the host TCP socket
- Fixes non-loopback published port throughput being throttled to ~30-120 KB/s

Fixes #914

## Description

The `inbound_relay_task` in `crates/network/lib/publisher.rs` drains guest response data from the `to_host_rx` channel and writes it to the host-side TCP socket. However, it was not waking the smoltcp poll loop after consuming channel capacity. This meant the poll loop had to wait for the full `poll(2)` timeout (up to 100ms) before it could refill the channel from the guest's TCP socket buffer.

The fix adds `shared.proxy_wake.wake()` after a successful write, mirroring the pattern already used in the host-to-guest direction at `proxy.rs:174`.

## Test Plan

Reproduced with the exact steps from the issue:

```bash
msb run -d -p 0.0.0.0:33333:33333 --copy serve.py:/serve.py python
msb exec <sandbox> -- sh -c 'nohup python3 /serve.py > /tmp/serve.log 2>&1 &'

# Non-loopback test via Docker bridge:
docker run --rm alpine sh -c \
  'apk add -q curl && curl -o /dev/null -w "size=%{size_download} time=%{time_total}s speed=%{speed_download}\n" --max-time 15 http://172.17.0.1:33333/'
```

**Before:** `size=2085856 time=15.002s speed=139034` (~139 KB/s, times out)
**After:** `size=2099200 time=0.005-0.007s speed=280-385 MB/s` (full 2MB in <8ms)

All 336 existing unit tests in `microsandbox-network` continue to pass. Clippy and fmt clean.