### PR TITLE
feat(agent-client): add connect_stream byte-stream transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,13 +3178,11 @@ name = "microsandbox-agent-client"
 version = "0.5.6"
 dependencies = [
  "ciborium",
- "futures-util",
  "microsandbox-protocol",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
  "tracing",
 ]
 
@@ -6625,18 +6623,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6890,22 +6876,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "sha1 0.10.6",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "typed-builder"

--- a/agent-client/rust/Cargo.toml
+++ b/agent-client/rust/Cargo.toml
@@ -12,7 +12,12 @@ path = "lib/lib.rs"
 
 [features]
 default = []
-uds = []
+# Generic byte-stream transport: drive the client over any
+# `AsyncRead + AsyncWrite` (e.g. a caller-owned, pre-authenticated WebSocket
+# adapted to bytes). No extra dependencies.
+stream = []
+# Unix domain socket transport. Builds on the generic byte-stream path.
+uds = ["stream"]
 websocket = ["dep:futures-util", "dep:tokio-tungstenite"]
 
 [dependencies]

--- a/agent-client/rust/Cargo.toml
+++ b/agent-client/rust/Cargo.toml
@@ -18,19 +18,15 @@ default = []
 stream = []
 # Unix domain socket transport. Builds on the generic byte-stream path.
 uds = ["stream"]
-websocket = ["dep:futures-util", "dep:tokio-tungstenite"]
 
 [dependencies]
 ciborium.workspace = true
-futures-util = { workspace = true, optional = true }
 microsandbox-protocol.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["io-util", "net", "sync"] }
-tokio-tungstenite = { workspace = true, optional = true }
 tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }
-tokio-tungstenite.workspace = true

--- a/agent-client/rust/README.md
+++ b/agent-client/rust/README.md
@@ -20,8 +20,9 @@ The crate is transport-agnostic by default. Enable exactly the transport adapter
 # Local microsandbox relay sockets.
 microsandbox-agent-client = { version = "0.5.6", features = ["uds"] }
 
-# WebSocket relay endpoints.
-microsandbox-agent-client = { version = "0.5.6", features = ["websocket"] }
+# Any caller-owned byte-stream transport (e.g. a pre-authenticated WebSocket
+# adapted to bytes).
+microsandbox-agent-client = { version = "0.5.6", features = ["stream"] }
 ```
 
 The high-level `microsandbox` SDK enables `uds` explicitly because local sandboxes are reached through Unix domain sockets.
@@ -93,27 +94,31 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-## WebSocket Example
+## Byte-Stream Example
 
-Enable the `websocket` feature:
+Enable the `stream` feature:
 
 ```toml
-microsandbox-agent-client = { version = "0.5.6", features = ["websocket"] }
+microsandbox-agent-client = { version = "0.5.6", features = ["stream"] }
 ```
 
-Then connect to a relay endpoint:
+Drive the client over any `AsyncRead + AsyncWrite` — the caller owns the dial and any authentication, then hands over the connected stream:
 
 ```rust
 use microsandbox_agent_client::AgentClient;
+use tokio::io::{AsyncRead, AsyncWrite};
 
-async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    let client = AgentClient::connect_websocket("wss://relay.example.com/agent").await?;
+async fn example<S>(stream: S) -> Result<(), Box<dyn std::error::Error>>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let client = AgentClient::connect_stream(stream).await?;
     println!("agent version: {}", client.agent_version());
     Ok(())
 }
 ```
 
-The WebSocket transport uses `tokio-tungstenite`. Each protocol frame is sent as one binary WebSocket message. Incoming binary messages may contain any number of bytes; the client buffers them and decodes complete protocol packets.
+`connect_stream` runs the relay handshake on the stream and treats it as a transparent byte pipe: protocol frames are length-prefixed, so the transport need not preserve message boundaries. This is the seam for transports the crate doesn't ship — e.g. a pre-authenticated WebSocket adapted to bytes.
 
 ## Typed And Raw APIs
 
@@ -164,8 +169,8 @@ async fn example(
 
 | Feature | Default | Description |
 | --- | --- | --- |
-| `uds` | no | Enables Unix domain socket connections with `AgentClient::connect*`. |
-| `websocket` | no | Enables `AgentClient::connect_websocket*` using `tokio-tungstenite`. |
+| `stream` | no | Enables `AgentClient::connect_stream*` over any `AsyncRead + AsyncWrite` byte stream. |
+| `uds` | no | Enables Unix domain socket connections with `AgentClient::connect*` (implies `stream`). |
 
 ## Validation
 
@@ -173,6 +178,6 @@ Useful focused checks:
 
 ```bash
 cargo check -p microsandbox-agent-client --no-default-features
+cargo test -p microsandbox-agent-client --features stream
 cargo test -p microsandbox-agent-client --features uds
