### PR TITLE
fix(metrics-collector): skip sandboxes whose slot stopped updating

### DIFF
--- a/crates/metrics-collector/bin/main.rs
+++ b/crates/metrics-collector/bin/main.rs
@@ -138,6 +138,13 @@ struct CollectorOpts {
     #[arg(long, value_parser = humantime::parse_duration, default_value = "30s")]
     export_timeout: Duration,
 
+    /// Stop emitting a sandbox once its most recent sample is older than this.
+    /// Guards against a stopped sandbox whose shm slot was never released (the
+    /// runtime was killed before releasing it) being re-exported forever with a
+    /// frozen value. `0s` disables. Accepts `30s`, `1m`, etc.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "30s")]
+    max_sample_age: Duration,
+
     /// `MSB_HOME` directory. Defaults to `$MSB_HOME` if set, otherwise
     /// `~/.microsandbox`. Used to derive the shm registry name and locate the
     /// catalog DB for labels.
@@ -261,6 +268,7 @@ async fn run_otel(args: OtelArgs) -> anyhow::Result<()> {
         .flush_interval(args.collector.flush_interval)
         .max_buffered_collections(args.collector.max_buffered)
         .export_timeout(args.collector.export_timeout)
+        .max_sample_age(Some(args.collector.max_sample_age))
         .register(exporter);
     if let Some(source) = label_source(&args.collector)? {
         builder = builder.enrich_labels(Arc::new(source));
@@ -291,6 +299,7 @@ async fn run_stdout(args: StdoutArgs) -> anyhow::Result<()> {
         .flush_interval(args.collector.flush_interval)
         .max_buffered_collections(args.collector.max_buffered)
         .export_timeout(args.collector.export_timeout)
+        .max_sample_age(Some(args.collector.max_sample_age))
         .register(exporter);
     if let Some(source) = label_source(&args.collector)? {
         builder = builder.enrich_labels(Arc::new(source));

--- a/crates/metrics-collector/lib/core/builder.rs
+++ b/crates/metrics-collector/lib/core/builder.rs
@@ -6,7 +6,7 @@ use crate::error::{MetricsCollectorError, MetricsCollectorResult};
 
 use super::driver::{CollectorConfig, MetricsCollector, MetricsErrorPolicy};
 use super::label_source::LabelSource;
-use super::reader::{CollectFn, enrich_with_labels, registry_collect_fn};
+use super::reader::{CollectFn, enrich_with_labels, filter_stale_samples, registry_collect_fn};
 use super::types::MetricsExporter;
 
 //--------------------------------------------------------------------------------------------------
@@ -21,6 +21,13 @@ pub const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Default per-exporter collection buffer limit.
 pub const DEFAULT_MAX_BUFFERED_COLLECTIONS: usize = 60;
+
+/// Default max age of a sandbox's most recent sample before the collector stops
+/// emitting it. A running sandbox samples ~1/s; a quiet slot is a stopped
+/// sandbox whose shm slot was never released, which would otherwise be
+/// re-exported with a frozen value forever (microsandbox#941). Generous enough
+/// that a brief sampler stall on a live sandbox does not drop it.
+pub const DEFAULT_MAX_SAMPLE_AGE: Duration = Duration::from_secs(30);
 
 /// Default per-exporter timeout for a single export call.
 pub const DEFAULT_EXPORT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -56,6 +63,7 @@ pub struct MetricsExporterConfig {
 /// Builder for [`MetricsCollector`].
 pub struct MetricsCollectorBuilder {
     collect_interval: Duration,
+    max_sample_age: Option<Duration>,
     default_collector_config: MetricsExporterConfig,
     collectors: Vec<Registered>,
     collect_fn: CollectFn,
@@ -121,6 +129,7 @@ impl MetricsCollectorBuilder {
     pub(crate) fn new(registry_name: String) -> Self {
         Self {
             collect_interval: DEFAULT_COLLECT_INTERVAL,
+            max_sample_age: Some(DEFAULT_MAX_SAMPLE_AGE),
             default_collector_config: MetricsExporterConfig::default(),
             collectors: Vec::new(),
             collect_fn: registry_collect_fn(registry_name),
@@ -130,6 +139,16 @@ impl MetricsCollectorBuilder {
     /// Set the collector-wide interval between shared-memory metrics reads.
     pub fn collect_interval(mut self, interval: Duration) -> Self {
         self.collect_interval = interval;
+        self
+    }
+
+    /// Stop emitting a sandbox once its most recent sample is older than
+    /// `max_age`. Guards against a stopped sandbox whose shm slot was never
+    /// released being re-exported forever with a frozen value
+    /// (microsandbox#941). `None` (or a zero duration) disables the filter.
+    /// Defaults to 30s (`DEFAULT_MAX_SAMPLE_AGE`).
+    pub fn max_sample_age(mut self, max_age: Option<Duration>) -> Self {
+        self.max_sample_age = max_age;
         self
     }
 
@@ -242,9 +261,16 @@ impl MetricsCollectorBuilder {
             }
         }
 
+        // Apply the staleness filter outermost so stopped-but-unreleased slots
+        // are dropped before export (microsandbox#941). Zero/None disables it.
+        let collect_fn = match self.max_sample_age {
+            Some(max_age) if !max_age.is_zero() => filter_stale_samples(self.collect_fn, max_age),
+            _ => self.collect_fn,
+        };
+
         Ok(MetricsCollector::from_config(CollectorConfig {
             collect_interval: self.collect_interval,
-            collect_fn: self.collect_fn,
+            collect_fn,
             collectors,
         }))
     }

--- a/crates/metrics-collector/lib/core/reader.rs
+++ b/crates/metrics-collector/lib/core/reader.rs
@@ -7,6 +7,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::future::BoxFuture;
 use microsandbox_metrics::{MetricsError, MetricsRegistry};
@@ -82,6 +83,49 @@ pub(crate) fn enrich_with_labels(base: CollectFn, source: Arc<dyn LabelSource>) 
     Arc::new(move || Box::pin(enriched_collection(base.clone(), source.clone())))
 }
 
+/// Wrap a base `CollectFn` to drop snapshots whose most recent sample is older
+/// than `max_age` (measured against the collection's `collected_at`).
+///
+/// A running sandbox writes a sample roughly once per second, so a slot that
+/// has gone quiet belongs to a sandbox that stopped without its slot being
+/// released — e.g. the runtime process was SIGKILL'd before its exit observer
+/// ran and no host reaper freed the slot. Such a slot stays `Active` holding a
+/// frozen final sample, and `active_snapshot` keeps returning it, so without
+/// this filter the collector re-exports that frozen value on every tick
+/// forever. See https://github.com/superradcompany/microsandbox/issues/941.
+///
+/// This only *skips* the snapshot (it does not release the slot): staleness is
+/// a safe signal to stop emitting, but not to reclaim — a live sandbox whose
+/// sampler merely stalled must reappear once it resumes, and slot reclamation
+/// needs PID liveness, which is the reaper's job.
+pub(crate) fn filter_stale_samples(base: CollectFn, max_age: Duration) -> CollectFn {
+    Arc::new(move || {
+        let base = base.clone();
+        Box::pin(async move {
+            let mut collection = base().await?;
+            let collected_at = collection.collected_at;
+            let before = collection.sandboxes.len();
+            collection.sandboxes.retain(|s| {
+                // A negative age (sample stamped just ahead of our clock) is
+                // treated as fresh; only a sample older than max_age is dropped.
+                collected_at
+                    .signed_duration_since(s.metrics.timestamp)
+                    .to_std()
+                    .map(|age| age <= max_age)
+                    .unwrap_or(true)
+            });
+            let dropped = before - collection.sandboxes.len();
+            if dropped > 0 {
+                tracing::debug!(
+                    dropped,
+                    "skipped stale sandbox snapshot(s): slot still Active but sampling stopped"
+                );
+            }
+            Ok(collection)
+        })
+    })
+}
+
 //--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
@@ -135,5 +179,53 @@ mod tests {
         );
         // Sandbox 2 has no labels, so no entry is added.
         assert!(collection.labels.get(&2).is_none());
+    }
+
+    #[tokio::test]
+    async fn filter_drops_snapshots_older_than_max_age() {
+        use microsandbox_metrics::{SandboxMetricSnapshot, SandboxMetrics};
+
+        use super::super::types::MetricsCollection;
+
+        let now = chrono::Utc::now();
+        let snap = |id: i32, age_secs: i64| SandboxMetricSnapshot {
+            sandbox_id: id,
+            run_id: id,
+            pid: id,
+            name: format!("s{id}"),
+            metrics: SandboxMetrics {
+                cpu_percent: 0.0,
+                memory_bytes: 0,
+                memory_limit_bytes: 0,
+                disk_read_bytes: 0,
+                disk_write_bytes: 0,
+                net_rx_bytes: 0,
+                net_tx_bytes: 0,
+                uptime: Duration::ZERO,
+                timestamp: now - chrono::Duration::seconds(age_secs),
+            },
+        };
+        // One fresh sandbox (1s old) and one stale (120s old).
+        let snaps = vec![snap(1, 1), snap(2, 120)];
+        let base: CollectFn = Arc::new(move || {
+            let snaps = snaps.clone();
+            Box::pin(async move {
+                Ok(MetricsCollection {
+                    collected_at: now,
+                    sandboxes: snaps,
+                    labels: HashMap::new(),
+                })
+            })
+        });
+
+        let filtered = filter_stale_samples(base, Duration::from_secs(30));
+        let collection = filtered().await.unwrap();
+
+        assert_eq!(
+            collection.sandboxes.len(),
+            1,
+            "stale snapshot must be dropped"
+        );
+        assert_eq!(collection.sandboxes[0].sandbox_id, 1);
     }
 }


### PR DESCRIPTION
Fixes #941.

## Problem

A **stopped** sandbox keeps being exported with a frozen value indefinitely — its CPU/memory readings stay visible and unchanging long after the sandbox is gone.

## Root cause

The runtime process is its own metrics writer (it samples itself via `--metrics-sample-interval-ms`). On a clean exit it releases its slot (`ReleaseMode::Stale`), and the collector already excludes `Stale` via `active_snapshot()`. But when the process is **SIGKILL'd** before its exit observer runs, nothing releases the slot. It stays `Active` holding its last sample, and:

- `MetricsRegistry::active_snapshot()` keeps returning it, so the collector re-exports the frozen value on every tick, and
- `spawn_reaper()` (the host reaper that would free it) only runs from the `msb` CLI, so embedders that spawn `msb sandbox` directly never reap it.

## Fix

A staleness filter on the collect path (`filter_stale_samples`): drop any snapshot whose most recent sample (`metrics.timestamp`) is older than `max_sample_age` relative to `collected_at`. A live sandbox samples ~1/s, so the default **30s** gives large headroom before a briefly-stalled live sandbox would be dropped, while a stopped one disappears within 30s.

- New `--max-sample-age` flag on `otel`/`stdout` (`0s` disables), default `30s`.
- New `MetricsCollectorBuilder::max_sample_age(Option<Duration>)`, default on.

### Why skip, not release

This only **skips emission**; it deliberately does not release the slot. Staleness is a safe signal to stop *emitting*, but not to *reclaim*: a live sandbox whose sampler briefly stalled must reappear once it resumes, and a staleness-based release would bump the slot generation and permanently stop a still-live writer. Proper slot reclamation needs PID liveness (the reaper's job) and is a separate follow-up — relevant for slot-exhaustion, not for this user-visible bug.

## Tests

`cargo test -p microsandbox-metrics-collector` — 37 unit + integration tests pass, incl. new `filter_drops_snapshots_older_than_max_age`. `cargo fmt --check`, `cargo clippy -- -D warnings`, and `RUSTDOCFLAGS=-D warnings cargo doc` clean.