### PR TITLE
docs: reposition microsandbox around untrusted workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <br />
 
-<div align="center"><b>——&nbsp;&nbsp;&nbsp;fast, local microVMs for untrusted workloads&nbsp;&nbsp;&nbsp;——</b></div>
+<div align="center"><b>——&nbsp;&nbsp;&nbsp;easy, fast, local microVMs for untrusted workloads&nbsp;&nbsp;&nbsp;——</b></div>
 
 <br />
 <br />

--- a/README.md
+++ b/README.md
@@ -25,29 +25,19 @@
 
 <br />
 
-**Microsandbox** runs **untrusted workloads** inside fast, local microVMs. Use it for AI agents, user-submitted code, plugins, dependency installs, CI jobs, dev environments, scrapers, and automation that should not inherit your host's full privileges.
+**Microsandbox** runs **untrusted workloads** inside fast, local microVMs: AI agents, user code, plugins, CI jobs, dev environments, scrapers, and automation.
 
-It uses standard OCI images, starts from your SDK or CLI, and needs no daemon or remote service. You get Docker-like workflows with a real VM isolation boundary, host-controlled networking, and secrets that stay on the host.
+Use standard OCI images from your SDK or CLI. No daemon. No remote service. Docker-like workflows, VM isolation, host-controlled networking, and secrets that stay on the host.
 
 ##
 
-- <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **Hardware Isolation**: Each sandbox is a microVM with its own Linux kernel, not just a host namespace.
+- <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **Hardware Isolation**: Hardware-level isolation with microVM technology.
 - <img height="14" src="https://octicons-col.vercel.app/zap/A770EF"> **Instant Startup**: Average boot times under 100 milliseconds.
