### PR TITLE
feat(network): support secret substitution through HTTP CONNECT tunnels

### DIFF
--- a/crates/microsandbox/tests/http_connect_secret.rs
+++ b/crates/microsandbox/tests/http_connect_secret.rs
@@ -1,0 +1,363 @@
+//! Integration tests for secret substitution through HTTP CONNECT tunnels.
+
+use std::io;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
+
+use microsandbox::{NetworkPolicy, Sandbox};
+use rcgen::CertificateParams;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use test_utils::msb_test;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+use tokio_rustls::TlsAcceptor;
+
+// Constants
+
+const CURL_IMAGE: &str = "mirror.gcr.io/curlimages/curl";
+const REAL_SECRET: &str = "real-secret-connect";
+const PLACEHOLDER: &str = "MSB_API_KEY";
+
+// Types
+
+/// Minimal HTTP CONNECT proxy that splices one tunnelled connection.
+struct ConnectProxy {
+    port: u16,
+    handle: Option<JoinHandle<io::Result<()>>>,
+}
+
+/// Minimal HTTPS server that records the Authorization header of one request.
+struct TargetHttps {
+    port: u16,
+    handle: Option<JoinHandle<io::Result<String>>>,
+}
+
+// Methods
+
+impl ConnectProxy {
+    async fn start(target_port: u16) -> io::Result<Self> {
+        let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+        let port = listener.local_addr()?.port();
+
+        let handle = tokio::spawn(async move {
+            let (client, _) = listener.accept().await?;
+            handle_connect(client, target_port).await
+        });
+
+        Ok(Self {
+            port,
+            handle: Some(handle),
+        })
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
+
+    async fn join(&mut self) -> io::Result<()> {
+        self.handle
+            .take()
+            .expect("proxy fixture already consumed")
+            .await
+            .map_err(io::Error::other)?
+    }
+}
+
+impl Drop for ConnectProxy {
+    fn drop(&mut self) {
+        if let Some(h) = self.handle.take() {
+            h.abort();
+        }
+    }
+}
+
+impl TargetHttps {
+    async fn start() -> io::Result<Self> {
+        let v4 = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+        let port = v4.local_addr()?.port();
+        let v6 = TcpListener::bind(SocketAddr::from((Ipv6Addr::LOCALHOST, port))).await?;
+        let acceptor = TlsAcceptor::from(test_server_tls_config());
+
+        let handle = tokio::spawn(async move {
+            let (stream, _) = tokio::select! {
+                a = v4.accept() => a?,
+                a = v6.accept() => a?,
+            };
+            let tls = acceptor.accept(stream).await?;
+            received_auth_header(tls).await
+        });
+
+        Ok(Self {
+            port,
+            handle: Some(handle),
+        })
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
+
+    async fn received_auth(&mut self) -> io::Result<String> {
+        self.handle
+            .take()
+            .expect("target fixture already consumed")
+            .await
+            .map_err(io::Error::other)?
+    }
+}
+
+impl Drop for TargetHttps {
+    fn drop(&mut self) {
+        if let Some(h) = self.handle.take() {
+            h.abort();
+        }
+    }
+}
+
+// Functions
+
+async fn handle_connect(client: TcpStream, target_port: u16) -> io::Result<()> {
+    let (read_half, write_half) = client.into_split();
+    let mut reader = BufReader::new(read_half);
+
+    let mut request_line = String::new();
+    reader.read_line(&mut request_line).await?;
+    let target = parse_connect_target(&request_line).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("expected CONNECT request, got: {request_line:?}"),
+        )
+    })?;
+
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).await?;
+        if line == "\r\n" || line.is_empty() {
+            break;
+        }
+    }
+
+    // host.microsandbox.internal only resolves inside the VM; rewrite to loopback.
+    let connect_addr = if target.starts_with("host.microsandbox.internal:") {
+        format!("127.0.0.1:{target_port}")
+    } else {
+        target
+    };
+
+    let upstream = TcpStream::connect(&connect_addr).await?;
+
+    let mut client_write = write_half;
+    client_write
+        .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        .await?;
+
+    let mut client_read = reader.into_inner();
+    let (mut up_read, mut up_write) = upstream.into_split();
+
+    tokio::try_join!(
+        tokio::io::copy(&mut client_read, &mut up_write),
+        tokio::io::copy(&mut up_read, &mut client_write),
+    )?;
+
+    Ok(())
+}
+
+fn parse_connect_target(line: &str) -> Option<String> {
+    let mut parts = line.split_whitespace();
+    let method = parts.next()?;
+    let target = parts.next()?;
+    if !method.eq_ignore_ascii_case("CONNECT") {
+        return None;
+    }
+    Some(target.to_string())
+}
+
+async fn received_auth_header(
+    mut stream: tokio_rustls::server::TlsStream<TcpStream>,
+) -> io::Result<String> {
+    let mut buf = Vec::new();
+    loop {
+        let mut chunk = [0u8; 4096];
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let headers = String::from_utf8_lossy(&buf);
+    let auth = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("authorization")
+                .then(|| value.trim().to_string())
+        })
+        .unwrap_or_default();
+
+    stream
+        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+        .await?;
+    stream.shutdown().await?;
+
+    Ok(auth)
+}
+
+fn test_server_tls_config() -> Arc<rustls::ServerConfig> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let key_pair = rcgen::KeyPair::generate().expect("generate key");
+    let params = CertificateParams::new(vec!["host.microsandbox.internal".to_string()])
+        .expect("cert params");
+    let cert = params.self_signed(&key_pair).expect("self-sign cert");
+    let chain = vec![CertificateDer::from(cert.der().to_vec())];
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
+    Arc::new(
+        rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(chain, key)
+            .expect("server config"),
+    )
+}
+
+async fn teardown(sb: Sandbox, name: &str) {
+    let _ = sb.stop().await;
+    let _ = Sandbox::remove(name).await;
+}
+
+// Tests
+
+#[msb_test]
+async fn https_connect_proxy_substitutes_secret_in_authorization_header() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut target = TargetHttps::start().await.expect("target fixture");
+    let target_port = target.port();
+    let mut proxy = ConnectProxy::start(target_port)
+        .await
+        .expect("proxy fixture");
+    let proxy_port = proxy.port();
+    let name = "http-connect-secret-auth";
+
+    let sb = Sandbox::builder(name)
+        .image(CURL_IMAGE)
+        .cpus(1)
+        .memory(256)
+        .user("0")
+        .replace()
+        .secret(|s| {
+            s.env("API_KEY")
+                .value(REAL_SECRET)
+                .allow_host("host.microsandbox.internal")
+        })
+        .network(|n| {
+            n.policy(NetworkPolicy::allow_all()).tls(|t| {
+                t.intercepted_ports(vec![target_port])
+                    .verify_upstream(false)
+            })
+        })
+        .create()
+        .await
+        .expect("create sandbox");
+
+    let out = sb
+        .shell(format!(
+            r#"curl -k --http1.1 -m 30 -sS -o /dev/null \
+  -w 'code=%{{http_code}}' \
+  -H "Authorization: Bearer $API_KEY" \
+  --proxytunnel \
+  --proxy http://host.microsandbox.internal:{proxy_port} \
+  https://host.microsandbox.internal:{target_port}/api"#
+        ))
+        .await
+        .expect("curl through connect proxy");
+
+    let stdout = out.stdout().unwrap_or_default();
+    assert!(
+        stdout.contains("code=200"),
+        "expected 200 from target, got: {stdout} (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+
+    let auth = target.received_auth().await.expect("target auth");
+    assert_eq!(
+        auth,
+        format!("Bearer {REAL_SECRET}"),
+        "proxy must substitute placeholder in tunnelled HTTPS request; got: {auth:?}"
+    );
+
+    let _ = proxy.join().await;
+    teardown(sb, name).await;
+}
+
+#[msb_test]
+async fn https_connect_proxy_blocks_secret_for_wrong_host() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut target = TargetHttps::start().await.expect("target fixture");
+    let target_port = target.port();
+    let proxy = ConnectProxy::start(target_port)
+        .await
+        .expect("proxy fixture");
+    let proxy_port = proxy.port();
+    let name = "http-connect-secret-wrong-host";
+
+    let sb = Sandbox::builder(name)
+        .image(CURL_IMAGE)
+        .cpus(1)
+        .memory(256)
+        .user("0")
+        .replace()
+        .secret(|s| {
+            s.env("API_KEY")
+                .value(REAL_SECRET)
+                .allow_host("api.allowed.test")
+        })
+        .network(|n| {
+            n.policy(NetworkPolicy::allow_all()).tls(|t| {
+                t.intercepted_ports(vec![target_port])
+                    .verify_upstream(false)
+            })
+        })
+        .create()
+        .await
+        .expect("create sandbox");
+
+    let out = sb
+        .shell(format!(
+            r#"set +e
+curl -k --http1.1 -m 10 -sS -o /dev/null \
+  -w 'code=%{{http_code}}' \
+  -H "Authorization: Bearer $API_KEY" \
+  --proxytunnel \
+  --proxy http://host.microsandbox.internal:{proxy_port} \
+  https://host.microsandbox.internal:{target_port}/api
+echo "status=$?"
+"#
+        ))
+        .await
+        .expect("curl wrong host");
+
+    let stdout = out.stdout().unwrap_or_default();
+    assert!(
+        !stdout.ends_with("status=0"),
+        "expected curl to fail when secret host does not match tunnel target; got: {stdout:?}"
+    );
+
+    let auth =
+        tokio::time::timeout(std::time::Duration::from_secs(5), target.received_auth()).await;
+    let auth_val = match auth {
+        Ok(Ok(a)) => a,
+        _ => String::new(),
+    };
+    assert!(
+        !auth_val.contains(REAL_SECRET) && !auth_val.contains(PLACEHOLDER),
+        "real secret must not reach target when host does not match; got: {auth_val:?}"
+    );
+
+    drop(proxy);
+    teardown(sb, name).await;
+}

