### PR TITLE
fix(cli): inherit global log level for sandbox runs

### DIFF
--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -266,12 +266,17 @@ fn main() {
         // no explicit level is set so lifecycle events and VMM diagnostics
         // are captured in runtime.log for post-mortem debugging.
         Commands::Sandbox(args) => {
-            let sandbox_level = log_level.or(Some(microsandbox_runtime::logging::LogLevel::Info));
+            let mut args = *args;
+            let sandbox_level = args
+                .log_level
+                .or(log_level)
+                .or(Some(microsandbox_runtime::logging::LogLevel::Info));
+            args.log_level = sandbox_level;
             // The sandbox subprocess's stderr is redirected into
             // runtime.log via setup_log_capture(), so disable ANSI —
             // color escapes have nowhere useful to render.
             log_args::init_tracing(sandbox_level, false);
-            sandbox_cmd::run(*args, log_level); // returns `!`
+            sandbox_cmd::run(args); // returns `!`
         }
         command => {
             // CLI commands write tracing to the user's terminal.
@@ -537,7 +542,7 @@ fn extract_quoted_token_str(s: &str) -> Option<String> {
 
 fn run_async_command_anyhow(
     command: Commands,
-    _log_level: Option<microsandbox::LogLevel>,
+    log_level: Option<microsandbox::LogLevel>,
 ) -> anyhow::Result<()> {
     // Pull and create can overlap network I/O, decompression, and progress UI.
     // Use a small-but-not-tiny worker pool so foreground UI tasks still get
@@ -559,8 +564,8 @@ fn run_async_command_anyhow(
         match command {
             Commands::Sandbox(_) => unreachable!("handled before Tokio starts"),
 
-            Commands::Run(args) => run::run(args).await,
-            Commands::Create(args) => create::run(args).await,
+            Commands::Run(args) => run::run(args, log_level).await,
+            Commands::Create(args) => create::run(args, log_level).await,
             Commands::Start(args) => start::run(args).await,
             Commands::Stop(args) => stop::run(args).await,
             Commands::List(args) => list::run(args).await,

--- a/crates/cli/lib/commands/create.rs
+++ b/crates/cli/lib/commands/create.rs
@@ -26,9 +26,18 @@ pub struct CreateArgs {
 //--------------------------------------------------------------------------------------------------
 
 /// Execute the `msb create` command.
-pub async fn run(args: CreateArgs) -> anyhow::Result<()> {
+pub async fn run(
+    mut args: CreateArgs,
+    log_level: Option<microsandbox::LogLevel>,
+) -> anyhow::Result<()> {
     let is_named = args.sandbox.name.is_some();
     let name = args.sandbox.name.clone().unwrap_or_else(ui::generate_name);
+
+    if args.sandbox.log_level.is_none()
+        && let Some(log_level) = log_level
+    {
+        args.sandbox.log_level = Some(log_level.to_string());
+    }
 
     let builder = Sandbox::builder(&name).image(args.image.as_str());
     let builder = apply_sandbox_opts(builder, &args.sandbox)?;

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -96,7 +96,7 @@ impl ExecOpts {
 //--------------------------------------------------------------------------------------------------
 
 /// Execute the `msb run` command.
-pub async fn run(args: RunArgs) -> anyhow::Result<()> {
+pub async fn run(args: RunArgs, log_level: Option<microsandbox::LogLevel>) -> anyhow::Result<()> {
     let is_named = args.sandbox.name.is_some();
     let name = args.sandbox.name.clone().unwrap_or_else(ui::generate_name);
 
@@ -108,7 +108,7 @@ pub async fn run(args: RunArgs) -> anyhow::Result<()> {
         return run_existing(name, args).await;
     }
 
-    run_new(name, is_named, args).await
+    run_new(name, is_named, args, log_level).await
 }
 
 /// Run in an existing named sandbox — start if stopped, connect if running.
@@ -150,7 +150,12 @@ async fn run_existing(name: String, args: RunArgs) -> anyhow::Result<()> {
 }
 
 /// Create a new sandbox and run in it.
-async fn run_new(name: String, is_named: bool, args: RunArgs) -> anyhow::Result<()> {
+async fn run_new(
+    name: String,
+    is_named: bool,
+    mut args: RunArgs,
+    log_level: Option<microsandbox::LogLevel>,
+) -> anyhow::Result<()> {
     let mut builder = Sandbox::builder(&name);
     if let Some(ref snap) = args.snapshot {
         builder = builder.from_snapshot(snap.clone());
@@ -158,6 +163,11 @@ async fn run_new(name: String, is_named: bool, args: RunArgs) -> anyhow::Result<
         builder = builder.image(image.as_str());
     } else {
         anyhow::bail!("either an image or --snapshot is required");
+    }
+    if args.sandbox.log_level.is_none()
+        && let Some(log_level) = log_level
+    {
+        args.sandbox.log_level = Some(log_level.to_string());
     }
     let builder = apply_sandbox_opts(builder, &args.sandbox)?;
 

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -41,6 +41,10 @@ pub struct SandboxArgs {
     #[arg(long)]
     pub log_dir: PathBuf,
 
+    /// Log verbosity for the sandbox runtime (error, warn, info, debug, trace).
+    #[arg(long = "log-level", value_name = "LOG_LEVEL", value_parser = parse_log_level)]
+    pub log_level: Option<LogLevel>,
+
     /// Runtime directory (scripts, heartbeat).
     #[arg(long)]
     pub runtime_dir: PathBuf,
@@ -161,8 +165,22 @@ pub struct SandboxArgs {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
+/// Parse a sandbox runtime log level.
+fn parse_log_level(s: &str) -> Result<LogLevel, String> {
+    match s {
+        "error" => Ok(LogLevel::Error),
+        "warn" => Ok(LogLevel::Warn),
+        "info" => Ok(LogLevel::Info),
+        "debug" => Ok(LogLevel::Debug),
+        "trace" => Ok(LogLevel::Trace),
+        _ => Err(format!(
+            "invalid log level: {s} (expected: error, warn, info, debug, trace)"
+        )),
+    }
+}
+
 /// Run the sandbox process. This function **never returns**.
-pub fn run(args: SandboxArgs, log_level: Option<LogLevel>) -> ! {
+pub fn run(args: SandboxArgs) -> ! {
     let parent_watchdog = match args
         .parent_watch_fd
         .map(parent_watchdog_from_fd)
@@ -225,7 +243,7 @@ pub fn run(args: SandboxArgs, log_level: Option<LogLevel>) -> ! {
     let config = Config {
         sandbox_name: args.sandbox_name,
         sandbox_id: args.sandbox_id,
-        log_level,
+        log_level: args.log_level,
         sandbox_db_path: args.sandbox_db_path,
         sandbox_db_connect_timeout_secs: args.sandbox_db_connect_timeout_secs,
         log_dir: args.log_dir,

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -1171,7 +1171,8 @@ fn sandbox_cli_args(
     let mut args = vec![OsString::from("sandbox")];
 
     if let Some(log_level) = config.log_level {
-        args.push(OsString::from(log_level.as_cli_flag()));
+        args.push(OsString::from("--log-level"));
+        args.push(OsString::from(log_level.to_string()));
     }
 
     args.push(OsString::from("--name"));
@@ -1781,7 +1782,10 @@ mod tests {
 
         let args = render_args(&config);
 
-        assert!(args.iter().any(|arg| arg == "--debug"));
+        assert!(
+            args.windows(2)
+                .any(|window| window[0] == "--log-level" && window[1] == "debug")
+        );
     }
 
     #[tokio::test]
@@ -1794,12 +1798,7 @@ mod tests {
 
         let args = render_args(&config);
 
-        assert!(!args.iter().any(|arg| {
-            matches!(
-                arg.as_str(),
-                "--error" | "--warn" | "--info" | "--debug" | "--trace"
-            )
-        }));
+        assert!(!args.iter().any(|arg| arg == "--log-level"));
     }
 
     #[tokio::test]

--- a/crates/runtime/lib/logging.rs
+++ b/crates/runtime/lib/logging.rs
@@ -1,6 +1,7 @@
 //! Log file management with rotation for capturing VM console output.
 
 use std::{
+    fmt,
     fs::{self, File, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
@@ -9,6 +10,13 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::RuntimeResult;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Maximum number of rotated log files to keep.
+const MAX_ROTATED_FILES: u32 = 3;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -53,17 +61,21 @@ pub struct RotatingLog {
 }
 
 //--------------------------------------------------------------------------------------------------
-// Constants
-//--------------------------------------------------------------------------------------------------
-
-/// Maximum number of rotated log files to keep.
-const MAX_ROTATED_FILES: u32 = 3;
-
-//--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
 
 impl LogLevel {
+    /// Return the lowercase string representation for this level.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+            Self::Trace => "trace",
+        }
+    }
+
     /// Return the CLI flag corresponding to this level.
     pub const fn as_cli_flag(self) -> &'static str {
         match self {
@@ -157,6 +169,16 @@ impl RotatingLog {
 }
 
 //--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
 
@@ -171,5 +193,14 @@ mod tests {
         assert_eq!(LogLevel::Info.as_cli_flag(), "--info");
         assert_eq!(LogLevel::Debug.as_cli_flag(), "--debug");
         assert_eq!(LogLevel::Trace.as_cli_flag(), "--trace");
+    }
+
+    #[test]
+    fn test_log_level_display_values() {
+        assert_eq!(LogLevel::Error.to_string(), "error");
+        assert_eq!(LogLevel::Warn.to_string(), "warn");
+        assert_eq!(LogLevel::Info.to_string(), "info");
+        assert_eq!(LogLevel::Debug.to_string(), "debug");
+        assert_eq!(LogLevel::Trace.to_string(), "trace");
     }
 }


### PR DESCRIPTION
PR Title: fix(cli): inherit global log level for sandbox runs

## TL;DR
Global log flags now flow into sandbox runtime log levels when `msb run` or `msb create` does not set `--log-level`. The hidden `msb sandbox` command now receives sandbox log levels through `--log-level <LOG_LEVEL>` instead of global-style flags.

## Description
- Apply the selected global log level to new `msb run` and `msb create` sandbox configs only when `--log-level` is not set.
- Add `msb sandbox --log-level <LOG_LEVEL>` so the internal sandbox process uses the same sandbox-specific flag shape as run and create.
- Resolve the hidden sandbox process log level from explicit `--log-level`, then inherited global level, then the existing internal `info` default.
- Emit `--log-level <level>` when spawning sandbox subprocesses instead of passing `--debug`, `--trace`, or other global log flags.
- Add lowercase `LogLevel` display values so subprocess args can render `error`, `warn`, `info`, `debug`, and `trace` consistently.
- Update spawn arg tests for the new `--log-level debug` handoff and the silent default case.

```bash
msb --debug run alpine -- echo hello
msb create --log-level trace alpine
msb sandbox --log-level debug --help
```

## Test Plan
- [x] `cargo fmt --all`
- [x] `cargo test -p microsandbox-runtime logging`
- [x] `cargo test -p microsandbox test_sandbox_cli_args`
- [x] `cargo check -p microsandbox-cli`
- [x] `cargo test -p microsandbox-cli`
- [x] `just build-msb`
- [x] `./build/msb --debug run alpine -- echo msb-log-level-e2e`
- [x] `./build/msb --debug create --name codex-log-level-e2e --replace alpine` shows DEBUG entries in `runtime.log`, then `./build/msb stop codex-log-level-e2e` and `./build/msb remove codex-log-level-e2e` clean it up
