### PR TITLE
fix(network): harden CONNECT secret boundaries

### DIFF
--- a/crates/microsandbox/tests/http_connect_secret.rs
+++ b/crates/microsandbox/tests/http_connect_secret.rs
@@ -33,15 +33,25 @@ struct TargetHttps {
     handle: Option<JoinHandle<io::Result<String>>>,
 }
 
+/// Minimal proxy fixture that records a `Proxy-Authorization` CONNECT header.
+struct ProxyAuthCapture {
+    port: u16,
+    handle: Option<JoinHandle<io::Result<Option<String>>>>,
+}
+
 // Methods
 
 impl ConnectProxy {
     async fn start(target_port: u16) -> io::Result<Self> {
-        let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
-        let port = listener.local_addr()?.port();
+        let v4 = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+        let port = v4.local_addr()?.port();
+        let v6 = TcpListener::bind(SocketAddr::from((Ipv6Addr::LOCALHOST, port))).await?;
 
         let handle = tokio::spawn(async move {
-            let (client, _) = listener.accept().await?;
+            let (client, _) = tokio::select! {
+                a = v4.accept() => a?,
+                a = v6.accept() => a?,
+            };
             handle_connect(client, target_port).await
         });
 
@@ -115,6 +125,47 @@ impl Drop for TargetHttps {
     }
 }
 
+impl ProxyAuthCapture {
+    async fn start() -> io::Result<Self> {
+        let v4 = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+        let port = v4.local_addr()?.port();
+        let v6 = TcpListener::bind(SocketAddr::from((Ipv6Addr::LOCALHOST, port))).await?;
+
+        let handle = tokio::spawn(async move {
+            let (client, _) = tokio::select! {
+                a = v4.accept() => a?,
+                a = v6.accept() => a?,
+            };
+            read_proxy_auth_header(client).await
+        });
+
+        Ok(Self {
+            port,
+            handle: Some(handle),
+        })
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
+
+    async fn try_received_auth(&mut self, timeout: std::time::Duration) -> Option<String> {
+        let handle = self.handle.take().expect("proxy fixture already consumed");
+        match tokio::time::timeout(timeout, handle).await {
+            Ok(joined) => joined.ok().and_then(|res| res.ok()).flatten(),
+            Err(_) => None,
+        }
+    }
+}
+
+impl Drop for ProxyAuthCapture {
+    fn drop(&mut self) {
+        if let Some(h) = self.handle.take() {
+            h.abort();
+        }
+    }
+}
+
 // Functions
 
 async fn handle_connect(client: TcpStream, target_port: u16) -> io::Result<()> {
@@ -145,20 +196,33 @@ async fn handle_connect(client: TcpStream, target_port: u16) -> io::Result<()> {
         target
     };
 
-    let upstream = TcpStream::connect(&connect_addr).await?;
+    let mut upstream = TcpStream::connect(&connect_addr).await?;
+    let buffered_client_bytes = reader.buffer().to_vec();
 
     let mut client_write = write_half;
     client_write
         .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
         .await?;
+    if !buffered_client_bytes.is_empty() {
+        upstream.write_all(&buffered_client_bytes).await?;
+    }
 
     let mut client_read = reader.into_inner();
     let (mut up_read, mut up_write) = upstream.into_split();
 
-    tokio::try_join!(
-        tokio::io::copy(&mut client_read, &mut up_write),
-        tokio::io::copy(&mut up_read, &mut client_write),
-    )?;
+    let client_to_upstream = tokio::io::copy(&mut client_read, &mut up_write);
+    let upstream_to_client = tokio::io::copy(&mut up_read, &mut client_write);
+    tokio::pin!(client_to_upstream);
+    tokio::pin!(upstream_to_client);
+
+    tokio::select! {
+        result = &mut client_to_upstream => {
+            result?;
+        }
+        result = &mut upstream_to_client => {
+            result?;
+        }
+    }
 
     Ok(())
 }
@@ -171,6 +235,32 @@ fn parse_connect_target(line: &str) -> Option<String> {
         return None;
     }
     Some(target.to_string())
+}
+
+async fn read_proxy_auth_header(client: TcpStream) -> io::Result<Option<String>> {
+    let mut reader = BufReader::new(client);
+    let mut proxy_auth = None;
+
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).await?;
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = trimmed.split_once(':')
+            && name.eq_ignore_ascii_case("proxy-authorization")
+        {
+            proxy_auth = Some(value.trim().to_string());
+        }
+    }
+
+    reader
+        .into_inner()
+        .write_all(b"HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: 0\r\n\r\n")
+        .await?;
+
+    Ok(proxy_auth)
 }
 
 async fn received_auth_header(
@@ -276,11 +366,21 @@ async fn https_connect_proxy_substitutes_secret_in_authorization_header() {
         .expect("curl through connect proxy");
 
     let stdout = out.stdout().unwrap_or_default();
-    assert!(
-        stdout.contains("code=200"),
-        "expected 200 from target, got: {stdout} (stderr: {})",
-        out.stderr().unwrap_or_default()
-    );
+    if !stdout.contains("code=200") {
+        let proxy_status = tokio::time::timeout(std::time::Duration::from_secs(3), proxy.join())
+            .await
+            .map_err(|_| "proxy timed out".to_string())
+            .and_then(|res| res.map_err(|err| err.to_string()));
+        let target_auth =
+            tokio::time::timeout(std::time::Duration::from_secs(3), target.received_auth())
+                .await
+                .map_err(|_| "target timed out".to_string())
+                .and_then(|res| res.map_err(|err| err.to_string()));
+        panic!(
+            "expected 200 from target, got: {stdout} (stderr: {}), proxy={proxy_status:?}, target={target_auth:?}",
+            out.stderr().unwrap_or_default()
+        );
+    }
 
     let auth = target.received_auth().await.expect("target auth");
     assert_eq!(
@@ -359,5 +459,138 @@ echo "status=$?"
     );
 
     drop(proxy);
+    teardown(sb, name).await;
+}
+
+#[msb_test]
+async fn https_connect_proxy_leaves_non_intercepted_target_port_opaque() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut target = TargetHttps::start().await.expect("target fixture");
+    let target_port = target.port();
+    let mut proxy = ConnectProxy::start(target_port)
+        .await
+        .expect("proxy fixture");
+    let proxy_port = proxy.port();
+    let intercepted_port = if target_port == 443 { 444 } else { 443 };
+    let name = "http-connect-secret-non-intercepted";
+
+    let sb = Sandbox::builder(name)
+        .image(CURL_IMAGE)
+        .cpus(1)
+        .memory(256)
+        .user("0")
+        .replace()
+        .secret(|s| {
+            s.env("API_KEY")
+                .value(REAL_SECRET)
+                .allow_host("host.microsandbox.internal")
+        })
+        .network(|n| {
+            n.policy(NetworkPolicy::allow_all()).tls(|t| {
+                t.intercepted_ports(vec![intercepted_port])
+                    .verify_upstream(false)
+            })
+        })
+        .create()
+        .await
+        .expect("create sandbox");
+
+    let out = sb
+        .shell(format!(
+            r#"curl -k --http1.1 -m 30 -sS -o /dev/null \
+  -w 'code=%{{http_code}}' \
+  -H "Authorization: Bearer $API_KEY" \
+  --proxytunnel \
+  --proxy http://host.microsandbox.internal:{proxy_port} \
+  https://host.microsandbox.internal:{target_port}/api"#
+        ))
+        .await
+        .expect("curl through connect proxy");
+
+    let stdout = out.stdout().unwrap_or_default();
+    if !stdout.contains("code=200") {
+        let proxy_status = tokio::time::timeout(std::time::Duration::from_secs(3), proxy.join())
+            .await
+            .map_err(|_| "proxy timed out".to_string())
+            .and_then(|res| res.map_err(|err| err.to_string()));
+        let target_auth =
+            tokio::time::timeout(std::time::Duration::from_secs(3), target.received_auth())
+                .await
+                .map_err(|_| "target timed out".to_string())
+                .and_then(|res| res.map_err(|err| err.to_string()));
+        panic!(
+            "expected 200 from opaque target tunnel, got: {stdout} (stderr: {}), proxy={proxy_status:?}, target={target_auth:?}",
+            out.stderr().unwrap_or_default()
+        );
+    }
+
+    let auth = target.received_auth().await.expect("target auth");
+    assert!(
+        auth.contains(PLACEHOLDER),
+        "non-intercepted target port must receive the placeholder unchanged; got: {auth:?}"
+    );
+    assert!(
+        !auth.contains(REAL_SECRET),
+        "non-intercepted target port must not receive the real secret; got: {auth:?}"
+    );
+
+    let _ = proxy.join().await;
+    teardown(sb, name).await;
+}
+
+#[msb_test]
+async fn https_connect_proxy_blocks_secret_in_outer_connect_headers() {
+    let mut proxy = ProxyAuthCapture::start()
+        .await
+        .expect("proxy capture fixture");
+    let proxy_port = proxy.port();
+    let name = "http-connect-secret-outer-header";
+
+    let sb = Sandbox::builder(name)
+        .image(CURL_IMAGE)
+        .cpus(1)
+        .memory(256)
+        .user("0")
+        .replace()
+        .secret(|s| {
+            s.env("API_KEY")
+                .value(REAL_SECRET)
+                .allow_host("host.microsandbox.internal")
+        })
+        .network(|n| n.policy(NetworkPolicy::allow_all()))
+        .create()
+        .await
+        .expect("create sandbox");
+
+    let out = sb
+        .shell(format!(
+            r#"set +e
+curl -k --http1.1 -m 10 -sS -o /dev/null \
+  --proxytunnel \
+  --proxy http://host.microsandbox.internal:{proxy_port} \
+  --proxy-header "Proxy-Authorization: Bearer $API_KEY" \
+  https://example.com/
+echo "status=$?"
+"#
+        ))
+        .await
+        .expect("curl through connect proxy");
+
+    let stdout = out.stdout().unwrap_or_default();
+    assert!(
+        !stdout.trim_end().ends_with("status=0"),
+        "expected curl to fail when the outer CONNECT header carries a protected placeholder; got: {stdout:?}"
+    );
+
+    let proxy_auth = proxy
+        .try_received_auth(std::time::Duration::from_secs(5))
+        .await
+        .unwrap_or_default();
+    assert!(
+        !proxy_auth.contains(PLACEHOLDER) && !proxy_auth.contains(REAL_SECRET),
+        "CONNECT proxy must not receive a raw placeholder or real secret in outer headers; got: {proxy_auth:?}"
+    );
+
     teardown(sb, name).await;
 }

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -649,61 +649,8 @@ fn sanitize_connect_headers<'a>(
         return Ok(Cow::Borrowed(header_bytes));
     }
 
