### PR TITLE
fix(agentd): disable DAD for IPv6 addresses in virtual network

### DIFF
--- a/crates/agentd/lib/network.rs
+++ b/crates/agentd/lib/network.rs
@@ -409,7 +409,7 @@ mod linux {
         unsafe {
             (*ifa).ifa_family = family;
             (*ifa).ifa_prefixlen = prefix_len;
-            (*ifa).ifa_flags = 0;
+            (*ifa).ifa_flags = if is_ipv4 { 0 } else { libc::IFA_F_NODAD as u8 };
             (*ifa).ifa_index = ifindex;
             (*ifa).ifa_scope = libc::RT_SCOPE_UNIVERSE;
         }

--- a/crates/microsandbox/tests/host_access.rs
+++ b/crates/microsandbox/tests/host_access.rs
@@ -358,3 +358,37 @@ async fn group_host_deny_blocks_host_only() {
 
     teardown(sb, name).await;
 }
+
+/// Guest ULA IPv6 address is present and in preferred state on boot.
+///
+/// Skipped when the host has no IPv6 route — the runtime does not provision
+/// a guest IPv6 address on IPv4-only hosts.
+#[msb_test]
+async fn guest_ipv6_address_is_preferred() {
+    use std::net::{Ipv6Addr, UdpSocket};
+
+    let host_has_ipv6 = UdpSocket::bind((Ipv6Addr::UNSPECIFIED, 0))
+        .and_then(|s| s.connect((Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1), 443)))
+        .is_ok();
+    if !host_has_ipv6 {
+        eprintln!("skip: host has no IPv6 route — guest IPv6 would not be provisioned");
+        return;
+    }
+
+    let name = "host-ipv6-addr";
+    let sb = spawn_sandbox(name, Some(NetworkPolicy::allow_all())).await;
+
+    let out = sb.shell("ip -6 addr show dev eth0").await.expect("ip addr");
+    let stdout = out.stdout().unwrap_or_default();
+    teardown(sb, name).await;
+
+    let ula_line = stdout
+        .lines()
+        .find(|l| l.contains("fd42:"))
+        .unwrap_or_else(|| panic!("expected ULA IPv6 address (fd42:…) on eth0; got:\n{stdout}"));
+
+    assert!(
+        !ula_line.contains("tentative"),
+        "ULA IPv6 address is still tentative — DAD did not complete; got:\n{ula_line}"
+    );
+}


### PR DESCRIPTION
Closes #948.

## Problem

Sandbox guests on IPv6-capable hosts are provisioned with a ULA address
(`fd42:6d73:62:N::2/64`) but the address stays permanently `tentative`
and the kernel drops all outbound IPv6 traffic.

The root cause is that smoltcp has no `RouterSolicit` handler — without a
Router Advertisement the guest's DAD state machine never completes.

## Approach

Set `IFA_F_NODAD` on the `RTM_NEWADDR` netlink message for IPv6 in agentd.
The kernel skips DAD and immediately marks the address `PREFERRED`.

Kata Containers applies [the same flag for the same reason](https://github.com/kata-containers/agent/blob/master/network.go#L136-L142)
- in a single-tenant virtual network the orchestration layer owns address
assignment, so uniqueness is guaranteed by construction. Each sandbox slot
owns a deterministically assigned prefix (`fd42:6d73:62:N::/64`); no peer
can hold a duplicate.

## Alternate approach considered

Implementing a `RouterSolicit` → `RouterAdvertisement` handler at the
gateway . Protocol-correct but requires synthesising raw
ICMPv6 frames outside smoltcp's abstraction with no practical benefit given
the uniqueness guarantee the slot allocator already provides.