-cargo test -p microsandbox-agent-client --features websocket
 ```

--- a/agent-client/rust/lib/client.rs
+++ b/agent-client/rust/lib/client.rs
@@ -19,21 +19,21 @@
 //!   primitives over [`Message`]; the SDK serializes payloads with CBOR.
 
 use std::collections::HashMap;
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 use std::future::Future;
 #[cfg(feature = "uds")]
 use std::path::Path;
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 use std::pin::Pin;
 use std::sync::{Arc, atomic::AtomicU32};
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 use std::time::Duration;
 
 #[cfg(feature = "websocket")]
 use futures_util::{SinkExt, StreamExt};
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 use microsandbox_protocol::message::FLAG_TERMINAL;
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 use microsandbox_protocol::{codec::MAX_FRAME_SIZE, message::FRAME_HEADER_SIZE};
 use microsandbox_protocol::{
     codec::{self, RawFrame},
@@ -41,11 +41,13 @@ use microsandbox_protocol::{
     message::{Message, MessageType, PROTOCOL_VERSION},
 };
 use serde::Serialize;
+#[cfg(feature = "stream")]
+use tokio::io::{AsyncRead, AsyncWrite};
 #[cfg(feature = "uds")]
 use tokio::net::UnixStream;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 use tokio::time::Instant;
 #[cfg(feature = "websocket")]
 use tokio_tungstenite::tungstenite::Message as WebSocketMessage;
@@ -57,10 +59,10 @@ use super::error::{AgentClientError, AgentClientResult};
 //--------------------------------------------------------------------------------------------------
 
 /// Default handshake timeout used by [`AgentClient::connect`].
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 const WRITER_QUEUE_CAPACITY: usize = 1024;
 const REQUEST_QUEUE_CAPACITY: usize = 1;
 const STREAM_QUEUE_CAPACITY: usize = 1024;
@@ -70,7 +72,7 @@ const MAX_WEBSOCKET_BUFFER_SIZE: usize = MAX_FRAME_SIZE as usize + 12;
 const LEGACY_PROTOCOL_VERSION: u8 = 1;
 // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
 // compatibility for versions before 0.5 is no longer supported.
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 const LEGACY_RELAY_ID_RANGE_STEP: u32 = u32::MAX / 16;
 
 //--------------------------------------------------------------------------------------------------
@@ -121,7 +123,7 @@ pub struct AgentClient {
     ready: Ready,
 }
 
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 struct AgentHandshake {
     id_min: u32,
     id_max: u32,
@@ -131,13 +133,13 @@ struct AgentHandshake {
     ready: Ready,
 }
 
-#[cfg_attr(not(any(feature = "uds", feature = "websocket")), allow(dead_code))]
+#[cfg_attr(not(any(feature = "stream", feature = "websocket")), allow(dead_code))]
 struct WriterCommand {
     frame: RawFrame,
     ack: oneshot::Sender<AgentClientResult<()>>,
 }
 
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 trait HandshakeReader {
     fn read_exact_handshake<'a>(
         &'a mut self,
@@ -199,8 +201,54 @@ impl AgentClient {
                     path: sock_path.to_path_buf(),
                     source,
                 })?;
+        Self::connect_stream_with_deadline(stream, deadline).await
+    }
 
-        let (mut reader, writer) = stream.into_split();
+    /// Connect over an arbitrary byte-stream transport using the default 10s
+    /// handshake timeout.
+    ///
+    /// The stream must be a transparent pipe to the agent relay: the relay's
+    /// `[id_min][id_max]` + `core.ready` prologue and the framed protocol that
+    /// follows flow over it verbatim. This is the injection point for
+    /// caller-owned transports — e.g. a pre-authenticated WebSocket adapted to
+    /// bytes — so the caller owns the dial and its credentials and this crate
+    /// stays transport- (and dependency-) agnostic.
+    #[cfg(feature = "stream")]
+    pub async fn connect_stream<S>(stream: S) -> AgentClientResult<Self>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        Self::connect_stream_with_timeout(stream, DEFAULT_HANDSHAKE_TIMEOUT).await
+    }
+
+    /// Connect over an arbitrary byte-stream transport using an explicit
+    /// handshake timeout.
+    #[cfg(feature = "stream")]
+    pub async fn connect_stream_with_timeout<S>(
+        stream: S,
+        timeout: Duration,
+    ) -> AgentClientResult<Self>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let deadline = Instant::now() + timeout;
+        Self::connect_stream_with_deadline(stream, deadline).await
+    }
+
+    /// Connect over an arbitrary byte-stream transport with an explicit
+    /// handshake deadline.
+    ///
+    /// `deadline` bounds both handshake reads so an accepted-but-stalled
+    /// transport cannot block this call indefinitely.
+    #[cfg(feature = "stream")]
+    pub async fn connect_stream_with_deadline<S>(
+        stream: S,
+        deadline: Instant,
+    ) -> AgentClientResult<Self>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let (mut reader, writer) = tokio::io::split(stream);
         let handshake = perform_handshake(&mut reader, deadline).await?;
 
         tracing::info!(
@@ -224,7 +272,7 @@ impl AgentClient {
 
         let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
         let reader_handle = tokio::spawn(reader_loop(reader, Arc::clone(&pending)));
-        let writer_handle = tokio::spawn(uds_writer_loop(writer, writer_rx));
+        let writer_handle = tokio::spawn(stream_writer_loop(writer, writer_rx));
 
         Ok(Self {
             writer: writer_tx,
@@ -537,7 +585,7 @@ impl AgentClient {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 async fn perform_handshake<R>(
     reader: &mut R,
     deadline: Instant,
@@ -630,7 +678,7 @@ fn first_request_id(id_min: u32) -> u32 {
     id_min.max(1)
 }
 
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 fn ensure_usable_id_range(id_min: u32, id_max: u32) -> AgentClientResult<()> {
     if usable_id_count(id_min, id_max) == 0 {
         return Err(AgentClientError::Handshake(format!(
@@ -644,7 +692,7 @@ fn usable_id_count(id_min: u32, id_max: u32) -> u32 {
     id_max.saturating_sub(first_request_id(id_min))
 }
 
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 fn looks_like_legacy_relay_handshake(id_min: u32, id_max: u32) -> bool {
     // TODO(upgrade-0.6): Remove in 0.6.x or later once pre-0.5 relay
     // handshakes are no longer accepted.
@@ -659,7 +707,7 @@ fn looks_like_legacy_relay_handshake(id_min: u32, id_max: u32) -> bool {
         && (id_min == 0 || id_min >= id_max)
 }
 
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 async fn read_raw_frame_after_len_prefix<R>(
     reader: &mut R,
     len_buf: [u8; 4],
@@ -697,7 +745,7 @@ where
     Ok(RawFrame { id, flags, body })
 }
 
-#[cfg(feature = "uds")]
+#[cfg(feature = "stream")]
 impl<R> HandshakeReader for R
 where
     R: tokio::io::AsyncRead + Unpin + Send,
@@ -725,14 +773,14 @@ where
     }
 }
 
-#[cfg(feature = "uds")]
-async fn uds_writer_loop(
-    mut writer: tokio::net::unix::OwnedWriteHalf,
-    mut rx: mpsc::Receiver<WriterCommand>,
-) {
+#[cfg(feature = "stream")]
+async fn stream_writer_loop<W>(mut writer: W, mut rx: mpsc::Receiver<WriterCommand>)
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
     while let Some(command) = rx.recv().await {
         if let Err(e) = codec::write_raw_frame(&mut writer, &command.frame).await {
-            tracing::debug!("agent client: UDS writer error: {e}");
+            tracing::debug!("agent client: stream writer error: {e}");
             let _ = command.ack.send(Err(AgentClientError::Protocol(e)));
             break;
         }
@@ -742,7 +790,7 @@ async fn uds_writer_loop(
 
 /// Background task that reads frames from the relay and dispatches them to
 /// pending channels by correlation ID. Operates on raw frames — no CBOR.
-#[cfg(feature = "uds")]
+#[cfg(feature = "stream")]
 async fn reader_loop<R>(mut reader: R, pending: Arc<Mutex<HashMap<u32, mpsc::Sender<RawFrame>>>>)
 where
     R: tokio::io::AsyncRead + Unpin,
@@ -939,7 +987,7 @@ where
     }
 }
 
-#[cfg(any(feature = "uds", feature = "websocket"))]
+#[cfg(any(feature = "stream", feature = "websocket"))]
 async fn dispatch_frame(
     frame: RawFrame,
     pending: &Arc<Mutex<HashMap<u32, mpsc::Sender<RawFrame>>>>,
@@ -1268,6 +1316,84 @@ mod tests {
         assert_eq!(decoded.boot_time_ns, ready.boot_time_ns);
         assert_eq!(decoded.init_time_ns, ready.init_time_ns);
         assert_eq!(decoded.ready_time_ns, ready.ready_time_ns);
+    }
+
+    #[cfg(feature = "stream")]
+    #[tokio::test]
+    async fn connect_stream_handshakes_and_streams_exec() {
+        use microsandbox_protocol::exec::{ExecExited, ExecRequest, ExecStdout};
+        use tokio::io::AsyncWriteExt;
+
+        let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
+        let ready = Ready {
+            boot_time_ns: 11,
+            init_time_ns: 22,
+            ready_time_ns: 33,
+            agent_version: "stream-test".to_string(),
+        };
+        let ready_msg = Message::with_payload(MessageType::Ready, 0, &ready).unwrap();
+
+        tokio::spawn(async move {
+            // Relay handshake: [id_min][id_max] then the core.ready frame.
+            server_io.write_all(&1u32.to_be_bytes()).await.unwrap();
+            server_io.write_all(&1024u32.to_be_bytes()).await.unwrap();
+            codec::write_message(&mut server_io, &ready_msg)
+                .await
+                .unwrap();
+
+            // One exec stream echoed back: stdout, then a terminal exited.
+            let request = codec::read_raw_frame(&mut server_io).await.unwrap();
+            let stdout = Message::with_payload(
+                MessageType::ExecStdout,
+                request.id,
+                &ExecStdout {
+                    data: b"hi".to_vec(),
+                },
+            )
+            .unwrap();
+            codec::write_message(&mut server_io, &stdout).await.unwrap();
+            let exited =
+                Message::with_payload(MessageType::ExecExited, request.id, &ExecExited { code: 0 })
+                    .unwrap();
+            codec::write_message(&mut server_io, &exited).await.unwrap();
+        });
+
+        let client = AgentClient::connect_stream_with_deadline(
+            client_io,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(client.protocol(), AgentProtocol::Current);
+        assert_eq!(client.agent_version(), "stream-test");
+        assert!(client.supports(MessageType::ExecRequest));
+
+        let request = ExecRequest {
+            cmd: "echo".into(),
+            args: vec!["hi".into()],
+            env: Vec::new(),
+            cwd: None,
+            user: None,
+            tty: false,
+            rows: 24,
+            cols: 80,
+            rlimits: Vec::new(),
+        };
+        let (_id, mut rx) = client
+            .stream(MessageType::ExecRequest, &request)
+            .await
+            .unwrap();
+
+        let first = rx.recv().await.unwrap();
+        assert_eq!(first.t, MessageType::ExecStdout);
+        let out: ExecStdout = first.payload().unwrap();
+        assert_eq!(out.data, b"hi");
+
+        let second = rx.recv().await.unwrap();
+        assert_eq!(second.t, MessageType::ExecExited);
+        let exit: ExecExited = second.payload().unwrap();
+        assert_eq!(exit.code, 0);
     }
 
     #[cfg(feature = "websocket")]

--- a/agent-client/rust/lib/client.rs
+++ b/agent-client/rust/lib/client.rs
@@ -4,8 +4,9 @@
 //! During connection, the relay assigns a non-overlapping correlation ID range
 //! and sends the cached `core.ready` payload so the client can begin issuing
 //! commands immediately. Unix domain sockets are available with the `uds`
-//! feature, and WebSocket connections are available with the `websocket`
-//! feature.
+//! feature; the `stream` feature drives the client over any
+//! `AsyncRead + AsyncWrite` byte stream (e.g. a caller-owned, pre-authenticated
+//! transport adapted to bytes).
 //!
 //! Two API tiers share one socket and one reader task:
 //!
@@ -19,21 +20,19 @@
 //!   primitives over [`Message`]; the SDK serializes payloads with CBOR.
 
 use std::collections::HashMap;
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 use std::future::Future;
 #[cfg(feature = "uds")]
 use std::path::Path;
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 use std::pin::Pin;
 use std::sync::{Arc, atomic::AtomicU32};
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 use std::time::Duration;
 
-#[cfg(feature = "websocket")]
-use futures_util::{SinkExt, StreamExt};
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 use microsandbox_protocol::message::FLAG_TERMINAL;
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 use microsandbox_protocol::{codec::MAX_FRAME_SIZE, message::FRAME_HEADER_SIZE};
 use microsandbox_protocol::{
     codec::{self, RawFrame},
@@ -47,10 +46,8 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::UnixStream;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 use tokio::time::Instant;
-#[cfg(feature = "websocket")]
-use tokio_tungstenite::tungstenite::Message as WebSocketMessage;
 
 use super::error::{AgentClientError, AgentClientResult};
 
@@ -59,20 +56,18 @@ use super::error::{AgentClientError, AgentClientResult};
 //--------------------------------------------------------------------------------------------------
 
 /// Default handshake timeout used by [`AgentClient::connect`].
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 const WRITER_QUEUE_CAPACITY: usize = 1024;
 const REQUEST_QUEUE_CAPACITY: usize = 1;
 const STREAM_QUEUE_CAPACITY: usize = 1024;
-#[cfg(feature = "websocket")]
-const MAX_WEBSOCKET_BUFFER_SIZE: usize = MAX_FRAME_SIZE as usize + 12;
 
 const LEGACY_PROTOCOL_VERSION: u8 = 1;
 // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
 // compatibility for versions before 0.5 is no longer supported.
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 const LEGACY_RELAY_ID_RANGE_STEP: u32 = u32::MAX / 16;
 
 //--------------------------------------------------------------------------------------------------
@@ -123,7 +118,7 @@ pub struct AgentClient {
     ready: Ready,
 }
 
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 struct AgentHandshake {
     id_min: u32,
     id_max: u32,
@@ -133,13 +128,13 @@ struct AgentHandshake {
     ready: Ready,
 }
 
-#[cfg_attr(not(any(feature = "stream", feature = "websocket")), allow(dead_code))]
+#[cfg_attr(not(feature = "stream"), allow(dead_code))]
 struct WriterCommand {
     frame: RawFrame,
     ack: oneshot::Sender<AgentClientResult<()>>,
 }
 
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 trait HandshakeReader {
     fn read_exact_handshake<'a>(
         &'a mut self,
@@ -273,66 +268,6 @@ impl AgentClient {
         let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
         let reader_handle = tokio::spawn(reader_loop(reader, Arc::clone(&pending)));
         let writer_handle = tokio::spawn(stream_writer_loop(writer, writer_rx));
-
-        Ok(Self {
-            writer: writer_tx,
-            next_id: AtomicU32::new(first_request_id(handshake.id_min)),
-            id_min: handshake.id_min,
-            id_max: handshake.id_max,
-            protocol: handshake.protocol,
-            negotiated_version: handshake.negotiated_version,
-            pending,
-            reader_handle,
-            writer_handle,
-            ready_body: handshake.ready_body,
-            ready: handshake.ready,
-        })
-    }
-
-    /// Connect to an agent relay over WebSocket using the default 10s
-    /// handshake timeout.
-    #[cfg(feature = "websocket")]
-    pub async fn connect_websocket(url: &str) -> AgentClientResult<Self> {
-        Self::connect_websocket_with_timeout(url, DEFAULT_HANDSHAKE_TIMEOUT).await
-    }
-
-    /// Connect to an agent relay over WebSocket using an explicit handshake
-    /// timeout.
-    #[cfg(feature = "websocket")]
-    pub async fn connect_websocket_with_timeout(
-        url: &str,
-        timeout: Duration,
-    ) -> AgentClientResult<Self> {
-        let deadline = Instant::now() + timeout;
-        Self::connect_websocket_with_deadline(url, deadline).await
-    }
-
-    /// Connect to an agent relay over WebSocket with an explicit handshake
-    /// deadline.
-    #[cfg(feature = "websocket")]
-    pub async fn connect_websocket_with_deadline(
-        url: &str,
-        deadline: Instant,
-    ) -> AgentClientResult<Self> {
-        let (stream, _) = tokio_tungstenite::connect_async(url)
-            .await
-            .map_err(|e| AgentClientError::WebSocket(format!("connect {url}: {e}")))?;
-        let (writer, reader) = stream.split();
-        let mut reader = WebSocketByteReader::new(reader);
-        let handshake = perform_handshake(&mut reader, deadline).await?;
-        if handshake.protocol == AgentProtocol::LegacyV1 {
-            // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
-            // compatibility for versions before 0.5 is no longer supported.
-            tracing::warn!(
-                "agent client: connected to a sandbox started before microsandbox 0.5; exec compatibility is temporary and filesystem/SFTP require stop/start"
-            );
-        }
-
-        let pending: Arc<Mutex<HashMap<u32, mpsc::Sender<RawFrame>>>> =
-            Arc::new(Mutex::new(HashMap::new()));
-        let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
-        let reader_handle = tokio::spawn(websocket_reader_loop(reader, Arc::clone(&pending)));
-        let writer_handle = tokio::spawn(websocket_writer_loop(writer, writer_rx));
 
         Ok(Self {
             writer: writer_tx,
@@ -585,7 +520,7 @@ impl AgentClient {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 async fn perform_handshake<R>(
     reader: &mut R,
     deadline: Instant,
@@ -678,7 +613,7 @@ fn first_request_id(id_min: u32) -> u32 {
     id_min.max(1)
 }
 
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 fn ensure_usable_id_range(id_min: u32, id_max: u32) -> AgentClientResult<()> {
     if usable_id_count(id_min, id_max) == 0 {
         return Err(AgentClientError::Handshake(format!(
@@ -692,7 +627,7 @@ fn usable_id_count(id_min: u32, id_max: u32) -> u32 {
     id_max.saturating_sub(first_request_id(id_min))
 }
 
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 fn looks_like_legacy_relay_handshake(id_min: u32, id_max: u32) -> bool {
     // TODO(upgrade-0.6): Remove in 0.6.x or later once pre-0.5 relay
     // handshakes are no longer accepted.
@@ -707,7 +642,7 @@ fn looks_like_legacy_relay_handshake(id_min: u32, id_max: u32) -> bool {
         && (id_min == 0 || id_min >= id_max)
 }
 
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 async fn read_raw_frame_after_len_prefix<R>(
     reader: &mut R,
     len_buf: [u8; 4],
@@ -812,182 +747,7 @@ where
     map.clear();
 }
 
-#[cfg(feature = "websocket")]
-struct WebSocketByteReader<S> {
-    stream: S,
-    buffer: Vec<u8>,
-    cursor: usize,
-}
-
-#[cfg(feature = "websocket")]
-impl<S> WebSocketByteReader<S>
-where
-    S: futures_util::Stream<Item = Result<WebSocketMessage, tokio_tungstenite::tungstenite::Error>>
-        + Unpin
-        + Send,
-{
-    fn new(stream: S) -> Self {
-        Self {
-            stream,
-            buffer: Vec::new(),
-            cursor: 0,
-        }
-    }
-
-    async fn read_exact(&mut self, out: &mut [u8]) -> AgentClientResult<()> {
-        while self.available_bytes() < out.len() {
-            let Some(message) = self.stream.next().await else {
-                return Err(AgentClientError::WebSocket(
-                    "websocket closed before enough bytes were available".to_string(),
-                ));
-            };
-            match message.map_err(|e| AgentClientError::WebSocket(e.to_string()))? {
-                WebSocketMessage::Binary(bytes) => {
-                    if self.available_bytes() + bytes.len() > MAX_WEBSOCKET_BUFFER_SIZE {
-                        return Err(AgentClientError::WebSocket(format!(
-                            "websocket buffer exceeded maximum size: {} bytes (max {MAX_WEBSOCKET_BUFFER_SIZE})",
-                            self.available_bytes() + bytes.len()
-                        )));
-                    }
-                    self.compact_consumed();
-                    self.buffer.extend_from_slice(&bytes);
-                }
-                WebSocketMessage::Close(_) => {
-                    return Err(AgentClientError::WebSocket(
-                        "websocket closed before enough bytes were available".to_string(),
-                    ));
-                }
-                WebSocketMessage::Ping(_) | WebSocketMessage::Pong(_) => {}
-                WebSocketMessage::Text(_) | WebSocketMessage::Frame(_) => {
-                    return Err(AgentClientError::WebSocket(
-                        "websocket message is not binary".to_string(),
-                    ));
-                }
-            }
-        }
-
-        out.copy_from_slice(&self.buffer[self.cursor..self.cursor + out.len()]);
-        self.cursor += out.len();
-        self.compact_consumed();
-        Ok(())
-    }
-
-    fn available_bytes(&self) -> usize {
-        self.buffer.len().saturating_sub(self.cursor)
-    }
-
-    fn compact_consumed(&mut self) {
-        if self.cursor == 0 {
-            return;
-        }
-        if self.cursor == self.buffer.len() {
-            self.buffer.clear();
-        } else {
-            self.buffer.drain(..self.cursor);
-        }
-        self.cursor = 0;
-    }
-
-    async fn read_raw_frame(&mut self) -> AgentClientResult<RawFrame> {
-        let mut len_buf = [0u8; 4];
-        self.read_exact(&mut len_buf).await?;
-        let frame_len = u32::from_be_bytes(len_buf);
-        if frame_len > MAX_FRAME_SIZE {
-            return Err(AgentClientError::Protocol(
-                microsandbox_protocol::ProtocolError::FrameTooLarge {
-                    size: frame_len,
-                    max: MAX_FRAME_SIZE,
-                },
-            ));
-        }
-        if frame_len < FRAME_HEADER_SIZE as u32 {
-            return Err(AgentClientError::Protocol(
-                microsandbox_protocol::ProtocolError::FrameTooShort {
-                    size: frame_len,
-                    min: FRAME_HEADER_SIZE as u32,
-                },
-            ));
-        }
-
-        let mut payload = vec![0u8; frame_len as usize];
-        self.read_exact(&mut payload).await?;
-        let id = u32::from_be_bytes(payload[0..4].try_into().unwrap());
-        let flags = payload[4];
-        let body = payload[FRAME_HEADER_SIZE..].to_vec();
-        Ok(RawFrame { id, flags, body })
-    }
-}
-
-#[cfg(feature = "websocket")]
-impl<S> HandshakeReader for WebSocketByteReader<S>
-where
-    S: futures_util::Stream<Item = Result<WebSocketMessage, tokio_tungstenite::tungstenite::Error>>
-        + Unpin
-        + Send,
-{
-    fn read_exact_handshake<'a>(
-        &'a mut self,
-        out: &'a mut [u8],
-    ) -> Pin<Box<dyn Future<Output = AgentClientResult<()>> + Send + 'a>> {
-        Box::pin(async move { self.read_exact(out).await })
-    }
-
-    fn read_frame_handshake<'a>(
-        &'a mut self,
-    ) -> Pin<Box<dyn Future<Output = AgentClientResult<RawFrame>> + Send + 'a>> {
-        Box::pin(async move { self.read_raw_frame().await })
-    }
-}
-
-#[cfg(feature = "websocket")]
-async fn websocket_reader_loop<S>(
-    mut reader: WebSocketByteReader<S>,
-    pending: Arc<Mutex<HashMap<u32, mpsc::Sender<RawFrame>>>>,
-) where
-    S: futures_util::Stream<Item = Result<WebSocketMessage, tokio_tungstenite::tungstenite::Error>>
-        + Unpin
-        + Send,
-{
-    loop {
-        let frame = match reader.read_raw_frame().await {
-            Ok(frame) => frame,
-            Err(e) => {
-                tracing::debug!("agent client: websocket reader EOF or error: {e}");
-                break;
-            }
-        };
-
-        dispatch_frame(frame, &pending).await;
-    }
-
-    let mut map = pending.lock().await;
-    map.clear();
-}
-
-#[cfg(feature = "websocket")]
-async fn websocket_writer_loop<S>(mut writer: S, mut rx: mpsc::Receiver<WriterCommand>)
-where
-    S: futures_util::Sink<WebSocketMessage, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
-{
-    while let Some(command) = rx.recv().await {
-        let mut buf = Vec::new();
-        if let Err(e) = codec::encode_raw_to_buf(&command.frame, &mut buf) {
-            tracing::debug!("agent client: websocket encode error: {e}");
-            let _ = command.ack.send(Err(AgentClientError::Protocol(e)));
-            break;
-        }
-        if let Err(e) = writer.send(WebSocketMessage::Binary(buf.into())).await {
-            tracing::debug!("agent client: websocket writer error: {e}");
-            let _ = command
-                .ack
-                .send(Err(AgentClientError::WebSocket(e.to_string())));
-            break;
-        }
-        let _ = command.ack.send(Ok(()));
-    }
-}
-
-#[cfg(any(feature = "stream", feature = "websocket"))]
+#[cfg(feature = "stream")]
 async fn dispatch_frame(
     frame: RawFrame,
     pending: &Arc<Mutex<HashMap<u32, mpsc::Sender<RawFrame>>>>,
@@ -1048,21 +808,17 @@ fn encode_message_body<T: Serialize>(
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(feature = "uds", feature = "websocket"))]
+    #[cfg(feature = "uds")]
     use microsandbox_protocol::core::Ready;
-    #[cfg(any(feature = "uds", feature = "websocket"))]
+    #[cfg(feature = "uds")]
     use microsandbox_protocol::exec::ExecRequest;
-    #[cfg(feature = "websocket")]
-    use microsandbox_protocol::fs::{FsOp, FsRequest, FsResponse};
     #[cfg(feature = "uds")]
     use microsandbox_protocol::message::PROTOCOL_VERSION;
     #[cfg(feature = "uds")]
     use tokio::io::AsyncWriteExt;
-    #[cfg(feature = "websocket")]
-    use tokio::net::TcpListener;
     #[cfg(feature = "uds")]
     use tokio::net::UnixListener;
-    #[cfg(any(feature = "uds", feature = "websocket"))]
+    #[cfg(feature = "uds")]
     use tokio::sync::oneshot;
 
     use super::*;
@@ -1394,171 +1150,6 @@ mod tests {
         assert_eq!(second.t, MessageType::ExecExited);
         let exit: ExecExited = second.payload().unwrap();
         assert_eq!(exit.code, 0);
-    }
-
-    #[cfg(feature = "websocket")]
-    #[tokio::test]
-    async fn websocket_connects_and_completes_request() {
-        use futures_util::{SinkExt, StreamExt};
-        use tokio_tungstenite::accept_async;
-        use tokio_tungstenite::tungstenite::Message as WebSocketMessage;
-
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let ready = Ready {
-            boot_time_ns: 11,
-            init_time_ns: 22,
-            ready_time_ns: 33,
-            agent_version: "ws-test".to_string(),
-        };
-
-        tokio::spawn(async move {
-            let (stream, _) = listener.accept().await.unwrap();
-            let mut ws = accept_async(stream).await.unwrap();
-
-            let mut range = Vec::new();
-            range.extend_from_slice(&1u32.to_be_bytes());
-            range.extend_from_slice(&1024u32.to_be_bytes());
-            ws.send(WebSocketMessage::Binary(range.into()))
-                .await
-                .unwrap();
-
-            let ready_msg = Message::with_payload(MessageType::Ready, 0, &ready).unwrap();
-            let mut ready_packet = Vec::new();
-            codec::encode_to_buf(&ready_msg, &mut ready_packet).unwrap();
-            ws.send(WebSocketMessage::Binary(ready_packet.into()))
-                .await
-                .unwrap();
-
-            let request_packet = loop {
-                match ws.next().await.unwrap().unwrap() {
-                    WebSocketMessage::Binary(bytes) => break bytes.to_vec(),
-                    _ => continue,
-                }
-            };
-            let mut request_buf = request_packet;
-            let request = codec::try_decode_raw_from_buf(&mut request_buf)
-                .unwrap()
-                .unwrap();
-            let request_msg = codec::raw_frame_to_message(request.clone()).unwrap();
-            assert_eq!(request_msg.t, MessageType::FsRequest);
-
-            let response = Message::with_payload(
-                MessageType::FsResponse,
-                request.id,
-                &FsResponse {
-                    ok: true,
-                    error: None,
-                    data: None,
-                },
-            )
-            .unwrap();
-            let mut response_packet = Vec::new();
-            codec::encode_to_buf(&response, &mut response_packet).unwrap();
-            ws.send(WebSocketMessage::Binary(response_packet.into()))
-                .await
-                .unwrap();
-        });
-
-        let client = AgentClient::connect_websocket(&format!("ws://{addr}"))
-            .await
-            .unwrap();
-        assert_eq!(client.agent_version(), "ws-test");
-
-        let response = client
-            .request(
-                MessageType::FsRequest,
-                &FsRequest {
-                    op: FsOp::Stat {
-                        path: "/tmp".to_string(),
-                        follow_symlink: true,
-                    },
-                },
-            )
-            .await
-            .unwrap();
-        assert_eq!(response.t, MessageType::FsResponse);
-        let payload: FsResponse = response.payload().unwrap();
-        assert!(payload.ok);
-    }
-
-    #[cfg(feature = "websocket")]
-    #[tokio::test]
-    async fn websocket_accepts_legacy_relay_handshake() {
-        use futures_util::{SinkExt, StreamExt};
-        use tokio_tungstenite::accept_async;
-        use tokio_tungstenite::tungstenite::Message as WebSocketMessage;
-
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let ready = Ready {
-            boot_time_ns: 11,
-            init_time_ns: 22,
-            ready_time_ns: 33,
-            agent_version: "legacy-ws-test".to_string(),
-        };
-        let id_offset = 268_435_455u32;
-        let (frame_tx, frame_rx) = oneshot::channel();
-
-        tokio::spawn(async move {
-            let (stream, _) = listener.accept().await.unwrap();
-            let mut ws = accept_async(stream).await.unwrap();
-
-            ws.send(WebSocketMessage::Binary(
-                id_offset.to_be_bytes().to_vec().into(),
-            ))
-            .await
-            .unwrap();
-
-            let ready_msg = Message::with_payload(MessageType::Ready, 0, &ready).unwrap();
-            let mut ready_packet = Vec::new();
-            codec::encode_to_buf(&ready_msg, &mut ready_packet).unwrap();
-            ws.send(WebSocketMessage::Binary(ready_packet.into()))
-                .await
-                .unwrap();
-
-            let request_packet = loop {
-                match ws.next().await.unwrap().unwrap() {
-                    WebSocketMessage::Binary(bytes) => break bytes.to_vec(),
-                    _ => continue,
-                }
-            };
-            let mut request_buf = request_packet;
-            let request = codec::try_decode_raw_from_buf(&mut request_buf)
-                .unwrap()
-                .unwrap();
-            frame_tx.send(request).unwrap();
-        });
-
-        let client = AgentClient::connect_websocket(&format!("ws://{addr}"))
-            .await
-            .unwrap();
-        assert_eq!(client.protocol(), AgentProtocol::LegacyV1);
-        assert_eq!(client.negotiated_version(), LEGACY_PROTOCOL_VERSION);
-        assert_eq!(client.agent_version(), "legacy-ws-test");
-
-        let request = ExecRequest {
-            cmd: "/bin/true".into(),
-            args: Vec::new(),
-            env: Vec::new(),
-            cwd: None,
-            user: None,
-            tty: false,
-            rows: 24,
-            cols: 80,
-            rlimits: Vec::new(),
-        };
-        let (id, _rx) = client
-            .stream(MessageType::ExecRequest, &request)
-            .await
-            .unwrap();
-        let frame = frame_rx.await.unwrap();
-        let message = codec::raw_frame_to_message(frame).unwrap();
-
-        assert_eq!(id, id_offset + 1);
-        assert_eq!(message.id, id_offset + 1);
-        assert_eq!(message.v, LEGACY_PROTOCOL_VERSION);
-        assert_eq!(message.t, MessageType::ExecRequest);
     }
 }
 

--- a/agent-client/rust/lib/error.rs
+++ b/agent-client/rust/lib/error.rs
@@ -38,10 +38,6 @@ pub enum AgentClientError {
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
 
-    /// A WebSocket transport error occurred.
-    #[error("websocket: {0}")]
-    WebSocket(String),
-
     /// A wire-protocol error (framing, CBOR, oversize frame).
     #[error("protocol: {0}")]
     Protocol(#[from] microsandbox_protocol::ProtocolError),

--- a/agent-client/rust/lib/lib.rs
+++ b/agent-client/rust/lib/lib.rs
@@ -5,7 +5,9 @@
 //! SDK crates remain responsible for sandbox lifecycle and name resolution.
 //!
 //! No transport is enabled by default. Enable `uds` for local microsandbox relay
-//! sockets or `websocket` for relay endpoints exposed over WebSocket.
+//! sockets, or `stream` to drive the client over any `AsyncRead + AsyncWrite`
+//! byte stream (e.g. a caller-owned, pre-authenticated transport adapted to
+//! bytes).
 
 #![warn(missing_docs)]
 


### PR DESCRIPTION
## What
1. Add a `stream` feature to `microsandbox-agent-client` — `connect_stream{,_with_timeout,_with_deadline}` drive `AgentClient` over any `AsyncRead + AsyncWrite` byte stream.
2. Drop the now-redundant `websocket` transport.

## Why
An `AgentClient` was only constructable by dialing a UDS (`connect`) or a **bare** WS URL (`connect_websocket`). Neither takes a caller-owned, pre-authenticated transport — e.g. a `Bearer`-auth WS to a cloud relay. The `AgentTransport` trait can't express it either (the `[id_min][id_max]` handshake prologue is raw bytes, not a packet), so the seam is a byte stream. Signature is std-io-typed — no `tokio-tungstenite` in the public API.

`connect_websocket` then had no reason to exist: no in-repo consumers (the only user enables `uds`; the browser uses the TS client), couldn't auth (bare URL), and duplicated what `stream` does (dial WS → adapt to bytes → run the byte client).

## How
- New `stream` feature (no deps); `uds = ["stream"]`. `connect_stream*` = `tokio::io::split` → existing `perform_handshake` → existing `reader_loop` + a generalized `stream_writer_loop<W>`.
- `uds` now **delegates**: `connect_with_deadline` dials, then calls `connect_stream_with_deadline`. Drops the duplicated post-handshake setup + `uds_writer_loop`.
- Remove the `websocket` feature, `connect_websocket*`, `WebSocketByteReader`, the ws loops, the dead `WebSocket` error variant, and the `tokio-tungstenite` + `futures-util` deps. Two transports remain: `uds` (→ `stream`) and `stream`. Net −440 lines.

## Tests
Green across `stream` / `uds` / default. New `connect_stream` handshake+exec round-trip over `tokio::io::duplex`; existing uds suite still passes after the de-dup.
