### PR TITLE
feat(installer): link commands through local bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@
 > curl -fsSL https://install.microsandbox.dev | sh
 > ```
 >
+> The installer creates command links in `~/.local/bin/` and does not edit shell startup files.
+>
 > On macOS you can also install with Homebrew:
 >
 > ```sh

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -1,5 +1,6 @@
 //! `msb self` subcommands for managing the msb installation itself.
 
+use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -37,7 +38,7 @@ pub enum SelfCommand {
     #[command(visible_alias = "upgrade")]
     Update(SelfUpdateArgs),
 
-    /// Remove msb, libkrunfw, and shell configuration.
+    /// Remove msb, libkrunfw, and command links.
     Uninstall(SelfUninstallArgs),
 }
 
@@ -84,7 +85,7 @@ impl UninstallCategory {
 
     fn label(&self) -> &'static str {
         match self {
-            Self::All => "All — remove everything and clean shell config",
+            Self::All => "All — remove everything and command links",
             Self::Sandboxes => "Sandboxes — sandbox state and rootfs",
             Self::Volumes => "Volumes — named volumes",
             Self::Cache => "Cache — OCI image layers",
@@ -133,6 +134,7 @@ async fn run_update(args: SelfUpdateArgs) -> anyhow::Result<()> {
     let latest_clean = latest.strip_prefix('v').unwrap_or(&latest);
     if !args.force && latest_clean == CURRENT_VERSION {
         done("Already up to date.");
+        link_public_commands(&resolve_base_dir()?)?;
         return Ok(());
     }
 
@@ -142,7 +144,7 @@ async fn run_update(args: SelfUpdateArgs) -> anyhow::Result<()> {
 
     let spinner = ui::Spinner::start("Updating", &format!("to {latest}"));
     let result = microsandbox::setup::Setup::builder()
-        .base_dir(base_dir)
+        .base_dir(base_dir.clone())
         .version(latest_clean.to_string())
         .force(true)
         .build()
@@ -154,6 +156,7 @@ async fn run_update(args: SelfUpdateArgs) -> anyhow::Result<()> {
             spinner.finish_clear();
             done(&format!("Updated msb in {}", bin_dir.display()));
             done(&format!("Updated libkrunfw in {}/", lib_dir.display()));
+            link_public_commands(&base_dir)?;
         }
         Err(e) => {
             spinner.finish_clear();
@@ -228,12 +231,13 @@ async fn run_uninstall(args: SelfUninstallArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Remove everything: shell config + entire base directory.
+/// Remove everything: command links, legacy shell config, and entire base directory.
 fn uninstall_all(base_dir: &Path) -> anyhow::Result<()> {
-    clean_shell_config()?;
-    std::fs::remove_dir_all(base_dir)?;
+    remove_public_command_links(base_dir)?;
+    clean_legacy_shell_config()?;
+    fs::remove_dir_all(base_dir)?;
     ui::success("Removed", &base_dir.display().to_string());
-    done("Uninstall complete. Restart your shell to apply changes.");
+    done("Uninstall complete.");
     Ok(())
 }
 
@@ -406,6 +410,74 @@ fn resolve_base_dir() -> anyhow::Result<PathBuf> {
     Ok(microsandbox_utils::resolve_home())
 }
 
+fn local_bin_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".local").join("bin"))
+}
+
+fn public_command_links(base_dir: &Path) -> Option<Vec<(PathBuf, PathBuf)>> {
+    let local_bin = local_bin_dir()?;
+    let bin_dir = base_dir.join(microsandbox_utils::BIN_SUBDIR);
+
+    Some(vec![
+        (local_bin.join("msb"), bin_dir.join("msb")),
+        (local_bin.join("microsandbox"), bin_dir.join("microsandbox")),
+    ])
+}
+
+fn link_public_commands(base_dir: &Path) -> anyhow::Result<()> {
+    let Some(links) = public_command_links(base_dir) else {
+        ui::warn("Skipped command links because no home directory was found");
+        return Ok(());
+    };
+
+    if let Some(parent) = links.first().and_then(|(link, _)| link.parent()) {
+        fs::create_dir_all(parent)?;
+    }
+
+    for (link, target) in links {
+        if link.exists() && !link.is_symlink() {
+            ui::warn(&format!(
+                "Skipped {} because it already exists",
+                link.display()
+            ));
+            continue;
+        }
+
+        if link.is_symlink() {
+            fs::remove_file(&link)?;
+        }
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&target, &link)?;
+
+        ui::success(
+            "Linked",
+            &format!("{} -> {}", link.display(), target.display()),
+        );
+    }
+
+    Ok(())
+}
+
+fn remove_public_command_links(base_dir: &Path) -> anyhow::Result<()> {
+    let Some(links) = public_command_links(base_dir) else {
+        return Ok(());
+    };
+
+    for (link, target) in links {
+        if !link.is_symlink() {
+            continue;
+        }
+
+        if fs::read_link(&link)? == target {
+            fs::remove_file(&link)?;
+            ui::success("Removed", &link.display().to_string());
+        }
+    }
+
+    Ok(())
+}
+
 fn info(msg: &str) {
     eprintln!("{} {msg}", style("info").cyan().bold());
 }
@@ -467,7 +539,7 @@ fn remove_installed_aliases(base_dir: &Path) -> anyhow::Result<()> {
         if let Ok(content) = std::fs::read_to_string(&path)
             && content.lines().nth(1) == Some(INSTALL_MARKER)
         {
-            std::fs::remove_file(&path)?;
+            fs::remove_file(&path)?;
             let name = entry.file_name().to_string_lossy().to_string();
             ui::success("Removed", &format!("alias {name}"));
         }
@@ -476,21 +548,24 @@ fn remove_installed_aliases(base_dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Remove microsandbox marker blocks from shell config files.
-fn clean_shell_config() -> anyhow::Result<()> {
+/// Remove microsandbox marker blocks from shell config files left by older installers.
+fn clean_legacy_shell_config() -> anyhow::Result<()> {
     let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
 
     for rc in [".profile", ".bash_profile", ".bashrc", ".zshrc"] {
         let path = home.join(rc);
         if path.exists() && remove_marker_block(&path)? {
-            ui::success("Cleaned", &format!("~/{rc}"));
+            ui::success("Cleaned legacy shell config", &format!("~/{rc}"));
         }
     }
 
     let fish_conf = home.join(".config/fish/conf.d/microsandbox.fish");
     if fish_conf.exists() {
-        std::fs::remove_file(&fish_conf)?;
-        ui::success("Removed", "~/.config/fish/conf.d/microsandbox.fish");
+        fs::remove_file(&fish_conf)?;
+        ui::success(
+            "Removed legacy shell config",
+            "~/.config/fish/conf.d/microsandbox.fish",
+        );
     }
 
     Ok(())

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -13,6 +13,8 @@ The `msb` CLI lets you create, manage, and interact with sandboxes from the term
 curl -fsSL https://install.microsandbox.dev | sh
 ```
 
+The installer writes the runtime to `~/.microsandbox/` and creates command links in `~/.local/bin/`. It does not edit shell startup files. If `~/.local/bin` is not on your `PATH`, the installer prints the command to add it.
+
 <Note>
   microsandbox requires Linux with KVM enabled, or macOS with Apple Silicon (M-series chip). Both use hardware virtualization.
 </Note>

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -383,8 +383,8 @@ msb self uninstall --yes      # Skip confirmation
 
 | Subcommand | Description |
 |------------|-------------|
-| `update` (alias: `upgrade`) | Update msb and libkrunfw to the latest release |
-| `uninstall` | Remove msb, libkrunfw, and shell configuration |
+| `update` (alias: `upgrade`) | Update msb and libkrunfw to the latest release and refresh command links |
+| `uninstall` | Remove msb, libkrunfw, and command links |
 
 | Flag | Subcommand | Description |
 |------|------------|-------------|

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -42,6 +42,8 @@ icon: "bolt"
     ```
 
     </CodeGroup>
+
+    The CLI installer creates command links in `~/.local/bin/` and does not edit shell startup files. If `~/.local/bin` is not on your `PATH`, the installer prints the command to add it.
   </Step>
 
   <Step title="Run code in a sandbox">

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,9 +8,10 @@ set -eu
 # ---------------------------------------------------------------------------
 
 GITHUB_REPO="superradcompany/microsandbox"
-INSTALL_DIR="$HOME/.microsandbox"
+INSTALL_DIR="${MSB_HOME:-$HOME/.microsandbox}"
 BIN_DIR="$INSTALL_DIR/bin"
 LIB_DIR="$INSTALL_DIR/lib"
+LOCAL_BIN_DIR="$HOME/.local/bin"
 
 # libkrunfw versioned filenames (must match the build)
 LIBKRUNFW_VERSION="5.2.1"
@@ -19,10 +20,6 @@ LIBKRUNFW_ABI="5"
 # Current Linux release bundles are built on GitHub Actions ubuntu-latest,
 # which currently maps to Ubuntu 24.04 (glibc 2.39).
 LINUX_GLIBC_MIN_VERSION="2.39"
-
-# Shell config markers
-MARKER_START="# >>> microsandbox >>>"
-MARKER_END="# <<< microsandbox <<<"
 
 # Progress bar
 BAR_WIDTH=40
@@ -73,134 +70,38 @@ need_cmd() {
     fi
 }
 
-# ---------------------------------------------------------------------------
-# Shell configuration
-# ---------------------------------------------------------------------------
+link_command() {
+    _name=$1
+    _target=$2
+    _link="$LOCAL_BIN_DIR/$_name"
 
-detect_current_shell() {
-    _shell_path="${SHELL:-/bin/sh}"
-    case "$(basename "$_shell_path")" in
-        bash) CURRENT_SHELL="bash" ;;
-        zsh)  CURRENT_SHELL="zsh" ;;
-        fish) CURRENT_SHELL="fish" ;;
-        *)    CURRENT_SHELL="sh" ;;
-    esac
+    if [ -e "$_link" ] && [ ! -L "$_link" ]; then
+        warn "Skipped $_link because it already exists and is not a symlink"
+        return
+    fi
+
+    mkdir -p "$LOCAL_BIN_DIR"
+    ln -sf "$_target" "$_link"
+    success "Linked $_link -> $_target"
 }
 
-# Update a shell config file idempotently with a marker block.
-# If the file doesn't exist it is created. If a marker block already
-# exists it is replaced in-place. Otherwise the block is appended.
-update_shell_config() {
-    _file=$1
-    _block=$2
+link_commands() {
+    link_command msb "$BIN_DIR/msb"
+    link_command microsandbox "$BIN_DIR/microsandbox"
 
-    if [ ! -f "$_file" ]; then
-        mkdir -p "$(dirname "$_file")"
-        printf '%s\n' "$_block" > "$_file"
-        return 0
-    fi
-
-    # Back up the original file on first modification
-    if [ ! -f "${_file}.pre-microsandbox" ]; then
-        cp -p "$_file" "${_file}.pre-microsandbox"
-    fi
-
-    if grep -qF "$MARKER_START" "$_file"; then
-        # Replace existing block in-place (ENVIRON avoids awk -v escape issues)
-        _tmp="${_file}.msb_tmp"
-        _MSB_BLOCK="$_block" awk '
-            BEGIN { block = ENVIRON["_MSB_BLOCK"] }
-            /^# >>> microsandbox >>>/ {
-                if (!done) { print block; done=1 }
-                skip=1; next
-            }
-            /^# <<< microsandbox <<</ { skip=0; next }
-            !skip
-        ' "$_file" > "$_tmp"
-        mv "$_tmp" "$_file"
-    else
-        # Append with a leading blank line
-        printf '\n%s\n' "$_block" >> "$_file"
-    fi
-}
-
-# Configure all relevant shell config files with PATH.
-configure_shell() {
-    detect_current_shell
-
-    # Build POSIX block (sh, bash, zsh)
-    _path_line='export PATH="$HOME/.microsandbox/bin:$PATH"'
-    _posix_block="${MARKER_START}
-${_path_line}
-${MARKER_END}"
-
-    # Build fish block
-    _fish_path='set -gx PATH "$HOME/.microsandbox/bin" $PATH'
-    _fish_block="${MARKER_START}
-${_fish_path}
-${MARKER_END}"
-
-    _did_bashrc=false
-    _did_zshrc=false
-    _did_profile=false
-
-    printf "\n"
-    printf "  ${BOLD}Shell Configuration${RESET}\n"
-    printf "\n"
-
-    # Update existing POSIX shell config files
-    for _file in "$HOME/.profile" "$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.zshrc"; do
-        if [ -f "$_file" ]; then
-            update_shell_config "$_file" "$_posix_block"
-            _display="${_file#$HOME}"
-            success "Configured ~${_display}"
-            case "$_file" in
-                */.bashrc)  _did_bashrc=true ;;
-                */.zshrc)   _did_zshrc=true ;;
-                */.profile) _did_profile=true ;;
-            esac
-        fi
-    done
-
-    # If current shell's primary config wasn't updated, create it
-    case "$CURRENT_SHELL" in
-        bash)
-            if [ "$_did_bashrc" = false ]; then
-                update_shell_config "$HOME/.bashrc" "$_posix_block"
-                success "Configured ~/.bashrc"
-            fi
-            ;;
-        zsh)
-            if [ "$_did_zshrc" = false ]; then
-                update_shell_config "$HOME/.zshrc" "$_posix_block"
-                success "Configured ~/.zshrc"
-            fi
-            ;;
-        sh)
-            if [ "$_did_profile" = false ]; then
-                update_shell_config "$HOME/.profile" "$_posix_block"
-                success "Configured ~/.profile"
-            fi
+    COMMAND_HINT="msb"
+    case ":$PATH:" in
+        *":$LOCAL_BIN_DIR:"*) ;;
+        *)
+            COMMAND_HINT="$LOCAL_BIN_DIR/msb"
+            printf "\n"
+            printf "  ${YELLOW}Note:${RESET} %s is not on your PATH.\n" "$LOCAL_BIN_DIR"
+            printf "  Add it to your shell profile if you want to run ${BOLD}msb${RESET} directly:\n"
+            printf "\n"
+            printf "    ${DIM}export${RESET} PATH=\"%s:\$PATH\"\n" "$LOCAL_BIN_DIR"
+            printf "\n"
             ;;
     esac