-    let mut handler = SecretsHandler::new_plain_http_invalid_host(secrets);
-    match handler.substitute(header_bytes) {
-        Ok(headers) => Ok(headers),
-        Err(action) => {
-            let Some(stripped) = strip_placeholder_header_lines(header_bytes, secrets) else {
-                return Err(action);
-            };
-            let mut handler = SecretsHandler::new_plain_http_invalid_host(secrets);
-            handler
-                .substitute(&stripped)
-                .map(|headers| Cow::Owned(headers.into_owned()))
-        }
-    }
-}
-
-fn strip_placeholder_header_lines(headers: &[u8], secrets: &SecretsConfig) -> Option<Vec<u8>> {
-    let mut out = Vec::with_capacity(headers.len());
-    let mut cursor = 0;
-    let mut first_line = true;
-    let mut stripped = false;
-
-    while cursor < headers.len() {
-        let Some(relative_end) = headers[cursor..].windows(2).position(|w| w == b"\r\n") else {
-            out.extend_from_slice(&headers[cursor..]);
-            break;
-        };
-        let line_end = cursor + relative_end;
-        let line = &headers[cursor..line_end];
-        let line_with_crlf = &headers[cursor..line_end + 2];
-        cursor = line_end + 2;
-
-        if first_line || line.is_empty() || !line_contains_secret_placeholder(line, secrets) {
-            out.extend_from_slice(line_with_crlf);
-        } else {
-            stripped = true;
-        }
-        first_line = false;
-    }
-
-    stripped.then_some(out)
-}
-
-fn line_contains_secret_placeholder(line: &[u8], secrets: &SecretsConfig) -> bool {
-    secrets.secrets.iter().any(|secret| {
-        !secret.placeholder.is_empty() && contains_bytes(line, secret.placeholder.as_bytes())
-    })
-}
-
-fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
-    if needle.is_empty() || haystack.len() < needle.len() {
-        return false;
-    }
-    haystack
-        .windows(needle.len())
-        .any(|window| window == needle)
+    let mut handler = SecretsHandler::new_plain_http_untrusted_metadata(secrets);
+    handler.substitute(header_bytes)
 }
 
 /// Returns the byte offset just past the `\r\n\r\n` header terminator, or `None`.
