### PR TITLE
feat(init): support detached auto init entrypoints

### DIFF
--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -34,7 +34,7 @@ use crate::session::{
     ExecSession, RawActivity, RawSessionCompletion, SessionOutput, resolve_default_user,
 };
 use crate::tcp::TcpSession;
-use crate::{clock, fs, heartbeat, serial};
+use crate::{clock, fs, handoff, heartbeat, serial};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -192,6 +192,12 @@ pub async fn run(
                     match guard.try_io(|inner| read_from_fd(inner.get_ref().as_raw_fd(), &mut read_buf)) {
                         Ok(Ok(0)) => {
                             // EOF on serial — host disconnected.
+                            if !handoff::is_pid_1() {
+                                guard.clear_ready();
+                                drop(guard);
+                                time::sleep(Duration::from_millis(100)).await;
+                                break;
+                            }
                             break 'agent;
                         }
                         Ok(Ok(n)) => {
@@ -273,6 +279,12 @@ pub async fn run(
                             }
                         }
                         Ok(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                        Ok(Err(_)) if !handoff::is_pid_1() => {
+                            guard.clear_ready();
+                            drop(guard);
+                            time::sleep(Duration::from_millis(100)).await;
+                            break;
+                        }
                         Ok(Err(e)) => return Err(e.into()),
                         Err(_would_block) => break,
                     }

--- a/crates/agentd/lib/handoff.rs
+++ b/crates/agentd/lib/handoff.rs
@@ -24,7 +24,7 @@
 //! don't move the fork point later.
 
 use std::ffi::{CString, OsString};
-use std::fs::OpenOptions;
+use std::fs::{Metadata, OpenOptions};
 use std::io::Write;
 use std::os::fd::AsRawFd;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
@@ -32,7 +32,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use nix::sys::signal::{SigSet, SigmaskHow, Signal, sigprocmask};
-use nix::unistd::{ForkResult, fork};
+use nix::unistd::{ForkResult, fork, setsid};
 
 use microsandbox_protocol::{HANDOFF_INIT_AUTO, HANDOFF_INIT_AUTO_CANDIDATES};
 
@@ -98,6 +98,7 @@ pub fn do_handoff(spec: HandoffInit) -> AgentdResult<()> {
             process::exit(127);
         }
         ForkResult::Child => {
+            isolate_child_from_init()?;
             redirect_child_stderr();
             Ok(())
         }
@@ -105,7 +106,7 @@ pub fn do_handoff(spec: HandoffInit) -> AgentdResult<()> {
 }
 
 /// Resolves the user-supplied cmd, expanding the `auto` sentinel
-/// into the first existing entry from
+/// into the first executable regular file from
 /// [`HANDOFF_INIT_AUTO_CANDIDATES`].
 ///
 /// Non-`auto` paths are returned unchanged; downstream `preflight`
@@ -115,16 +116,20 @@ fn resolve_cmd(cmd: &Path) -> AgentdResult<PathBuf> {
         return Ok(cmd.to_path_buf());
     }
 
-    for candidate in HANDOFF_INIT_AUTO_CANDIDATES {
+    resolve_auto_cmd(HANDOFF_INIT_AUTO_CANDIDATES)
+}
+
+fn resolve_auto_cmd(candidates: &[&str]) -> AgentdResult<PathBuf> {
+    for candidate in candidates {
         let p = Path::new(candidate);
-        if p.exists() {
+        if init_candidate_is_executable_file(p) {
             return Ok(p.to_path_buf());
         }
     }
 
     Err(AgentdError::Init(format!(
         "{HANDOFF_INIT_AUTO}: no init binary found, checked: {}",
-        HANDOFF_INIT_AUTO_CANDIDATES.join(", ")
+        candidates.join(", ")
     )))
 }
 
@@ -152,6 +157,18 @@ fn preflight(cmd: &Path) -> AgentdResult<()> {
         )));
     }
     Ok(())
+}
+
+fn init_candidate_is_executable_file(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .map(|metadata| metadata_is_executable_file(&metadata))
+        .unwrap_or(false)
+}
+
+fn metadata_is_executable_file(metadata: &Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
 }
 
 /// Builds the C argv list for execve.
@@ -241,6 +258,14 @@ fn reset_signals() {
     let _ = sigprocmask(SigmaskHow::SIG_SETMASK, Some(&empty), None);
 }
 
+/// Moves the surviving agentd process into a new session so init
+/// systems that manage their original session/process group do not
+/// accidentally signal the agent relay.
+fn isolate_child_from_init() -> AgentdResult<()> {
+    setsid().map_err(|e| AgentdError::Init(format!("failed to isolate agentd session: {e}")))?;
+    Ok(())
+}
+
 /// Redirects the child's stderr to the post-handoff log file. Best
 /// effort — a failure here just leaves stderr pointing at the serial
 /// console (interleaved with the new init's output). The agent loop
@@ -304,6 +329,17 @@ pub fn signal_init_term() -> AgentdResult<()> {
 mod tests {
     use super::*;
 
+    fn unique_test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "microsandbox-agentd-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp test dir");
+        dir
+    }
+
     #[test]
     fn resolve_cmd_passes_explicit_path_through() {
         let p = Path::new("/lib/systemd/systemd");
@@ -345,5 +381,30 @@ mod tests {
             }
             Err(e) => panic!("unexpected error variant: {e}"),
         }
