### PR TITLE
docs(mintlify): sync Docker recipe from main

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -188,8 +188,8 @@
             "group": "Docker",
             "icon": "docker",
             "pages": [
-              "recipes/docker/docker",
               "recipes/docker/docker-in-sandbox",
+              "recipes/docker/docker",
               "recipes/docker/local-images"
             ]
           },

--- a/docs/recipes/docker/docker-in-sandbox.mdx
+++ b/docs/recipes/docker/docker-in-sandbox.mdx
@@ -13,7 +13,7 @@ The command below boots the `docker:dind` image, starts Docker inside the sandbo
 ```sh
 msb run --name docker-demo --replace \
   --memory 2G \
-  --mount-named docker-data:/var/lib/docker \
+  --mount-named docker-data:/var/lib/docker:kind=disk,size=10G \
   --script start='dockerd >/tmp/dockerd.log 2>&1 &
   timeout 60 sh -c "until docker info>/dev/null 2>&1;do sleep 1;done" || {
     cat /tmp/dockerd.log
@@ -27,10 +27,10 @@ msb run --name docker-demo --replace \
 This command does three things:
 
 - Starts the `docker:dind` image in a sandbox named `docker-demo`.
-- Mounts a named volume called `docker-data` at `/var/lib/docker`, where Docker stores images, containers, and build cache.
+- Mounts a disk-backed named volume called `docker-data` at `/var/lib/docker`, where Docker stores images, containers, and build cache.
 - Runs the inline `start` script as the entrypoint. The script starts Docker, waits until it is ready, and then opens a shell.
 
-`--mount-named docker-data:/var/lib/docker` is idempotent. If `docker-data` does not exist, the CLI creates it before starting the sandbox. If it already exists with compatible settings, the same command reuses it, so pulled images and created containers can survive `msb rm docker-demo`.
+`--mount-named docker-data:/var/lib/docker:kind=disk,size=10G` is idempotent. If `docker-data` does not exist, the CLI creates it before starting the sandbox. If it already exists with compatible disk settings, the same command reuses it, so pulled images and created containers can survive `msb rm docker-demo`.
 
 ## Run a container
 
@@ -58,30 +58,9 @@ msb volume rm docker-data
 
 Remove `docker-data` only when you no longer need the images, containers, and build cache stored by the nested daemon.
 
-## Details and alternatives
+## Details
 
-Use the default security profile for this recipe. Docker-in-Docker needs normal guest-root mount privileges, so restricted sandboxes are not supported here.
-
-The named mount gives Docker its own storage at `/var/lib/docker`. That matters because the sandbox root filesystem is already overlay-backed, and Docker's default storage driver also uses overlay layers. Keeping Docker's data directory on a named mount avoids putting Docker's overlay storage directly on top of the sandbox root overlay.
-
-### VFS alternative
-
-If you want to avoid the named volume, you can ask Docker to use the `vfs` storage driver instead:
-
-```sh
-msb run --name docker-demo --replace \
-  --memory 2G \
-  --script start='dockerd --storage-driver=vfs >/tmp/dockerd.log 2>&1 &
-  timeout 60 sh -c "until docker info>/dev/null 2>&1;do sleep 1;done" || {
-    cat /tmp/dockerd.log
-    false
-  }
-  exec sh' \
-  --entrypoint start \
-  docker:dind
-```
-
-The tradeoff is performance and disk usage. `vfs` copies full filesystem trees instead of using overlay layers, so pulls and builds can be slower and use more space. Prefer the named-mount version for normal Docker-in-Docker work.
+The disk-backed named mount gives Docker its own ext4 filesystem at `/var/lib/docker`. That matters because the sandbox root filesystem is already overlay-backed, and Docker's default storage driver also uses overlay layers. Keeping Docker's data root on a dedicated disk-backed volume avoids putting Docker's overlay storage directly on top of the sandbox root overlay.
 
 ## Notes
 


### PR DESCRIPTION
## TL;DR
Merge `main` into `mintlify` so the docs deploy branch gets the corrected Docker-in-sandbox recipe.

## Description
- Bring over the Docker recipe update from `main`.
- Use a disk-backed named volume for `/var/lib/docker` with `kind=disk,size=10G`.
- Remove the stale VFS alternative from the Mintlify docs branch.
- Keep the existing `mintlify` branch docs-only changes intact.

## Test Plan
- [x] `git merge --no-ff origin/main` completed without conflicts.
- [x] `git log --show-signature -1 --stat` shows the merge commit is GPG signed.
- [x] `git diff origin/mintlify..HEAD -- docs/recipes/docker/docker-in-sandbox.mdx` shows only the Docker recipe sync.
- [x] `rg -n 'storage-driver=vfs|VFS alternative|kind=disk,size=10G|docker-data:/var/lib/docker|## Details and alternatives|## Details' docs/recipes/docker/docker-in-sandbox.mdx` confirms the corrected recipe text.