@@ -1536,15 +1483,40 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_connect_headers_strips_placeholder_metadata_header() {
+    fn sanitize_connect_headers_blocks_placeholder_metadata_header_by_default() {
         let secrets = make_host_bound_secret("$MSB_KEY", "real-secret-value", "example.com");
         let headers = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nProxy-Authorization: Bearer $MSB_KEY\r\nUser-Agent: curl\r\n\r\n";
 
-        let sanitized = sanitize_connect_headers(headers, &secrets).unwrap();
+        assert_eq!(
+            sanitize_connect_headers(headers, &secrets),
+            Err(ViolationAction::BlockAndLog)
+        );
+    }
+
+    #[test]
+    fn sanitize_connect_headers_respects_block_and_terminate() {
+        let mut secrets = make_host_bound_secret("$MSB_KEY", "real-secret-value", "example.com");
+        secrets.on_violation = ViolationAction::BlockAndTerminate;
+        let headers = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nProxy-Authorization: Bearer $MSB_KEY\r\n\r\n";
 
         assert_eq!(
-            sanitized.as_ref(),
-            b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nUser-Agent: curl\r\n\r\n"
+            sanitize_connect_headers(headers, &secrets),
+            Err(ViolationAction::BlockAndTerminate)
+        );
+    }
+
+    #[test]
+    fn sanitize_connect_headers_respects_explicit_passthrough() {
+        let mut secrets = make_host_bound_secret("$MSB_KEY", "real-secret-value", "example.com");
+        secrets.on_violation = ViolationAction::Passthrough(vec![HostPattern::Any]);
+        let headers = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nProxy-Authorization: Bearer $MSB_KEY\r\n\r\n";
+
+        let sanitized = sanitize_connect_headers(headers, &secrets).unwrap();
+
+        assert_eq!(sanitized.as_ref(), headers);
+        assert!(
+            !String::from_utf8_lossy(sanitized.as_ref()).contains("real-secret-value"),
+            "passthrough must never substitute real secrets into CONNECT metadata"
         );
     }
 

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -7,7 +7,7 @@
 
 use std::borrow::Cow;
 use std::io;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -43,6 +43,73 @@ const PEEK_BUF_SIZE: usize = 16384;
 /// Upper bound on time spent buffering the first flight before
 /// falling back to a cache-only egress decision.
 const PEEK_BUDGET: Duration = Duration::from_secs(5);
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct ConnectRequest {
+    bytes: Vec<u8>,
+    header_end: usize,
+    target: ConnectTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConnectTarget {
+    host: String,
+    port: u16,
+    expected_sni: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ConnectRequest {
+    fn header_bytes(&self) -> &[u8] {
+        &self.bytes[..self.header_end]
+    }
+
+    fn post_header_bytes(&self) -> &[u8] {
+        &self.bytes[self.header_end..]
+    }
+}
+
+impl ConnectTarget {
+    fn is_intercepted(&self, tls_state: &TlsState) -> bool {
+        tls_state.config.intercepted_ports.contains(&self.port)
+    }
+
+    fn guest_dst(&self, fallback: SocketAddr, shared: &SharedState) -> SocketAddr {
+        if let Ok(ip) = self.host.parse::<IpAddr>() {
+            return SocketAddr::new(ip, self.port);
+        }
+
+        if self.host.eq_ignore_ascii_case(crate::HOST_ALIAS) {
+            match fallback.ip() {
+                IpAddr::V4(_) => {
+                    if let Some(ip) = shared.gateway_ipv4() {
+                        return SocketAddr::new(IpAddr::V4(ip), self.port);
+                    }
+                }
+                IpAddr::V6(_) => {
+                    if let Some(ip) = shared.gateway_ipv6() {
+                        return SocketAddr::new(IpAddr::V6(ip), self.port);
+                    }
+                }
+            }
+            if let Some(ip) = shared.gateway_ipv4() {
+                return SocketAddr::new(IpAddr::V4(ip), self.port);
+            }
+            if let Some(ip) = shared.gateway_ipv6() {
+                return SocketAddr::new(IpAddr::V6(ip), self.port);
+            }
+        }
+
+        SocketAddr::new(fallback.ip(), self.port)
+    }
+}
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -172,11 +239,11 @@ async fn tcp_proxy_task(
             let (peeked, _) = peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await;
             initial_buf = peeked;
         }
-        if initial_buf.starts_with(b"CONNECT ") {
+        if could_be_connect_request(&initial_buf) {
             return handle_connect_tunnel(
                 guest_dst,
                 connect_dst,
-                &initial_buf,
+                initial_buf,
                 from_smoltcp,
                 to_smoltcp,
                 shared,
@@ -333,20 +400,30 @@ async fn tcp_proxy_task(
 async fn handle_connect_tunnel(
     guest_dst: SocketAddr,
     proxy_dst: SocketAddr,
-    connect_req: &[u8],
-    from_smoltcp: mpsc::Receiver<Bytes>,
+    initial_buf: Vec<u8>,
+    mut from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
     network_policy: Arc<NetworkPolicy>,
     tls_state: Arc<TlsState>,
     proxy_connect: Arc<ProxyConnectState>,
 ) -> io::Result<()> {
-    if !is_valid_connect_request(connect_req) {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "malformed CONNECT request line",
-        ));
-    }
+    let connect_req =
+        parse_connect_request(buffer_connect_request(initial_buf, &mut from_smoltcp).await?)?;
+
+    let connect_headers = match sanitize_connect_headers(
+        connect_req.header_bytes(),
+        &tls_state.secrets,
+    ) {
+        Ok(headers) => headers,
+        Err(action) => {
+            tracing::warn!(dst = %proxy_dst, violation = ?action, "secret violation in CONNECT headers");
+            if matches!(action, ViolationAction::BlockAndTerminate) {
+                shared.trigger_termination();
+            }
+            return Ok(());
+        }
+    };
 
     // Dial the proxy and forward the CONNECT request so it opens the tunnel.
     let mut proxy_stream = match TcpStream::connect(proxy_dst).await {
@@ -357,39 +434,55 @@ async fn handle_connect_tunnel(
             return Err(e);
         }
     };
-    proxy_stream.write_all(connect_req).await?;
+
+    if !connect_req.target.is_intercepted(&tls_state) {
+        proxy_stream.write_all(&connect_headers).await?;
+        proxy_stream.flush().await?;
+        let (proxy_resp, header_end) = read_connect_response_headers(&mut proxy_stream).await?;
+        if to_smoltcp
+            .send(Bytes::copy_from_slice(&proxy_resp[..header_end]))
+            .await
+            .is_err()
+        {
+            return Ok(());
+        }
+        if !proxy_resp[header_end..].is_empty()
+            && to_smoltcp
+                .send(Bytes::copy_from_slice(&proxy_resp[header_end..]))
+                .await
+                .is_err()
+        {
+            return Ok(());
+        }
+        shared.proxy_wake.wake();
+        if !connect_response_is_success(&proxy_resp[..header_end]) {
+            proxy_connect.mark_connected();
+            return Ok(());
+        }
+        if !connect_req.post_header_bytes().is_empty() {
+            proxy_stream
+                .write_all(connect_req.post_header_bytes())
+                .await?;
+        }
+        proxy_stream.flush().await?;
+        proxy_connect.mark_connected();
+        return relay_connected_stream(proxy_stream, from_smoltcp, to_smoltcp, shared).await;
+    }
+
+    proxy_stream.write_all(&connect_headers).await?;
     proxy_stream.flush().await?;
 
-    let mut proxy_resp = Vec::with_capacity(256);
-    let mut buf = [0u8; 4096];
-    let header_end = loop {
-        let n = proxy_stream.read(&mut buf).await?;
-        if n == 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "proxy closed before sending CONNECT response",
-            ));
-        }
-        proxy_resp.extend_from_slice(&buf[..n]);
-        if let Some(end) = headers_end(&proxy_resp) {
-            break end;
-        }
-        if proxy_resp.len() > CONNECT_RESP_LIMIT {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "proxy CONNECT response too large",
-            ));
-        }
-    };
-
-    let status_line = proxy_resp[..header_end]
-        .split(|&b| b == b'\n')
-        .next()
-        .unwrap_or(&[]);
-    if !status_line.windows(4).any(|w| w == b" 200") {
+    let (proxy_resp, header_end) = read_connect_response_headers(&mut proxy_stream).await?;
+    if !connect_response_is_success(&proxy_resp[..header_end]) {
         return Err(io::Error::new(
             io::ErrorKind::ConnectionRefused,
             "proxy rejected CONNECT",
+        ));
+    }
+    if !proxy_resp[header_end..].is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "proxy sent unexpected bytes after CONNECT response headers",
         ));
     }
     proxy_connect.mark_connected();
