### PR TITLE
feat(api): add runloop-compatible local server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http",
@@ -420,7 +420,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -432,6 +432,44 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "axum-macros",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "multer",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1 0.10.6",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -457,6 +495,36 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3074,6 +3142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,6 +3257,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "microsandbox-api"
+version = "0.5.4"
+dependencies = [
+ "anyhow",
+ "axum 0.8.9",
+ "bytes",
+ "chrono",
+ "clap",
+ "dirs",
+ "futures",
+ "microsandbox",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "microsandbox-cli"
 version = "0.5.4"
 dependencies = [
@@ -3198,6 +3296,7 @@ dependencies = [
  "ipnetwork",
  "libc",
  "microsandbox",
+ "microsandbox-api",
  "microsandbox-image",
  "microsandbox-network",
  "microsandbox-protocol",
@@ -3683,6 +3782,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "napi"
 version = "3.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3786,7 +3902,7 @@ dependencies = [
 name = "net-secrets-body"
 version = "0.1.0"
 dependencies = [
- "axum",
+ "axum 0.7.9",
  "hyper",
  "hyper-util",
  "microsandbox",
@@ -6599,6 +6715,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6758,6 +6886,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6852,6 +6981,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "typed-builder"
@@ -7040,6 +7185,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
     "crates/agentd",
+    "crates/api",
     "crates/cli",
     "crates/db",
     "crates/filesystem",
@@ -74,6 +75,7 @@ test-utils = { path = "crates/test-utils" }
 # External crates.
 anyhow = "1.0"
 astral-tokio-tar = "0.6"
+axum = { version = "0.8", features = ["macros", "multipart", "ws"] }
 base64 = "0.22"
 async-compression = "0.4"
 bytes = "1.9"
@@ -117,9 +119,12 @@ tempfile = "3.15"
 thiserror = "2.0"
 tokio = { version = "1.42", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["trace", "cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 typed-builder = "0.23"
+uuid = { version = "1", features = ["v4", "serde"] }
 which = "8"
 xattr = "1.3"
 sea-orm = { version = "1.1", default-features = false, features = [

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "microsandbox-api"
+description = "RunLoop-compatible local HTTP API for microsandbox."
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
+[lib]
+name = "microsandbox_api"
+path = "lib/lib.rs"
+
+[[bin]]
+name = "microsandbox-api"
+path = "bin/main.rs"
+
+[features]
+default = ["net", "prebuilt"]
+net = ["microsandbox/net"]
+prebuilt = ["microsandbox/prebuilt"]
+
+[dependencies]
+anyhow.workspace = true
+axum.workspace = true
+bytes.workspace = true
+chrono.workspace = true
+clap.workspace = true
+dirs.workspace = true
+futures.workspace = true
+microsandbox.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sqlx.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tower.workspace = true
+tower-http.workspace = true
+tracing.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/api/bin/main.rs
+++ b/crates/api/bin/main.rs
@@ -1,0 +1,46 @@
+//! Entry point for the `microsandbox-api` binary.
+
+use clap::Parser;
+use microsandbox_api::{ServeConfig, serve};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Run the local Microsandbox API server.
+#[derive(Debug, Parser)]
+#[command(name = "microsandbox-api", version)]
+struct Args {
+    /// Address to bind.
+    #[arg(long, default_value = "127.0.0.1:8080")]
+    addr: std::net::SocketAddr,
+
+    /// Allow binding to non-loopback addresses.
+    #[arg(long)]
+    allow_non_loopback: bool,
+
+    /// API execution database path.
+    #[arg(long)]
+    api_db: Option<std::path::PathBuf>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let mut config = ServeConfig {
+        addr: args.addr,
+        allow_non_loopback: args.allow_non_loopback,
+        ..ServeConfig::default()
+    };
+    if let Some(path) = args.api_db {
+        config.api_db_path = path;
+    }
+    let handle = serve(config).await?;
+    println!("microsandbox-api listening on http://{}", handle.addr);
+    tokio::signal::ctrl_c().await?;
+    Ok(())
+}

--- a/crates/api/lib/adapter.rs
+++ b/crates/api/lib/adapter.rs
@@ -1,0 +1,128 @@
+//! Adapter helpers over public microsandbox APIs.
+
+use std::collections::HashMap;
+
+use axum::http::StatusCode;
+use microsandbox::{
+    MicrosandboxError, Sandbox, SandboxConfig,
+    sandbox::{SandboxHandle, SandboxStatus},
+};
+
+use crate::{
+    dto::{DevboxCreateRequest, DevboxView},
+    error::ApiError,
+    ids,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Create a local devbox.
+pub async fn create_devbox(request: DevboxCreateRequest) -> Result<DevboxView, ApiError> {
+    reject_unsupported_create_fields(&request)?;
+
+    let id = ids::new_devbox_id();
+    let metadata = request.metadata.unwrap_or_default();
+    let mut builder = Sandbox::builder(&id);
+
+    if let Some(image) = &request.image {
+        builder = builder.image(image.as_str());
+    }
+    if let Some(env) = &request.environment_variables {
+        builder = builder.envs(env.iter());
+    }
+    builder = builder.labels(metadata.iter());
+
+    let sandbox = builder
+        .detached(true)
+        .create()
+        .await
+        .map_err(map_create_error)?;
+    sandbox.detach().await;
+
+    Ok(DevboxView {
+        id,
+        name: request.name,
+        status: status_to_runloop(SandboxStatus::Running).into(),
+        metadata,
+    })
+}
+
+/// List local devboxes.
+pub async fn list_devboxes() -> Result<Vec<DevboxView>, ApiError> {
+    let handles = Sandbox::list()
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    Ok(handles.into_iter().map(devbox_view).collect())
+}
+
+/// Get a local devbox.
+pub async fn get_devbox(id: &str) -> Result<DevboxView, ApiError> {
+    let handle = Sandbox::get(id)
+        .await
+        .map_err(|_| ApiError::not_found(format!("Devbox '{id}' was not found.")))?;
+    Ok(devbox_view(handle))
+}
+
+fn devbox_view(handle: SandboxHandle) -> DevboxView {
+    DevboxView {
+        id: handle.name().to_string(),
+        name: None,
+        status: status_to_runloop(handle.status()).into(),
+        metadata: metadata_from_config(handle.config().ok()),
+    }
+}
+
+fn metadata_from_config(config: Option<SandboxConfig>) -> HashMap<String, String> {
+    config.map(|config| config.labels).unwrap_or_default()
+}
+
+fn reject_unsupported_create_fields(request: &DevboxCreateRequest) -> Result<(), ApiError> {
+    if request.blueprint_id.is_some() {
+        return Err(ApiError::bad_request(
+            "unsupported_field",
+            "blueprint_id is not supported by the local Microsandbox API POC.",
+        ));
+    }
+    if request.blueprint_name.is_some() {
+        return Err(ApiError::bad_request(
+            "unsupported_field",
+            "blueprint_name is not supported by the local Microsandbox API POC.",
+        ));
+    }
+    Ok(())
+}
+
+fn map_create_error(err: MicrosandboxError) -> ApiError {
+    let message = err.to_string();
+    match err {
+        MicrosandboxError::InvalidConfig(_) if is_image_reference_error(&message) => {
+            ApiError::bad_request("invalid_image_reference", message)
+        }
+        MicrosandboxError::InvalidConfig(_) => ApiError::bad_request("invalid_request", message),
+        MicrosandboxError::Image(_) | MicrosandboxError::ImageNotFound(_) => {
+            ApiError::new(StatusCode::BAD_GATEWAY, "image_pull_failed", message)
+        }
+        MicrosandboxError::SandboxAlreadyExists(_) => {
+            ApiError::new(StatusCode::CONFLICT, "already_exists", message)
+        }
+        other => ApiError::internal(other.to_string()),
+    }
+}
+
+fn is_image_reference_error(message: &str) -> bool {
+    message.contains("image")
+        || message.contains("reference")
+        || message.contains("rootfs")
+        || message.contains("oci")
+}
+
+fn status_to_runloop(status: SandboxStatus) -> &'static str {
+    match status {
+        SandboxStatus::Running | SandboxStatus::Draining => "running",
+        SandboxStatus::Stopped => "shutdown",
+        SandboxStatus::Crashed => "failure",
+        SandboxStatus::Paused => "suspended",
+    }
+}

--- a/crates/api/lib/auth.rs
+++ b/crates/api/lib/auth.rs
@@ -1,0 +1,13 @@
+//! Authentication middleware.
+
+use axum::{body::Body, http::Request, middleware::Next, response::Response};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Permissive local auth middleware for the POC.
+pub async fn optional_auth(request: Request<Body>, next: Next) -> Response {
+    // TODO(CRITICAL): Require a configured local API token before this server is used outside localhost.
+    next.run(request).await
+}

--- a/crates/api/lib/dto.rs
+++ b/crates/api/lib/dto.rs
@@ -1,0 +1,287 @@
+//! RunLoop-shaped request and response DTOs.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+//--------------------------------------------------------------------------------------------------
+// Types: Devboxes
+//--------------------------------------------------------------------------------------------------
+
+/// Create Devbox request.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DevboxCreateRequest {
+    /// Optional display name.
+    pub name: Option<String>,
+
+    /// Public OCI image reference for the local POC.
+    pub image: Option<String>,
+
+    /// RunLoop blueprint ID. Unsupported locally.
+    pub blueprint_id: Option<String>,
+
+    /// RunLoop blueprint name. Unsupported locally.
+    pub blueprint_name: Option<String>,
+
+    /// User metadata.
+    pub metadata: Option<HashMap<String, String>>,
+
+    /// Environment variables.
+    pub environment_variables: Option<HashMap<String, String>>,
+}
+
+/// Devbox response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DevboxView {
+    /// Devbox ID.
+    pub id: String,
+
+    /// Optional display name.
+    pub name: Option<String>,
+
+    /// Devbox status.
+    pub status: String,
+
+    /// Metadata.
+    pub metadata: HashMap<String, String>,
+}
+
+/// List response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DevboxListView {
+    /// Devboxes.
+    pub devboxes: Vec<DevboxView>,
+
+    /// Whether another page exists.
+    pub has_more: bool,
+
+    /// Optional total count.
+    pub total_count: Option<i32>,
+}
+
+/// Read text file request.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ReadFileRequest {
+    /// Path to read.
+    pub file_path: String,
+}
+
+/// Write text file request.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WriteFileRequest {
+    /// Path to write.
+    pub file_path: String,
+
+    /// UTF-8 contents.
+    pub contents: String,
+}
+
+/// Download file request.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DownloadFileRequest {
+    /// Path to read.
+    pub path: String,
+}
+
+/// Wait for devbox status request.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WaitForStatusRequest {
+    /// Statuses to wait for.
+    pub statuses: Vec<String>,
+
+    /// Timeout in seconds, capped at 30.
+    pub timeout_seconds: Option<u64>,
+}
+
+/// Log entry response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LogEntryView {
+    /// RFC 3339 timestamp.
+    pub timestamp: String,
+
+    /// Source tag.
+    pub source: String,
+
+    /// Optional session ID.
+    pub session_id: Option<u64>,
+
+    /// Log data decoded as UTF-8 lossily.
+    pub data: String,
+}
+
+/// Usage metrics response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct UsageView {
+    /// CPU usage as a percentage across all host CPUs.
+    pub cpu_percent: f32,
+
+    /// Resident memory usage in bytes.
+    pub memory_bytes: u64,
+
+    /// Configured guest memory limit in bytes.
+    pub memory_limit_bytes: u64,
+
+    /// Cumulative disk bytes read by the sandbox process.
+    pub disk_read_bytes: u64,
+
+    /// Cumulative disk bytes written by the sandbox process.
+    pub disk_write_bytes: u64,
+
+    /// Cumulative network bytes delivered from the runtime to the guest.
+    pub net_rx_bytes: u64,
+
+    /// Cumulative network bytes transmitted from the guest into the runtime.
+    pub net_tx_bytes: u64,
+
+    /// Sandbox uptime in milliseconds.
+    pub uptime_ms: u128,
+
+    /// RFC 3339 timestamp of the sample.
+    pub timestamp: String,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Disk Snapshots
+//--------------------------------------------------------------------------------------------------
+
+/// Disk snapshot response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DiskSnapshotView {
+    /// Snapshot ID.
+    pub id: String,
+
+    /// Optional snapshot display name.
+    pub name: Option<String>,
+
+    /// Metadata.
+    pub metadata: HashMap<String, String>,
+
+    /// Source Devbox ID, when known.
+    pub source_devbox_id: String,
+
+    /// Creation time in milliseconds since the Unix epoch.
+    pub create_time_ms: i64,
+
+    /// Snapshot size in bytes.
+    pub size_bytes: Option<u64>,
+}
+
+/// List disk snapshots response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DiskSnapshotListView {
+    /// Disk snapshots.
+    pub snapshots: Vec<DiskSnapshotView>,
+
+    /// Whether another page exists.
+    pub has_more: bool,
+
+    /// Optional total count.
+    pub total_count: Option<i32>,
+}
+
+/// Disk snapshot status response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DiskSnapshotStatusView {
+    /// Snapshot status.
+    pub status: String,
+
+    /// Snapshot details.
+    pub snapshot: DiskSnapshotView,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Executions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute request.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ExecuteRequest {
+    /// Idempotency and tracking ID.
+    pub command_id: Option<String>,
+
+    /// Shell command.
+    pub command: String,
+
+    /// Persistent shell name. Unsupported locally.
+    pub shell_name: Option<String>,
+
+    /// Optimistic wait timeout in seconds.
+    pub optimistic_timeout: Option<u64>,
+}
+
+/// Async execute request.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ExecuteAsyncRequest {
+    /// Shell command.
+    pub command: String,
+
+    /// Persistent shell name. Unsupported locally.
+    pub shell_name: Option<String>,
+
+    /// Whether stdin is attached.
+    pub attach_stdin: Option<bool>,
+}
+
+/// Execution detail response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ExecutionView {
+    /// Execution ID.
+    pub id: String,
+
+    /// Devbox ID.
+    pub devbox_id: String,
+
+    /// Execution status.
+    pub status: String,
+
+    /// Exit code.
+    pub exit_code: Option<i32>,
+
+    /// Captured stdout.
+    pub stdout: String,
+
+    /// Captured stderr.
+    pub stderr: String,
+
+    /// Error message.
+    pub error: Option<String>,
+}
+
+/// Send stdin request.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SendStdinRequest {
+    /// Content to write to stdin.
+    pub content: String,
+}
+
+/// Wait for execution status request.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WaitForExecutionStatusRequest {
+    /// Statuses to wait for.
+    pub statuses: Vec<String>,
+
+    /// Timeout in seconds, capped at 25.
+    pub timeout_seconds: Option<u64>,
+}
+
+/// Empty object response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EmptyRecord {}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl From<crate::store::StoredExecution> for ExecutionView {
+    fn from(row: crate::store::StoredExecution) -> Self {
+        Self {
+            id: row.execution_id,
+            devbox_id: row.devbox_id,
+            status: row.status.as_str().into(),
+            exit_code: row.exit_code,
+            stdout: row.stdout,
+            stderr: row.stderr,
+            error: row.error,
+        }
+    }
+}