+    }
+
+    #[test]
+    fn resolve_auto_cmd_skips_non_executable_candidates() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = unique_test_dir("auto-skip");
+        let non_executable = dir.join("sbin-init");
+        let executable = dir.join("systemd");
+
+        std::fs::write(&non_executable, b"not executable").expect("write non-executable");
+        std::fs::set_permissions(&non_executable, std::fs::Permissions::from_mode(0o644))
+            .expect("chmod non-executable");
+        std::fs::write(&executable, b"#!/bin/sh\n").expect("write executable");
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod executable");
+
+        let candidates = [
+            non_executable.to_str().expect("utf-8 temp path"),
+            executable.to_str().expect("utf-8 temp path"),
+        ];
+        let resolved = resolve_auto_cmd(&candidates).expect("resolve executable candidate");
+
+        assert_eq!(resolved, executable);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -15,6 +15,12 @@ use super::common::{SandboxOpts, apply_sandbox_opts};
 use crate::ui;
 
 //--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const INIT_ENTRYPOINT_STOP_TIMEOUT: Duration = Duration::from_secs(10);
+
+//--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
 
@@ -175,7 +181,9 @@ async fn run_new(
         args.sandbox.log_level = Some(log_level.to_string());
     }
     let mut builder = apply_sandbox_opts(builder, &args.sandbox)?;