@@ -403,18 +496,20 @@ async fn handle_connect_tunnel(
     }
     shared.proxy_wake.wake();
 
-    let mut tls_seed = body_after_headers(connect_req).to_vec();
-    tls_seed.extend_from_slice(&proxy_resp[header_end..]);
+    let tls_seed = connect_req.post_header_bytes().to_vec();
+    let tls_guest_dst = connect_req.target.guest_dst(guest_dst, &shared);
+    let expected_sni = connect_req.target.expected_sni.clone();
 
     tls_proxy_task(
         TlsProxyContext {
-            guest_dst,
+            guest_dst: tls_guest_dst,
             connect_dst: proxy_dst,
             shared,
             tls_state,
             network_policy,
             proxy_connect,
             upstream_stream: Some(proxy_stream),
+            expected_sni,
         },
         from_smoltcp,
         to_smoltcp,
@@ -423,29 +518,322 @@ async fn handle_connect_tunnel(
     .await
 }
 
+/// Relay an established TCP stream without inspecting or substituting bytes.
+async fn relay_connected_stream(
+    stream: TcpStream,
+    mut from_smoltcp: mpsc::Receiver<Bytes>,
+    to_smoltcp: mpsc::Sender<Bytes>,
+    shared: Arc<SharedState>,
+) -> io::Result<()> {
+    let (mut server_rx, mut server_tx) = stream.into_split();
+    let mut server_buf = vec![0u8; SERVER_READ_BUF_SIZE];
+
+    loop {
+        tokio::select! {
+            data = from_smoltcp.recv() => {
+                match data {
+                    Some(bytes) => {
+                        server_tx.write_all(&bytes).await?;
+                        server_tx.flush().await?;
+                    }
+                    None => break,
+                }
+            }
+            result = server_rx.read(&mut server_buf) => {
+                match result {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        if to_smoltcp
+                            .send(Bytes::copy_from_slice(&server_buf[..n]))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                        shared.proxy_wake.wake();
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn buffer_connect_request(
+    mut buf: Vec<u8>,
+    from_smoltcp: &mut mpsc::Receiver<Bytes>,
+) -> io::Result<Vec<u8>> {
+    let timeout_fut = tokio::time::sleep(PEEK_BUDGET);
+    tokio::pin!(timeout_fut);
+
+    loop {
+        if !could_be_connect_request(&buf) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "malformed CONNECT request prefix",
+            ));
+        }
+        if headers_end(&buf).is_some() {
+            return Ok(buf);
+        }
+        if buf.len() >= PEEK_BUF_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "CONNECT request headers too large",
+            ));
+        }
+
+        tokio::select! {
+            biased;
+            _ = &mut timeout_fut => {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out waiting for complete CONNECT request headers",
+                ));
+            }
+            data = from_smoltcp.recv() => match data {
+                Some(bytes) => {
+                    buf.extend_from_slice(&bytes);
+                }
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "channel closed before complete CONNECT request headers",
+                    ));
+                }
+            }
+        }
+    }
+}
+
+async fn read_connect_response_headers(stream: &mut TcpStream) -> io::Result<(Vec<u8>, usize)> {
+    tokio::time::timeout(PEEK_BUDGET, async {
+        let mut proxy_resp = Vec::with_capacity(256);
+        let mut buf = [0u8; 4096];
+        loop {
+            let n = stream.read(&mut buf).await?;
+            if n == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "proxy closed before sending CONNECT response",
+                ));
+            }
+            proxy_resp.extend_from_slice(&buf[..n]);
+            if let Some(end) = headers_end(&proxy_resp) {
+                return Ok((proxy_resp, end));
+            }
+            if proxy_resp.len() > CONNECT_RESP_LIMIT {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "proxy CONNECT response too large",
+                ));
+            }
+        }
+    })
+    .await
+    .map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::TimedOut,
+            "timed out waiting for proxy CONNECT response",
+        )
+    })?
+}
+
+fn sanitize_connect_headers<'a>(
+    header_bytes: &'a [u8],
+    secrets: &SecretsConfig,
+) -> Result<Cow<'a, [u8]>, ViolationAction> {
+    if secrets.secrets.is_empty() {
+        return Ok(Cow::Borrowed(header_bytes));
+    }
+
+    let mut handler = SecretsHandler::new_plain_http_invalid_host(secrets);
+    match handler.substitute(header_bytes) {
+        Ok(headers) => Ok(headers),
+        Err(action) => {
+            let Some(stripped) = strip_placeholder_header_lines(header_bytes, secrets) else {
+                return Err(action);
+            };
+            let mut handler = SecretsHandler::new_plain_http_invalid_host(secrets);
+            handler
+                .substitute(&stripped)
+                .map(|headers| Cow::Owned(headers.into_owned()))
+        }
+    }
+}
+
+fn strip_placeholder_header_lines(headers: &[u8], secrets: &SecretsConfig) -> Option<Vec<u8>> {
+    let mut out = Vec::with_capacity(headers.len());
+    let mut cursor = 0;
+    let mut first_line = true;
+    let mut stripped = false;
+
+    while cursor < headers.len() {
+        let Some(relative_end) = headers[cursor..].windows(2).position(|w| w == b"\r\n") else {
+            out.extend_from_slice(&headers[cursor..]);
+            break;
+        };
+        let line_end = cursor + relative_end;
+        let line = &headers[cursor..line_end];
+        let line_with_crlf = &headers[cursor..line_end + 2];
+        cursor = line_end + 2;
+
+        if first_line || line.is_empty() || !line_contains_secret_placeholder(line, secrets) {
+            out.extend_from_slice(line_with_crlf);
+        } else {
+            stripped = true;
+        }
+        first_line = false;
+    }
+
+    stripped.then_some(out)
+}
+
+fn line_contains_secret_placeholder(line: &[u8], secrets: &SecretsConfig) -> bool {
+    secrets.secrets.iter().any(|secret| {
+        !secret.placeholder.is_empty() && contains_bytes(line, secret.placeholder.as_bytes())
+    })
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return false;
+    }
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}
+
 /// Returns the byte offset just past the `\r\n\r\n` header terminator, or `None`.
 fn headers_end(buf: &[u8]) -> Option<usize> {
     buf.windows(4).position(|w| w == b"\r\n\r\n").map(|p| p + 4)
 }
 
