### PR TITLE
feat(volumes): add idempotent named volume mounts

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use clap::Args;
+use microsandbox::VolumeKind;
 use microsandbox::sandbox::{
     DiskImageFormat, MountBuilder, Patch, Sandbox, SandboxBuilder, SandboxFilter, SecurityProfile,
 };
@@ -348,6 +349,8 @@ struct CliMountOptions {
     stat_virtualization: Option<microsandbox::sandbox::StatVirtualization>,
     host_permissions: Option<microsandbox::sandbox::HostPermissions>,
     size_mib: Option<u32>,
+    quota_mib: Option<u32>,
+    named_kind: Option<VolumeKind>,
     fstype: Option<String>,
     format: Option<DiskImageFormat>,
 }
@@ -357,6 +360,8 @@ struct CliMountOptions {
 struct CliMountOptionSupport {
     policies: bool,
     size: bool,
+    quota: bool,
+    named_kind: bool,
     fstype: bool,
     format: bool,
 }
@@ -730,7 +735,7 @@ pub fn apply_volume(builder: SandboxBuilder, spec: &str) -> anyhow::Result<Sandb
         m = if is_path {
             m.bind(&source)
         } else {
-            m.named(&source)
+            m.named_with(&source, |v| v.ensure_exists())
         };
         if options.readonly {
             m = m.readonly();
@@ -868,6 +873,9 @@ pub fn apply_explicit_named_mount(
         spec,
         CliMountOptionSupport {
             policies: true,
+            size: true,
+            quota: true,
+            named_kind: true,
             ..CliMountOptionSupport::default()
         },
     )?;
@@ -877,12 +885,43 @@ pub fn apply_explicit_named_mount(
             parsed.source
         );
     }
+    if parsed.options.size_mib.is_some()
+        && !matches!(parsed.options.named_kind, Some(VolumeKind::Disk))
+    {
+        anyhow::bail!("mount-named option `size` requires kind=disk");
+    }
+    if matches!(parsed.options.named_kind, Some(VolumeKind::Disk))
+        && parsed.options.size_mib.is_none()
+    {
+        anyhow::bail!("mount-named kind=disk requires size=...");
+    }
+    if matches!(parsed.options.named_kind, Some(VolumeKind::Disk))
+        && parsed.options.quota_mib.is_some()
+    {
+        anyhow::bail!("mount-named kind=disk does not support quota=...");
+    }
 
     let source = parsed.source.to_string();
     let guest = parsed.guest.to_string();
     let options = parsed.options;
     Ok(builder.volume(guest, move |m| {
-        apply_common_mount_options(m.named(&source), options)
+        let mount = m.named_with(&source, |mut v| {
+            v = v.ensure_exists();
+            if let Some(kind) = options.named_kind {
+                v = match kind {
+                    VolumeKind::Directory => v.directory(),
+                    VolumeKind::Disk => v.disk(),
+                };
+            }
+            if let Some(size_mib) = options.size_mib {
+                v = v.size(size_mib);
+            }
+            if let Some(quota_mib) = options.quota_mib {
+                v = v.quota(quota_mib);
+            }
+            v
+        });
+        apply_common_mount_options(mount, options)
     }))
 }
 
@@ -966,6 +1005,8 @@ fn parse_cli_mount_options(
     let mut seen_stat_virt = false;
     let mut seen_host_perms = false;
     let mut seen_size = false;
+    let mut seen_quota = false;
+    let mut seen_named_kind = false;
     let mut seen_fstype = false;
     let mut seen_format = false;
 
@@ -1050,6 +1091,27 @@ fn parse_cli_mount_options(
                         parsed.size_mib =
                             Some(ui::parse_size_mib(value).map_err(anyhow::Error::msg)?);
                     }
+                    "quota" if support.quota => {
+                        if seen_quota {
+                            anyhow::bail!("mount option `quota` specified more than once");
+                        }
+                        seen_quota = true;
+                        parsed.quota_mib =
+                            Some(ui::parse_size_mib(value).map_err(anyhow::Error::msg)?);
+                    }
+                    "kind" if support.named_kind => {
+                        if seen_named_kind {
+                            anyhow::bail!("mount option `kind` specified more than once");
+                        }
+                        seen_named_kind = true;
+                        parsed.named_kind = Some(match value {
+                            "dir" | "directory" => VolumeKind::Directory,
+                            "disk" => VolumeKind::Disk,
+                            other => anyhow::bail!(
+                                "invalid named volume kind {other:?} (expected dir|disk)"
+                            ),
+                        });
+                    }
                     "fstype" if support.fstype => {
                         if seen_fstype {
                             anyhow::bail!("mount option `fstype` specified more than once");
@@ -1067,7 +1129,8 @@ fn parse_cli_mount_options(
                             anyhow::anyhow!("invalid disk image format {value:?}: {e}")
                         })?);
                     }