--- a/crates/api/lib/error.rs
+++ b/crates/api/lib/error.rs
@@ -1,0 +1,103 @@
+//! API error types and response mapping.
+
+use axum::{Json, http::StatusCode, response::IntoResponse};
+use serde::Serialize;
+use serde_json::{Value, json};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// JSON error response.
+#[derive(Debug, Clone, Serialize)]
+pub struct ErrorResponse {
+    /// Error payload.
+    pub error: ErrorBody,
+}
+
+/// JSON error body.
+#[derive(Debug, Clone, Serialize)]
+pub struct ErrorBody {
+    /// Stable error code.
+    pub code: String,
+
+    /// Human-readable error message.
+    pub message: String,
+
+    /// Structured extra details.
+    pub details: Value,
+}
+
+/// API error with HTTP status.
+#[derive(Debug, Clone)]
+pub struct ApiError {
+    status: StatusCode,
+    code: String,
+    message: String,
+    details: Value,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ApiError {
+    /// Build a not-found error.
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::NOT_FOUND, "not_found", message)
+    }
+
+    /// Build a bad-request error.
+    pub fn bad_request(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::BAD_REQUEST, code, message)
+    }
+
+    /// Build an internal error.
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", message)
+    }
+
+    /// Build a local unsupported endpoint error.
+    pub fn unsupported_locally(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::NOT_IMPLEMENTED, "unsupported_locally", message)
+    }
+
+    /// Build an error with status and code.
+    pub fn new(status: StatusCode, code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            code: code.into(),
+            message: message.into(),
+            details: json!({}),
+        }
+    }
+
+    /// Add JSON details.
+    pub fn with_details(mut self, details: Value) -> Self {
+        self.details = details;
+        self
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl From<ApiError> for ErrorResponse {
+    fn from(error: ApiError) -> Self {
+        Self {
+            error: ErrorBody {
+                code: error.code,
+                message: error.message,
+                details: error.details,
+            },
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> axum::response::Response {
+        let status = self.status;
+        (status, Json(ErrorResponse::from(self))).into_response()
+    }
+}

--- a/crates/api/lib/ids.rs
+++ b/crates/api/lib/ids.rs
@@ -1,0 +1,15 @@
+//! Identifier generation.
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Generate a local Devbox ID that is also a valid Microsandbox sandbox name.
+pub fn new_devbox_id() -> String {
+    format!("dbx_{}", uuid::Uuid::new_v4().simple())
+}
+
+/// Generate a local execution ID.
+pub fn new_execution_id() -> String {
+    format!("exec_{}", uuid::Uuid::new_v4().simple())
+}

--- a/crates/api/lib/lib.rs
+++ b/crates/api/lib/lib.rs
@@ -1,0 +1,19 @@
+//! RunLoop-compatible local HTTP API for microsandbox.
+
+#![warn(missing_docs)]
+
+pub mod adapter;
+pub mod auth;
+pub mod dto;
+pub mod error;
+pub mod ids;
+pub mod routes;
+pub mod server;
+pub mod state;
+pub mod store;
+
+//--------------------------------------------------------------------------------------------------
+// Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use server::{ServeConfig, ServeHandle, serve};

--- a/crates/api/lib/routes/devboxes.rs
+++ b/crates/api/lib/routes/devboxes.rs
@@ -1,0 +1,362 @@
+//! Devbox routes.
+
+use std::{convert::Infallible, time::Duration};
+
+use axum::{
+    Json,
+    extract::{Multipart, Path, State},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{
+        IntoResponse,
+        sse::{Event, Sse},
+    },
+};
+use chrono::SecondsFormat;
+use futures::{Stream, StreamExt};
+use microsandbox::{
+    Sandbox,
+    logs::{LogOptions, LogSource, LogStreamOptions},
+    sandbox::SandboxMetrics,
+};
+
+use crate::{
+    adapter,
+    dto::{
+        DevboxCreateRequest, DevboxListView, DevboxView, DownloadFileRequest, EmptyRecord,
+        LogEntryView, ReadFileRequest, UsageView, WaitForStatusRequest, WriteFileRequest,
+    },
+    error::ApiError,
+    state::ApiState,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Maximum UTF-8 file payload size.
+pub const TEXT_FILE_LIMIT: usize = 10 * 1024 * 1024;
+
+/// Maximum binary file payload size.
+pub const BINARY_FILE_LIMIT: usize = 100 * 1024 * 1024;
+
+const DEFAULT_WAIT_TIMEOUT_SECONDS: u64 = 10;
+const MAX_WAIT_TIMEOUT_SECONDS: u64 = 30;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Create a devbox.
+pub async fn create(
+    State(_state): State<ApiState>,
+    Json(request): Json<DevboxCreateRequest>,
+) -> Result<Json<DevboxView>, ApiError> {
+    Ok(Json(adapter::create_devbox(request).await?))
+}
+
+/// List devboxes.
+pub async fn list(State(_state): State<ApiState>) -> Result<Json<DevboxListView>, ApiError> {
+    let devboxes = adapter::list_devboxes().await?;
+    Ok(Json(DevboxListView {
+        total_count: Some(devboxes.len() as i32),
+        has_more: false,
+        devboxes,
+    }))
+}
+
+/// Get devbox details.
+pub async fn get(
+    State(_state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<DevboxView>, ApiError> {
+    Ok(Json(adapter::get_devbox(&id).await?))
+}
+
+/// Shutdown a devbox.
+pub async fn shutdown(
+    State(_state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<EmptyRecord>, ApiError> {
+    let handle = Sandbox::get(&id)
+        .await
+        .map_err(|_| ApiError::not_found(format!("Devbox '{id}' was not found.")))?;
+    handle
+        .stop()
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    Ok(Json(EmptyRecord {}))
+}
+
+/// Wait for a devbox status.
+pub async fn wait_for_status(
+    State(_state): State<ApiState>,
+    Path(id): Path<String>,
+    Json(request): Json<WaitForStatusRequest>,
+) -> Result<Json<DevboxView>, ApiError> {
+    if request.statuses.is_empty() {
+        return Err(ApiError::bad_request(
+            "invalid_request",
+            "statuses must not be empty",
+        ));
+    }
+
+    let timeout = Duration::from_secs(
+        request
+            .timeout_seconds
+            .unwrap_or(DEFAULT_WAIT_TIMEOUT_SECONDS)
+            .min(MAX_WAIT_TIMEOUT_SECONDS),
+    );
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        let devbox = adapter::get_devbox(&id).await?;
+        if request
+            .statuses
+            .iter()
+            .any(|status| status == &devbox.status)
+        {
+            return Ok(Json(devbox));
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(ApiError::new(
+                StatusCode::REQUEST_TIMEOUT,
+                "timeout",
+                "timed out waiting for devbox status",
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Read text file contents.
+pub async fn read_file_contents(
+    Path(id): Path<String>,
+    Json(request): Json<ReadFileRequest>,
+) -> Result<String, ApiError> {
+    let sandbox = Sandbox::get(&id)
+        .await
+        .map_err(|_| ApiError::not_found(format!("Devbox '{id}' was not found.")))?
+        .connect()
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    let contents = sandbox
+        .fs()
+        .read_to_string(&request.file_path)
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    if contents.len() > TEXT_FILE_LIMIT {
+        return Err(size_limit_exceeded("file exceeds text response size limit"));
+    }
+    Ok(contents)
+}
+
+/// Write text file contents.
+pub async fn write_file_contents(
+    Path(id): Path<String>,
+    Json(request): Json<WriteFileRequest>,
+) -> Result<Json<EmptyRecord>, ApiError> {
+    if request.contents.len() > TEXT_FILE_LIMIT {
+        return Err(size_limit_exceeded(
+            "contents exceeds text request size limit",
+        ));
+    }
+
+    let sandbox = Sandbox::get(&id)
+        .await
+        .map_err(|_| ApiError::not_found(format!("Devbox '{id}' was not found.")))?
+        .connect()
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    sandbox
+        .fs()
+        .write(&request.file_path, request.contents)
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    Ok(Json(EmptyRecord {}))
+}
+
+/// Download binary file.
+pub async fn download_file(
+    Path(id): Path<String>,
+    Json(request): Json<DownloadFileRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let sandbox = Sandbox::get(&id)
+        .await
+        .map_err(|_| ApiError::not_found(format!("Devbox '{id}' was not found.")))?
+        .connect()
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    let data = sandbox
+        .fs()
+        .read(&request.path)
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    if data.len() > BINARY_FILE_LIMIT {
+        return Err(size_limit_exceeded(
+            "file exceeds binary response size limit",
+        ));
+    }
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/octet-stream"),
+    );
+    headers.insert(
+        header::CONTENT_DISPOSITION,
+        content_disposition(&request.path)?,
+    );
+    Ok((headers, data))
+}
+
+/// Upload binary file.
+pub async fn upload_file(
+    Path(id): Path<String>,
+    mut multipart: Multipart,
+) -> Result<Json<EmptyRecord>, ApiError> {
+    let mut path = None;
+    let mut file = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|err| ApiError::bad_request("invalid_multipart", err.to_string()))?
+    {
+        match field.name() {
+            Some("path") => {
+                path =
+                    Some(field.text().await.map_err(|err| {
+                        ApiError::bad_request("invalid_multipart", err.to_string())
+                    })?);
+            }
+            Some("file") => {
+                let data = field
+                    .bytes()
+                    .await
+                    .map_err(|err| ApiError::bad_request("invalid_multipart", err.to_string()))?;
+                if data.len() > BINARY_FILE_LIMIT {
+                    return Err(size_limit_exceeded(
+                        "file exceeds binary request size limit",
+                    ));
+                }
+                file = Some(data);
+            }
+            _ => {}
+        }
+    }
+
+    let path = path.ok_or_else(|| ApiError::bad_request("invalid_request", "path is required"))?;
+    let file = file.ok_or_else(|| ApiError::bad_request("invalid_request", "file is required"))?;
+    let sandbox = Sandbox::get(&id)
+        .await
+        .map_err(|_| ApiError::not_found(format!("Devbox '{id}' was not found.")))?
+        .connect()
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    sandbox
+        .fs()
+        .write(&path, file)
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    Ok(Json(EmptyRecord {}))
+}
+
+/// Get devbox logs.
+pub async fn logs(Path(id): Path<String>) -> Result<Json<Vec<LogEntryView>>, ApiError> {
+    let logs = microsandbox::logs::read_logs(&id, &LogOptions::default())
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?
+        .into_iter()
+        .map(log_entry_view)
+        .collect();
+    Ok(Json(logs))
+}
+
+/// Tail devbox logs.
+pub async fn logs_tail(
+    Path(id): Path<String>,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    let stream = microsandbox::logs::log_stream(
+        &id,
+        &LogStreamOptions {
+            follow: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .map_err(|err| ApiError::internal(err.to_string()))?
+    .map(|item| {
+        let data = match item {
+            Ok(entry) => {
+                serde_json::to_string(&log_entry_view(entry)).unwrap_or_else(|_| "{}".into())
+            }
+            Err(err) => serde_json::json!({ "error": err.to_string() }).to_string(),
+        };
+        Ok(Event::default().data(data))
+    });
+    Ok(Sse::new(stream))
+}
+
+/// Get usage metrics.
+pub async fn usage(Path(id): Path<String>) -> Result<Json<UsageView>, ApiError> {
+    let metrics = Sandbox::get(&id)
+        .await
+        .map_err(|_| ApiError::not_found(format!("Devbox '{id}' was not found.")))?
+        .metrics()
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    Ok(Json(usage_view(metrics)))
+}
+
+fn size_limit_exceeded(message: &'static str) -> ApiError {
+    ApiError::new(
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "size_limit_exceeded",
+        message,
+    )
+}
+
+fn content_disposition(path: &str) -> Result<HeaderValue, ApiError> {
+    let filename = path
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty())
+        .unwrap_or("download");
+    let sanitized = filename.replace(['\\', '"', '\r', '\n'], "_");
+    HeaderValue::from_str(&format!("attachment; filename=\"{sanitized}\""))
+        .map_err(|err| ApiError::internal(err.to_string()))
+}
+
+fn log_entry_view(entry: microsandbox::logs::LogEntry) -> LogEntryView {
+    LogEntryView {
+        timestamp: entry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+        source: log_source(entry.source).into(),
+        session_id: entry.session_id,
+        data: String::from_utf8_lossy(&entry.data).into_owned(),
+    }
+}
+
+fn log_source(source: LogSource) -> &'static str {
+    match source {
+        LogSource::Stdout => "stdout",
+        LogSource::Stderr => "stderr",
+        LogSource::Output => "output",
+        LogSource::System => "system",
+    }
+}
+
+fn usage_view(metrics: SandboxMetrics) -> UsageView {
+    UsageView {
+        cpu_percent: metrics.cpu_percent,
+        memory_bytes: metrics.memory_bytes,
+        memory_limit_bytes: metrics.memory_limit_bytes,
+        disk_read_bytes: metrics.disk_read_bytes,
+        disk_write_bytes: metrics.disk_write_bytes,
+        net_rx_bytes: metrics.net_rx_bytes,
+        net_tx_bytes: metrics.net_tx_bytes,
+        uptime_ms: metrics.uptime.as_millis(),
+        timestamp: metrics
+            .timestamp
+            .to_rfc3339_opts(SecondsFormat::Millis, true),
+    }
+}

--- a/crates/api/lib/routes/executions.rs
+++ b/crates/api/lib/routes/executions.rs
@@ -1,0 +1,320 @@
+//! Execution routes.
+
+use std::time::Duration;
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use microsandbox::{ExecEvent, Sandbox};
+
+use crate::{
+    dto::{
+        EmptyRecord, ExecuteAsyncRequest, ExecuteRequest, ExecutionView, SendStdinRequest,
+        WaitForExecutionStatusRequest,
+    },
+    error::ApiError,
+    ids::new_execution_id,
+    state::ApiState,
+    store::{ExecutionInsert, StoredExecution},
+};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const DEFAULT_EXECUTION_WAIT_SECONDS: u64 = 25;
+const MAX_EXECUTION_WAIT_SECONDS: u64 = 25;
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute with optimistic wait.
+pub async fn execute(
+    State(state): State<ApiState>,
+    Path(devbox_id): Path<String>,
+    Json(request): Json<ExecuteRequest>,
+) -> Result<Json<ExecutionView>, ApiError> {
+    reject_shell_name(request.shell_name.as_ref())?;
+    let execution_id = request.command_id.unwrap_or_else(new_execution_id);
+    start_execution(
+        state.clone(),
+        devbox_id.clone(),
+        execution_id.clone(),
+        request.command,
+        false,
+    )
+    .await?;
+
+    let timeout = execution_wait_timeout(request.optimistic_timeout);
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let row = get_required(&state, &devbox_id, &execution_id).await?;
+        if is_terminal(&row) || tokio::time::Instant::now() >= deadline {
+            return Ok(Json(row.into()));
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Execute asynchronously.
+pub async fn execute_async(
+    State(state): State<ApiState>,
+    Path(devbox_id): Path<String>,
+    Json(request): Json<ExecuteAsyncRequest>,
+) -> Result<Json<ExecutionView>, ApiError> {
+    reject_shell_name(request.shell_name.as_ref())?;
+    let execution_id = new_execution_id();
+    start_execution(
+        state.clone(),
+        devbox_id.clone(),
+        execution_id.clone(),
+        request.command,
+        request.attach_stdin.unwrap_or(false),
+    )
+    .await?;
+    Ok(Json(
+        get_required(&state, &devbox_id, &execution_id)
+            .await?
+            .into(),
+    ))
+}
+
+/// Get execution status.
+pub async fn get(
+    State(state): State<ApiState>,
+    Path((devbox_id, execution_id)): Path<(String, String)>,
+) -> Result<Json<ExecutionView>, ApiError> {
+    Ok(Json(
+        get_required(&state, &devbox_id, &execution_id)
+            .await?
+            .into(),
+    ))
+}
+
+/// Kill a live execution.
+pub async fn kill(
+    State(state): State<ApiState>,
+    Path((devbox_id, execution_id)): Path<(String, String)>,
+) -> Result<Json<EmptyRecord>, ApiError> {
+    let control = state
+        .live
+        .read()
+        .await
+        .control(&devbox_id, &execution_id)
+        .ok_or_else(|| ApiError::not_found(format!("Execution '{execution_id}' is not live.")))?;
+    control
+        .kill()
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    Ok(Json(EmptyRecord {}))
+}
+
+/// Send stdin to a live execution.
+pub async fn send_std_in(
+    State(state): State<ApiState>,
+    Path((devbox_id, execution_id)): Path<(String, String)>,
+    Json(request): Json<SendStdinRequest>,
+) -> Result<Json<EmptyRecord>, ApiError> {
+    let stdin = state
+        .live
+        .read()
+        .await
+        .stdin(&devbox_id, &execution_id)
+        .ok_or_else(|| {
+            ApiError::bad_request(
+                "stdin_unavailable",
+                "execution stdin is not attached or is no longer live",
+            )
+        })?;
+    stdin
+        .write(request.content.as_bytes())
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+    Ok(Json(EmptyRecord {}))
+}
+
+/// Wait for execution status.
+pub async fn wait_for_status(
+    State(state): State<ApiState>,
+    Path((devbox_id, execution_id)): Path<(String, String)>,
+    Json(request): Json<WaitForExecutionStatusRequest>,
+) -> Result<Json<ExecutionView>, ApiError> {
+    if request.statuses.is_empty() {
+        return Err(ApiError::bad_request(
+            "invalid_request",
+            "statuses must not be empty",
+        ));
+    }
+
+    let timeout = execution_wait_timeout(request.timeout_seconds);
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let row = get_required(&state, &devbox_id, &execution_id).await?;
+        if request
+            .statuses
+            .iter()
+            .any(|status| status == row.status.as_str())
+        {
+            return Ok(Json(row.into()));
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(ApiError::new(
+                StatusCode::REQUEST_TIMEOUT,
+                "timeout",
+                "timed out waiting for execution status",
+            ));
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+async fn start_execution(
+    state: ApiState,
+    devbox_id: String,
+    execution_id: String,
+    command: String,
+    attach_stdin: bool,
+) -> Result<(), ApiError> {
+    let sandbox = Sandbox::get(&devbox_id)
+        .await
+        .map_err(|_| ApiError::not_found(format!("Devbox '{devbox_id}' was not found.")))?
+        .connect()
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+
+    state
+        .store
+        .insert(ExecutionInsert {
+            devbox_id: devbox_id.clone(),
+            execution_id: execution_id.clone(),
+            command: command.clone(),
+            stdin_attached: attach_stdin,
+        })
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+
+    let mut handle = match sandbox
+        .shell_stream_with(command, |exec| {
+            if attach_stdin {
+                exec.stdin_pipe()
+            } else {
+                exec
+            }
+        })
+        .await
+    {
+        Ok(handle) => handle,
+        Err(err) => {
+            let message = err.to_string();
+            let _ = state
+                .store
+                .mark_failed(&devbox_id, &execution_id, &message)
+                .await;
+            return Err(ApiError::internal(message));
+        }
+    };
+
+    state
+        .store
+        .mark_running(&devbox_id, &execution_id)
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+
+    let store = state.store.clone();
+    let live = state.live.clone();
+    let control = handle.control();
+    let stdin = handle.take_stdin();
+    {
+        let mut live = live.write().await;
+        live.insert_control(devbox_id.clone(), execution_id.clone(), control);
+        if let Some(stdin) = stdin {
+            live.insert_stdin(devbox_id.clone(), execution_id.clone(), stdin);
+        }
+    }
+
+    tokio::spawn(async move {
+        let mut terminal_event = false;
+        while let Some(event) = handle.recv().await {
+            match event {
+                ExecEvent::Started { .. } => {}
+                ExecEvent::Stdout(bytes) => {
+                    let _ = store
+                        .append_output(&devbox_id, &execution_id, &bytes, b"")
+                        .await;
+                }
+                ExecEvent::Stderr(bytes) => {
+                    let _ = store
+                        .append_output(&devbox_id, &execution_id, b"", &bytes)
+                        .await;
+                }
+                ExecEvent::Exited { code } => {
+                    terminal_event = true;
+                    let _ = store.mark_completed(&devbox_id, &execution_id, code).await;
+                    break;
+                }
+                ExecEvent::Failed(failed) => {
+                    terminal_event = true;
+                    let _ = store
+                        .mark_failed(&devbox_id, &execution_id, &failed.message)
+                        .await;
+                    break;
+                }
+                ExecEvent::StdinError(_) => {}
+            }
+        }
+        if !terminal_event {
+            let _ = store
+                .mark_failed(
+                    &devbox_id,
+                    &execution_id,
+                    "execution event stream ended before completion",
+                )
+                .await;
+        }
+        live.write().await.remove(&devbox_id, &execution_id);
+    });
+
+    Ok(())
+}
+
+fn reject_shell_name(shell_name: Option<&String>) -> Result<(), ApiError> {
+    if shell_name.is_some() {
+        return Err(ApiError::bad_request(
+            "unsupported_field",
+            "shell_name is not supported by the local Microsandbox API POC.",
+        ));
+    }
+    Ok(())
+}
+
+fn execution_wait_timeout(timeout_seconds: Option<u64>) -> Duration {
+    Duration::from_secs(
+        timeout_seconds
+            .unwrap_or(DEFAULT_EXECUTION_WAIT_SECONDS)
+            .min(MAX_EXECUTION_WAIT_SECONDS),
+    )
+}
+
+fn is_terminal(row: &StoredExecution) -> bool {
+    matches!(
+        row.status,
+        crate::store::ExecutionStatus::Completed | crate::store::ExecutionStatus::Failed
+    )
+}
+
+async fn get_required(
+    state: &ApiState,
+    devbox_id: &str,
+    execution_id: &str,
+) -> Result<StoredExecution, ApiError> {
+    state
+        .store
+        .get(devbox_id, execution_id)
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?
+        .ok_or_else(|| ApiError::not_found(format!("Execution '{execution_id}' was not found.")))
+}

--- a/crates/api/lib/routes/mod.rs
+++ b/crates/api/lib/routes/mod.rs
@@ -1,0 +1,110 @@
+//! API route assembly.
+
+use axum::{
+    Router,
+    extract::DefaultBodyLimit,
+    http::{Method, Uri},
+    routing::{get, post},
+};
+use serde_json::json;
+
+use crate::{auth::optional_auth, error::ApiError, state::ApiState};
+
+pub mod devboxes;
+pub mod executions;
+pub mod snapshots;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Build the API router.
+pub fn router(state: ApiState) -> Router {
+    Router::new()
+        .route("/v1/devboxes", post(devboxes::create).get(devboxes::list))
+        .route("/v1/devboxes/{id}", get(devboxes::get))
+        .route("/v1/devboxes/{id}/execute", post(executions::execute))
+        .route("/v1/devboxes/{id}/execute_sync", post(executions::execute))
+        .route(
+            "/v1/devboxes/{id}/execute_async",
+            post(executions::execute_async),
+        )
+        .route("/v1/devboxes/{id}/shutdown", post(devboxes::shutdown))
+        .route(
+            "/v1/devboxes/{id}/wait_for_status",
+            post(devboxes::wait_for_status),
+        )
+        .route(
+            "/v1/devboxes/{devbox_id}/executions/{execution_id}",
+            get(executions::get),
+        )
+        .route(
+            "/v1/devboxes/{devbox_id}/executions/{execution_id}/kill",
+            post(executions::kill),
+        )
+        .route(
+            "/v1/devboxes/{devbox_id}/executions/{execution_id}/send_std_in",
+            post(executions::send_std_in),
+        )
+        .route(
+            "/v1/devboxes/{devbox_id}/executions/{execution_id}/wait_for_status",
+            post(executions::wait_for_status),
+        )
+        .route(
+            "/v1/devboxes/{id}/keep_alive",
+            post(|| async { axum::Json(crate::dto::EmptyRecord {}) }),
+        )
+        .route(
+            "/v1/devboxes/{id}/read_file_contents",
+            post(devboxes::read_file_contents)
+                .layer(DefaultBodyLimit::max(devboxes::TEXT_FILE_LIMIT + 1024)),
+        )
+        .route(
+            "/v1/devboxes/{id}/write_file_contents",
+            post(devboxes::write_file_contents)
+                .layer(DefaultBodyLimit::max(devboxes::TEXT_FILE_LIMIT + 1024)),
+        )
+        .route(
+            "/v1/devboxes/{id}/download_file",
+            post(devboxes::download_file),
+        )
+        .route(
+            "/v1/devboxes/{id}/upload_file",
+            post(devboxes::upload_file)
+                .layer(DefaultBodyLimit::max(devboxes::BINARY_FILE_LIMIT + 1024)),
+        )
+        .route("/v1/devboxes/{id}/logs", get(devboxes::logs))
+        .route("/v1/devboxes/{id}/logs/tail", get(devboxes::logs_tail))
+        .route("/v1/devboxes/{id}/usage", get(devboxes::usage))
+        .route(
+            "/v1/devboxes/{id}/snapshot_disk",
+            post(snapshots::snapshot_disk),
+        )
+        .route(
+            "/v1/devboxes/disk_snapshots",
+            get(snapshots::list_disk_snapshots),
+        )
+        .route(
+            "/v1/devboxes/disk_snapshots/{id}/status",
+            get(snapshots::disk_snapshot_status),
+        )
+        .route(
+            "/v1/devboxes/disk_snapshots/{id}/delete",
+            post(snapshots::delete_disk_snapshot),
+        )
+        .fallback(unsupported_local)
+        .with_state(state)
+        .layer(axum::middleware::from_fn(optional_auth))
+}
+
+/// Return a visible local unsupported response for unmatched RunLoop API routes.
+pub async fn unsupported_local(method: Method, uri: Uri) -> ApiError {
+    ApiError::unsupported_locally(format!(
+        "{method} {} is not implemented by the local Microsandbox API POC",
+        uri.path()
+    ))
+    .with_details(json!({
+        "method": method.as_str(),
+        "path": uri.path(),
+    }))
+}

--- a/crates/api/lib/routes/snapshots.rs
+++ b/crates/api/lib/routes/snapshots.rs
@@ -1,0 +1,116 @@
+//! Snapshot routes.
+
+use std::collections::HashMap;
+
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use chrono::DateTime;
+use microsandbox::{MicrosandboxError, Sandbox, Snapshot, SnapshotHandle};
+
+use crate::{
+    dto::{DiskSnapshotListView, DiskSnapshotStatusView, DiskSnapshotView, EmptyRecord},
+    error::ApiError,
+    ids::new_execution_id,
+    state::ApiState,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Create a disk snapshot.
+pub async fn snapshot_disk(
+    State(_state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<DiskSnapshotView>, ApiError> {
+    let snapshot_name = format!("snap_{}", new_execution_id().trim_start_matches("exec_"));
+    let snapshot = Sandbox::get(&id)
+        .await
+        .map_err(|_| ApiError::not_found(format!("Devbox '{id}' was not found.")))?
+        .snapshot(&snapshot_name)
+        .await
+        .map_err(snapshot_error)?;
+    Ok(Json(snapshot_view_from_snapshot(
+        &snapshot,
+        Some(snapshot_name),
+        id,
+    )?))
+}
+
+/// List disk snapshots.
+pub async fn list_disk_snapshots() -> Result<Json<DiskSnapshotListView>, ApiError> {
+    let snapshots = Snapshot::list().await.map_err(snapshot_error)?;
+    let total_count = snapshots.len();
+    let snapshots = snapshots
+        .into_iter()
+        .map(|snapshot| snapshot_view_from_handle(&snapshot, ""))
+        .collect();
+    Ok(Json(DiskSnapshotListView {
+        snapshots,
+        has_more: false,
+        total_count: Some(total_count as i32),
+    }))
+}
+
+/// Get disk snapshot status.
+pub async fn disk_snapshot_status(
+    Path(id): Path<String>,
+) -> Result<Json<DiskSnapshotStatusView>, ApiError> {
+    let snapshot = Snapshot::get(&id).await.map_err(snapshot_error)?;
+    Ok(Json(DiskSnapshotStatusView {
+        status: "complete".into(),
+        snapshot: snapshot_view_from_handle(&snapshot, ""),
+    }))
+}
+
+/// Delete a disk snapshot.
+pub async fn delete_disk_snapshot(Path(id): Path<String>) -> Result<Json<EmptyRecord>, ApiError> {
+    Snapshot::remove(&id, false).await.map_err(snapshot_error)?;
+    Ok(Json(EmptyRecord {}))
+}
+
+fn snapshot_view_from_snapshot(
+    snapshot: &Snapshot,
+    name: Option<String>,
+    source_devbox_id: String,
+) -> Result<DiskSnapshotView, ApiError> {
+    Ok(DiskSnapshotView {
+        id: snapshot.digest().to_string(),
+        name,
+        metadata: HashMap::new(),
+        source_devbox_id,
+        create_time_ms: snapshot_create_time_ms(snapshot)?,
+        size_bytes: Some(snapshot.size_bytes()),
+    })
+}
+
+fn snapshot_view_from_handle(
+    snapshot: &SnapshotHandle,
+    source_devbox_id: impl Into<String>,
+) -> DiskSnapshotView {
+    DiskSnapshotView {
+        id: snapshot.digest().to_string(),
+        name: snapshot.name().map(str::to_string),
+        metadata: HashMap::new(),
+        source_devbox_id: source_devbox_id.into(),
+        create_time_ms: snapshot.created_at().and_utc().timestamp_millis(),
+        size_bytes: snapshot.size_bytes(),
+    }
+}
+
+fn snapshot_create_time_ms(snapshot: &Snapshot) -> Result<i64, ApiError> {
+    DateTime::parse_from_rfc3339(&snapshot.manifest().created_at)
+        .map(|created_at| created_at.timestamp_millis())
+        .map_err(|err| ApiError::internal(err.to_string()))
+}
+
+fn snapshot_error(err: MicrosandboxError) -> ApiError {
+    match err {
+        MicrosandboxError::SnapshotNotFound(snapshot) => {
+            ApiError::not_found(format!("Snapshot '{snapshot}' was not found."))
+        }
+        err => ApiError::internal(err.to_string()),
+    }
+}

--- a/crates/api/lib/server.rs
+++ b/crates/api/lib/server.rs
@@ -1,0 +1,91 @@
+//! HTTP server startup.
+
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::PathBuf,
+};
+
+use tokio::net::TcpListener;
+
+use crate::{routes, state::ApiState};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Configuration for the local API server.
+#[derive(Debug, Clone)]
+pub struct ServeConfig {
+    /// Address to bind.
+    pub addr: SocketAddr,
+
+    /// Whether non-loopback bind addresses are allowed.
+    pub allow_non_loopback: bool,
+
+    /// API execution database path.
+    pub api_db_path: PathBuf,
+}
+
+/// Handle returned by the server startup path.
+#[derive(Debug)]
+pub struct ServeHandle {
+    /// Address the server is listening on.
+    pub addr: SocketAddr,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for ServeConfig {
+    fn default() -> Self {
+        Self {
+            addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080),
+            allow_non_loopback: false,
+            api_db_path: default_api_db_path(),
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Start the local API server.
+pub async fn serve(config: ServeConfig) -> anyhow::Result<ServeHandle> {
+    validate_bind_addr(&config)?;
+    let listener = TcpListener::bind(config.addr).await?;
+    let addr = listener.local_addr()?;
+    let state = ApiState::new(config.api_db_path.clone()).await?;
+
+    tokio::spawn(async move {
+        let app = routes::router(state);
+        if let Err(err) = axum::serve(listener, app).await {
+            tracing::error!(error = %err, "microsandbox api server exited");
+        }
+    });
+
+    Ok(ServeHandle { addr })
+}
+
+/// Test-only wrapper for bind address validation.
+pub fn validate_bind_addr_for_test(config: &ServeConfig) -> anyhow::Result<()> {
+    validate_bind_addr(config)
+}
+
+fn validate_bind_addr(config: &ServeConfig) -> anyhow::Result<()> {
+    if !config.allow_non_loopback && !config.addr.ip().is_loopback() {
+        anyhow::bail!(
+            "refusing to bind non-loopback address {}; pass --allow-non-loopback to opt in",
+            config.addr
+        );
+    }
+    Ok(())
+}
+
+fn default_api_db_path() -> PathBuf {
+    dirs::data_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("microsandbox")
+        .join("api.sqlite")
+}

--- a/crates/api/lib/state.rs
+++ b/crates/api/lib/state.rs
@@ -1,0 +1,134 @@
+//! Shared API server state.
+
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+use crate::store::ExecutionStore;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Shared API state.
+#[derive(Clone)]
+pub struct ApiState {
+    /// Execution store.
+    pub store: ExecutionStore,
+
+    /// Live execution controls.
+    pub live: Arc<RwLock<LiveExecutionRegistry>>,
+}
+
+/// Process-local live execution registry.
+#[derive(Default)]
+pub struct LiveExecutionRegistry {
+    controls: HashMap<(String, String), microsandbox::ExecControl>,
+    stdins: HashMap<(String, String), Arc<microsandbox::sandbox::exec::ExecSink>>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ApiState {
+    /// Create API state.
+    pub async fn new(api_db_path: PathBuf) -> anyhow::Result<Self> {
+        let store = ExecutionStore::open(api_db_path).await?;
+        store.reconcile_incomplete_on_startup().await?;
+        Ok(Self {
+            store,
+            live: Arc::new(RwLock::new(LiveExecutionRegistry::default())),
+        })
+    }
+
+    /// Create test state with a temporary database.
+    pub async fn for_test() -> anyhow::Result<Self> {
+        Self::new(temp_db_path()).await
+    }
+}
+
+impl LiveExecutionRegistry {
+    /// Insert a live execution control handle.
+    pub fn insert_control(
+        &mut self,
+        devbox_id: String,
+        execution_id: String,
+        control: microsandbox::ExecControl,
+    ) {
+        self.controls.insert((devbox_id, execution_id), control);
+    }
+
+    /// Insert a live stdin sink.
+    pub fn insert_stdin(
+        &mut self,
+        devbox_id: String,
+        execution_id: String,
+        stdin: microsandbox::sandbox::exec::ExecSink,
+    ) {
+        self.stdins
+            .insert((devbox_id, execution_id), Arc::new(stdin));
+    }
+
+    /// Return a cloneable live execution control handle.
+    pub fn control(
+        &self,
+        devbox_id: &str,
+        execution_id: &str,
+    ) -> Option<microsandbox::ExecControl> {
+        self.controls
+            .get(&(devbox_id.to_string(), execution_id.to_string()))
+            .cloned()
+    }
+
+    /// Return a live stdin sink.
+    pub fn stdin(
+        &self,
+        devbox_id: &str,
+        execution_id: &str,
+    ) -> Option<Arc<microsandbox::sandbox::exec::ExecSink>> {
+        self.stdins
+            .get(&(devbox_id.to_string(), execution_id.to_string()))
+            .cloned()
+    }
+
+    /// Remove live execution handles.
+    pub fn remove(&mut self, devbox_id: &str, execution_id: &str) {
+        let key = (devbox_id.to_string(), execution_id.to_string());
+        self.controls.remove(&key);
+        self.stdins.remove(&key);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for ApiState {
+    fn default() -> Self {
+        build_default_state()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn temp_db_path() -> PathBuf {
+    std::env::temp_dir().join(format!("microsandbox-api-{}.sqlite", Uuid::new_v4()))
+}
+
+fn build_default_state() -> ApiState {
+    let path = temp_db_path();
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("create API state runtime");
+        runtime.block_on(ApiState::new(path))
+    })
+    .join()
+    .expect("join API state initialization thread")
+    .expect("create default API state")
+}

--- a/crates/api/lib/store.rs
+++ b/crates/api/lib/store.rs
@@ -1,0 +1,439 @@
+//! Persistent API-owned execution store.
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use sqlx::{
+    Row, SqlitePool,
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
+const RESTART_ERROR: &str = "API server restarted before execution completion; Microsandbox does \
+    not persist live exec sessions.";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Persistent execution store.
+#[derive(Debug, Clone)]
+pub struct ExecutionStore {
+    pool: SqlitePool,
+}
+
+/// New execution insert data.
+#[derive(Debug, Clone)]
+pub struct ExecutionInsert {
+    /// Devbox ID.
+    pub devbox_id: String,
+
+    /// Execution ID.
+    pub execution_id: String,
+
+    /// Command.
+    pub command: String,
+
+    /// Whether stdin is attached.
+    pub stdin_attached: bool,
+}
+
+/// Stored execution row.
+#[derive(Debug, Clone)]
+pub struct StoredExecution {
+    /// Devbox ID.
+    pub devbox_id: String,
+
+    /// Execution ID.
+    pub execution_id: String,
+
+    /// Command.
+    pub command: String,
+
+    /// Status.
+    pub status: ExecutionStatus,
+
+    /// Whether stdin is attached.
+    pub stdin_attached: bool,
+
+    /// Exit code.
+    pub exit_code: Option<i32>,
+
+    /// Captured stdout.
+    pub stdout: String,
+
+    /// Captured stderr.
+    pub stderr: String,
+
+    /// Whether stdout was truncated.
+    pub stdout_truncated: bool,
+
+    /// Whether stderr was truncated.
+    pub stderr_truncated: bool,
+
+    /// Error message.
+    pub error: Option<String>,
+
+    /// Created timestamp.
+    pub created_at: DateTime<Utc>,
+
+    /// Updated timestamp.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Execution status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionStatus {
+    /// Execution is queued.
+    Queued,
+
+    /// Execution is running.
+    Running,
+
+    /// Execution completed successfully or with an exit code.
+    Completed,
+
+    /// Execution failed before completion.
+    Failed,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ExecutionStore {
+    /// Open and migrate the store at `path`.
+    pub async fn open(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let path = path.as_ref();
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        let options = SqliteConnectOptions::new()
+            .filename(path)
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await?;
+        let store = Self { pool };
+        store.migrate().await?;
+        Ok(store)
+    }
+
+    /// Insert a queued execution.
+    pub async fn insert(&self, insert: ExecutionInsert) -> anyhow::Result<()> {
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            r#"
+            INSERT INTO api_executions (
+                devbox_id,
+                execution_id,
+                command,
+                status,
+                stdin_attached,
+                stdout,
+                stderr,
+                stdout_truncated,
+                stderr_truncated,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'queued', ?, '', '', 0, 0, ?, ?)
+            "#,
+        )
+        .bind(insert.devbox_id)
+        .bind(insert.execution_id)
+        .bind(insert.command)
+        .bind(insert.stdin_attached)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Mark an execution running.
+    pub async fn mark_running(&self, devbox_id: &str, execution_id: &str) -> anyhow::Result<()> {
+        self.update_status(
+            devbox_id,
+            execution_id,
+            ExecutionStatus::Running,
+            None,
+            None,
+        )
+        .await
+    }
+
+    /// Mark an execution completed with an exit code.
+    pub async fn mark_completed(
+        &self,
+        devbox_id: &str,
+        execution_id: &str,
+        exit_code: i32,
+    ) -> anyhow::Result<()> {
+        self.update_status(
+            devbox_id,
+            execution_id,
+            ExecutionStatus::Completed,
+            Some(exit_code),
+            None,
+        )
+        .await
+    }
+
+    /// Mark an execution failed with an error message.
+    pub async fn mark_failed(
+        &self,
+        devbox_id: &str,
+        execution_id: &str,
+        error: &str,
+    ) -> anyhow::Result<()> {
+        self.update_status(
+            devbox_id,
+            execution_id,
+            ExecutionStatus::Failed,
+            None,
+            Some(error),
+        )
+        .await
+    }
+
+    /// Append captured stdout and stderr, retaining the newest 1 MiB per stream.
+    pub async fn append_output(
+        &self,
+        devbox_id: &str,
+        execution_id: &str,
+        stdout: &[u8],
+        stderr: &[u8],
+    ) -> anyhow::Result<()> {
+        let Some(row) = self.get(devbox_id, execution_id).await? else {
+            anyhow::bail!("execution {execution_id} for devbox {devbox_id} not found");
+        };
+        let (stdout, stdout_truncated) = append_capped(&row.stdout, stdout);
+        let (stderr, stderr_truncated) = append_capped(&row.stderr, stderr);
+        let result = sqlx::query(
+            r#"
+            UPDATE api_executions
+            SET stdout = ?,
+                stderr = ?,
+                stdout_truncated = ?,
+                stderr_truncated = ?,
+                updated_at = ?
+            WHERE devbox_id = ? AND execution_id = ?
+            "#,
+        )
+        .bind(stdout)
+        .bind(stderr)
+        .bind(row.stdout_truncated || stdout_truncated)
+        .bind(row.stderr_truncated || stderr_truncated)
+        .bind(Utc::now().to_rfc3339())
+        .bind(devbox_id)
+        .bind(execution_id)
+        .execute(&self.pool)
+        .await?;
+
+        ensure_updated(result.rows_affected(), devbox_id, execution_id)
+    }
+
+    /// Get a stored execution.
+    pub async fn get(
+        &self,
+        devbox_id: &str,
+        execution_id: &str,
+    ) -> anyhow::Result<Option<StoredExecution>> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                devbox_id,
+                execution_id,
+                command,
+                status,
+                stdin_attached,
+                exit_code,
+                stdout,
+                stderr,
+                stdout_truncated,
+                stderr_truncated,
+                error,
+                created_at,
+                updated_at
+            FROM api_executions
+            WHERE devbox_id = ? AND execution_id = ?
+            "#,
+        )
+        .bind(devbox_id)
+        .bind(execution_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(row_to_execution).transpose()
+    }
+
+    /// Mark queued or running executions as failed after an API restart.
+    pub async fn reconcile_incomplete_on_startup(&self) -> anyhow::Result<u64> {
+        let result = sqlx::query(
+            r#"
+            UPDATE api_executions
+            SET status = 'failed',
+                exit_code = NULL,
+                error = ?,
+                updated_at = ?
+            WHERE status IN ('queued', 'running')
+            "#,
+        )
+        .bind(RESTART_ERROR)
+        .bind(Utc::now().to_rfc3339())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+
+    async fn migrate(&self) -> anyhow::Result<()> {
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS api_executions (
+                devbox_id TEXT NOT NULL,
+                execution_id TEXT NOT NULL,
+                command TEXT NOT NULL,
+                status TEXT NOT NULL,
+                stdin_attached INTEGER NOT NULL,
+                exit_code INTEGER,
+                stdout TEXT NOT NULL,
+                stderr TEXT NOT NULL,
+                stdout_truncated INTEGER NOT NULL,
+                stderr_truncated INTEGER NOT NULL,
+                error TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (devbox_id, execution_id)
+            )
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn update_status(
+        &self,
+        devbox_id: &str,
+        execution_id: &str,
+        status: ExecutionStatus,
+        exit_code: Option<i32>,
+        error: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let result = sqlx::query(
+            r#"
+            UPDATE api_executions
+            SET status = ?,
+                exit_code = ?,
+                error = ?,
+                updated_at = ?
+            WHERE devbox_id = ? AND execution_id = ?
+            "#,
+        )
+        .bind(status.as_str())
+        .bind(exit_code)
+        .bind(error)
+        .bind(Utc::now().to_rfc3339())
+        .bind(devbox_id)
+        .bind(execution_id)
+        .execute(&self.pool)
+        .await?;
+
+        ensure_updated(result.rows_affected(), devbox_id, execution_id)
+    }
+}
+
+impl ExecutionStatus {
+    /// Return the lowercase SQLite/API representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn append_capped(existing: &str, addition: &[u8]) -> (String, bool) {
+    if addition.is_empty() {
+        return (existing.to_owned(), false);
+    }
+
+    let addition = String::from_utf8_lossy(addition);
+    let mut output = String::with_capacity(existing.len() + addition.len());
+    output.push_str(existing);
+    output.push_str(&addition);
+
+    cap_newest_utf8(output)
+}
+
+fn cap_newest_utf8(output: String) -> (String, bool) {
+    if output.len() <= MAX_OUTPUT_BYTES {
+        return (output, false);
+    }
+
+    let mut start = output.len() - MAX_OUTPUT_BYTES;
+    while !output.is_char_boundary(start) {
+        start += 1;
+    }
+
+    (output[start..].to_owned(), true)
+}
+
+fn ensure_updated(rows_affected: u64, devbox_id: &str, execution_id: &str) -> anyhow::Result<()> {
+    if rows_affected == 0 {
+        anyhow::bail!("execution {execution_id} for devbox {devbox_id} not found");
+    }
+
+    Ok(())
+}
+
+fn row_to_execution(row: sqlx::sqlite::SqliteRow) -> anyhow::Result<StoredExecution> {
+    let status: String = row.try_get("status")?;
+    let created_at: String = row.try_get("created_at")?;
+    let updated_at: String = row.try_get("updated_at")?;
+
+    Ok(StoredExecution {
+        devbox_id: row.try_get("devbox_id")?,
+        execution_id: row.try_get("execution_id")?,
+        command: row.try_get("command")?,
+        status: parse_status(&status)?,
+        stdin_attached: row.try_get("stdin_attached")?,
+        exit_code: row.try_get("exit_code")?,
+        stdout: row.try_get("stdout")?,
+        stderr: row.try_get("stderr")?,
+        stdout_truncated: row.try_get("stdout_truncated")?,
+        stderr_truncated: row.try_get("stderr_truncated")?,
+        error: row.try_get("error")?,
+        created_at: DateTime::parse_from_rfc3339(&created_at)?.with_timezone(&Utc),
+        updated_at: DateTime::parse_from_rfc3339(&updated_at)?.with_timezone(&Utc),
+    })
+}
+
+fn parse_status(status: &str) -> anyhow::Result<ExecutionStatus> {
+    match status {
+        "queued" => Ok(ExecutionStatus::Queued),
+        "running" => Ok(ExecutionStatus::Running),
+        "completed" => Ok(ExecutionStatus::Completed),
+        "failed" => Ok(ExecutionStatus::Failed),
+        other => anyhow::bail!("unknown execution status {other}"),
+    }
+}

--- a/crates/api/tests/contract.rs
+++ b/crates/api/tests/contract.rs
@@ -1,0 +1,54 @@
+use std::collections::HashMap;
+
+use microsandbox_api::dto::{DevboxListView, DevboxView, ExecutionView};
+use serde_json::json;
+
+#[test]
+fn devbox_view_matches_runloop_shape() {
+    let value = serde_json::to_value(DevboxView {
+        id: "dbx_123".into(),
+        name: Some("worker".into()),
+        status: "running".into(),
+        metadata: HashMap::new(),
+    })
+    .unwrap();
+
+    assert_eq!(value["id"], "dbx_123");
+    assert_eq!(value["name"], "worker");
+    assert_eq!(value["status"], "running");
+    assert!(value["metadata"].is_object());
+}
+
+#[test]
+fn devbox_list_view_matches_runloop_shape() {
+    let value = serde_json::to_value(DevboxListView {
+        devboxes: vec![],
+        has_more: false,
+        total_count: Some(0),
+    })
+    .unwrap();
+
+    assert_eq!(
+        value,
+        json!({ "devboxes": [], "has_more": false, "total_count": 0 })
+    );
+}
+
+#[test]
+fn execution_view_matches_runloop_core_shape() {
+    let value = serde_json::to_value(ExecutionView {
+        id: "exec_123".into(),
+        devbox_id: "dbx_123".into(),
+        status: "completed".into(),
+        exit_code: Some(0),
+        stdout: "ok\n".into(),
+        stderr: String::new(),
+        error: None,
+    })
+    .unwrap();
+
+    assert_eq!(value["id"], "exec_123");
+    assert_eq!(value["devbox_id"], "dbx_123");
+    assert_eq!(value["status"], "completed");
+    assert_eq!(value["exit_code"], 0);
+}

--- a/crates/api/tests/devboxes.rs
+++ b/crates/api/tests/devboxes.rs
@@ -1,0 +1,51 @@
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use microsandbox_api::{routes, state::ApiState};
+use serde_json::json;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn create_rejects_blueprint_id() {
+    let app = routes::router(ApiState::default());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/devboxes")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "blueprint_id": "bp_1" }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value["error"]["code"], "unsupported_field");
+}
+
+#[tokio::test]
+async fn create_rejects_blueprint_name() {
+    let app = routes::router(ApiState::default());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/devboxes")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "blueprint_name": "python" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value["error"]["code"], "unsupported_field");
+}

--- a/crates/api/tests/executions.rs
+++ b/crates/api/tests/executions.rs
@@ -1,0 +1,144 @@
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use microsandbox_api::{
+    dto::ExecutionView,
+    routes,
+    state::ApiState,
+    store::{ExecutionInsert, ExecutionStatus},
+};
+use serde_json::json;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn execute_rejects_shell_name() {
+    let app = routes::router(ApiState::for_test().await.unwrap());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/devboxes/dbx_1/execute")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "command": "pwd", "shell_name": "main" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn execute_async_rejects_shell_name() {
+    let app = routes::router(ApiState::for_test().await.unwrap());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/devboxes/dbx_1/execute_async")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "command": "pwd", "shell_name": "main" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn execute_missing_devbox_does_not_persist_execution() {
+    let state = ApiState::for_test().await.unwrap();
+    let app = routes::router(state.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/devboxes/dbx_missing/execute")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "command_id": "exec_missing", "command": "pwd" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let row = state
+        .store
+        .get("dbx_missing", "exec_missing")
+        .await
+        .unwrap();
+    assert!(row.is_none());
+}
+
+#[tokio::test]
+async fn get_execution_returns_persisted_row() {
+    let state = ApiState::for_test().await.unwrap();
+    state
+        .store
+        .insert(ExecutionInsert {
+            devbox_id: "dbx_1".into(),
+            execution_id: "exec_1".into(),
+            command: "echo hello".into(),
+            stdin_attached: false,
+        })
+        .await
+        .unwrap();
+    state.store.mark_running("dbx_1", "exec_1").await.unwrap();
+    state
+        .store
+        .append_output("dbx_1", "exec_1", b"hello\n", b"")
+        .await
+        .unwrap();
+    state
+        .store
+        .mark_completed("dbx_1", "exec_1", 0)
+        .await
+        .unwrap();
+
+    let app = routes::router(state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/devboxes/dbx_1/executions/exec_1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: ExecutionView = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value.id, "exec_1");
+    assert_eq!(value.devbox_id, "dbx_1");
+    assert_eq!(value.status, ExecutionStatus::Completed.as_str());
+    assert_eq!(value.exit_code, Some(0));
+    assert_eq!(value.stdout, "hello\n");
+    assert_eq!(value.stderr, "");
+}
+
+#[tokio::test]
+async fn wait_for_status_rejects_empty_statuses_without_vm() {
+    let app = routes::router(ApiState::for_test().await.unwrap());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/devboxes/dbx_1/executions/exec_1/wait_for_status")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "statuses": [] }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/crates/api/tests/foundations.rs
+++ b/crates/api/tests/foundations.rs
@@ -1,0 +1,145 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode, header::AUTHORIZATION},
+};
+use microsandbox_api::{
+    auth::optional_auth,
+    dto::{
+        DevboxCreateRequest, DevboxListView, DevboxView, EmptyRecord, ExecuteAsyncRequest,
+        ExecuteRequest, ExecutionView, SendStdinRequest, WaitForExecutionStatusRequest,
+    },
+    error::{ApiError, ErrorResponse},
+    ids::{new_devbox_id, new_execution_id},
+    server::{ServeConfig, validate_bind_addr_for_test},
+};
+use tower::ServiceExt;
+
+#[test]
+fn generated_ids_are_prefixed_and_short() {
+    let devbox_id = new_devbox_id();
+    let execution_id = new_execution_id();
+
+    assert!(devbox_id.starts_with("dbx_"));
+    assert!(devbox_id.len() <= 128);
+    assert!(execution_id.starts_with("exec_"));
+    assert!(execution_id.len() <= 128);
+}
+
+#[test]
+fn non_loopback_bind_requires_opt_in() {
+    let config = ServeConfig {
+        addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 8080),
+        allow_non_loopback: false,
+        ..ServeConfig::default()
+    };
+
+    assert!(validate_bind_addr_for_test(&config).is_err());
+}
+
+#[test]
+fn api_error_serializes_expected_shape() {
+    let response = ErrorResponse::from(ApiError::not_found("Devbox 'dbx_1' was not found."));
+    let value = serde_json::to_value(response).unwrap();
+
+    assert_eq!(value["error"]["code"], "not_found");
+    assert_eq!(value["error"]["message"], "Devbox 'dbx_1' was not found.");
+}
+
+#[tokio::test]
+async fn optional_auth_allows_missing_bearer_token() {
+    let app = axum::Router::new()
+        .route("/ok", axum::routing::get(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(optional_auth));
+
+    let response = app
+        .oneshot(Request::builder().uri("/ok").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn optional_auth_allows_arbitrary_bearer_token() {
+    let app = axum::Router::new()
+        .route("/ok", axum::routing::get(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(optional_auth));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/ok")
+                .header(AUTHORIZATION, "Bearer arbitrary")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[test]
+fn dtos_serialize_and_deserialize_expected_shapes() {
+    let _: DevboxCreateRequest = serde_json::from_value(serde_json::json!({
+        "name": "local",
+        "image": "ubuntu:latest",
+        "blueprint_id": null,
+        "blueprint_name": null,
+        "metadata": { "owner": "test" },
+        "environment_variables": { "RUST_LOG": "debug" }
+    }))
+    .unwrap();
+    let _: ExecuteRequest = serde_json::from_value(serde_json::json!({
+        "command_id": "cmd_1",
+        "command": "echo ok",
+        "shell_name": null,
+        "optimistic_timeout": 1
+    }))
+    .unwrap();
+    let _: ExecuteAsyncRequest = serde_json::from_value(serde_json::json!({
+        "command": "sleep 1",
+        "shell_name": null,
+        "attach_stdin": true
+    }))
+    .unwrap();
+    let _: SendStdinRequest = serde_json::from_value(serde_json::json!({
+        "content": "input\n"
+    }))
+    .unwrap();
+    let _: WaitForExecutionStatusRequest = serde_json::from_value(serde_json::json!({
+        "statuses": ["completed"],
+        "timeout_seconds": 25
+    }))
+    .unwrap();
+
+    let value = serde_json::to_value(DevboxListView {
+        devboxes: vec![DevboxView {
+            id: "dbx_test".into(),
+            name: Some("local".into()),
+            status: "running".into(),
+            metadata: [("owner".into(), "test".into())].into(),
+        }],
+        has_more: false,
+        total_count: Some(1),
+    })
+    .unwrap();
+    assert_eq!(value["devboxes"][0]["id"], "dbx_test");
+
+    let execution = serde_json::to_value(ExecutionView {
+        id: "exec_test".into(),
+        devbox_id: "dbx_test".into(),
+        status: "completed".into(),
+        exit_code: Some(0),
+        stdout: "ok\n".into(),
+        stderr: String::new(),
+        error: None,
+    })
+    .unwrap();
+    assert_eq!(execution["id"], "exec_test");
+
+    let empty = serde_json::to_value(EmptyRecord {}).unwrap();
+    assert_eq!(empty, serde_json::json!({}));
+}

--- a/crates/api/tests/route_shapes.rs
+++ b/crates/api/tests/route_shapes.rs
@@ -1,0 +1,137 @@
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use microsandbox_api::{routes, state::ApiState};
+use serde_json::json;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn unsupported_api_routes_return_not_implemented() {
+    let app = routes::router(ApiState::for_test().await.unwrap());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/devboxes/dbx_missing/pty_sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value["error"]["code"], "unsupported_locally");
+}
+
+#[tokio::test]
+async fn wait_for_status_rejects_empty_statuses_without_vm() {
+    let app = routes::router(ApiState::for_test().await.unwrap());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/devboxes/dbx_missing/wait_for_status")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "statuses": [] }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value["error"]["code"], "invalid_request");
+}
+
+#[tokio::test]
+async fn write_file_contents_rejects_large_contents_without_vm() {
+    let app = routes::router(ApiState::for_test().await.unwrap());
+    let contents = "x".repeat(10 * 1024 * 1024 + 1);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/devboxes/dbx_missing/write_file_contents")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "file_path": "/tmp/large.txt", "contents": contents }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value["error"]["code"], "size_limit_exceeded");
+}
+
+#[tokio::test]
+async fn upload_file_requires_path_without_vm() {
+    let app = routes::router(ApiState::for_test().await.unwrap());
+    let boundary = "microsandbox-boundary";
+    let body = format!(
+        "--{boundary}\r\n\
+         Content-Disposition: form-data; name=\"file\"; filename=\"hello.txt\"\r\n\
+         Content-Type: application/octet-stream\r\n\r\n\
+         hello\r\n\
+         --{boundary}--\r\n"
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/devboxes/dbx_missing/upload_file")
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value["error"]["code"], "invalid_request");
+}
+
+#[tokio::test]
+async fn upload_file_requires_file_without_vm() {
+    let app = routes::router(ApiState::for_test().await.unwrap());
+    let boundary = "microsandbox-boundary";
+    let body = format!(
+        "--{boundary}\r\n\
+         Content-Disposition: form-data; name=\"path\"\r\n\r\n\
+         /tmp/hello.txt\r\n\
+         --{boundary}--\r\n"
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/devboxes/dbx_missing/upload_file")
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value["error"]["code"], "invalid_request");
+}

--- a/crates/api/tests/store.rs
+++ b/crates/api/tests/store.rs
@@ -1,0 +1,128 @@
+use microsandbox_api::store::{ExecutionInsert, ExecutionStatus, ExecutionStore};
+
+#[tokio::test]
+async fn execution_store_creates_parent_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("nested").join("api.sqlite");
+
+    ExecutionStore::open(&path).await.unwrap();
+
+    assert!(path.exists());
+}
+
+#[tokio::test]
+async fn execution_store_persists_and_updates_execution() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = ExecutionStore::open(dir.path().join("api.sqlite"))
+        .await
+        .unwrap();
+
+    store
+        .insert(ExecutionInsert {
+            devbox_id: "dbx_test".into(),
+            execution_id: "exec_test".into(),
+            command: "echo hello".into(),
+            stdin_attached: false,
+        })
+        .await
+        .unwrap();
+
+    store.mark_running("dbx_test", "exec_test").await.unwrap();
+    store
+        .append_output("dbx_test", "exec_test", b"hello\n", b"")
+        .await
+        .unwrap();
+    store
+        .mark_completed("dbx_test", "exec_test", 0)
+        .await
+        .unwrap();
+
+    let execution = store.get("dbx_test", "exec_test").await.unwrap().unwrap();
+
+    assert_eq!(execution.status, ExecutionStatus::Completed);
+    assert_eq!(execution.exit_code, Some(0));
+    assert_eq!(execution.stdout, "hello\n");
+}
+
+#[tokio::test]
+async fn startup_reconciliation_marks_queued_and_running_executions_failed() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = ExecutionStore::open(dir.path().join("api.sqlite"))
+        .await
+        .unwrap();
+
+    store
+        .insert(ExecutionInsert {
+            devbox_id: "dbx_test".into(),
+            execution_id: "exec_queued".into(),
+            command: "echo queued".into(),
+            stdin_attached: false,
+        })
+        .await
+        .unwrap();
+    store
+        .insert(ExecutionInsert {
+            devbox_id: "dbx_test".into(),
+            execution_id: "exec_running".into(),
+            command: "sleep 60".into(),
+            stdin_attached: false,
+        })
+        .await
+        .unwrap();
+    store
+        .mark_running("dbx_test", "exec_running")
+        .await
+        .unwrap();
+
+    let count = store.reconcile_incomplete_on_startup().await.unwrap();
+    let queued = store.get("dbx_test", "exec_queued").await.unwrap().unwrap();
+    let running = store
+        .get("dbx_test", "exec_running")
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(count, 2);
+    assert_eq!(queued.status, ExecutionStatus::Failed);
+    assert_eq!(running.status, ExecutionStatus::Failed);
+    assert!(queued.error.unwrap().contains("API server restarted"));
+    assert!(running.error.unwrap().contains("API server restarted"));
+}
+
+#[tokio::test]
+async fn execution_store_keeps_newest_output_after_cap() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = ExecutionStore::open(dir.path().join("api.sqlite"))
+        .await
+        .unwrap();
+
+    store
+        .insert(ExecutionInsert {
+            devbox_id: "dbx_test".into(),
+            execution_id: "exec_test".into(),
+            command: "yes".into(),
+            stdin_attached: false,
+        })
+        .await
+        .unwrap();
+
+    store
+        .append_output(
+            "dbx_test",
+            "exec_test",
+            vec![b'a'; 1024 * 1024].as_slice(),
+            b"",
+        )
+        .await
+        .unwrap();
+    store
+        .append_output("dbx_test", "exec_test", b"tail", b"")
+        .await
+        .unwrap();
+
+    let execution = store.get("dbx_test", "exec_test").await.unwrap().unwrap();
+
+    assert_eq!(execution.stdout.len(), 1024 * 1024);
+    assert!(execution.stdout.ends_with("tail"));
+    assert!(execution.stdout_truncated);
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -41,6 +41,7 @@ indicatif.workspace = true
 ipnetwork = { workspace = true, optional = true }
 libc.workspace = true
 microsandbox.workspace = true
+microsandbox-api = { path = "../api", default-features = false, features = ["net", "prebuilt"] }
 microsandbox-image.workspace = true
 microsandbox-network = { workspace = true, optional = true }
 microsandbox-protocol.workspace = true

--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -6,7 +6,7 @@ use clap::{CommandFactory, Parser, Subcommand};
 use microsandbox_cli::{
     commands::{
         copy, create, exec, image, inspect, install, list, logs, metrics, ps, pull, registry,
-        remove, run, self_cmd, snapshot, start, stop, uninstall, volume,
+        remove, run, self_cmd, serve, snapshot, start, stop, uninstall, volume,
     },
     log_args::{self, LogArgs},
     sandbox_cmd::{self, SandboxArgs},
@@ -117,6 +117,9 @@ enum Commands {
     /// Manage disk snapshots.
     #[command(visible_alias = "snap")]
     Snapshot(snapshot::SnapshotArgs),
+
+    /// Serve the local RunLoop-compatible API.
+    Serve(serve::ServeArgs),
 
     /// Install a sandbox as a system command.
     Install(install::InstallArgs),
@@ -335,6 +338,7 @@ fn run_async_command_anyhow(
             Commands::Inspect(args) => inspect::run(args).await,
             Commands::Volume(args) => volume::run(args).await,
             Commands::Snapshot(args) => snapshot::run(args).await,
+            Commands::Serve(args) => serve::run(args).await,
             Commands::Install(args) => install::run(args).await,
             Commands::Uninstall(args) => uninstall::run(args).await,
             Commands::Self_(args) => self_cmd::run(args).await,

--- a/crates/cli/lib/commands/mod.rs
+++ b/crates/cli/lib/commands/mod.rs
@@ -24,6 +24,7 @@ pub mod registry;
 pub mod remove;
 pub mod run;
 pub mod self_cmd;
+pub mod serve;
 pub mod snapshot;
 #[cfg(feature = "ssh")]
 pub mod ssh;

--- a/crates/cli/lib/commands/serve.rs
+++ b/crates/cli/lib/commands/serve.rs
@@ -1,0 +1,46 @@
+//! `msb serve` command - serve the local RunLoop-compatible API.
+
+use std::{net::SocketAddr, path::PathBuf};
+
+use clap::Args;
+use microsandbox_api::{ServeConfig, serve};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Serve the local RunLoop-compatible API.
+#[derive(Debug, Args)]
+pub struct ServeArgs {
+    /// Address to bind.
+    #[arg(long, default_value = "127.0.0.1:8080")]
+    pub addr: SocketAddr,
+
+    /// Allow binding to non-loopback addresses.
+    #[arg(long)]
+    pub allow_non_loopback: bool,
+
+    /// API execution database path.
+    #[arg(long)]
+    pub api_db: Option<PathBuf>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb serve` command.
+pub async fn run(args: ServeArgs) -> anyhow::Result<()> {
+    let mut config = ServeConfig {
+        addr: args.addr,
+        allow_non_loopback: args.allow_non_loopback,
+        ..ServeConfig::default()
+    };
+    if let Some(path) = args.api_db {
+        config.api_db_path = path;
+    }
+    let handle = serve(config).await?;
+    println!("microsandbox-api listening on http://{}", handle.addr);
+    tokio::signal::ctrl_c().await?;
+    Ok(())
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -178,6 +178,13 @@
             "pages": [
               "configuration"
             ]
+          },
+          {
+            "group": "Local API",
+            "icon": "plug",
+            "pages": [
+              "runloop-compatible-api"
+            ]
           }
         ]
       },

--- a/docs/runloop-compatible-api.mdx
+++ b/docs/runloop-compatible-api.mdx
@@ -1,0 +1,82 @@
+# RunLoop-Compatible Local API
+
+Microsandbox can run a local HTTP API with RunLoop-shaped Devbox endpoints.
+This POC implements endpoints backed by local Microsandbox primitives and
+documents cloud-only RunLoop endpoints as unsupported locally.
+
+## Run
+
+```bash
+microsandbox-api --addr 127.0.0.1:8080
+msb serve --addr 127.0.0.1:8080
+msb serve --api-db ~/.microsandbox/api.sqlite
+```
+
+The server binds to `127.0.0.1:8080` by default. Passing a non-loopback address
+requires `--allow-non-loopback`.
+
+Pass `--api-db PATH` to override the SQLite database used for persisted
+execution records.
+
+Authentication is permissive in this POC. Do not expose the server outside a
+trusted local environment until token enforcement is implemented.
+
+## Create From A Public Image
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/devboxes \
+  -H 'Content-Type: application/json' \
+  -d '{"image":"python:3.12","metadata":{"project":"demo"}}'
+```
+
+Public Docker Hub and GHCR image references are supported when Microsandbox can
+pull them.
+
+## Execute
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/devboxes/dbx_example/execute \
+  -H 'Content-Type: application/json' \
+  -d '{"command_id":"exec_example","command":"python --version","optimistic_timeout":25}'
+```
+
+Execution records are persisted in the API database. Live execution control is
+not recoverable after API server restart because Microsandbox does not persist
+exec sessions.
+
+## Implemented Endpoints
+
+- `POST /v1/devboxes`
+- `GET /v1/devboxes`
+- `GET /v1/devboxes/{id}`
+- `POST /v1/devboxes/{id}/shutdown`
+- `POST /v1/devboxes/{id}/wait_for_status`
+- `POST /v1/devboxes/{id}/keep_alive`
+- `POST /v1/devboxes/{id}/execute`
+- `POST /v1/devboxes/{id}/execute_async`
+- `POST /v1/devboxes/{id}/execute_sync`
+- `GET /v1/devboxes/{devbox_id}/executions/{execution_id}`
+- `POST /v1/devboxes/{devbox_id}/executions/{execution_id}/kill`
+- `POST /v1/devboxes/{devbox_id}/executions/{execution_id}/send_std_in`
+- `POST /v1/devboxes/{devbox_id}/executions/{execution_id}/wait_for_status`
+- `POST /v1/devboxes/{id}/read_file_contents`
+- `POST /v1/devboxes/{id}/write_file_contents`
+- `POST /v1/devboxes/{id}/download_file`
+- `POST /v1/devboxes/{id}/upload_file`
+- `GET /v1/devboxes/{id}/logs`
+- `GET /v1/devboxes/{id}/logs/tail`
+- `GET /v1/devboxes/{id}/usage`
+- `POST /v1/devboxes/{id}/snapshot_disk`
+- `GET /v1/devboxes/disk_snapshots`
+- `GET /v1/devboxes/disk_snapshots/{id}/status`
+- `POST /v1/devboxes/disk_snapshots/{id}/delete`
+
+## Unsupported Locally
+
+Unsupported endpoint groups: PTY and tunnels, accounts and API keys, agents,
+axons, benchmarks, scenarios, hosted blueprints, snapshot metadata and async
+snapshot jobs, cloud suspend/resume/SSH-key features, gateway configs, MCP
+configs, network policy resources, objects, and secrets.
+
+Unmatched RunLoop-shaped API routes return `501 Not Implemented` with error code
+`unsupported_locally`.


### PR DESCRIPTION
## TL;DR
Adds a local RunLoop-compatible HTTP API POC for Microsandbox and exposes it through `microsandbox-api` and `msb serve`.

## Description
- Adds `crates/api` with RunLoop-shaped Devbox, execution, file, log, usage, and disk snapshot endpoints.
- Persists execution records in SQLite and reconciles live executions as failed after API restart.
- Supports public image refs for devbox create and documents unsupported local endpoint groups.
- Adds `msb serve` with loopback default binding, explicit non-loopback opt-in, and configurable `--api-db`.
- Returns structured `501 unsupported_locally` for unmatched RunLoop-shaped routes.

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test -p microsandbox-api`
- `cargo build -p microsandbox-cli`
- `target/debug/msb serve --help`
- `cargo clippy -p microsandbox-api --no-deps -- -D warnings`
- `cargo clippy -p microsandbox-cli -- -D warnings`

## Notes
- `cargo clippy -p microsandbox-api -- -D warnings` without `--no-deps` currently fails on an existing `needless_return` warning in `crates/microsandbox/lib/config/mod.rs`, outside this branch.