### PR TITLE
chore(deps): bump msb_krun crates from libkrun krun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,8 +3564,7 @@ dependencies = [
 [[package]]
 name = "msb_krun"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df0f4dbc4771ed8df8a7ed584221e48bc3fe1726242378332a02ce27518ca53"
+source = "git+https://github.com/zerocore-ai/libkrun?branch=krun#11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3584,8 +3583,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_arch"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923b2f7ed0d299b37ea9bbc47e9d8fe1a46c44e1ecf1d9ecf306377b20f90762"
+source = "git+https://github.com/zerocore-ai/libkrun?branch=krun#11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3600,14 +3598,12 @@ dependencies = [
 [[package]]
 name = "msb_krun_arch_gen"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff114cab67c406f051985749d7cd4aedab3fd445936f6759fd95de9c0352bb7"
+source = "git+https://github.com/zerocore-ai/libkrun?branch=krun#11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8"
 
 [[package]]
 name = "msb_krun_cpuid"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4a5cf30e814f211c32c43ee88e9a711ed0b17b88396a80baf5360f49ade848"
+source = "git+https://github.com/zerocore-ai/libkrun?branch=krun#11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3617,8 +3613,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_devices"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f22c8cd187fc729c7f3b0922ae9e2e078809172f305dd343a6c4c71a219d68"
+source = "git+https://github.com/zerocore-ai/libkrun?branch=krun#11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3645,8 +3640,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_hvf"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c816c66f7eb6ccf751cb250a1c7ab0bc261cac6cef36ee68a8b673864ce5800"
+source = "git+https://github.com/zerocore-ai/libkrun?branch=krun#11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -3657,8 +3651,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_kernel"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294eaf9998761721183f080866ddca635f3186da8541d2a273f60cf719ee92c3"
+source = "git+https://github.com/zerocore-ai/libkrun?branch=krun#11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -3667,8 +3660,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_polly"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778c4a9713517f131ae5b0c3e6c299a7e70ced97edeedd6e469639b9d7390fe2"
+source = "git+https://github.com/zerocore-ai/libkrun?branch=krun#11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3677,8 +3669,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_smbios"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775c50a8ab2688083eaf8636af96bed12974d5be9e5811e4c5665cea4fd06ff8"
+source = "git+https://github.com/zerocore-ai/libkrun?branch=krun#11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8"
 dependencies = [
  "vm-memory 0.16.2",
 ]
@@ -3686,8 +3677,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_utils"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f620c8707cd19f6c67c004c2e80744a0bdab7349e18564ec982f8542712a375"
+source = "git+https://github.com/zerocore-ai/libkrun?branch=krun#11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3701,8 +3691,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_vmm"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb70c044c60e011e6f43c2e336687850b0910853a0efe37010e9649eff1395fe"
+source = "git+https://github.com/zerocore-ai/libkrun?branch=krun#11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ microsandbox-network = { version = "0.5.7", path = "crates/network" }
 microsandbox-protocol = { version = "0.5.7", path = "crates/protocol" }
 microsandbox-runtime = { version = "0.5.7", path = "crates/runtime", default-features = false }
 microsandbox-utils = { version = "0.5.7", path = "crates/utils" }
-msb_krun = { version = "0.1.16" }
+msb_krun = { version = "0.1.16", git = "https://github.com/zerocore-ai/libkrun", branch = "krun" }
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }
 


### PR DESCRIPTION
## TL;DR
Bump the `msb_krun*` crate family to the latest `krun` branch from `zerocore-ai/libkrun`. The lockfile pins the branch at `11b72b31efc23b1c2fef2f5581aff9a79bdcdfc8`.

## Description
- Point the workspace `msb_krun` dependency at `https://github.com/zerocore-ai/libkrun` on branch `krun`.
- Move all locked `msb_krun*` packages from crates.io to the same libkrun git source.
- Keep the crate version constraint at `0.1.16`, matching the package versions on the libkrun branch.
- Leave the change scoped to `Cargo.toml` and `Cargo.lock`.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `CARGO_HOME=/tmp/cargo-msb-krun CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_TARGET_DIR=/tmp/msb-krun-target cargo metadata --locked --no-deps --format-version 1`
- [x] `awk 'BEGIN{pkg=""} /^name = /{pkg=$3; gsub(/"/, "", pkg)} /^source = / && pkg ~ /^msb_krun/{print pkg " " $0}' Cargo.lock`
- [x] `CARGO_HOME=/tmp/cargo-msb-krun CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_TARGET_DIR=/tmp/msb-krun-target cargo check -p microsandbox-filesystem -p microsandbox-network -p microsandbox-runtime -p microsandbox-cli`
- [x] `CARGO_HOME=/tmp/cargo-msb-krun CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_TARGET_DIR=/tmp/msb-krun-target cargo check --workspace --bins`