### PR TITLE
fix(runtime): harden heartbeat idle detection

### DIFF
--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -8,7 +8,7 @@ use std::{env, ptr};
 
 use chrono::Utc;
 use tokio::io::unix::AsyncFd;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio::time::{self, Duration};
 
 use microsandbox_protocol::HANDOFF_POWEROFF_TIMEOUT;
@@ -22,6 +22,7 @@ use microsandbox_protocol::exec::{
     ExecStderr, ExecStdin, ExecStdinError, ExecStdout,
 };
 use microsandbox_protocol::fs::{FsData, FsRequest};
+use microsandbox_protocol::heartbeat::{ActivityCounters, Heartbeat};
 use microsandbox_protocol::message::{Message, MessageType};
 use microsandbox_protocol::tcp::{TcpClose, TcpConnect, TcpData, TcpEof, TcpFailed};
 
@@ -29,7 +30,9 @@ use crate::config::AgentdConfig;
 use crate::error::{AgentdError, AgentdResult};
 use crate::fs::{FsReadSession, FsState, FsStreamSession, FsWriteSession};
 use crate::serial::AGENT_PORT_NAME;
-use crate::session::{ExecSession, SessionOutput, resolve_default_user};
+use crate::session::{
+    ExecSession, RawActivity, RawSessionCompletion, SessionOutput, resolve_default_user,
+};
 use crate::tcp::TcpSession;
 use crate::{clock, fs, heartbeat, serial};
 