-/// Returns the slice after the `\r\n\r\n` header terminator, or empty if not found.
-fn body_after_headers(buf: &[u8]) -> &[u8] {
-    headers_end(buf).map_or(&[], |end| &buf[end..])
+fn could_be_connect_request(buf: &[u8]) -> bool {
+    const PREFIX: &[u8] = b"CONNECT ";
+    if buf.is_empty() {
+        return false;
+    }
+    let n = buf.len().min(PREFIX.len());
+    buf[..n].eq_ignore_ascii_case(&PREFIX[..n])
 }
 
-/// Returns `true` if `buf` starts with a valid `CONNECT host:port HTTP/x.y` request line.
-fn is_valid_connect_request(buf: &[u8]) -> bool {
-    let Some(line) = buf.split(|&b| b == b'\n').next() else {
+fn parse_connect_request(bytes: Vec<u8>) -> io::Result<ConnectRequest> {
+    let header_end = headers_end(&bytes).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "incomplete CONNECT request headers",
+        )
+    })?;
+    let target = {
+        let request_line = bytes[..header_end]
+            .split(|&b| b == b'\n')
+            .next()
+            .unwrap_or(&[]);
+        let request_line = std::str::from_utf8(request_line)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "CONNECT line is not UTF-8"))?
+            .trim_end_matches('\r');
+        let mut parts = request_line.split_ascii_whitespace();
+        let method = parts.next().unwrap_or_default();
+        let authority = parts.next().unwrap_or_default();
+        let version = parts.next().unwrap_or_default();
+        if !method.eq_ignore_ascii_case("CONNECT")
+            || authority.is_empty()
+            || !is_http_version(version)
+            || parts.next().is_some()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "malformed CONNECT request line",
+            ));
+        }
+        parse_connect_target(authority)?
+    };
+
+    Ok(ConnectRequest {
+        bytes,
+        header_end,
+        target,
+    })
+}
+
+fn parse_connect_target(authority: &str) -> io::Result<ConnectTarget> {
+    let authority = authority.trim();
+    let (host, port) = if let Some(rest) = authority.strip_prefix('[') {
+        let (host, rest) = rest.split_once(']').ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "malformed CONNECT IPv6 authority",
+            )
+        })?;
+        let port = rest.strip_prefix(':').ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "CONNECT authority missing port")
+        })?;
+        (host, port)
+    } else {
+        let (host, port) = authority.rsplit_once(':').ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "CONNECT authority missing port")
+        })?;
+        if host.contains(':') {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "CONNECT IPv6 authority must be bracketed",
+            ));
+        }
+        (host, port)
+    };
+    let host = host.trim().trim_end_matches('.');
+    if host.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "CONNECT authority missing host",
+        ));
+    }
+    let port = port
+        .parse::<u16>()
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid CONNECT port"))?;
+    let expected_sni = host
+        .parse::<IpAddr>()
+        .is_err()
+        .then(|| host.to_ascii_lowercase());
+
+    Ok(ConnectTarget {
+        host: host.to_ascii_lowercase(),
+        port,
+        expected_sni,
+    })
+}
+
+fn is_http_version(version: &str) -> bool {
+    let Some(version) = version.strip_prefix("HTTP/") else {
         return false;
     };
-    let Ok(line) = std::str::from_utf8(line) else {
+    let Some((major, minor)) = version.split_once('.') else {
         return false;
     };
-    let mut parts = line.split_ascii_whitespace();
-    parts
-        .next()
-        .is_some_and(|m| m.eq_ignore_ascii_case("CONNECT"))
-        && parts.next().is_some()
+    !major.is_empty()
+        && !minor.is_empty()
+        && major.bytes().all(|b| b.is_ascii_digit())
+        && minor.bytes().all(|b| b.is_ascii_digit())
+}
+
+fn connect_response_is_success(headers: &[u8]) -> bool {
+    let Some(status_line) = headers.split(|&b| b == b'\n').next() else {
+        return false;
+    };
+    let Ok(status_line) = std::str::from_utf8(status_line) else {
+        return false;
+    };
+    let mut parts = status_line.trim_end_matches('\r').split_ascii_whitespace();
+    let version = parts.next().unwrap_or_default();
+    let status = parts.next().unwrap_or_default();
+    is_http_version(version)
+        && status.len() == 3
+        && status
+            .parse::<u16>()
+            .is_ok_and(|code| (200..300).contains(&code))
 }
 
 /// Extract the `Host:` header value from an already-buffered HTTP header block.
@@ -675,6 +1063,75 @@ mod tests {
         record.extend_from_slice(&hs);
 
         record
+    }
+
+    #[test]
+    fn could_be_connect_request_matches_split_prefixes_only() {
+        assert!(could_be_connect_request(b"C"));
+        assert!(could_be_connect_request(b"connect "));
+        assert!(could_be_connect_request(b"CONNECT example.com:443"));
+        assert!(!could_be_connect_request(b"CLIENT"));
+        assert!(!could_be_connect_request(b"GET / HTTP/1.1\r\n"));
+    }
+
+    #[tokio::test]
+    async fn buffer_connect_request_reads_split_headers() {
+        let (tx, mut rx) = mpsc::channel(4);
+        tx.send(Bytes::from_static(b"NECT example.com:443 HTTP/1.1\r\n"))
+            .await
+            .unwrap();
+        tx.send(Bytes::from_static(b"Host: example.com\r\n\r\n"))
+            .await
+            .unwrap();
+        drop(tx);
+
+        let buffered = buffer_connect_request(b"CON".to_vec(), &mut rx)
+            .await
+            .unwrap();
+        let parsed = parse_connect_request(buffered).unwrap();
+
+        assert_eq!(parsed.target.host, "example.com");
+        assert_eq!(parsed.target.port, 443);
+        assert_eq!(parsed.target.expected_sni.as_deref(), Some("example.com"));
+        assert!(parsed.post_header_bytes().is_empty());
+    }
+
+    #[test]
+    fn parse_connect_request_preserves_post_header_tls_seed() {
+        let mut request = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com\r\n\r\n".to_vec();
+        request.extend_from_slice(b"\x16\x03\x01client-hello");
+
+        let parsed = parse_connect_request(request).unwrap();
+
+        assert_eq!(
+            parsed.header_bytes(),
+            b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com\r\n\r\n"
+        );
+        assert_eq!(parsed.post_header_bytes(), b"\x16\x03\x01client-hello");
+    }
+
+    #[test]
+    fn parse_connect_target_requires_authority_port() {
+        assert!(parse_connect_target("example.com").is_err());
+        assert!(parse_connect_target("2001:db8::1:443").is_err());
+
+        let target = parse_connect_target("[2001:db8::1]:8443").unwrap();
+        assert_eq!(target.host, "2001:db8::1");
+        assert_eq!(target.port, 8443);
+        assert_eq!(target.expected_sni, None);
+    }
+
+    #[test]
+    fn connect_response_success_requires_exact_2xx_status_code() {
+        assert!(connect_response_is_success(
+            b"HTTP/1.1 200 Connection Established\r\n\r\n"
+        ));
+        assert!(connect_response_is_success(
+            b"HTTP/1.1 204 Connection Established\r\n\r\n"
+        ));
+        assert!(!connect_response_is_success(b"HTTP/1.1 2000 Weird\r\n\r\n"));
+        assert!(!connect_response_is_success(b"HTTP/1.1 199 Nope\r\n\r\n"));
+        assert!(!connect_response_is_success(b"NOTHTTP 200 OK\r\n\r\n"));
     }
 
     #[tokio::test]
@@ -1061,6 +1518,56 @@ mod tests {
             }],
             ..Default::default()
         }