--- a/crates/microsandbox/tests/http_connect_secret.rs
+++ b/crates/microsandbox/tests/http_connect_secret.rs
@@ -343,7 +343,7 @@ echo "status=$?"
 
     let stdout = out.stdout().unwrap_or_default();
     assert!(
-        !stdout.ends_with("status=0"),
+        !stdout.trim_end().ends_with("status=0"),
         "expected curl to fail when secret host does not match tunnel target; got: {stdout:?}"
     );
 

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -23,7 +23,9 @@ use crate::secrets::handler::{
     SecretsHandler, first_line_is_not_http_request, looks_like_http_request_prefix,
 };
 use crate::shared::SharedState;
+use crate::tls::proxy::{TlsProxyContext, tls_proxy_task};
 use crate::tls::sni;
+use crate::tls::state::TlsState;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -31,6 +33,9 @@ use crate::tls::sni;
 
 /// Buffer size for reading from the real server.
 const SERVER_READ_BUF_SIZE: usize = 16384;
+
+/// Max bytes buffered while reading the proxy's CONNECT response headers.
+const CONNECT_RESP_LIMIT: usize = 8192;
 
 /// Max bytes to buffer while peeking for the ClientHello's SNI.
 const PEEK_BUF_SIZE: usize = 16384;
@@ -42,6 +47,25 @@ const PEEK_BUDGET: Duration = Duration::from_secs(5);
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
+
+/// Dial `dst` and update proxy state; wakes the poll thread on failure.
+pub(crate) async fn connect_upstream(
+    dst: SocketAddr,
+    proxy_connect: &ProxyConnectState,
+    shared: &SharedState,
+) -> io::Result<TcpStream> {
+    match TcpStream::connect(dst).await {
+        Ok(s) => {
+            proxy_connect.mark_connected();
+            Ok(s)
+        }
+        Err(e) => {
+            proxy_connect.mark_upstream_connect_failed();
+            shared.proxy_wake.wake();
+            Err(e)
+        }
+    }
+}
 
 /// Spawn a TCP proxy task for a newly established connection.
 ///
