### PR TITLE
docs(mintlify): sync docs to v0.5.6

### DIFF
--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -13,6 +13,8 @@ The `msb` CLI lets you create, manage, and interact with sandboxes from the term
 curl -fsSL https://install.microsandbox.dev | sh
 ```
 
+The installer writes the runtime to `~/.microsandbox/` and creates command links in `~/.local/bin/`. It does not edit shell startup files. If `~/.local/bin` is not on your `PATH`, the installer prints the command to add it.
+
 <Note>
   microsandbox requires Linux with KVM enabled, or macOS with Apple Silicon (M-series chip). Both use hardware virtualization.
 </Note>

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -42,6 +42,7 @@ Common flags:
 | `-c`, `--cpus` | Virtual CPU limit |
 | `-m`, `--memory` | Memory limit, such as `512M` or `1G` |
 | `-v`, `--volume` | Mount a host path or named volume, such as `./src:/app:ro` |
+| `--mount-dir`, `--mount-file`, `--mount-disk`, `--mount-named` | Mount a source with an explicit kind (`SOURCE:DEST[:OPTIONS]` or `NAME:DEST[:OPTIONS]`). `--mount-named` creates missing named volumes idempotently and accepts `kind=dir\|disk`, `size=...`, and `quota=...` |
 | `-p`, `--port` | Publish a port, such as `8000:8000` or `0.0.0.0:8000:8000` |
 | `-e`, `--env` | Set an environment variable |
 | `--label` | Attach a label for metric attribution (`KEY=VALUE`, or bare `KEY`). Repeatable |
@@ -350,6 +351,7 @@ msb install --list                   # List installed commands
 | `-c`, `--cpus` | Number of virtual CPUs to allocate |
 | `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
 | `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST[:OPTIONS]`, e.g. `./src:/app:ro,noexec`) |
+| `--mount-dir`, `--mount-file`, `--mount-disk`, `--mount-named` | Mount a source with an explicit kind (`SOURCE:DEST[:OPTIONS]` or `NAME:DEST[:OPTIONS]`). `--mount-named` creates missing named volumes idempotently and accepts `kind=dir\|disk`, `size=...`, and `quota=...` |
 | `--security` | In-guest security profile (`default` or `restricted`) |
 | `-w`, `--workdir` | Working directory inside the sandbox |
 | `--shell` | Shell for interactive sessions |
@@ -381,8 +383,8 @@ msb self uninstall --yes      # Skip confirmation
 
 | Subcommand | Description |
 |------------|-------------|
-| `update` (alias: `upgrade`) | Update msb and libkrunfw to the latest release |
-| `uninstall` | Remove msb, libkrunfw, and shell configuration |
+| `update` (alias: `upgrade`) | Update msb and libkrunfw to the latest release and refresh command links |
+| `uninstall` | Remove msb, libkrunfw, and command links |
 
 | Flag | Subcommand | Description |
 |------|------------|-------------|

--- a/docs/cli/volume-commands.mdx
+++ b/docs/cli/volume-commands.mdx
@@ -11,12 +11,15 @@ Named volumes persist independently of sandboxes and are stored by default under
 
 ```bash
 msb volume create my-data
-msb volume create my-data --size 10G
+msb volume create --name my-data
+msb volume create docker-data --kind disk --size 10G
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--size` | Storage quota (e.g. `100M`, `1G`, `10G`) |
+| `--name` | Volume name, as an alternative to the positional name |
+| `--kind` | Volume kind (`dir` or `disk`; default `dir`) |
+| `--size` | Disk capacity for `--kind disk` (e.g. `100M`, `1G`, `10G`) |
 | `-q`, `--quiet` | Suppress output (only print the volume name) |
 
 ## msb volume ls
@@ -51,17 +54,23 @@ msb volume rm cache-1 cache-2   # Remove multiple
 
 ## Using volumes with sandboxes
 
-Mount a named volume when creating or running a sandbox. The volume name goes before the colon, the guest path after.
+Mount a named volume when creating or running a sandbox. The volume name goes before the colon, the guest path after. CLI named mounts are idempotent: if the named volume is missing, microsandbox creates it; if it already exists with compatible settings, microsandbox reuses it.
 
 ```bash
-# Create a volume, then mount it
-msb volume create app-data --size 5G
+# Create or reuse a directory-backed named volume, then mount it
 msb run --name worker -v app-data:/data python
+
+# Create or reuse a disk-backed named volume, then mount it
+msb run --name docker-demo \
+  --mount-named docker-data:/var/lib/docker:kind=disk,size=20G \
+  docker:dind
 
 # Share between sandboxes
 msb run --name writer -v shared:/data alpine -- sh -c "echo hello > /data/msg.txt"
 msb run --name reader -v shared:/data alpine -- cat /data/msg.txt
 ```
+
+`--mount-named` accepts named-volume creation options in the mount option block: `kind=dir|disk`, `size=<size>` for disk-backed volumes, and `quota=<size>` for directory-backed volumes. `kind=disk` requires `size=...`; `size=...` without `kind=disk` is rejected. If an existing volume has a different kind, capacity, or quota than the requested settings, sandbox creation fails instead of silently changing the volume.
 
 <Tip>
   The CLI distinguishes bind mounts from named volumes by looking for a `/` or `.` prefix. `./src:/app` is a bind mount (host path). `myvolume:/data` is a named volume. This matches Docker's convention.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -238,7 +238,7 @@
   "appearance": {
     "default": "system"
   },