-    if !args.detach {
+    if args.detach {
+        builder = builder.persistent_initial_command(args.command.clone());
+    } else {
         builder = builder.initial_command(args.command.clone());
     }
 
@@ -204,7 +212,9 @@ async fn run_new(
 
     // Detach mode: just print the name and exit.
     if args.detach {
-        warn_detached_command_ignored(&name, &args);
+        if !sandbox.config().initial_command_consumed_by_init() {
+            warn_detached_command_ignored(&name, &args);
+        }
         sandbox.detach().await;
         println!("{name}");
         return Ok(());
@@ -214,7 +224,7 @@ async fn run_new(
     if sandbox.config().initial_command_consumed_by_init() {
         let result = wait_for_init_entrypoint(&sandbox, &exec_opts).await;
         if !is_named {
-            let _ = Sandbox::remove(sandbox.name()).await;
+            remove_ephemeral_sandbox(sandbox.name()).await;
         }
         return handle_exit(result?);
     }
@@ -262,9 +272,7 @@ async fn wait_for_init_entrypoint(sandbox: &Sandbox, opts: &ExecOpts) -> anyhow:
         Some(duration) => match tokio::time::timeout(duration, wait_fut).await {
             Ok(result) => result.map_err(anyhow::Error::from),
             Err(_) => {
-                if let Err(e) = sandbox.stop().await {
-                    ui::warn(&format!("failed to stop sandbox after timeout: {e}"));
-                }
+                stop_init_entrypoint_after_timeout(sandbox).await;
                 Err(anyhow::anyhow!("command timed out after {duration:?}"))
             }
         },
@@ -323,6 +331,27 @@ async fn stream_init_entrypoint_logs(name: String, since: DateTime<Utc>) -> anyh
     }
 
     Ok(())
+}
+
+async fn stop_init_entrypoint_after_timeout(sandbox: &Sandbox) {
+    match Sandbox::get(sandbox.name()).await {
+        Ok(handle) => {
+            if let Err(e) = handle.stop_with_timeout(INIT_ENTRYPOINT_STOP_TIMEOUT).await {
+                ui::warn(&format!("failed to stop sandbox after timeout: {e}"));
+            }
+        }
+        Err(_) => {
+            if let Err(e) = sandbox.stop().await {
+                ui::warn(&format!("failed to stop sandbox after timeout: {e}"));
+            }
+        }
+    }
+}
+
+async fn remove_ephemeral_sandbox(name: &str) {
+    if let Err(e) = Sandbox::remove(name).await {
+        ui::warn(&format!("failed to remove ephemeral sandbox: {e}"));
+    }
 }
 
 async fn stop_init_entrypoint_log_task(mut task: tokio::task::JoinHandle<anyhow::Result<()>>) {

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -57,6 +57,10 @@ pub struct SandboxArgs {
     #[arg(long = "parent-watch-fd", hide = true)]
     pub parent_watch_fd: Option<i32>,
 
+    /// Write end of the startup JSON pipe.
+    #[arg(long = "startup-fd", hide = true)]
+    pub startup_fd: Option<i32>,
+
     /// Forward VM console output to stdout.
     #[arg(long = "forward")]
     pub forward_output: bool,
@@ -192,6 +196,13 @@ pub fn run(args: SandboxArgs) -> ! {
             std::process::exit(2);
         }
     };
+    let startup_fd = match args.startup_fd.map(startup_from_fd).transpose() {
+        Ok(fd) => fd,
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(2);
+        }
+    };
     let is_vmdk = args.rootfs_disk_format.as_deref() == Some("vmdk");
     let disks = match parse_disk_args(&args.disk) {
         Ok(disks) => disks,
@@ -249,6 +260,7 @@ pub fn run(args: SandboxArgs) -> ! {
         log_dir: args.log_dir,
         runtime_dir: args.runtime_dir,
         agent_sock_path: args.agent_sock,
+        startup_fd,
         parent_watchdog,
         forward_output: args.forward_output,
         idle_timeout_secs: args.idle_timeout,
@@ -277,26 +289,35 @@ pub fn run(args: SandboxArgs) -> ! {
 }
 
 fn parent_watchdog_from_fd(fd: i32) -> Result<OwnedFd, String> {
-    validate_parent_watchdog_fd(fd, microsandbox_runtime::vm::PARENT_WATCH_FD)?;
+    validate_pipe_fd(
+        fd,
+        microsandbox_runtime::vm::PARENT_WATCH_FD,
+        "parent-watch-fd",
+    )?;
     Ok(unsafe { OwnedFd::from_raw_fd(fd) })
 }
 
-fn validate_parent_watchdog_fd(fd: i32, expected_fd: i32) -> Result<(), String> {
+fn startup_from_fd(fd: i32) -> Result<OwnedFd, String> {
+    validate_pipe_fd(fd, microsandbox_runtime::vm::STARTUP_FD, "startup-fd")?;
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+fn validate_pipe_fd(fd: i32, expected_fd: i32, arg_name: &str) -> Result<(), String> {
     if fd < 0 {
         return Err(format!(
-            "invalid --parent-watch-fd: fd must be non-negative, got {fd}"
+            "invalid --{arg_name}: fd must be non-negative, got {fd}"
         ));
     }
     if fd != expected_fd {
         return Err(format!(
-            "invalid --parent-watch-fd: expected {expected_fd}, got {fd}",
+            "invalid --{arg_name}: expected {expected_fd}, got {fd}",
         ));
     }
 
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
     if flags < 0 {
         return Err(format!(
-            "invalid --parent-watch-fd {fd}: {}",
+            "invalid --{arg_name} {fd}: {}",
             std::io::Error::last_os_error()
         ));
     }
@@ -304,14 +325,14 @@ fn validate_parent_watchdog_fd(fd: i32, expected_fd: i32) -> Result<(), String> 
     let mut stat = MaybeUninit::<libc::stat>::uninit();
     if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } != 0 {
         return Err(format!(
-            "invalid --parent-watch-fd {fd}: {}",
+            "invalid --{arg_name} {fd}: {}",
             std::io::Error::last_os_error()
         ));
     }
     let stat = unsafe { stat.assume_init() };
     let file_type = stat.st_mode & libc::S_IFMT as libc::mode_t;
     if file_type != libc::S_IFIFO as libc::mode_t {
-        return Err(format!("invalid --parent-watch-fd {fd}: fd is not a pipe"));
+        return Err(format!("invalid --{arg_name} {fd}: fd is not a pipe"));
     }
 
     Ok(())

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -490,16 +490,24 @@ mod tests {
 
     #[test]
     fn test_validate_parent_watchdog_fd_rejects_negative_fd() {
-        let err =
-            validate_parent_watchdog_fd(-1, microsandbox_runtime::vm::PARENT_WATCH_FD).unwrap_err();
+        let err = validate_pipe_fd(
+            -1,
+            microsandbox_runtime::vm::PARENT_WATCH_FD,
+            "parent-watch-fd",
+        )
+        .unwrap_err();
 
         assert!(err.contains("non-negative"));
     }
 
     #[test]
     fn test_validate_parent_watchdog_fd_rejects_wrong_fd_number() {
-        let err =
-            validate_parent_watchdog_fd(0, microsandbox_runtime::vm::PARENT_WATCH_FD).unwrap_err();
+        let err = validate_pipe_fd(
+            0,
+            microsandbox_runtime::vm::PARENT_WATCH_FD,
+            "parent-watch-fd",
+        )
+        .unwrap_err();
 
         assert!(err.contains("expected 97"));
     }
@@ -509,7 +517,7 @@ mod tests {
         let file = tempfile::tempfile().unwrap();
         let fd = file.as_raw_fd();
 
-        let err = validate_parent_watchdog_fd(fd, fd).unwrap_err();
+        let err = validate_pipe_fd(fd, fd, "parent-watch-fd").unwrap_err();
 
         assert!(err.contains("not a pipe"));
     }
@@ -521,6 +529,6 @@ mod tests {
         let read_fd = unsafe { OwnedFd::from_raw_fd(fds[0]) };
         let _write_fd = unsafe { OwnedFd::from_raw_fd(fds[1]) };
 
-        validate_parent_watchdog_fd(read_fd.as_raw_fd(), read_fd.as_raw_fd()).unwrap();
+        validate_pipe_fd(read_fd.as_raw_fd(), read_fd.as_raw_fd(), "parent-watch-fd").unwrap();
     }
 }

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -59,6 +59,9 @@ const AGENT_UNRESPONSIVE_SHUTDOWN_PUSH_TIMEOUT: Duration = Duration::from_secs(1
 /// Fixed fd used to pass the attached-parent watchdog pipe into `msb sandbox`.
 pub const PARENT_WATCH_FD: i32 = 97;
 
+/// Fixed fd used to pass startup JSON from `msb sandbox` to its launcher.
+pub const STARTUP_FD: i32 = 98;
+
 /// Control byte sent by the owner to stop parent-watch monitoring without stopping the sandbox.
 pub const PARENT_WATCH_DETACH: u8 = 1;
 
@@ -95,6 +98,12 @@ pub struct Config {
 
     /// Path to the Unix domain socket for the agent relay.
     pub agent_sock_path: PathBuf,
+
+    /// Dedicated startup JSON write fd.
+    ///
+    /// When present, startup info is written here instead of stdout so
+    /// detached launchers can detach stdout/stderr from birth.
+    pub startup_fd: Option<OwnedFd>,
 
     /// Read end of the attached-parent watchdog pipe.
     pub parent_watchdog: Option<OwnedFd>,
@@ -362,7 +371,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     let startup_json = serde_json::to_string(&startup)
         .map_err(|e| RuntimeError::Custom(format!("serialize startup: {e}")))?;
 
-    write_startup_info(&startup_json)?;
+    write_startup_info(config.startup_fd.as_ref(), &startup_json)?;
     setup_log_capture(&config.log_dir, config.forward_output)?;
 
     tracing::info!(sandbox = %config.sandbox_name, "sandbox starting");
@@ -1157,8 +1166,20 @@ fn setup_log_capture(log_dir: &std::path::Path, forward: bool) -> RuntimeResult<
     Ok(())
 }
 
-/// Write startup info JSON to stdout.
-fn write_startup_info(json: &str) -> RuntimeResult<()> {
+/// Write startup info JSON to the dedicated startup fd when supplied,
+/// otherwise stdout.
+fn write_startup_info(startup_fd: Option<&OwnedFd>, json: &str) -> RuntimeResult<()> {
+    if let Some(fd) = startup_fd {
+        let dup = unsafe { libc::dup(fd.as_raw_fd()) };
+        if dup < 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        let mut file = unsafe { std::fs::File::from_raw_fd(dup) };
+        writeln!(file, "{json}")?;
+        file.flush()?;
+        return Ok(());
+    }
+
     let mut stdout = std::io::stdout().lock();
     writeln!(stdout, "{json}")?;
     stdout.flush()?;

--- a/sdk/go/integration/config_test.go
+++ b/sdk/go/integration/config_test.go
@@ -127,6 +127,13 @@ func TestWithInitAuto(t *testing.T) {
 	if !strings.Contains(h.ConfigJSON(), `"auto"`) {
 		t.Errorf("Init.Auto not visible in ConfigJSON: %s", h.ConfigJSON())
 	}
+	parsed, err := h.Config()
+	if err != nil {
+		t.Fatalf("Config: %v", err)
+	}
+	if parsed.Init == nil || parsed.Init.Cmd != "auto" {
+		t.Errorf("Init.Auto not visible in parsed Config: %+v", parsed.Init)
+	}
 }
 
 // TestWithLogLevelRoundTrip verifies that WithLogLevel surfaces in the

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -57,25 +57,32 @@ type SandboxConfig struct {
 type SandboxOption func(*SandboxConfig)
 
 type persistedSandboxConfig struct {
-	Name            string            `json:"name"`
-	Image           json.RawMessage   `json:"image"`
-	ImageFstype     string            `json:"image_fstype"`
-	OCIUpperSizeMiB uint32            `json:"oci_upper_size_mib"`
-	MemoryMiB       uint32            `json:"memory_mib"`
-	CPUs            uint8             `json:"cpus"`
-	Workdir         string            `json:"workdir"`
-	Shell           string            `json:"shell"`
-	SecurityProfile SecurityProfile   `json:"security_profile"`
-	Hostname        string            `json:"hostname"`
-	User            string            `json:"user"`
-	Replace         bool              `json:"replace"`
-	Labels          map[string]string `json:"labels"`
-	Detached        bool              `json:"detached"`
-	Entrypoint      []string          `json:"entrypoint"`
-	LogLevel        LogLevel          `json:"log_level"`
-	QuietLogs       bool              `json:"quiet_logs"`
-	Scripts         map[string]string `json:"scripts"`
-	PullPolicy      PullPolicy        `json:"pull_policy"`
+	Name            string               `json:"name"`
+	Image           json.RawMessage      `json:"image"`
+	ImageFstype     string               `json:"image_fstype"`
+	OCIUpperSizeMiB uint32               `json:"oci_upper_size_mib"`
+	MemoryMiB       uint32               `json:"memory_mib"`
+	CPUs            uint8                `json:"cpus"`
+	Workdir         string               `json:"workdir"`
+	Shell           string               `json:"shell"`
+	SecurityProfile SecurityProfile      `json:"security_profile"`
+	Hostname        string               `json:"hostname"`
+	User            string               `json:"user"`
+	Replace         bool                 `json:"replace"`
+	Labels          map[string]string    `json:"labels"`
+	Detached        bool                 `json:"detached"`
+	Entrypoint      []string             `json:"entrypoint"`
+	Init            *persistedInitConfig `json:"init"`
+	LogLevel        LogLevel             `json:"log_level"`
+	QuietLogs       bool                 `json:"quiet_logs"`
+	Scripts         map[string]string    `json:"scripts"`
+	PullPolicy      PullPolicy           `json:"pull_policy"`
+}
+
+type persistedInitConfig struct {
+	Cmd  string      `json:"cmd"`
+	Args []string    `json:"args"`
+	Env  [][2]string `json:"env"`
 }
 
 // UnmarshalJSON decodes the persisted Rust sandbox config into the Go SDK's
@@ -115,12 +122,30 @@ func (c *SandboxConfig) UnmarshalJSON(data []byte) error {
 		Labels:          raw.Labels,
 		Detached:        raw.Detached,
 		Entrypoint:      raw.Entrypoint,
+		Init:            decodePersistedInit(raw.Init),
 		LogLevel:        raw.LogLevel,
 		QuietLogs:       raw.QuietLogs,
 		Scripts:         raw.Scripts,
 		PullPolicy:      raw.PullPolicy,
 	}
 	return nil
+}
+
+func decodePersistedInit(raw *persistedInitConfig) *InitConfig {
+	if raw == nil {
+		return nil
+	}
+	cfg := &InitConfig{
+		Cmd:  raw.Cmd,
+		Args: append([]string(nil), raw.Args...),
+	}
+	if len(raw.Env) > 0 {
+		cfg.Env = make(map[string]string, len(raw.Env))
+		for _, entry := range raw.Env {
+			cfg.Env[entry[0]] = entry[1]
+		}
+	}
+	return cfg
 }
 
 func decodePersistedRootfsSource(raw json.RawMessage) (string, string, uint32, bool, error) {

--- a/sdk/go/options_test.go
+++ b/sdk/go/options_test.go
@@ -1,6 +1,7 @@
 package microsandbox
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -494,6 +495,36 @@ func TestWithInitFactories(t *testing.T) {
 	}
 	if o2.Init.Args[0] != "--daemon" || o2.Init.Env["FOO"] != "BAR" {
 		t.Errorf("Cmd init args/env: got %+v", o2.Init)
+	}
+}
+
+func TestSandboxConfigUnmarshalJSONIncludesPersistedInit(t *testing.T) {
+	var cfg SandboxConfig
+	data := []byte(`{
+		"name": "dev",
+		"image": "alpine",
+		"init": {
+			"cmd": "/sbin/init",
+			"args": ["--daemon"],
+			"env": [["FOO", "BAR"], ["PATH", "/usr/bin:/bin"]]
+		}
+	}`)
+
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	if cfg.Init == nil {
+		t.Fatal("Init = nil, want persisted init config")
+	}
+	if cfg.Init.Cmd != "/sbin/init" {
+		t.Errorf("Init.Cmd = %q, want /sbin/init", cfg.Init.Cmd)
+	}
+	if !reflect.DeepEqual(cfg.Init.Args, []string{"--daemon"}) {
+		t.Errorf("Init.Args = %v, want [--daemon]", cfg.Init.Args)
+	}
+	wantEnv := map[string]string{"FOO": "BAR", "PATH": "/usr/bin:/bin"}
+	if !reflect.DeepEqual(cfg.Init.Env, wantEnv) {
+		t.Errorf("Init.Env = %v, want %v", cfg.Init.Env, wantEnv)
 	}
 }
 

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -26,7 +26,10 @@ use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as Sha2Digest, Sha256};
 use tempfile::TempDir;
-use tokio::{io::AsyncBufReadExt, process::Command};
+use tokio::{
+    io::{AsyncBufRead, AsyncBufReadExt},
+    process::Command,
+};
 
 use microsandbox_image::{Digest, GlobalCache};
 use microsandbox_metrics::{MetricsRegistry, ReserveSlot, SlotReservation};
@@ -79,7 +82,7 @@ struct MetricsReservation {
     generation: u64,
 }
 
-struct ParentWatchdogPipe {
+struct Pipe {
     read_fd: OwnedFd,
     write_fd: OwnedFd,
 }
@@ -179,6 +182,16 @@ pub async fn spawn_sandbox(
         },
         SpawnMode::Detached => None,
     };
+    let startup_pipe = match mode {
+        SpawnMode::Attached => None,
+        SpawnMode::Detached => match create_startup_pipe() {
+            Ok(pipe) => Some(pipe),
+            Err(err) => {
+                release_metrics_reservation(config, metrics_reservation.as_ref());
+                return Err(err);
+            }
+        },
+    };
 
     // Build the command.
     let mut cmd = Command::new(&msb_path);
@@ -197,6 +210,9 @@ pub async fn spawn_sandbox(
         parent_watchdog
             .as_ref()
             .map(|_| microsandbox_runtime::vm::PARENT_WATCH_FD),
+        startup_pipe
+            .as_ref()
+            .map(|_| microsandbox_runtime::vm::STARTUP_FD),
     ));
 
     // Prevent the sandbox process from inheriting the parent's terminal on
@@ -204,43 +220,36 @@ pub async fn spawn_sandbox(
     // mode, which corrupts the parent's terminal output (\n without \r).
     cmd.stdin(Stdio::null());
 
-    if let Some(pipe) = parent_watchdog.as_ref() {
-        let read_fd = pipe.read_fd.as_raw_fd();
+    if parent_watchdog.is_some() || startup_pipe.is_some() {
+        let parent_watch_fd = parent_watchdog
+            .as_ref()
+            .map(|pipe| pipe.read_fd.as_raw_fd());
+        let startup_write_fd = startup_pipe.as_ref().map(|pipe| pipe.write_fd.as_raw_fd());
         unsafe {
             cmd.pre_exec(move || {
-                if libc::dup2(read_fd, microsandbox_runtime::vm::PARENT_WATCH_FD) < 0 {
-                    return Err(std::io::Error::last_os_error());
+                if startup_write_fd.is_some() {
+                    detach_from_launcher_session()?;
                 }
-                if read_fd != microsandbox_runtime::vm::PARENT_WATCH_FD && libc::close(read_fd) < 0
-                {
-                    return Err(std::io::Error::last_os_error());
+                if let Some(fd) = parent_watch_fd {
+                    dup_inherited_fd(fd, microsandbox_runtime::vm::PARENT_WATCH_FD)?;
                 }
-                let flags = libc::fcntl(microsandbox_runtime::vm::PARENT_WATCH_FD, libc::F_GETFD);
-                if flags < 0 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                if libc::fcntl(
-                    microsandbox_runtime::vm::PARENT_WATCH_FD,
-                    libc::F_SETFD,
-                    flags & !libc::FD_CLOEXEC,
-                ) < 0
-                {
-                    return Err(std::io::Error::last_os_error());
+                if let Some(fd) = startup_write_fd {
+                    dup_inherited_fd(fd, microsandbox_runtime::vm::STARTUP_FD)?;
                 }
                 Ok(())
             });
         }
     }
 
-    if mode == SpawnMode::Detached {
-        // Detached sandboxes outlive the creating CLI process, so the
-        // sandbox must not stay coupled to the foreground job or terminal.
-        cmd.process_group(0);
+    // Capture stdout for attached startup JSON. Detached mode uses a
+    // dedicated startup fd so stdio can be severed from the launcher.
+    if startup_pipe.is_some() {
+        cmd.stdout(Stdio::null());
+        cmd.stderr(Stdio::null());
+    } else {
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::inherit());
     }
-
-    // Capture stdout (for startup JSON), inherit stderr so errors are visible.
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::inherit());
 
     ensure_sigchld_handler_uses_alt_stack_before_spawn().await?;
 
@@ -264,13 +273,24 @@ pub async fn spawn_sandbox(
     };
     tracing::debug!(pid = _pid, sandbox = %config.name, "spawn_sandbox: process started");
 
-    // Read the startup JSON from stdout.
-    let stdout = child.stdout.take().ok_or_else(|| {
-        release_metrics_reservation(config, metrics_reservation.as_ref());
-        crate::MicrosandboxError::Runtime("failed to capture sandbox stdout".into())
-    })?;
-
-    let mut reader = tokio::io::BufReader::new(stdout);
+    // Read the startup JSON from the dedicated startup pipe in detached
+    // mode, otherwise stdout.
+    let mut reader: Box<dyn AsyncBufRead + Send + Unpin> = match startup_pipe {
+        Some(pipe) => {
+            let Pipe { read_fd, write_fd } = pipe;
+            drop(write_fd);
+            Box::new(tokio::io::BufReader::new(tokio::fs::File::from_std(
+                std::fs::File::from(read_fd),
+            )))
+        }
+        None => {
+            let stdout = child.stdout.take().ok_or_else(|| {
+                release_metrics_reservation(config, metrics_reservation.as_ref());
+                crate::MicrosandboxError::Runtime("failed to capture sandbox stdout".into())
+            })?;
+            Box::new(tokio::io::BufReader::new(stdout))
+        }
+    };
     let mut line = String::new();
     match tokio::time::timeout(
         std::time::Duration::from_secs(30),
@@ -371,7 +391,15 @@ fn reserve_metrics_slot(
     }
 }
 
-fn create_parent_watchdog_pipe() -> MicrosandboxResult<ParentWatchdogPipe> {
+fn create_parent_watchdog_pipe() -> MicrosandboxResult<Pipe> {
+    create_pipe()
+}
+
+fn create_startup_pipe() -> MicrosandboxResult<Pipe> {
+    create_pipe()
+}
+
+fn create_pipe() -> MicrosandboxResult<Pipe> {
     let mut fds = [0; 2];
     let rc = create_cloexec_pipe(&mut fds);
     if rc != 0 {
@@ -387,7 +415,40 @@ fn create_parent_watchdog_pipe() -> MicrosandboxResult<ParentWatchdogPipe> {
         set_cloexec(&write_fd, true)?;
     }
 
-    Ok(ParentWatchdogPipe { read_fd, write_fd })
+    Ok(Pipe { read_fd, write_fd })
+}
+
+fn dup_inherited_fd(src: i32, dst: i32) -> std::io::Result<()> {
+    if unsafe { libc::dup2(src, dst) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if src != dst && unsafe { libc::close(src) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let flags = unsafe { libc::fcntl(dst, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(dst, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn detach_from_launcher_session() -> std::io::Result<()> {
+    if unsafe { libc::setsid() } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    let mut action: libc::sigaction = unsafe { std::mem::zeroed() };
+    action.sa_sigaction = libc::SIG_IGN;
+    if unsafe { libc::sigemptyset(&mut action.sa_mask) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::sigaction(libc::SIGHUP, &action, std::ptr::null_mut()) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
@@ -991,6 +1052,7 @@ fn sandbox_cli_args(
     staged_file_mounts: &HashMap<String, (PathBuf, String, String)>,
     metrics_reservation: Option<&MetricsReservation>,
     parent_watch_fd: Option<i32>,
+    startup_fd: Option<i32>,
 ) -> Vec<OsString> {
     let mut args = vec![OsString::from("sandbox")];
 
@@ -1014,6 +1076,10 @@ fn sandbox_cli_args(
     args.push(agent_sock_path.as_os_str().to_os_string());
     if let Some(fd) = parent_watch_fd {
         args.push(OsString::from("--parent-watch-fd"));
+        args.push(OsString::from(fd.to_string()));
+    }
+    if let Some(fd) = startup_fd {
+        args.push(OsString::from("--startup-fd"));
         args.push(OsString::from(fd.to_string()));
     }
 
@@ -1319,6 +1385,7 @@ fn sandbox_cli_args(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::ffi::OsString;
     use std::path::{Path, PathBuf};
 
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
@@ -1361,6 +1428,7 @@ mod tests {
             &HashMap::new(),
             None,
             None,
+            None,
         )
         .iter()
         .map(|arg| arg.to_string_lossy().into_owned())
@@ -1388,6 +1456,7 @@ mod tests {
             Path::new("/tmp/agent.sock"),
             Path::new("/tmp/libkrunfw.dylib"),
             staged_file_mounts,
+            None,
             None,
             None,
         )
@@ -1446,6 +1515,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_sandbox_cli_args_include_startup_fd_when_supplied() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .build()
+            .await
+            .unwrap();
+
+        let local = test_local_backend();
+        let args = sandbox_cli_args(
+            &local,
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            30,
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/agent.sock"),
+            Path::new("/tmp/libkrunfw.dylib"),
+            &HashMap::new(),
+            None,
+            None,
+            Some(microsandbox_runtime::vm::STARTUP_FD),
+        );
+
+        assert!(args.windows(2).any(|pair| pair
+            == [
+                OsString::from("--startup-fd"),
+                OsString::from(microsandbox_runtime::vm::STARTUP_FD.to_string()),
+            ]));
+    }
+
+    #[tokio::test]
     async fn test_agent_socket_candidates_follow_explicit_local_backend_paths() {
         let temp = tempdir().unwrap();
         let home = temp.path().join("msb-home");
@@ -1487,6 +1588,7 @@ mod tests {
             Path::new("/tmp/agent.sock"),
             Path::new("/tmp/libkrunfw.dylib"),
             &HashMap::new(),
+            None,
             None,
             None,
         );

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -314,6 +314,17 @@ impl SandboxBuilder {
         self
     }
 
+    /// Set the persisted startup command for detached CLI `run`.
+    #[doc(hidden)]
+    pub fn persistent_initial_command(
+        mut self,
+        command: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.config
+            .set_persistent_initial_command(command.into_iter().map(Into::into).collect());
+        self
+    }
+
     /// Hand off PID 1 to a guest init binary after agentd's setup.
     ///
     /// `cmd` is either an absolute path inside the guest rootfs or

--- a/sdk/rust/lib/sandbox/config.rs
+++ b/sdk/rust/lib/sandbox/config.rs
@@ -251,13 +251,21 @@ pub struct SandboxConfig {
     #[serde(skip)]
     pub(crate) snapshot_upper_source: Option<PathBuf>,
 
-    /// Initial command requested by an attached `msb run` invocation.
+    /// Initial command requested by a CLI `msb run` invocation.
     ///
-    /// This is transient CLI intent, not persisted sandbox config. It lets
-    /// `--init auto` decide before VM spawn whether an image-declared init
-    /// entrypoint should receive the OCI command as argv.
+    /// This is transient CLI intent. It lets `--init auto` decide before VM
+    /// spawn whether an image-declared init entrypoint should receive the OCI
+    /// command as argv.
     #[serde(skip)]
     pub(crate) initial_command: Option<Vec<String>>,
+
+    /// Whether a consumed initial command should become persisted startup argv.
+    ///
+    /// Attached `msb run` commands are one-shot foreground intent; detached
+    /// `msb run -d` commands are startup intent when an image init consumes
+    /// them.
+    #[serde(skip)]
+    pub(crate) initial_command_persistent: bool,
 
     /// Whether [`initial_command`](Self::initial_command) was consumed by
     /// the handoff init instead of being executed through agentd.
@@ -286,9 +294,37 @@ impl SandboxConfig {
         self.initial_command_consumed_by_init
     }
 
-    /// Set transient initial command intent for attached `msb run`.
+    /// Return the config shape that should be persisted for future starts.
+    ///
+    /// Attached `msb run --init auto` may pass a one-off foreground command to
+    /// an image-declared init entrypoint. Detached `msb run -d --init auto`
+    /// uses the same handoff path for startup intent. Only the latter should
+    /// be replayed by `msb start`.
+    pub(crate) fn clone_for_persistence(&self) -> Self {
+        let mut config = self.clone();
+        if config.initial_command_consumed_by_init
+            && !config.initial_command_persistent
+            && let Some(init) = &mut config.init
+        {
+            init.args.clear();
+        }
+        config.initial_command = None;
+        config.initial_command_persistent = false;
+        config.initial_command_consumed_by_init = false;
+        config
+    }
+
+    /// Set one-shot initial command intent for attached `msb run`.
     pub(crate) fn set_initial_command(&mut self, command: Vec<String>) {
         self.initial_command = Some(command);
+        self.initial_command_persistent = false;
+        self.initial_command_consumed_by_init = false;
+    }
+
+    /// Set startup initial command intent for detached `msb run -d`.
+    pub(crate) fn set_persistent_initial_command(&mut self, command: Vec<String>) {
+        self.initial_command = Some(command);
+        self.initial_command_persistent = true;
         self.initial_command_consumed_by_init = false;
     }
 
@@ -297,7 +333,7 @@ impl SandboxConfig {
     /// - `env`: image env vars form the base; user env vars override by key, otherwise append.
     /// - `labels`: image labels form the base; user labels override by key.
     /// - `cmd`, `entrypoint`, `workdir`, `user`: image value used only if user did not set one.
-    /// - `init`: an `auto` init may resolve from a known init at the start of the image entrypoint.
+    /// - `init`: an `auto` init may resolve from a known init at the start of the image entrypoint and inherit the effective entrypoint env.
     pub fn merge_image_defaults(&mut self, image: &ImageConfig) {
         self.env = merge_env(&image.env, &self.env);
         self.labels = merge_image_labels(&image.labels, &self.labels);
@@ -375,6 +411,7 @@ impl SandboxConfig {
             .as_mut()
             .expect("init was present at start of auto resolution");
         init.cmd = PathBuf::from(init_path);
+        init.env = merge_env_pairs(&self.env, &init.env);
         if let Some(argv_tail) = init_argv_tail {
             init.args = argv_tail;
             self.initial_command_consumed_by_init = true;
@@ -574,6 +611,7 @@ impl Default for SandboxConfig {
             manifest_digest: None,
             snapshot_upper_source: None,
             initial_command: None,
+            initial_command_persistent: false,
             initial_command_consumed_by_init: false,
         }
     }
@@ -747,6 +785,140 @@ mod tests {
         assert_eq!(
             config.entrypoint,
             Some(vec!["/opt/hermes/docker/main-wrapper.sh".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_merge_image_defaults_passes_effective_env_to_init_entrypoint() {
+        let image = ImageConfig {
+            entrypoint: Some(vec![
+                "/init".to_string(),
+                "/opt/hermes/docker/main-wrapper.sh".to_string(),
+            ]),
+            env: vec![
+                "PATH=/image/bin:/usr/bin:/bin".to_string(),
+                "IMAGE_ONLY=1".to_string(),
+                "OVERRIDE=image".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        let mut config = SandboxConfig {
+            init: Some(HandoffInit {
+                cmd: PathBuf::from("auto"),
+                args: Vec::new(),
+                env: vec![
+                    ("PATH".to_string(), "/init/bin:/usr/bin:/bin".to_string()),
+                    ("INIT_ONLY".to_string(), "1".to_string()),
+                ],
+            }),
+            env: vec![
+                ("HERMES_DASHBOARD".to_string(), "1".to_string()),
+                ("OVERRIDE".to_string(), "user".to_string()),
+            ],
+            ..Default::default()
+        };
+        config.set_initial_command(vec!["gateway".to_string(), "run".to_string()]);
+        config.merge_image_defaults(&image);
+
+        let init = config.init.as_ref().expect("init should remain configured");
+        assert_eq!(
+            init.env,
+            vec![
+                ("IMAGE_ONLY".to_string(), "1".to_string()),
+                ("HERMES_DASHBOARD".to_string(), "1".to_string()),
+                ("OVERRIDE".to_string(), "user".to_string()),
+                ("PATH".to_string(), "/init/bin:/usr/bin:/bin".to_string()),
+                ("INIT_ONLY".to_string(), "1".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_clone_for_persistence_drops_consumed_init_args() {
+        let mut config = SandboxConfig {
+            init: Some(HandoffInit {
+                cmd: PathBuf::from("/init"),
+                args: vec![
+                    "/opt/hermes/docker/main-wrapper.sh".to_string(),
+                    "gateway".to_string(),
+                    "run".to_string(),
+                ],
+                env: vec![("HERMES_DASHBOARD".to_string(), "1".to_string())],
+            }),
+            ..Default::default()
+        };
+        config.set_initial_command(vec!["gateway".to_string(), "run".to_string()]);
+        config.initial_command_consumed_by_init = true;
+
+        let persisted = config.clone_for_persistence();
+
+        let runtime_init = config.init.as_ref().expect("runtime init");
+        assert_eq!(
+            runtime_init.args,
+            vec![
+                "/opt/hermes/docker/main-wrapper.sh".to_string(),
+                "gateway".to_string(),
+                "run".to_string(),
+            ]
+        );
+        let persisted_init = persisted.init.as_ref().expect("persisted init");
+        assert!(persisted_init.args.is_empty());
+        assert_eq!(
+            persisted_init.env,
+            vec![("HERMES_DASHBOARD".to_string(), "1".to_string())]
+        );
+        assert!(!persisted.initial_command_consumed_by_init());
+    }
+
+    #[test]
+    fn test_clone_for_persistence_keeps_detached_startup_init_args() {
+        let mut config = SandboxConfig {
+            init: Some(HandoffInit {
+                cmd: PathBuf::from("/init"),
+                args: vec![
+                    "/opt/hermes/docker/main-wrapper.sh".to_string(),
+                    "gateway".to_string(),
+                    "run".to_string(),
+                ],
+                env: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        config.set_persistent_initial_command(vec!["gateway".to_string(), "run".to_string()]);
+        config.initial_command_consumed_by_init = true;
+
+        let persisted = config.clone_for_persistence();
+
+        let persisted_init = persisted.init.as_ref().expect("persisted init");
+        assert_eq!(
+            persisted_init.args,
+            vec![
+                "/opt/hermes/docker/main-wrapper.sh".to_string(),
+                "gateway".to_string(),
+                "run".to_string(),
+            ]
+        );
+        assert!(!persisted.initial_command_consumed_by_init());
+    }
+
+    #[test]
+    fn test_clone_for_persistence_keeps_user_init_args() {
+        let config = SandboxConfig {
+            init: Some(HandoffInit {
+                cmd: PathBuf::from("/lib/systemd/systemd"),
+                args: vec!["--unit=multi-user.target".to_string()],
+                env: Vec::new(),
+            }),
+            ..Default::default()
+        };
+
+        let persisted = config.clone_for_persistence();
+
+        let persisted_init = persisted.init.as_ref().expect("persisted init");
+        assert_eq!(
+            persisted_init.args,
+            vec!["--unit=multi-user.target".to_string()]
         );
     }
 

--- a/sdk/rust/lib/sandbox/init.rs
+++ b/sdk/rust/lib/sandbox/init.rs
@@ -12,7 +12,7 @@
 //! ```ignore
 //! Sandbox::builder("dev")
 //!     .image("debian:bookworm")
-//!     .init("/lib/systemd/systemd", ["--unit=multi-user.target"])
+//!     .init("/lib/systemd/systemd")
 //!     .build().await?;
 //!
 //! Sandbox::builder("dev")

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -572,7 +572,8 @@ pub(crate) async fn create_local(
 
     // Insert the sandbox record and keep its stable database ID.
     let write_db = db.write();
-    let sandbox_id = insert_sandbox_record(write_db, &config).await?;
+    let persisted_config = config.clone_for_persistence();
+    let sandbox_id = insert_sandbox_record(write_db, &persisted_config).await?;
     tracing::debug!(sandbox_id, sandbox = %config.name, "create_local: db record inserted");
 
     // Spawn the sandbox process and create the bridge. On failure, mark the sandbox


### PR DESCRIPTION
## TL;DR
Teach `--init auto` to boot Docker-style init entrypoints in both attached and detached runs. This gets s6-overlay images like `nousresearch/hermes-agent` running through their image `/init` without needing a daemon.

## Description
- Resolve image-declared init entrypoints for `--init auto`, including `/init`, and pass the effective image and user environment through to PID 1.
- Persist detached `msb run -d --init auto -- ...` commands as startup intent, while attached `msb run --init auto -- ...` commands stay one-shot and are stripped from saved config.
- Keep post-handoff agentd alive beside guest init systems by isolating the handoff child and tolerating serial disconnects after PID 1 handoff.
- Add a hidden startup fd so detached sandbox launches can detach stdio from the caller without losing startup JSON.
- Expose persisted init config through Go `SandboxHandle.Config()` so Go callers can read back `WithInit` settings.
- Fix the Rust init builder docs to use the current `.init(...)` API.

```bash
msb run nousresearch/hermes-agent \
  --name hermes --replace -d \
  -v ~/.hermes:/opt/data \
  -p 8642:8642 \
  -p 9119:9119 \
  -e HERMES_DASHBOARD=1 \
  -e HERMES_DASHBOARD_INSECURE=1 \
  --init auto \
  -- gateway run
```

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p microsandbox-runtime`
- [x] `cargo check -p microsandbox-cli --no-default-features --features net,ssh`
- [x] `cargo test -p microsandbox test_sandbox_cli_args_include_startup_fd_when_supplied`
- [x] `go test -count=1 .` from `sdk/go`
- [x] Commit hook passed `cargo clippy (workspace)`, `cargo fmt (agentd)`, `cargo clippy (agentd)`, `cargo doc (workspace)`, and `cargo build (msb)`
- [x] Launched `nousresearch/hermes-agent` through launchd with `AbandonProcessGroup=true` and verified the sandbox stayed running, heartbeat advanced, and `http://127.0.0.1:19121/` returned `HTTP/1.1 200 OK`