+    }
+
+    fn make_host_bound_secret(placeholder: &str, value: &str, host: &str) -> SecretsConfig {
+        SecretsConfig {
+            secrets: vec![SecretEntry {
+                env_var: "API_KEY".into(),
+                value: value.into(),
+                placeholder: placeholder.into(),
+                allowed_hosts: vec![HostPattern::Exact(host.into())],
+                injection: SecretInjection::default(),
+                on_violation: None,
+                require_tls_identity: true,
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn sanitize_connect_headers_strips_placeholder_metadata_header() {
+        let secrets = make_host_bound_secret("$MSB_KEY", "real-secret-value", "example.com");
+        let headers = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nProxy-Authorization: Bearer $MSB_KEY\r\nUser-Agent: curl\r\n\r\n";
+
+        let sanitized = sanitize_connect_headers(headers, &secrets).unwrap();
+
+        assert_eq!(
+            sanitized.as_ref(),
+            b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nUser-Agent: curl\r\n\r\n"
+        );
+    }
+
+    #[test]
+    fn sanitize_connect_headers_keeps_safe_metadata_headers() {
+        let secrets = make_host_bound_secret("$MSB_KEY", "real-secret-value", "example.com");
+        let headers =
+            b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nUser-Agent: curl\r\n\r\n";
+
+        let sanitized = sanitize_connect_headers(headers, &secrets).unwrap();
+
+        assert_eq!(sanitized.as_ref(), headers);
+    }
+
+    #[test]
+    fn sanitize_connect_headers_blocks_placeholder_in_request_line() {
+        let secrets = make_host_bound_secret("$MSB_KEY", "real-secret-value", "example.com");
+        let headers = b"CONNECT $MSB_KEY:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
+
+        assert_eq!(
+            sanitize_connect_headers(headers, &secrets),
+            Err(ViolationAction::BlockAndLog)
+        );
     }
 
     async fn spawn_sink() -> (SocketAddr, JoinHandle<Vec<u8>>) {

--- a/crates/network/lib/secrets/handler.rs
+++ b/crates/network/lib/secrets/handler.rs
@@ -103,6 +103,9 @@ pub struct SecretsHandler {
     /// Buffered HTTP bytes while waiting for complete headers or a complete
     /// body-rewriteable request.
     http_pending: Vec<u8>,
+    /// Body-only tail for detecting eligible placeholders inside HTTP/1 bodies
+    /// whose framing or encoding cannot be rewritten safely.
+    unsupported_body_tail: Vec<u8>,
     /// HTTP/2 parser/rewriter state once an HTTP/2 preface is observed.
     http2_state: Option<Http2State>,
 }
@@ -602,6 +605,7 @@ impl SecretsHandler {
             http_sni: enforce_http_authority.then(|| sni.to_string()),
             http1_request_summary: None,
             http_pending: Vec::new(),
+            unsupported_body_tail: Vec::new(),
             http2_state: None,
         }
     }
@@ -794,6 +798,20 @@ impl SecretsHandler {
             String::from_utf8_lossy(header_bytes).as_ref(),
             RequestLocation::Unknown,
         ))?;
+        if !body_substitution_allowed {
+            self.block_unsupported_body_placeholder(&self.unsupported_body_tail, body_bytes)?;
+            if matches!(self.http_state, HttpState::InBody { .. }) {
+                update_tail_buffer(
+                    &mut self.unsupported_body_tail,
+                    body_bytes,
+                    self.max_body_placeholder_len.saturating_sub(1),
+                );
+            } else {
+                self.unsupported_body_tail.clear();
+            }
+        } else {
+            self.unsupported_body_tail.clear();
+        }
         self.update_tail(this_request);
 
         if self.eligible_for_substitution.is_empty() {
@@ -1066,6 +1084,7 @@ impl SecretsHandler {
             None => (data, &[] as &[u8]),
         };
 
+        self.block_unsupported_body_placeholder(&self.unsupported_body_tail, body_part)?;
         self.apply_blocking_action(self.detect_blocking_action(
             body_part,
             "",
@@ -1078,11 +1097,19 @@ impl SecretsHandler {
         self.http_state = match body_end {
             Some(_) => {
                 self.http1_request_summary = None;
+                self.unsupported_body_tail.clear();
                 HttpState::AwaitingHeaders
             }
-            None => HttpState::InBody {
-                remaining: remaining - body_part.len(),
-            },
+            None => {
+                update_tail_buffer(
+                    &mut self.unsupported_body_tail,
+                    body_part,
+                    self.max_body_placeholder_len.saturating_sub(1),
+                );
+                HttpState::InBody {
+                    remaining: remaining - body_part.len(),
+                }
+            }
         };
 
         self.append_pipelined_spillover(data, body_part, spillover)
@@ -1157,6 +1184,7 @@ impl SecretsHandler {
     pub fn is_empty(&self) -> bool {
         self.http_sni.is_none()
             && self.http_pending.is_empty()
+            && self.unsupported_body_tail.is_empty()
             && self.http1_request_summary.is_none()
             && self.http2_state.is_none()
             && matches!(self.http_state, HttpState::AwaitingHeaders)
@@ -1170,7 +1198,21 @@ impl SecretsHandler {
         })
     }
 
-    fn contains_eligible_http2_body_placeholder(&self, prev_tail: &[u8], data: &[u8]) -> bool {
+    fn block_unsupported_body_placeholder(
+        &self,
+        prev_tail: &[u8],
+        data: &[u8],
+    ) -> Result<(), ViolationAction> {
+        if self.contains_eligible_body_placeholder(prev_tail, data) {
+            tracing::warn!(
+                "secret substitution in this request body is unsupported; blocking placeholder"
+            );
+            return Err(ViolationAction::Block);
+        }
+        Ok(())
+    }
+
+    fn contains_eligible_body_placeholder(&self, prev_tail: &[u8], data: &[u8]) -> bool {
         if !self.needs_body_injection() {
             return false;
         }
@@ -1261,6 +1303,7 @@ impl SecretsHandler {
             let ChunkedBodyEvent::Payload(payload) = event else {
                 return Ok(());
             };
+            self.block_unsupported_body_placeholder(&decoded_tail, payload)?;
             self.apply_blocking_action(detect_blocking_action_with_tail(
                 &self.ineligible_for_substitution,
                 &decoded_tail,
@@ -1628,7 +1671,7 @@ impl Http2State {
 
         let data = http2_data_payload(frame.flags, frame.payload)?;
         let tail = self.data_tails.entry(frame.stream_id).or_default();
-        if handler.contains_eligible_http2_body_placeholder(tail, data) {
+        if handler.contains_eligible_body_placeholder(tail, data) {
             tracing::warn!(
                 "secret substitution in HTTP/2 DATA frames is unsupported; blocking placeholder"
             );
@@ -3536,16 +3579,18 @@ mod tests {
     }
 
     #[test]
-    fn chunked_body_injection_skips_content_encoded_body() {
+    fn chunked_body_injection_blocks_content_encoded_placeholder() {
         let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
         secret.injection.body = true;
         let config = make_config(vec![secret]);
         let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
         let input = b"POST / HTTP/1.1\r\nHost: api.openai.com\r\nTransfer-Encoding: chunked\r\nContent-Encoding: gzip\r\n\r\n4\r\n$KEY\r\n0\r\n\r\n";
-        let output = handler.substitute(input).unwrap();
 
-        assert_eq!(output.as_ref(), input);
+        assert_eq!(
+            handler.substitute(input).unwrap_err(),
+            ViolationAction::Block
+        );
     }
 
     #[test]
@@ -3609,7 +3654,7 @@ mod tests {
     }
 
     #[test]
-    fn body_injection_skips_content_encoded_body() {
+    fn body_injection_blocks_content_encoded_placeholder() {
         let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
         secret.injection.body = true;
         let config = make_config(vec![secret]);
@@ -3623,8 +3668,27 @@ mod tests {
         .into_bytes();
         input.extend_from_slice(body);
 
-        let output = handler.substitute(&input).unwrap();
-        assert_eq!(&*output, input.as_slice());
+        assert_eq!(
+            handler.substitute(&input).unwrap_err(),
+            ViolationAction::Block
+        );
+    }
+
+    #[test]
+    fn body_injection_blocks_split_content_encoded_placeholder() {
+        let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+        secret.injection.body = true;
+        let config = make_config(vec![secret]);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
+
+        let first = b"POST /git-upload-pack HTTP/1.1\r\nContent-Encoding: gzip\r\nContent-Length: 4\r\n\r\n$K";
+
+        let output = handler.substitute(first).unwrap();
+        assert_eq!(&*output, first.as_slice());
+        assert_eq!(
+            handler.substitute(b"EY").unwrap_err(),
+            ViolationAction::Block
+        );
     }
 
     #[test]

--- a/crates/network/lib/secrets/handler.rs
+++ b/crates/network/lib/secrets/handler.rs
@@ -527,6 +527,15 @@ impl SecretsHandler {
         Self::new_inner(config, "", false, None, host_scoped)
     }
 
+    /// Handler for HTTP metadata that must never receive substituted secrets.
+    ///
+    /// This is used for proxy-owned CONNECT headers. Placeholders there are
+    /// treated as violations according to their configured action unless a
+    /// passthrough policy explicitly allows forwarding the placeholder.
+    pub(crate) fn new_plain_http_untrusted_metadata(config: &SecretsConfig) -> Self {
+        Self::new_inner(config, "", false, None, true)
+    }
+
     fn new_inner(
         config: &SecretsConfig,
         sni: &str,

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -47,6 +47,8 @@ pub(crate) struct TlsProxyContext {
     pub(crate) proxy_connect: Arc<ProxyConnectState>,
     /// Pre-connected upstream; when `Some`, skips dialing `connect_dst`.
     pub(crate) upstream_stream: Option<TcpStream>,
+    /// Hostname from a CONNECT authority that must match the ClientHello SNI.
+    pub(crate) expected_sni: Option<String>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -78,6 +80,7 @@ pub fn spawn_tls_proxy(
             network_policy,
             proxy_connect,
             upstream_stream: None,
+            expected_sni: None,
         };
 
         if let Err(e) = tls_proxy_task(context, from_smoltcp, to_smoltcp, Vec::new()).await {
@@ -101,6 +104,7 @@ pub(crate) async fn tls_proxy_task(
         network_policy,
         proxy_connect,
         upstream_stream,
+        expected_sni,
     } = context;
 
     // Buffer initial data to extract SNI from ClientHello. Timeout prevents a
@@ -115,6 +119,20 @@ pub(crate) async fn tls_proxy_task(
 
     // Canonicalize so byte equality against rule destinations works.
     let sni_name = sni_name.trim_end_matches('.').to_ascii_lowercase();
+
+    if let Some(expected) = expected_sni.as_deref()
+        && !sni_name.eq_ignore_ascii_case(expected.trim_end_matches('.'))
+    {
+        tracing::debug!(
+            sni = %sni_name,
+            expected = %expected,
+            dst = %connect_dst,
+            "TLS SNI did not match CONNECT authority",
+        );
+        proxy_connect.mark_policy_denied();
+        shared.proxy_wake.wake();
+        return Ok(());
+    }
 
     // Apply Domain / DomainSuffix rules against the SNI.
     let eval = network_policy.evaluate_egress_with_source(


### PR DESCRIPTION
## TL;DR
Harden HTTP CONNECT secret handling so proxy metadata cannot leak placeholders and only configured target ports are intercepted. This also adds real SDK/CLI coverage for the CONNECT flows that motivated the fix.

## Description
- Parse and buffer complete CONNECT requests before dialing the proxy, including split headers, bracketed IPv6 authorities, and strict port validation.
- Enforce the configured secret violation action for placeholders in CONNECT metadata, so proxy headers do not become a secret exfiltration path.
- Keep CONNECT tunnels for non-intercepted target ports opaque, while still forwarding proxy responses and relaying the established stream.
- Require the intercepted TLS ClientHello SNI to match the CONNECT authority before applying secret substitution inside a tunnel.
- Block eligible body placeholders in encoded or otherwise unsupported body paths instead of forwarding them unchanged.
- Expand the ignored Rust SDK integration test to run real curl-through-CONNECT scenarios against the CLI runtime for happy path, wrong host, outer proxy headers, and non-intercepted target ports.

## Test Plan
- [x] `just build-msb`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p microsandbox-network --lib`
- [x] `cargo clippy -p microsandbox-network -- -D warnings`
- [x] `cargo test -p microsandbox --test http_connect_secret --no-run`
- [x] `MSB_HOME=/tmp/msb-v0 build/msb run --name cli-connect-smoke --replace --memory 256M --user 0 --entrypoint /bin/sh mirror.gcr.io/curlimages/curl -- -lc 'echo cli-smoke-ok'`
- [x] `names=(https_connect_proxy_substitutes_secret_in_authorization_header https_connect_proxy_blocks_secret_for_wrong_host https_connect_proxy_leaves_non_intercepted_target_port_opaque https_connect_proxy_blocks_secret_in_outer_connect_headers); i=10; for test in "${names[@]}"; do home="/tmp/msb-v$i"; rm -rf "$home" && mkdir -p "$home" && MSB_HOME="$home" MSB_PATH="$PWD/build/msb" cargo test -p microsandbox --test http_connect_secret "$test" -- --ignored --exact --nocapture; i=$((i + 1)); done`