-                    "stat-virt" | "host-perms" | "size" | "fstype" | "format" => {
+                    "stat-virt" | "host-perms" | "size" | "quota" | "kind" | "fstype"
+                    | "format" => {
                         anyhow::bail!("mount option `{key}` is not valid here");
                     }
                     other => anyhow::bail!("unknown mount option {other:?}"),
@@ -2204,10 +2267,15 @@ mod tests {
             VolumeMount::Named {
                 name,
                 stat_virtualization,
+                create,
                 ..
             } => {
                 assert_eq!(name, "mycache");
                 assert!(matches!(stat_virtualization, StatVirtualization::Relaxed));
+                assert_eq!(
+                    create.as_ref().map(|create| create.mode()),
+                    Some(microsandbox::sandbox::NamedVolumeMode::EnsureExists)
+                );
             }
             other => panic!("expected Named, got {other:?}"),
         }
@@ -2292,11 +2360,37 @@ mod tests {
                 name,
                 guest,
                 stat_virtualization,
+                create,
                 ..
             } => {
                 assert_eq!(name, "cache");
                 assert_eq!(guest, "/data");
                 assert!(matches!(stat_virtualization, StatVirtualization::Relaxed));
+                assert_eq!(
+                    create.as_ref().map(|create| create.mode()),
+                    Some(microsandbox::sandbox::NamedVolumeMode::EnsureExists)
+                );
+            }
+            other => panic!("expected Named, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_apply_explicit_named_mount_disk_ensure_options() {
+        let mount = build_explicit(
+            "cache-disk:/data:kind=disk,size=2G",
+            apply_explicit_named_mount,
+        )
+        .await;
+        match mount {
+            VolumeMount::Named { create, .. } => {
+                let create = create.expect("mount-named should ensure the named volume");
+                assert_eq!(
+                    create.mode(),
+                    microsandbox::sandbox::NamedVolumeMode::EnsureExists
+                );
+                assert_eq!(create.kind(), VolumeKind::Disk);
+                assert_eq!(create.capacity_mib(), Some(2048));
             }
             other => panic!("expected Named, got {other:?}"),
         }

--- a/crates/cli/lib/commands/inspect.rs
+++ b/crates/cli/lib/commands/inspect.rs
@@ -161,6 +161,7 @@ pub async fn run(args: InspectArgs) -> anyhow::Result<()> {
                         options,
                         stat_virtualization,
                         host_permissions,
+                        ..
                     } => {
                         let flags = mount_flags_suffix(*options);
                         let suffix = mount_policy_suffix(*stat_virtualization, *host_permissions);

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -1325,6 +1325,7 @@ fn sandbox_cli_args(
                 options,
                 stat_virtualization,
                 host_permissions,
+                create: _,
             } => match named_volumes.get(name) {
                 Some(ResolvedNamedVolume {
                     kind: VolumeKind::Disk,

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -672,9 +672,9 @@ impl SandboxBuilder {
     /// .volume("/data", |m| m.bind("/host/data"))
     /// .volume("/config", |m| m.bind("/host/config").readonly())
     /// .volume("/cache", |m| m.named("my-cache"))
-    /// .volume("/tmp", |m| m.create_named("my-sandbox-tmp"))
+    /// .volume("/tmp", |m| m.named_with("my-sandbox-tmp", |v| v.create()))
     /// .volume("/scratch", |m| m
-    ///     .create_named_with("my-sandbox-scratch", |v| v.quota(1024).label("owner", "team"))
+    ///     .named_with("my-sandbox-scratch", |v| v.ensure_exists().quota(1024).label("owner", "team"))
     ///     .readonly())
     /// .volume("/tmpfs", |m| m.tmpfs().size(100))
     /// ```
@@ -683,17 +683,7 @@ impl SandboxBuilder {
         guest_path: impl Into<String>,
         f: impl FnOnce(MountBuilder) -> MountBuilder,
     ) -> Self {
-        let mut mb = f(MountBuilder::new(guest_path));
-        if let Some(intent) = mb.take_create_intent() {
-            if let Err(e) = crate::volume::validate_volume_name(&intent.name)
-                && self.build_error.is_none()
-            {
-                self.build_error = Some(e);
-                return self;
-            }
-            self.config.auto_volumes.push(intent);
-        }
-        match mb.build() {
+        match f(MountBuilder::new(guest_path)).build() {
             Ok(mount) => self.config.mounts.push(mount),
             Err(e) => {
                 if self.build_error.is_none() {
@@ -977,7 +967,7 @@ impl From<SandboxConfig> for SandboxBuilder {
 mod tests {
     use super::SandboxBuilder;
     use crate::LogLevel;
-    use crate::sandbox::{MAX_SANDBOX_NAME_BYTES, RlimitResource};
+    use crate::sandbox::{MAX_SANDBOX_NAME_BYTES, NamedVolumeMode, RlimitResource};
     #[cfg(feature = "net")]
     use microsandbox_network::config::PortProtocol;
     #[cfg(feature = "net")]
@@ -1469,65 +1459,96 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_named_registers_intent_and_mount() {
+    async fn test_named_with_create_registers_create_metadata_on_mount() {
         let config = SandboxBuilder::new("sb")
             .image("alpine")
-            .volume("/tmp", |m| m.create_named("sb-tmp"))
+            .volume("/tmp", |m| m.named_with("sb-tmp", |v| v.create()))
             .build()
             .await
             .unwrap();
 
-        assert_eq!(config.auto_volumes.len(), 1);
-        assert_eq!(config.auto_volumes[0].name, "sb-tmp");
         assert_eq!(config.mounts.len(), 1);
         match &config.mounts[0] {
-            super::VolumeMount::Named { name, guest, .. } => {
+            super::VolumeMount::Named {
+                name,
+                guest,
+                create,
+                ..
+            } => {
                 assert_eq!(name, "sb-tmp");
                 assert_eq!(guest, "/tmp");
+                let create = create.as_ref().unwrap();
+                assert_eq!(create.mode, NamedVolumeMode::Create);
+                assert_eq!(create.name, "sb-tmp");
             }
             _ => panic!("expected Named mount"),
         }
     }
 
     #[tokio::test]
-    async fn test_create_named_with_carries_quota_and_labels() {
+    async fn test_named_with_ensure_exists_carries_quota_and_labels() {
         let config = SandboxBuilder::new("sb")
             .image("alpine")
             .volume("/scratch", |m| {
-                m.create_named_with("sb-scratch", |v| v.quota(1024u32).label("owner", "my-team"))
-                    .readonly()
+                m.named_with("sb-scratch", |v| {
+                    v.ensure_exists().quota(1024u32).label("owner", "my-team")
+                })
+                .readonly()
             })
             .build()
             .await
             .unwrap();
 
-        assert_eq!(config.auto_volumes[0].name, "sb-scratch");
-        assert_eq!(config.auto_volumes[0].quota_mib, Some(1024));
-        assert_eq!(
-            config.auto_volumes[0].labels,
-            vec![("owner".to_string(), "my-team".to_string())]
-        );
         match &config.mounts[0] {
-            super::VolumeMount::Named { options, .. } => assert!(options.readonly),
+            super::VolumeMount::Named {
+                create, options, ..
+            } => {
+                let create = create.as_ref().unwrap();
+                assert_eq!(create.mode, NamedVolumeMode::EnsureExists);
+                assert_eq!(create.name, "sb-scratch");
+                assert_eq!(create.quota_mib, Some(1024));
+                assert_eq!(
+                    create.labels,
+                    vec![("owner".to_string(), "my-team".to_string())]
+                );
+                assert!(options.readonly);
+            }
             _ => panic!("expected Named mount"),
         }
     }
 
     #[tokio::test]
-    async fn test_create_named_with_name_override() {
+    async fn test_named_with_name_override() {
         let config = SandboxBuilder::new("sb")
             .image("alpine")
             .volume("/tmp", |m| {
-                m.create_named_with("initial", |v| v.name("overridden"))
+                m.named_with("initial", |v| v.create().name("overridden"))
             })
             .build()
             .await
             .unwrap();
 
-        assert_eq!(config.auto_volumes[0].name, "overridden");
         match &config.mounts[0] {
-            super::VolumeMount::Named { name, .. } => assert_eq!(name, "overridden"),
+            super::VolumeMount::Named { name, create, .. } => {
+                assert_eq!(name, "overridden");
+                assert_eq!(create.as_ref().unwrap().name, "overridden");
+            }
             _ => panic!("expected Named mount"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_named_with_metadata_is_cleared_when_mount_kind_changes() {
+        let config = SandboxBuilder::new("sb")
+            .image("alpine")
+            .volume("/tmp", |m| m.named_with("stale", |v| v.create()).tmpfs())
+            .build()
+            .await
+            .unwrap();
+
+        match &config.mounts[0] {
+            super::VolumeMount::Tmpfs { guest, .. } => assert_eq!(guest, "/tmp"),
+            _ => panic!("expected Tmpfs mount"),
         }
     }
 }

--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -254,26 +254,6 @@ pub struct SandboxConfig {
     /// during `create_with_mode`. Never persisted.
     #[serde(skip)]
     pub(crate) snapshot_upper_source: Option<PathBuf>,
-
-    /// Volumes to provision atomically alongside this sandbox.
-    ///
-    /// Each entry is registered in the same DB transaction that inserts
-    /// the sandbox row, so `Volume::list` cannot observe one of these
-    /// before the owning sandbox exists. Set by
-    /// [`SandboxBuilder::auto_volume`] and friends. The matching
-    /// [`VolumeMount::Named`] entries are appended to `mounts`.
-    #[serde(skip)]
-    pub(crate) auto_volumes: Vec<AutoVolumeIntent>,
-}
-
-/// Intent to atomically create a named volume alongside the sandbox.
-#[derive(Debug, Clone)]
-pub(crate) struct AutoVolumeIntent {
-    pub name: String,
-    pub kind: crate::volume::VolumeKind,
-    pub quota_mib: Option<u32>,
-    pub capacity_mib: Option<u32>,
-    pub labels: Vec<(String, String)>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -480,7 +460,6 @@ impl Default for SandboxConfig {
             replace_with_timeout: DEFAULT_REPLACE_TIMEOUT,
             manifest_digest: None,
             snapshot_upper_source: None,
-            auto_volumes: Vec::new(),
         }
     }
 }

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -55,6 +55,7 @@ use crate::{
         },
     },
     runtime::{ProcessHandle, SpawnMode, spawn_sandbox},
+    volume::VolumeProvision,
 };
 
 use self::attach::AttachOptions;
@@ -70,6 +71,15 @@ use self::exec::{ExecEvent, ExecHandle, ExecOptions, ExecSink, StdinMode};
 /// metrics slot, so SDK names can be copied into live metrics without
 /// truncation.
 pub const MAX_SANDBOX_NAME_BYTES: usize = microsandbox_metrics::SLOT_NAME_BYTES;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+struct InsertedSandboxRecord {
+    sandbox_id: i32,
+    inserted_named_volume_creates: Vec<types::NamedVolumeCreate>,
+}
 
 //--------------------------------------------------------------------------------------------------
 // Re-Exports
@@ -105,13 +115,9 @@ pub use ssh::{
 };
 pub use types::{
     DiskImageFormat, HostPermissions, ImageBuilder, ImageSource, IntoImage, MountBuilder,
-    MountOptions, Patch, PatchBuilder, RootfsSource, SecurityProfile, StatVirtualization,
-    VolumeMount,
+    MountOptions, NamedVolumeBuilder, NamedVolumeMode, Patch, PatchBuilder, RootfsSource,
+    SecurityProfile, StatVirtualization, VolumeMount,
 };
-
-//--------------------------------------------------------------------------------------------------
-// Types
-//--------------------------------------------------------------------------------------------------
 
 /// Transient registry overrides from the SDK, merged with global config at pull time.
 pub(crate) struct RegistryOverrides {
@@ -400,25 +406,37 @@ impl Sandbox {
         }
 
         // Insert the sandbox record and keep its stable database ID.
-        // Auto-volumes (from `SandboxBuilder::auto_volume`) are inserted
-        // in the same transaction so a concurrent `Volume::list` can't
-        // see them without the owning sandbox.
+        // Sandbox-created named volumes are inserted in the same transaction
+        // so a concurrent `Volume::list` can't observe one before the owning
+        // sandbox exists.
         let write_db = db.write();
-        let sandbox_id = insert_sandbox_record(write_db, &config).await?;
+        let named_volume_creates = named_volume_creates(&config);
+        let _named_volume_locks = lock_named_volume_create_names(&named_volume_creates)?;
+        let inserted_record = insert_sandbox_record_with_named_volumes(write_db, &config).await?;
+        let sandbox_id = inserted_record.sandbox_id;
+        let inserted_named_volume_creates = inserted_record.inserted_named_volume_creates;
         tracing::debug!(sandbox_id, sandbox = %config.name, "create_with_mode: db record inserted");
 
-        // Materialise the on-disk directory for each auto-volume after
-        // the transaction commits. On failure, remove any directories
-        // we already created plus the sandbox row so the partial state
-        // doesn't leak.
-        if !config.auto_volumes.is_empty()
-            && let Err(e) = materialise_auto_volume_dirs(&config.auto_volumes).await
+        // Materialise the on-disk directory for each sandbox-created volume after
+        // the transaction commits. On failure, remove only directories
+        // this create attempt actually materialised plus the DB rows so
+        // unrelated orphaned host data is never deleted.
+        let mut materialised_named_volumes = Vec::new();
+        if !inserted_named_volume_creates.is_empty()
+            && let Err(e) = materialise_named_volume_dirs(
+                &inserted_named_volume_creates,
+                &mut materialised_named_volumes,
+            )
+            .await
         {
-            rollback_auto_volume_dirs(&config.auto_volumes).await;
-            let _ = remove_sandbox_row(write_db, sandbox_id).await;
-            for intent in &config.auto_volumes {
-                let _ = remove_volume_row(write_db, &intent.name).await;
-            }
+            cleanup_named_volume_create_failure(
+                write_db,
+                sandbox_id,
+                &inserted_named_volume_creates,
+                &materialised_named_volumes,
+                true,
+            )
+            .await;
             return Err(e);
         }
 
@@ -428,17 +446,22 @@ impl Sandbox {
         // exit observer cannot be relied upon if the child was SIGKILL'd
         // before activation, and `reconcile_sandbox_runtime_state` will not
         // run reaper cleanup for a Stopped sandbox.
-        // Move auto_volumes out so we can use them after the config
-        // is consumed by create_inner.
-        let auto_volumes = std::mem::take(&mut config.auto_volumes);
         let sandbox = match Self::create_inner(config, sandbox_id, mode).await {
             Ok(sandbox) => sandbox,
             Err(e) => {
-                let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
                 free_metrics_slot_for(sandbox_id, None, microsandbox_metrics::ReleaseMode::Free);
-                rollback_auto_volume_dirs(&auto_volumes).await;
-                for intent in &auto_volumes {
-                    let _ = remove_volume_row(write_db, &intent.name).await;
+                if inserted_named_volume_creates.is_empty() {
+                    let _ =
+                        update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
+                } else {
+                    cleanup_named_volume_create_failure(
+                        write_db,
+                        sandbox_id,
+                        &inserted_named_volume_creates,
+                        &materialised_named_volumes,
+                        true,
+                    )
+                    .await;
                 }
                 return Err(e);
             }
@@ -450,8 +473,19 @@ impl Sandbox {
         ) && let Err(err) = persist_oci_manifest_pin(write_db, sandbox_id, manifest_digest).await
         {
             let _ = sandbox.stop().await;
-            let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
             free_metrics_slot_for(sandbox_id, None, microsandbox_metrics::ReleaseMode::Free);
+            if inserted_named_volume_creates.is_empty() {
+                let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
+            } else {
+                cleanup_named_volume_create_failure(
+                    write_db,
+                    sandbox_id,
+                    &inserted_named_volume_creates,
+                    &materialised_named_volumes,
+                    true,
+                )
+                .await;
+            }
             return Err(err);
         }
 
@@ -461,26 +495,48 @@ impl Sandbox {
                 Ok(metadata) if metadata.kind == fs::FsEntryKind::Directory => {}
                 Ok(_) => {
                     let _ = sandbox.stop().await;
-                    let _ =
-                        update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
                     free_metrics_slot_for(
                         sandbox_id,
                         None,
                         microsandbox_metrics::ReleaseMode::Free,
                     );
+                    if inserted_named_volume_creates.is_empty() {
+                        let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped)
+                            .await;
+                    } else {
+                        cleanup_named_volume_create_failure(
+                            write_db,
+                            sandbox_id,
+                            &inserted_named_volume_creates,
+                            &materialised_named_volumes,
+                            true,
+                        )
+                        .await;
+                    }
                     return Err(MicrosandboxError::InvalidConfig(format!(
                         "workdir is not a directory in guest: {workdir}"
                     )));
                 }
                 Err(error) => {
                     let _ = sandbox.stop().await;
-                    let _ =
-                        update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
                     free_metrics_slot_for(
                         sandbox_id,
                         None,
                         microsandbox_metrics::ReleaseMode::Free,
                     );
+                    if inserted_named_volume_creates.is_empty() {
+                        let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped)
+                            .await;
+                    } else {
+                        cleanup_named_volume_create_failure(
+                            write_db,
+                            sandbox_id,
+                            &inserted_named_volume_creates,
+                            &materialised_named_volumes,
+                            true,
+                        )
+                        .await;
+                    }
                     return Err(MicrosandboxError::InvalidConfig(format!(
                         "workdir does not exist in guest: {workdir}: {error}"
                     )));
@@ -2410,18 +2466,26 @@ fn validate_start_state(config: &SandboxConfig, sandbox_dir: &Path) -> Microsand
 }
 
 /// Insert the sandbox record in the database and return its ID.
+#[cfg(test)]
 async fn insert_sandbox_record(
     db: &DbWriteConnection,
     config: &SandboxConfig,
 ) -> MicrosandboxResult<i32> {
+    Ok(insert_sandbox_record_with_named_volumes(db, config)
+        .await?
+        .sandbox_id)
+}
+
+async fn insert_sandbox_record_with_named_volumes(
+    db: &DbWriteConnection,
+    config: &SandboxConfig,
+) -> MicrosandboxResult<InsertedSandboxRecord> {
     let config_json = serde_json::to_string(config)?;
-    // `auto_volumes` is `#[serde(skip)]` so the cloned config carries
-    // no record of these intents — capture them before the move.
-    let auto_volumes = config.auto_volumes.clone();
+    let named_volume_creates = named_volume_creates(config);
 
     db.transaction(|txn| {
         let config_json = config_json.clone();
-        let auto_volumes = auto_volumes.clone();
+        let named_volume_creates = named_volume_creates.clone();
         async move {
             let now = chrono::Utc::now().naive_utc();
             let model = sandbox_entity::ActiveModel {
@@ -2450,44 +2514,99 @@ async fn insert_sandbox_record(
                     .await?;
             }
 
-            for intent in &auto_volumes {
+            let mut inserted_named_volume_creates = Vec::new();
+            for create in &named_volume_creates {
                 let vol_config = crate::volume::VolumeConfig {
-                    name: intent.name.clone(),
-                    kind: intent.kind,
-                    quota_mib: intent.quota_mib,
-                    capacity_mib: intent.capacity_mib,
-                    labels: intent.labels.clone(),
+                    name: create.name.clone(),
+                    kind: create.kind,
+                    quota_mib: create.quota_mib,
+                    capacity_mib: create.capacity_mib,
+                    labels: create.labels.clone(),
                 };
-                crate::volume::Volume::create_in_transaction(&txn, &vol_config).await?;
+                if matches!(
+                    crate::volume::Volume::provision_in_transaction(
+                        &txn,
+                        &vol_config,
+                        create.mode,
+                    )
+                    .await?,
+                    VolumeProvision::Inserted
+                ) {
+                    inserted_named_volume_creates.push(create.clone());
+                }
             }
 
-            Ok((txn, sandbox_id))
+            Ok((
+                txn,
+                InsertedSandboxRecord {
+                    sandbox_id,
+                    inserted_named_volume_creates,
+                },
+            ))
         }
     })
     .await
 }
 
-async fn materialise_auto_volume_dirs(
-    intents: &[crate::sandbox::config::AutoVolumeIntent],
+fn named_volume_creates(config: &SandboxConfig) -> Vec<types::NamedVolumeCreate> {
+    config
+        .mounts
+        .iter()
+        .filter_map(|mount| mount.named_create().cloned())
+        .collect()
+}
+
+fn lock_named_volume_create_names(
+    creates: &[types::NamedVolumeCreate],
+) -> MicrosandboxResult<Vec<std::fs::File>> {
+    let mut names: Vec<&str> = creates.iter().map(|create| create.name.as_str()).collect();
+    names.sort_unstable();
+    names.dedup();
+
+    names
+        .into_iter()
+        .map(crate::volume::lock_volume_name)
+        .collect()
+}
+
+async fn materialise_named_volume_dirs(
+    creates: &[types::NamedVolumeCreate],
+    materialised: &mut Vec<String>,
 ) -> MicrosandboxResult<()> {
-    for intent in intents {
+    for create in creates {
         let vol_config = crate::volume::VolumeConfig {
-            name: intent.name.clone(),
-            kind: intent.kind,
-            quota_mib: intent.quota_mib,
-            capacity_mib: intent.capacity_mib,
-            labels: intent.labels.clone(),
+            name: create.name.clone(),
+            kind: create.kind,
+            quota_mib: create.quota_mib,
+            capacity_mib: create.capacity_mib,
+            labels: create.labels.clone(),
         };
         crate::volume::Volume::materialise_for(&vol_config).await?;
+        materialised.push(create.name.clone());
     }
     Ok(())
 }
 
-async fn rollback_auto_volume_dirs(intents: &[crate::sandbox::config::AutoVolumeIntent]) {
-    for intent in intents {
-        let path = crate::volume::Volume::path_for(&intent.name);
+async fn rollback_named_volume_dirs(names: &[String]) {
+    for name in names {
+        let path = crate::volume::Volume::path_for(name);
         let _ = tokio::fs::remove_dir_all(&path).await;
     }
+}
+
+async fn cleanup_named_volume_create_failure(
+    db: &DbWriteConnection,
+    sandbox_id: i32,
+    creates: &[types::NamedVolumeCreate],
+    materialised: &[String],
+    remove_sandbox: bool,
+) {
+    rollback_named_volume_dirs(materialised).await;
+    if remove_sandbox {
+        let _ = remove_sandbox_row(db, sandbox_id).await;
+    }
+    let names: Vec<String> = creates.iter().map(|create| create.name.clone()).collect();
+    let _ = remove_volume_rows(db, &names).await;
 }
 
 async fn remove_sandbox_row(db: &DbWriteConnection, sandbox_id: i32) -> MicrosandboxResult<()> {
@@ -2500,14 +2619,19 @@ async fn remove_sandbox_row(db: &DbWriteConnection, sandbox_id: i32) -> Microsan
     .await
 }
 
-async fn remove_volume_row(db: &DbWriteConnection, name: &str) -> MicrosandboxResult<()> {
+async fn remove_volume_rows(db: &DbWriteConnection, names: &[String]) -> MicrosandboxResult<()> {
     use crate::db::entity::volume as volume_entity;
-    let name = name.to_string();
+
+    if names.is_empty() {
+        return Ok(());
+    }
+
+    let names = names.to_vec();
     db.transaction(|txn| {
-        let name = name.clone();
+        let names = names.clone();
         async move {
             volume_entity::Entity::delete_many()
-                .filter(volume_entity::Column::Name.eq(name))
+                .filter(volume_entity::Column::Name.is_in(names))
                 .exec(&txn)
                 .await?;
             Ok((txn, ()))
@@ -2634,11 +2758,11 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        MAX_SANDBOX_NAME_BYTES, RootfsSource, SandboxConfig, SandboxFilter, SandboxStatus,
-        digest_pinned_reference, filter_sandbox_ids, insert_sandbox_record,
-        persist_oci_manifest_pin, prepare_create_target, reconcile_sandbox_runtime_state,
-        remove_dir_if_exists, validate_labels, validate_rootfs_source,
-        validate_sandbox_name_for_runtime,
+        HostPermissions, MAX_SANDBOX_NAME_BYTES, RootfsSource, SandboxConfig, SandboxFilter,
+        SandboxStatus, StatVirtualization, VolumeMount, digest_pinned_reference,
+        filter_sandbox_ids, insert_sandbox_record, persist_oci_manifest_pin, prepare_create_target,
+        reconcile_sandbox_runtime_state, remove_dir_if_exists, validate_labels,
+        validate_rootfs_source, validate_sandbox_name_for_runtime,
     };
 
     /// Open both pools at `db_path` for tests, with migrations applied.
@@ -2664,6 +2788,33 @@ mod tests {
             .unwrap()
             .as_nanos();
         std::env::temp_dir().join(format!("microsandbox-rootfs-{suffix}-{nanos}"))
+    }
+
+    fn unique_volume_name(prefix: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        format!("{prefix}-{nanos}")
+    }
+
+    fn named_create_mount(name: impl Into<String>, guest: impl Into<String>) -> VolumeMount {
+        let name = name.into();
+        VolumeMount::Named {
+            create: Some(super::types::NamedVolumeCreate {
+                mode: super::types::NamedVolumeMode::Create,
+                name: name.clone(),
+                kind: crate::volume::VolumeKind::Directory,
+                quota_mib: None,
+                capacity_mib: None,
+                labels: Vec::new(),
+            }),
+            name,
+            guest: guest.into(),
+            options: Default::default(),
+            stat_virtualization: StatVirtualization::Strict,
+            host_permissions: HostPermissions::Private,
+        }
     }
 
     fn dead_pid() -> i32 {
@@ -3109,9 +3260,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_insert_sandbox_record_atomic_with_auto_volumes() {
+    async fn test_insert_sandbox_record_atomic_with_named_volume_creates() {
         use crate::db::entity::volume as volume_entity;
-        use crate::sandbox::config::AutoVolumeIntent;
 
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
@@ -3122,13 +3272,15 @@ mod tests {
             image: RootfsSource::oci("docker.io/library/alpine"),
             ..Default::default()
         };
-        config.auto_volumes.push(AutoVolumeIntent {
-            name: "atomic-host-tmp".into(),
-            kind: crate::volume::VolumeKind::Directory,
-            quota_mib: None,
-            capacity_mib: None,
-            labels: vec![("owner".into(), "atomic-host".into())],
-        });
+        let mut mount = named_create_mount("atomic-host-tmp", "/tmp");
+        if let VolumeMount::Named {
+            create: Some(create),
+            ..
+        } = &mut mount
+        {
+            create.labels.push(("owner".into(), "atomic-host".into()));
+        }
+        config.mounts.push(mount);
 
         let _sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
 
@@ -3151,7 +3303,6 @@ mod tests {
     #[tokio::test]
     async fn test_insert_sandbox_record_rolls_back_when_volume_name_collides() {
         use crate::db::entity::volume as volume_entity;
-        use crate::sandbox::config::AutoVolumeIntent;
 
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
@@ -3175,13 +3326,7 @@ mod tests {
             image: RootfsSource::oci("docker.io/library/alpine"),
             ..Default::default()
         };
-        config.auto_volumes.push(AutoVolumeIntent {
-            name: "collision".into(),
-            kind: crate::volume::VolumeKind::Directory,
-            quota_mib: None,
-            capacity_mib: None,
-            labels: Vec::new(),
-        });
+        config.mounts.push(named_create_mount("collision", "/tmp"));
 
         let result = insert_sandbox_record(pools.write(), &config).await;
         assert!(
@@ -3199,6 +3344,167 @@ mod tests {
             sb.is_none(),
             "transaction must roll back the sandbox row when volume insert fails"
         );
+    }
+
+    #[tokio::test]
+    async fn test_insert_sandbox_record_ensure_reuses_existing_named_volume() {
+        use crate::db::entity::volume as volume_entity;
+
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let pools = open_test_pools(&db_path).await;
+
+        let now = chrono::Utc::now().naive_utc();
+        volume_entity::Entity::insert(volume_entity::ActiveModel {
+            name: Set("existing-cache".into()),
+            kind: Set(crate::volume::VolumeKind::Directory.as_str().to_string()),
+            labels: Set(Some(
+                serde_json::to_string(&vec![("owner".to_string(), "tests".to_string())]).unwrap(),
+            )),
+            created_at: Set(Some(now)),
+            updated_at: Set(Some(now)),
+            ..Default::default()
+        })
+        .exec(pools.write())
+        .await
+        .unwrap();
+
+        let mut config = SandboxConfig {
+            name: "ensure-host".into(),
+            image: RootfsSource::oci("docker.io/library/alpine"),
+            ..Default::default()
+        };
+        let mut mount = named_create_mount("existing-cache", "/cache");
+        if let VolumeMount::Named {
+            create: Some(create),
+            ..
+        } = &mut mount
+        {
+            create.mode = super::types::NamedVolumeMode::EnsureExists;
+        }
+        config.mounts.push(mount);
+
+        let record = super::insert_sandbox_record_with_named_volumes(pools.write(), &config)
+            .await
+            .unwrap();
+
+        assert!(record.inserted_named_volume_creates.is_empty());
+        let sb = super::sandbox_entity::Entity::find_by_id(record.sandbox_id)
+            .one(pools.read())
+            .await
+            .unwrap();
+        assert!(sb.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_named_volume_create_cleanup_preserves_unmaterialised_orphan_dir() {
+        use crate::db::entity::volume as volume_entity;
+
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let pools = open_test_pools(&db_path).await;
+        let name = unique_volume_name("orphan-named-volume");
+        let path = crate::volume::Volume::path_for(&name);
+        let marker = path.join("marker");
+        if path.exists() {
+            tokio::fs::remove_dir_all(&path).await.unwrap();
+        }
+        tokio::fs::create_dir_all(&path).await.unwrap();
+        tokio::fs::write(&marker, b"keep").await.unwrap();
+
+        let mut config = SandboxConfig {
+            name: "orphan-cleanup-host".into(),
+            image: RootfsSource::oci("docker.io/library/alpine"),
+            ..Default::default()
+        };
+        config.mounts.push(named_create_mount(name.clone(), "/tmp"));
+
+        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
+        let creates = super::named_volume_creates(&config);
+        let mut materialised = Vec::new();
+        let err = super::materialise_named_volume_dirs(&creates, &mut materialised)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+
+        super::cleanup_named_volume_create_failure(
+            pools.write(),
+            sandbox_id,
+            &creates,
+            &materialised,
+            true,
+        )
+        .await;
+
+        assert!(
+            marker.exists(),
+            "cleanup must not delete a directory it did not materialise"
+        );
+        let vol = volume_entity::Entity::find()
+            .filter(volume_entity::Column::Name.eq(&name))
+            .one(pools.read())
+            .await
+            .unwrap();
+        assert!(vol.is_none());
+        let sb = super::sandbox_entity::Entity::find_by_id(sandbox_id)
+            .one(pools.read())
+            .await
+            .unwrap();
+        assert!(sb.is_none());
+
+        tokio::fs::remove_dir_all(&path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_named_volume_create_cleanup_removes_materialised_dirs_and_rows() {
+        use crate::db::entity::volume as volume_entity;
+
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let pools = open_test_pools(&db_path).await;
+        let name = unique_volume_name("materialised-named-volume");
+        let path = crate::volume::Volume::path_for(&name);
+        if path.exists() {
+            tokio::fs::remove_dir_all(&path).await.unwrap();
+        }
+
+        let mut config = SandboxConfig {
+            name: "materialised-cleanup-host".into(),
+            image: RootfsSource::oci("docker.io/library/alpine"),
+            ..Default::default()
+        };
+        config.mounts.push(named_create_mount(name.clone(), "/tmp"));
+
+        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
+        let creates = super::named_volume_creates(&config);
+        let mut materialised = Vec::new();
+        super::materialise_named_volume_dirs(&creates, &mut materialised)
+            .await
+            .unwrap();
+        assert_eq!(materialised, vec![name.clone()]);
+        assert!(path.exists());
+
+        super::cleanup_named_volume_create_failure(
+            pools.write(),
+            sandbox_id,
+            &creates,
+            &materialised,
+            true,
+        )
+        .await;
+
+        assert!(!path.exists());
+        let vol = volume_entity::Entity::find()
+            .filter(volume_entity::Column::Name.eq(&name))
+            .one(pools.read())
+            .await
+            .unwrap();
+        assert!(vol.is_none());
+        let sb = super::sandbox_entity::Entity::find_by_id(sandbox_id)
+            .one(pools.read())
+            .await
+            .unwrap();
+        assert!(sb.is_none());
     }
 
     #[tokio::test]

--- a/crates/microsandbox/lib/sandbox/types.rs
+++ b/crates/microsandbox/lib/sandbox/types.rs
@@ -204,6 +204,11 @@ pub enum VolumeMount {
         name: String,
         /// Guest mount path.
         guest: String,
+        /// Creation metadata for sandbox-time named volume provisioning.
+        ///
+        /// This is transient and intentionally skipped when sandbox configs are
+        /// persisted; restarting a sandbox mounts the already-created volume.
+        create: Option<NamedVolumeCreate>,
         /// Guest mount behavior.
         options: MountOptions,
         /// Guest-visible stat virtualization policy.
@@ -252,14 +257,16 @@ pub struct MountBuilder {
     disk_fstype: Option<String>,
     stat_virtualization: Option<StatVirtualization>,
     host_permissions: Option<HostPermissions>,
-    create_intent: Option<super::config::AutoVolumeIntent>,
     error: Option<crate::MicrosandboxError>,
 }
 
 /// Internal kind for the mount builder.
 enum MountKind {
     Bind(PathBuf),
-    Named(String),
+    Named {
+        name: String,
+        create: Option<NamedVolumeCreate>,
+    },
     Tmpfs,
     Disk(PathBuf),
     Unset,
@@ -356,15 +363,40 @@ pub enum Patch {
     },
 }
 
-/// Sub-builder for [`MountBuilder::create_named_with`].
-pub struct VolumeBuilder {
-    intent: super::config::AutoVolumeIntent,
+/// Creation metadata for sandbox-time named volume provisioning.
+///
+/// Values are produced by [`MountBuilder::named_with`].
+#[derive(Debug, Clone)]
+pub struct NamedVolumeCreate {
+    pub(crate) mode: NamedVolumeMode,
+    pub(crate) name: String,
+    pub(crate) kind: crate::volume::VolumeKind,
+    pub(crate) quota_mib: Option<u32>,
+    pub(crate) capacity_mib: Option<u32>,
+    pub(crate) labels: Vec<(String, String)>,
 }
 
-impl VolumeBuilder {
+/// Sandbox-time behavior for a named volume mount.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NamedVolumeMode {
+    /// Require the named volume to already exist.
+    Existing,
+    /// Create the named volume and fail if it already exists.
+    Create,
+    /// Ensure the named volume exists, or reuse a compatible existing volume.
+    EnsureExists,
+}
+
+/// Sub-builder for [`MountBuilder::named_with`].
+pub struct NamedVolumeBuilder {
+    create: NamedVolumeCreate,
+}
+
+impl NamedVolumeBuilder {
     pub(crate) fn new(name: String) -> Self {
         Self {
-            intent: super::config::AutoVolumeIntent {
+            create: NamedVolumeCreate {
+                mode: NamedVolumeMode::Existing,
                 name,
                 kind: crate::volume::VolumeKind::Directory,
                 quota_mib: None,
@@ -374,26 +406,96 @@ impl VolumeBuilder {
         }
     }
 
+    /// Require the volume to already exist.
+    pub fn existing(mut self) -> Self {
+        self.create.mode = NamedVolumeMode::Existing;
+        self
+    }
+
+    /// Create the volume and fail if it already exists.
+    pub fn create(mut self) -> Self {
+        self.create.mode = NamedVolumeMode::Create;
+        self
+    }
+
+    /// Create the volume if it does not exist, or reuse a compatible existing volume.
+    pub fn ensure_exists(mut self) -> Self {
+        self.create.mode = NamedVolumeMode::EnsureExists;
+        self
+    }
+
     /// Override the volume name.
     pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.intent.name = name.into();
+        self.create.name = name.into();
+        self
+    }
+
+    /// Use directory-backed storage.
+    pub fn directory(mut self) -> Self {
+        self.create.kind = crate::volume::VolumeKind::Directory;
+        self.create.capacity_mib = None;
+        self
+    }
+
+    /// Use raw ext4 disk-image storage.
+    pub fn disk(mut self) -> Self {
+        self.create.kind = crate::volume::VolumeKind::Disk;
+        self.create.quota_mib = None;
         self
     }
 
     /// Set a storage quota for the volume.
     pub fn quota(mut self, size: impl Into<Mebibytes>) -> Self {
-        self.intent.quota_mib = Some(size.into().as_u32());
+        self.create.quota_mib = Some(size.into().as_u32());
+        self
+    }
+
+    /// Set disk volume capacity.
+    pub fn size(mut self, size: impl Into<Mebibytes>) -> Self {
+        self.create.capacity_mib = Some(size.into().as_u32());
         self
     }
 
     /// Attach a label to the volume. Can be called multiple times.
     pub fn label(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.intent.labels.push((key.into(), value.into()));
+        self.create.labels.push((key.into(), value.into()));
         self
     }
 
-    pub(crate) fn build(self) -> super::config::AutoVolumeIntent {
-        self.intent
+    pub(crate) fn build(self) -> NamedVolumeCreate {
+        self.create
+    }
+}
+
+impl NamedVolumeCreate {
+    /// Creation behavior for this named volume mount.
+    pub fn mode(&self) -> NamedVolumeMode {
+        self.mode
+    }
+
+    /// Volume name to create or ensure exists.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Storage kind to create or ensure exists.
+    pub fn kind(&self) -> crate::volume::VolumeKind {
+        self.kind
+    }
+
+    /// Directory quota in MiB, if configured.
+    pub fn quota_mib(&self) -> Option<u32> {
+        self.quota_mib
+    }
+
+    /// Disk capacity in MiB, if configured.
+    pub fn capacity_mib(&self) -> Option<u32> {
+        self.capacity_mib
+    }
+
+    /// Labels to attach to newly-created volumes.
+    pub fn labels(&self) -> &[(String, String)] {
+        &self.labels
     }
 }
 
@@ -418,7 +520,6 @@ impl MountBuilder {
             disk_fstype: None,
             stat_virtualization: None,
             host_permissions: None,
-            create_intent: None,
             error: None,
         }
     }
@@ -432,41 +533,25 @@ impl MountBuilder {
     /// Mount a named volume created via [`Volume::create`](crate::volume::Volume::create).
     /// The volume persists across sandbox restarts and can be shared between sandboxes.
     pub fn named(mut self, name: impl Into<String>) -> Self {
-        self.mount = MountKind::Named(name.into());
+        self.mount = MountKind::Named {
+            name: name.into(),
+            create: None,
+        };
         self
     }
 
-    /// Provision a fresh named volume atomically with the sandbox and
-    /// mount it. The volume row is inserted in the same DB transaction
-    /// as the sandbox row.
-    pub fn create_named(mut self, name: impl Into<String>) -> Self {
-        let name = name.into();
-        self.mount = MountKind::Named(name.clone());
-        self.create_intent = Some(super::config::AutoVolumeIntent {
-            name,
-            kind: crate::volume::VolumeKind::Directory,
-            quota_mib: None,
-            capacity_mib: None,
-            labels: Vec::new(),
-        });
-        self
-    }
-
-    /// Same as [`create_named`](Self::create_named) but with builder-driven
-    /// volume metadata (quota, labels, name override).
-    pub fn create_named_with(
+    /// Mount a named volume with explicit existence behavior.
+    pub fn named_with(
         mut self,
         name: impl Into<String>,
-        f: impl FnOnce(VolumeBuilder) -> VolumeBuilder,
+        f: impl FnOnce(NamedVolumeBuilder) -> NamedVolumeBuilder,
     ) -> Self {
-        let intent = f(VolumeBuilder::new(name.into())).build();
-        self.mount = MountKind::Named(intent.name.clone());
-        self.create_intent = Some(intent);
+        let name = name.into();
+        let create = f(NamedVolumeBuilder::new(name)).build();
+        let name = create.name.clone();
+        let create = (create.mode != NamedVolumeMode::Existing).then_some(create);
+        self.mount = MountKind::Named { name, create };
         self
-    }
-
-    pub(crate) fn take_create_intent(&mut self) -> Option<super::config::AutoVolumeIntent> {
-        self.create_intent.take()
     }
 
     /// Use tmpfs (memory-backed).
@@ -610,7 +695,7 @@ impl MountBuilder {
         // Reject options set on the wrong kind.
         let is_tmpfs = matches!(self.mount, MountKind::Tmpfs);
         let is_disk = matches!(self.mount, MountKind::Disk(_));
-        let is_virtiofs = matches!(self.mount, MountKind::Bind(_) | MountKind::Named(_));
+        let is_virtiofs = matches!(self.mount, MountKind::Bind(_) | MountKind::Named { .. });
         if self.size_mib.is_some() && !is_tmpfs {
             return Err(crate::MicrosandboxError::InvalidConfig(
                 ".size() is only valid for tmpfs mounts".into(),
@@ -695,11 +780,12 @@ impl MountBuilder {
                     host_permissions,
                 }
             }
-            MountKind::Named(name) => {
+            MountKind::Named { name, create } => {
                 crate::volume::validate_volume_name(&name)?;
                 VolumeMount::Named {
                     name,
                     guest: self.guest,
+                    create,
                     options: self.options,
                     stat_virtualization,
                     host_permissions,
@@ -871,6 +957,13 @@ impl VolumeMount {
             | Self::Named { guest, .. }
             | Self::Tmpfs { guest, .. }
             | Self::DiskImage { guest, .. } => guest,
+        }
+    }
+
+    pub(crate) fn named_create(&self) -> Option<&NamedVolumeCreate> {
+        match self {
+            Self::Named { create, .. } => create.as_ref(),
+            _ => None,
         }
     }
 }
@@ -1326,6 +1419,7 @@ impl Serialize for VolumeMount {
             Self::Named {
                 name,
                 guest,
+                create: _,
                 options,
                 stat_virtualization,
                 host_permissions,
@@ -1457,6 +1551,7 @@ impl<'de> Deserialize<'de> for VolumeMount {
             } => Self::Named {
                 name,
                 guest,
+                create: None,
                 options: decode_mount_options(options, readonly),
                 stat_virtualization,
                 host_permissions,
@@ -1509,6 +1604,7 @@ impl std::fmt::Debug for VolumeMount {
             Self::Named {
                 name,
                 guest,
+                create,
                 options,
                 stat_virtualization,
                 host_permissions,
@@ -1516,6 +1612,7 @@ impl std::fmt::Debug for VolumeMount {
                 .debug_struct("Named")
                 .field("name", name)
                 .field("guest", guest)
+                .field("create", create)
                 .field("options", options)
                 .field("stat_virtualization", stat_virtualization)
                 .field("host_permissions", host_permissions)
@@ -1686,6 +1783,7 @@ mod tests {
             VolumeMount::Named {
                 name: "cache".to_string(),
                 guest: "/data".to_string(),
+                create: None,
                 options: MountOptions::default(),
                 stat_virtualization: StatVirtualization::Strict,
                 host_permissions: HostPermissions::Private,

--- a/crates/microsandbox/lib/volume/mod.rs
+++ b/crates/microsandbox/lib/volume/mod.rs
@@ -14,7 +14,7 @@ use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder
 use crate::{
     MicrosandboxError, MicrosandboxResult,
     db::entity::{sandbox as sandbox_entity, volume as volume_entity},
-    sandbox::{SandboxConfig, SandboxStatus, VolumeMount},
+    sandbox::{NamedVolumeMode, SandboxConfig, SandboxStatus, VolumeMount},
     size::Mebibytes,
 };
 
@@ -82,6 +82,15 @@ pub struct VolumeHandle {
 /// Builder for creating a volume.
 pub struct VolumeBuilder {
     config: VolumeConfig,
+}
+
+/// Result of provisioning a named volume record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VolumeProvision {
+    /// The volume record was inserted by this operation.
+    Inserted,
+    /// A compatible existing record was reused.
+    Existing,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -299,21 +308,22 @@ impl Volume {
         })
     }
 
-    /// Insert the volume DB record inside the caller's transaction.
+    /// Provision the volume DB record inside the caller's transaction.
     ///
-    /// Lets `SandboxBuilder::auto_volume` create the volume and the
-    /// sandbox in one atomic write so a concurrent `Volume::list`
-    /// cannot observe the volume before the owning sandbox exists.
+    /// Lets sandbox-time named volume creation insert the volume and sandbox
+    /// in one atomic write so a concurrent `Volume::list` cannot observe the
+    /// volume before the owning sandbox exists.
     /// Returns [`MicrosandboxError::VolumeAlreadyExists`] if the name
     /// is already in the table.
     ///
     /// The caller is responsible for creating the on-disk directory
     /// after the transaction commits (or rolling back via
     /// `Volume::remove` if the directory step fails).
-    pub(crate) async fn create_in_transaction<C: ConnectionTrait>(
+    pub(crate) async fn provision_in_transaction<C: ConnectionTrait>(
         txn: &C,
         config: &VolumeConfig,
-    ) -> MicrosandboxResult<()> {
+        mode: NamedVolumeMode,
+    ) -> MicrosandboxResult<VolumeProvision> {
         validate_volume_name(&config.name)?;
         validate_volume_config(config)?;
 
@@ -321,8 +331,21 @@ impl Volume {
             .filter(volume_entity::Column::Name.eq(&config.name))
             .one(txn)
             .await?;
-        if existing.is_some() {
-            return Err(MicrosandboxError::VolumeAlreadyExists(config.name.clone()));
+        if let Some(existing) = existing {
+            return match mode {
+                NamedVolumeMode::Create => {
+                    Err(MicrosandboxError::VolumeAlreadyExists(config.name.clone()))
+                }
+                NamedVolumeMode::EnsureExists => {
+                    validate_existing_volume_config(&existing, config)?;
+                    Ok(VolumeProvision::Existing)
+                }
+                NamedVolumeMode::Existing => Ok(VolumeProvision::Existing),
+            };
+        }
+
+        if mode == NamedVolumeMode::Existing {
+            return Err(MicrosandboxError::VolumeNotFound(config.name.clone()));
         }
 
         let labels_json = if config.labels.is_empty() {
@@ -346,7 +369,7 @@ impl Volume {
             ..Default::default()
         };
         volume_entity::Entity::insert(model).exec(txn).await?;
-        Ok(())
+        Ok(VolumeProvision::Inserted)
     }
 
     /// Resolve the on-disk path for a named volume.
@@ -355,7 +378,7 @@ impl Volume {
     }
 
     /// Provision the on-disk artifact for a volume registered via
-    /// [`create_in_transaction`].
+    /// [`provision_in_transaction`].
     pub(crate) async fn materialise_for(config: &VolumeConfig) -> MicrosandboxResult<()> {
         let volumes_dir = crate::config::config().volumes_dir();
         tokio::fs::create_dir_all(&volumes_dir).await?;
@@ -614,7 +637,55 @@ fn validate_volume_config(config: &VolumeConfig) -> MicrosandboxResult<()> {
     }
 }
 
-fn lock_volume_name(name: &str) -> MicrosandboxResult<File> {
+fn validate_existing_volume_config(
+    existing: &volume_entity::Model,
+    requested: &VolumeConfig,
+) -> MicrosandboxResult<()> {
+    let existing_kind = VolumeKind::from_db_value(&existing.kind);
+    if existing_kind != requested.kind {
+        return Err(MicrosandboxError::InvalidConfig(format!(
+            "named volume {:?} already exists with kind {:?}, requested {:?}",
+            requested.name, existing_kind, requested.kind
+        )));
+    }
+
+    let requested_quota = requested.quota_mib.map(|value| value as i32);
+    if existing.quota_mib != requested_quota {
+        return Err(MicrosandboxError::InvalidConfig(format!(
+            "named volume {:?} already exists with quota {:?}, requested {:?}",
+            requested.name, existing.quota_mib, requested_quota
+        )));
+    }
+
+    let requested_capacity = requested
+        .capacity_mib
+        .map(|value| i64::from(value) * 1024 * 1024);
+    if existing.capacity_bytes != requested_capacity {
+        return Err(MicrosandboxError::InvalidConfig(format!(
+            "named volume {:?} already exists with capacity {:?}, requested {:?}",
+            requested.name, existing.capacity_bytes, requested_capacity
+        )));
+    }
+
+    if !requested.labels.is_empty() {
+        let existing_labels = existing
+            .labels
+            .as_deref()
+            .map(serde_json::from_str::<Vec<(String, String)>>)
+            .transpose()?
+            .unwrap_or_default();
+        if existing_labels != requested.labels {
+            return Err(MicrosandboxError::InvalidConfig(format!(
+                "named volume {:?} already exists with different labels",
+                requested.name
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn lock_volume_name(name: &str) -> MicrosandboxResult<File> {
     let volumes_dir = crate::config::config().volumes_dir();
     std::fs::create_dir_all(&volumes_dir)?;
     let locks_dir = volumes_dir.join(".locks");

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -42,7 +42,7 @@ Common flags:
 | `-c`, `--cpus` | Virtual CPU limit |
 | `-m`, `--memory` | Memory limit, such as `512M` or `1G` |
 | `-v`, `--volume` | Mount a host path or named volume, such as `./src:/app:ro` |
-| `--mount-dir`, `--mount-file`, `--mount-disk`, `--mount-named` | Mount a source with an explicit kind (`SOURCE:DEST[:OPTIONS]` or `NAME:DEST[:OPTIONS]`) |
+| `--mount-dir`, `--mount-file`, `--mount-disk`, `--mount-named` | Mount a source with an explicit kind (`SOURCE:DEST[:OPTIONS]` or `NAME:DEST[:OPTIONS]`). `--mount-named` creates missing named volumes idempotently and accepts `kind=dir\|disk`, `size=...`, and `quota=...` |
 | `-p`, `--port` | Publish a port, such as `8000:8000` or `0.0.0.0:8000:8000` |
 | `-e`, `--env` | Set an environment variable |
 | `--label` | Attach a label for metric attribution (`KEY=VALUE`, or bare `KEY`). Repeatable |
@@ -351,7 +351,7 @@ msb install --list                   # List installed commands
 | `-c`, `--cpus` | Number of virtual CPUs to allocate |
 | `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
 | `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST[:OPTIONS]`, e.g. `./src:/app:ro,noexec`) |
-| `--mount-dir`, `--mount-file`, `--mount-disk`, `--mount-named` | Mount a source with an explicit kind (`SOURCE:DEST[:OPTIONS]` or `NAME:DEST[:OPTIONS]`) |
+| `--mount-dir`, `--mount-file`, `--mount-disk`, `--mount-named` | Mount a source with an explicit kind (`SOURCE:DEST[:OPTIONS]` or `NAME:DEST[:OPTIONS]`). `--mount-named` creates missing named volumes idempotently and accepts `kind=dir\|disk`, `size=...`, and `quota=...` |
 | `--security` | In-guest security profile (`default` or `restricted`) |
 | `-w`, `--workdir` | Working directory inside the sandbox |
 | `--shell` | Shell for interactive sessions |

--- a/docs/cli/volume-commands.mdx
+++ b/docs/cli/volume-commands.mdx
@@ -54,21 +54,23 @@ msb volume rm cache-1 cache-2   # Remove multiple
 
 ## Using volumes with sandboxes
 
-Mount a named volume when creating or running a sandbox. The volume name goes before the colon, the guest path after.
+Mount a named volume when creating or running a sandbox. The volume name goes before the colon, the guest path after. CLI named mounts are idempotent: if the named volume is missing, microsandbox creates it; if it already exists with compatible settings, microsandbox reuses it.
 
 ```bash
-# Create a volume, then mount it
-msb volume create app-data
+# Create or reuse a directory-backed named volume, then mount it
 msb run --name worker -v app-data:/data python
 
-# Create a disk-backed volume, then mount it
-msb volume create docker-data --kind disk --size 20G
-msb run --name docker-demo --mount-named docker-data:/var/lib/docker docker:dind
+# Create or reuse a disk-backed named volume, then mount it
+msb run --name docker-demo \
+  --mount-named docker-data:/var/lib/docker:kind=disk,size=20G \
+  docker:dind
 
 # Share between sandboxes
 msb run --name writer -v shared:/data alpine -- sh -c "echo hello > /data/msg.txt"
 msb run --name reader -v shared:/data alpine -- cat /data/msg.txt
 ```
+
+`--mount-named` accepts named-volume creation options in the mount option block: `kind=dir|disk`, `size=<size>` for disk-backed volumes, and `quota=<size>` for directory-backed volumes. `kind=disk` requires `size=...`; `size=...` without `kind=disk` is rejected. If an existing volume has a different kind, capacity, or quota than the requested settings, sandbox creation fails instead of silently changing the volume.
 
 <Tip>
   The CLI distinguishes bind mounts from named volumes by looking for a `/` or `.` prefix. `./src:/app` is a bind mount (host path). `myvolume:/data` is a named volume. This matches Docker's convention.

--- a/docs/recipes/docker/docker-in-sandbox.mdx
+++ b/docs/recipes/docker/docker-in-sandbox.mdx
@@ -4,128 +4,86 @@ description: Start dockerd inside a microsandbox VM and run containers from an i
 icon: "docker"
 ---
 
-<iframe
-  className="w-full aspect-video rounded-xl"
-  src="https://www.youtube.com/embed/scFFZWsbrbo"
-  title="Docker in a Sandbox demo"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
-></iframe>
+This recipe starts a complete Docker environment inside a microsandbox VM. It is useful for sandboxed builds, agent workflows that need their own Docker daemon, or experiments you do not want leaking onto the dev machine. The host's Docker setup, if any, is left untouched.
 
-This recipe gives you a complete, throwaway Docker environment inside a microsandbox VM. It is useful for sandboxed builds, isolating agent workflows that need their own Docker, or any experiment you don't want leaking onto the dev machine. The host's Docker setup (if any) is left untouched.
+The command below boots the `docker:dind` image, starts Docker inside the sandbox, waits for it to be ready, and then opens an interactive shell. From there, Docker commands run against the daemon inside the sandbox, not your host.
 
-`docker:dind` is a regular OCI image, so microsandbox can boot one inside a microVM. You boot the image into a shell, start `dockerd`, and from there every Docker command in that shell talks to the nested daemon rather than the host's.
+## Start Docker in a sandbox
 
-Use the default security profile for this recipe. Docker-in-Docker needs normal guest-root mount privileges for containerd's bind and overlay mounts, so it does not work in the restricted profile.
-
-Storage needs one small workaround. The sandbox root is already an overlayfs mount, and Docker's default storage driver also wants overlayfs for container layers. Stacking the two produces overlay-on-overlay mount errors. The fix is to point Docker's data root at a disk-backed named volume.
-
-<Tip>
-  Docker's data lives on the `docker-data` volume in this recipe. Pulled images and created containers survive sandbox removal until you remove the volume.
-</Tip>
-
-## Step 1: Create the volume
-
-```bash
-msb volume create docker-data --kind disk --size 20G
-```
-
-## Step 2: Create the helper script
-
-Save this as `start-docker` in the directory you'll run `msb` from:
-
-```bash start-docker
-#!/bin/sh
-set -eu
-
-if docker info >/dev/null 2>&1; then
-  echo "Docker is already running."
-  exit 0
-fi
-
-dockerd --data-root=/var/lib/docker >/tmp/dockerd.log 2>&1 &
-
-printf "Starting Docker"
-i=0
-while ! docker info >/dev/null 2>&1; do
-  i=$((i + 1))
-  if [ "$i" -ge 60 ]; then
-    echo
-    cat /tmp/dockerd.log
-    exit 1
-  fi
-  printf "."
-  sleep 1
-done
-echo " ready"
-```
-
-Make it executable:
-
-```bash
-chmod +x start-docker
-```
-
-## Step 3: Boot the sandbox
-
-```bash
+```sh
 msb run --name docker-demo --replace \
   --memory 2G \
   --mount-named docker-data:/var/lib/docker \
-  --entrypoint sh \
-  --script-path start-docker:./start-docker \
+  --script start='dockerd >/tmp/dockerd.log 2>&1 &
+  timeout 60 sh -c "until docker info>/dev/null 2>&1;do sleep 1;done" || {
+    cat /tmp/dockerd.log
+    false
+  }
+  exec sh' \
+  --entrypoint start \
   docker:dind
 ```
 
-`--entrypoint sh` replaces the image's default DinD entrypoint with an interactive shell. `--script-path` makes `start-docker` available inside the sandbox at `/.msb/scripts/start-docker`, which is already on `PATH`.
+This command does three things:
 
-## Step 4: Start the daemon
+- Starts the `docker:dind` image in a sandbox named `docker-demo`.
+- Mounts a named volume called `docker-data` at `/var/lib/docker`, where Docker stores images, containers, and build cache.
+- Runs the inline `start` script as the entrypoint. The script starts Docker, waits until it is ready, and then opens a shell.
 
-From the sandbox shell, run the helper:
+`--mount-named docker-data:/var/lib/docker` is idempotent. If `docker-data` does not exist, the CLI creates it before starting the sandbox. If it already exists with compatible settings, the same command reuses it, so pulled images and created containers can survive `msb rm docker-demo`.
 
-```bash
-start-docker
+## Run a container
+
+From the sandbox shell, run a nested Ubuntu container:
+
+```sh
+docker run -it --rm ubuntu bash
 ```
 
-Once it prints `ready`, the daemon is running and the Docker client in the same shell is connected to it.
+You are now in a container running inside Docker, which is itself running inside the microsandbox VM. Exit the Ubuntu container with `exit` to return to the `docker-demo` sandbox shell.
 
-## Step 5: Run something
+You can also verify the daemon with a short non-interactive command:
 
-Verify the daemon with hello-world:
-
-```bash
+```sh
 docker run --rm hello-world
 ```
 
-For something closer to a real workload, start a long-running container and tail its logs:
-
-```bash
-docker run -d --name heartbeat alpine sh -c 'while true; do date; sleep 1; done'
-docker ps
-docker logs -f heartbeat
-```
-
-`Ctrl-C` stops the tail; `heartbeat` continues running in the background.
-
-For a visual demo, run cmatrix in a nested Alpine container:
-
-```bash
-docker run --rm -it alpine sh -lc 'apk add --no-cache cmatrix >/dev/null && cmatrix -ab'
-```
-
-`q` exits.
-
 ## Cleanup
 
-```bash
+```sh
 exit
 msb rm -f docker-demo
 msb volume rm docker-data
 ```
 
+Remove `docker-data` only when you no longer need the images, containers, and build cache stored by the nested daemon.
+
+## Details and alternatives
+
+Use the default security profile for this recipe. Docker-in-Docker needs normal guest-root mount privileges, so restricted sandboxes are not supported here.
+
+The named mount gives Docker its own storage at `/var/lib/docker`. That matters because the sandbox root filesystem is already overlay-backed, and Docker's default storage driver also uses overlay layers. Keeping Docker's data directory on a named mount avoids putting Docker's overlay storage directly on top of the sandbox root overlay.
+
+### VFS alternative
+
+If you want to avoid the named volume, you can ask Docker to use the `vfs` storage driver instead:
+
+```sh
+msb run --name docker-demo --replace \
+  --memory 2G \
+  --script start='dockerd --storage-driver=vfs >/tmp/dockerd.log 2>&1 &
+  timeout 60 sh -c "until docker info>/dev/null 2>&1;do sleep 1;done" || {
+    cat /tmp/dockerd.log
+    false
+  }
+  exec sh' \
+  --entrypoint start \
+  docker:dind
+```
+
+The tradeoff is performance and disk usage. `vfs` copies full filesystem trees instead of using overlay layers, so pulls and builds can be slower and use more space. Prefer the named-mount version for normal Docker-in-Docker work.
+
 ## Notes
 
-- **Disk sizing.** `docker-data` is 20 GiB here. Increase `--size` if you plan to pull larger images.
-- **Directory volumes don't fix this.** They are virtiofs-backed host directories, and Docker's overlay snapshotter can't use those for `upperdir` / `workdir`.
-- **Tmpfs is still useful for scratch.** You can add `--tmpfs /tmp:N` for temporary build scratch, but Docker's data root should stay on the disk-backed volume.
+- **Memory.** The recipe uses `--memory 2G`. Increase it for larger builds or memory-hungry containers.
 - **Not the same as [Sandbox in Docker](/recipes/docker/docker).** That recipe covers the opposite direction.

--- a/docs/sandboxes/volumes.mdx
+++ b/docs/sandboxes/volumes.mdx
@@ -18,7 +18,7 @@ CLI mount flags use `SOURCE:DEST[:OPTIONS]`. The `:` before `OPTIONS` starts the
 |------|--------|---------|
 | `--mount-dir` | Host directory | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
 | `--mount-file` | Host file | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
-| `--mount-named` | Named volume | `ro`, `rw`, `noexec`, `nosuid`, `nodev`; directory-backed named volumes also support `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
+| `--mount-named` | Named volume | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `kind=dir\|disk`, `size=<size>` for `kind=disk`, `quota=<size>` for directory volumes; directory-backed named volumes also support `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
 | `--mount-disk` | Host disk image | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `format=raw\|qcow2\|vmdk`, `fstype=<type>` |
 | `--tmpfs` | Guest path | `ro`, `rw`, `noexec`, `nosuid`, `nodev`; size may be passed as `PATH:SIZE[:OPTIONS]` |
 
@@ -89,6 +89,10 @@ msb create alpine --name config-reader \
 Named volumes are managed by microsandbox and stored by default under `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox, so you can create a volume, populate it, and mount it into different sandboxes over time.
 
 Named volumes can be directory-backed or disk-backed. Directory volumes mount through virtiofs. Disk volumes are raw ext4 disk images managed by microsandbox and mount through virtio-blk.
+
+CLI named mounts are idempotent. `-v name:/path` and `--mount-named name:/path` create a directory-backed named volume if it does not already exist, then mount it. If the volume already exists, microsandbox reuses it when the requested storage settings are compatible and errors when they are not. Use `--mount-named name:/path:kind=disk,size=20G` to create or reuse a disk-backed named volume from the mount flag itself.
+
+SDK `named(...)` mount helpers are existing-only. They fail if the named volume does not already exist. Use each SDK's explicit named-volume mode API when you want sandbox creation to create or ensure the volume.
 
 ### Create a volume
 
@@ -196,6 +200,13 @@ msb create python --name worker \
 ```
 
 </CodeGroup>
+
+The CLI command above creates `pip-cache` as a directory-backed named volume if it is missing. To create or reuse a disk-backed named volume while mounting it:
+
+```bash
+msb create docker:dind --name docker-demo \
+  --mount-named docker-data:/var/lib/docker:kind=disk,size=20G
+```
 
 ### Sharing and host-side access
 

--- a/docs/sdk/go/volumes.mdx
+++ b/docs/sdk/go/volumes.mdx
@@ -325,7 +325,44 @@ Bind-mount a host directory into the sandbox. Changes in the guest are reflected
 func (mountFactory) Named(name string, opts MountOptions) MountConfig
 ```
 
-Mount a named persistent volume. The volume must already exist (create it with [`CreateVolume`](#createvolume)).
+Mount an existing named persistent volume. The volume must already exist (create it with [`CreateVolume`](#createvolume)).
+
+---
+
+#### Mount.NamedWith()
+
+```go
+func (mountFactory) NamedWith(name string, opts MountOptions, namedOpts NamedVolumeOptions) MountConfig
+```
+
+Mount a named persistent volume with explicit sandbox-time existence behavior. `NamedVolumeOptions.Mode` accepts `"existing"` (default), `"create"`, or `"ensure-exists"`. `NamedVolumeOptions.Kind` accepts `"dir"` (default) or `"disk"`.
+
+```go
+sb, err := m.CreateSandbox(ctx, "worker",
+    m.WithImage("python"),
+    m.WithMounts(map[string]m.MountConfig{
+        "/cache": m.Mount.NamedWith("pip-cache", m.MountOptions{}, m.NamedVolumeOptions{
+            Mode: "ensure-exists",
+        }),
+        "/var/lib/docker": m.Mount.NamedWith("docker-data", m.MountOptions{}, m.NamedVolumeOptions{
+            Mode:    "ensure-exists",
+            Kind:    "disk",
+            SizeMiB: 20 * 1024,
+        }),
+    }),
+)
+```
+
+`Mode: "create"` fails when the named volume already exists. `Mode: "ensure-exists"` creates the volume if it is missing and reuses a compatible existing volume. The ensure-exists mode errors when the existing volume has a different kind, quota, or capacity than the requested configuration; it does not mutate existing volume metadata.
+
+**NamedVolumeOptions**
+
+| Field | Description |
+|-------|-------------|
+| `Mode` | `"existing"`, `"create"`, or `"ensure-exists"`; empty means `"existing"` |
+| `Kind` | `"dir"` or `"disk"`; empty means `"dir"` |
+| `SizeMiB` | Disk capacity in MiB; required when creating or ensuring a missing disk volume |
+| `QuotaMiB` | Directory volume quota in MiB |
 
 ---
 

--- a/docs/sdk/python/volumes.mdx
+++ b/docs/sdk/python/volumes.mdx
@@ -154,6 +154,10 @@ Mount a host directory into the sandbox. Changes in the guest are reflected on t
 def Volume.named(
     name: str,
     *,
+    mode: str | None = None,
+    kind: str | None = None,
+    size_mib: int | None = None,
+    quota_mib: int | None = None,
     readonly: bool = False,
     noexec: bool = False,
     nosuid: bool = False,
@@ -161,13 +165,35 @@ def Volume.named(
 ) -> dict
 ```
 
-Mount a named volume. The volume must already exist (create it with [`Volume.create()`](#volumecreate)).
+Mount a named volume. By default, the volume must already exist (create it with [`Volume.create()`](#volumecreate)). Pass `mode="create"` to create the volume and fail if it already exists, or `mode="ensure-exists"` to create it if missing and reuse it if compatible.
+
+```python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    volumes={
+        "/cache": Volume.named("pip-cache", mode="ensure-exists"),
+        "/var/lib/docker": Volume.named(
+            "docker-data",
+            mode="ensure-exists",
+            kind="disk",
+            size_mib=20 * 1024,
+        ),
+    },
+)
+```
+
+The ensure-exists mode validates existing volume metadata. It errors when the existing volume has a different kind, quota, or capacity than the requested configuration; it does not mutate existing volume metadata.
 
 **Parameters**
 
 | Name | Type | Description |
 |------|------|-------------|
 | name | `str` | Volume name |
+| mode | `str \| None` | Named volume behavior: `"existing"` (default), `"create"`, or `"ensure-exists"` |
+| kind | `str \| None` | Storage kind for create or ensure-exists: `"dir"` (default) or `"disk"` |
+| size_mib | `int \| None` | Disk capacity in MiB; required when creating or ensuring a missing disk volume |
+| quota_mib | `int \| None` | Directory volume quota in MiB |
 | readonly | `bool` | Mount as read-only; virtiofs-backed mounts also reject writes in the host filesystem server |
 | noexec | `bool` | Prevent direct execution from the mount |
 | nosuid | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |

--- a/docs/sdk/rust/volumes.mdx
+++ b/docs/sdk/rust/volumes.mdx
@@ -193,6 +193,46 @@ Mount a named volume. The volume must already exist (create it with [`Volume::bu
 
 ---
 
+#### named_with()
+
+```rust
+fn named_with(
+    self,
+    name: impl Into<String>,
+    f: impl FnOnce(NamedVolumeBuilder) -> NamedVolumeBuilder,
+) -> Self
+```
+
+Mount a named volume with explicit sandbox-time existence behavior. `NamedVolumeMode::Existing` is the default and behaves like [`named()`](#named). `.create()` creates the volume and fails if it already exists. `.ensure_exists()` creates the volume if it is missing or reuses an existing compatible volume.
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .volume("/cache", |v| v.named_with("pip-cache", |n| n.ensure_exists()))
+    .volume("/var/lib/docker", |v| {
+        v.named_with("docker-data", |n| n.ensure_exists().disk().size(20.gib()))
+    })
+    .create()
+    .await?;
+```
+
+The ensure-exists mode validates existing volume metadata. It errors when the existing volume has a different kind, quota, capacity, or explicitly requested labels than the requested configuration; it does not mutate existing volume metadata.
+
+**Named volume builder methods**
+
+| Method | Description |
+|--------|-------------|
+| `existing()` | Require the volume to already exist. This is the default. |
+| `create()` | Create the volume and fail if it already exists. |
+| `ensure_exists()` | Create the volume if missing or reuse a compatible existing volume. |
+| `directory()` | Use directory-backed storage. This is the default. |
+| `disk()` | Use disk-backed raw ext4 storage. Requires `size(...)` when creating or ensuring a missing volume. |
+| `size(size)` | Disk capacity. |
+| `quota(size)` | Directory volume quota. |
+| `label(key, value)` | Attach a label to newly-created volumes and require matching labels for ensure-existing volumes when labels are requested. |
+
+---
+
 #### readonly()
 
 ```rust

--- a/docs/sdk/typescript/volumes.mdx
+++ b/docs/sdk/typescript/volumes.mdx
@@ -161,7 +161,8 @@ Used inside `SandboxBuilder.volume(guestPath, m => ...)`. Pick exactly one mount
 | Method | Description |
 |--------|-------------|
 | `bind(host)` | Mount a host directory into the guest. |
-| `named(name)` | Mount a named volume created via [`Volume.builder`](#volumebuilder). |
+| `named(name)` | Mount an existing named volume created via [`Volume.builder`](#volumebuilder). |
+| `namedWith(name, mode?, kind?, sizeMib?, quotaMib?)` | Mount a named volume with explicit behavior. `mode` is `"existing"`, `"create"`, or `"ensure-exists"`; `kind` is `"dir"` or `"disk"`. |
 | `tmpfs()` | Mount an in-memory filesystem. |
 | `disk(host)` | Mount a host disk image as a virtio-blk device. |
 | `format(fmt)` | Disk image format (`'qcow2' \| 'raw' \| 'vmdk'`). Defaults to the file extension. Disk only. |
@@ -172,6 +173,20 @@ Used inside `SandboxBuilder.volume(guestPath, m => ...)`. Pick exactly one mount
 | `nodev()` | Ignore device files on the mount. |
 | `size(mib)` | Cap in MiB. Tmpfs only. |
 | `build()` | Internal — produce a `VolumeMount`. |
+
+`named(name)` is existing-only. Use `namedWith` when sandbox creation should create or ensure the volume exists:
+
+```typescript
+await using sb = await Sandbox.builder("worker")
+  .image("python")
+  .volume("/cache", (m) => m.namedWith("pip-cache", "ensure-exists"))
+  .volume("/var/lib/docker", (m) =>
+    m.namedWith("docker-data", "ensure-exists", "disk", 20 * 1024)
+  )
+  .create();
+```
+
+`"create"` fails when the named volume already exists. `"ensure-exists"` creates the volume if it is missing and reuses a compatible existing volume. The ensure-exists mode errors when the existing volume has a different kind, quota, or capacity than the requested configuration; it does not mutate existing volume metadata.
 
 ### VolumeMount
 

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -1424,6 +1424,8 @@ type RegistryAuthOptions struct {
 type MountSpec struct {
 	Bind               string `json:"bind,omitempty"`
 	Named              string `json:"named,omitempty"`
+	NamedMode          string `json:"named_mode,omitempty"`
+	NamedKind          string `json:"named_kind,omitempty"`
 	Tmpfs              bool   `json:"tmpfs,omitempty"`
 	Disk               string `json:"disk,omitempty"`
 	Format             string `json:"format,omitempty"`
@@ -1433,6 +1435,7 @@ type MountSpec struct {
 	Nosuid             bool   `json:"nosuid,omitempty"`
 	Nodev              bool   `json:"nodev,omitempty"`
 	SizeMiB            uint32 `json:"size_mib,omitempty"`
+	QuotaMiB           uint32 `json:"quota_mib,omitempty"`
 	StatVirtualization string `json:"stat_virtualization,omitempty"`
 	HostPermissions    string `json:"host_permissions,omitempty"`
 }

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -1029,6 +1029,8 @@ struct SnapshotExportOpts {
 struct MountSpec {
     bind: Option<String>,
     named: Option<String>,
+    named_mode: Option<String>,
+    named_kind: Option<String>,
     #[serde(default)]
     tmpfs: bool,
     /// Mount a host disk image (.img/.qcow2/etc.).
@@ -1046,6 +1048,7 @@ struct MountSpec {
     #[serde(default)]
     nodev: bool,
     size_mib: Option<u32>,
+    quota_mib: Option<u32>,
     /// Per-mount stat-virtualization policy ("strict" | "relaxed" | "off").
     /// Only valid for bind / named mounts.
     stat_virtualization: Option<String>,
@@ -1620,6 +1623,11 @@ fn apply_volume(
 
     let bind = m.bind.clone();
     let named = m.named.clone();
+    let named_mode = m
+        .named_mode
+        .clone()
+        .unwrap_or_else(|| "existing".to_string());
+    let named_kind = m.named_kind.clone().unwrap_or_else(|| "dir".to_string());
     let tmpfs = m.tmpfs;
     let disk = m.disk.clone();
     let fstype = m.fstype.clone();
@@ -1628,6 +1636,18 @@ fn apply_volume(
     let nosuid = m.nosuid;
     let nodev = m.nodev;
     let size_mib = m.size_mib;
+    let quota_mib = m.quota_mib;
+
+    if !matches!(named_mode.as_str(), "existing" | "create" | "ensure-exists") {
+        return Err(FfiError::invalid_argument(format!(
+            "invalid named_mode {named_mode:?} (expected existing|create|ensure-exists)"
+        )));
+    }
+    if !matches!(named_kind.as_str(), "dir" | "directory" | "disk") {
+        return Err(FfiError::invalid_argument(format!(
+            "invalid named_kind {named_kind:?} (expected dir|disk)"
+        )));
+    }
 
     let kinds_set: u8 =
         bind.is_some() as u8 + named.is_some() as u8 + tmpfs as u8 + disk.is_some() as u8;
@@ -1641,7 +1661,26 @@ fn apply_volume(
         let mut mb = if let Some(ref host) = bind {
             mb.bind(host)
         } else if let Some(ref name) = named {
-            mb.named(name)
+            mb.named_with(name, |mut named| {
+                named = match named_mode.as_str() {
+                    "existing" => named.existing(),
+                    "create" => named.create(),
+                    "ensure-exists" => named.ensure_exists(),
+                    _ => unreachable!("validated named volume mode"),
+                };
+                named = match named_kind.as_str() {
+                    "dir" | "directory" => named.directory(),
+                    "disk" => named.disk(),
+                    _ => unreachable!("validated named volume kind"),
+                };
+                if let Some(size_mib) = size_mib {
+                    named = named.size(size_mib);
+                }
+                if let Some(quota_mib) = quota_mib {
+                    named = named.quota(quota_mib);
+                }
+                named
+            })
         } else if tmpfs {
             mb.tmpfs()
         } else if let Some(ref host) = disk {
@@ -1667,7 +1706,7 @@ fn apply_volume(
         if nodev {
             mb = mb.nodev();
         }
-        if let Some(siz) = size_mib {
+        if tmpfs && let Some(siz) = size_mib {
             mb = mb.size(siz);
         }
         if let Some(p) = stat_virt {

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -867,17 +867,20 @@ type MountConfig struct {
 	// to introspect; setting fields below directly is discouraged.
 	kind MountKind
 
-	Bind     string
-	Named    string
-	Tmpfs    bool
-	Disk     string
-	Format   string
-	Fstype   string
-	Readonly bool
-	Noexec   bool
-	Nosuid   bool
-	Nodev    bool
-	SizeMiB  uint32
+	Bind      string
+	Named     string
+	NamedMode string
+	NamedKind string
+	QuotaMiB  uint32
+	Tmpfs     bool
+	Disk      string
+	Format    string
+	Fstype    string
+	Readonly  bool
+	Noexec    bool
+	Nosuid    bool
+	Nodev     bool
+	SizeMiB   uint32
 
 	// StatVirtualization is the per-mount stat-virtualization policy. Only
 	// meaningful for Bind and Named mounts. Zero value preserves the
@@ -919,6 +922,14 @@ type MountOptions struct {
 	Nodev              bool
 	StatVirtualization StatVirtualization
 	HostPermissions    HostPermissions
+}
+
+// NamedVolumeOptions tunes sandbox-time named volume provisioning.
+type NamedVolumeOptions struct {
+	Mode     string // "existing", "create", or "ensure-exists"; empty means existing.
+	Kind     string // "dir" or "disk"; empty means dir.
+	SizeMiB  uint32
+	QuotaMiB uint32
 }
 
 // TmpfsOptions tunes the Tmpfs factory.
@@ -973,6 +984,25 @@ func (mountFactory) Named(name string, opts MountOptions) MountConfig {
 	return MountConfig{
 		kind:               MountKindNamed,
 		Named:              name,
+		Readonly:           opts.Readonly,
+		Noexec:             opts.Noexec,
+		Nosuid:             opts.Nosuid,
+		Nodev:              opts.Nodev,
+		StatVirtualization: opts.StatVirtualization,
+		HostPermissions:    opts.HostPermissions,
+	}
+}
+
+// NamedWith returns a MountConfig that mounts a named persistent volume with
+// explicit creation behavior.
+func (mountFactory) NamedWith(name string, opts MountOptions, namedOpts NamedVolumeOptions) MountConfig {
+	return MountConfig{
+		kind:               MountKindNamed,
+		Named:              name,
+		NamedMode:          namedOpts.Mode,
+		NamedKind:          namedOpts.Kind,
+		SizeMiB:            namedOpts.SizeMiB,
+		QuotaMiB:           namedOpts.QuotaMiB,
 		Readonly:           opts.Readonly,
 		Noexec:             opts.Noexec,
 		Nosuid:             opts.Nosuid,

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -105,6 +105,8 @@ func buildFFICreateOptions(o SandboxConfig) ffi.CreateOptions {
 			ffiOpts.Volumes[guestPath] = ffi.MountSpec{
 				Bind:               m.Bind,
 				Named:              m.Named,
+				NamedMode:          m.NamedMode,
+				NamedKind:          m.NamedKind,
 				Tmpfs:              m.Tmpfs,
 				Disk:               m.Disk,
 				Format:             m.Format,
@@ -114,6 +116,7 @@ func buildFFICreateOptions(o SandboxConfig) ffi.CreateOptions {
 				Nosuid:             m.Nosuid,
 				Nodev:              m.Nodev,
 				SizeMiB:            m.SizeMiB,
+				QuotaMiB:           m.QuotaMiB,
 				StatVirtualization: string(m.StatVirtualization),
 				HostPermissions:    string(m.HostPermissions),
 			}

--- a/sdk/node-ts/native/mount_builder.rs
+++ b/sdk/node-ts/native/mount_builder.rs
@@ -79,6 +79,54 @@ impl JsMountBuilder {
         self
     }
 
+    /// Mount a named volume with explicit existence behavior.
+    #[napi]
+    pub fn named_with(
+        &mut self,
+        name: String,
+        mode: Option<String>,
+        kind: Option<String>,
+        size_mib: Option<u32>,
+        quota_mib: Option<u32>,
+    ) -> napi::Result<&Self> {
+        let mode = mode.unwrap_or_else(|| "existing".to_string());
+        let kind = kind.unwrap_or_else(|| "dir".to_string());
+        if !matches!(mode.as_str(), "existing" | "create" | "ensure-exists") {
+            return Err(napi::Error::new(
+                Status::InvalidArg,
+                format!("invalid named volume mode {mode:?}"),
+            ));
+        }
+        if !matches!(kind.as_str(), "dir" | "directory" | "disk") {
+            return Err(napi::Error::new(
+                Status::InvalidArg,
+                format!("invalid named volume kind {kind:?}"),
+            ));
+        }
+        let prev = self.take_inner();
+        self.inner = Some(prev.named_with(name, |mut v| {
+            v = match mode.as_str() {
+                "existing" => v.existing(),
+                "create" => v.create(),
+                "ensure-exists" => v.ensure_exists(),
+                _ => unreachable!("validated named volume mode"),
+            };
+            v = match kind.as_str() {
+                "dir" | "directory" => v.directory(),
+                "disk" => v.disk(),
+                _ => unreachable!("validated named volume kind"),
+            };
+            if let Some(size_mib) = size_mib {
+                v = v.size(size_mib);
+            }
+            if let Some(quota_mib) = quota_mib {
+                v = v.quota(quota_mib);
+            }
+            v
+        }));
+        Ok(self)
+    }
+
     /// Mount an in-memory tmpfs at the guest path.
     #[napi]
     pub fn tmpfs(&mut self) -> &Self {
@@ -259,6 +307,7 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
         RustVolumeMount::Named {
             name,
             guest,
+            create: _,
             options,
             stat_virtualization,
             host_permissions,

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -937,6 +937,13 @@ export interface NapiBuiltNetworkPolicyDestination {
 export interface NapiMountBuilder {
   bind(host: string): this;
   named(name: string): this;
+  namedWith(
+    name: string,
+    mode?: "existing" | "create" | "ensure-exists",
+    kind?: "dir" | "directory" | "disk",
+    sizeMib?: number,
+    quotaMib?: number,
+  ): this;
   tmpfs(): this;
   disk(host: string): this;
   format(format: string): this;

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -317,6 +317,9 @@ class MountConfig:
     kind: MountKind
     bind: str | None = None
     named: str | None = None
+    named_mode: Literal["existing", "create", "ensure-exists"] | None = None
+    named_kind: Literal["dir", "directory", "disk"] | None = None
+    quota_mib: int | None = None
     size_mib: int | None = None
     readonly: bool = False
     noexec: bool = False
@@ -346,6 +349,14 @@ class MountConfig:
             if self.named is None:
                 raise ValueError("MountConfig kind=NAMED requires named=...")
             d["named"] = self.named
+            if self.named_mode is not None:
+                d["named_mode"] = self.named_mode
+            if self.named_kind is not None:
+                d["named_kind"] = self.named_kind
+            if self.size_mib is not None:
+                d["size_mib"] = self.size_mib
+            if self.quota_mib is not None:
+                d["quota_mib"] = self.quota_mib
         elif self.kind == MountKind.TMPFS:
             d["tmpfs"] = True
             if self.size_mib is not None:

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -480,8 +480,43 @@ fn apply_mount(
             m
         }))
     } else if let Some(vol_name) = extract_opt::<String>(mount, "named")? {
+        let named_mode =
+            extract_opt::<String>(mount, "named_mode")?.unwrap_or_else(|| "existing".to_string());
+        let named_kind =
+            extract_opt::<String>(mount, "named_kind")?.unwrap_or_else(|| "dir".to_string());
+        let size_mib = extract_opt::<u32>(mount, "size_mib")?;
+        let quota_mib = extract_opt::<u32>(mount, "quota_mib")?;
+        if !matches!(named_mode.as_str(), "existing" | "create" | "ensure-exists") {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "invalid named volume mode: {named_mode}"
+            )));
+        }
+        if !matches!(named_kind.as_str(), "dir" | "directory" | "disk") {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "invalid named volume kind: {named_kind}"
+            )));
+        }
         Ok(builder.volume(&guest_path, |v| {
-            let mut m = v.named(&vol_name);
+            let mut m = v.named_with(&vol_name, |mut named| {
+                named = match named_mode.as_str() {
+                    "existing" => named.existing(),
+                    "create" => named.create(),
+                    "ensure-exists" => named.ensure_exists(),
+                    _ => unreachable!("validated named volume mode"),
+                };
+                named = match named_kind.as_str() {
+                    "dir" | "directory" => named.directory(),
+                    "disk" => named.disk(),
+                    _ => unreachable!("validated named volume kind"),
+                };
+                if let Some(size_mib) = size_mib {
+                    named = named.size(size_mib);
+                }
+                if let Some(quota_mib) = quota_mib {
+                    named = named.quota(quota_mib);
+                }
+                named
+            });
             if readonly {
                 m = m.readonly();
             }

--- a/sdk/python/src/volume.rs
+++ b/sdk/python/src/volume.rs
@@ -155,10 +155,15 @@ impl PyVolume {
 
     /// Create a named volume mount config.
     #[staticmethod]
-    #[pyo3(signature = (name, *, readonly = false, noexec = false, nosuid = false, nodev = false))]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (name, *, mode = None, kind = None, size_mib = None, quota_mib = None, readonly = false, noexec = false, nosuid = false, nodev = false))]
     fn named(
         py: Python<'_>,
         name: String,
+        mode: Option<String>,
+        kind: Option<String>,
+        size_mib: Option<u32>,
+        quota_mib: Option<u32>,
         readonly: bool,
         noexec: bool,
         nosuid: bool,
@@ -167,6 +172,18 @@ impl PyVolume {
         let kwargs = PyDict::new(py);
         kwargs.set_item("kind", mount_kind(py, "NAMED")?)?;
         kwargs.set_item("named", name)?;
+        if let Some(mode) = mode {
+            kwargs.set_item("named_mode", mode)?;
+        }
+        if let Some(kind) = kind {
+            kwargs.set_item("named_kind", kind)?;
+        }
+        if let Some(size_mib) = size_mib {
+            kwargs.set_item("size_mib", size_mib)?;
+        }
+        if let Some(quota_mib) = quota_mib {
+            kwargs.set_item("quota_mib", quota_mib)?;
+        }
         kwargs.set_item("readonly", readonly)?;
         kwargs.set_item("noexec", noexec)?;
         kwargs.set_item("nosuid", nosuid)?;


### PR DESCRIPTION
PR Title: feat(volumes): add idempotent named volume mounts

## TL;DR
Add explicit named volume modes and make CLI named mounts create missing volumes idempotently. This lets users mount persistent volumes without a separate create step while SDKs keep existing-only `named()` helpers and expose explicit create and ensure-exists APIs.

## Description
- Add `NamedVolumeMode` and `named_with` in the Rust SDK so named mounts can be existing-only, create-only, or ensure-exists.
- Move sandbox-time volume creation metadata onto named mounts instead of a separate auto-volume list, so persisted sandbox configs restart as normal existing-volume mounts.
- Make `-v name:/path` and `--mount-named name:/path` ensure directory-backed named volumes by default.
- Add `kind=dir|disk`, `size=...`, and `quota=...` support to `--mount-named`, including validation for disk-backed named volumes.
- Add matching named volume mode options to the Go, Node, and Python SDKs.
- Keep ensure-exists cleanup scoped to volumes inserted by the current sandbox create attempt, so existing volumes are not removed on later startup failures.
- Update volume docs and the Docker-in-sandbox recipe to use the new idempotent named mount flow.

```bash
msb run --name docker-demo --replace \
  --memory 2G \
  --mount-named docker-data:/var/lib/docker \
  --script start='dockerd >/tmp/dockerd.log 2>&1 &
  timeout 60 sh -c "until docker info>/dev/null 2>&1;do sleep 1;done" || {
    cat /tmp/dockerd.log
    false
  }
  exec sh' \
  --entrypoint start \
  docker:dind
```

```rust
let sb = Sandbox::builder("worker")
    .image("python")
    .volume("/cache", |v| v.named_with("pip-cache", |n| n.ensure_exists()))
    .volume("/var/lib/docker", |v| {
        v.named_with("docker-data", |n| n.ensure_exists().disk().size(20.gib()))
    })
    .create()
    .await?;
```

```python
sb = await Sandbox.create(
    "worker",
    image="python",
    volumes={
        "/cache": Volume.named("pip-cache", mode="ensure-exists"),
        "/var/lib/docker": Volume.named("docker-data", mode="ensure-exists", kind="disk", size_mib=20 * 1024),
    },
)
```

```typescript
await using sb = await Sandbox.builder("worker")
  .image("python")
  .volume("/cache", (m) => m.namedWith("pip-cache", "ensure-exists"))
  .volume("/var/lib/docker", (m) => m.namedWith("docker-data", "ensure-exists", "disk", 20 * 1024))
  .create();
```

```go
sb, err := m.CreateSandbox(ctx, "worker",
    m.WithImage("python"),
    m.WithMounts(map[string]m.MountConfig{
        "/cache": m.Mount.NamedWith("pip-cache", m.MountOptions{}, m.NamedVolumeOptions{Mode: "ensure-exists"}),
        "/var/lib/docker": m.Mount.NamedWith("docker-data", m.MountOptions{}, m.NamedVolumeOptions{Mode: "ensure-exists", Kind: "disk", SizeMiB: 20 * 1024}),
    }),
)
```

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p microsandbox-cli`
- [x] `cargo check --manifest-path sdk/go/native/Cargo.toml`
- [x] `cargo check --manifest-path sdk/node-ts/Cargo.toml`
- [x] `cargo check --manifest-path sdk/python/Cargo.toml`
- [x] `cargo test -p microsandbox insert_sandbox_record_ensure --no-fail-fast`
- [x] `go test -count=1 ./...` from `sdk/go`
- [x] `npm run typecheck` from `sdk/node-ts`