@@ -63,6 +87,7 @@ pub fn spawn_tcp_proxy(
     shared: Arc<SharedState>,
     network_policy: Arc<NetworkPolicy>,
     secrets: Arc<SecretsConfig>,
+    tls_state: Option<Arc<TlsState>>,
     proxy_connect: Arc<ProxyConnectState>,
 ) {
     handle.spawn(async move {
@@ -74,6 +99,7 @@ pub fn spawn_tcp_proxy(
             shared,
             network_policy,
             secrets,
+            tls_state,
             proxy_connect,
         )
         .await
@@ -94,6 +120,7 @@ async fn tcp_proxy_task(
     shared: Arc<SharedState>,
     network_policy: Arc<NetworkPolicy>,
     secrets: Arc<SecretsConfig>,
+    tls_state: Option<Arc<TlsState>>,
     proxy_connect: Arc<ProxyConnectState>,
 ) -> io::Result<()> {
     // Pre-connect peek is only for domain policy: the hostname has to be known
@@ -101,7 +128,7 @@ async fn tcp_proxy_task(
     // *not* gate the connect, so they no longer force a peek here — that work is
     // deferred to `classify_first_flight` after the socket is open, where it can
     // run without stalling server-first protocols (see below).
-    let (initial_buf, sni) = if network_policy.has_domain_rules() {
+    let (mut initial_buf, sni) = if network_policy.has_domain_rules() {
         peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await
     } else {
         (Vec::new(), None)
@@ -139,21 +166,33 @@ async fn tcp_proxy_task(
         }
     }
 
+    // Peek for HTTP CONNECT before dialing upstream; hand off if detected.
+    if let Some(tls_state) = tls_state {
+        if initial_buf.is_empty() {
+            let (peeked, _) = peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+            initial_buf = peeked;
+        }
+        if initial_buf.starts_with(b"CONNECT ") {
+            return handle_connect_tunnel(
+                guest_dst,
+                connect_dst,
+                &initial_buf,
+                from_smoltcp,
+                to_smoltcp,
+                shared,
+                network_policy,
+                tls_state,
+                proxy_connect,
+            )
+            .await;
+        }
+    }
+
     // Connect upstream *before* finishing the secrets-side classification. A
     // server-first protocol (SSH, SMTP, a database) sends nothing until it has
     // seen the server's banner; with the socket already open we can relay that
     // banner while we wait, instead of burning the peek budget pre-connect.
-    let stream = match TcpStream::connect(connect_dst).await {
-        Ok(stream) => {
-            proxy_connect.mark_connected();
-            stream
-        }
-        Err(e) => {
-            proxy_connect.mark_upstream_connect_failed();
-            shared.proxy_wake.wake();
-            return Err(e);
-        }
-    };
+    let stream = connect_upstream(connect_dst, &proxy_connect, &shared).await?;
     let (mut server_rx, mut server_tx) = stream.into_split();
 
     // Finish classifying the first flight (TLS vs plain HTTP) and, for
@@ -283,6 +322,118 @@ async fn tcp_proxy_task(
     }
 
     Ok(())
+}
+
+/// Forward an HTTP CONNECT tunnel: dial the proxy, splice the handshake,
+/// then hand the established stream to `tls_proxy_task` for TLS MITM.
+///
+/// `guest_dst` is what the guest dialed; `proxy_dst` is the rewritten
+/// loopback address the gateway actually connects to.
+#[allow(clippy::too_many_arguments)]
+async fn handle_connect_tunnel(
+    guest_dst: SocketAddr,
+    proxy_dst: SocketAddr,
+    connect_req: &[u8],
+    from_smoltcp: mpsc::Receiver<Bytes>,
+    to_smoltcp: mpsc::Sender<Bytes>,
+    shared: Arc<SharedState>,
+    network_policy: Arc<NetworkPolicy>,
+    tls_state: Arc<TlsState>,
+    proxy_connect: Arc<ProxyConnectState>,
+) -> io::Result<()> {
+    if !is_valid_connect_request(connect_req) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "malformed CONNECT request line",
+        ));
+    }
+
+    // Dial the proxy and forward the CONNECT request so it opens the tunnel.
+    let mut proxy_stream = connect_upstream(proxy_dst, &proxy_connect, &shared).await?;
+    proxy_stream.write_all(connect_req).await?;
+    proxy_stream.flush().await?;
+
+    let mut proxy_resp = Vec::with_capacity(256);
+    let mut buf = [0u8; 4096];
+    let header_end = loop {
+        let n = proxy_stream.read(&mut buf).await?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "proxy closed before sending CONNECT response",
+            ));
+        }
+        proxy_resp.extend_from_slice(&buf[..n]);
+        if let Some(end) = headers_end(&proxy_resp) {
+            break end;
+        }
+        if proxy_resp.len() > CONNECT_RESP_LIMIT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "proxy CONNECT response too large",
+            ));
+        }
+    };
+
+    if !proxy_resp[..header_end].windows(3).any(|w| w == b"200") {
+        return Err(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            "proxy rejected CONNECT",
+        ));
+    }
+
+    if to_smoltcp
+        .send(Bytes::copy_from_slice(&proxy_resp[..header_end]))
+        .await
+        .is_err()
+    {
+        return Ok(());
+    }
+    shared.proxy_wake.wake();
+
+    let mut tls_seed = body_after_headers(connect_req).to_vec();
+    tls_seed.extend_from_slice(&proxy_resp[header_end..]);
+
+    tls_proxy_task(
+        TlsProxyContext {
+            guest_dst,
+            connect_dst: proxy_dst,
+            shared,
+            tls_state,
+            network_policy,
+            proxy_connect,
+            upstream_stream: Some(proxy_stream),
+        },
+        from_smoltcp,
+        to_smoltcp,
+        tls_seed,
+    )
+    .await
+}
+
+/// Returns the byte offset just past the `\r\n\r\n` header terminator, or `None`.
+fn headers_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n").map(|p| p + 4)
+}
+
+/// Returns the slice after the `\r\n\r\n` header terminator, or empty if not found.
+fn body_after_headers(buf: &[u8]) -> &[u8] {
+    headers_end(buf).map_or(&[], |end| &buf[end..])
+}
+
+/// Returns `true` if `buf` starts with a valid `CONNECT host:port HTTP/x.y` request line.
+fn is_valid_connect_request(buf: &[u8]) -> bool {
+    let Some(line) = buf.split(|&b| b == b'\n').next() else {
+        return false;
+    };
+    let Ok(line) = std::str::from_utf8(line) else {
+        return false;
+    };
+    let mut parts = line.split_ascii_whitespace();
+    parts
+        .next()
+        .is_some_and(|m| m.eq_ignore_ascii_case("CONNECT"))
+        && parts.next().is_some()
 }
 
 /// Extract the `Host:` header value from an already-buffered HTTP header block.