-  "description": "Every agent deserves its own machine",
+  "description": "Easy, fast, local microVMs for untrusted workloads",
   "footer": {
     "socials": {
       "github": "https://github.com/superradcompany/microsandbox",

--- a/docs/getting-started/agents.mdx
+++ b/docs/getting-started/agents.mdx
@@ -1,10 +1,14 @@
 ---
 title: AI agents
-description: Give AI agents the ability to create and manage their own sandboxes
+description: Connect AI agents to isolated microsandbox machines
 icon: "robot"
 ---
 
-microsandbox is built for AI agents. The SDK and CLI give you full programmatic control, but there are two additional ways to connect agents directly: **Agent Skills** for coding assistants and an **MCP server** for any MCP-compatible client.
+AI agents are a natural fit for microsandbox. They run tools, inspect files, install packages, call APIs, and execute generated code, often with more ambient access than they should have.
+
+microsandbox gives those actions a dedicated microVM instead of your host process. Agents can still work normally, but their filesystem, network, lifecycle, and secrets are controlled by the sandbox boundary.
+
+The SDK and CLI give you full programmatic control, and there are two additional ways to connect agents directly: **Agent Skills** for coding assistants and an **MCP server** for any MCP-compatible client.
 
 ## Agent Skills
 
@@ -18,7 +22,7 @@ npx skills add superradcompany/skills
 
 This installs a set of skill files into your project that the agent reads as context. No server process, no configuration, just files that describe how to use microsandbox.
 
-## MCP server
+## MCP Server
 
 The [microsandbox MCP server](https://github.com/superradcompany/microsandbox-mcp) exposes microsandbox as a set of structured tool calls over the [Model Context Protocol](https://modelcontextprotocol.io). Any MCP-compatible client can use it to manage sandbox lifecycle, execute commands, access the filesystem, work with volumes, and monitor sandbox state.
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -1,12 +1,14 @@
 ---
 title: "Introduction"
-description: "Every agent deserves its own computer"
+description: "Easy, fast, local microVMs for untrusted workloads"
 icon: "house"
 ---
 
-AI agents run with whatever privileges you give them, and most of the time that's too many. They can see host environment variables, reach the network freely, and modify files wherever the process is allowed to write. A prompt injection turns those privileges into attack surface.
+microsandbox is a local microVM runtime for untrusted workloads: AI agents, user code, plugins, package installs, CI jobs, dev environments, scrapers, and automation.
 
-microsandbox gives each workload its own local microVM: a real Linux kernel, isolated filesystem, and host-controlled network stack. It keeps the developer loop simple while moving untrusted code out of the host process.
+Each sandbox is a lightweight VM with its own Linux kernel, filesystem, and network boundary. Your app or the `msb` CLI starts it locally, talks to it through a host-guest command channel, and controls what it can access.
+
+It keeps the familiar workflow of OCI images and command execution, while moving risky work out of the host process.
 
 <Tip>
   Boot a microVM in one command.
@@ -21,9 +23,18 @@ microsandbox gives each workload its own local microVM: a real Linux kernel, iso
 - **Hardware isolation.** Each sandbox is a VM, not a container namespace on the host kernel.
 - **Local runtime.** The SDK starts the sandbox process directly. No daemon, remote service, or infrastructure setup.
 - **Fast startup.** Sandboxes are lightweight enough to create from application code.
-- **OCI images.** Use familiar images from Docker Hub, GHCR, ECR, GCR, or another OCI-compatible registry.
+- **Docker-like inputs.** Use familiar OCI images from Docker Hub, GHCR, ECR, GCR, or another registry.
 - **Programmable controls.** Configure resources, volumes, secrets, networking, and lifecycle from the CLI or SDK.
 - **Multi-language SDKs.** Rust, TypeScript, Python, and Go expose the same core model.
+
+## Common workloads
+
+- **AI agents.** Give coding agents and tool-using assistants a dedicated machine for commands, files, package installs, and generated code.
+- **User code execution.** Run submitted scripts, notebooks, plugins, and extensions away from the host.
+- **CI/CD and builds.** Isolate test jobs, compilers, package managers, and build tools.
+- **Dev environments.** Create disposable Linux machines without touching your laptop or host Docker daemon.
+- **Scrapers and automation.** Allow internet access while blocking private networks and metadata services.
+- **Secure tool execution.** Run CLIs and dependencies that should not see host secrets or ambient credentials.
 
 ## What makes it different
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -42,6 +42,8 @@ icon: "bolt"
     ```
 
     </CodeGroup>
+
+    The CLI installer creates command links in `~/.local/bin/` and does not edit shell startup files. If `~/.local/bin` is not on your `PATH`, the installer prints the command to add it.
   </Step>
 
   <Step title="Run code in a sandbox">

--- a/docs/images/overview.mdx
+++ b/docs/images/overview.mdx
@@ -197,7 +197,7 @@ Images are cached in the global microsandbox home directory:
 | `~/.microsandbox/cache/vmdk/` | VMDK descriptors used to boot cached images |
 | `~/.microsandbox/db/` | Database tracking image metadata and digests |
 
-Layers are content-addressable and deduplicated. If `python` and `node` share a base layer, it's stored once.
+Layers are content-addressable and deduplicated. If `python` and `python` share a base layer, it's stored once.
 
 <Tip>
   Use `msb pull` from the CLI to pre-pull images before creating sandboxes. This avoids blocking on a download during `Sandbox.create`.

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -66,7 +66,7 @@ let policy = NetworkPolicy::builder()
     .egress(|e| e.udp().tcp().port(53).allow_host())
     .build()?;
 
-let sb = Sandbox::builder("secure-agent")
+let sb = Sandbox::builder("restricted-worker")
     .image("alpine")
     .network(|n| n.policy(policy))
     .create()
@@ -76,7 +76,7 @@ let sb = Sandbox::builder("secure-agent")
 ```typescript TypeScript
 import { NetworkPolicy, Sandbox } from "microsandbox";
 
-await using sb = await Sandbox.builder("secure-agent")
+await using sb = await Sandbox.builder("restricted-worker")
     .image("alpine")
     .network((n) => n.policy(
         NetworkPolicy.builder()
@@ -92,7 +92,7 @@ await using sb = await Sandbox.builder("secure-agent")
 from microsandbox import Network, Sandbox
 
 sb = await Sandbox.create(
-    "secure-agent",
+    "restricted-worker",
     image="alpine",
     network={
         "policy": {
@@ -107,7 +107,7 @@ sb = await Sandbox.create(
 ```
 
 ```go Go
-sb, err := m.CreateSandbox(ctx, "secure-agent",
+sb, err := m.CreateSandbox(ctx, "restricted-worker",
     m.WithImage("alpine"),
     m.WithNetwork(&m.NetworkConfig{
         DefaultEgress: m.PolicyActionDeny,
@@ -120,7 +120,7 @@ sb, err := m.CreateSandbox(ctx, "secure-agent",
 ```
 
 ```bash CLI
-msb create alpine --name secure-agent \
+msb create alpine --name restricted-worker \
   --net-default-egress deny \
   --net-rule "allow@public:tcp:443,allow@host:udp:53"
 ```
@@ -173,7 +173,7 @@ Use an explicit bind address, such as `0.0.0.0`, only when you intentionally wan
 From inside the sandbox, `host.microsandbox.internal` resolves to the host machine. The default policy denies host access, so allow the `host` group when a sandbox needs to call a dev server, database, or other local service.
 
 ```bash
-msb create python --name dev-agent \
+msb create python --name devbox \
   --net-rule "allow@public,allow@host"
 ```
 

--- a/docs/networking/security-model.mdx
+++ b/docs/networking/security-model.mdx
@@ -4,7 +4,7 @@ description: What the networking stack defends against
 icon: "shield-halved"
 ---
 
-microsandbox's networking defaults are shaped around giving an AI agent, a scraper, or some other untrusted workload access to the internet without letting it pivot into your internal infrastructure. This page walks through the specific threats the stack is designed to handle and where each defense lives.
+microsandbox's networking defaults are shaped around giving untrusted workloads access to the internet without letting them pivot into your internal infrastructure. That includes AI agents, scrapers, package managers, build jobs, plugins, and other code that should not see your host or private network. This page walks through the specific threats the stack is designed to handle and where each defense lives.
 
 ## Private IPs and the host's local network
 
@@ -16,14 +16,14 @@ The largest class of real damage comes from workloads reaching things that live 
 - `169.254.169.254` (cloud metadata, takes precedence over link-local)
 - the per-sandbox gateway IPs (`Group::Host`)
 
-If an agent runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Override the default with `--net-default-egress allow` only when the workload genuinely needs broad reach, or use `--no-net` when it doesn't need network at all.
+If a workload runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Override the default with `--net-default-egress allow` only when the workload genuinely needs broad reach, or use `--no-net` when it doesn't need network at all.
 
 ## Cloud metadata endpoints
 
 On AWS, GCP, Azure, and similar platforms, `169.254.169.254` is the instance metadata service, a well-known SSRF target because it hands out temporary credentials to anything that can connect. The default policy blocks it via the `Group::Public` complement. For custom policies that flip `default_egress` to `Allow`, `Group::Metadata` lets you deny it explicitly:
 
 ```bash
-msb create python --name agent \
+msb create python --name worker \
     --net-default-egress allow \
     --net-rule "deny@meta"
 ```

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -23,7 +23,7 @@ The default CA is intentionally local to the host, not to one sandbox lifetime. 
 ```rust Rust
 use microsandbox::Sandbox;
 
-let sb = Sandbox::builder("agent")
+let sb = Sandbox::builder("worker")
     .image("python")
     .network(|n| n
         .tls(|t| t
@@ -38,7 +38,7 @@ let sb = Sandbox::builder("agent")
 ```typescript TypeScript
 import { Sandbox } from "microsandbox";
 
-await using sb = await Sandbox.builder("agent")
+await using sb = await Sandbox.builder("worker")
     .image("python")
     .network((n) => n.tls((t) =>
         t.bypass("pinned-api.example.com").bypass("*.gov"),
@@ -50,7 +50,7 @@ await using sb = await Sandbox.builder("agent")
 from microsandbox import Network, Sandbox, TlsConfig
 
 sb = await Sandbox.create(
-    "agent",
+    "worker",
     image="python",
     network=Network(
         tls=TlsConfig(bypass=("pinned-api.example.com", "*.gov")),
@@ -59,7 +59,7 @@ sb = await Sandbox.create(
 ```
 
 ```go Go
-sb, err := m.CreateSandbox(ctx, "agent",
+sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("python"),
     m.WithNetwork(&m.NetworkConfig{
         TLS: &m.TLSConfig{
@@ -70,7 +70,7 @@ sb, err := m.CreateSandbox(ctx, "agent",
 ```
 
 ```bash CLI
-msb create python --name agent \
+msb create python --name worker \
   --tls-intercept \
   --tls-bypass "pinned-api.example.com" \
   --tls-bypass "*.gov"
@@ -105,7 +105,7 @@ It matches the existing threat model (a host-access attacker already owns the sa
 <CodeGroup>
 
 ```rust Rust
-let sb = Sandbox::builder("agent")
+let sb = Sandbox::builder("devbox")
     .image("alpine")
     .network(|n| n.trust_host_cas(true))
     .create()
@@ -113,7 +113,7 @@ let sb = Sandbox::builder("agent")
 ```
 
 ```typescript TypeScript
-await using sb = await Sandbox.builder("agent")
+await using sb = await Sandbox.builder("devbox")
     .image("alpine")
     .network((n) => n.trustHostCAs(true))
     .create();
@@ -121,7 +121,7 @@ await using sb = await Sandbox.builder("agent")
 
 ```python Python
 sb = await Sandbox.create(
-    "agent",
+    "devbox",
     image="alpine",
     network=Network(trust_host_cas=True),
 )
@@ -129,7 +129,7 @@ sb = await Sandbox.create(
 
 ```go Go
 trustHostCAs := true
-sb, err := m.CreateSandbox(ctx, "agent",
+sb, err := m.CreateSandbox(ctx, "devbox",
     m.WithImage("alpine"),
     m.WithNetwork(&m.NetworkConfig{
         TrustHostCAs: &trustHostCAs,

--- a/docs/observability/msb-metrics.mdx
+++ b/docs/observability/msb-metrics.mdx
@@ -123,7 +123,7 @@ attributes, so you can build per-user, per-tenant, or per-environment
 views without naming every sandbox.
 
 ```bash
-msb create alpine --name agent-1 --label user.id=alice --label tenant=acme
+msb create alpine --name worker-1 --label user.id=alice --label tenant=acme
 ```
 
 `msb-metrics` reads those labels from the catalog and attaches them to

--- a/docs/recipes/docker/docker-in-sandbox.mdx
+++ b/docs/recipes/docker/docker-in-sandbox.mdx
@@ -4,121 +4,86 @@ description: Start dockerd inside a microsandbox VM and run containers from an i
 icon: "docker"
 ---
 
-<iframe
-  className="w-full aspect-video rounded-xl"
-  src="https://www.youtube.com/embed/scFFZWsbrbo"
-  title="Docker in a Sandbox demo"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
-></iframe>
+This recipe starts a complete Docker environment inside a microsandbox VM. It is useful for sandboxed builds, agent workflows that need their own Docker daemon, or experiments you do not want leaking onto the dev machine. The host's Docker setup, if any, is left untouched.
 
-This recipe gives you a complete, throwaway Docker environment inside a microsandbox VM. It is useful for sandboxed builds, isolating agent workflows that need their own Docker, or any experiment you don't want leaking onto the dev machine. The host's Docker setup (if any) is left untouched.
+The command below boots the `docker:dind` image, starts Docker inside the sandbox, waits for it to be ready, and then opens an interactive shell. From there, Docker commands run against the daemon inside the sandbox, not your host.
 
-`docker:dind` is a regular OCI image, so microsandbox can boot one inside a microVM. You boot the image into a shell, start `dockerd`, and from there every Docker command in that shell talks to the nested daemon rather than the host's.
+## Start Docker in a sandbox
 
-Use the default security profile for this recipe. Docker-in-Docker needs normal guest-root mount privileges for containerd's bind and overlay mounts, so it does not work in the restricted profile.
-
-Storage needs one small workaround. The sandbox root is already an overlayfs mount, and Docker's default storage driver also wants overlayfs for container layers. Stacking the two produces overlay-on-overlay mount errors. The fix is to point Docker's data root at `/tmp`, which microsandbox already mounts as tmpfs.
-
-<Warning>
-  Docker's data lives on tmpfs in this recipe. Pulled images and created containers do not survive sandbox removal.
-</Warning>
-
-## Step 1: Create the helper script
-
-Save this as `start-docker` in the directory you'll run `msb` from:
-
-```bash start-docker
-#!/bin/sh
-set -eu
-
-if docker info >/dev/null 2>&1; then
-  echo "Docker is already running."
-  exit 0
-fi
-
-dockerd --data-root=/tmp/docker >/tmp/dockerd.log 2>&1 &
-
-printf "Starting Docker"
-i=0
-while ! docker info >/dev/null 2>&1; do
-  i=$((i + 1))
-  if [ "$i" -ge 60 ]; then
-    echo
-    cat /tmp/dockerd.log
-    exit 1
-  fi
-  printf "."
-  sleep 1
-done
-echo " ready"
-```
-
-Make it executable:
-
-```bash
-chmod +x start-docker
-```
-
-## Step 2: Boot the sandbox
-
-```bash
+```sh
 msb run --name docker-demo --replace \
   --memory 2G \
-  --tmpfs /tmp:1G \
-  --entrypoint sh \
-  --script-path start-docker:./start-docker \
+  --mount-named docker-data:/var/lib/docker \
+  --script start='dockerd >/tmp/dockerd.log 2>&1 &
+  timeout 60 sh -c "until docker info>/dev/null 2>&1;do sleep 1;done" || {
+    cat /tmp/dockerd.log
+    false
+  }
+  exec sh' \
+  --entrypoint start \
   docker:dind
 ```
 
-`--entrypoint sh` replaces the image's default DinD entrypoint with an interactive shell. `--script-path` makes `start-docker` available inside the sandbox at `/.msb/scripts/start-docker`, which is already on `PATH`.
+This command does three things:
 
-## Step 3: Start the daemon
+- Starts the `docker:dind` image in a sandbox named `docker-demo`.
+- Mounts a named volume called `docker-data` at `/var/lib/docker`, where Docker stores images, containers, and build cache.
+- Runs the inline `start` script as the entrypoint. The script starts Docker, waits until it is ready, and then opens a shell.
 
-From the sandbox shell, run the helper:
+`--mount-named docker-data:/var/lib/docker` is idempotent. If `docker-data` does not exist, the CLI creates it before starting the sandbox. If it already exists with compatible settings, the same command reuses it, so pulled images and created containers can survive `msb rm docker-demo`.
 
-```bash
-start-docker
+## Run a container
+
+From the sandbox shell, run a nested Ubuntu container:
+
+```sh
+docker run -it --rm ubuntu bash
 ```
 
-Once it prints `ready`, the daemon is running and the Docker client in the same shell is connected to it.
+You are now in a container running inside Docker, which is itself running inside the microsandbox VM. Exit the Ubuntu container with `exit` to return to the `docker-demo` sandbox shell.
 
-## Step 4: Run something
+You can also verify the daemon with a short non-interactive command:
 
-Verify the daemon with hello-world:
-
-```bash
+```sh
 docker run --rm hello-world
 ```
 
-For something closer to a real workload, start a long-running container and tail its logs:
-
-```bash
-docker run -d --name heartbeat alpine sh -c 'while true; do date; sleep 1; done'
-docker ps
-docker logs -f heartbeat
-```
-
-`Ctrl-C` stops the tail; `heartbeat` continues running in the background.
-
-For a visual demo, run cmatrix in a nested Alpine container:
-
-```bash
-docker run --rm -it alpine sh -lc 'apk add --no-cache cmatrix >/dev/null && cmatrix -ab'
-```
-
-`q` exits.
-
 ## Cleanup
 
-```bash
+```sh
 exit
 msb rm -f docker-demo
+msb volume rm docker-data
 ```
+
+Remove `docker-data` only when you no longer need the images, containers, and build cache stored by the nested daemon.
+
+## Details and alternatives
+
+Use the default security profile for this recipe. Docker-in-Docker needs normal guest-root mount privileges, so restricted sandboxes are not supported here.
+
+The named mount gives Docker its own storage at `/var/lib/docker`. That matters because the sandbox root filesystem is already overlay-backed, and Docker's default storage driver also uses overlay layers. Keeping Docker's data directory on a named mount avoids putting Docker's overlay storage directly on top of the sandbox root overlay.
+
+### VFS alternative
+
+If you want to avoid the named volume, you can ask Docker to use the `vfs` storage driver instead:
+
+```sh
+msb run --name docker-demo --replace \
+  --memory 2G \
+  --script start='dockerd --storage-driver=vfs >/tmp/dockerd.log 2>&1 &
+  timeout 60 sh -c "until docker info>/dev/null 2>&1;do sleep 1;done" || {
+    cat /tmp/dockerd.log
+    false
+  }
+  exec sh' \
+  --entrypoint start \
+  docker:dind
+```
+
+The tradeoff is performance and disk usage. `vfs` copies full filesystem trees instead of using overlay layers, so pulls and builds can be slower and use more space. Prefer the named-mount version for normal Docker-in-Docker work.
 
 ## Notes
 
-- **Tmpfs sizing.** `/tmp` is 1 GiB here. Increase `--tmpfs /tmp:N` if you plan to pull larger images.
-- **Named volumes don't fix this.** They are virtiofs-backed host directories, and Docker's overlay snapshotter can't use those for `upperdir` / `workdir`.
-- **Disk-image-backed volumes.** The SDKs can already mount host disk images as virtio-blk devices. Once the CLI has a first-class `msb volume` flow for disk images, Docker's data root can sit on a real block device and survive sandbox removal.
+- **Memory.** The recipe uses `--memory 2G`. Increase it for larger builds or memory-hungry containers.
 - **Not the same as [Sandbox in Docker](/recipes/docker/docker).** That recipe covers the opposite direction.

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -12,7 +12,7 @@ Understanding the lifecycle is useful once you start managing long-running sandb
 stateDiagram-v2
     [*] --> Creating: create()
     Creating --> Running: boot complete
-    Running --> Draining: drain()
+    Running --> Draining: request_drain()
     Running --> Stopped: stop()
     Running --> Crashed: unexpected exit
     Draining --> Stopped: drain complete
@@ -180,48 +180,48 @@ err := sb.Detach(ctx)
 
 </CodeGroup>
 
-## Drain
+## Request drain
 
 Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and transitions to `Stopped` when all in-flight commands complete. This is useful for zero-downtime rotation of worker sandboxes.
 
 <CodeGroup>
 ```rust Rust
-sb.drain().await?;
+sb.request_drain().await?;
 ```
 
 ```typescript TypeScript
-await sb.drain()
+await sb.requestDrain()
 ```
 
 ```python Python
-await sb.drain()
+await sb.request_drain()
 ```
 
 ```go Go
-err := sb.Drain(ctx)
+err := sb.RequestDrain(ctx)
 ```
 
 </CodeGroup>
 
-## Wait
+## Wait until stopped
 
-Block until the sandbox exits on its own, without triggering a stop.
+Block until the sandbox is observed in a terminal non-running state, without triggering a stop or kill request.
 
 <CodeGroup>
 ```rust Rust
-let exit_status = sb.wait().await?;
+let result = sb.wait_until_stopped().await?;
 ```
 
 ```typescript TypeScript
-const exitStatus = await sb.wait()
+const result = await sb.waitUntilStopped()
 ```
 
 ```python Python
-code, success = await sb.wait()
+result = await sb.wait_until_stopped()
 ```
 
 ```go Go
-code, err := sb.Wait(ctx)
+result, err := sb.WaitUntilStopped(ctx)
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -6,7 +6,7 @@ icon: "circle-info"
 
 A sandbox is a local microVM with its own Linux kernel, filesystem, and network stack. Your application or the `msb` CLI starts it as a child process, then talks to the guest agent to run commands, move files, and control lifecycle.
 
-The security boundary is hardware virtualization, not Linux namespaces. That makes sandboxes a good fit for running agent-generated code, untrusted tools, dependency installs, and other workloads that should not inherit the host process's full privileges.
+The security boundary is hardware virtualization, not Linux namespaces. That makes sandboxes a good fit for untrusted workloads: user-submitted code, AI agent actions, plugins, dependency installs, CI jobs, scrapers, and tools that should not inherit the host process's full privileges.
 
 ## Create a sandbox
 

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -16,7 +16,7 @@ Allowed hosts are checked against the sandbox's observed DNS and TLS identity. K
 ```rust Rust
 use microsandbox::Sandbox;
 
-let sb = Sandbox::builder("agent")
+let sb = Sandbox::builder("worker")
     .image("python")
     .secret(|s| s
         .env("GITHUB_TOKEN")
@@ -24,7 +24,7 @@ let sb = Sandbox::builder("agent")
         .allow_host("api.github.com")
         .allow_host_pattern("*.githubusercontent.com")
     )
-    .secret_env("OPENAI_API_KEY", api_key, "api.openai.com")
+    .secret_env("SERVICE_API_KEY", service_api_key, "api.example.com")
     .create()
     .await?;
 ```
@@ -32,7 +32,7 @@ let sb = Sandbox::builder("agent")
 ```typescript TypeScript
 import { Sandbox } from "microsandbox";
 
-await using sb = await Sandbox.builder("agent")
+await using sb = await Sandbox.builder("worker")
     .image("python")
     .secret((s) =>
         s.env("GITHUB_TOKEN")
@@ -40,7 +40,7 @@ await using sb = await Sandbox.builder("agent")
             .allowHost("api.github.com")
             .allowHostPattern("*.githubusercontent.com"),
     )
-    .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+    .secretEnv("SERVICE_API_KEY", process.env.SERVICE_API_KEY!, "api.example.com")
     .create();
 ```
 
@@ -49,7 +49,7 @@ import os
 from microsandbox import Sandbox, Secret
 
 sb = await Sandbox.create(
-    "agent",
+    "worker",
     image="python",
     secrets=[
         Secret.env(
@@ -59,16 +59,16 @@ sb = await Sandbox.create(
             allow_host_patterns=["*.githubusercontent.com"],
         ),
         Secret.env(
-            "OPENAI_API_KEY",
-            value=os.environ["OPENAI_API_KEY"],
-            allow_hosts=["api.openai.com"],
+            "SERVICE_API_KEY",
+            value=os.environ["SERVICE_API_KEY"],
+            allow_hosts=["api.example.com"],
         ),
     ],
 )
 ```
 
 ```go Go
-sb, err := m.CreateSandbox(ctx, "agent",
+sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("python"),
     m.WithSecrets(
         m.Secret.Env("GITHUB_TOKEN", os.Getenv("GITHUB_TOKEN"),
@@ -77,17 +77,17 @@ sb, err := m.CreateSandbox(ctx, "agent",
                 AllowHostPatterns: []string{"*.githubusercontent.com"},
             },
         ),
-        m.Secret.Env("OPENAI_API_KEY", os.Getenv("OPENAI_API_KEY"),
-            m.SecretEnvOptions{AllowHosts: []string{"api.openai.com"}},
+        m.Secret.Env("SERVICE_API_KEY", os.Getenv("SERVICE_API_KEY"),
+            m.SecretEnvOptions{AllowHosts: []string{"api.example.com"}},
         ),
     ),
 )
 ```
 
 ```bash CLI
-msb create python --name agent \
+msb create python --name worker \
   --secret "GITHUB_TOKEN@api.github.com" \
-  --secret "OPENAI_API_KEY@api.openai.com"
+  --secret "SERVICE_API_KEY@api.example.com"
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/ssh.mdx
+++ b/docs/sandboxes/ssh.mdx
@@ -43,7 +43,7 @@ msb ssh --name authorize -- uptime
 <CodeGroup>
 ```rust Rust
 let sb = Sandbox::start("devbox").await?;
-let ssh = sb.ssh().connect().await?;
+let ssh = sb.ssh().open_client().await?;
 
 let output = ssh.exec("uname -a").await?;
 println!("{}", String::from_utf8_lossy(&output.stdout));
@@ -53,7 +53,7 @@ ssh.close().await?;
 
 ```typescript TypeScript
 const sb = await Sandbox.start("devbox");
-const ssh = await sb.ssh().connect();
+const ssh = await sb.ssh().open_client();
 
 const output = await ssh.exec("uname -a");
 console.log(output.stdout.toString());
@@ -63,7 +63,7 @@ await ssh.close();
 
 ```python Python
 sb = await Sandbox.start("devbox")
-ssh = await sb.ssh().connect()
+ssh = await sb.ssh().open_client()
 
 output = await ssh.exec("uname -a")
 print(output.stdout_text)
@@ -78,7 +78,7 @@ if err != nil {
 }
 defer sb.Close()
 
-ssh, err := sb.SSH().Connect(ctx)
+ssh, err := sb.SSH().OpenClient(ctx)
 if err != nil {
     return err
 }
@@ -107,17 +107,17 @@ let code = sb
 ```
 
 ```typescript TypeScript
-const ssh = await sb.ssh().connect({ term: "xterm-256color" });
+const ssh = await sb.ssh().open_client({ term: "xterm-256color" });
 const code = await ssh.attach({ detachKeys: "ctrl-]" });
 ```
 
 ```python Python
-ssh = await sb.ssh().connect(term="xterm-256color")
+ssh = await sb.ssh().open_client(term="xterm-256color")
 code = await ssh.attach(detach_keys="ctrl-]")
 ```
 
 ```go Go
-ssh, err := sb.SSH().Connect(ctx, m.WithSSHTerm("xterm-256color"))
+ssh, err := sb.SSH().OpenClient(ctx, m.WithSSHTerm("xterm-256color"))
 if err != nil {
     return err
 }

--- a/docs/sandboxes/volumes.mdx
+++ b/docs/sandboxes/volumes.mdx
@@ -12,6 +12,16 @@ Mounts use normal Linux behavior by default: writable, executable, suid-enabled,
 
 For stronger in-guest hardening, create the sandbox with the restricted security profile. Restricted sandboxes set `no_new_privs`, drop mount-admin capability from user commands, and force `nosuid,nodev` on user mounts. This profile is incompatible with workloads such as `sudo` and Docker-in-Docker.
 
+CLI mount flags use `SOURCE:DEST[:OPTIONS]`. The `:` before `OPTIONS` starts the option block, and commas separate options inside that block.
+
+| Flag | Source | Options |
+|------|--------|---------|
+| `--mount-dir` | Host directory | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
+| `--mount-file` | Host file | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
+| `--mount-named` | Named volume | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `kind=dir\|disk`, `size=<size>` for `kind=disk`, `quota=<size>` for directory volumes; directory-backed named volumes also support `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
+| `--mount-disk` | Host disk image | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `format=raw\|qcow2\|vmdk`, `fstype=<type>` |
+| `--tmpfs` | Guest path | `ro`, `rw`, `noexec`, `nosuid`, `nodev`; size may be passed as `PATH:SIZE[:OPTIONS]` |
+
 ## Bind mounts
 
 Mount a directory from the host directly into the sandbox. Changes inside the sandbox are reflected on the host, and vice versa.
@@ -31,7 +41,7 @@ import { Sandbox } from "microsandbox";
 
 await using sb = await Sandbox.builder("dev")
     .image("python")
-    .volume("/app/src", (m) => m.bind("./src").readonly().noexec())
+    .volume("/app/src",  (m) => m.bind("./src").readonly().noexec())
     .volume("/app/data", (m) => m.bind("./data"))
     .create();
 ```
@@ -53,7 +63,7 @@ sb = await Sandbox.create(
 sb, err := m.CreateSandbox(ctx, "dev",
     m.WithImage("python"),
     m.WithMounts(map[string]m.MountConfig{
-        "/app/src": m.Mount.Bind("./src", m.MountOptions{Readonly: true, Noexec: true}),
+        "/app/src":  m.Mount.Bind("./src", m.MountOptions{Readonly: true, Noexec: true}),
         "/app/data": m.Mount.Bind("./data", m.MountOptions{}),
     }),
 )
@@ -61,22 +71,34 @@ sb, err := m.CreateSandbox(ctx, "dev",
 
 ```bash CLI
 msb create python --name dev \
-  -v ./src:/app/src:ro,noexec \
-  -v ./data:/app/data
+  --mount-dir ./src:/app/src:ro,noexec \
+  --mount-dir ./data:/app/data
 ```
 
 </CodeGroup>
 
+Use `--mount-file` when you want to bind one host file instead of an entire directory.
+
+```bash
+msb create alpine --name config-reader \
+  --mount-file ./config.toml:/etc/app/config.toml:ro,nodev
+```
+
 ## Named volumes
 
 Named volumes are managed by microsandbox and stored by default under `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox, so you can create a volume, populate it, and mount it into different sandboxes over time.
+
+Named volumes can be directory-backed or disk-backed. Directory volumes mount through virtiofs. Disk volumes are raw ext4 disk images managed by microsandbox and mount through virtio-blk.
+
+CLI named mounts are idempotent. `-v name:/path` and `--mount-named name:/path` create a directory-backed named volume if it does not already exist, then mount it. If the volume already exists, microsandbox reuses it when the requested storage settings are compatible and errors when they are not. Use `--mount-named name:/path:kind=disk,size=20G` to create or reuse a disk-backed named volume from the mount flag itself.
+
+SDK `named(...)` mount helpers are existing-only. They fail if the named volume does not already exist. Use each SDK's explicit named-volume mode API when you want sandbox creation to create or ensure the volume.
 
 ### Create a volume
 
 <CodeGroup>
 ```rust Rust
 let cache = Volume::builder("pip-cache")
-    .quota(1024)
     .create()
     .await?;
 ```
@@ -84,23 +106,55 @@ let cache = Volume::builder("pip-cache")
 ```typescript TypeScript
 import { Volume } from "microsandbox";
 
-const cache = await Volume.builder("pip-cache").quota(1024).create();
+const cache = await Volume.builder("pip-cache").create();
 ```
 
 ```python Python
-cache = await Volume.create("pip-cache", quota_mib=1024)
+cache = await Volume.create("pip-cache")
 ```
 
 ```go Go
-cache, err := m.CreateVolume(ctx, "pip-cache",
-    m.WithVolumeQuota(1024),
+cache, err := m.CreateVolume(ctx, "pip-cache")
+```
+
+```bash CLI
+msb volume create pip-cache
+```
+
+</CodeGroup>
+
+Create a disk-backed named volume when a workload needs a real guest block filesystem, such as Docker's data root:
+
+<CodeGroup>
+```rust Rust
+let docker_data = Volume::builder("docker-data")
+    .disk()
+    .size(20.gib())
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+const dockerData = await Volume.builder("docker-data")
+  .disk()
+  .size(20 * 1024)
+  .create();
+```
+
+```python Python
+docker_data = await Volume.create("docker-data", kind="disk", size_mib=20 * 1024)
+```
+
+```go Go
+dockerData, err := m.CreateVolume(ctx, "docker-data",
+    m.WithVolumeKind(m.VolumeKindDisk),
+    m.WithVolumeSize(20 * 1024),
 )
 ```
 
 ```bash CLI
-msb volume create pip-cache --size 1024
+msb volume create docker-data --kind disk --size 20G
 ```
-
 </CodeGroup>
 
 ### Mount in a sandbox
@@ -142,16 +196,23 @@ sb, err := m.CreateSandbox(ctx, "worker",
 
 ```bash CLI
 msb create python --name worker \
-  -v pip-cache:/root/.cache/pip
+  --mount-named pip-cache:/root/.cache/pip
 ```
 
 </CodeGroup>
 
+The CLI command above creates `pip-cache` as a directory-backed named volume if it is missing. To create or reuse a disk-backed named volume while mounting it:
+
+```bash
+msb create docker:dind --name docker-demo \
+  --mount-named docker-data:/var/lib/docker:kind=disk,size=20G
+```
+
 ### Sharing and host-side access
 
-Mount the same named volume into multiple sandboxes when they need to share files. Use `readonly` on consumers that should not write.
+Mount the same directory-backed named volume into multiple sandboxes when they need to share files. Use `readonly` on consumers that should not write. Disk-backed named volumes are attached as block devices; use one writable sandbox at a time, or read-only mounts where sharing is intended.
 
-Named volumes are also accessible from the host without a running sandbox, so you can pre-populate a cache or inspect output after the sandbox stops. See the SDK references for filesystem helpers on volume handles.
+Directory-backed named volumes are also accessible from the host without a running sandbox, so you can pre-populate a cache or inspect output after the sandbox stops. Disk-backed named volumes store guest data inside `disk.raw`; host filesystem helpers operate on the managed volume directory, not the filesystem inside the disk image.
 
 ### Manage volumes
 
@@ -219,6 +280,11 @@ sb, err := m.CreateSandbox(ctx, "seeded",
     }),
 )
 ```
+
+```bash CLI
+msb create alpine --name seeded \
+  --mount-disk ./seed.raw:/seed:ro,noexec,fstype=ext4
+```
 </CodeGroup>
 
 ## Tmpfs
@@ -267,4 +333,39 @@ msb create alpine --name worker \
   --tmpfs /tmp/scratch:100:noexec
 ```
 
+</CodeGroup>
+
+## Combining mounts
+
+Mount flags may be repeated, so a sandbox can combine host directories, individual files, named volumes, disk images, and tmpfs scratch space.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("full")
+    .image("python")
+    .volume("/app/src", |v| v.bind("./src").readonly().noexec())
+    .volume("/app/pyproject.toml", |v| v.bind("./pyproject.toml").readonly())
+    .volume("/root/.cache/pip", |v| {
+        v.named("pip-cache")
+            .stat_virtualization(StatVirtualization::Relaxed)
+    })
+    .volume("/dataset", |v| {
+        v.disk("./dataset.qcow2")
+            .format(DiskImageFormat::Qcow2)
+            .fstype("ext4")
+            .readonly()
+    })
+    .volume("/tmp", |v| v.tmpfs().size(1024).noexec().nosuid().nodev())
+    .create()
+    .await?;
+```
+
+```bash CLI
+msb create python --name full \
+  --mount-dir ./src:/app/src:ro,noexec \
+  --mount-file ./pyproject.toml:/app/pyproject.toml:ro \
+  --mount-named pip-cache:/root/.cache/pip:stat-virt=relaxed \
+  --mount-disk ./dataset.qcow2:/dataset:ro,format=qcow2,fstype=ext4 \
+  --tmpfs /tmp:1G:noexec,nosuid,nodev
+```
 </CodeGroup>

--- a/docs/sdk/errors.mdx
+++ b/docs/sdk/errors.mdx
@@ -356,7 +356,7 @@ The CLI prepends the same payload as a styled `error:` block before any captured
 
 ## Resource cleanup
 
-Sandboxes hold compute resources, so release them when done. In Rust, `Drop` handles cleanup when the sandbox goes out of scope. In TypeScript, prefer `await using` (Node 22+) which calls `Sandbox.stop()` automatically when the binding leaves scope. In Go, pair every `CreateSandbox` with a `defer` that calls `StopAndWait` + `Close`.
+Sandboxes hold compute resources, so release them when done. In Rust, `Drop` handles cleanup when the sandbox goes out of scope. In TypeScript, prefer `await using` (Node 22+) which calls `Sandbox.stop()` automatically when the binding leaves scope. In Go, pair every `CreateSandbox` with a `defer` that calls `Stop` + `Close`.
 
 <CodeGroup>
 ```rust Rust
@@ -405,7 +405,7 @@ if err != nil {
 defer func() {
     stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
     defer cancel()
-    _, _ = sb.StopAndWait(stopCtx)
+    _, _ = sb.Stop(stopCtx)
     _ = sb.Close()
 }()
 

--- a/docs/sdk/go/filesystem.mdx
+++ b/docs/sdk/go/filesystem.mdx
@@ -5,7 +5,7 @@ description: Go SDK - Filesystem API reference
 
 See [Filesystem](/sandboxes/filesystem) for usage examples.
 
-## SandboxFs
+## SandboxFsOps
 
 Filesystem accessor for a running sandbox. Obtained via [`Sandbox.FS()`](/sdk/go/sandbox#fs). All operations go through the same host-guest channel as command execution — no SSH, no network involved. For bulk file operations, consider using a [volume](/sdk/go/volumes) instead.
 
@@ -23,7 +23,7 @@ content, err := fs.ReadString(ctx, "/tmp/config.json")
 #### Read()
 
 ```go
-func (fs *SandboxFs) Read(ctx context.Context, path string) ([]byte, error)
+func (fs *SandboxFSOps) Read(ctx context.Context, path string) ([]byte, error)
 ```
 
 Read the entire contents of a file as raw bytes.
@@ -48,7 +48,7 @@ The default FFI buffer is 1 MiB. For files larger than ~750 KiB (after base64 in
 #### ReadString()
 
 ```go
-func (fs *SandboxFs) ReadString(ctx context.Context, path string) (string, error)
+func (fs *SandboxFSOps) ReadString(ctx context.Context, path string) (string, error)
 ```
 
 Read the entire contents of a file and return as a string (UTF-8 reinterpretation of the bytes; no validation).
@@ -58,7 +58,7 @@ Read the entire contents of a file and return as a string (UTF-8 reinterpretatio
 #### Write()
 
 ```go
-func (fs *SandboxFs) Write(ctx context.Context, path string, data []byte) error
+func (fs *SandboxFSOps) Write(ctx context.Context, path string, data []byte) error
 ```
 
 Write bytes to a file, creating it if it doesn't exist and truncating if it does.
@@ -68,7 +68,7 @@ Write bytes to a file, creating it if it doesn't exist and truncating if it does
 #### WriteString()
 
 ```go
-func (fs *SandboxFs) WriteString(ctx context.Context, path, content string) error
+func (fs *SandboxFSOps) WriteString(ctx context.Context, path, content string) error
 ```
 
 Write a UTF-8 string to a file.
@@ -78,7 +78,7 @@ Write a UTF-8 string to a file.
 #### List()
 
 ```go
-func (fs *SandboxFs) List(ctx context.Context, path string) ([]FsEntry, error)
+func (fs *SandboxFSOps) List(ctx context.Context, path string) ([]FsEntry, error)
 ```
 
 List the entries in a directory.
@@ -101,7 +101,7 @@ for _, e := range entries {
 #### Stat()
 
 ```go
-func (fs *SandboxFs) Stat(ctx context.Context, path string) (*FsStat, error)
+func (fs *SandboxFSOps) Stat(ctx context.Context, path string) (*FsStat, error)
 ```
 
 Get detailed metadata for a file or directory.
@@ -117,7 +117,7 @@ Get detailed metadata for a file or directory.
 #### Mkdir()
 
 ```go
-func (fs *SandboxFs) Mkdir(ctx context.Context, path string) error
+func (fs *SandboxFSOps) Mkdir(ctx context.Context, path string) error
 ```
 
 Create a directory and all missing parents.
@@ -127,7 +127,7 @@ Create a directory and all missing parents.
 #### Remove()
 
 ```go
-func (fs *SandboxFs) Remove(ctx context.Context, path string) error
+func (fs *SandboxFSOps) Remove(ctx context.Context, path string) error
 ```
 
 Remove a single file. Use [`RemoveDir`](#removedir) for directories.
@@ -137,7 +137,7 @@ Remove a single file. Use [`RemoveDir`](#removedir) for directories.
 #### RemoveDir()
 
 ```go
-func (fs *SandboxFs) RemoveDir(ctx context.Context, path string) error
+func (fs *SandboxFSOps) RemoveDir(ctx context.Context, path string) error
 ```
 
 Remove a directory recursively.
@@ -147,7 +147,7 @@ Remove a directory recursively.
 #### Copy()
 
 ```go
-func (fs *SandboxFs) Copy(ctx context.Context, src, dst string) error
+func (fs *SandboxFSOps) Copy(ctx context.Context, src, dst string) error
 ```
 
 Copy a file within the sandbox.
@@ -157,7 +157,7 @@ Copy a file within the sandbox.
 #### Rename()
 
 ```go
-func (fs *SandboxFs) Rename(ctx context.Context, src, dst string) error
+func (fs *SandboxFSOps) Rename(ctx context.Context, src, dst string) error
 ```
 
 Rename or move a file or directory within the sandbox.
@@ -167,7 +167,7 @@ Rename or move a file or directory within the sandbox.
 #### Exists()
 
 ```go
-func (fs *SandboxFs) Exists(ctx context.Context, path string) (bool, error)
+func (fs *SandboxFSOps) Exists(ctx context.Context, path string) (bool, error)
 ```
 
 Report whether a path exists inside the sandbox.
@@ -177,7 +177,7 @@ Report whether a path exists inside the sandbox.
 #### CopyFromHost()
 
 ```go
-func (fs *SandboxFs) CopyFromHost(ctx context.Context, hostPath, guestPath string) error
+func (fs *SandboxFSOps) CopyFromHost(ctx context.Context, hostPath, guestPath string) error
 ```
 
 Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sdk/go/volumes#mountbind) instead.
@@ -187,7 +187,7 @@ Copy a file from the host machine into the sandbox. For transferring many files,
 #### CopyToHost()
 
 ```go
-func (fs *SandboxFs) CopyToHost(ctx context.Context, guestPath, hostPath string) error
+func (fs *SandboxFSOps) CopyToHost(ctx context.Context, guestPath, hostPath string) error
 ```
 
 Copy a file from the sandbox to the host machine.
@@ -197,7 +197,7 @@ Copy a file from the sandbox to the host machine.
 #### ReadStream()
 
 ```go
-func (fs *SandboxFs) ReadStream(ctx context.Context, path string) (*FsReadStream, error)
+func (fs *SandboxFSOps) ReadStream(ctx context.Context, path string) (*FsReadStream, error)
 ```
 
 Open a streaming reader for a file. Data is transferred in chunks (~3 MiB each). Use this for files too large to fit in memory. The caller must `Close` the returned [`*FsReadStream`](#fsreadstream).
@@ -230,7 +230,7 @@ _, err = rs.WriteTo(os.Stdout)
 #### WriteStream()
 
 ```go
-func (fs *SandboxFs) WriteStream(ctx context.Context, path string) (*FsWriteStream, error)
+func (fs *SandboxFSOps) WriteStream(ctx context.Context, path string) (*FsWriteStream, error)
 ```
 
 Open a streaming writer for a file. Use this for files too large to fit in memory. The caller must call `Close(ctx)` on the returned [`*FsWriteStream`](#fswritestream) to finalise the operation.

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -65,7 +65,7 @@ Allow public + private (LAN) destinations; ingress allowed by default. Blocks lo
 Build a custom firewall by populating [`NetworkConfig.Rules`](#networkconfig). Rules are evaluated **first-match-wins** per direction. `DefaultEgress` and `DefaultIngress` set the fall-through action.
 
 ```go
-sb, err := m.CreateSandbox(ctx, "agent",
+sb, err := m.CreateSandbox(ctx, "ci-runner",
     m.WithImage("python:3.12"),
     m.WithNetwork(&m.NetworkConfig{
         DefaultEgress:  m.PolicyActionDeny,
@@ -74,7 +74,7 @@ sb, err := m.CreateSandbox(ctx, "agent",
             {
                 Action:      m.PolicyActionAllow,
                 Direction:   m.PolicyDirectionEgress,
-                Destination: "api.openai.com",
+                Destination: "api.example.com",
                 Protocol:    m.PolicyProtocolTCP,
                 Port:        "443",
             },

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -90,7 +90,7 @@ func CreateSandbox(
 ) (*Sandbox, error)
 ```
 
-Create and boot a new sandbox. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes. The returned [`*Sandbox`](#instance-methods) owns the VM process — call `Close` (or `StopAndWait` + `Close`) when done.
+Create and boot a new sandbox. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes. The returned [`*Sandbox`](#instance-methods) owns the VM process — call `Close` (or `Stop` + `Close`) when done.
 
 **Parameters**
 
@@ -118,7 +118,7 @@ if err != nil {
     return err
 }
 defer func() {
-    _, _ = sb.StopAndWait(context.Background())
+    _ = sb.Stop(context.Background())
     _ = sb.Close()
 }()
 ```
@@ -217,7 +217,7 @@ Return the sandbox's name.
 #### FS()
 
 ```go
-func (s *Sandbox) FS() *SandboxFs
+func (s *Sandbox) FS() *SandboxFsOps
 ```
 
 Return a filesystem accessor for reading and writing files inside the running sandbox. See [Filesystem](/sdk/go/filesystem) for API details.
@@ -327,33 +327,23 @@ Attach to the sandbox's default shell (configured via [`WithShell`](#withshell),
 
 ---
 
-#### Drain()
-
-```go
-func (s *Sandbox) Drain(ctx context.Context) error
-```
-
-Send a graceful drain signal (SIGUSR1) to the sandbox. Existing commands run to completion, new `exec` calls are rejected. Errors if this handle does not own the lifecycle.
-
----
-
 #### Stop()
 
 ```go
 func (s *Sandbox) Stop(ctx context.Context) error
 ```
 
-Gracefully shut down the sandbox (SIGTERM). Does **not** wait for the VM process to exit — use [`StopAndWait`](#stopandwait) for that.
+Gracefully shut down the sandbox and wait until stopped state is observed. Pass `WithStopTimeout(...)` to control the graceful shutdown window before force-kill.
 
 ---
 
-#### StopAndWait()
+#### RequestStop()
 
 ```go
-func (s *Sandbox) StopAndWait(ctx context.Context) (int, error)
+func (s *Sandbox) RequestStop(ctx context.Context) error
 ```
 
-Stop the sandbox and wait for the VM process to exit. Returns the guest exit code, or `-1` if the guest did not report one.
+Request graceful shutdown and return once the request is sent.
 
 ---
 
@@ -363,21 +353,37 @@ Stop the sandbox and wait for the VM process to exit. Returns the guest exit cod
 func (s *Sandbox) Kill(ctx context.Context) error
 ```
 
-Force-terminate the sandbox immediately (SIGKILL). No graceful
-shutdown. Pending writes that the workload hasn't `fsync`'d may be
-lost — same durability semantics as a sudden power loss on a physical
-machine. Use [`Stop()`](#stop) for graceful shutdown that gives the
-workload a chance to flush.
+Force-terminate the sandbox and wait until stopped state is observed. Pass `WithKillTimeout(...)` to control the observation timeout.
 
 ---
 
-#### Wait()
+#### RequestKill()
 
 ```go
-func (s *Sandbox) Wait(ctx context.Context) (int, error)
+func (s *Sandbox) RequestKill(ctx context.Context) error
 ```
 
-Block until the sandbox process exits on its own and return the exit code (`-1` if the guest did not report one). Errors if this handle does not own the lifecycle.
+Request force termination and return once the request is sent.
+
+---
+
+#### RequestDrain()
+
+```go
+func (s *Sandbox) RequestDrain(ctx context.Context) error
+```
+
+Request graceful drain and return once the request is sent.
+
+---
+
+#### WaitUntilStopped()
+
+```go
+func (s *Sandbox) WaitUntilStopped(ctx context.Context) (*SandboxStopResult, error)
+```
+
+Block until the sandbox is observed in terminal state.
 
 ---
 
@@ -423,13 +429,13 @@ Convenience that swallows the error and returns `false` on any failure. Suitable
 
 ---
 
-#### RemovePersisted()
+#### RemoveSandbox()
 
 ```go
-func (s *Sandbox) RemovePersisted(ctx context.Context) error
+func RemoveSandbox(ctx context.Context, name string) error
 ```
 
-Remove the sandbox's persisted state (filesystem and database record). The sandbox must already be stopped. This handle becomes invalid after the call.
+Remove a stopped sandbox's persisted state by name.
 
 ---
 

--- a/docs/sdk/go/secrets.mdx
+++ b/docs/sdk/go/secrets.mdx
@@ -5,22 +5,22 @@ description: Go SDK - Secret injection API reference
 
 See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
 
-Secrets never enter the VM. The Go SDK passes each [`SecretEntry`](#secretentry) to the runtime, which exposes a placeholder string inside the guest (e.g. `$MSB_OPENAI_API_KEY`) and substitutes the real value at the network layer only when traffic reaches an allowed host.
+Secrets never enter the VM. The Go SDK passes each [`SecretEntry`](#secretentry) to the runtime, which exposes a placeholder string inside the guest (e.g. `$MSB_SERVICE_API_KEY`) and substitutes the real value at the network layer only when traffic reaches an allowed host.
 
 ```go
-sb, err := m.CreateSandbox(ctx, "agent",
+sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("python:3.12"),
     m.WithSecrets(m.Secret.Env(
-        "OPENAI_API_KEY",
-        os.Getenv("OPENAI_API_KEY"),
+        "SERVICE_API_KEY",
+        os.Getenv("SERVICE_API_KEY"),
         m.SecretEnvOptions{
-            AllowHosts: []string{"api.openai.com"},
+            AllowHosts: []string{"api.example.com"},
         },
     )),
 )
 ```
 
-## Host matching
+## Host Matching
 
 Go does not expose the Rust `HostPattern` enum directly. Instead, exact and wildcard host patterns are represented with fields on `SecretEntry` and `SecretEnvOptions`.
 

--- a/docs/sdk/go/volumes.mdx
+++ b/docs/sdk/go/volumes.mdx
@@ -11,8 +11,12 @@ Named volumes are managed by microsandbox and stored by default under `~/.micros
 
 ```go
 vol, err := m.CreateVolume(ctx, "my-data",
-    m.WithVolumeQuota(100),
     m.WithVolumeLabels(map[string]string{"env": "prod"}),
+)
+
+dockerData, err := m.CreateVolume(ctx, "docker-data",
+    m.WithVolumeKind(m.VolumeKindDisk),
+    m.WithVolumeSize(20 * 1024),
 )
 ```
 
@@ -103,7 +107,27 @@ Delete a volume by name. All sandboxes referencing the volume must be stopped.
 func WithVolumeQuota(mebibytes uint32) VolumeOption
 ```
 
-Set the volume's maximum storage size in MiB. Zero means unlimited.
+Set recorded quota metadata for directory volumes. Zero means unlimited.
+
+---
+
+#### WithVolumeKind()
+
+```go
+func WithVolumeKind(kind VolumeKind) VolumeOption
+```
+
+Select the volume kind. Valid values are `VolumeKindDir` and `VolumeKindDisk`.
+
+---
+
+#### WithVolumeSize()
+
+```go
+func WithVolumeSize(mebibytes uint32) VolumeOption
+```
+
+Set disk volume capacity in MiB. Required with `VolumeKindDisk`.
 
 ---
 
@@ -125,8 +149,12 @@ Metadata reference returned by [`GetVolume`](#getvolume) and [`ListVolumes`](#li
 |--------|---------|-------------|
 | `Name()` | `string` | Volume name |
 | `Path()` | `string` | Host filesystem path of the volume's data directory |
+| `Kind()` | `VolumeKind` | Volume kind: `VolumeKindDir` or `VolumeKindDisk` |
 | `QuotaMiB()` | `*uint32` | Quota in MiB, or `nil` if unlimited |
 | `UsedBytes()` | `uint64` | Current disk usage in bytes |
+| `CapacityBytes()` | `*uint64` | Disk capacity in bytes |
+| `DiskFormat()` | `*string` | Disk image format |
+| `DiskFstype()` | `*string` | Disk filesystem type |
 | `Labels()` | `map[string]string` | Metadata labels |
 | `CreatedAt()` | `time.Time` | Creation timestamp, zero value if unknown |
 | `FS()` | [`*VolumeFs`](#volumefs) | Host-side filesystem accessor |
@@ -297,7 +325,44 @@ Bind-mount a host directory into the sandbox. Changes in the guest are reflected
 func (mountFactory) Named(name string, opts MountOptions) MountConfig
 ```
 
-Mount a named persistent volume. The volume must already exist (create it with [`CreateVolume`](#createvolume)).
+Mount an existing named persistent volume. The volume must already exist (create it with [`CreateVolume`](#createvolume)).
+
+---
+
+#### Mount.NamedWith()
+
+```go
+func (mountFactory) NamedWith(name string, opts MountOptions, namedOpts NamedVolumeOptions) MountConfig
+```
+
+Mount a named persistent volume with explicit sandbox-time existence behavior. `NamedVolumeOptions.Mode` accepts `"existing"` (default), `"create"`, or `"ensure-exists"`. `NamedVolumeOptions.Kind` accepts `"dir"` (default) or `"disk"`.
+
+```go
+sb, err := m.CreateSandbox(ctx, "worker",
+    m.WithImage("python"),
+    m.WithMounts(map[string]m.MountConfig{
+        "/cache": m.Mount.NamedWith("pip-cache", m.MountOptions{}, m.NamedVolumeOptions{
+            Mode: "ensure-exists",
+        }),
+        "/var/lib/docker": m.Mount.NamedWith("docker-data", m.MountOptions{}, m.NamedVolumeOptions{
+            Mode:    "ensure-exists",
+            Kind:    "disk",
+            SizeMiB: 20 * 1024,
+        }),
+    }),
+)
+```
+
+`Mode: "create"` fails when the named volume already exists. `Mode: "ensure-exists"` creates the volume if it is missing and reuses a compatible existing volume. The ensure-exists mode errors when the existing volume has a different kind, quota, or capacity than the requested configuration; it does not mutate existing volume metadata.
+
+**NamedVolumeOptions**
+
+| Field | Description |
+|-------|-------------|
+| `Mode` | `"existing"`, `"create"`, or `"ensure-exists"`; empty means `"existing"` |
+| `Kind` | `"dir"` or `"disk"`; empty means `"dir"` |
+| `SizeMiB` | Disk capacity in MiB; required when creating or ensuring a missing disk volume |
+| `QuotaMiB` | Directory volume quota in MiB |
 
 ---
 
@@ -402,7 +467,9 @@ The config struct populated by [`VolumeOption`](#volumeoption) functions. Most c
 
 | Field | Type | Description |
 |-------|------|-------------|
+| Kind | `VolumeKind` | Volume kind (`VolumeKindDir` by default) |
 | QuotaMiB | `uint32` | Maximum storage size in MiB (zero = unlimited) |
+| SizeMiB | `uint32` | Disk capacity in MiB for `VolumeKindDisk` |
 | Labels | `map[string]string` | Metadata labels |
 
 ### VolumeOption

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -96,7 +96,7 @@ func main() {
         log.Fatal(err)
     }
     defer func() {
-        _, _ = sb.StopAndWait(context.Background())
+        _, _ = sb.Stop(context.Background())
         _ = sb.Close()
     }()
 

--- a/docs/sdk/python/filesystem.mdx
+++ b/docs/sdk/python/filesystem.mdx
@@ -5,7 +5,7 @@ description: Python SDK - Filesystem API reference
 
 See [Filesystem](/sandboxes/filesystem) for usage examples.
 
-## SandboxFs
+## SandboxFsOps
 
 Filesystem handle for a running sandbox. Obtained via the `sandbox.fs` property. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -199,7 +199,7 @@ Whether this handle owns the sandbox lifecycle. A sandbox returned directly by [
 
 ```python
 @property
-def fs(self) -> SandboxFs
+def fs(self) -> SandboxFsOps
 ```
 
 Get a filesystem handle for reading and writing files inside the running sandbox. This is a synchronous property -- use `sb.fs` (no `await`). See [Filesystem](/sdk/python/filesystem) for API details.
@@ -208,7 +208,7 @@ Get a filesystem handle for reading and writing files inside the running sandbox
 
 | Type | Description |
 |------|-------------|
-| [`SandboxFs`](/sdk/python/filesystem) | Filesystem handle |
+| [`SandboxFsOps`](/sdk/python/filesystem) | Filesystem handle |
 
 ---
 
@@ -277,13 +277,13 @@ Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.
 
 ---
 
-#### drain()
+#### request_drain()
 
 ```python
-async def drain() -> None
+async def request_drain() -> None
 ```
 
-Start a graceful drain (SIGUSR1). Existing commands run to completion, new `exec` calls are rejected.
+Request a graceful drain and return once the request is sent. Existing commands run to completion, but new `exec` calls are rejected. Use [`wait_until_stopped()`](#wait_until_stopped) when the caller needs stopped-state observation.
 
 ---
 
@@ -386,14 +386,10 @@ Like [`exec()`](#exec), pass per-execution options as keyword-only arguments. Th
 #### kill()
 
 ```python
-async def kill() -> None
+async def kill(timeout: float | None = None) -> None
 ```
 
-Force-terminate the sandbox immediately (SIGKILL). No graceful
-shutdown. Pending writes that the workload hasn't `fsync`'d may be
-lost — same durability semantics as a sudden power loss on a physical
-machine. Use [`stop()`](#stop) for graceful shutdown that gives the
-workload a chance to flush.
+Force-terminate the sandbox and wait until stopped state is observed. Pass `timeout` to control the observation timeout. No graceful shutdown. Pending writes that the workload hasn't `fsync`'d may be lost — same durability semantics as a sudden power loss on a physical machine. Use [`stop()`](#stop) for graceful shutdown that gives the workload a chance to flush.
 
 ---
 
@@ -507,10 +503,10 @@ dt = datetime.fromtimestamp(e.timestamp_ms / 1000, timezone.utc)
 
 ---
 
-#### remove_persisted()
+#### remove()
 
 ```python
-async def remove_persisted() -> None
+async def remove() -> None
 ```
 
 Remove the sandbox and all its persisted state from disk.
@@ -581,46 +577,46 @@ Shell command with streaming output.
 #### stop()
 
 ```python
-async def stop() -> None
+async def stop(timeout: float | None = None) -> None
 ```
 
-Gracefully shut down the sandbox. Lets the sandbox finish writing
-any pending data to disk before it exits, so files written inside
-the sandbox aren't lost across a later restart. Waits up to ten
-seconds for a clean exit; if the sandbox is still running after
-that, it is force-killed.
+Gracefully shut down the sandbox and wait until stopped state is observed. Lets the sandbox finish writing any pending data to disk before it exits, so files written inside the sandbox aren't lost across a later restart. Waits up to ten seconds by default; pass `timeout` to override the graceful shutdown window before force-kill escalation.
 
 ---
 
-#### stop_and_wait()
+#### request_stop()
 
 ```python
-async def stop_and_wait() -> tuple[int, bool]
+async def request_stop() -> None
 ```
 
-Stop the sandbox and wait for the exit status.
+Request graceful shutdown and return once the request is sent.
+
+---
+
+#### request_kill()
+
+```python
+async def request_kill() -> None
+```
+
+Request force termination and return once the signal is sent.
+
+---
+
+#### wait_until_stopped()
+
+```python
+async def wait_until_stopped() -> SandboxStopResult
+```
+
+Block until the sandbox is observed in a terminal non-running state, without triggering a stop or kill request.
 
 **Returns**
 
 | Type | Description |
 |------|-------------|
-| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
-
----
-
-#### wait()
-
-```python
-async def wait() -> tuple[int, bool]
-```
-
-Block until the sandbox exits on its own.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
+| [`SandboxStopResult`](#sandboxstopresult) | Terminal status and optional observed exit code |
 
 ---
 
@@ -1011,15 +1007,26 @@ A lightweight handle to an existing sandbox (running or stopped). Obtained via [
 | config_json | `str` | Raw JSON configuration |
 | created_at | `float \| None` | Creation timestamp (ms since epoch) |
 | updated_at | `float \| None` | Last update timestamp (ms since epoch) |
-| connect() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Connect to a running sandbox; returns an error if it doesn't respond within 10 seconds |
-| connect_with_timeout(timeout) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Same as `connect()` with an explicit timeout in seconds |
+| connect(timeout=None) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Connect to a running sandbox, optionally with an explicit timeout in seconds |
 | start(*, detached=False) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Start in attached or detached mode |
-| stop() | `Awaitable[None]` | Gracefully shut down. Waits up to 10 seconds for pending writes to flush, then force-kills |
-| stop_with_timeout(timeout) | `Awaitable[None]` | Same as `stop()` with an explicit timeout in seconds; `0` force-kills immediately |
-| kill() | `Awaitable[None]` | Force terminate immediately. Pending writes may be lost |
+| stop(timeout=None) | `Awaitable[None]` | Gracefully shut down and wait until stopped state is observed |
+| request_stop() | `Awaitable[None]` | Request graceful shutdown without waiting |
+| kill(timeout=None) | `Awaitable[None]` | Force terminate and wait until stopped state is observed |
+| request_kill() | `Awaitable[None]` | Request force termination without waiting |
+| request_drain() | `Awaitable[None]` | Request graceful drain without waiting |
+| wait_until_stopped() | `Awaitable[`[`SandboxStopResult`](#sandboxstopresult)`]` | Block until the sandbox reaches terminal state |
 | remove() | `Awaitable[None]` | Delete sandbox and state |
 | metrics() | `Awaitable[`[`SandboxMetrics`](#sandboxmetrics)`]` | Point-in-time resource metrics |
 | logs() | `Awaitable[list[`[`LogEntry`](#logentry)`]]` | Read captured `exec.log` (works without starting) |
+
+### SandboxStopResult
+
+Observed terminal sandbox state returned by [`wait_until_stopped()`](#wait_until_stopped).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| status | `str` | Terminal status that was observed |
+| exit_code | `int \| None` | Process exit code when it is available |
 
 ### SandboxMetrics
 

--- a/docs/sdk/python/secrets.mdx
+++ b/docs/sdk/python/secrets.mdx
@@ -51,7 +51,7 @@ Create a secret entry that maps an environment variable to a real value. The gue
 
 ---
 
-## Host matching
+## Host Matching
 
 Python host settings map to the runtime `HostPattern` model. Allow-list fields decide where the real secret value may be substituted; passthrough fields decide where the placeholder may be forwarded unchanged.
 

--- a/docs/sdk/python/ssh.mdx
+++ b/docs/sdk/python/ssh.mdx
@@ -12,7 +12,7 @@ See [SSH](/sandboxes/ssh) for usage flows.
 #### ssh()
 
 ```python
-def ssh() -> SandboxSsh
+def ssh() -> SandboxSshOps
 ```
 
 Return the SSH namespace for this sandbox.
@@ -21,9 +21,9 @@ Return the SSH namespace for this sandbox.
 
 | Type | Description |
 |------|-------------|
-| [`SandboxSsh`](#sandboxssh) | SSH client and server helpers |
+| [`SandboxSshOps`](#sandboxssh) | SSH client and server helpers |
 
-## SandboxSsh
+## SandboxSshOps
 
 ---
 
@@ -182,10 +182,10 @@ Close the native SSH client session.
 
 ---
 
-#### serve_stdio()
+#### serve_connection()
 
 ```python
-async def serve_stdio() -> None
+async def serve_connection() -> None
 ```
 
 Serve one SSH transport over stdin/stdout.

--- a/docs/sdk/python/volumes.mdx
+++ b/docs/sdk/python/volumes.mdx
@@ -19,6 +19,8 @@ Named volumes are managed by microsandbox and stored by default under `~/.micros
 async def Volume.create(
     name: str,
     *,
+    kind: str = "dir",
+    size_mib: int | None = None,
     quota_mib: int | None = None,
     labels: dict[str, str] | None = None,
 ) -> Volume
@@ -31,7 +33,9 @@ Create a new named volume.
 | Name | Type | Description |
 |------|------|-------------|
 | name | `str` | Volume name (required) |
-| quota_mib | `int \| None` | Maximum storage size in MiB |
+| kind | `str` | Volume kind: `"dir"` or `"disk"` |
+| size_mib | `int \| None` | Disk capacity in MiB; required with `kind="disk"` |
+| quota_mib | `int \| None` | Recorded quota metadata for directory volumes |
 | labels | `dict[str, str] \| None` | Metadata labels |
 
 **Returns**
@@ -150,6 +154,10 @@ Mount a host directory into the sandbox. Changes in the guest are reflected on t
 def Volume.named(
     name: str,
     *,
+    mode: str | None = None,
+    kind: str | None = None,
+    size_mib: int | None = None,
+    quota_mib: int | None = None,
     readonly: bool = False,
     noexec: bool = False,
     nosuid: bool = False,
@@ -157,13 +165,35 @@ def Volume.named(
 ) -> dict
 ```
 
-Mount a named volume. The volume must already exist (create it with [`Volume.create()`](#volumecreate)).
+Mount a named volume. By default, the volume must already exist (create it with [`Volume.create()`](#volumecreate)). Pass `mode="create"` to create the volume and fail if it already exists, or `mode="ensure-exists"` to create it if missing and reuse it if compatible.
+
+```python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    volumes={
+        "/cache": Volume.named("pip-cache", mode="ensure-exists"),
+        "/var/lib/docker": Volume.named(
+            "docker-data",
+            mode="ensure-exists",
+            kind="disk",
+            size_mib=20 * 1024,
+        ),
+    },
+)
+```
+
+The ensure-exists mode validates existing volume metadata. It errors when the existing volume has a different kind, quota, or capacity than the requested configuration; it does not mutate existing volume metadata.
 
 **Parameters**
 
 | Name | Type | Description |
 |------|------|-------------|
 | name | `str` | Volume name |
+| mode | `str \| None` | Named volume behavior: `"existing"` (default), `"create"`, or `"ensure-exists"` |
+| kind | `str \| None` | Storage kind for create or ensure-exists: `"dir"` (default) or `"disk"` |
+| size_mib | `int \| None` | Disk capacity in MiB; required when creating or ensuring a missing disk volume |
+| quota_mib | `int \| None` | Directory volume quota in MiB |
 | readonly | `bool` | Mount as read-only; virtiofs-backed mounts also reject writes in the host filesystem server |
 | noexec | `bool` | Prevent direct execution from the mount |
 | nosuid | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
@@ -254,8 +284,12 @@ Handle to an existing named volume, returned by [`Volume.get()`](#volumeget) and
 | Property / Method | Type | Description |
 |-------------------|------|-------------|
 | name | `str` | Volume name |
+| kind | `str` | Volume kind: `dir` or `disk` |
 | quota_mib | `int \| None` | Storage quota in MiB |
 | used_bytes | `int` | Current disk usage in bytes |
+| capacity_bytes | `int \| None` | Disk capacity in bytes |
+| disk_format | `str \| None` | Disk image format |
+| disk_fstype | `str \| None` | Disk filesystem type |
 | labels | `dict[str, str]` | Metadata labels |
 | created_at | `float \| None` | Creation timestamp (ms since epoch) |
 | fs | [`VolumeFs`](#volumefs) | Host-side filesystem handle |

--- a/docs/sdk/rust/agent-client.mdx
+++ b/docs/sdk/rust/agent-client.mdx
@@ -14,20 +14,21 @@ The raw body is the full CBOR-encoded protocol `Message` body: `v`, `t`, and `p`
 
 ```rust
 use microsandbox::{
-    AgentClient,
+    agent,
     protocol::{
         fs::{FsOp, FsRequest, FsResponse},
         message::MessageType,
     },
 };
 
-let client = AgentClient::connect_sandbox("dev").await?;
+let client = agent::connect_sandbox("dev").await?;
 let response = client
     .request(
         MessageType::FsRequest,
         &FsRequest {
             op: FsOp::Stat {
                 path: "/etc/os-release".to_string(),
+                follow_symlink: true,
             },
         },
     )
@@ -47,10 +48,10 @@ Connect to an agent relay socket by path. The connection performs the relay hand
 
 ---
 
-#### connect_sandbox()
+#### agent::connect_sandbox()
 
 ```rust
-async fn connect_sandbox(name: &str) -> AgentClientResult<AgentClient>
+async fn agent::connect_sandbox(name: &str) -> AgentClientResult<AgentClient>
 ```
 
 Resolve a sandbox name to its relay socket path and connect to it. Sandbox names are limited to 128 UTF-8 bytes.
@@ -70,7 +71,7 @@ Send one typed protocol message and wait for one response frame with the same co
 #### stream()
 
 ```rust
-async fn stream<T: Serialize>(&self, t: MessageType, payload: &T) -> AgentClientResult<(u32, UnboundedReceiver<Message>)>
+async fn stream<T: Serialize>(&self, t: MessageType, payload: &T) -> AgentClientResult<(u32, Receiver<Message>)>
 ```
 
 Open a typed streaming session. The returned id is the protocol correlation id. Use it with [`send()`](#send) for follow-up messages such as stdin, resize, signal, or file data chunks.
@@ -102,7 +103,7 @@ Allocate a correlation id, send one raw frame, and wait for one raw response fra
 #### stream_raw()
 
 ```rust
-async fn stream_raw(&self, flags: u8, body: Vec<u8>) -> AgentClientResult<(u32, UnboundedReceiver<RawFrame>)>
+async fn stream_raw(&self, flags: u8, body: Vec<u8>) -> AgentClientResult<(u32, Receiver<RawFrame>)>
 ```
 
 Open a raw streaming session. The receiver yields raw frames for the returned correlation id until a terminal frame is delivered or the receiver is dropped.

--- a/docs/sdk/rust/filesystem.mdx
+++ b/docs/sdk/rust/filesystem.mdx
@@ -5,7 +5,7 @@ description: Rust SDK - Filesystem API reference
 
 See [Filesystem](/sandboxes/filesystem) for usage examples.
 
-## SandboxFs
+## SandboxFsOps
 
 Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead, which give the guest direct filesystem access.
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -159,20 +159,20 @@ Release the handle without stopping the sandbox. The sandbox continues running a
 
 ---
 
-#### drain()
+#### request_drain()
 
 ```rust
-async fn drain(&self) -> MicrosandboxResult<()>
+async fn request_drain(&self) -> MicrosandboxResult<()>
 ```
 
-Start a graceful drain. Existing commands run to completion, but new `exec` calls are rejected. The sandbox transitions to `Stopped` when all in-flight commands finish. Useful for zero-downtime rotation of worker sandboxes.
+Request a graceful drain and return once the request is sent. Existing commands run to completion, but new `exec` calls are rejected. Use [`wait_until_stopped()`](#wait_until_stopped) when the caller needs stopped-state observation.
 
 ---
 
 #### fs()
 
 ```rust
-fn fs(&self) -> SandboxFs<'_>
+fn fs(&self) -> SandboxFsOps<'_>
 ```
 
 Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/rust/filesystem) for API details.
@@ -181,7 +181,7 @@ Get a filesystem handle for reading and writing files inside the running sandbox
 
 | Type | Description |
 |------|-------------|
-| [`SandboxFs`](/sdk/rust/filesystem) | Filesystem handle |
+| [`SandboxFsOps`](/sdk/rust/filesystem) | Filesystem handle |
 
 ---
 
@@ -191,12 +191,7 @@ Get a filesystem handle for reading and writing files inside the running sandbox
 async fn kill(&self) -> MicrosandboxResult<()>
 ```
 
-Force-terminate the sandbox immediately with SIGKILL. No graceful
-shutdown — use when the sandbox is unresponsive. Pending writes that
-the workload hasn't `fsync`'d may be lost, same durability semantics
-as a sudden power loss on a physical machine. Prefer
-[`stop()`](#stop) for graceful shutdown that gives the workload a
-chance to flush.
+Force-terminate the sandbox with SIGKILL and wait until stopped state is observed. No graceful shutdown — use when the sandbox is unresponsive. Pending writes that the workload hasn't `fsync`'d may be lost, same durability semantics as a sudden power loss on a physical machine. Prefer [`stop()`](#stop) for graceful shutdown that gives the workload a chance to flush.
 
 ---
 
@@ -334,10 +329,10 @@ Whether this handle owns the sandbox lifecycle. `true` in attached mode (sandbox
 
 ---
 
-#### remove_persisted()
+#### remove()
 
 ```rust
-async fn remove_persisted(self) -> MicrosandboxResult<()>
+async fn remove(self) -> MicrosandboxResult<()>
 ```
 
 Remove the sandbox and all its persisted state from disk.
@@ -350,43 +345,63 @@ Remove the sandbox and all its persisted state from disk.
 async fn stop(&self) -> MicrosandboxResult<()>
 ```
 
-Gracefully shut down the sandbox. Lets the sandbox finish writing
-any pending data to disk before it exits, so files written inside
-the sandbox aren't lost across a later restart. Waits up to ten
-seconds for a clean exit; if the sandbox is still running after
-that, it is force-killed.
+Gracefully shut down the sandbox and wait until stopped state is observed. Lets the sandbox finish writing any pending data to disk before it exits, so files written inside the sandbox aren't lost across a later restart. Waits up to ten seconds for a clean exit; if the sandbox is still running after that, it is force-killed.
 
 ---
 
-#### stop_and_wait()
+#### stop_with_timeout()
 
 ```rust
-async fn stop_and_wait(&self) -> MicrosandboxResult<ExitStatus>
+async fn stop_with_timeout(&self, timeout: Duration) -> MicrosandboxResult<()>
 ```
 
-Stop the sandbox and wait for the exit status.
+Gracefully shut down the sandbox with an explicit observation timeout before force-kill escalation.
+
+---
+
+#### request_stop()
+
+```rust
+async fn request_stop(&self) -> MicrosandboxResult<()>
+```
+
+Request graceful shutdown and return once the request is sent.
+
+---
+
+#### request_kill()
+
+```rust
+async fn request_kill(&self) -> MicrosandboxResult<()>
+```
+
+Request force termination and return once the signal is sent.
+
+---
+
+#### kill_with_timeout()
+
+```rust
+async fn kill_with_timeout(&self, timeout: Duration) -> MicrosandboxResult<()>
+```
+
+Force-terminate the sandbox and wait up to `timeout` for stopped-state observation.
+
+---
+
+#### wait_until_stopped()
+
+```rust
+async fn wait_until_stopped(&self) -> MicrosandboxResult<SandboxStopResult>
+```
+
+Block until the sandbox is observed in a terminal non-running state, without triggering a stop or kill request.
 
 **Returns**
 
 | Type | Description |
 |------|-------------|
-| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
-
----
-
-#### wait()
-
-```rust
-async fn wait(&self) -> MicrosandboxResult<ExitStatus>
-```
-
-Block until the sandbox exits on its own (without triggering a stop). Returns the exit status.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
+| [`SandboxStopResult`](#sandboxstopresult) | Terminal status and optional observed exit code |
 
 ---
 
@@ -541,12 +556,6 @@ fn idle_timeout(self, secs: u64) -> Self
 
 Auto-drain the sandbox after this many seconds of inactivity (no active exec sessions). Enforced on the host side.
 
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| secs | `u64` | Idle timeout in seconds |
-
 ---
 
 #### init()
@@ -607,6 +616,12 @@ let sb = Sandbox::builder("worker")
 ```
 
 Calling `init` or `init_with` more than once overwrites — different from `env`, which appends. The init is one-shot pre-boot.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `u64` | Idle timeout in seconds |
 
 ---
 
@@ -1207,17 +1222,32 @@ A lightweight handle to an existing sandbox (running or stopped). Obtained via [
 | connect() | `Result<`[`Sandbox`](#instance-methods)`>` | Connect to a running sandbox; returns an error if it doesn't respond within ten seconds |
 | connect_with_timeout(timeout) | `Result<`[`Sandbox`](#instance-methods)`>` | Same as `connect()` with an explicit timeout |
 | created_at() | `Option<DateTime<Utc>>` | Creation timestamp |
-| kill() | `Result<()>` | Force terminate immediately. Pending writes may be lost |
+| kill() | `Result<()>` | Force terminate and wait until stopped state is observed |
+| kill_with_timeout(timeout) | `Result<()>` | Same as `kill()` with an explicit observation timeout |
 | logs() | `Result<Vec<`[`LogEntry`](#logentry)`>>` | Read captured `exec.log` (works without starting) |
 | metrics() | `Result<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
 | name() | `&str` | Sandbox name, up to 128 UTF-8 bytes |
+| refresh() | `Result<`[`SandboxHandle`](#sandboxhandle)`>` | Fetch a fresh handle snapshot from persisted state |
 | remove() | `Result<()>` | Delete sandbox and state |
+| request_drain() | `Result<()>` | Request graceful drain without waiting |
+| request_kill() | `Result<()>` | Request force termination without waiting |
+| request_stop() | `Result<()>` | Request graceful shutdown without waiting |
 | start() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
 | start_detached() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |
 | status() | [`SandboxStatus`](#sandboxstatus) | Current status |
 | stop() | `Result<()>` | Gracefully shut down. Waits up to ten seconds for pending writes to flush, then force-kills |
 | stop_with_timeout(timeout) | `Result<()>` | Same as `stop()` with an explicit timeout; `Duration::ZERO` force-kills immediately |
 | updated_at() | `Option<DateTime<Utc>>` | Last update timestamp |
+| wait_until_stopped() | `Result<`[`SandboxStopResult`](#sandboxstopresult)`>` | Block until the sandbox reaches terminal state |
+
+### SandboxStopResult
+
+Observed terminal sandbox state returned by [`wait_until_stopped()`](#wait_until_stopped).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| status | [`SandboxStatus`](#sandboxstatus) | Terminal status that was observed |
+| exit_code | `Option<i32>` | Process exit code when it is available |
 
 ### SandboxMetrics
 

--- a/docs/sdk/rust/secrets.mdx
+++ b/docs/sdk/rust/secrets.mdx
@@ -53,7 +53,7 @@ Add a host that is allowed to receive the real secret value. The proxy checks th
 
 | Name | Type | Description |
 |------|------|-------------|
-| host | `impl Into<String>` | Exact hostname (e.g. `"api.openai.com"`) |
+| host | `impl Into<String>` | Exact hostname (e.g. `"api.example.com"`) |
 
 ---
 

--- a/docs/sdk/rust/ssh.mdx
+++ b/docs/sdk/rust/ssh.mdx
@@ -16,7 +16,7 @@ microsandbox = { version = "0.4.6", features = ["ssh"] }
 #### ssh()
 
 ```rust
-fn ssh(&self) -> SandboxSsh
+fn ssh(&self) -> SandboxSshOps
 ```
 
 Return the SSH namespace for this sandbox.
@@ -25,9 +25,9 @@ Return the SSH namespace for this sandbox.
 
 | Type | Description |
 |------|-------------|
-| [`SandboxSsh`](#sandboxssh) | SSH client and server helpers |
+| [`SandboxSshOps`](#sandboxssh) | SSH client and server helpers |
 
-## SandboxSsh
+## SandboxSshOps
 
 ---
 

--- a/docs/sdk/rust/volumes.mdx
+++ b/docs/sdk/rust/volumes.mdx
@@ -17,7 +17,7 @@ Named volumes are managed by microsandbox and stored by default under `~/.micros
 fn builder(name: impl Into<String>) -> VolumeBuilder
 ```
 
-Create a builder for a new named volume. Call `.quota()` to set a storage limit, then `.create()` to finalize.
+Create a builder for a new named volume. Directory-backed volumes are the default. Call `.disk().size(...)` to create a disk-backed volume.
 
 **Parameters**
 
@@ -29,7 +29,7 @@ Create a builder for a new named volume. Call `.quota()` to set a storage limit,
 
 | Type | Description |
 |------|-------------|
-| [`VolumeBuilder`](#volumebuilder) | Builder with `.quota()` and `.create()` |
+| [`VolumeBuilder`](#volumebuilder) | Builder with `.directory()`, `.disk()`, `.size()`, `.quota()`, and `.create()` |
 
 ---
 
@@ -115,13 +115,43 @@ Create the volume on disk.
 fn quota(self, mib: u64) -> Self
 ```
 
-Set the maximum storage size for this volume. The guest cannot write beyond this limit.
+Set the recorded quota metadata for a directory-backed volume.
 
 **Parameters**
 
 | Name | Type | Description |
 |------|------|-------------|
 | mib | `u64` | Quota in MiB |
+
+---
+
+#### directory()
+
+```rust
+fn directory(self) -> Self
+```
+
+Create a directory-backed named volume. This is the default.
+
+---
+
+#### disk()
+
+```rust
+fn disk(self) -> Self
+```
+
+Create a raw ext4 disk-backed named volume.
+
+---
+
+#### size()
+
+```rust
+fn size(self, size: impl Into<Mebibytes>) -> Self
+```
+
+Set disk volume capacity. Required after `.disk()`.
 
 ---
 
@@ -160,6 +190,46 @@ Mount a named volume. The volume must already exist (create it with [`Volume::bu
 | Name | Type | Description |
 |------|------|-------------|
 | name | `impl Into<String>` | Volume name |
+
+---
+
+#### named_with()
+
+```rust
+fn named_with(
+    self,
+    name: impl Into<String>,
+    f: impl FnOnce(NamedVolumeBuilder) -> NamedVolumeBuilder,
+) -> Self
+```
+
+Mount a named volume with explicit sandbox-time existence behavior. `NamedVolumeMode::Existing` is the default and behaves like [`named()`](#named). `.create()` creates the volume and fails if it already exists. `.ensure_exists()` creates the volume if it is missing or reuses an existing compatible volume.
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .volume("/cache", |v| v.named_with("pip-cache", |n| n.ensure_exists()))
+    .volume("/var/lib/docker", |v| {
+        v.named_with("docker-data", |n| n.ensure_exists().disk().size(20.gib()))
+    })
+    .create()
+    .await?;
+```
+
+The ensure-exists mode validates existing volume metadata. It errors when the existing volume has a different kind, quota, capacity, or explicitly requested labels than the requested configuration; it does not mutate existing volume metadata.
+
+**Named volume builder methods**
+
+| Method | Description |
+|--------|-------------|
+| `existing()` | Require the volume to already exist. This is the default. |
+| `create()` | Create the volume and fail if it already exists. |
+| `ensure_exists()` | Create the volume if missing or reuse a compatible existing volume. |
+| `directory()` | Use directory-backed storage. This is the default. |
+| `disk()` | Use disk-backed raw ext4 storage. Requires `size(...)` when creating or ensuring a missing volume. |
+| `size(size)` | Disk capacity. |
+| `quota(size)` | Directory volume quota. |
+| `label(key, value)` | Attach a label to newly-created volumes and require matching labels for ensure-existing volumes when labels are requested. |
 
 ---
 
@@ -249,4 +319,8 @@ Handle for interacting with a named volume from the host side.
 |-------------------|------|-------------|
 | fs() | `VolumeFsHandle` | Host-side filesystem access - read and write files without a running sandbox |
 | name() | `&str` | Volume name |
+| kind() | `VolumeKind` | Volume kind: `Directory` or `Disk` |
+| capacity_bytes() | `Option<u64>` | Disk capacity in bytes |
+| disk_format() | `Option<&str>` | Disk image format |
+| disk_fstype() | `Option<&str>` | Disk filesystem type |
 | remove() | `()` | Delete this volume from disk |

--- a/docs/sdk/typescript/filesystem.mdx
+++ b/docs/sdk/typescript/filesystem.mdx
@@ -5,7 +5,7 @@ description: TypeScript SDK - Filesystem API reference
 
 See [Filesystem](/sandboxes/filesystem) for usage examples.
 
-## SandboxFs
+## SandboxFsOps
 
 Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution — no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
 

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -17,7 +17,7 @@ const custom = {
   defaultEgress: "deny",
   defaultIngress: "allow",
   rules: [
-    Rule.allowEgress(Destination.domain("api.openai.com")),
+    Rule.allowEgress(Destination.domain("api.example.com")),
     Rule.denyEgress(Destination.group("metadata")),
   ],
 };

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -177,20 +177,20 @@ Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.
 
 ---
 
-#### drain()
+#### requestDrain()
 
 ```typescript
-drain(): Promise<void>
+requestDrain(): Promise<void>
 ```
 
-Start a graceful drain. Existing commands run to completion, new `exec` calls are rejected.
+Request a graceful drain and return once the request is sent. Existing commands run to completion, but new `exec` calls are rejected. Use [`waitUntilStopped()`](#waituntilstopped) when the caller needs stopped-state observation.
 
 ---
 
 #### fs()
 
 ```typescript
-fs(): SandboxFs
+fs(): SandboxFsOps
 ```
 
 Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/typescript/filesystem) for API details.
@@ -199,7 +199,7 @@ Get a filesystem handle for reading and writing files inside the running sandbox
 
 | Type | Description |
 |------|-------------|
-| [`SandboxFs`](/sdk/typescript/filesystem) | Filesystem handle |
+| [`SandboxFsOps`](/sdk/typescript/filesystem) | Filesystem handle |
 
 ---
 
@@ -209,11 +209,7 @@ Get a filesystem handle for reading and writing files inside the running sandbox
 kill(): Promise<void>
 ```
 
-Force-terminate the sandbox immediately. No graceful shutdown.
-Pending writes that the workload hasn't `fsync`'d may be lost — same
-durability semantics as a sudden power loss on a physical machine.
-Use [`stop()`](#stop) for graceful shutdown that gives the workload a
-chance to flush.
+Force-terminate the sandbox and wait until stopped state is observed. No graceful shutdown. Pending writes that the workload hasn't `fsync`'d may be lost — same durability semantics as a sudden power loss on a physical machine. Use [`stop()`](#stop) for graceful shutdown that gives the workload a chance to flush.
 
 ---
 
@@ -317,10 +313,10 @@ const recent = await handle.logs({
 
 ---
 
-#### removePersisted()
+#### remove()
 
 ```typescript
-removePersisted(): Promise<void>
+remove(): Promise<void>
 ```
 
 Remove the sandbox and all its persisted state from disk.
@@ -333,43 +329,63 @@ Remove the sandbox and all its persisted state from disk.
 stop(): Promise<void>
 ```
 
-Gracefully shut down the sandbox. Lets the sandbox finish writing
-any pending data to disk before it exits, so files written inside
-the sandbox aren't lost across a later restart. Waits up to ten
-seconds for a clean exit; if the sandbox is still running after
-that, it is force-killed.
+Gracefully shut down the sandbox and wait until stopped state is observed. Lets the sandbox finish writing any pending data to disk before it exits, so files written inside the sandbox aren't lost across a later restart. Waits up to 10_000 ms for a clean exit; if the sandbox is still running after that, it is force-killed.
 
 ---
 
-#### stopAndWait()
+#### stopWithTimeout()
 
 ```typescript
-stopAndWait(): Promise<ExitStatus>
+stopWithTimeout(timeoutMs: number): Promise<void>
 ```
 
-Stop the sandbox and wait for the exit status.
+Gracefully shut down the sandbox with an explicit observation timeout before force-kill escalation.
+
+---
+
+#### requestStop()
+
+```typescript
+requestStop(): Promise<void>
+```
+
+Request graceful shutdown and return once the request is sent.
+
+---
+
+#### requestKill()
+
+```typescript
+requestKill(): Promise<void>
+```
+
+Request force termination and return once the signal is sent.
+
+---
+
+#### killWithTimeout()
+
+```typescript
+killWithTimeout(timeoutMs: number): Promise<void>
+```
+
+Force-terminate the sandbox and wait up to `timeoutMs` for stopped-state observation.
+
+---
+
+#### waitUntilStopped()
+
+```typescript
+waitUntilStopped(): Promise<SandboxStopResult>
+```
+
+Block until the sandbox is observed in a terminal non-running state, without triggering a stop or kill request.
 
 **Returns**
 
 | Type | Description |
 |------|-------------|
-| [`ExitStatus`](/sdk/typescript/execution#exitstatus) | Exit code and success flag |
-
----
-
-#### wait()
-
-```typescript
-wait(): Promise<ExitStatus>
-```
-
-Block until the sandbox exits on its own.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`ExitStatus`](/sdk/typescript/execution#exitstatus) | Exit code and success flag |
+| [`SandboxStopResult`](#sandboxstopresult) | Terminal status and optional observed exit code |
 
 ---
 
@@ -767,8 +783,22 @@ Handles from `Sandbox.get(name)` are **live** — they expose lifecycle methods 
 | connectWithTimeout(timeoutMs) | `Promise<`[`Sandbox`](#instance-methods)`>` | Same as `connect()` with an explicit timeout in milliseconds |
 | stop() | `Promise<void>` | Gracefully shut down. Waits up to 10_000 ms for pending writes to flush, then force-kills |
 | stopWithTimeout(timeoutMs) | `Promise<void>` | Same as `stop()` with an explicit timeout in milliseconds; `0` force-kills immediately |
-| kill() | `Promise<void>` | Force terminate immediately. Pending writes may be lost |
+| requestStop() | `Promise<void>` | Request graceful shutdown without waiting |
+| kill() | `Promise<void>` | Force terminate and wait until stopped state is observed |
+| killWithTimeout(timeoutMs) | `Promise<void>` | Same as `kill()` with an explicit observation timeout |
+| requestKill() | `Promise<void>` | Request force termination without waiting |
+| requestDrain() | `Promise<void>` | Request graceful drain without waiting |
+| waitUntilStopped() | `Promise<`[`SandboxStopResult`](#sandboxstopresult)`>` | Block until the sandbox reaches terminal state |
 | remove() | `Promise<void>` | Delete sandbox and state |
+
+### SandboxStopResult
+
+Observed terminal sandbox state returned by [`waitUntilStopped()`](#waituntilstopped).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| status | [`SandboxStatus`](#sandboxstatus) | Terminal status that was observed |
+| exitCode | `number \| null` | Process exit code when it is available |
 
 ### SandboxMetrics
 

--- a/docs/sdk/typescript/secrets.mdx
+++ b/docs/sdk/typescript/secrets.mdx
@@ -12,14 +12,14 @@ Secrets are configured on a sandbox via `SandboxBuilder.secret(s => ...)` (or it
 ```typescript
 import { Sandbox } from "microsandbox";
 
-// Auto-placeholder shorthand: generates `$MSB_OPENAI_API_KEY`.
-await using sb = await Sandbox.builder("agent")
+// Auto-placeholder shorthand: generates `$MSB_SERVICE_API_KEY`.
+await using sb = await Sandbox.builder("worker")
   .image("python")
-  .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+  .secretEnv("SERVICE_API_KEY", process.env.SERVICE_API_KEY!, "api.example.com")
   .create();
 
 // Full control via SecretBuilder.
-await using sb2 = await Sandbox.builder("agent2")
+await using sb2 = await Sandbox.builder("payments-worker")
   .image("python")
   .secret((s) =>
     s.env("STRIPE_KEY")
@@ -36,7 +36,7 @@ The same `secret(...)` and `secretEnv(...)` methods are also available inside `S
 
 ---
 
-## Host matching
+## Host Matching
 
 TypeScript host settings map to the runtime `HostPattern` model. Allow-list methods decide where the real secret value may be substituted; passthrough methods decide where the placeholder may be forwarded unchanged.
 

--- a/docs/sdk/typescript/ssh.mdx
+++ b/docs/sdk/typescript/ssh.mdx
@@ -12,7 +12,7 @@ See [SSH](/sandboxes/ssh) for usage flows.
 #### ssh()
 
 ```typescript
-ssh(): SandboxSsh
+ssh(): SandboxSshOps
 ```
 
 Return the SSH namespace for this sandbox.
@@ -21,9 +21,9 @@ Return the SSH namespace for this sandbox.
 
 | Type | Description |
 |------|-------------|
-| [`SandboxSsh`](#sandboxssh) | SSH client and server helpers |
+| [`SandboxSshOps`](#sandboxssh) | SSH client and server helpers |
 
-## SandboxSsh
+## SandboxSshOps
 
 ---
 
@@ -161,10 +161,10 @@ Close the native SSH client session.
 
 ---
 
-#### serveStdio()
+#### serveConnection()
 
 ```typescript
-serveStdio(): Promise<void>
+serveConnection(): Promise<void>
 ```
 
 Serve one SSH transport over stdin/stdout.

--- a/docs/sdk/typescript/volumes.mdx
+++ b/docs/sdk/typescript/volumes.mdx
@@ -13,8 +13,12 @@ Named volumes are managed by microsandbox and stored by default under `~/.micros
 import { Volume } from "microsandbox";
 
 const data = await Volume.builder("my-data")
-  .quota(100)
   .label("env", "prod")
+  .create();
+
+const dockerData = await Volume.builder("docker-data")
+  .disk()
+  .size(20 * 1024)
   .create();
 ```
 
@@ -28,7 +32,7 @@ const data = await Volume.builder("my-data")
 static builder(name: string): VolumeBuilder
 ```
 
-Begin building a named volume. Configure with `.quota(...)` and `.label(...)`, then call `.create()`.
+Begin building a named volume. Directory-backed volumes are the default. Call `.disk().size(...)` to create a disk-backed volume.
 
 **Parameters**
 
@@ -157,7 +161,8 @@ Used inside `SandboxBuilder.volume(guestPath, m => ...)`. Pick exactly one mount
 | Method | Description |
 |--------|-------------|
 | `bind(host)` | Mount a host directory into the guest. |
-| `named(name)` | Mount a named volume created via [`Volume.builder`](#volumebuilder). |
+| `named(name)` | Mount an existing named volume created via [`Volume.builder`](#volumebuilder). |
+| `namedWith(name, mode?, kind?, sizeMib?, quotaMib?)` | Mount a named volume with explicit behavior. `mode` is `"existing"`, `"create"`, or `"ensure-exists"`; `kind` is `"dir"` or `"disk"`. |
 | `tmpfs()` | Mount an in-memory filesystem. |
 | `disk(host)` | Mount a host disk image as a virtio-blk device. |
 | `format(fmt)` | Disk image format (`'qcow2' \| 'raw' \| 'vmdk'`). Defaults to the file extension. Disk only. |
@@ -168,6 +173,20 @@ Used inside `SandboxBuilder.volume(guestPath, m => ...)`. Pick exactly one mount
 | `nodev()` | Ignore device files on the mount. |
 | `size(mib)` | Cap in MiB. Tmpfs only. |
 | `build()` | Internal — produce a `VolumeMount`. |
+
+`named(name)` is existing-only. Use `namedWith` when sandbox creation should create or ensure the volume exists:
+
+```typescript
+await using sb = await Sandbox.builder("worker")
+  .image("python")
+  .volume("/cache", (m) => m.namedWith("pip-cache", "ensure-exists"))
+  .volume("/var/lib/docker", (m) =>
+    m.namedWith("docker-data", "ensure-exists", "disk", 20 * 1024)
+  )
+  .create();
+```
+
+`"create"` fails when the named volume already exists. `"ensure-exists"` creates the volume if it is missing and reuses a compatible existing volume. The ensure-exists mode errors when the existing volume has a different kind, quota, or capacity than the requested configuration; it does not mutate existing volume metadata.
 
 ### VolumeMount
 
@@ -205,7 +224,10 @@ type DiskImageFormat = "qcow2" | "raw" | "vmdk";
 
 | Method | Description |
 |--------|-------------|
-| `quota(mib)` | Maximum storage size in MiB |
+| `directory()` | Create a directory-backed volume |
+| `disk()` | Create a raw ext4 disk-backed volume |
+| `size(mib)` | Disk capacity in MiB; required after `disk()` |
+| `quota(mib)` | Recorded quota metadata for directory volumes |
 | `label(key, value)` | Add a metadata label |
 | `build()` | Materialize a [`VolumeConfig`](#volumeconfig) |
 | `create()` | Build and create the volume; returns a [`Volume`](#volume) |
@@ -217,7 +239,9 @@ Frozen configuration produced by `VolumeBuilder.build()`.
 | Field | Type | Description |
 |-------|------|-------------|
 | name | `string` | Volume name |
+| kind | `"dir" \| "disk"` | Volume kind |
 | quotaMib | `number \| null` | Maximum storage size in MiB |
+| capacityMib | `number \| null` | Disk capacity in MiB |
 | labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
 
 ### VolumeHandle
@@ -225,8 +249,12 @@ Frozen configuration produced by `VolumeBuilder.build()`.
 | Property / Method | Type | Description |
 |-------------------|------|-------------|
 | name | `string` | Volume name |
+| kind | `string` | Volume kind |
 | quotaMib | `number \| null` | Storage quota |
 | usedBytes | `number` | Current disk usage in bytes |
+| capacityBytes | `number \| null` | Disk capacity in bytes |
+| diskFormat | `string \| null` | Disk image format |
+| diskFstype | `string \| null` | Inner disk filesystem |
 | labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
 | createdAt | `Date \| null` | Creation timestamp |
 | fs() | [`VolumeFs`](#volumefs) | Host-side filesystem on this volume (live handles only) |
@@ -236,4 +264,4 @@ Handles in the array returned by `Volume.list()` are read-only: calling `.fs()` 
 
 ### VolumeFs
 
-Host-side filesystem operations on a volume's directory. Same surface area as [`SandboxFs`](/sdk/typescript/filesystem) (read, readToString, readStream, write, writeStream, list, mkdir, removeDir, remove, copy, rename, stat, exists) — but operates directly on the host without booting a sandbox.
+Host-side filesystem operations on a volume's directory. Same surface area as [`SandboxFsOps`](/sdk/typescript/filesystem) (read, readToString, readStream, write, writeStream, list, mkdir, removeDir, remove, copy, rename, stat, exists) — but operates directly on the host without booting a sandbox.


### PR DESCRIPTION
## TL;DR
Update the Mintlify docs branch with the current v0.5.6 documentation from main. Keep the Mintlify-only changelog pages and navigation entries intact.

## Description
- Refresh the CLI, sandbox, networking, observability, recipe, and SDK docs from the v0.5.6 docs on main.
- Keep the existing June 5 and May 29 changelog pages on the Mintlify branch.
- Preserve the changelog navigation entries while updating the site description to the current product positioning.
- Keep the PR docs-only, with no code, SDK, workflow, lockfile, or submodule changes.

## Test Plan
- [x] `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('docs/docs.json','utf8')); console.log('docs/docs.json ok')"` exits 0
- [x] `git diff --cached --check` exits 0 before commit
- [x] `git diff origin/mintlify..HEAD --name-only | grep -v '^docs/' || true` prints no files
- [x] `git diff origin/main..HEAD --name-status -- docs/changelog docs/docs.json` shows only preserved changelog pages and nav differences