### PR TITLE
fix(init): preserve image init entrypoint commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,6 +3202,7 @@ dependencies = [
 name = "microsandbox-agentd"
 version = "0.5.7"
 dependencies = [
+ "base64",
  "chrono",
  "ciborium",
  "libc",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -15,6 +15,7 @@ path = "bin/main.rs"
 path = "lib/lib.rs"
 
 [dependencies]
+base64.workspace = true
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true

--- a/crates/agentd/lib/config.rs
+++ b/crates/agentd/lib/config.rs
@@ -18,12 +18,14 @@ use std::ffi::OsString;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
 
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use microsandbox_protocol::{
     ENV_BLOCK_ROOT, ENV_DIR_MOUNTS, ENV_DISK_MOUNTS, ENV_FILE_MOUNTS, ENV_HANDOFF_INIT,
     ENV_HANDOFF_INIT_ARGS, ENV_HANDOFF_INIT_ENV, ENV_HOST_ALIAS, ENV_HOSTNAME, ENV_NET,
     ENV_NET_IPV4, ENV_NET_IPV6, ENV_RLIMITS, ENV_SECURITY_PROFILE, ENV_TMPFS, ENV_USER,
-    HANDOFF_INIT_AUTO, HANDOFF_INIT_SEP, exec::ExecRlimit,
+    HANDOFF_INIT_AUTO, exec::ExecRlimit,
 };
+use serde::de::DeserializeOwned;
 
 use crate::error::{AgentdError, AgentdResult};
 use crate::rlimit;
@@ -958,8 +960,8 @@ fn parse_cidr_v6(s: &str) -> AgentdResult<(Ipv6Addr, u8)> {
 ///
 /// Returns `Ok(None)` when `MSB_HANDOFF_INIT` is unset/empty (the
 /// default no-handoff path). Returns `Err` when the cmd path is
-/// not absolute, or when `MSB_HANDOFF_INIT_ENV` contains an entry
-/// without an `=`.
+/// not absolute, or when `MSB_HANDOFF_INIT_ARGS` / `MSB_HANDOFF_INIT_ENV`
+/// contain invalid base64url JSON.
 fn parse_handoff_init() -> AgentdResult<Option<HandoffInit>> {
     let Some(cmd_str) = read_env_raw(ENV_HANDOFF_INIT) else {
         return Ok(None);
@@ -979,31 +981,42 @@ fn parse_handoff_init() -> AgentdResult<Option<HandoffInit>> {
     }
 
     let argv = match read_env_raw(ENV_HANDOFF_INIT_ARGS) {
-        Some(val) if !val.is_empty() => val.split(HANDOFF_INIT_SEP).map(OsString::from).collect(),
+        Some(val) if !val.is_empty() => {
+            decode_handoff_json::<Vec<String>>(ENV_HANDOFF_INIT_ARGS, &val)?
+                .into_iter()
+                .map(OsString::from)
+                .collect()
+        }
         _ => Vec::new(),
     };
 
     let env = match read_env_raw(ENV_HANDOFF_INIT_ENV) {
-        Some(val) if !val.is_empty() => val
-            .split(HANDOFF_INIT_SEP)
-            .map(|entry| {
-                let (k, v) = entry.split_once('=').ok_or_else(|| {
-                    AgentdError::Config(format!(
-                        "{ENV_HANDOFF_INIT_ENV} entry missing '=': {entry}"
-                    ))
-                })?;
-                if k.is_empty() {
-                    return Err(AgentdError::Config(format!(
-                        "{ENV_HANDOFF_INIT_ENV} entry has empty key: {entry}"
-                    )));
-                }
-                Ok((OsString::from(k), OsString::from(v)))
-            })
-            .collect::<AgentdResult<Vec<_>>>()?,
+        Some(val) if !val.is_empty() => {
+            let entries = decode_handoff_json::<Vec<(String, String)>>(ENV_HANDOFF_INIT_ENV, &val)?;
+            entries
+                .into_iter()
+                .map(|(k, v)| {
+                    if k.is_empty() {
+                        return Err(AgentdError::Config(format!(
+                            "{ENV_HANDOFF_INIT_ENV} entry has empty key"
+                        )));
+                    }
+                    Ok((OsString::from(k), OsString::from(v)))
+                })
+                .collect::<AgentdResult<Vec<_>>>()?
+        }
         _ => Vec::new(),
     };
 
     Ok(Some(HandoffInit { cmd, argv, env }))
+}
+
+fn decode_handoff_json<T: DeserializeOwned>(env_name: &str, value: &str) -> AgentdResult<T> {
+    let json = URL_SAFE_NO_PAD.decode(value).map_err(|e| {
+        AgentdError::Config(format!("{env_name} must be base64url-no-padding JSON: {e}"))
+    })?;
+    serde_json::from_slice(&json)
+        .map_err(|e| AgentdError::Config(format!("{env_name} contains invalid JSON: {e}")))
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1020,8 +1033,8 @@ fn read_env(key: &str) -> Option<String> {
 
 /// Reads a single environment variable without trimming whitespace.
 ///
-/// Used for the handoff-init vars where the `\x1f` separator and argv
-/// content are sensitive to byte-exact preservation.
+/// Used for the handoff-init vars where argv content is sensitive to
+/// byte-exact preservation.
 fn read_env_raw(key: &str) -> Option<String> {
     env::var(key).ok().filter(|v| !v.is_empty())
 }
@@ -1477,6 +1490,13 @@ mod tests {
         out
     }
 
+    fn encode_handoff_json<T: serde::Serialize>(value: &T) -> String {
+        use base64::Engine as _;
+
+        let json = serde_json::to_vec(value).unwrap();
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json)
+    }
+
     #[test]
     fn test_parse_handoff_init_unset_returns_none() {
         let res = with_handoff_env(None, None, None, parse_handoff_init).unwrap();
@@ -1501,7 +1521,7 @@ mod tests {
 
     #[test]
     fn test_parse_handoff_init_with_argv() {
-        let argv = format!("--unit=multi-user.target{HANDOFF_INIT_SEP}--log-level=warning");
+        let argv = encode_handoff_json(&vec!["--unit=multi-user.target", "--log-level=warning"]);
         let res = with_handoff_env(
             Some("/lib/systemd/systemd"),
             Some(&argv),
@@ -1521,7 +1541,7 @@ mod tests {
 
     #[test]
     fn test_parse_handoff_init_with_env() {
-        let envs = format!("container=microsandbox{HANDOFF_INIT_SEP}LANG=C.UTF-8");
+        let envs = encode_handoff_json(&vec![("container", "microsandbox"), ("LANG", "C.UTF-8")]);
         let res = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
             .unwrap()
             .unwrap();
@@ -1536,8 +1556,11 @@ mod tests {
 
     #[test]
     fn test_parse_handoff_init_argv_with_spaces_preserved() {
-        // Argv entries can contain any characters except '\x1f' and NUL.
-        let argv = format!("--label=hello world{HANDOFF_INIT_SEP}--config=/etc/foo;bar");
+        let argv = encode_handoff_json(&vec![
+            "--label=hello world",
+            "--config=/etc/foo;bar",
+            "old\x1fseparator",
+        ]);
         let res = with_handoff_env(Some("/sbin/init"), Some(&argv), None, parse_handoff_init)
             .unwrap()
             .unwrap();
@@ -1546,6 +1569,7 @@ mod tests {
             vec![
                 OsString::from("--label=hello world"),
                 OsString::from("--config=/etc/foo;bar"),
+                OsString::from("old\x1fseparator"),
             ]
         );
     }
@@ -1557,17 +1581,20 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_handoff_init_env_entry_missing_equals() {
-        let envs = format!("KEY=value{HANDOFF_INIT_SEP}NOEQUALS");
-        let err = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
-            .unwrap_err();
-        assert!(err.to_string().contains("missing '='"));
+    fn test_parse_handoff_init_env_rejects_invalid_base64() {
+        let err = with_handoff_env(
+            Some("/sbin/init"),
+            None,
+            Some("not base64!"),
+            parse_handoff_init,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("base64url-no-padding JSON"));
     }
 
     #[test]
     fn test_parse_handoff_init_env_entry_empty_key_rejected() {
-        // `=value` (empty key) used to silently produce a nameless env entry.
-        let envs = "=value".to_string();
+        let envs = encode_handoff_json(&vec![("", "value")]);
         let err = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
             .unwrap_err();
         assert!(err.to_string().contains("empty key"));
@@ -1575,8 +1602,7 @@ mod tests {
 
     #[test]
     fn test_parse_handoff_init_env_value_with_equals_is_value() {
-        // Only the first '=' splits; the rest is part of the value.
-        let envs = "PATH=/a:/b=/c".to_string();
+        let envs = encode_handoff_json(&vec![("PATH", "/a:/b=/c")]);
         let res = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
             .unwrap()
             .unwrap();

--- a/crates/agentd/lib/config.rs
+++ b/crates/agentd/lib/config.rs
@@ -961,7 +961,9 @@ fn parse_cidr_v6(s: &str) -> AgentdResult<(Ipv6Addr, u8)> {
 /// Returns `Ok(None)` when `MSB_HANDOFF_INIT` is unset/empty (the
 /// default no-handoff path). Returns `Err` when the cmd path is
 /// not absolute, or when `MSB_HANDOFF_INIT_ARGS` / `MSB_HANDOFF_INIT_ENV`
-/// contain invalid base64url JSON.
+/// contain invalid base64url JSON. The args/env payloads are the one
+/// structured exception to the delimiter-based `MSB_*` boot envs because
+/// they carry exact process argv/env strings.
 fn parse_handoff_init() -> AgentdResult<Option<HandoffInit>> {
     let Some(cmd_str) = read_env_raw(ENV_HANDOFF_INIT) else {
         return Ok(None);
@@ -984,8 +986,9 @@ fn parse_handoff_init() -> AgentdResult<Option<HandoffInit>> {
         Some(val) if !val.is_empty() => {
             decode_handoff_json::<Vec<String>>(ENV_HANDOFF_INIT_ARGS, &val)?
                 .into_iter()
-                .map(OsString::from)
-                .collect()
+                .enumerate()
+                .map(|(index, arg)| parse_handoff_arg(index, arg))
+                .collect::<AgentdResult<Vec<_>>>()?
         }
         _ => Vec::new(),
     };
@@ -995,14 +998,7 @@ fn parse_handoff_init() -> AgentdResult<Option<HandoffInit>> {
             let entries = decode_handoff_json::<Vec<(String, String)>>(ENV_HANDOFF_INIT_ENV, &val)?;
             entries
                 .into_iter()
-                .map(|(k, v)| {
-                    if k.is_empty() {
-                        return Err(AgentdError::Config(format!(
-                            "{ENV_HANDOFF_INIT_ENV} entry has empty key"
-                        )));
-                    }
-                    Ok((OsString::from(k), OsString::from(v)))
-                })
+                .map(|(key, value)| parse_handoff_env_pair(key, value))
                 .collect::<AgentdResult<Vec<_>>>()?
         }
         _ => Vec::new(),
@@ -1017,6 +1013,39 @@ fn decode_handoff_json<T: DeserializeOwned>(env_name: &str, value: &str) -> Agen
     })?;
     serde_json::from_slice(&json)
         .map_err(|e| AgentdError::Config(format!("{env_name} contains invalid JSON: {e}")))
+}
+
+fn parse_handoff_arg(index: usize, arg: String) -> AgentdResult<OsString> {
+    if arg.contains('\0') {
+        return Err(AgentdError::Config(format!(
+            "{ENV_HANDOFF_INIT_ARGS} entry #{index} must not contain NUL"
+        )));
+    }
+    Ok(OsString::from(arg))
+}
+
+fn parse_handoff_env_pair(key: String, value: String) -> AgentdResult<(OsString, OsString)> {
+    if key.is_empty() {
+        return Err(AgentdError::Config(format!(
+            "{ENV_HANDOFF_INIT_ENV} entry has empty key"
+        )));
+    }
+    if key.contains('=') {
+        return Err(AgentdError::Config(format!(
+            "{ENV_HANDOFF_INIT_ENV} key {key:?} must not contain '='"
+        )));
+    }
+    if key.contains('\0') {
+        return Err(AgentdError::Config(format!(
+            "{ENV_HANDOFF_INIT_ENV} key {key:?} must not contain NUL"
+        )));
+    }
+    if value.contains('\0') {
+        return Err(AgentdError::Config(format!(
+            "{ENV_HANDOFF_INIT_ENV} value for {key:?} must not contain NUL"
+        )));
+    }
+    Ok((OsString::from(key), OsString::from(value)))
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1598,6 +1627,41 @@ mod tests {
         let err = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
             .unwrap_err();
         assert!(err.to_string().contains("empty key"));
+    }
+
+    #[test]
+    fn test_parse_handoff_init_arg_rejects_nul() {
+        let argv = encode_handoff_json(&vec!["ok", "bad\0arg"]);
+        let err = with_handoff_env(Some("/sbin/init"), Some(&argv), None, parse_handoff_init)
+            .unwrap_err();
+        assert!(err.to_string().contains("entry #1"));
+        assert!(err.to_string().contains("NUL"));
+    }
+
+    #[test]
+    fn test_parse_handoff_init_env_key_rejects_equals() {
+        let envs = encode_handoff_json(&vec![("BAD=KEY", "value")]);
+        let err = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
+            .unwrap_err();
+        assert!(err.to_string().contains("must not contain '='"));
+    }
+
+    #[test]
+    fn test_parse_handoff_init_env_key_rejects_nul() {
+        let envs = encode_handoff_json(&vec![("BAD\0KEY", "value")]);
+        let err = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
+            .unwrap_err();
+        assert!(err.to_string().contains("key"));
+        assert!(err.to_string().contains("NUL"));
+    }
+
+    #[test]
+    fn test_parse_handoff_init_env_value_rejects_nul() {
+        let envs = encode_handoff_json(&vec![("KEY", "bad\0value")]);
+        let err = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
+            .unwrap_err();
+        assert!(err.to_string().contains("value for"));
+        assert!(err.to_string().contains("NUL"));
     }
 
     #[test]

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -168,9 +168,10 @@ pub struct SandboxOpts {
     pub entrypoint: Option<String>,
 
     /// Hand off PID 1 to this init binary inside the guest after agentd
-    /// finishes setup. Use `auto` to probe `/sbin/init`,
-    /// `/lib/systemd/systemd`, `/usr/lib/systemd/systemd` (first hit
-    /// wins), or supply an explicit absolute path.
+    /// finishes setup. Use `auto` to honor a known init at the start of
+    /// the image ENTRYPOINT (for example /init in s6-overlay images),
+    /// preserving attached init-entrypoint commands when needed, or to
+    /// probe common distro init paths when the image does not declare one.
     #[arg(long, value_name = "PATH|auto")]
     pub init: Option<String>,
 

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -1,9 +1,14 @@
 //! `msb run` command — create and start a new sandbox.
 
 use std::io::{IsTerminal, Write};
+use std::pin::pin;
 use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use clap::Args;
+use futures::StreamExt;
+use microsandbox::MicrosandboxError;
+use microsandbox::logs::{self, LogOptions, LogSource, LogStreamOptions, LogStreamStart};
 use microsandbox::sandbox::{ExecOutput, RlimitResource, Sandbox};
 
 use super::common::{SandboxOpts, apply_sandbox_opts};
@@ -169,7 +174,10 @@ async fn run_new(
     {
         args.sandbox.log_level = Some(log_level.to_string());
     }
-    let builder = apply_sandbox_opts(builder, &args.sandbox)?;
+    let mut builder = apply_sandbox_opts(builder, &args.sandbox)?;
+    if !args.detach {
+        builder = builder.initial_command(args.command.clone());
+    }
 
     // Create sandbox with pull progress — select attached vs detached mode.
     let (mut progress, task) = builder.detached(args.detach).create_with_pull_progress()?;
@@ -203,6 +211,14 @@ async fn run_new(
     }
 
     let exec_opts = ExecOpts::parse(&args)?;
+    if sandbox.config().initial_command_consumed_by_init() {
+        let result = wait_for_init_entrypoint(&sandbox, &exec_opts).await;
+        if !is_named {
+            let _ = Sandbox::remove(sandbox.name()).await;
+        }
+        return handle_exit(result?);
+    }
+
     let interactive = std::io::stdin().is_terminal();
 
     let (cmd, cmd_args) =
@@ -233,6 +249,113 @@ async fn run_new(
     }
 
     handle_exit(result?)
+}
+
+/// Wait for an image-declared init entrypoint to own the foreground command.
+async fn wait_for_init_entrypoint(sandbox: &Sandbox, opts: &ExecOpts) -> anyhow::Result<i32> {
+    let log_task = tokio::spawn(stream_init_entrypoint_logs(
+        sandbox.name().to_string(),
+        Utc::now(),
+    ));
+    let wait_fut = sandbox.wait();
+    let wait_result = match opts.timeout {
+        Some(duration) => match tokio::time::timeout(duration, wait_fut).await {
+            Ok(result) => result.map_err(anyhow::Error::from),
+            Err(_) => {
+                if let Err(e) = sandbox.stop().await {
+                    ui::warn(&format!("failed to stop sandbox after timeout: {e}"));
+                }
+                Err(anyhow::anyhow!("command timed out after {duration:?}"))
+            }
+        },
+        None => wait_fut.await.map_err(anyhow::Error::from),
+    };
+    stop_init_entrypoint_log_task(log_task).await;
+
+    let status = wait_result?;
+
+    Ok(if status.success() {
+        0
+    } else {
+        status.code().unwrap_or(1)
+    })
+}
+
+/// Stream the sandbox log path while an init-owned foreground command runs.
+async fn stream_init_entrypoint_logs(name: String, since: DateTime<Utc>) -> anyhow::Result<()> {
+    let sources = vec![
+        LogSource::Stdout,
+        LogSource::Stderr,
+        LogSource::Output,
+        LogSource::System,
+    ];
+    let snapshot_opts = LogOptions {
+        tail: None,
+        since: Some(since),
+        until: None,
+        sources: sources.clone(),
+    };
+    let snapshot = logs::read_logs_snapshot(&name, &snapshot_opts).await?;
+    for entry in &snapshot.entries {
+        render_init_entrypoint_log(entry)?;
+    }
+
+    let stream_opts = LogStreamOptions {
+        sources,
+        start: LogStreamStart::From(snapshot.cursor),
+        until: None,
+        follow: true,
+    };
+    let mut stream = pin!(logs::log_stream(&name, &stream_opts).await?);
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(entry) => render_init_entrypoint_log(&entry)?,
+            Err(MicrosandboxError::MissedRotation {
+                dropped_from_offset,
+            }) => {
+                ui::warn(&format!(
+                    "log follower fell behind at offset {dropped_from_offset}; output is still available with `msb logs --source all {name}`"
+                ));
+                return Ok(());
+            }
+            Err(err) => return Err(anyhow::Error::from(err)),
+        }
+    }
+
+    Ok(())
+}
+
+async fn stop_init_entrypoint_log_task(mut task: tokio::task::JoinHandle<anyhow::Result<()>>) {
+    let result = tokio::select! {
+        result = &mut task => result,
+        _ = tokio::time::sleep(Duration::from_millis(250)) => {
+            task.abort();
+            task.await
+        }
+    };
+
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => ui::warn(&format!("failed to stream init-owned command logs: {err}")),
+        Err(err) if err.is_cancelled() => {}
+        Err(err) => ui::warn(&format!("init-owned command log task failed: {err}")),
+    }
+}
+
+fn render_init_entrypoint_log(entry: &microsandbox::logs::LogEntry) -> anyhow::Result<()> {
+    match entry.source {
+        LogSource::Stdout | LogSource::Output => {
+            let mut stdout = std::io::stdout().lock();
+            stdout.write_all(&entry.data)?;
+            stdout.flush()?;
+        }
+        LogSource::Stderr | LogSource::System => {
+            let mut stderr = std::io::stderr().lock();
+            stderr.write_all(&entry.data)?;
+            stderr.flush()?;
+        }
+    }
+    Ok(())
 }
 
 /// Execute or attach to a command in a sandbox.

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -284,19 +284,6 @@ pub const ENV_HOST_ALIAS: &str = "MSB_HOST_ALIAS";
 /// inherits the raised baseline instead of having to opt into per-exec rlimits.
 pub const ENV_RLIMITS: &str = "MSB_RLIMITS";
 
-/// Separator byte for argv/env entries in handoff-init env vars.
-///
-/// ASCII Unit Separator (`0x1F`). Argv entries and `KEY=VAL` env pairs
-/// are arbitrary user strings, so the `;` separator other MSB_* vars use
-/// is unsafe — they collide with realistic shell input. `0x1F` is
-/// purpose-built for this and absent from any printable string.
-pub const HANDOFF_INIT_SEP: char = '\x1f';
-
-/// String form of [`HANDOFF_INIT_SEP`] for use with `&str`-friendly
-/// APIs like `[T]::join`. Avoids per-call `char.to_string()` allocations
-/// on the host's encoder side.
-pub const HANDOFF_INIT_SEP_STR: &str = "\x1f";
-
 /// Environment variable selecting a guest init binary for PID 1 handoff.
 ///
 /// When set, agentd performs initial setup (mounts, runtime dirs), then
@@ -315,11 +302,28 @@ pub const ENV_HANDOFF_INIT: &str = "MSB_HANDOFF_INIT";
 
 /// Sentinel value for [`ENV_HANDOFF_INIT`] requesting auto-detection.
 ///
-/// When the env var matches this exact string, agentd probes
-/// [`HANDOFF_INIT_AUTO_CANDIDATES`] in order and uses the first path
-/// that exists and is executable. If none match, boot fails with a
-/// clear error in `kernel.log` listing the paths it checked.
+/// The host may resolve this sentinel before boot when an OCI image
+/// declares a known init as the first entrypoint token. If the sentinel
+/// reaches the guest unchanged, agentd probes [`HANDOFF_INIT_AUTO_CANDIDATES`]
+/// in order and uses the first path that exists and is executable. If
+/// none match, boot fails with a clear error in `kernel.log` listing the
+/// paths it checked.
 pub const HANDOFF_INIT_AUTO: &str = "auto";
+
+/// Ordered list of image entrypoint paths that `--init auto` may treat
+/// as an explicit handoff init.
+///
+/// This host-side list is intentionally slightly wider than
+/// [`HANDOFF_INIT_AUTO_CANDIDATES`]: `/init` is common in s6-overlay
+/// images but too broad to probe blindly inside every guest rootfs.
+/// Matching it only when the image declares it as ENTRYPOINT keeps the
+/// behavior image-directed.
+pub const HANDOFF_INIT_IMAGE_ENTRYPOINT_CANDIDATES: &[&str] = &[
+    "/init",
+    "/sbin/init",
+    "/lib/systemd/systemd",
+    "/usr/lib/systemd/systemd",
+];
 
 /// Ordered list of init-binary paths agentd probes when
 /// [`ENV_HANDOFF_INIT`] is set to [`HANDOFF_INIT_AUTO`].
@@ -339,21 +343,20 @@ pub const HANDOFF_INIT_AUTO_CANDIDATES: &[&str] = &[
 
 /// Argv list for the handoff init binary.
 ///
-/// Format: entries separated by [`HANDOFF_INIT_SEP`] (ASCII `0x1F`).
+/// Format: base64url-no-padding encoded JSON array of strings.
 /// Empty or unset means the init is exec'd with `argv = [program]`.
 ///
 /// Example:
-/// - `MSB_HANDOFF_INIT_ARGS=--unit=multi-user.target\x1f--log-level=warning`
+/// - `MSB_HANDOFF_INIT_ARGS=WyItdW5pdD1tdWx0aS11c2VyLnRhcmdldCJd`
 pub const ENV_HANDOFF_INIT_ARGS: &str = "MSB_HANDOFF_INIT_ARGS";
 
 /// Extra environment variables for the handoff init binary.
 ///
-/// Format: `KEY=VAL` pairs separated by [`HANDOFF_INIT_SEP`]
-/// (ASCII `0x1F`). Each entry must contain at least one `=`. Merged on
-/// top of the inherited env.
+/// Format: base64url-no-padding encoded JSON array of `[key, value]`
+/// pairs. Merged on top of the inherited env.
 ///
 /// Example:
-/// - `MSB_HANDOFF_INIT_ENV=container=microsandbox\x1fLANG=C.UTF-8`
+/// - `MSB_HANDOFF_INIT_ENV=W1siY29udGFpbmVyIiwibWljcm9zYW5kYm94Il1d`
 pub const ENV_HANDOFF_INIT_ENV: &str = "MSB_HANDOFF_INIT_ENV";
 
 /// Guest-side path to the CA certificate for TLS interception.

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -345,6 +345,10 @@ pub const HANDOFF_INIT_AUTO_CANDIDATES: &[&str] = &[
 ///
 /// Format: base64url-no-padding encoded JSON array of strings.
 /// Empty or unset means the init is exec'd with `argv = [program]`.
+/// This deliberately differs from the delimiter-based `MSB_*` boot env
+/// formats because argv entries are arbitrary strings; wrapping JSON in
+/// base64url preserves spaces, separators, empty strings, and Unicode
+/// without inventing a second escaping language.
 ///
 /// Example:
 /// - `MSB_HANDOFF_INIT_ARGS=WyItdW5pdD1tdWx0aS11c2VyLnRhcmdldCJd`
@@ -354,6 +358,9 @@ pub const ENV_HANDOFF_INIT_ARGS: &str = "MSB_HANDOFF_INIT_ARGS";
 ///
 /// Format: base64url-no-padding encoded JSON array of `[key, value]`
 /// pairs. Merged on top of the inherited env.
+/// This uses the same structured payload exception as
+/// [`ENV_HANDOFF_INIT_ARGS`] so env values can contain the delimiter
+/// characters used by older `MSB_*` boot env formats.
 ///
 /// Example:
 /// - `MSB_HANDOFF_INIT_ENV=W1siY29udGFpbmVyIiwibWljcm9zYW5kYm94Il1d`

--- a/docs/recipes/guest/systemd-services.mdx
+++ b/docs/recipes/guest/systemd-services.mdx
@@ -17,7 +17,7 @@ msb run ghcr.io/superradcompany/debian-systemd:12 \
   -- bash
 ```
 
-`debian-systemd` is one of the optional bases we maintain in [guest-images](https://github.com/superradcompany/guest-images) for cases like this. `--init auto` probes a small set of well-known paths and picks the first that exists. See [Custom init system](/sandboxes/customize#custom-init-system) for the full list and for pinning to an exact path.
+`debian-systemd` is one of the optional bases we maintain in [guest-images](https://github.com/superradcompany/guest-images) for cases like this. `--init auto` uses a known init from the image ENTRYPOINT when one is declared, then falls back to probing common distro paths. Image-declared `/init` wrappers keep their OCI launch contract for attached `msb run`; bare systemd images still run your trailing command through agentd after boot. See [Custom init system](/sandboxes/customize#custom-init-system) for the exact behavior and for pinning to an explicit path.
 
 ## Step 2: Confirm systemd is PID 1
 
@@ -60,6 +60,6 @@ Microsandbox is detected as a container, so packages with `policy-rc.d` deferral
 
 ## Notes
 
-- **Image choice matters.** Distroless / minimal images (`python:3.13-slim`, `alpine`) don't ship a systemd init binary; `--init auto` will fail and `kernel.log` will list every path it tried. Use a systemd-equipped base or layer one in.
+- **Image choice matters.** Distroless / minimal images (`python:3.13-slim`, `alpine`) don't ship a systemd init binary; `--init auto` will fail if it cannot resolve a known image ENTRYPOINT init or find a guest-side probe match. Use a systemd-equipped base or layer one in.
 - **Memory budget.** systemd's idle footprint is ~50 MiB; daemons add more. Bump `--memory` if your service is hungry.
-- **Other inits work.** `--init` accepts any absolute path. s6, OpenRC, runit, or a hand-rolled `/sbin/init` shell script are all fine; `auto` just covers the systemd-on-Debian/Ubuntu case.
+- **Other inits work.** `--init` accepts any absolute path. s6, OpenRC, runit, or a hand-rolled `/sbin/init` shell script are all fine; `auto` covers known image ENTRYPOINT inits plus common distro init paths.

--- a/docs/sandboxes/customize.mdx
+++ b/docs/sandboxes/customize.mdx
@@ -174,7 +174,7 @@ By default the microsandbox agent runs as PID 1 inside the guest: small, fast, m
 
 Common reasons to opt in: long-lived daemons, system service tests, anything that talks to dbus or expects `systemctl` to work.
 
-Use `auto` to pick a known init binary from the image, or pass an absolute path when you need to pin the entry point for reproducible CI.
+Use `auto` to pick a known init binary from the image, or pass an absolute path when you need to pin the entry point for reproducible CI. When an OCI image declares a known init path as the first ENTRYPOINT token, such as `/init` in s6-overlay images, `auto` hands PID 1 to that path. For attached `msb run`, microsandbox preserves the OCI launch contract by passing the remaining ENTRYPOINT plus CMD or trailing command to that init instead of direct-executing the wrapper through agentd. Otherwise, `auto` falls back to probing common distro paths: `/sbin/init`, `/lib/systemd/systemd`, and `/usr/lib/systemd/systemd`.
 
 <CodeGroup>
 ```rust Rust
@@ -236,7 +236,7 @@ $ msb run ghcr.io/superradcompany/debian-systemd:12 --init auto -- cat /proc/1/c
 systemd
 ```
 
-If `--init=auto` cannot find an init binary, boot fails with a clear error in `kernel.log`. Use an explicit path when you know where the init lives.
+If `--init=auto` cannot find an init binary from the image ENTRYPOINT or the guest-side probe list, boot fails with a clear error in `kernel.log`. Use an explicit path when you know where the init lives.
 
 ### Argv and env
 
@@ -307,4 +307,4 @@ msb run ghcr.io/superradcompany/debian-systemd:12 \
 
 Most slim Docker base images do not include systemd or another full init. Use an image that ships the init you want, or build a small custom image that installs it.
 
-`--init` controls PID 1. `--entrypoint` and the trailing command control the workload you run after boot, so the two can be combined.
+`--init` controls PID 1. `--entrypoint` and the trailing command normally control the workload you run after boot, so the two can be combined. The special case is an image-declared init entrypoint such as `/init`: with `--init auto` and attached `msb run`, the trailing command is passed to PID 1 as part of the image's own launch contract.

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -590,7 +590,7 @@ Helpers that construct [`InitConfig`](#initconfig) values for [`WithInit`](#with
 func (initFactory) Auto() InitConfig
 ```
 
-Probe common init paths inside the guest (`/sbin/init`, `/lib/systemd/systemd`, ...).
+Use a known init at the start of the image ENTRYPOINT when present, or probe common init paths inside the guest (`/sbin/init`, `/lib/systemd/systemd`, ...). For attached `msb run` against image-declared init entrypoints, microsandbox passes the remaining ENTRYPOINT plus CMD or trailing command to that init instead of direct-executing the wrapper through agentd.
 
 ```go
 m.WithInit(m.Init.Auto())
@@ -1026,7 +1026,7 @@ Custom init specification.
 
 | Field | Type                | Description                                                          |
 | ----- | ------------------- | -------------------------------------------------------------------- |
-| Cmd   | `string`            | Absolute path or `"auto"` to the init binary inside the guest rootfs |
+| Cmd   | `string`            | Absolute path or `"auto"` to the init binary. Auto honors known image ENTRYPOINT inits before probing common guest paths and preserves attached init-entrypoint commands |
 | Args  | `[]string`          | Supplemental argv (`argv[0]` is implicitly `Cmd`)                    |
 | Env   | `map[string]string` | Extra env vars merged on top of the inherited env                    |
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -966,7 +966,7 @@ class InitConfig:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| cmd | `str` | Absolute path or `"auto"` to the init binary inside the guest rootfs |
+| cmd | `str` | Absolute path or `"auto"` to the init binary. Auto honors known image ENTRYPOINT inits before probing common guest paths and preserves attached init-entrypoint commands |
 | args | `tuple[str, ...]` | Supplemental argv (`argv[0]` is implicitly `cmd`) |
 | env | `dict[str, str]` | Extra env vars merged on top of the inherited env |
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -537,7 +537,7 @@ fn init(self, cmd: impl Into<PathBuf>) -> Self
 
 Hand off PID 1 inside the guest to `cmd` after agentd finishes its boot-time setup. The agent forks; the parent execs the init and becomes PID 1, the agent continues as a child process. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks, shutdown semantics, and tradeoffs.
 
-`cmd` is either an absolute path inside the guest rootfs or the literal `"auto"` (probes `/sbin/init`, `/lib/systemd/systemd`, `/usr/lib/systemd/systemd`). For init binaries that take argv or extra env (rare), use [`init_with`](#init_with).
+`cmd` is either an absolute path inside the guest rootfs or the literal `"auto"`. Auto first honors a known init at the start of the image ENTRYPOINT, such as `/init` in s6-overlay images, then falls back to probing `/sbin/init`, `/lib/systemd/systemd`, and `/usr/lib/systemd/systemd` inside the guest. When attached `msb run` uses an image-declared init entrypoint, the remaining ENTRYPOINT plus CMD or trailing command is passed to that init instead of direct-executed through agentd. For init binaries that take argv or extra env (rare), use [`init_with`](#init_with).
 
 **Parameters**
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -580,7 +580,7 @@ Fluent configuration builder returned by `Sandbox.builder(name)`. Every setter r
 | `shell(shell)` | Shell binary used by `sandbox.shell(...)` |
 | `security(profile)` | In-guest security profile (`"default"` or `"restricted"`) |
 | `entrypoint(iter)` | Override the image's stored ENTRYPOINT. Consulted by `msb exec` / `msb run` (CLI command resolution), **not** by `sandbox.exec` / `sandbox.shell` — those pass `cmd` literally |
-| `init(cmd, args?)` | Hand off PID 1 to `cmd` (absolute path or `"auto"`) after agentd setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
+| `init(cmd, args?)` | Hand off PID 1 to `cmd` (absolute path or `"auto"`, including known image ENTRYPOINT inits and attached init-entrypoint commands) after agentd setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
 | `initWith(cmd, i => ...)` | Like `init` but with a closure-builder for argv and env (`.arg`, `.args`, `.env`, `.envs`) |
 | `hostname(name)` | Guest hostname |
 | `user(user)` | Default guest user |

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -479,7 +479,8 @@ type initFactory struct{}
 //	microsandbox.WithInit(microsandbox.Init.Cmd("/sbin/init", microsandbox.InitOptions{}))
 var Init initFactory
 
-// Auto delegates to agentd to probe common init paths.
+// Auto uses a known image ENTRYPOINT init when present, preserving attached
+// init-entrypoint commands, otherwise it delegates to agentd to probe common init paths.
 func (initFactory) Auto() InitConfig { return InitConfig{Cmd: "auto"} }
 
 // Cmd sets the init binary path with optional args/env.

--- a/sdk/node-ts/native/sandbox_builder.rs
+++ b/sdk/node-ts/native/sandbox_builder.rs
@@ -262,8 +262,10 @@ impl JsSandboxBuilder {
     /// Hand off PID 1 to a guest init binary after agentd's setup.
     ///
     /// `cmd` is either an absolute path inside the guest rootfs or
-    /// the literal `"auto"`. `args` is the supplemental argv;
-    /// `argv[0]` is implicitly `cmd`. For env vars, use `initWith`.
+    /// the literal `"auto"`. Auto honors known image ENTRYPOINT inits,
+    /// preserves attached init-entrypoint commands, then probes common
+    /// guest paths. `args` is the supplemental argv; `argv[0]` is
+    /// implicitly `cmd`. For env vars, use `initWith`.
     #[napi]
     pub fn init(&mut self, cmd: String, args: Option<Vec<String>>) -> &Self {
         let prev = self.take_inner();

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -287,8 +287,10 @@ class InitConfig:
     as a bare string: ``init="auto"``.
 
     ``cmd`` is either an absolute path inside the guest rootfs or the
-    literal ``"auto"`` (probes /sbin/init, /lib/systemd/systemd,
-    /usr/lib/systemd/systemd).
+    literal ``"auto"``. Auto honors a known init at the start of the
+    image ENTRYPOINT, preserves attached init-entrypoint commands, then
+    probes /sbin/init, /lib/systemd/systemd, and /usr/lib/systemd/systemd
+    inside the guest.
     """
     cmd: str
     args: tuple[str, ...] = ()

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -20,9 +20,10 @@ use std::{
     process::Stdio,
 };
 
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use rand::RngExt;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest as Sha2Digest, Sha256};
 use tempfile::TempDir;
 use tokio::{io::AsyncBufReadExt, process::Command};
@@ -32,7 +33,7 @@ use microsandbox_metrics::{MetricsRegistry, ReserveSlot, SlotReservation};
 use microsandbox_protocol::{
     ENV_BLOCK_ROOT, ENV_DIR_MOUNTS, ENV_DISK_MOUNTS, ENV_FILE_MOUNTS, ENV_HANDOFF_INIT,
     ENV_HANDOFF_INIT_ARGS, ENV_HANDOFF_INIT_ENV, ENV_HOSTNAME, ENV_SECURITY_PROFILE, ENV_TMPFS,
-    ENV_USER, HANDOFF_INIT_SEP_STR,
+    ENV_USER,
 };
 use microsandbox_utils::{DB_FILENAME, DB_SUBDIR};
 
@@ -929,6 +930,12 @@ fn encode_rlimits(rlimits: &[Rlimit]) -> String {
     out
 }
 
+/// Encodes a handoff-init argv/env payload into printable env-var text.
+fn encode_handoff_json<T: Serialize>(value: &T) -> String {
+    let json = serde_json::to_vec(value).expect("handoff init payload is JSON-serializable");
+    URL_SAFE_NO_PAD.encode(json)
+}
+
 /// Derive a stable, collision-resistant identifier from a guest mount path.
 ///
 /// Used for virtiofs tags and for virtio-blk `serial` fields (the block id
@@ -1272,8 +1279,8 @@ fn sandbox_cli_args(
 
     // Handoff-init: PID 1 hand-off to a user-supplied init binary.
     // The builder's `validate()` rejects non-UTF-8 cmd paths, args/env
-    // containing the separator byte (\x1f) or NUL, and env keys containing
-    // `=`, so the joins below can't produce a corrupted wire format.
+    // containing NUL, and env keys containing `=`, so the JSON payloads
+    // below can't produce a corrupted execve wire format.
     if let Some(ref init) = config.init {
         let cmd = init
             .cmd
@@ -1283,7 +1290,7 @@ fn sandbox_cli_args(
         args.push(OsString::from(format!("{ENV_HANDOFF_INIT}={cmd}")));
 
         if !init.args.is_empty() {
-            let argv_val = init.args.join(HANDOFF_INIT_SEP_STR);
+            let argv_val = encode_handoff_json(&init.args);
             args.push(OsString::from("--env"));
             args.push(OsString::from(format!(
                 "{ENV_HANDOFF_INIT_ARGS}={argv_val}"
@@ -1291,12 +1298,7 @@ fn sandbox_cli_args(
         }
 
         if !init.env.is_empty() {
-            let env_val = init
-                .env
-                .iter()
-                .map(|(k, v)| format!("{k}={v}"))
-                .collect::<Vec<_>>()
-                .join(HANDOFF_INIT_SEP_STR);
+            let env_val = encode_handoff_json(&init.env);
             args.push(OsString::from("--env"));
             args.push(OsString::from(format!("{ENV_HANDOFF_INIT_ENV}={env_val}")));
         }
@@ -1319,6 +1321,10 @@ mod tests {
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
 
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use serde::de::DeserializeOwned;
+    use tempfile::tempdir;
+
     use super::sandbox_cli_args;
     use crate::{
         LogLevel,
@@ -1328,7 +1334,6 @@ mod tests {
             SandboxConfig,
         },
     };
-    use tempfile::tempdir;
 
     //----------------------------------------------------------------------------------------------
     // Functions: Helpers
@@ -1360,6 +1365,11 @@ mod tests {
         .iter()
         .map(|arg| arg.to_string_lossy().into_owned())
         .collect()
+    }
+
+    fn decode_handoff_json<T: DeserializeOwned>(value: &str) -> T {
+        let json = URL_SAFE_NO_PAD.decode(value).expect("base64url payload");
+        serde_json::from_slice(&json).expect("handoff JSON payload")
     }
 
     fn render_args_with_file_mounts(
@@ -1966,11 +1976,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handoff_init_joins_argv_with_unit_separator() {
+    async fn test_handoff_init_encodes_argv_as_base64url_json() {
         let config = SandboxBuilder::new("test")
             .image("/tmp/rootfs")
             .init_with("/lib/systemd/systemd", |i| {
-                i.args(["--unit=multi-user.target", "--log-level=warning"])
+                i.args([
+                    "--unit=multi-user.target",
+                    "--log-level=warning",
+                    "literal\x1funit-separator",
+                ])
             })
             .build()
             .await
@@ -1978,16 +1992,26 @@ mod tests {
 
         let args = render_args(&config);
         let argv = find_env(&args, "MSB_HANDOFF_INIT_ARGS").expect("argv env present");
+        let decoded: Vec<String> = decode_handoff_json(&argv);
 
-        assert_eq!(argv, "--unit=multi-user.target\x1f--log-level=warning");
+        assert_eq!(
+            decoded,
+            vec![
+                "--unit=multi-user.target",
+                "--log-level=warning",
+                "literal\x1funit-separator"
+            ]
+        );
     }
 
     #[tokio::test]
-    async fn test_handoff_init_emits_env_pairs_separated_by_unit_separator() {
+    async fn test_handoff_init_encodes_env_pairs_as_base64url_json() {
         let config = SandboxBuilder::new("test")
             .image("/tmp/rootfs")
             .init_with("/sbin/init", |i| {
-                i.env("container", "microsandbox").env("LANG", "C.UTF-8")
+                i.env("container", "microsandbox")
+                    .env("LANG", "C.UTF-8")
+                    .env("TOKEN", "a=b;c\x1fd")
             })
             .build()
             .await
@@ -1995,8 +2019,16 @@ mod tests {
 
         let args = render_args(&config);
         let env_val = find_env(&args, "MSB_HANDOFF_INIT_ENV").expect("env present");
+        let decoded: Vec<(String, String)> = decode_handoff_json(&env_val);
 
-        assert_eq!(env_val, "container=microsandbox\x1fLANG=C.UTF-8");
+        assert_eq!(
+            decoded,
+            vec![
+                ("container".to_string(), "microsandbox".to_string()),
+                ("LANG".to_string(), "C.UTF-8".to_string()),
+                ("TOKEN".to_string(), "a=b;c\x1fd".to_string())
+            ]
+        );
     }
 
     #[tokio::test]
@@ -2015,14 +2047,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handoff_init_separator_in_arg_rejected_at_build_time() {
-        let err = SandboxBuilder::new("test")
+    async fn test_handoff_init_unit_separator_in_arg_allowed() {
+        let config = SandboxBuilder::new("test")
             .image("/tmp/rootfs")
             .init_with("/sbin/init", |i| i.args(["foo\x1fbar"]))
             .build()
             .await
-            .unwrap_err();
-        assert!(format!("{err}").contains("0x1F"));
+            .unwrap();
+        let args = render_args(&config);
+        let argv = find_env(&args, "MSB_HANDOFF_INIT_ARGS").expect("argv env present");
+        let decoded: Vec<String> = decode_handoff_json(&argv);
+
+        assert_eq!(decoded, vec!["foo\x1fbar"]);
     }
 
     #[tokio::test]

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -306,11 +306,21 @@ impl SandboxBuilder {
         self
     }
 
+    /// Set the transient initial command for attached CLI `run`.
+    #[doc(hidden)]
+    pub fn initial_command(mut self, command: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.config
+            .set_initial_command(command.into_iter().map(Into::into).collect());
+        self
+    }
+
     /// Hand off PID 1 to a guest init binary after agentd's setup.
     ///
     /// `cmd` is either an absolute path inside the guest rootfs or
-    /// the literal `"auto"` (probes `/sbin/init`,
-    /// `/lib/systemd/systemd`, `/usr/lib/systemd/systemd`).
+    /// the literal `"auto"`. Auto first honors a known init path at
+    /// the start of the image ENTRYPOINT, preserving attached
+    /// init-entrypoint commands when needed, then falls back to
+    /// guest-side probing of common distro init paths.
     ///
     /// ```ignore
     /// .init("auto")

--- a/sdk/rust/lib/sandbox/config.rs
+++ b/sdk/rust/lib/sandbox/config.rs
@@ -8,6 +8,7 @@ use microsandbox_runtime::{logging::LogLevel, policy::SandboxPolicy};
 use serde::{Deserialize, Serialize};
 
 use microsandbox_image::{ImageConfig, PullPolicy, RegistryAuth};
+use microsandbox_protocol::{HANDOFF_INIT_AUTO, HANDOFF_INIT_IMAGE_ENTRYPOINT_CANDIDATES};
 
 use super::{
     exec::Rlimit,
@@ -249,6 +250,19 @@ pub struct SandboxConfig {
     /// during `create_with_mode`. Never persisted.
     #[serde(skip)]
     pub(crate) snapshot_upper_source: Option<PathBuf>,
+
+    /// Initial command requested by an attached `msb run` invocation.
+    ///
+    /// This is transient CLI intent, not persisted sandbox config. It lets
+    /// `--init auto` decide before VM spawn whether an image-declared init
+    /// entrypoint should receive the OCI command as argv.
+    #[serde(skip)]
+    pub(crate) initial_command: Option<Vec<String>>,
+
+    /// Whether [`initial_command`](Self::initial_command) was consumed by
+    /// the handoff init instead of being executed through agentd.
+    #[serde(skip)]
+    pub(crate) initial_command_consumed_by_init: bool,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -265,14 +279,30 @@ impl SandboxConfig {
         }
     }
 
+    /// Return whether the attached initial command was launched by the
+    /// handoff init rather than through agentd.
+    #[doc(hidden)]
+    pub fn initial_command_consumed_by_init(&self) -> bool {
+        self.initial_command_consumed_by_init
+    }
+
+    /// Set transient initial command intent for attached `msb run`.
+    pub(crate) fn set_initial_command(&mut self, command: Vec<String>) {
+        self.initial_command = Some(command);
+        self.initial_command_consumed_by_init = false;
+    }
+
     /// Apply OCI image config as defaults. User-provided values take precedence.
     ///
     /// - `env`: image env vars form the base; user env vars override by key, otherwise append.
     /// - `labels`: image labels form the base; user labels override by key.
     /// - `cmd`, `entrypoint`, `workdir`, `user`: image value used only if user did not set one.
+    /// - `init`: an `auto` init may resolve from a known init at the start of the image entrypoint.
     pub fn merge_image_defaults(&mut self, image: &ImageConfig) {
         self.env = merge_env(&image.env, &self.env);
         self.labels = merge_image_labels(&image.labels, &self.labels);
+
+        let inherit_entrypoint = self.entrypoint.is_none();
 
         if self.cmd.is_none() {
             self.cmd = image.cmd.clone();
@@ -294,6 +324,97 @@ impl SandboxConfig {
                 .filter(|s| !s.is_empty())
                 .map(String::from);
         }
+
+        self.resolve_auto_init_from_image_entrypoint(
+            image.entrypoint.as_deref(),
+            inherit_entrypoint,
+        );
+    }
+
+    /// Resolve `init = "auto"` from a known init path declared as the
+    /// image entrypoint.
+    ///
+    /// When an attached `msb run` provided an initial command, and the
+    /// image declares a container-init entrypoint such as `/init`, the
+    /// remaining OCI process vector is passed to the init as argv. The
+    /// image init token is still stripped from the persisted workload
+    /// entrypoint so later agentd exec command resolution never tries
+    /// to direct-exec `/init`.
+    fn resolve_auto_init_from_image_entrypoint(
+        &mut self,
+        image_entrypoint: Option<&[String]>,
+        inherited_entrypoint: bool,
+    ) {
+        let Some(init) = self.init.as_ref() else {
+            return;
+        };
+        if init.cmd.as_os_str() != HANDOFF_INIT_AUTO {
+            return;
+        }
+        let init_args_empty = init.args.is_empty();
+
+        let Some(entrypoint) = image_entrypoint else {
+            return;
+        };
+        let Some(init_path) = entrypoint
+            .first()
+            .map(String::as_str)
+            .filter(|path| is_image_entrypoint_init(path))
+        else {
+            return;
+        };
+
+        let init_argv_tail = if inherited_entrypoint && init_args_empty {
+            self.image_init_entrypoint_argv_tail(init_path, entrypoint)
+        } else {
+            None
+        };
+
+        let init = self
+            .init
+            .as_mut()
+            .expect("init was present at start of auto resolution");
+        init.cmd = PathBuf::from(init_path);
+        if let Some(argv_tail) = init_argv_tail {
+            init.args = argv_tail;
+            self.initial_command_consumed_by_init = true;
+        }
+
+        if !inherited_entrypoint {
+            return;
+        }
+
+        let Some(mut entrypoint) = self.entrypoint.take() else {
+            return;
+        };
+        if entrypoint
+            .first()
+            .is_some_and(|first| first.as_str() == init_path)
+        {
+            entrypoint.remove(0);
+        }
+        self.entrypoint = (!entrypoint.is_empty()).then_some(entrypoint);
+    }
+
+    fn image_init_entrypoint_argv_tail(
+        &self,
+        init_path: &str,
+        image_entrypoint: &[String],
+    ) -> Option<Vec<String>> {
+        let initial_command = self.initial_command.as_ref()?;
+        if init_path != "/init" && image_entrypoint.len() <= 1 {
+            return None;
+        }
+
+        let mut process = image_entrypoint.to_vec();
+        if initial_command.is_empty() {
+            process.extend(self.cmd.iter().flatten().cloned());
+        } else {
+            process.extend(initial_command.iter().cloned());
+        }
+
+        let argv_tail: Vec<_> = process.into_iter().skip(1).collect();
+        (!argv_tail.is_empty()).then_some(argv_tail)
     }
 
     /// Materialize rootfs defaults that should be persisted with the sandbox.
@@ -389,6 +510,10 @@ fn merge_image_labels(
     merged
 }
 
+fn is_image_entrypoint_init(path: &str) -> bool {
+    HANDOFF_INIT_IMAGE_ENTRYPOINT_CANDIDATES.contains(&path)
+}
+
 fn default_oci_tmpfs_size_mib(memory_mib: u32) -> u32 {
     (memory_mib / DEFAULT_OCI_TMPFS_MEMORY_DIVISOR).clamp(1, DEFAULT_OCI_TMPFS_MAX_SIZE_MIB)
 }
@@ -448,6 +573,8 @@ impl Default for SandboxConfig {
             replace_with_timeout: DEFAULT_REPLACE_TIMEOUT,
             manifest_digest: None,
             snapshot_upper_source: None,
+            initial_command: None,
+            initial_command_consumed_by_init: false,
         }
     }
 }
@@ -458,8 +585,10 @@ impl Default for SandboxConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::{SandboxConfig, merge_env};
-    use crate::sandbox::{MountOptions, RootfsSource, VolumeMount};
+    use crate::sandbox::{HandoffInit, MountOptions, RootfsSource, VolumeMount};
     use microsandbox_image::ImageConfig;
 
     #[test]
@@ -552,6 +681,180 @@ mod tests {
         assert_eq!(config.entrypoint, Some(vec!["/entrypoint.sh".to_string()]));
         assert_eq!(config.workdir, Some("/workspace".to_string()));
         assert_eq!(config.user, Some("root".to_string()));
+    }
+
+    #[test]
+    fn test_merge_image_defaults_resolves_auto_init_from_image_entrypoint() {
+        let image = ImageConfig {
+            entrypoint: Some(vec![
+                "/init".to_string(),
+                "/opt/hermes/docker/main-wrapper.sh".to_string(),
+            ]),
+            ..Default::default()
+        };
+
+        let mut config = SandboxConfig {
+            init: Some(HandoffInit {
+                cmd: PathBuf::from("auto"),
+                args: Vec::new(),
+                env: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        config.merge_image_defaults(&image);
+
+        let init = config.init.as_ref().expect("init should remain configured");
+        assert_eq!(init.cmd, PathBuf::from("/init"));
+        assert!(init.args.is_empty());
+        assert_eq!(
+            config.entrypoint,
+            Some(vec!["/opt/hermes/docker/main-wrapper.sh".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_merge_image_defaults_passes_initial_command_to_init_entrypoint() {
+        let image = ImageConfig {
+            entrypoint: Some(vec![
+                "/init".to_string(),
+                "/opt/hermes/docker/main-wrapper.sh".to_string(),
+            ]),
+            ..Default::default()
+        };
+
+        let mut config = SandboxConfig {
+            init: Some(HandoffInit {
+                cmd: PathBuf::from("auto"),
+                args: Vec::new(),
+                env: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        config.set_initial_command(vec!["gateway".to_string(), "run".to_string()]);
+        config.merge_image_defaults(&image);
+
+        let init = config.init.as_ref().expect("init should remain configured");
+        assert_eq!(init.cmd, PathBuf::from("/init"));
+        assert_eq!(
+            init.args,
+            vec![
+                "/opt/hermes/docker/main-wrapper.sh".to_string(),
+                "gateway".to_string(),
+                "run".to_string()
+            ]
+        );
+        assert!(config.initial_command_consumed_by_init());
+        assert_eq!(
+            config.entrypoint,
+            Some(vec!["/opt/hermes/docker/main-wrapper.sh".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_merge_image_defaults_passes_image_cmd_to_init_entrypoint() {
+        let image = ImageConfig {
+            entrypoint: Some(vec!["/init".to_string()]),
+            cmd: Some(vec!["/app/server".to_string(), "--serve".to_string()]),
+            ..Default::default()
+        };
+
+        let mut config = SandboxConfig {
+            init: Some(HandoffInit {
+                cmd: PathBuf::from("auto"),
+                args: Vec::new(),
+                env: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        config.set_initial_command(Vec::new());
+        config.merge_image_defaults(&image);
+
+        let init = config.init.as_ref().expect("init should remain configured");
+        assert_eq!(init.cmd, PathBuf::from("/init"));
+        assert_eq!(
+            init.args,
+            vec!["/app/server".to_string(), "--serve".to_string()]
+        );
+        assert!(config.initial_command_consumed_by_init());
+        assert_eq!(config.entrypoint, None);
+    }
+
+    #[test]
+    fn test_merge_image_defaults_bare_systemd_does_not_consume_initial_command() {
+        let image = ImageConfig {
+            entrypoint: Some(vec!["/lib/systemd/systemd".to_string()]),
+            ..Default::default()
+        };
+
+        let mut config = SandboxConfig {
+            init: Some(HandoffInit {
+                cmd: PathBuf::from("auto"),
+                args: Vec::new(),
+                env: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        config.set_initial_command(vec!["bash".to_string()]);
+        config.merge_image_defaults(&image);
+
+        let init = config.init.as_ref().expect("init should remain configured");
+        assert_eq!(init.cmd, PathBuf::from("/lib/systemd/systemd"));
+        assert!(init.args.is_empty());
+        assert!(!config.initial_command_consumed_by_init());
+        assert_eq!(config.entrypoint, None);
+    }
+
+    #[test]
+    fn test_merge_image_defaults_keeps_user_entrypoint_when_resolving_auto_init() {
+        let image = ImageConfig {
+            entrypoint: Some(vec![
+                "/init".to_string(),
+                "/opt/hermes/docker/main-wrapper.sh".to_string(),
+            ]),
+            ..Default::default()
+        };
+
+        let mut config = SandboxConfig {
+            entrypoint: Some(vec!["/bin/sh".to_string()]),
+            init: Some(HandoffInit {
+                cmd: PathBuf::from("auto"),
+                args: Vec::new(),
+                env: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        config.set_initial_command(vec!["gateway".to_string(), "run".to_string()]);
+        config.merge_image_defaults(&image);
+
+        let init = config.init.as_ref().expect("init should remain configured");
+        assert_eq!(init.cmd, PathBuf::from("/init"));
+        assert!(init.args.is_empty());
+        assert_eq!(config.entrypoint, Some(vec!["/bin/sh".to_string()]));
+        assert!(!config.initial_command_consumed_by_init());
+    }
+
+    #[test]
+    fn test_merge_image_defaults_leaves_auto_init_for_unknown_entrypoint() {
+        let image = ImageConfig {
+            entrypoint: Some(vec!["/entrypoint.sh".to_string()]),
+            ..Default::default()
+        };
+
+        let mut config = SandboxConfig {
+            init: Some(HandoffInit {
+                cmd: PathBuf::from("auto"),
+                args: Vec::new(),
+                env: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        config.merge_image_defaults(&image);
+
+        assert_eq!(
+            config.init.expect("init should remain configured").cmd,
+            PathBuf::from("auto")
+        );
+        assert_eq!(config.entrypoint, Some(vec!["/entrypoint.sh".to_string()]));
     }
 
     #[test]

--- a/sdk/rust/lib/sandbox/init.rs
+++ b/sdk/rust/lib/sandbox/init.rs
@@ -26,7 +26,7 @@
 
 use std::path::{Path, PathBuf};
 
-use microsandbox_protocol::{HANDOFF_INIT_AUTO, HANDOFF_INIT_SEP};
+use microsandbox_protocol::HANDOFF_INIT_AUTO;
 use serde::{Deserialize, Serialize};
 
 use crate::{MicrosandboxError, MicrosandboxResult};
@@ -118,11 +118,10 @@ impl InitOptionsBuilder {
 /// - `cmd` must be either an absolute path or the literal sentinel
 ///   [`HANDOFF_INIT_AUTO`] (which agentd resolves at boot time).
 /// - `cmd` must not contain a NUL byte (CString incompatibility).
-/// - Each argv entry must be free of `\x1f` and `\0` (the wire-format
-///   separator and CString terminator respectively).
-/// - Each env key must be non-empty, free of `=`, `\x1f`, and `\0`
-///   (POSIX disallows `=` in keys; `\x1f` is the separator).
-/// - Each env value must be free of `\x1f` and `\0`.
+/// - Each argv entry must be free of `\0` (CString terminator).
+/// - Each env key must be non-empty and free of `=` and `\0`
+///   (POSIX disallows `=` in keys).
+/// - Each env value must be free of `\0`.
 pub(crate) fn validate(spec: &HandoffInit) -> MicrosandboxResult<()> {
     validate_cmd(&spec.cmd)?;
     for (i, arg) in spec.args.iter().enumerate() {
@@ -157,11 +156,6 @@ fn validate_cmd(cmd: &Path) -> MicrosandboxResult<()> {
 }
 
 fn validate_arg(index: usize, arg: &str) -> MicrosandboxResult<()> {
-    if arg.contains(HANDOFF_INIT_SEP) {
-        return Err(MicrosandboxError::InvalidConfig(format!(
-            "init arg #{index} contains the reserved separator byte (0x1F)"
-        )));
-    }
     if arg.contains('\0') {
         return Err(MicrosandboxError::InvalidConfig(format!(
             "init arg #{index} must not contain a NUL byte"
@@ -181,14 +175,14 @@ fn validate_env_pair(key: &str, value: &str) -> MicrosandboxResult<()> {
             "init env key {key:?} must not contain '='"
         )));
     }
-    if key.contains(HANDOFF_INIT_SEP) || key.contains('\0') {
+    if key.contains('\0') {
         return Err(MicrosandboxError::InvalidConfig(format!(
-            "init env key {key:?} must not contain 0x1F or NUL"
+            "init env key {key:?} must not contain NUL"
         )));
     }
-    if value.contains(HANDOFF_INIT_SEP) || value.contains('\0') {
+    if value.contains('\0') {
         return Err(MicrosandboxError::InvalidConfig(format!(
-            "init env value for {key:?} must not contain 0x1F or NUL"
+            "init env value for {key:?} must not contain NUL"
         )));
     }
     Ok(())
@@ -224,10 +218,9 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_separator_in_arg() {
+    fn validate_accepts_unit_separator_in_arg() {
         let spec = ok("/sbin/init", &["foo\x1fbar"], &[]);
-        let err = validate(&spec).unwrap_err();
-        assert!(format!("{err}").contains("0x1F"));
+        assert!(validate(&spec).is_ok());
     }
 
     #[test]
@@ -245,10 +238,9 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_separator_in_env_value() {
+    fn validate_accepts_unit_separator_in_env_value() {
         let spec = ok("/sbin/init", &[], &[("KEY", "v\x1fbad")]);
-        let err = validate(&spec).unwrap_err();
-        assert!(format!("{err}").contains("0x1F"));
+        assert!(validate(&spec).is_ok());
     }
 
     #[test]

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -453,6 +453,9 @@ pub(crate) async fn create_local(
     validate_rootfs_source(&config.image)?;
     validate_env(&config.env)?;
     validate_labels(&config.labels)?;
+    if let Some(init) = &config.init {
+        init::validate(init)?;
+    }
 
     // Initialize the database before any expensive image pull so we can
     // fail fast on conflicting persisted sandbox state.
@@ -482,6 +485,9 @@ pub(crate) async fn create_local(
 
         // Merge image config defaults under user-provided config.
         config.merge_image_defaults(&pull_result.config);
+        if let Some(init) = &config.init {
+            init::validate(init)?;
+        }
 
         pinned_manifest_digest = Some(pull_result.manifest_digest.to_string());
         pinned_reference = Some(reference.clone());


### PR DESCRIPTION
## TL;DR
`--init auto` now honors init binaries declared by OCI image entrypoints, including `/init` in s6-overlay images, so attached `msb run` can start the image's real command through PID 1 instead of direct-execing the wrapper after boot.

## Description
- Resolve `--init auto` from known image ENTRYPOINT init paths before falling back to guest-side probing.
- Preserve the attached `msb run` command for image-owned init entrypoints, then skip the duplicate agentd exec when PID 1 owns that workload.
- Stream sandbox logs while waiting for init-owned foreground commands, so attached runs still show startup and service output.
- Encode handoff init argv and env as base64url JSON instead of separator-joined strings, so realistic args and env values round-trip safely.
- Keep bare systemd-style entrypoints on the normal agentd exec path, so `--init auto` does not treat every init as an app launcher.
- Update CLI help, SDK comments, and docs to describe image ENTRYPOINT init behavior.

```bash
msb run nousresearch/hermes-agent \
  --name hermes --replace \
  -p 8642:8642 \
  --init auto \
  -- gateway run
```

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo fmt --manifest-path crates/agentd/Cargo.toml -- --check`
- [x] `git diff --check origin/main..HEAD`
- [x] `cargo test -p microsandbox test_merge_image_defaults && cargo test -p microsandbox test_handoff_init && cargo test -p microsandbox-cli existing_reuse_warns_for_snapshot`
- [x] `cargo test --manifest-path crates/agentd/Cargo.toml --lib`
- [x] `just build-msb`
- [x] `./build/msb run nousresearch/hermes-agent --name hermes-pr-smoke --replace -p 18642:8642 --init auto --timeout 12s -- gateway run` reaches s6-overlay and Hermes Gateway before the expected timeout