@@ -942,6 +1093,7 @@ mod tests {
             Arc::new(shared),
             policy,
             secrets,
+            None,
             proxy_connect,
         )
         .await
@@ -981,6 +1133,7 @@ mod tests {
             Arc::new(SharedState::new(4)),
             Arc::new(NetworkPolicy::default()),
             Arc::new(secrets),
+            None,
             proxy_connect,
         )
         .await
@@ -1049,6 +1202,7 @@ mod tests {
             Arc::new(shared),
             Arc::new(NetworkPolicy::default()),
             Arc::new(secrets),
+            None,
             proxy_connect,
         )
         .await
@@ -1148,6 +1302,7 @@ mod tests {
             Arc::new(SharedState::new(4)),
             Arc::new(NetworkPolicy::default()),
             Arc::new(secrets),
+            None,
             proxy_connect,
         )
         .await

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -349,7 +349,14 @@ async fn handle_connect_tunnel(
     }
 
     // Dial the proxy and forward the CONNECT request so it opens the tunnel.
-    let mut proxy_stream = connect_upstream(proxy_dst, &proxy_connect, &shared).await?;
+    let mut proxy_stream = match TcpStream::connect(proxy_dst).await {
+        Ok(s) => s,
+        Err(e) => {
+            proxy_connect.mark_upstream_connect_failed();
+            shared.proxy_wake.wake();
+            return Err(e);
+        }
+    };
     proxy_stream.write_all(connect_req).await?;
     proxy_stream.flush().await?;
 
