### PR TITLE
docs: clarify Docker recipe ordering

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -188,8 +188,8 @@
             "group": "Docker",
             "icon": "docker",
             "pages": [
-              "recipes/docker/docker",
               "recipes/docker/docker-in-sandbox",
+              "recipes/docker/docker",
               "recipes/docker/local-images"
             ]
           },


### PR DESCRIPTION
## TL;DR
Put the Docker-in-a-sandbox recipe first in the Docker recipes group and rename the containerized deployment recipe so the two pages are easier to tell apart.

## Description
- Move `Docker in a sandbox` above the container deployment page in the Docker recipe navigation.
- Rename `Sandbox in Docker` to `Sandbox in a Docker container`.
- Update the cross-link text from the Docker-in-a-sandbox page to match the new title.

## Test Plan
- [x] `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('docs/docs.json','utf8')); console.log('docs/docs.json ok')"` exits 0
- [x] `git diff --cached --check` exits 0 before commit
- [x] signed commit hook checks passed during `git commit -S`