### PR TITLE
fix(ci): stop disk cleanup from deleting the active checkout

### DIFF
--- a/scripts/ci/clean-runner-disk.sh
+++ b/scripts/ci/clean-runner-disk.sh
@@ -20,9 +20,18 @@ sudo find /tmp -mindepth 1 -maxdepth 1 -type d \
   \( -name 'codex-*' -o -name 'microsandbox-*' -o -name 'libkrun-*' \) \
   -mmin +360 -exec rm -rf {} + 2>/dev/null || true
 
+# Prune stale sibling checkouts left by previous runs, but never the one the
+# current job runs from. $GITHUB_WORKSPACE lives directly under
+# $RUNNER_WORKSPACE and matches 'microsandbox*', and a git checkout that
+# doesn't add or remove top-level entries leaves the directory's own mtime
+# untouched, so the -mmin guard alone would let this find delete the live
+# working directory mid-job (the next step then fails with "No such file or
+# directory" on its working directory).
 if [[ -n "${RUNNER_WORKSPACE:-}" && -d "${RUNNER_WORKSPACE}" ]]; then
   find "${RUNNER_WORKSPACE}" -mindepth 1 -maxdepth 1 -type d \
-    -name 'microsandbox*' -mmin +360 -exec rm -rf {} + 2>/dev/null || true
+    -name 'microsandbox*' \
+    ! -path "${GITHUB_WORKSPACE:-/nonexistent}" \
+    -mmin +360 -exec rm -rf {} + 2>/dev/null || true
 fi
 
 echo "::group::runner disk after cleanup"


### PR DESCRIPTION
## what

the cli smoke test (and the integration / node sdk jobs) were failing in ci with errors like:

```
##[error]An error occurred trying to start process '/usr/bin/bash' with working directory
'/home/runner07/actions-runner/_work/microsandbox/microsandbox'. No such file or directory
```

the failure was not in the smoke scripts. `scripts/ci/clean-runner-disk.sh` was deleting the job's own checkout mid-run.

## why

the cleanup pruned any directory matching `microsandbox*` directly under `$RUNNER_WORKSPACE` older than 360 minutes. the live checkout `$GITHUB_WORKSPACE` is `$RUNNER_WORKSPACE/microsandbox`, which matches that glob. a `git checkout --force` that adds or removes no top-level entries leaves the directory's own mtime untouched (only file contents change), so on a reused self-hosted runner the checkout aged past the threshold and got deleted while the job was still running. the next step then failed on a missing working directory.

confirmed against two real runs:

- cli smoke (run #935, runner07): `clean-runner-disk.sh` completed, then `download-artifact` immediately failed on the missing cwd (self-deletion).
- integration tests (run #934, runner02): the checkout was already gone by the script's first `df`, deleted by a sibling job sharing the same `_work/microsandbox/microsandbox`.

## fix

excluded `$GITHUB_WORKSPACE` from the find so the active checkout is never pruned. since every job on a runner shares the same `$GITHUB_WORKSPACE` path, this one exclusion covers both the self-deletion and concurrent-sibling cases while still pruning genuinely stale leftovers.

## test plan

- [x] `bash -n` and `shellcheck` clean
- [x] local simulation of the ci layout: aged the live checkout plus stale siblings past the threshold, confirmed the live checkout survives and stale siblings are pruned