### PR TITLE
docs(getting-started): clarify onboarding wording

### DIFF
--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -46,9 +46,9 @@ Instead of putting real credentials inside the VM, microsandbox injects placehol
 
 All sandbox traffic flows through a host-side network stack. You can allow public internet access, block private networks, publish ports, deny by default, pin DNS behavior, or inspect TLS traffic without relying on guest cooperation.
 
-### Filesystems are disposable or persistent by choice
+### Filesystem state is explicit
 
-Use OCI images for disposable roots, bind mounts for host data, named volumes for persistent state, tmpfs for scratch space, and snapshots when you want to reuse prepared sandbox state.
+Sandboxes can start from OCI images with copy-on-write storage, so writes do not modify cached image layers. Use volumes when data should come from the host or survive beyond one run, tmpfs for temporary scratch space, and snapshots when you want to boot again from a prepared filesystem state.
 
 ## Minimal example
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -46,9 +46,9 @@ Instead of putting real credentials inside the VM, microsandbox injects placehol
 
 All sandbox traffic flows through a host-side network stack. You can allow public internet access, block private networks, publish ports, deny by default, pin DNS behavior, or inspect TLS traffic without relying on guest cooperation.
 
-### Filesystem state is explicit
+### Storage is private by default
 
-Sandboxes can start from OCI images with copy-on-write storage, so writes do not modify cached image layers. Use volumes when data should come from the host or survive beyond one run, tmpfs for temporary scratch space, and snapshots when you want to boot again from a prepared filesystem state.
+For the normal OCI image workflow, each sandbox gets its own writable root filesystem on top of the image. Writes there do not change the cached image. Data reaches the host or another sandbox only when you choose a sharing mechanism, such as a bind mount, named volume, disk image, or snapshot.
 
 ## Minimal example
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -27,7 +27,7 @@ It keeps the familiar workflow of OCI images and command execution, while moving
 - **Programmable controls.** Configure resources, volumes, secrets, networking, and lifecycle from the CLI or SDK.
 - **Multi-language SDKs.** Rust, TypeScript, Python, and Go expose the same core model.
 
-## Common workloads
+## Example use cases
 
 - **AI agents.** Give coding agents and tool-using assistants a dedicated machine for commands, files, package installs, and generated code.
 - **User code execution.** Run submitted scripts, notebooks, plugins, and extensions away from the host.

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -18,7 +18,7 @@ icon: "bolt"
 
 <Steps>
   <Step title="Install microsandbox">
-    The SDK **embeds the runtime directly**, so no separate server process is needed. Only install the `msb` CLI if you want to manage images, volumes, and sandboxes from the terminal.
+    Install the SDK for the language you are using, and install the `msb` CLI for terminal workflows such as managing images, volumes, and sandboxes. Both run microsandbox locally; there is no separate server or daemon to set up.
 
     <CodeGroup>
     ```bash Rust


### PR DESCRIPTION
## TL;DR
Clarify the getting started docs so the CLI is not framed as optional and the intro uses "Example use cases" for the workload list.

## Description
- Present the SDK and `msb` CLI as complementary local workflows in the quickstart install step.
- Keep the no-server setup message while avoiding the implication that users only need the CLI for optional terminal management.
- Rename the intro workload section to "Example use cases" to better match product language.

## Test Plan
- [ ] Pre-commit hooks passed during `git commit -S`
- [ ] Reviewed `git diff origin/main..HEAD`