@@ -375,12 +382,17 @@ async fn handle_connect_tunnel(
         }
     };
 
-    if !proxy_resp[..header_end].windows(3).any(|w| w == b"200") {
+    let status_line = proxy_resp[..header_end]
+        .split(|&b| b == b'\n')
+        .next()
+        .unwrap_or(&[]);
+    if !status_line.windows(4).any(|w| w == b" 200") {
         return Err(io::Error::new(
             io::ErrorKind::ConnectionRefused,
             "proxy rejected CONNECT",
         ));
     }
+    proxy_connect.mark_connected();
 
     if to_smoltcp
         .send(Bytes::copy_from_slice(&proxy_resp[..header_end]))

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -525,6 +525,7 @@ pub fn smoltcp_poll_loop(
                 shared.clone(),
                 network_policy.clone(),
                 secrets.clone(),
+                tls_state.clone(),
                 conn.proxy_connect,
             );
         }

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -19,6 +19,7 @@ use super::sni;
 use super::state::TlsState;
 use crate::conn::ProxyConnectState;
 use crate::policy::{EgressEvaluation, HostnameSource, NetworkPolicy, Protocol};
+use crate::proxy::connect_upstream;
 use crate::secrets::config::ViolationAction;
 use crate::secrets::handler::SecretsHandler;
 use crate::shared::SharedState;
