### PR TITLE
docs(recipes): shorten docker sandbox subtitle

### DIFF
--- a/docs/recipes/docker/docker-in-sandbox.mdx
+++ b/docs/recipes/docker/docker-in-sandbox.mdx
@@ -1,6 +1,6 @@
 ---
 title: Docker in a sandbox
-description: Start dockerd inside a microsandbox VM and run containers from an interactive shell
+description: Run Docker inside a microsandbox VM
 icon: "docker"
 ---
 


### PR DESCRIPTION
## TL;DR
Shorten the Docker-in-sandbox recipe subtitle shown in the docs preview.

## Description
- Replace the long `docker-in-sandbox` frontmatter description with `Run Docker inside a microsandbox VM`.

## Test Plan
- [x] pre-commit hooks for docs-only change