-
-    # Fish: update if config dir exists or fish is the current shell
-    if [ -d "$HOME/.config/fish" ] || [ "$CURRENT_SHELL" = "fish" ]; then
-        _fish_conf="$HOME/.config/fish/conf.d/microsandbox.fish"
-        update_shell_config "$_fish_conf" "$_fish_block"
-        success "Configured ~/.config/fish/conf.d/microsandbox.fish"
-    fi
-
-    printf "\n"
-    printf "  Restart your shell or run:\n"
-    printf "\n"
-    case "$CURRENT_SHELL" in
-        fish) printf "    ${DIM}source ~/.config/fish/conf.d/microsandbox.fish${RESET}\n" ;;
-        zsh)  printf "    ${DIM}source ~/.zshrc${RESET}\n" ;;
-        bash) printf "    ${DIM}source ~/.bashrc${RESET}\n" ;;
-        *)    printf "    ${DIM}. ~/.profile${RESET}\n" ;;
-    esac
-    printf "\n"
 }
 
 # ---------------------------------------------------------------------------
@@ -395,14 +296,6 @@ get_latest_version() {
 # ---------------------------------------------------------------------------
 
 main() {
-    # Parse arguments
-    MODIFY_PATH="yes"
-    for _arg in "$@"; do
-        case "$_arg" in
-            --no-modify-path) MODIFY_PATH="no" ;;
-        esac
-    done
-
     need_cmd curl
     need_cmd tar
     need_cmd uname
@@ -480,22 +373,9 @@ main() {
     success "Linked microsandbox -> msb in $BIN_DIR/"
     success "Installed libkrunfw to $LIB_DIR/"
 
-    # Configure shell environment
-    if [ "$MODIFY_PATH" = "yes" ]; then
-        configure_shell
-    else
-        printf "\n"
-        printf "  Add the following to your shell profile:\n"
-        printf "\n"
-        if [ "$OS" = "linux" ]; then
-            printf "    ${DIM}export${RESET} PATH=\"%s:\$PATH\"\n" "$BIN_DIR"
-        elif [ "$OS" = "darwin" ]; then
-            printf "    ${DIM}export${RESET} PATH=\"%s:\$PATH\"\n" "$BIN_DIR"
-        fi
-        printf "\n"
-    fi
+    link_commands
 
-    success "Installation complete! Run 'msb --tree' to get started."
+    success "Installation complete! Run '$COMMAND_HINT --help' to get started."
     printf "\n"
 }
 


### PR DESCRIPTION
## TL;DR
Stop editing shell startup files during CLI install. The installer now exposes `msb` through `~/.local/bin` links and only prints a PATH hint when needed.

## Description
- Install runtime files under `${MSB_HOME:-$HOME/.microsandbox}` while exposing `msb` and `microsandbox` through `~/.local/bin` symlinks.
- Skip existing non-symlink command paths instead of overwriting user-owned files.
- Print a PATH hint only when `~/.local/bin` is missing from `PATH`, and point the first-run hint at `--help`.
- Refresh public command links from `msb self update`, including when the installed version is already current.
- Remove command links owned by the current install from `msb self uninstall`, while still cleaning legacy shell marker blocks from older installs.
- Update README and CLI docs to say the installer does not edit shell startup files.
- Fixes https://github.com/superradcompany/microsandbox/issues/944

```bash
curl -fsSL https://install.microsandbox.dev | sh
# If ~/.local/bin is not on PATH, add:
export PATH="$HOME/.local/bin:$PATH"
```

## Test Plan
- [x] `sh -n scripts/install.sh` exits 0
- [x] `cargo fmt --all -- --check` exits 0
- [x] `cargo check -p microsandbox-cli` exits 0