@@ -63,6 +66,60 @@ struct AgentState {
     read_sessions: HashMap<u32, FsReadSession>,
     tcp_sessions: HashMap<u32, TcpSession>,
     fs: FsState,
+}
+
+struct ActivityTracker {
+    activity_seq: u64,
+    counters: ActivityCounters,
+}
+
+#[derive(Clone)]
+struct HeartbeatSnapshot {
+    activity_seq: u64,
+    active_exec_sessions: u32,
+    active_fs_streams: u32,
+    active_tcp_streams: u32,
+    counters: ActivityCounters,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ActivityTracker {
+    fn new() -> Self {
+        Self {
+            activity_seq: 0,
+            counters: ActivityCounters::default(),
+        }
+    }
+
+    fn record_host_message(&mut self) {
+        self.touch();
+        self.counters.host_messages = self.counters.host_messages.saturating_add(1);
+    }
+
+    fn record_guest_message(&mut self) {
+        self.touch();
+        self.counters.guest_messages = self.counters.guest_messages.saturating_add(1);
+    }
+
+    fn add_exec_output_bytes(&mut self, len: usize) {
+        self.counters.exec_output_bytes =
+            self.counters.exec_output_bytes.saturating_add(len as u64);
+    }
+
+    fn add_fs_bytes(&mut self, len: usize) {
+        self.counters.fs_bytes = self.counters.fs_bytes.saturating_add(len as u64);
+    }
+
+    fn add_tcp_bytes(&mut self, len: usize) {
+        self.counters.tcp_bytes = self.counters.tcp_bytes.saturating_add(len as u64);
+    }
+
+    fn touch(&mut self) {
+        self.activity_seq = self.activity_seq.saturating_add(1);
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -100,9 +157,10 @@ pub async fn run(
     // Channel for session output events.
     let (session_tx, mut session_rx) = mpsc::unbounded_channel::<(u32, SessionOutput)>();
 
-    // Heartbeat state.
-    let mut last_activity = Utc::now();
-    let mut heartbeat_timer = time::interval(Duration::from_secs(HEARTBEAT_INTERVAL_SECS));
+    // Heartbeat/activity state.
+    let mut activity = ActivityTracker::new();
+    let (heartbeat_tx, heartbeat_rx) = watch::channel(heartbeat_snapshot(&state, &activity));
+    let heartbeat_task = tokio::spawn(heartbeat_writer_task(heartbeat_rx));
 
     // Send core.ready with boot timing data.
     let ready_time_ns = clock::boottime_ns();
@@ -163,11 +221,8 @@ pub async fn run(
                                     }
                                 };
 
-                                if message_refreshes_idle_timer(&msg.t) {
-                                    last_activity = Utc::now();
-                                }
-
                                 if msg.flags != msg.t.flags() {
+                                    let out_before = serial_out_buf.len();
                                     encode_core_error_if_supported(
                                         &msg,
                                         msg.id,
@@ -181,16 +236,35 @@ pub async fn run(
                                         Some(msg.t.as_str().to_string()),
                                         &mut serial_out_buf,
                                     )?;
+                                    record_encoded_guest_messages(
+                                        &serial_out_buf,
+                                        out_before,
+                                        &mut activity,
+                                    );
+                                    publish_heartbeat_snapshot(&heartbeat_tx, &state, &activity);
                                     continue;
                                 }
 
+                                if message_refreshes_idle_timer(&msg.t) {
+                                    activity.record_host_message();
+                                    publish_heartbeat_snapshot(&heartbeat_tx, &state, &activity);
+                                }
+
+                                let out_before = serial_out_buf.len();
                                 handle_message(
                                     msg,
                                     &mut state,
+                                    &mut activity,
                                     &session_tx,
                                     &mut serial_out_buf,
                                     config,
                                 ).await?;
+                                record_encoded_guest_messages(
+                                    &serial_out_buf,
+                                    out_before,
+                                    &mut activity,
+                                );
+                                publish_heartbeat_snapshot(&heartbeat_tx, &state, &activity);
                             }
 
                             // Flush any outgoing messages.
@@ -209,16 +283,22 @@ pub async fn run(
             Some((id, output)) = session_rx.recv() => {
                 match output {
                     SessionOutput::Stdout(data) => {
+                        let len = data.len();
                         let msg = Message::with_payload(MessageType::ExecStdout, id, &ExecStdout { data })
                             .map_err(|e| AgentdError::ExecSession(format!("encode stdout: {e}")))?;
                         codec::encode_to_buf(&msg, &mut serial_out_buf)
                             .map_err(|e| AgentdError::ExecSession(format!("encode stdout frame: {e}")))?;
+                        activity.record_guest_message();
+                        activity.add_exec_output_bytes(len);
                     }
                     SessionOutput::Stderr(data) => {
+                        let len = data.len();
                         let msg = Message::with_payload(MessageType::ExecStderr, id, &ExecStderr { data })
                             .map_err(|e| AgentdError::ExecSession(format!("encode stderr: {e}")))?;
                         codec::encode_to_buf(&msg, &mut serial_out_buf)
                             .map_err(|e| AgentdError::ExecSession(format!("encode stderr frame: {e}")))?;
+                        activity.record_guest_message();
+                        activity.add_exec_output_bytes(len);
                     }
                     SessionOutput::Exited(code) => {
                         let msg = Message::with_payload(MessageType::ExecExited, id, &ExecExited { code })
@@ -226,34 +306,30 @@ pub async fn run(
                         codec::encode_to_buf(&msg, &mut serial_out_buf)
                             .map_err(|e| AgentdError::ExecSession(format!("encode exited frame: {e}")))?;
                         state.sessions.remove(&id);
+                        activity.record_guest_message();
                     }
-                    SessionOutput::Raw(frame_bytes) => {
-                        remove_completed_raw_sessions(
-                            &frame_bytes,
+                    SessionOutput::Raw(output) => {
+                        apply_raw_activity(output.activity, &mut activity);
+                        complete_raw_session(
+                            id,
+                            output.completion,
                             &mut state.read_sessions,
                             &mut state.tcp_sessions,
                         );
                         // Pre-encoded frame — write directly to output buffer.
-                        serial_out_buf.extend_from_slice(&frame_bytes);
+                        serial_out_buf.extend_from_slice(&output.frame);
                     }
                 }
+                publish_heartbeat_snapshot(&heartbeat_tx, &state, &activity);
 
                 if !serial_out_buf.is_empty() {
                     flush_write_buf(&async_port, &mut serial_out_buf).await?;
                 }
             }
-
-            // Heartbeat tick.
-            _ = heartbeat_timer.tick() => {
-                if heartbeat::heartbeat_dir_exists() {
-                    let _ = heartbeat::write_heartbeat(
-                        state.sessions.len() as u32,
-                        last_activity,
-                    ).await;
-                }
-            }
         }
     }
+
+    heartbeat_task.abort();
 
     Ok(())
 }
@@ -299,6 +375,7 @@ pub fn report_init_context(port_file: &File, default_user: Option<&str>) -> Agen
 async fn handle_message(
     msg: Message,
     state: &mut AgentState,
+    activity: &mut ActivityTracker,
     session_tx: &mpsc::UnboundedSender<(u32, SessionOutput)>,
     out_buf: &mut Vec<u8>,
     config: &AgentdConfig,
@@ -417,13 +494,16 @@ async fn handle_message(
             let Some(data) = decode_payload_or_core_error::<FsData>(&msg, out_buf)? else {
                 return Ok(());
             };
+            let len = data.data.len();
             if let Some(session) = state.write_sessions.get_mut(&msg.id) {
                 match fs::handle_fs_data(msg.id, data, session, out_buf).await {
                     Ok(true) => {
                         // Session complete — remove it.
                         state.write_sessions.remove(&msg.id);
                     }
-                    Ok(false) => {}
+                    Ok(false) => {
+                        activity.add_fs_bytes(len);
+                    }
                     Err(e) => {
                         eprintln!("fs data error for {}: {e}", msg.id);
                         state.write_sessions.remove(&msg.id);
@@ -457,10 +537,13 @@ async fn handle_message(
             let Some(data) = decode_payload_or_core_error::<TcpData>(&msg, out_buf)? else {
                 return Ok(());
             };
+            let len = data.data.len();
             if let Some(session) = state.tcp_sessions.get(&msg.id) {
                 if let Err(e) = session.write_data(data.data).await {
                     state.tcp_sessions.remove(&msg.id);
                     encode_tcp_failed(msg.id, e, out_buf)?;
+                } else {
+                    activity.add_tcp_bytes(len);
                 }
             } else {
                 encode_tcp_failed(msg.id, format!("unknown TCP session: {}", msg.id), out_buf)?;
@@ -562,31 +645,105 @@ fn message_refreshes_idle_timer(t: &MessageType) -> bool {
     !matches!(t, MessageType::ClockSync)
 }
 
-fn remove_completed_raw_sessions(
-    frame_bytes: &[u8],
+async fn heartbeat_writer_task(snapshot_rx: watch::Receiver<HeartbeatSnapshot>) {
+    let mut heartbeat_seq = 0u64;
+    let mut last_activity_seq = snapshot_rx.borrow().activity_seq;
+    let mut last_activity = Utc::now();
+    let mut heartbeat_timer = time::interval(Duration::from_secs(HEARTBEAT_INTERVAL_SECS));
+
+    loop {
+        heartbeat_timer.tick().await;
+        if !heartbeat::heartbeat_dir_exists() {
+            continue;
+        }
+
+        heartbeat_seq = heartbeat_seq.saturating_add(1);
+        let snapshot = snapshot_rx.borrow().clone();
+        let timestamp = Utc::now();
+        if snapshot.activity_seq != last_activity_seq {
+            last_activity_seq = snapshot.activity_seq;
+            last_activity = timestamp;
+        }
+        let heartbeat = Heartbeat {
+            heartbeat_seq,
+            activity_seq: snapshot.activity_seq,
+            timestamp,
+            last_activity,
+            active_exec_sessions: snapshot.active_exec_sessions,
+            active_fs_streams: snapshot.active_fs_streams,
+            active_tcp_streams: snapshot.active_tcp_streams,
+            activity_counters: snapshot.counters,
+        };
+        let _ = heartbeat::write_heartbeat(&heartbeat).await;
+    }
+}
+
+fn heartbeat_snapshot(state: &AgentState, activity: &ActivityTracker) -> HeartbeatSnapshot {
+    HeartbeatSnapshot {
+        activity_seq: activity.activity_seq,
+        active_exec_sessions: state.sessions.len() as u32,
+        active_fs_streams: state
+            .read_sessions
+            .len()
+            .saturating_add(state.write_sessions.len()) as u32,
+        active_tcp_streams: state.tcp_sessions.len() as u32,
+        counters: activity.counters,
+    }
+}
+
+fn publish_heartbeat_snapshot(
+    heartbeat_tx: &watch::Sender<HeartbeatSnapshot>,
+    state: &AgentState,
+    activity: &ActivityTracker,
+) {
+    let _ = heartbeat_tx.send(heartbeat_snapshot(state, activity));
+}
+
+fn record_encoded_guest_messages(out_buf: &[u8], start: usize, activity: &mut ActivityTracker) {
+    let mut offset = start;
+    while offset + 4 <= out_buf.len() {
+        let frame_len = u32::from_be_bytes([
+            out_buf[offset],
+            out_buf[offset + 1],
+            out_buf[offset + 2],
+            out_buf[offset + 3],
+        ]) as usize;
+        let total = 4usize.saturating_add(frame_len);
+        if offset.saturating_add(total) > out_buf.len() {
+            break;
+        }
+
+        activity.record_guest_message();
+        offset += total;
+    }
+}
+
+fn apply_raw_activity(raw: RawActivity, activity: &mut ActivityTracker) {
+    if raw.guest_message {
+        activity.record_guest_message();
+    }
+    if raw.fs_bytes > 0 {
+        activity.add_fs_bytes(raw.fs_bytes);
+    }
+    if raw.tcp_bytes > 0 {
+        activity.add_tcp_bytes(raw.tcp_bytes);
+    }
+}
+
+fn complete_raw_session(
+    id: u32,
+    completion: Option<RawSessionCompletion>,
     read_sessions: &mut HashMap<u32, FsReadSession>,
     tcp_sessions: &mut HashMap<u32, TcpSession>,
 ) {
-    if frame_bytes
-        .get(4 + std::mem::size_of::<u32>())
-        .is_none_or(|flags| flags & microsandbox_protocol::message::FLAG_TERMINAL == 0)
-    {
-        return;
-    };
-
-    let mut buf = frame_bytes.to_vec();
-    let Ok(Some(msg)) = codec::try_decode_from_buf(&mut buf) else {
-        return;
-    };
-
-    match msg.t {
-        MessageType::FsResponse => {
-            read_sessions.remove(&msg.id);
+    match completion {
+        Some(RawSessionCompletion::FsRead) => {
+            read_sessions.remove(&id);
         }
-        MessageType::TcpClosed | MessageType::TcpFailed => {
-            tcp_sessions.remove(&msg.id);
+        Some(RawSessionCompletion::Tcp) => {
+            tcp_sessions.remove(&id);
         }
-        _ => {}
+        None => {}
     }
 }
 
@@ -944,4 +1101,45 @@ fn remount_root_readonly() -> AgentdResult<()> {
     }
 
     Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_encoded_guest_messages_counts_only_appended_frames() {
+        let mut out_buf = Vec::new();
+        let existing =
+            Message::with_payload(MessageType::ExecStarted, 1, &ExecStarted { pid: 123 }).unwrap();
+        codec::encode_to_buf(&existing, &mut out_buf).unwrap();
+        let start = out_buf.len();
+
+        let appended =
+            Message::with_payload(MessageType::ExecStarted, 2, &ExecStarted { pid: 456 }).unwrap();
+        codec::encode_to_buf(&appended, &mut out_buf).unwrap();
+
+        let mut activity = ActivityTracker::new();
+        record_encoded_guest_messages(&out_buf, start, &mut activity);
+
+        assert_eq!(activity.activity_seq, 1);
+        assert_eq!(activity.counters.guest_messages, 1);
+    }
+
+    #[test]
+    fn apply_raw_activity_updates_guest_and_byte_counters() {
+        let mut activity = ActivityTracker::new();
+
+        apply_raw_activity(RawActivity::fs_bytes(42), &mut activity);
+        apply_raw_activity(RawActivity::tcp_bytes(7), &mut activity);
+
+        assert_eq!(activity.activity_seq, 2);
+        assert_eq!(activity.counters.guest_messages, 2);
+        assert_eq!(activity.counters.fs_bytes, 42);
+        assert_eq!(activity.counters.tcp_bytes, 7);
+    }
 }

--- a/crates/agentd/lib/fs.rs
+++ b/crates/agentd/lib/fs.rs
@@ -22,7 +22,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinHandle;
 
-use crate::session::SessionOutput;
+use crate::session::{RawActivity, RawSessionCompletion, RawSessionOutput, SessionOutput};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -795,7 +795,8 @@ async fn handle_read_stream(
                     );
                     return;
                 }
-                if tx.send((id, SessionOutput::Raw(buf.clone()))).is_err() {
+                let output = RawSessionOutput::new(buf.clone(), RawActivity::fs_bytes(n), None);
+                if tx.send((id, SessionOutput::Raw(output))).is_err() {
                     return;
                 }
             }
@@ -990,7 +991,12 @@ fn send_raw_response(
             let mut buf = Vec::new();
             match codec::encode_to_buf(&msg, &mut buf) {
                 Ok(()) => {
-                    let _ = tx.send((id, SessionOutput::Raw(buf)));
+                    let output = RawSessionOutput::new(
+                        buf,
+                        RawActivity::guest_message(),
+                        Some(RawSessionCompletion::FsRead),
+                    );
+                    let _ = tx.send((id, SessionOutput::Raw(output)));
                 }
                 Err(e) => {
                     eprintln!("failed to encode fs response frame for {id}: {e}");

--- a/crates/agentd/lib/heartbeat.rs
+++ b/crates/agentd/lib/heartbeat.rs
@@ -2,8 +2,6 @@
 
 use std::path::Path;
 
-use chrono::{DateTime, Utc};
-
 use microsandbox_protocol::heartbeat::Heartbeat;
 
 use crate::error::AgentdResult;
@@ -23,19 +21,10 @@ const HEARTBEAT_TMP_PATH: &str = "/.msb/heartbeat.tmp";
 //--------------------------------------------------------------------------------------------------
 
 /// Atomically writes the heartbeat JSON to `/.msb/heartbeat.json`.
-pub async fn write_heartbeat(
-    active_sessions: u32,
-    last_activity: DateTime<Utc>,
-) -> AgentdResult<()> {
-    let heartbeat = Heartbeat {
-        timestamp: Utc::now(),
-        active_sessions,
-        last_activity,
-    };
+pub async fn write_heartbeat(heartbeat: &Heartbeat) -> AgentdResult<()> {
+    let json = serde_json::to_vec(&heartbeat)?;
 
-    let json = serde_json::to_string_pretty(&heartbeat)?;
-
-    tokio::fs::write(HEARTBEAT_TMP_PATH, json.as_bytes()).await?;
+    tokio::fs::write(HEARTBEAT_TMP_PATH, json).await?;
     tokio::fs::rename(HEARTBEAT_TMP_PATH, HEARTBEAT_PATH).await?;
 
     Ok(())

--- a/crates/agentd/lib/session.rs
+++ b/crates/agentd/lib/session.rs
@@ -141,10 +141,42 @@ pub enum SessionOutput {
     Exited(i32),
 
     /// Pre-encoded frame bytes to write directly to the serial output buffer.
-    ///
-    /// Used by filesystem streaming operations that encode their own
-    /// `FsData`/`FsResponse` messages.
-    Raw(Vec<u8>),
+    Raw(RawSessionOutput),
+}
+
+/// Pre-encoded session output plus the accounting metadata known by its producer.
+pub struct RawSessionOutput {
+    /// Encoded protocol frame bytes.
+    pub frame: Vec<u8>,
+
+    /// Activity represented by the frame.
+    pub activity: RawActivity,
+
+    /// Session table entry completed by the frame, if any.
+    pub completion: Option<RawSessionCompletion>,
+}
+
+/// Activity represented by a pre-encoded session frame.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RawActivity {
+    /// Whether this frame is a meaningful guest-to-host protocol message.
+    pub guest_message: bool,
+
+    /// Filesystem bytes moved by this frame.
+    pub fs_bytes: usize,
+
+    /// TCP bytes moved by this frame.
+    pub tcp_bytes: usize,
+}
+
+/// Session table entry completed by a pre-encoded session frame.
+#[derive(Debug, Clone, Copy)]
+pub enum RawSessionCompletion {
+    /// A filesystem read stream completed.
+    FsRead,
+
+    /// A TCP stream completed.
+    Tcp,
 }
 
 struct ResolvedUser {
@@ -188,6 +220,49 @@ struct CapUserData {
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
+
+impl RawSessionOutput {
+    /// Creates pre-encoded output with activity metadata.
+    pub fn new(
+        frame: Vec<u8>,
+        activity: RawActivity,
+        completion: Option<RawSessionCompletion>,
+    ) -> Self {
+        Self {
+            frame,
+            activity,
+            completion,
+        }
+    }
+}
+
+impl RawActivity {
+    /// A guest-to-host frame with no byte counter.
+    pub fn guest_message() -> Self {
+        Self {
+            guest_message: true,
+            ..Self::default()
+        }
+    }
+
+    /// A guest-to-host filesystem data frame.
+    pub fn fs_bytes(len: usize) -> Self {
+        Self {
+            guest_message: true,
+            fs_bytes: len,
+            tcp_bytes: 0,
+        }
+    }
+
+    /// A guest-to-host TCP data frame.
+    pub fn tcp_bytes(len: usize) -> Self {
+        Self {
+            guest_message: true,
+            fs_bytes: 0,
+            tcp_bytes: len,
+        }
+    }
+}
 
 impl ExecSession {
     /// Spawns a new exec session.

--- a/crates/agentd/lib/tcp.rs
+++ b/crates/agentd/lib/tcp.rs
@@ -14,7 +14,7 @@ use microsandbox_protocol::codec;
 use microsandbox_protocol::message::{Message, MessageType};
 use microsandbox_protocol::tcp::{TcpClosed, TcpConnect, TcpConnected, TcpData, TcpEof, TcpFailed};
 
-use crate::session::SessionOutput;
+use crate::session::{RawActivity, RawSessionCompletion, RawSessionOutput, SessionOutput};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -150,6 +150,8 @@ async fn connect_and_relay(
                 &TcpFailed {
                     error: format!("connect {}:{}: {e}", req.host, req.port),
                 },
+                RawActivity::guest_message(),
+                Some(RawSessionCompletion::Tcp),
                 &tx,
             );
             return;
@@ -161,13 +163,22 @@ async fn connect_and_relay(
                 &TcpFailed {
                     error: format!("connect {}:{} timed out", req.host, req.port),
                 },
+                RawActivity::guest_message(),
+                Some(RawSessionCompletion::Tcp),
                 &tx,
             );
             return;
         }
     };
 
-    if !send_raw_tcp_message(id, MessageType::TcpConnected, &TcpConnected {}, &tx) {
+    if !send_raw_tcp_message(
+        id,
+        MessageType::TcpConnected,
+        &TcpConnected {},
+        RawActivity::guest_message(),
+        None,
+        &tx,
+    ) {
         return;
     }
 
@@ -191,16 +202,24 @@ async fn relay_tcp_session(
             read = stream.read(&mut read_buf), if !read_eof => {
                 match read {
                     Ok(0) => {
-                        send_raw_tcp_message(id, MessageType::TcpEof, &TcpEof {}, &tx);
+                        send_raw_tcp_message(
+                            id,
+                            MessageType::TcpEof,
+                            &TcpEof {},
+                            RawActivity::guest_message(),
+                            None,
+                            &tx,
+                        );
                         read_eof = true;
                     }
                     Ok(n) => {
+                        let data = read_buf[..n].to_vec();
                         if !send_raw_tcp_message(
                             id,
                             MessageType::TcpData,
-                            &TcpData {
-                                data: read_buf[..n].to_vec(),
-                            },
+                            &TcpData { data },
+                            RawActivity::tcp_bytes(n),
+                            None,
                             &tx,
                         ) {
                             break;
@@ -213,6 +232,8 @@ async fn relay_tcp_session(
                             &TcpFailed {
                                 error: format!("read TCP stream: {e}"),
                             },
+                            RawActivity::guest_message(),
+                            Some(RawSessionCompletion::Tcp),
                             &tx,
                         );
                         break;
@@ -229,6 +250,8 @@ async fn relay_tcp_session(
                                 &TcpFailed {
                                     error: format!("write TCP stream: {e}"),
                                 },
+                                RawActivity::guest_message(),
+                                Some(RawSessionCompletion::Tcp),
                                 &tx,
                             );
                             break;
@@ -242,6 +265,8 @@ async fn relay_tcp_session(
                                 &TcpFailed {
                                     error: format!("shutdown TCP stream: {e}"),
                                 },
+                                RawActivity::guest_message(),
+                                Some(RawSessionCompletion::Tcp),
                                 &tx,
                             );
                             break;
@@ -256,7 +281,14 @@ async fn relay_tcp_session(
     }
 
     if !terminal_sent {
-        send_raw_tcp_message(id, MessageType::TcpClosed, &TcpClosed {}, &tx);
+        send_raw_tcp_message(
+            id,
+            MessageType::TcpClosed,
+            &TcpClosed {},
+            RawActivity::guest_message(),
+            Some(RawSessionCompletion::Tcp),
+            &tx,
+        );
     }
 }
 
@@ -275,11 +307,18 @@ fn send_raw_tcp_message<T: serde::Serialize>(
     id: u32,
     t: MessageType,
     payload: &T,
+    activity: RawActivity,
+    completion: Option<RawSessionCompletion>,
     tx: &mpsc::UnboundedSender<(u32, SessionOutput)>,
 ) -> bool {
     let mut buf = Vec::new();
     match encode_tcp_message(id, t, payload, &mut buf) {
-        Ok(()) => tx.send((id, SessionOutput::Raw(buf))).is_ok(),
+        Ok(()) => tx
+            .send((
+                id,
+                SessionOutput::Raw(RawSessionOutput::new(buf, activity, completion)),
+            ))
+            .is_ok(),
         Err(e) => {
             eprintln!("failed to encode tcp message for {id}: {e}");
             false
@@ -419,9 +458,9 @@ mod tests {
 
     async fn recv_message(rx: &mut mpsc::UnboundedReceiver<(u32, SessionOutput)>) -> Message {
         let (_id, output) = rx.recv().await.unwrap();
-        let SessionOutput::Raw(mut bytes) = output else {
+        let SessionOutput::Raw(mut output) = output else {
             panic!("expected SessionOutput::Raw frame");
         };
-        decode_one_message(&mut bytes)
+        decode_one_message(&mut output.frame)
     }
 }

--- a/crates/db/lib/entity/run.rs
+++ b/crates/db/lib/entity/run.rs
@@ -39,6 +39,14 @@ pub enum TerminationReason {
     #[sea_orm(string_value = "IdleTimeout")]
     IdleTimeout,
 
+    /// agentd stopped reporting fresh heartbeat data.
+    #[sea_orm(string_value = "AgentUnresponsive")]
+    AgentUnresponsive,
+
+    /// User or client requested shutdown explicitly.
+    #[sea_orm(string_value = "ShutdownRequested")]
+    ShutdownRequested,
+
     /// SIGUSR1 received (explicit drain request).
     #[sea_orm(string_value = "DrainRequested")]
     DrainRequested,
@@ -104,6 +112,8 @@ impl std::fmt::Display for TerminationReason {
             Self::Failed => f.write_str("Failed"),
             Self::MaxDurationExceeded => f.write_str("MaxDurationExceeded"),
             Self::IdleTimeout => f.write_str("IdleTimeout"),
+            Self::AgentUnresponsive => f.write_str("AgentUnresponsive"),
+            Self::ShutdownRequested => f.write_str("ShutdownRequested"),
             Self::DrainRequested => f.write_str("DrainRequested"),
             Self::Signal => f.write_str("Signal"),
             Self::InternalError => f.write_str("InternalError"),

--- a/crates/protocol/lib/heartbeat.rs
+++ b/crates/protocol/lib/heartbeat.rs
@@ -10,12 +10,46 @@ use serde::{Deserialize, Serialize};
 /// Heartbeat data written to `/.msb/heartbeat.json` inside the guest.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Heartbeat {
+    /// Monotonic sequence incremented for every heartbeat write.
+    pub heartbeat_seq: u64,
+
+    /// Monotonic sequence incremented for every meaningful activity event.
+    pub activity_seq: u64,
+
     /// Timestamp of this heartbeat.
     pub timestamp: DateTime<Utc>,
 
-    /// Number of currently active exec sessions.
-    pub active_sessions: u32,
-
-    /// Timestamp of the last message received from the host.
+    /// Timestamp of the last meaningful activity event.
     pub last_activity: DateTime<Utc>,
+
+    /// Number of currently active exec sessions.
+    pub active_exec_sessions: u32,
+
+    /// Number of currently active filesystem stream sessions.
+    pub active_fs_streams: u32,
+
+    /// Number of currently active TCP stream sessions.
+    pub active_tcp_streams: u32,
+
+    /// Cumulative activity counters.
+    pub activity_counters: ActivityCounters,
+}
+
+/// Cumulative counters for meaningful sandbox activity.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct ActivityCounters {
+    /// Meaningful host-to-guest protocol messages.
+    pub host_messages: u64,
+
+    /// Meaningful guest-to-host protocol messages.
+    pub guest_messages: u64,
+
+    /// Bytes emitted by exec stdout, stderr, or PTY output.
+    pub exec_output_bytes: u64,
+
+    /// Bytes moved by filesystem streaming.
+    pub fs_bytes: u64,
+
+    /// Bytes moved by TCP streaming.
+    pub tcp_bytes: u64,
 }

--- a/crates/runtime/lib/heartbeat.rs
+++ b/crates/runtime/lib/heartbeat.rs
@@ -5,9 +5,9 @@
 //! virtiofs mount. The sandbox process reads it to detect idle sandboxes.
 
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
-use chrono::Utc;
-use microsandbox_protocol::heartbeat::Heartbeat;
+use serde::Deserialize;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -24,6 +24,77 @@ const HEARTBEAT_TMP_FILE: &str = "heartbeat.tmp";
 pub struct HeartbeatReader {
     /// Path to the heartbeat.json file on the host.
     path: PathBuf,
+
+    /// Host time when this reader was created.
+    created_at: Instant,
+
+    /// Last heartbeat content read successfully.
+    last_heartbeat: Option<HeartbeatSnapshot>,
+
+    /// Last heartbeat sequence observed.
+    last_heartbeat_seq: Option<u64>,
+
+    /// Host time when the heartbeat sequence last advanced.
+    last_heartbeat_seen_at: Option<Instant>,
+
+    /// Last activity sequence observed.
+    last_activity_seq: Option<u64>,
+
+    /// Host time when the activity sequence last advanced.
+    last_activity_seen_at: Option<Instant>,
+
+    /// Host time when heartbeat staleness first crossed the stale budget.
+    stale_confirmed_at: Option<Instant>,
+}
+
+/// Idle decision derived from the heartbeat stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HeartbeatDecision {
+    /// No heartbeat is available yet, but startup grace has not elapsed.
+    PendingBoot(HeartbeatStatus),
+
+    /// The sandbox is not idle.
+    Active(HeartbeatStatus),
+
+    /// The sandbox is idle.
+    Idle(HeartbeatStatus),
+
+    /// agentd stopped producing fresh heartbeat data.
+    AgentUnresponsive(HeartbeatStatus),
+}
+
+/// Snapshot of host-observed heartbeat state used to make a decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeartbeatStatus {
+    /// Last heartbeat sequence observed.
+    pub heartbeat_seq: Option<u64>,
+
+    /// Last activity sequence observed.
+    pub activity_seq: Option<u64>,
+
+    /// Number of currently active exec sessions.
+    pub active_exec_sessions: u32,
+
+    /// Number of currently active filesystem stream sessions.
+    pub active_fs_streams: u32,
+
+    /// Number of currently active TCP stream sessions.
+    pub active_tcp_streams: u32,
+
+    /// Host-observed age of the latest heartbeat sequence.
+    pub heartbeat_stale_for: Option<Duration>,
+
+    /// Host-observed age of the latest activity sequence.
+    pub idle_for: Option<Duration>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+struct HeartbeatSnapshot {
+    heartbeat_seq: u64,
+    activity_seq: u64,
+    active_exec_sessions: u32,
+    active_fs_streams: u32,
+    active_tcp_streams: u32,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -33,8 +104,19 @@ pub struct HeartbeatReader {
 impl HeartbeatReader {
     /// Create a new heartbeat reader for the given runtime directory.
     pub fn new(runtime_dir: &Path) -> Self {
+        Self::new_at(runtime_dir, Instant::now())
+    }
+
+    fn new_at(runtime_dir: &Path, created_at: Instant) -> Self {
         Self {
             path: runtime_dir.join(HEARTBEAT_FILE),
+            created_at,
+            last_heartbeat: None,
+            last_heartbeat_seq: None,
+            last_heartbeat_seen_at: None,
+            last_activity_seq: None,
+            last_activity_seen_at: None,
+            stale_confirmed_at: None,
         }
     }
 
@@ -42,34 +124,100 @@ impl HeartbeatReader {
     ///
     /// Returns `None` if the file doesn't exist or can't be parsed
     /// (e.g., agentd hasn't started writing yet).
-    pub fn read(&self) -> Option<Heartbeat> {
-        let content = std::fs::read_to_string(&self.path).ok()?;
-        serde_json::from_str(&content).ok()
+    fn read(&self) -> Option<HeartbeatSnapshot> {
+        let content = std::fs::read(&self.path).ok()?;
+        serde_json::from_slice(&content).ok()
     }
 
-    /// Check whether the sandbox is idle based on the heartbeat.
-    ///
-    /// Returns `true` if no exec is in flight and `last_activity` is older than
-    /// `timeout_secs`. Returns `false` if the heartbeat file doesn't exist
-    /// (agent still booting).
-    pub fn is_idle(&self, timeout_secs: u64) -> bool {
-        let heartbeat = match self.read() {
-            Some(hb) => hb,
-            None => return false,
-        };
+    /// Check whether the sandbox is idle based on host-observed heartbeat and
+    /// activity sequence changes.
+    pub fn check(
+        &mut self,
+        idle_timeout: Option<Duration>,
+        stale_heartbeat_timeout: Duration,
+        boot_grace: Duration,
+    ) -> HeartbeatDecision {
+        self.check_at(
+            Instant::now(),
+            idle_timeout,
+            stale_heartbeat_timeout,
+            boot_grace,
+        )
+    }
 
-        // `last_activity` only advances on host→guest messages, so a long exec
-        // that takes no input (a build, a `sleep`) ages past the timeout below
-        // while still running — the timer alone would reclaim it mid-exec.
-        if heartbeat.active_sessions > 0 {
-            return false;
+    fn check_at(
+        &mut self,
+        now: Instant,
+        idle_timeout: Option<Duration>,
+        stale_heartbeat_timeout: Duration,
+        boot_grace: Duration,
+    ) -> HeartbeatDecision {
+        if let Some(heartbeat) = self.read() {
+            self.observe(heartbeat, now);
         }
 
-        let elapsed = Utc::now()
-            .signed_duration_since(heartbeat.last_activity)
-            .num_seconds();
+        let status = self.status(now);
 
-        elapsed >= 0 && elapsed as u64 >= timeout_secs
+        let Some(heartbeat_stale_for) = status.heartbeat_stale_for else {
+            if now.duration_since(self.created_at) >= boot_grace {
+                return HeartbeatDecision::AgentUnresponsive(status);
+            }
+            return HeartbeatDecision::PendingBoot(status);
+        };
+
+        if heartbeat_stale_for >= stale_heartbeat_timeout {
+            let stale_confirmed_at = *self.stale_confirmed_at.get_or_insert(now);
+            if now.duration_since(stale_confirmed_at) >= stale_heartbeat_timeout {
+                return HeartbeatDecision::AgentUnresponsive(status);
+            }
+            return HeartbeatDecision::Active(status);
+        }
+
+        self.stale_confirmed_at = None;
+
+        if status.active_exec_sessions > 0 {
+            return HeartbeatDecision::Active(status);
+        }
+
+        match (idle_timeout, status.idle_for) {
+            (Some(idle_timeout), Some(idle_for)) if idle_for >= idle_timeout => {
+                HeartbeatDecision::Idle(status)
+            }
+            _ => HeartbeatDecision::Active(status),
+        }
+    }
+
+    fn observe(&mut self, heartbeat: HeartbeatSnapshot, now: Instant) {
+        if self.last_heartbeat_seq != Some(heartbeat.heartbeat_seq) {
+            self.last_heartbeat_seq = Some(heartbeat.heartbeat_seq);
+            self.last_heartbeat_seen_at = Some(now);
+            self.stale_confirmed_at = None;
+        }
+
+        if self.last_activity_seq != Some(heartbeat.activity_seq) {
+            self.last_activity_seq = Some(heartbeat.activity_seq);
+            self.last_activity_seen_at = Some(now);
+        }
+
+        self.last_heartbeat = Some(heartbeat);
+    }
+
+    fn status(&self, now: Instant) -> HeartbeatStatus {
+        let heartbeat = self.last_heartbeat.as_ref();
+
+        HeartbeatStatus {
+            heartbeat_seq: self.last_heartbeat_seq,
+            activity_seq: self.last_activity_seq,
+            active_exec_sessions: heartbeat.map_or(0, |hb| hb.active_exec_sessions),
+            active_fs_streams: heartbeat.map_or(0, |hb| hb.active_fs_streams),
+            active_tcp_streams: heartbeat.map_or(0, |hb| hb.active_tcp_streams),
+            heartbeat_stale_for: self
+                .last_heartbeat_seen_at
+                .map(|seen_at| now.duration_since(seen_at)),
+            idle_for: self
+                .last_activity_seen_at
+                .map(|seen_at| now.duration_since(seen_at)),
+        }
     }
 }
 
@@ -98,8 +246,10 @@ fn remove_file_if_exists(path: &Path) -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use chrono::{Duration, Utc};
-    use microsandbox_protocol::heartbeat::Heartbeat;
+    use std::time::{Duration, Instant};
+
+    use chrono::Utc;
+    use microsandbox_protocol::heartbeat::{ActivityCounters, Heartbeat};
 
     use super::*;
 
@@ -108,49 +258,193 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let heartbeat_path = dir.path().join(HEARTBEAT_FILE);
         let tmp_path = dir.path().join(HEARTBEAT_TMP_FILE);
-        let stale_time = Utc::now() - Duration::seconds(120);
-        let heartbeat = Heartbeat {
-            timestamp: stale_time,
-            active_sessions: 0,
-            last_activity: stale_time,
-        };
 
-        std::fs::write(&heartbeat_path, serde_json::to_vec(&heartbeat).unwrap()).unwrap();
+        write_heartbeat_file(&heartbeat_path, heartbeat(1, 1, 0));
         std::fs::write(&tmp_path, b"stale").unwrap();
-
-        let reader = HeartbeatReader::new(dir.path());
-        assert!(reader.is_idle(60));
 
         clear_stale(dir.path()).unwrap();
 
         assert!(!heartbeat_path.exists());
         assert!(!tmp_path.exists());
-        assert!(!reader.is_idle(60));
+
+        let start = Instant::now();
+        let mut reader = HeartbeatReader::new_at(dir.path(), start);
+        assert!(matches!(
+            reader.check_at(
+                start + Duration::from_secs(1),
+                Some(Duration::from_secs(60)),
+                Duration::from_secs(5),
+                Duration::from_secs(2),
+            ),
+            HeartbeatDecision::PendingBoot(_)
+        ));
     }
 
     #[test]
-    fn in_flight_exec_is_never_idle_despite_stale_last_activity() {
+    fn running_exec_prevents_idle_despite_stale_activity_sequence() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(HEARTBEAT_FILE);
-        let stale = Utc::now() - Duration::seconds(120);
-        let reader = HeartbeatReader::new(dir.path());
+        let start = Instant::now();
+        let mut reader = HeartbeatReader::new_at(dir.path(), start);
 
-        let write = |active_sessions| {
-            let hb = Heartbeat {
-                timestamp: Utc::now(),
-                active_sessions,
-                last_activity: stale,
-            };
-            std::fs::write(&path, serde_json::to_vec(&hb).unwrap()).unwrap();
-        };
+        write_heartbeat_file(&path, heartbeat(1, 1, 1));
+        assert!(matches!(
+            reader.check_at(
+                start,
+                Some(Duration::from_secs(60)),
+                Duration::from_secs(5),
+                Duration::ZERO,
+            ),
+            HeartbeatDecision::Active(_)
+        ));
 
-        // An exec is running; `last_activity` is 120s stale because the host
-        // sent the guest nothing, but the sandbox is busy and must not be idle.
-        write(1);
-        assert!(!reader.is_idle(60));
+        write_heartbeat_file(&path, heartbeat(2, 1, 1));
+        assert!(matches!(
+            reader.check_at(
+                start + Duration::from_secs(120),
+                Some(Duration::from_secs(60)),
+                Duration::from_secs(5),
+                Duration::ZERO,
+            ),
+            HeartbeatDecision::Active(_)
+        ));
+    }
 
-        // Negative control: same staleness with no exec in flight IS idle.
-        write(0);
-        assert!(reader.is_idle(60));
+    #[test]
+    fn no_exec_is_idle_when_activity_sequence_is_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(HEARTBEAT_FILE);
+        let start = Instant::now();
+        let mut reader = HeartbeatReader::new_at(dir.path(), start);
+
+        write_heartbeat_file(&path, heartbeat(1, 1, 0));
+        assert!(matches!(
+            reader.check_at(
+                start,
+                Some(Duration::from_secs(60)),
+                Duration::from_secs(5),
+                Duration::ZERO,
+            ),
+            HeartbeatDecision::Active(_)
+        ));
+
+        write_heartbeat_file(&path, heartbeat(2, 1, 0));
+        assert!(matches!(
+            reader.check_at(
+                start + Duration::from_secs(120),
+                Some(Duration::from_secs(60)),
+                Duration::from_secs(5),
+                Duration::ZERO,
+            ),
+            HeartbeatDecision::Idle(_)
+        ));
+    }
+
+    #[test]
+    fn no_idle_timeout_keeps_fresh_inactive_sandbox_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(HEARTBEAT_FILE);
+        let start = Instant::now();
+        let mut reader = HeartbeatReader::new_at(dir.path(), start);
+
+        write_heartbeat_file(&path, heartbeat(1, 1, 0));
+        assert!(matches!(
+            reader.check_at(start, None, Duration::from_secs(5), Duration::ZERO,),
+            HeartbeatDecision::Active(_)
+        ));
+
+        write_heartbeat_file(&path, heartbeat(2, 1, 0));
+        assert!(matches!(
+            reader.check_at(
+                start + Duration::from_secs(120),
+                None,
+                Duration::from_secs(5),
+                Duration::ZERO,
+            ),
+            HeartbeatDecision::Active(_)
+        ));
+    }
+
+    #[test]
+    fn stale_heartbeat_with_running_exec_is_unresponsive_not_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(HEARTBEAT_FILE);
+        let start = Instant::now();
+        let mut reader = HeartbeatReader::new_at(dir.path(), start);
+
+        write_heartbeat_file(&path, heartbeat(1, 1, 1));
+        assert!(matches!(
+            reader.check_at(
+                start,
+                Some(Duration::from_secs(60)),
+                Duration::from_secs(5),
+                Duration::ZERO,
+            ),
+            HeartbeatDecision::Active(_)
+        ));
+
+        assert!(matches!(
+            reader.check_at(
+                start + Duration::from_secs(6),
+                Some(Duration::from_secs(60)),
+                Duration::from_secs(5),
+                Duration::ZERO,
+            ),
+            HeartbeatDecision::Active(_)
+        ));
+
+        assert!(matches!(
+            reader.check_at(
+                start + Duration::from_secs(12),
+                Some(Duration::from_secs(60)),
+                Duration::from_secs(5),
+                Duration::ZERO,
+            ),
+            HeartbeatDecision::AgentUnresponsive(_)
+        ));
+    }
+
+    #[test]
+    fn missing_heartbeat_becomes_unresponsive_after_boot_grace() {
+        let dir = tempfile::tempdir().unwrap();
+        let start = Instant::now();
+        let mut reader = HeartbeatReader::new_at(dir.path(), start);
+
+        assert!(matches!(
+            reader.check_at(
+                start + Duration::from_secs(1),
+                Some(Duration::from_secs(60)),
+                Duration::from_secs(5),
+                Duration::from_secs(2),
+            ),
+            HeartbeatDecision::PendingBoot(_)
+        ));
+
+        assert!(matches!(
+            reader.check_at(
+                start + Duration::from_secs(3),
+                Some(Duration::from_secs(60)),
+                Duration::from_secs(5),
+                Duration::from_secs(2),
+            ),
+            HeartbeatDecision::AgentUnresponsive(_)
+        ));
+    }
+
+    fn heartbeat(heartbeat_seq: u64, activity_seq: u64, active_exec_sessions: u32) -> Heartbeat {
+        Heartbeat {
+            heartbeat_seq,
+            activity_seq,
+            timestamp: Utc::now(),
+            last_activity: Utc::now(),
+            active_exec_sessions,
+            active_fs_streams: 0,
+            active_tcp_streams: 0,
+            activity_counters: ActivityCounters::default(),
+        }
+    }
+
+    fn write_heartbeat_file(path: &Path, heartbeat: Heartbeat) {
+        std::fs::write(path, serde_json::to_vec(&heartbeat).unwrap()).unwrap();
     }
 }

--- a/crates/runtime/lib/relay.rs
+++ b/crates/runtime/lib/relay.rs
@@ -518,9 +518,17 @@ fn poll_fd_readable_timeout(fd: RawFd, timeout_ms: i32) {
 
 pub(crate) fn push_guest_frame_blocking(
     shared: &ConsoleSharedState,
-    mut frame: Vec<u8>,
+    frame: Vec<u8>,
 ) -> RuntimeResult<()> {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    push_guest_frame_until(shared, frame, std::time::Duration::from_secs(60))
+}
+
+pub(crate) fn push_guest_frame_until(
+    shared: &ConsoleSharedState,
+    mut frame: Vec<u8>,
+    timeout: std::time::Duration,
+) -> RuntimeResult<()> {
+    let deadline = std::time::Instant::now() + timeout;
 
     loop {
         match shared.rx_ring.push(frame) {

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -28,7 +28,7 @@ use sea_orm::{ColumnTrait, EntityTrait, Set};
 use serde::Serialize;
 
 use crate::console::{AgentConsoleBackend, ConsoleSharedState};
-use crate::heartbeat::{self, HeartbeatReader};
+use crate::heartbeat::{self, HeartbeatDecision, HeartbeatReader};
 use crate::logging::LogLevel;
 use crate::metrics::run_metrics_sampler;
 use crate::relay::{self, AgentRelay};
@@ -44,6 +44,17 @@ const EXIT_REASON_IDLE_TIMEOUT: u8 = 1;
 const EXIT_REASON_MAX_DURATION: u8 = 2;
 const EXIT_REASON_SIGNAL: u8 = 3;
 const EXIT_REASON_PARENT_EXIT: u8 = 4;
+const EXIT_REASON_AGENT_UNRESPONSIVE: u8 = 5;
+const EXIT_REASON_SHUTDOWN_REQUESTED: u8 = 6;
+
+/// Host-observed stale heartbeat budget before agentd is considered unresponsive.
+const STALE_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Startup grace before a missing heartbeat is considered an agentd failure.
+const HEARTBEAT_BOOT_GRACE: Duration = Duration::from_secs(60);
+
+/// Short best-effort send budget once agentd is already considered unresponsive.
+const AGENT_UNRESPONSIVE_SHUTDOWN_PUSH_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Fixed fd used to pass the attached-parent watchdog pipe into `msb sandbox`.
 pub const PARENT_WATCH_FD: i32 = 97;
@@ -450,6 +461,8 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
             let reason_tag = exit_reason_for_observer.load(std::sync::atomic::Ordering::SeqCst);
             let reason = match reason_tag {
                 EXIT_REASON_IDLE_TIMEOUT => run_entity::TerminationReason::IdleTimeout,
+                EXIT_REASON_AGENT_UNRESPONSIVE => run_entity::TerminationReason::AgentUnresponsive,
+                EXIT_REASON_SHUTDOWN_REQUESTED => run_entity::TerminationReason::ShutdownRequested,
                 EXIT_REASON_MAX_DURATION => run_entity::TerminationReason::MaxDurationExceeded,
                 EXIT_REASON_PARENT_EXIT => run_entity::TerminationReason::Signal,
                 EXIT_REASON_SIGNAL => run_entity::TerminationReason::Signal,
@@ -629,8 +642,13 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     // time in microsandbox-protocol.
     {
         let shutdown_exit_handle = exit_handle.clone();
+        let shutdown_reason = Arc::clone(&exit_reason);
         tokio_rt.spawn(async move {
             if relay_drain_rx.recv().await.is_some() {
+                shutdown_reason.store(
+                    EXIT_REASON_SHUTDOWN_REQUESTED,
+                    std::sync::atomic::Ordering::SeqCst,
+                );
                 tracing::info!(
                     "core.shutdown forwarded to agentd, allowing flush window before host fallback"
                 );
@@ -641,38 +659,89 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         });
     }
 
-    // Heartbeat/idle timeout monitor.
-    if let Some(idle_secs) = config.idle_timeout_secs {
-        let heartbeat_reader = HeartbeatReader::new(&config.runtime_dir);
-        let idle_exit_handle = exit_handle.clone();
-        let idle_reason = Arc::clone(&exit_reason);
-        let idle_shared = Arc::clone(&shared);
+    // Heartbeat health monitor. Idle reclamation is optional, but missing or stale
+    // heartbeat data means the in-guest agent is not healthy.
+    {
+        let mut heartbeat_reader = HeartbeatReader::new(&config.runtime_dir);
+        let idle_timeout = config.idle_timeout_secs.map(Duration::from_secs);
+        let heartbeat_exit_handle = exit_handle.clone();
+        let heartbeat_reason = Arc::clone(&exit_reason);
+        let heartbeat_shared = Arc::clone(&shared);
         tokio_rt.spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(1));
             loop {
                 interval.tick().await;
-                if heartbeat_reader.is_idle(idle_secs) {
-                    tracing::info!("sandbox idle for {idle_secs}s, requesting guest shutdown");
-                    idle_reason.store(
-                        EXIT_REASON_IDLE_TIMEOUT,
-                        std::sync::atomic::Ordering::SeqCst,
-                    );
-                    match request_guest_shutdown(&idle_shared) {
-                        Ok(()) => {
-                            tokio::time::sleep(microsandbox_protocol::SHUTDOWN_FLUSH_TIMEOUT).await;
-                            tracing::info!(
-                                "idle shutdown flush window elapsed, triggering host exit"
-                            );
+                let decision =
+                    heartbeat_reader.check(idle_timeout, STALE_HEARTBEAT_TIMEOUT, HEARTBEAT_BOOT_GRACE);
+
+                match decision {
+                    HeartbeatDecision::Idle(status) => {
+                        let idle_secs = idle_timeout.map(|timeout| timeout.as_secs()).unwrap_or(0);
+                        tracing::info!(
+                            idle_secs,
+                            heartbeat_seq = ?status.heartbeat_seq,
+                            activity_seq = ?status.activity_seq,
+                            idle_for = ?status.idle_for,
+                            active_exec_sessions = status.active_exec_sessions,
+                            active_fs_streams = status.active_fs_streams,
+                            active_tcp_streams = status.active_tcp_streams,
+                            "sandbox idle, requesting guest shutdown"
+                        );
+                        heartbeat_reason.store(
+                            EXIT_REASON_IDLE_TIMEOUT,
+                            std::sync::atomic::Ordering::SeqCst,
+                        );
+                        match request_guest_shutdown(&heartbeat_shared) {
+                            Ok(()) => {
+                                tokio::time::sleep(microsandbox_protocol::SHUTDOWN_FLUSH_TIMEOUT).await;
+                                tracing::info!(
+                                    "idle shutdown flush window elapsed, triggering host exit"
+                                );
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    error = %err,
+                                    "idle shutdown request failed, triggering host exit"
+                                );
+                            }
                         }
-                        Err(err) => {
-                            tracing::warn!(
-                                error = %err,
-                                "idle shutdown request failed, triggering host exit"
-                            );
-                        }
+                        heartbeat_exit_handle.trigger();
+                        break;
                     }
-                    idle_exit_handle.trigger();
-                    break;
+                    HeartbeatDecision::AgentUnresponsive(status) => {
+                        tracing::warn!(
+                            heartbeat_seq = ?status.heartbeat_seq,
+                            activity_seq = ?status.activity_seq,
+                            heartbeat_stale_for = ?status.heartbeat_stale_for,
+                            active_exec_sessions = status.active_exec_sessions,
+                            active_fs_streams = status.active_fs_streams,
+                            active_tcp_streams = status.active_tcp_streams,
+                            "agent heartbeat stale, triggering host exit"
+                        );
+                        heartbeat_reason.store(
+                            EXIT_REASON_AGENT_UNRESPONSIVE,
+                            std::sync::atomic::Ordering::SeqCst,
+                        );
+                        match request_guest_shutdown_with_timeout(
+                            &heartbeat_shared,
+                            AGENT_UNRESPONSIVE_SHUTDOWN_PUSH_TIMEOUT,
+                        ) {
+                            Ok(()) => {
+                                tracing::info!(
+                                    "agent-unresponsive shutdown request sent, triggering host exit"
+                                );
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    error = %err,
+                                    "agent-unresponsive shutdown request failed, triggering host exit"
+                                );
+                            }
+                        }
+                        heartbeat_exit_handle.trigger();
+                        break;
+                    }
+                    HeartbeatDecision::PendingBoot(_) | HeartbeatDecision::Active(_) => {}
                 }
             }
         });
@@ -1140,12 +1209,19 @@ async fn mark_run_failed(db: &DbWriteConnection, run_id: i32) -> RuntimeResult<(
 
 /// Request guest poweroff through agentd without requiring a client connection.
 fn request_guest_shutdown(shared: &ConsoleSharedState) -> RuntimeResult<()> {
+    request_guest_shutdown_with_timeout(shared, Duration::from_secs(60))
+}
+
+fn request_guest_shutdown_with_timeout(
+    shared: &ConsoleSharedState,
+    timeout: Duration,
+) -> RuntimeResult<()> {
     let msg = Message::with_payload(MessageType::Shutdown, 0, &())
         .map_err(|e| RuntimeError::Custom(format!("encode idle shutdown: {e}")))?;
     let mut frame = Vec::new();
     codec::encode_to_buf(&msg, &mut frame)
         .map_err(|e| RuntimeError::Custom(format!("encode idle shutdown frame: {e}")))?;
-    relay::push_guest_frame_blocking(shared, frame)
+    relay::push_guest_frame_until(shared, frame, timeout)
 }
 
 fn spawn_parent_watchdog(
@@ -1453,12 +1529,14 @@ mod tests {
         BindIdentityMapRegistration, ConsoleSharedState, HostPermissions, PARENT_WATCH_DETACH,
         ParentWatchdogSignal, StatVirtualization, append_block_root_env,
         bind_identity_map_for_mount, parse_mount_spec, prepend_scripts_path,
-        read_parent_watchdog_signal, request_guest_shutdown, validate_disk_format,
+        read_parent_watchdog_signal, request_guest_shutdown, request_guest_shutdown_with_timeout,
+        validate_disk_format,
     };
 
     use microsandbox_protocol::{codec, message::MessageType};
     use std::io::Write;
     use std::sync::Arc;
+    use std::time::Duration;
 
     #[test]
     fn test_parse_mount_spec_minimal() {
@@ -1576,6 +1654,19 @@ mod tests {
         let msg = codec::try_decode_from_buf(&mut frame).unwrap().unwrap();
         assert_eq!(msg.t, MessageType::Shutdown);
         assert_eq!(msg.id, 0);
+    }
+
+    #[test]
+    fn test_request_guest_shutdown_with_timeout_fails_when_ring_full() {
+        let shared = ConsoleSharedState::with_capacity(1);
+        shared.rx_ring.push(b"occupied".to_vec()).unwrap();
+
+        let err = request_guest_shutdown_with_timeout(&shared, Duration::ZERO).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("timed out sending frame to agentd")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR
Fix idle timeout detection so long-running execs do not get reclaimed just because they stop sending host input, and stale agentd heartbeats are handled as agent health failures.

## Description
- Replace the old `last_activity` idle check with host-observed heartbeat and activity sequences.
- Keep sandboxes active while exec sessions are running, while FS/TCP streams stay telemetry and activity signals.
- Move agentd heartbeat writes to an independent snapshot task so serial or stream backpressure does not stop liveness updates.
- Track host messages, guest messages, exec output bytes, and FS/TCP byte movement in the heartbeat file.
- Carry FS/TCP raw stream activity metadata instead of decoding forwarded frames again in the agent loop.
- Run heartbeat health monitoring even when idle timeout is disabled, and persist `AgentUnresponsive` and `ShutdownRequested` termination reasons.
- Bound shutdown-frame enqueue time after agentd is already considered unresponsive.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p microsandbox-cli`
- [x] `cargo test -p microsandbox-runtime`
- [x] `cargo clippy -p microsandbox-runtime -- -D warnings`
- [x] `cargo clippy --manifest-path crates/agentd/Cargo.toml --target x86_64-unknown-linux-gnu -- -D warnings`
- [x] `build/msb run --name idle-repro-fixed-1780849945 --replace --idle-timeout 5s --pull if-missing alpine -- sh -lc 'echo start:$(date +%s); sleep 20; echo end:$(date +%s)'`