@@ -37,13 +38,15 @@ const RELAY_BUF_SIZE: usize = 16384;
 // Types
 //--------------------------------------------------------------------------------------------------
 
-struct TlsProxyContext {
-    guest_dst: SocketAddr,
-    connect_dst: SocketAddr,
-    shared: Arc<SharedState>,
-    tls_state: Arc<TlsState>,
-    network_policy: Arc<NetworkPolicy>,
-    proxy_connect: Arc<ProxyConnectState>,
+pub(crate) struct TlsProxyContext {
+    pub(crate) guest_dst: SocketAddr,
+    pub(crate) connect_dst: SocketAddr,
+    pub(crate) shared: Arc<SharedState>,
+    pub(crate) tls_state: Arc<TlsState>,
+    pub(crate) network_policy: Arc<NetworkPolicy>,
+    pub(crate) proxy_connect: Arc<ProxyConnectState>,
+    /// Pre-connected upstream; when `Some`, skips dialing `connect_dst`.
+    pub(crate) upstream_stream: Option<TcpStream>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -74,19 +77,21 @@ pub fn spawn_tls_proxy(
             tls_state,
             network_policy,
             proxy_connect,
+            upstream_stream: None,
         };
 
-        if let Err(e) = tls_proxy_task(context, from_smoltcp, to_smoltcp).await {
+        if let Err(e) = tls_proxy_task(context, from_smoltcp, to_smoltcp, Vec::new()).await {
             tracing::debug!(dst = %connect_dst, guest_dst = %guest_dst, error = %e, "TLS proxy task ended");
         }
     });
 }
 
 /// Core TLS proxy task.
-async fn tls_proxy_task(
+pub(crate) async fn tls_proxy_task(
     context: TlsProxyContext,
     mut from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
+    tls_initial_buf: Vec<u8>,
 ) -> io::Result<()> {
     let TlsProxyContext {
         guest_dst,
@@ -95,13 +100,14 @@ async fn tls_proxy_task(
         tls_state,
         network_policy,
         proxy_connect,
+        upstream_stream,
     } = context;
 
-    // Phase 0: Buffer initial data to extract SNI from ClientHello.
-    // Timeout prevents a slow/malicious guest from holding a proxy slot indefinitely.
+    // Buffer initial data to extract SNI from ClientHello. Timeout prevents a
+    // slow/malicious guest from holding a proxy slot indefinitely.
     let sni_name = tokio::time::timeout(
         std::time::Duration::from_secs(10),
-        extract_sni_from_channel(&mut from_smoltcp),
+        extract_sni_from_channel(&mut from_smoltcp, tls_initial_buf),
     )
     .await
     .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "SNI extraction timed out"))?;
@@ -137,6 +143,7 @@ async fn tls_proxy_task(
             to_smoltcp,
             shared,
             proxy_connect,
+            upstream_stream,
         )
         .await
     } else {
@@ -151,6 +158,7 @@ async fn tls_proxy_task(
             shared,
             tls_state,
             proxy_connect,
+            upstream_stream,
         )
         .await
     }