-- <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **Docker-Like Inputs**: Run standard OCI images from Docker Hub, GHCR, ECR, GCR, or any registry.
-- <img height="14" src="https://octicons-col.vercel.app/plug/A770EF"> **SDK-Native**: Create and control sandboxes directly from Rust, TypeScript, Python, Go, or the CLI.
-- <img height="14" src="https://octicons-col.vercel.app/globe/A770EF"> **Host-Controlled Networking**: Allow, deny, inspect, and publish traffic from outside the guest.
-- <img height="14" src="https://octicons-col.vercel.app/lock/A770EF"> **Secrets Stay on the Host**: The guest sees placeholders; real credentials are injected only at allowed destinations.
-- <img height="14" src="https://octicons-col.vercel.app/database/A770EF"> **Persistent or Disposable**: Use ephemeral roots, bind mounts, named volumes, snapshots, logs, metrics, and detached mode.
-- <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **Agent-Ready**: Connect AI agents through [Agent Skills](https://github.com/superradcompany/skills) or the [MCP server](https://github.com/superradcompany/microsandbox-mcp) when they need their own sandboxed machine.
-
-#### <img height="14" src="https://octicons-col.vercel.app/package-dependencies/A770EF">&nbsp;&nbsp;Built For
-
-- **AI agents**: Give coding agents and tool-using assistants a dedicated machine for commands, files, package installs, and generated code.
-- **User code execution**: Run submitted scripts, notebooks, plugins, and extensions away from the host.
-- **CI/CD and builds**: Isolate test jobs, compilers, package managers, and build tools.
-- **Dev environments**: Create disposable Linux machines without touching your laptop or host Docker daemon.
-- **Scrapers and automation**: Allow internet access while blocking private networks and metadata services.
-- **Secure tool execution**: Run CLIs and dependencies that should not see host secrets or ambient credentials.
+- <img height="14" src="https://octicons-col.vercel.app/plug/A770EF"> **Embeddable**: Spawn VMs right within your code. No setup server. No long-running daemon.
+- <img height="14" src="https://octicons-col.vercel.app/lock/A770EF"> **Secrets That Can't Leak**: Unexploitable secret keys that never enter the VM.
+- <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **OCI Compatible**: Runs standard container images from Docker Hub, GHCR, or any OCI registry.
+- <img height="14" src="https://octicons-col.vercel.app/database/A770EF"> **Long-Running**: Sandboxes can run in detached mode. Great for long-lived sessions.
+- <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **Agent-Ready**: Your agents can create their own sandboxes with our [Agent Skills](https://github.com/superradcompany/skills) and [MCP server](https://github.com/superradcompany/microsandbox-mcp).
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@
 ##
 
 - <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **Hardware Isolation**: Hardware-level isolation with microVM technology.
+- <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **OCI Compatible**: Runs standard container images from Docker Hub, GHCR, or any OCI registry.
+- <img height="14" src="https://octicons-col.vercel.app/container/A770EF"> **Docker-Like Workflows**: Run images, commands, shells, volumes, and named sandboxes with familiar container-style ergonomics.
 - <img height="14" src="https://octicons-col.vercel.app/zap/A770EF"> **Instant Startup**: Average boot times under 100 milliseconds.
 - <img height="14" src="https://octicons-col.vercel.app/plug/A770EF"> **Embeddable**: Spawn VMs right within your code. No setup server. No long-running daemon.
 - <img height="14" src="https://octicons-col.vercel.app/lock/A770EF"> **Secrets That Can't Leak**: Unexploitable secret keys that never enter the VM.
-- <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **OCI Compatible**: Runs standard container images from Docker Hub, GHCR, or any OCI registry.
 - <img height="14" src="https://octicons-col.vercel.app/database/A770EF"> **Long-Running**: Sandboxes can run in detached mode. Great for long-lived sessions.
 - <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **Agent-Ready**: Your agents can create their own sandboxes with our [Agent Skills](https://github.com/superradcompany/skills) and [MCP server](https://github.com/superradcompany/microsandbox-mcp).
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ It uses standard OCI images, starts from your SDK or CLI, and needs no daemon or
 > curl -fsSL https://install.microsandbox.dev | sh
 > ```
 >
-> The installer creates command links in `~/.local/bin/` and does not edit shell startup files.
->
 > <details>
 > <summary><em>&nbsp;We also support other package managers  →</em></summary>
 >

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@
 
 **Microsandbox** runs **untrusted workloads** inside fast, local microVMs: AI agents, user code, plugins, CI jobs, dev environments, scrapers, and automation.
 
-Use standard OCI images from your SDK or CLI. No daemon. No remote service. Docker-like workflows, VM isolation, host-controlled networking, and secrets that stay on the host.
-
 ##
 
 - <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **Hardware Isolation**: Hardware-level isolation with microVM technology.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <br />
 
-<div align="center"><b>——&nbsp;&nbsp;&nbsp;the easiest way to give your agent their own computer&nbsp;&nbsp;&nbsp;——</b></div>
+<div align="center"><b>——&nbsp;&nbsp;&nbsp;fast, local microVMs for untrusted workloads&nbsp;&nbsp;&nbsp;——</b></div>
 
 <br />
 <br />
@@ -25,17 +25,29 @@
 
 <br />
 
-**Microsandbox** spins up **lightweight VMs in milliseconds** from our SDKs. Runs locally on your machine. No server to set up. No lingering daemon. It is all embedded and rootless!
+**Microsandbox** runs **untrusted workloads** inside fast, local microVMs. Use it for AI agents, user-submitted code, plugins, dependency installs, CI jobs, dev environments, scrapers, and automation that should not inherit your host's full privileges.
+
+It uses standard OCI images, starts from your SDK or CLI, and needs no daemon or remote service. You get Docker-like workflows with a real VM isolation boundary, host-controlled networking, and secrets that stay on the host.
 
 ##
 
-- <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **Hardware Isolation**: Hardware-level isolation with microVM technology.
+- <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **Hardware Isolation**: Each sandbox is a microVM with its own Linux kernel, not just a host namespace.
 - <img height="14" src="https://octicons-col.vercel.app/zap/A770EF"> **Instant Startup**: Average boot times under 100 milliseconds.
-- <img height="14" src="https://octicons-col.vercel.app/plug/A770EF"> **Embeddable**: Spawn VMs right within your code. No setup server. No long-running daemon.
-- <img height="14" src="https://octicons-col.vercel.app/lock/A770EF"> **Secrets That Can't Leak**: Unexploitable secret keys that never enter the VM.
-- <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **OCI Compatible**: Runs standard container images from Docker Hub, GHCR, or any OCI registry.
-- <img height="14" src="https://octicons-col.vercel.app/database/A770EF"> **Long-Running**: Sandboxes can run in detached mode. Great for long-lived sessions.
-- <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **Agent-Ready**: Your agents can create their own sandboxes with our [Agent Skills](https://github.com/superradcompany/skills) and [MCP server](https://github.com/superradcompany/microsandbox-mcp).
+- <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **Docker-Like Inputs**: Run standard OCI images from Docker Hub, GHCR, ECR, GCR, or any registry.
+- <img height="14" src="https://octicons-col.vercel.app/plug/A770EF"> **SDK-Native**: Create and control sandboxes directly from Rust, TypeScript, Python, Go, or the CLI.
+- <img height="14" src="https://octicons-col.vercel.app/globe/A770EF"> **Host-Controlled Networking**: Allow, deny, inspect, and publish traffic from outside the guest.
+- <img height="14" src="https://octicons-col.vercel.app/lock/A770EF"> **Secrets Stay on the Host**: The guest sees placeholders; real credentials are injected only at allowed destinations.
+- <img height="14" src="https://octicons-col.vercel.app/database/A770EF"> **Persistent or Disposable**: Use ephemeral roots, bind mounts, named volumes, snapshots, logs, metrics, and detached mode.
+- <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **Agent-Ready**: Connect AI agents through [Agent Skills](https://github.com/superradcompany/skills) or the [MCP server](https://github.com/superradcompany/microsandbox-mcp) when they need their own sandboxed machine.
+
+#### <img height="14" src="https://octicons-col.vercel.app/package-dependencies/A770EF">&nbsp;&nbsp;Built For
+
+- **AI agents**: Give coding agents and tool-using assistants a dedicated machine for commands, files, package installs, and generated code.
+- **User code execution**: Run submitted scripts, notebooks, plugins, and extensions away from the host.
+- **CI/CD and builds**: Isolate test jobs, compilers, package managers, and build tools.
+- **Dev environments**: Create disposable Linux machines without touching your laptop or host Docker daemon.
+- **Scrapers and automation**: Allow internet access while blocking private networks and metadata services.
+- **Secure tool execution**: Run CLIs and dependencies that should not see host secrets or ambient credentials.
 
 <br />
 
@@ -314,7 +326,9 @@ The `msb` CLI provides a complete interface for managing sandboxes, images, and 
 
 ## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/dependabot/ffffff" alt="agents-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/dependabot/000000" alt="agents"></a>&nbsp;&nbsp;AI Agents
 
-Give your AI agents the ability to create and manage their own sandboxes.
+AI agents are a natural fit for microsandbox. They run tools, inspect files, install packages, call APIs, and execute generated code, often with more ambient access than they should have.
+
+microsandbox gives those actions a dedicated microVM instead of your host process. Agents can still work normally, but their filesystem, network, lifecycle, and secrets are controlled by the sandbox boundary.
 
 #### <img height="14" src="https://octicons-col.vercel.app/book/A770EF">&nbsp;&nbsp;Agent Skills
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 - <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **Hardware Isolation**: Hardware-level isolation with microVM technology.
 - <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **OCI Compatible**: Runs standard container images from Docker Hub, GHCR, or any OCI registry.
-- <img height="14" src="https://octicons-col.vercel.app/container/A770EF"> **Docker-Like Workflows**: Run images, commands, shells, volumes, and named sandboxes with familiar container-style ergonomics.
+- <img height="14" src="https://octicons-col.vercel.app/container/A770EF"> **Docker-Like Workflows**: Familiar image, command, shell, and volume workflows.
 - <img height="14" src="https://octicons-col.vercel.app/zap/A770EF"> **Instant Startup**: Average boot times under 100 milliseconds.
 - <img height="14" src="https://octicons-col.vercel.app/plug/A770EF"> **Embeddable**: Spawn VMs right within your code. No setup server. No long-running daemon.
 - <img height="14" src="https://octicons-col.vercel.app/lock/A770EF"> **Secrets That Can't Leak**: Unexploitable secret keys that never enter the VM.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -236,7 +236,7 @@
   "appearance": {
     "default": "system"
   },
-  "description": "Every agent deserves its own machine",
+  "description": "Fast, local microVMs for untrusted workloads",
   "footer": {
     "socials": {
       "github": "https://github.com/superradcompany/microsandbox",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -236,7 +236,7 @@
   "appearance": {
     "default": "system"
   },
-  "description": "Fast, local microVMs for untrusted workloads",
+  "description": "Easy, fast, local microVMs for untrusted workloads",
   "footer": {
     "socials": {
       "github": "https://github.com/superradcompany/microsandbox",

--- a/docs/getting-started/agents.mdx
+++ b/docs/getting-started/agents.mdx
@@ -1,10 +1,14 @@
 ---
 title: AI agents
-description: Give AI agents the ability to create and manage their own sandboxes
+description: Connect AI agents to isolated microsandbox machines
 icon: "robot"
 ---
 
-microsandbox is built for AI agents. The SDK and CLI give you full programmatic control, but there are two additional ways to connect agents directly: **Agent Skills** for coding assistants and an **MCP server** for any MCP-compatible client.
+AI agents are a natural fit for microsandbox. They run tools, inspect files, install packages, call APIs, and execute generated code, often with more ambient access than they should have.
+
+microsandbox gives those actions a dedicated microVM instead of your host process. Agents can still work normally, but their filesystem, network, lifecycle, and secrets are controlled by the sandbox boundary.
+
+The SDK and CLI give you full programmatic control, and there are two additional ways to connect agents directly: **Agent Skills** for coding assistants and an **MCP server** for any MCP-compatible client.
 
 ## Agent Skills
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -1,12 +1,14 @@
 ---
 title: "Introduction"
-description: "Every agent deserves its own computer"
+description: "Fast, local microVMs for untrusted workloads"
 icon: "house"
 ---
 
-AI agents run with whatever privileges you give them, and most of the time that's too many. They can see host environment variables, reach the network freely, and modify files wherever the process is allowed to write. A prompt injection turns those privileges into attack surface.
+microsandbox is a local microVM runtime for untrusted workloads: AI agents, user code, plugins, package installs, CI jobs, dev environments, scrapers, and automation.
 
-microsandbox gives each workload its own local microVM: a real Linux kernel, isolated filesystem, and host-controlled network stack. It keeps the developer loop simple while moving untrusted code out of the host process.
+Each sandbox is a lightweight VM with its own Linux kernel, filesystem, and network boundary. Your app or the `msb` CLI starts it locally, talks to it through a host-guest command channel, and controls what it can access.
+
+It keeps the familiar workflow of OCI images and command execution, while moving risky work out of the host process.
 
 <Tip>
   Boot a microVM in one command.
@@ -21,9 +23,18 @@ microsandbox gives each workload its own local microVM: a real Linux kernel, iso
 - **Hardware isolation.** Each sandbox is a VM, not a container namespace on the host kernel.
 - **Local runtime.** The SDK starts the sandbox process directly. No daemon, remote service, or infrastructure setup.
 - **Fast startup.** Sandboxes are lightweight enough to create from application code.
-- **OCI images.** Use familiar images from Docker Hub, GHCR, ECR, GCR, or another OCI-compatible registry.
+- **Docker-like inputs.** Use familiar OCI images from Docker Hub, GHCR, ECR, GCR, or another registry.
 - **Programmable controls.** Configure resources, volumes, secrets, networking, and lifecycle from the CLI or SDK.
 - **Multi-language SDKs.** Rust, TypeScript, Python, and Go expose the same core model.
+
+## Common workloads
+
+- **AI agents.** Give coding agents and tool-using assistants a dedicated machine for commands, files, package installs, and generated code.
+- **User code execution.** Run submitted scripts, notebooks, plugins, and extensions away from the host.
+- **CI/CD and builds.** Isolate test jobs, compilers, package managers, and build tools.
+- **Dev environments.** Create disposable Linux machines without touching your laptop or host Docker daemon.
+- **Scrapers and automation.** Allow internet access while blocking private networks and metadata services.
+- **Secure tool execution.** Run CLIs and dependencies that should not see host secrets or ambient credentials.
 
 ## What makes it different
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-description: "Fast, local microVMs for untrusted workloads"
+description: "Easy, fast, local microVMs for untrusted workloads"
 icon: "house"
 ---
 

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -66,7 +66,7 @@ let policy = NetworkPolicy::builder()
     .egress(|e| e.udp().tcp().port(53).allow_host())
     .build()?;
 
-let sb = Sandbox::builder("secure-agent")
+let sb = Sandbox::builder("restricted-worker")
     .image("alpine")
     .network(|n| n.policy(policy))
     .create()
@@ -76,7 +76,7 @@ let sb = Sandbox::builder("secure-agent")
 ```typescript TypeScript
 import { NetworkPolicy, Sandbox } from "microsandbox";
 
-await using sb = await Sandbox.builder("secure-agent")
+await using sb = await Sandbox.builder("restricted-worker")
     .image("alpine")
     .network((n) => n.policy(
         NetworkPolicy.builder()
@@ -92,7 +92,7 @@ await using sb = await Sandbox.builder("secure-agent")
 from microsandbox import Network, Sandbox
 
 sb = await Sandbox.create(
-    "secure-agent",
+    "restricted-worker",
     image="alpine",
     network={
         "policy": {
@@ -107,7 +107,7 @@ sb = await Sandbox.create(
 ```
 
 ```go Go
-sb, err := m.CreateSandbox(ctx, "secure-agent",
+sb, err := m.CreateSandbox(ctx, "restricted-worker",
     m.WithImage("alpine"),
     m.WithNetwork(&m.NetworkConfig{
         DefaultEgress: m.PolicyActionDeny,
@@ -120,7 +120,7 @@ sb, err := m.CreateSandbox(ctx, "secure-agent",
 ```
 
 ```bash CLI
-msb create alpine --name secure-agent \
+msb create alpine --name restricted-worker \
   --net-default-egress deny \
   --net-rule "allow@public:tcp:443,allow@host:udp:53"
 ```
@@ -173,7 +173,7 @@ Use an explicit bind address, such as `0.0.0.0`, only when you intentionally wan
 From inside the sandbox, `host.microsandbox.internal` resolves to the host machine. The default policy denies host access, so allow the `host` group when a sandbox needs to call a dev server, database, or other local service.
 
 ```bash
-msb create python --name dev-agent \
+msb create python --name devbox \
   --net-rule "allow@public,allow@host"
 ```
 

--- a/docs/networking/security-model.mdx
+++ b/docs/networking/security-model.mdx
@@ -4,7 +4,7 @@ description: What the networking stack defends against
 icon: "shield-halved"
 ---
 
-microsandbox's networking defaults are shaped around giving an AI agent, a scraper, or some other untrusted workload access to the internet without letting it pivot into your internal infrastructure. This page walks through the specific threats the stack is designed to handle and where each defense lives.
+microsandbox's networking defaults are shaped around giving untrusted workloads access to the internet without letting them pivot into your internal infrastructure. That includes AI agents, scrapers, package managers, build jobs, plugins, and other code that should not see your host or private network. This page walks through the specific threats the stack is designed to handle and where each defense lives.
 
 ## Private IPs and the host's local network
 
@@ -16,14 +16,14 @@ The largest class of real damage comes from workloads reaching things that live 
 - `169.254.169.254` (cloud metadata, takes precedence over link-local)
 - the per-sandbox gateway IPs (`Group::Host`)
 
-If an agent runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Override the default with `--net-default-egress allow` only when the workload genuinely needs broad reach, or use `--no-net` when it doesn't need network at all.
+If a workload runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Override the default with `--net-default-egress allow` only when the workload genuinely needs broad reach, or use `--no-net` when it doesn't need network at all.
 
 ## Cloud metadata endpoints
 
 On AWS, GCP, Azure, and similar platforms, `169.254.169.254` is the instance metadata service, a well-known SSRF target because it hands out temporary credentials to anything that can connect. The default policy blocks it via the `Group::Public` complement. For custom policies that flip `default_egress` to `Allow`, `Group::Metadata` lets you deny it explicitly:
 
 ```bash
-msb create python --name agent \
+msb create python --name worker \
     --net-default-egress allow \
     --net-rule "deny@meta"
 ```

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -23,7 +23,7 @@ The default CA is intentionally local to the host, not to one sandbox lifetime. 
 ```rust Rust
 use microsandbox::Sandbox;
 
-let sb = Sandbox::builder("agent")
+let sb = Sandbox::builder("worker")
     .image("python")
     .network(|n| n
         .tls(|t| t
@@ -38,7 +38,7 @@ let sb = Sandbox::builder("agent")
 ```typescript TypeScript
 import { Sandbox } from "microsandbox";
 
-await using sb = await Sandbox.builder("agent")
+await using sb = await Sandbox.builder("worker")
     .image("python")
     .network((n) => n.tls((t) =>
         t.bypass("pinned-api.example.com").bypass("*.gov"),
@@ -50,7 +50,7 @@ await using sb = await Sandbox.builder("agent")
 from microsandbox import Network, Sandbox, TlsConfig
 
 sb = await Sandbox.create(
-    "agent",
+    "worker",
     image="python",
     network=Network(
         tls=TlsConfig(bypass=("pinned-api.example.com", "*.gov")),
@@ -59,7 +59,7 @@ sb = await Sandbox.create(
 ```
 
 ```go Go
-sb, err := m.CreateSandbox(ctx, "agent",
+sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("python"),
     m.WithNetwork(&m.NetworkConfig{
         TLS: &m.TLSConfig{
@@ -70,7 +70,7 @@ sb, err := m.CreateSandbox(ctx, "agent",
 ```
 
 ```bash CLI
-msb create python --name agent \
+msb create python --name worker \
   --tls-intercept \
   --tls-bypass "pinned-api.example.com" \
   --tls-bypass "*.gov"
@@ -105,7 +105,7 @@ It matches the existing threat model (a host-access attacker already owns the sa
 <CodeGroup>
 
 ```rust Rust
-let sb = Sandbox::builder("agent")
+let sb = Sandbox::builder("devbox")
     .image("alpine")
     .network(|n| n.trust_host_cas(true))
     .create()
@@ -113,7 +113,7 @@ let sb = Sandbox::builder("agent")
 ```
 
 ```typescript TypeScript
-await using sb = await Sandbox.builder("agent")
+await using sb = await Sandbox.builder("devbox")
     .image("alpine")
     .network((n) => n.trustHostCAs(true))
     .create();
@@ -121,7 +121,7 @@ await using sb = await Sandbox.builder("agent")
 
 ```python Python
 sb = await Sandbox.create(
-    "agent",
+    "devbox",
     image="alpine",
     network=Network(trust_host_cas=True),
 )
@@ -129,7 +129,7 @@ sb = await Sandbox.create(
 
 ```go Go
 trustHostCAs := true
-sb, err := m.CreateSandbox(ctx, "agent",
+sb, err := m.CreateSandbox(ctx, "devbox",
     m.WithImage("alpine"),
     m.WithNetwork(&m.NetworkConfig{
         TrustHostCAs: &trustHostCAs,

--- a/docs/observability/msb-metrics.mdx
+++ b/docs/observability/msb-metrics.mdx
@@ -123,7 +123,7 @@ attributes, so you can build per-user, per-tenant, or per-environment
 views without naming every sandbox.
 
 ```bash
-msb create alpine --name agent-1 --label user.id=alice --label tenant=acme
+msb create alpine --name worker-1 --label user.id=alice --label tenant=acme
 ```
 
 `msb-metrics` reads those labels from the catalog and attaches them to

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -6,7 +6,7 @@ icon: "circle-info"
 
 A sandbox is a local microVM with its own Linux kernel, filesystem, and network stack. Your application or the `msb` CLI starts it as a child process, then talks to the guest agent to run commands, move files, and control lifecycle.
 
-The security boundary is hardware virtualization, not Linux namespaces. That makes sandboxes a good fit for running agent-generated code, untrusted tools, dependency installs, and other workloads that should not inherit the host process's full privileges.
+The security boundary is hardware virtualization, not Linux namespaces. That makes sandboxes a good fit for untrusted workloads: user-submitted code, AI agent actions, plugins, dependency installs, CI jobs, scrapers, and tools that should not inherit the host process's full privileges.
 
 ## Create a sandbox
 

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -16,7 +16,7 @@ Allowed hosts are checked against the sandbox's observed DNS and TLS identity. K
 ```rust Rust
 use microsandbox::Sandbox;
 
-let sb = Sandbox::builder("agent")
+let sb = Sandbox::builder("worker")
     .image("python")
     .secret(|s| s
         .env("GITHUB_TOKEN")
@@ -24,7 +24,7 @@ let sb = Sandbox::builder("agent")
         .allow_host("api.github.com")
         .allow_host_pattern("*.githubusercontent.com")
     )
-    .secret_env("OPENAI_API_KEY", api_key, "api.openai.com")
+    .secret_env("SERVICE_API_KEY", service_api_key, "api.example.com")
     .create()
     .await?;
 ```
@@ -32,7 +32,7 @@ let sb = Sandbox::builder("agent")
 ```typescript TypeScript
 import { Sandbox } from "microsandbox";
 
-await using sb = await Sandbox.builder("agent")
+await using sb = await Sandbox.builder("worker")
     .image("python")
     .secret((s) =>
         s.env("GITHUB_TOKEN")
@@ -40,7 +40,7 @@ await using sb = await Sandbox.builder("agent")
             .allowHost("api.github.com")
             .allowHostPattern("*.githubusercontent.com"),
     )
-    .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+    .secretEnv("SERVICE_API_KEY", process.env.SERVICE_API_KEY!, "api.example.com")
     .create();
 ```
 
@@ -49,7 +49,7 @@ import os
 from microsandbox import Sandbox, Secret
 
 sb = await Sandbox.create(
-    "agent",
+    "worker",
     image="python",
     secrets=[
         Secret.env(
@@ -59,16 +59,16 @@ sb = await Sandbox.create(
             allow_host_patterns=["*.githubusercontent.com"],
         ),
         Secret.env(
-            "OPENAI_API_KEY",
-            value=os.environ["OPENAI_API_KEY"],
-            allow_hosts=["api.openai.com"],
+            "SERVICE_API_KEY",
+            value=os.environ["SERVICE_API_KEY"],
+            allow_hosts=["api.example.com"],
         ),
     ],
 )
 ```
 
 ```go Go
-sb, err := m.CreateSandbox(ctx, "agent",
+sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("python"),
     m.WithSecrets(
         m.Secret.Env("GITHUB_TOKEN", os.Getenv("GITHUB_TOKEN"),
@@ -77,17 +77,17 @@ sb, err := m.CreateSandbox(ctx, "agent",
                 AllowHostPatterns: []string{"*.githubusercontent.com"},
             },
         ),
-        m.Secret.Env("OPENAI_API_KEY", os.Getenv("OPENAI_API_KEY"),
-            m.SecretEnvOptions{AllowHosts: []string{"api.openai.com"}},
+        m.Secret.Env("SERVICE_API_KEY", os.Getenv("SERVICE_API_KEY"),
+            m.SecretEnvOptions{AllowHosts: []string{"api.example.com"}},
         ),
     ),
 )
 ```
 
 ```bash CLI
-msb create python --name agent \
+msb create python --name worker \
   --secret "GITHUB_TOKEN@api.github.com" \
-  --secret "OPENAI_API_KEY@api.openai.com"
+  --secret "SERVICE_API_KEY@api.example.com"
 ```
 
 </CodeGroup>

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -65,7 +65,7 @@ Allow public + private (LAN) destinations; ingress allowed by default. Blocks lo
 Build a custom firewall by populating [`NetworkConfig.Rules`](#networkconfig). Rules are evaluated **first-match-wins** per direction. `DefaultEgress` and `DefaultIngress` set the fall-through action.
 
 ```go
-sb, err := m.CreateSandbox(ctx, "agent",
+sb, err := m.CreateSandbox(ctx, "ci-runner",
     m.WithImage("python:3.12"),
     m.WithNetwork(&m.NetworkConfig{
         DefaultEgress:  m.PolicyActionDeny,
@@ -74,7 +74,7 @@ sb, err := m.CreateSandbox(ctx, "agent",
             {
                 Action:      m.PolicyActionAllow,
                 Direction:   m.PolicyDirectionEgress,
-                Destination: "api.openai.com",
+                Destination: "api.example.com",
                 Protocol:    m.PolicyProtocolTCP,
                 Port:        "443",
             },

--- a/docs/sdk/go/secrets.mdx
+++ b/docs/sdk/go/secrets.mdx
@@ -5,16 +5,16 @@ description: Go SDK - Secret injection API reference
 
 See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
 
-Secrets never enter the VM. The Go SDK passes each [`SecretEntry`](#secretentry) to the runtime, which exposes a placeholder string inside the guest (e.g. `$MSB_OPENAI_API_KEY`) and substitutes the real value at the network layer only when traffic reaches an allowed host.
+Secrets never enter the VM. The Go SDK passes each [`SecretEntry`](#secretentry) to the runtime, which exposes a placeholder string inside the guest (e.g. `$MSB_SERVICE_API_KEY`) and substitutes the real value at the network layer only when traffic reaches an allowed host.
 
 ```go
-sb, err := m.CreateSandbox(ctx, "agent",
+sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("python:3.12"),
     m.WithSecrets(m.Secret.Env(
-        "OPENAI_API_KEY",
-        os.Getenv("OPENAI_API_KEY"),
+        "SERVICE_API_KEY",
+        os.Getenv("SERVICE_API_KEY"),
         m.SecretEnvOptions{
-            AllowHosts: []string{"api.openai.com"},
+            AllowHosts: []string{"api.example.com"},
         },
     )),
 )

--- a/docs/sdk/rust/secrets.mdx
+++ b/docs/sdk/rust/secrets.mdx
@@ -53,7 +53,7 @@ Add a host that is allowed to receive the real secret value. The proxy checks th
 
 | Name | Type | Description |
 |------|------|-------------|
-| host | `impl Into<String>` | Exact hostname (e.g. `"api.openai.com"`) |
+| host | `impl Into<String>` | Exact hostname (e.g. `"api.example.com"`) |
 
 ---
 

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -17,7 +17,7 @@ const custom = {
   defaultEgress: "deny",
   defaultIngress: "allow",
   rules: [
-    Rule.allowEgress(Destination.domain("api.openai.com")),
+    Rule.allowEgress(Destination.domain("api.example.com")),
     Rule.denyEgress(Destination.group("metadata")),
   ],
 };

--- a/docs/sdk/typescript/secrets.mdx
+++ b/docs/sdk/typescript/secrets.mdx
@@ -12,14 +12,14 @@ Secrets are configured on a sandbox via `SandboxBuilder.secret(s => ...)` (or it
 ```typescript
 import { Sandbox } from "microsandbox";
 
-// Auto-placeholder shorthand: generates `$MSB_OPENAI_API_KEY`.
-await using sb = await Sandbox.builder("agent")
+// Auto-placeholder shorthand: generates `$MSB_SERVICE_API_KEY`.
+await using sb = await Sandbox.builder("worker")
   .image("python")
-  .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+  .secretEnv("SERVICE_API_KEY", process.env.SERVICE_API_KEY!, "api.example.com")
   .create();
 
 // Full control via SecretBuilder.
-await using sb2 = await Sandbox.builder("agent2")
+await using sb2 = await Sandbox.builder("payments-worker")
   .image("python")
   .secret((s) =>
     s.env("STRIPE_KEY")


### PR DESCRIPTION
## TL;DR
Refocus the README and docs around untrusted workloads, while keeping AI agents as a first-class use case.

## Description
- Replaces the agent-only front-door tagline with fast, local microVMs for untrusted workloads.
- Expands the README and docs introduction to cover agents, user code, plugins, CI/CD, dev environments, scrapers, automation, and secure tool execution.
- Reframes the AI agents page as a strong use case instead of the whole product identity.
- Updates sandbox, networking, secrets, and SDK reference examples so general docs use neutral worker, devbox, and service API examples.
- Keeps Docker-like workflows as supporting positioning without making microsandbox read like a Docker replacement.

## Test Plan
- [x] `git diff --check`
- [x] `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('docs/docs.json','utf8')); console.log('docs/docs.json ok')"`
- [x] `rg -n "Every agent|your agent|built for AI agents|AI agents run|agent-generated|secure-agent|dev-agent|--name agent|\"agent\"|OPENAI_API_KEY|api\\.openai\\.com" README.md docs -g '*.md' -g '*.mdx'`