### PR TITLE
fix(cli): use sandbox log-level flag

### DIFF
--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -11,6 +11,7 @@ use microsandbox_cli::{
     log_args::{self, LogArgs},
     sandbox_cmd::{self, SandboxArgs},
 };
+use microsandbox_runtime::logging::LogLevel;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -266,12 +267,12 @@ fn main() {
         // no explicit level is set so lifecycle events and VMM diagnostics
         // are captured in runtime.log for post-mortem debugging.
         Commands::Sandbox(args) => {
-            let sandbox_level = log_level.or(Some(microsandbox_runtime::logging::LogLevel::Info));
+            let sandbox_level = args.log_level.or(Some(LogLevel::Info));
             // The sandbox subprocess's stderr is redirected into
             // runtime.log via setup_log_capture(), so disable ANSI —
             // color escapes have nowhere useful to render.
             log_args::init_tracing(sandbox_level, false);
-            sandbox_cmd::run(*args, log_level); // returns `!`
+            sandbox_cmd::run(*args); // returns `!`
         }
         command => {
             // CLI commands write tracing to the user's terminal.

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -41,6 +41,10 @@ pub struct SandboxArgs {
     #[arg(long)]
     pub log_dir: PathBuf,
 
+    /// Log verbosity for the sandbox runtime (error, warn, info, debug, trace).
+    #[arg(long = "log-level", value_name = "LOG_LEVEL")]
+    pub log_level: Option<LogLevel>,
+
     /// Runtime directory (scripts, heartbeat).
     #[arg(long)]
     pub runtime_dir: PathBuf,
@@ -162,7 +166,7 @@ pub struct SandboxArgs {
 //--------------------------------------------------------------------------------------------------
 
 /// Run the sandbox process. This function **never returns**.
-pub fn run(args: SandboxArgs, log_level: Option<LogLevel>) -> ! {
+pub fn run(args: SandboxArgs) -> ! {
     let parent_watchdog = match args
         .parent_watch_fd
         .map(parent_watchdog_from_fd)
@@ -225,7 +229,7 @@ pub fn run(args: SandboxArgs, log_level: Option<LogLevel>) -> ! {
     let config = Config {
         sandbox_name: args.sandbox_name,
         sandbox_id: args.sandbox_id,
-        log_level,
+        log_level: args.log_level,
         sandbox_db_path: args.sandbox_db_path,
         sandbox_db_connect_timeout_secs: args.sandbox_db_connect_timeout_secs,
         log_dir: args.log_dir,

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -1171,7 +1171,8 @@ fn sandbox_cli_args(
     let mut args = vec![OsString::from("sandbox")];
 
     if let Some(log_level) = config.log_level {
-        args.push(OsString::from(log_level.as_cli_flag()));
+        args.push(OsString::from("--log-level"));
+        args.push(OsString::from(log_level.to_string()));
     }
 
     args.push(OsString::from("--name"));
@@ -1781,7 +1782,8 @@ mod tests {
 
         let args = render_args(&config);
 
-        assert!(args.iter().any(|arg| arg == "--debug"));
+        assert!(args.windows(2).any(|pair| pair == ["--log-level", "debug"]));
+        assert!(!args.iter().any(|arg| arg == "--debug"));
     }
 
     #[tokio::test]
@@ -1797,7 +1799,7 @@ mod tests {
         assert!(!args.iter().any(|arg| {
             matches!(
                 arg.as_str(),
-                "--error" | "--warn" | "--info" | "--debug" | "--trace"
+                "--log-level" | "--error" | "--warn" | "--info" | "--debug" | "--trace"
             )
         }));
     }

--- a/crates/runtime/lib/logging.rs
+++ b/crates/runtime/lib/logging.rs
@@ -34,6 +34,12 @@ pub enum LogLevel {
     Trace,
 }
 
+/// Error returned when parsing an invalid log level string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseLogLevelError {
+    value: String,
+}
+
 /// A simple rotating log writer.
 ///
 /// Writes to a log file and rotates when the file exceeds `max_bytes`.
@@ -64,6 +70,17 @@ const MAX_ROTATED_FILES: u32 = 3;
 //--------------------------------------------------------------------------------------------------
 
 impl LogLevel {
+    /// Return the canonical string representation for this level.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+            Self::Trace => "trace",
+        }
+    }
+
     /// Return the CLI flag corresponding to this level.
     pub const fn as_cli_flag(self) -> &'static str {
         match self {
@@ -157,6 +174,45 @@ impl RotatingLog {
 }
 
 //--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl std::fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for LogLevel {
+    type Err = ParseLogLevelError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "error" => Ok(Self::Error),
+            "warn" => Ok(Self::Warn),
+            "info" => Ok(Self::Info),
+            "debug" => Ok(Self::Debug),
+            "trace" => Ok(Self::Trace),
+            _ => Err(ParseLogLevelError {
+                value: s.to_owned(),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for ParseLogLevelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "invalid log level: {} (expected: error, warn, info, debug, trace)",
+            self.value
+        )
+    }
+}
+
+impl std::error::Error for ParseLogLevelError {}
+
+//--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
 
@@ -171,5 +227,24 @@ mod tests {
         assert_eq!(LogLevel::Info.as_cli_flag(), "--info");
         assert_eq!(LogLevel::Debug.as_cli_flag(), "--debug");
         assert_eq!(LogLevel::Trace.as_cli_flag(), "--trace");
+    }
+
+    #[test]
+    fn test_log_level_display() {
+        assert_eq!(LogLevel::Error.to_string(), "error");
+        assert_eq!(LogLevel::Warn.to_string(), "warn");
+        assert_eq!(LogLevel::Info.to_string(), "info");
+        assert_eq!(LogLevel::Debug.to_string(), "debug");
+        assert_eq!(LogLevel::Trace.to_string(), "trace");
+    }
+
+    #[test]
+    fn test_log_level_from_str() {
+        assert_eq!("error".parse::<LogLevel>().unwrap(), LogLevel::Error);
+        assert_eq!("warn".parse::<LogLevel>().unwrap(), LogLevel::Warn);
+        assert_eq!("info".parse::<LogLevel>().unwrap(), LogLevel::Info);
+        assert_eq!("debug".parse::<LogLevel>().unwrap(), LogLevel::Debug);
+        assert_eq!("trace".parse::<LogLevel>().unwrap(), LogLevel::Trace);
+        assert!("verbose".parse::<LogLevel>().is_err());
     }
 }


### PR DESCRIPTION
## TL;DR

Use `msb sandbox --log-level <LOG_LEVEL>` for sandbox runtime logging instead of the global CLI verbosity flags, matching the runtime subprocess contract used by `msb run` and `msb create`.

## Description

- Add a `log_level` field to `SandboxArgs` and pass it into the runtime `Config`.
- Initialize hidden `msb sandbox` tracing from `args.log_level`, defaulting to `info` when no sandbox-specific level is provided.
- Spawn sandbox subprocesses with `--log-level <level>` instead of global flags such as `--debug`.
- Add `Display` and `FromStr` support for `LogLevel` so clap can parse the sandbox flag directly.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p microsandbox-cli sandbox_cmd`
- `cargo test -p microsandbox-runtime test_log_level`
- `cargo test -p microsandbox test_sandbox_cli_args_include_selected_log_level`
- `cargo test -p microsandbox test_sandbox_cli_args_are_silent_by_default`
- `cargo clippy -p microsandbox-runtime -p microsandbox-cli -p microsandbox -- -D warnings`
- `git diff --check`
- Pre-commit hook: workspace fmt, workspace clippy, agentd fmt/clippy, workspace docs, and `msb` build