### PR TITLE
fix(runtime): exclude sandboxes with running execs from idle reclamation

### DIFF
--- a/crates/runtime/lib/heartbeat.rs
+++ b/crates/runtime/lib/heartbeat.rs
@@ -49,13 +49,21 @@ impl HeartbeatReader {
 
     /// Check whether the sandbox is idle based on the heartbeat.
     ///
-    /// Returns `true` if `last_activity` is older than `timeout_secs`.
-    /// Returns `false` if the heartbeat file doesn't exist (agent still booting).
+    /// Returns `true` if no exec is in flight and `last_activity` is older than
+    /// `timeout_secs`. Returns `false` if the heartbeat file doesn't exist
+    /// (agent still booting).
     pub fn is_idle(&self, timeout_secs: u64) -> bool {
         let heartbeat = match self.read() {
             Some(hb) => hb,
             None => return false,
         };
+
+        // `last_activity` only advances on host→guest messages, so a long exec
+        // that takes no input (a build, a `sleep`) ages past the timeout below
+        // while still running — the timer alone would reclaim it mid-exec.
+        if heartbeat.active_sessions > 0 {
+            return false;
+        }
 
         let elapsed = Utc::now()
             .signed_duration_since(heartbeat.last_activity)
@@ -118,5 +126,31 @@ mod tests {
         assert!(!heartbeat_path.exists());
         assert!(!tmp_path.exists());
         assert!(!reader.is_idle(60));
+    }
+
+    #[test]
+    fn in_flight_exec_is_never_idle_despite_stale_last_activity() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(HEARTBEAT_FILE);
+        let stale = Utc::now() - Duration::seconds(120);
+        let reader = HeartbeatReader::new(dir.path());
+
+        let write = |active_sessions| {
+            let hb = Heartbeat {
+                timestamp: Utc::now(),
+                active_sessions,
+                last_activity: stale,
+            };
+            std::fs::write(&path, serde_json::to_vec(&hb).unwrap()).unwrap();
+        };
+
+        // An exec is running; `last_activity` is 120s stale because the host
+        // sent the guest nothing, but the sandbox is busy and must not be idle.
+        write(1);
+        assert!(!reader.is_idle(60));
+
+        // Negative control: same staleness with no exec in flight IS idle.
+        write(0);
+        assert!(reader.is_idle(60));
     }
 }


### PR DESCRIPTION
## What

Honor the heartbeat's in-flight exec count in the idle check: a sandbox with `active_sessions > 0` is never idle. One file (`crates/runtime/lib/heartbeat.rs`), +36/-2, plus a unit test.

## Why

The idle-timeout monitor decided idle solely from the heartbeat's `last_activity`, which agentd advances only when the host sends a message to the guest. A long-running exec that takes no host input — a build, a `sleep`, any batch command — sends nothing after its initial request, so `last_activity` ages past the timeout and the sandbox is reclaimed while the command is still running. The heartbeat already reports `active_sessions`, but `is_idle` ignored it.

## How

- `HeartbeatReader::is_idle` returns `false` when `active_sessions > 0`, before the `last_activity` timeout check.
- The post-exec window is unaffected: `last_activity` is refreshed when the exec's client disconnects (a host→guest message), so the idle timer resumes from the exec's end.

## Notes

- Test: `cargo test -p microsandbox-runtime heartbeat` → `in_flight_exec_is_never_idle_despite_stale_last_activity` asserts a 120s-stale `last_activity` with `active_sessions = 1` is not idle, and (negative control) the same staleness with `active_sessions = 0` is idle. Removing the guard fails the test.