@@ -164,17 +172,11 @@ async fn bypass_relay(
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
     proxy_connect: Arc<ProxyConnectState>,
+    upstream_stream: Option<TcpStream>,
 ) -> io::Result<()> {
-    let mut server = match TcpStream::connect(dst).await {
-        Ok(server) => {
-            proxy_connect.mark_connected();
-            server
-        }
-        Err(e) => {
-            proxy_connect.mark_upstream_connect_failed();
-            shared.proxy_wake.wake();
-            return Err(e);
-        }
+    let mut server = match upstream_stream {
+        Some(s) => s,
+        None => connect_upstream(dst, &proxy_connect, &shared).await?,
     };
     server.write_all(&initial_buf).await?;
 
@@ -209,7 +211,7 @@ async fn bypass_relay(
 
 /// Intercept mode: MITM with guest-facing rustls + server-facing tokio_rustls.
 #[allow(clippy::too_many_arguments)]
-async fn intercept_relay(
+pub(crate) async fn intercept_relay(
     guest_dst: SocketAddr,
     connect_dst: SocketAddr,
     sni_name: &str,
@@ -219,6 +221,7 @@ async fn intercept_relay(
     shared: Arc<SharedState>,
     tls_state: Arc<TlsState>,
     proxy_connect: Arc<ProxyConnectState>,
+    upstream_stream: Option<TcpStream>,
 ) -> io::Result<()> {
     let mut secrets_handler =
         SecretsHandler::new_tls_intercepted(&tls_state.secrets, sni_name, guest_dst.ip(), &shared)
@@ -272,16 +275,9 @@ async fn intercept_relay(
     .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "TLS handshake timed out"))??;
 
     // Connect to real server with TLS.
-    let server_stream = match TcpStream::connect(connect_dst).await {
-        Ok(stream) => {
-            proxy_connect.mark_connected();
-            stream
-        }
-        Err(e) => {
-            proxy_connect.mark_upstream_connect_failed();
-            shared.proxy_wake.wake();
-            return Err(e);
-        }
+    let server_stream = match upstream_stream {
+        Some(s) => s,
+        None => connect_upstream(connect_dst, &proxy_connect, &shared).await?,
     };
     let server_name = ServerName::try_from(sni_name.to_string())
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
@@ -357,11 +353,26 @@ async fn intercept_relay(
 }
 
 /// Buffer channel data until a complete ClientHello with SNI is received.
-async fn extract_sni_from_channel(
+///
+/// `seed` carries bytes already read from the channel before this call
+/// (e.g. bytes trailing a CONNECT request). Pass an empty `Vec` when no
+/// bytes have been pre-consumed.
+pub(crate) async fn extract_sni_from_channel(
     from_smoltcp: &mut mpsc::Receiver<Bytes>,
+    seed: Vec<u8>,
 ) -> io::Result<(String, Vec<u8>)> {
-    let mut initial_buf = Vec::with_capacity(CLIENT_HELLO_BUF_SIZE);
+    let mut initial_buf = seed;
+    initial_buf.reserve(CLIENT_HELLO_BUF_SIZE.saturating_sub(initial_buf.len()));
     loop {
+        if let Some(name) = sni::extract_sni(&initial_buf) {
+            return Ok((name, initial_buf));
+        }
+        if initial_buf.len() >= CLIENT_HELLO_BUF_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "ClientHello too large or no SNI found",
+            ));
+        }
         let data = from_smoltcp
             .recv()
             .await


### PR DESCRIPTION
Closes #752

## Summary

When a guest uses a plain-HTTP forward proxy (`HTTPS_PROXY=http://proxy:port`), curl sends `CONNECT host:443` over plain TCP. The gateway had no CONNECT detection so the inner HTTPS was never intercepted and secret placeholders passed through unsubstituted.

## Implementation

Detects `CONNECT` in `tcp_proxy_task` before dialing upstream, forwards the handshake to the proxy via `handle_connect_tunnel`, then hands the established stream to `tls_proxy_task` as a pre-connected upstream via `upstream_stream: Option<TcpStream>` on `TlsProxyContext`. The upstream dial pattern is extracted into a shared `connect_upstream` helper. Two e2e tests cover the substitution and wrong-host blocking cases.
