### PR TITLE
chore(release): bump microsandbox to 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-go"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "base64",
  "cbindgen",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "chrono",
  "libc",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics-collector"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "base64",
  "bytes",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "bytes",
  "chrono",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "chrono",
  "futures",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "bytes",
  "chrono",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "dirs",
  "libc",
@@ -6430,14 +6430,14 @@ dependencies = [
 
 [[package]]
 name = "test-init"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "test-macros"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6446,7 +6446,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.5.4"
+version = "0.5.5"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -58,16 +58,16 @@ panic = "abort"
 # manifest; members reference them via `{ workspace = true }`.
 # `default-features = false` on crates whose consumers opt into features
 # explicitly (see each member manifest); other consumers re-enable defaults.
-microsandbox = { version = "0.5.4", path = "crates/microsandbox", default-features = false }
-microsandbox-db = { version = "0.5.4", path = "crates/db" }
-microsandbox-filesystem = { version = "0.5.4", path = "crates/filesystem", default-features = false }
-microsandbox-image = { version = "0.5.4", path = "crates/image" }
-microsandbox-metrics = { version = "0.5.4", path = "crates/metrics" }
-microsandbox-migration = { version = "0.5.4", path = "crates/migration" }
-microsandbox-network = { version = "0.5.4", path = "crates/network" }
-microsandbox-protocol = { version = "0.5.4", path = "crates/protocol" }
-microsandbox-runtime = { version = "0.5.4", path = "crates/runtime", default-features = false }
-microsandbox-utils = { version = "0.5.4", path = "crates/utils" }
+microsandbox = { version = "0.5.5", path = "crates/microsandbox", default-features = false }
+microsandbox-db = { version = "0.5.5", path = "crates/db" }
+microsandbox-filesystem = { version = "0.5.5", path = "crates/filesystem", default-features = false }
+microsandbox-image = { version = "0.5.5", path = "crates/image" }
+microsandbox-metrics = { version = "0.5.5", path = "crates/metrics" }
+microsandbox-migration = { version = "0.5.5", path = "crates/migration" }
+microsandbox-network = { version = "0.5.5", path = "crates/network" }
+microsandbox-protocol = { version = "0.5.5", path = "crates/protocol" }
+microsandbox-runtime = { version = "0.5.5", path = "crates/runtime", default-features = false }
+microsandbox-utils = { version = "0.5.5", path = "crates/utils" }
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }
 

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/init-handoff/package.json
+++ b/examples/typescript/init-handoff/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/snapshot-fork/package.json
+++ b/examples/typescript/snapshot-fork/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.5"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/sdk/go/setup.go
+++ b/sdk/go/setup.go
@@ -24,7 +24,7 @@ import (
 // embedded FFI library and the downloaded msb+libkrunfw artefacts are
 // both pinned to this version. Bump when cutting a new SDK release so
 // it matches published binaries.
-const sdkVersion = "0.5.4"
+const sdkVersion = "0.5.5"
 
 // libkrunfwABI is the major SONAME version of libkrunfw that msb links
 // against.

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.5.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -22,9 +22,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.5.4",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.4",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.4"
+        "@superradcompany/microsandbox-darwin-arm64": "0.5.5",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.5",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.5"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1849,52 +1849,13 @@
       "license": "MIT"
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.5.4.tgz",
-      "integrity": "sha512-K2R6aTVfUfOpMKP5kTLVm5y09R6QtaPMS8T/hyPQKZup0tGUdykx6UYweVjudARyfngwg9p1wO0A8yBcmKWIsA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.5.4.tgz",
-      "integrity": "sha512-PLjbxnmBDz9Em9mzJ0B4h7AGJ/lxzqaqfSRrWMwr1hGNNGmrrIYUnzxDjHYqCQobfEMKp5fJ6DLnb4MiMx8Z0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.5.4.tgz",
-      "integrity": "sha512-Qr4CzTTKHrbkAiD6SePm1d7qBxFTdTcK5/FtwzOH1UAS6YbHHNbIZN8B7UNHkLG4+kkY1oT1zeuT2dgCanUn+w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -48,9 +48,9 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.5.4",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.4",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.5.4"
+    "@superradcompany/microsandbox-darwin-arm64": "0.5.5",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.5",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.5.5"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## TL;DR
Bump the microsandbox release train to 0.5.5 across the Rust workspace, SDK package metadata, TypeScript examples, and release submodule pointers.

## Description
- Update the parent Rust workspace version and internal microsandbox crate dependency pins to 0.5.5
- Refresh Cargo.lock entries for workspace crates that follow the release train
- Update the Node SDK package, platform package manifests, native loader version checks, and package lock metadata to 0.5.5
- Update the Go SDK runtime download version to 0.5.5
- Update TypeScript example package pins to use microsandbox 0.5.5
- Advance the mcp submodule to its 0.5.5 release refs commit
- Advance the skills submodule to its 0.5.5 Rust SDK reference commit
- Leave the optional Node platform package lockfile entries as unpublished stubs until the 0.5.5 packages are published

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `npm run build` in `mcp`
- [x] `npm install --package-lock-only --ignore-scripts` in `sdk/node-ts`
- [x] `npm run build:ts` in `sdk/node-ts`
- [x] `go test -count=1 .` in `sdk/go`
- [x] `npm publish --dry-run` in `sdk/node-ts`