### PR TITLE
fix(snapshot): harden snapshot archive import

### DIFF
--- a/crates/image/lib/cache/store.rs
+++ b/crates/image/lib/cache/store.rs
@@ -338,7 +338,7 @@ impl GlobalCache {
     }
 
     /// Write cached metadata for an image reference using async filesystem I/O.
-    pub(crate) async fn write_image_metadata_async(
+    pub async fn write_image_metadata_async(
         &self,
         reference: &Reference,
         metadata: &CachedImageMetadata,
@@ -383,7 +383,7 @@ impl GlobalCache {
     }
 
     /// Path to the cached metadata file for an image reference.
-    fn image_metadata_path(&self, reference: &Reference) -> PathBuf {
+    pub fn image_metadata_path(&self, reference: &Reference) -> PathBuf {
         self.manifests_dir
             .join(format!("{}.json", image_cache_key(reference)))
     }

--- a/crates/image/lib/snapshot/manifest.rs
+++ b/crates/image/lib/snapshot/manifest.rs
@@ -6,6 +6,7 @@
 //! fields in declaration order, map keys sorted, no fields elided.
 
 use std::collections::BTreeMap;
+use std::path::{Component, Path};
 
 use serde::{Deserialize, Deserializer, Serialize};
 use sha2::{Digest as _, Sha256};
@@ -152,6 +153,7 @@ impl Manifest {
                 "snapshot manifest: empty upper.file".into(),
             ));
         }
+        validate_artifact_filename(&self.upper.file, "upper.file")?;
         if let Some(ref integrity) = self.upper.integrity {
             if integrity.algorithm.is_empty() {
                 return Err(ImageError::ManifestParse(
@@ -214,6 +216,21 @@ fn validate_digest_form(s: &str, field: &str) -> ImageResult<()> {
     if algo.is_empty() || hex.is_empty() {
         return Err(ImageError::ManifestParse(format!(
             "snapshot manifest: {field} has empty component: {s}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_artifact_filename(s: &str, field: &str) -> ImageResult<()> {
+    let mut components = Path::new(s).components();
+    let Some(Component::Normal(_)) = components.next() else {
+        return Err(ImageError::ManifestParse(format!(
+            "snapshot manifest: {field} must be a relative artifact filename: {s}"
+        )));
+    };
+    if components.next().is_some() {
+        return Err(ImageError::ManifestParse(format!(
+            "snapshot manifest: {field} must be a single artifact filename: {s}"
         )));
     }
     Ok(())

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -466,6 +466,10 @@ pub(crate) async fn create_local(
     // Resolve OCI images before spawning the sandbox process.
     if let RootfsSource::Oci(oci) = config.image.clone() {
         let reference = oci.reference;
+        let expected_snapshot_manifest_digest = config
+            .snapshot_upper_source
+            .as_ref()
+            .and(config.manifest_digest.clone());
         let upper_size_mib = oci
             .upper_size_mib
             .unwrap_or(config::DEFAULT_OCI_UPPER_SIZE_MIB);
@@ -482,6 +486,14 @@ pub(crate) async fn create_local(
             progress,
         )
         .await?;
+        if let Some(expected) = expected_snapshot_manifest_digest.as_deref()
+            && pull_result.manifest_digest.to_string() != expected
+        {
+            return Err(crate::MicrosandboxError::SnapshotIntegrity(format!(
+                "snapshot image digest mismatch: manifest pinned {}, resolved {}",
+                expected, pull_result.manifest_digest
+            )));
+        }
 
         // Merge image config defaults under user-provided config.
         config.merge_image_defaults(&pull_result.config);

--- a/sdk/rust/lib/snapshot/archive.rs
+++ b/sdk/rust/lib/snapshot/archive.rs
@@ -5,18 +5,20 @@
 //! gzip/zstd detection on the read side. Plain `.tar` archives are
 //! also accepted on import.
 
-use std::path::{Path, PathBuf};
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
 
 use async_compression::tokio::bufread::ZstdDecoder;
 use async_compression::tokio::write::ZstdEncoder;
 use microsandbox_image::snapshot::MANIFEST_FILENAME;
-use tokio::io::BufReader;
-use tokio_tar::{Archive, Builder};
+use sha2::{Digest as _, Sha256};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio_tar::{Archive, Builder, EntryType};
 
 use crate::backend::LocalBackend;
 use crate::{MicrosandboxError, MicrosandboxResult};
 
-use super::{SnapshotHandle, store};
+use super::{Snapshot, SnapshotHandle, store};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -32,6 +34,10 @@ pub struct ExportOpts {
     pub with_image: bool,
     /// Skip zstd compression and write a plain `.tar`. Default: zstd.
     pub plain_tar: bool,
+}
+
+struct UnpackedArchive {
+    manifest_dirs: Vec<PathBuf>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -50,9 +56,8 @@ pub(super) async fn export_snapshot(
     // and (optionally) all ancestors via parent_digest.
     let head = store::open_snapshot(local, name_or_path).await?;
     head.verify().await?;
-    let mut dirs: Vec<(PathBuf, String)> = Vec::new();
     let head_prefix = digest_prefix(head.digest());
-    dirs.push((head.path().to_path_buf(), head_prefix));
+    let mut parent_dirs: Vec<(PathBuf, String)> = Vec::new();
 
     if opts.with_parents {
         let mut current = head.manifest().parent.clone();
@@ -62,10 +67,14 @@ pub(super) async fn export_snapshot(
                 store::open_snapshot(local, parent_path.to_string_lossy().as_ref()).await?;
             parent.verify().await?;
             let prefix = digest_prefix(parent.digest());
-            dirs.push((parent.path().to_path_buf(), prefix));
+            parent_dirs.push((parent.path().to_path_buf(), prefix));
             current = parent.manifest().parent.clone();
         }
     }
+    parent_dirs.reverse();
+
+    let mut dirs: Vec<(PathBuf, String)> = parent_dirs;
+    dirs.push((head.path().to_path_buf(), head_prefix));
 
     // Optional image cache bundling.
     let mut cache_files: Vec<(PathBuf, String)> = Vec::new();
@@ -77,38 +86,44 @@ pub(super) async fn export_snapshot(
             .map_err(|e| MicrosandboxError::Custom(format!("invalid image digest: {e}")))?;
         let cache = microsandbox_image::GlobalCache::new_async(&cache_dir).await?;
 
+        let image_ref: microsandbox_image::Reference =
+            head.manifest().image.reference.parse().map_err(|e| {
+                MicrosandboxError::Custom(format!("invalid snapshot image reference: {e}"))
+            })?;
+        let metadata = cache
+            .read_image_metadata_async(&image_ref)
+            .await?
+            .ok_or_else(|| {
+                MicrosandboxError::Custom(format!(
+                    "image metadata missing from cache for {}",
+                    head.manifest().image.reference
+                ))
+            })?;
+        if metadata.manifest_digest != img_digest_str {
+            return Err(MicrosandboxError::Custom(format!(
+                "cached image metadata digest mismatch: snapshot={}, cache={}",
+                img_digest_str, metadata.manifest_digest
+            )));
+        }
+
+        let metadata_path = cache.image_metadata_path(&image_ref);
+        push_required_cache_file(&mut cache_files, &metadata_path, "manifests")?;
+
+        let fsmeta = cache.fsmeta_erofs_path(&img_digest);
+        push_required_cache_file(&mut cache_files, &fsmeta, "fsmeta")?;
+
         let vmdk = cache.vmdk_path(&img_digest);
-        if vmdk.exists() {
-            cache_files.push((
-                vmdk.clone(),
-                format!("cache/vmdk/{}", file_name_str(&vmdk)?),
-            ));
-        }
-        // Best-effort: walk fsmeta + layers dirs and ship anything
-        // referenced by the VMDK descriptor. For now, ship all files
-        // in the cache subdirs that match the image digest's
-        // dependent layers.
-        for entry in std::fs::read_dir(cache_dir.join("fsmeta"))
-            .into_iter()
-            .flatten()
-            .flatten()
-        {
-            let path = entry.path();
-            cache_files.push((
-                path.clone(),
-                format!("cache/fsmeta/{}", file_name_str(&path)?),
-            ));
-        }
-        for entry in std::fs::read_dir(cache_dir.join("layers"))
-            .into_iter()
-            .flatten()
-            .flatten()
-        {
-            let path = entry.path();
-            cache_files.push((
-                path.clone(),
-                format!("cache/layers/{}", file_name_str(&path)?),
-            ));
+        push_required_cache_file(&mut cache_files, &vmdk, "vmdk")?;
+
+        let mut seen_layers = HashSet::new();
+        for layer in &metadata.layers {
+            let diff_id: microsandbox_image::Digest = layer.diff_id.parse().map_err(|e| {
+                MicrosandboxError::Custom(format!("invalid cached layer diff_id: {e}"))
+            })?;
+            let layer_path = cache.layer_erofs_path(&diff_id);
+            if seen_layers.insert(layer_path.clone()) {
+                push_required_cache_file(&mut cache_files, &layer_path, "layers")?;
+            }
         }
     }
 
@@ -150,35 +165,48 @@ pub(super) async fn import_snapshot(
     };
     tokio::fs::create_dir_all(&snapshots_dir).await?;
     let cache_dir = local.cache_dir();
+    tokio::fs::create_dir_all(&cache_dir).await?;
+
+    let snapshot_stage = tempfile::Builder::new()
+        .prefix(".msb-snapshot-import-")
+        .tempdir_in(&snapshots_dir)?;
+    let cache_tmp_dir = cache_dir.join("tmp");
+    tokio::fs::create_dir_all(&cache_tmp_dir).await?;
+    let cache_stage = tempfile::Builder::new()
+        .prefix("snapshot-import-")
+        .tempdir_in(&cache_tmp_dir)?;
 
     // Stream rather than slurp — archives carry the full upper layer and are
     // routinely multi-GB.
     let file = tokio::fs::File::open(archive).await?;
-    let buf = BufReader::new(file);
-
-    let head_dir = if archive
-        .extension()
-        .and_then(|s| s.to_str())
-        .map(str::to_lowercase)
-        .as_deref()
-        == Some("zst")
-        || archive
-            .file_name()
-            .and_then(|s| s.to_str())
-            .map(|n| n.ends_with(".tar.zst"))
-            .unwrap_or(false)
-    {
-        let decoder = ZstdDecoder::new(buf);
-        unpack_archive(decoder, &snapshots_dir, &cache_dir).await?
-    } else {
-        unpack_archive(buf, &snapshots_dir, &cache_dir).await?
+    let mut buf = BufReader::new(file);
+    let is_zstd = {
+        let bytes = buf.fill_buf().await?;
+        bytes.starts_with(&[0x28, 0xb5, 0x2f, 0xfd])
     };
 
-    let head_path = head_dir.ok_or_else(|| {
-        MicrosandboxError::Custom("archive contained no snapshot manifest".into())
-    })?;
+    let unpacked = if is_zstd {
+        let decoder = ZstdDecoder::new(buf);
+        unpack_archive(decoder, snapshot_stage.path(), cache_stage.path()).await?
+    } else {
+        unpack_archive(buf, snapshot_stage.path(), cache_stage.path()).await?
+    };
+
+    let imported = verify_imported_snapshots(local, &unpacked.manifest_dirs).await?;
+    let head_index = select_head_snapshot(&imported)?;
+    let head_stage_path = imported[head_index].path().to_path_buf();
+    let head_relative = head_stage_path
+        .strip_prefix(snapshot_stage.path())
+        .map_err(|_| MicrosandboxError::Custom("imported snapshot escaped staging dir".into()))?
+        .to_path_buf();
+    let head_manifest = imported[head_index].manifest().clone();
+    let head_path = snapshots_dir.join(&head_relative);
+
+    ensure_promote_targets_available(snapshot_stage.path(), &snapshots_dir).await?;
+    install_staged_cache(cache_stage.path(), &cache_dir, &head_manifest).await?;
+    promote_stage(snapshot_stage.path(), &snapshots_dir).await?;
+
     let snap = store::open_snapshot(local, head_path.to_string_lossy().as_ref()).await?;
-    snap.verify().await?;
 
     // Index this and any sibling artifacts that landed in the dest dir.
     let _ = store::reindex_dir(local, &snapshots_dir).await;
@@ -251,17 +279,18 @@ async fn unpack_archive<R>(
     reader: R,
     snapshots_dir: &Path,
     cache_dir: &Path,
-) -> MicrosandboxResult<Option<PathBuf>>
+) -> MicrosandboxResult<UnpackedArchive>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut archive = Archive::new(reader);
     let mut entries = archive.entries()?;
-    let mut last_snapshot_dir: Option<PathBuf> = None;
+    let mut manifest_dirs: Vec<PathBuf> = Vec::new();
 
     while let Some(entry) = tokio_stream_next(&mut entries).await? {
         let mut entry = entry?;
         let path_in_archive = entry.path()?.into_owned();
+        let entry_type = entry.header().entry_type();
 
         // Reject suspicious paths (path traversal, absolute).
         if path_in_archive.is_absolute()
@@ -274,13 +303,21 @@ where
                 path_in_archive.display()
             )));
         }
+        validate_archive_entry_type(entry_type, &path_in_archive)?;
 
-        let dest_root = if path_in_archive.starts_with("cache") {
+        let is_cache_entry = path_in_archive.starts_with("cache");
+        if is_cache_entry {
+            validate_cache_archive_path(&path_in_archive, entry_type)?;
+        } else {
+            validate_snapshot_archive_path(&path_in_archive, entry_type)?;
+        }
+
+        let dest_root = if is_cache_entry {
             cache_dir.to_path_buf()
         } else {
             snapshots_dir.to_path_buf()
         };
-        let target = if path_in_archive.starts_with("cache") {
+        let target = if is_cache_entry {
             // Strip the leading "cache" component since it's already
             // implied by `cache_dir`.
             let stripped = path_in_archive
@@ -301,14 +338,476 @@ where
             .and_then(|s| s.to_str())
             .map(|n| n == MANIFEST_FILENAME)
             .unwrap_or(false)
-            && !path_in_archive.starts_with("cache")
+            && !is_cache_entry
             && let Some(parent) = target.parent()
         {
-            last_snapshot_dir = Some(parent.to_path_buf());
+            manifest_dirs.push(parent.to_path_buf());
         }
     }
 
-    Ok(last_snapshot_dir)
+    Ok(UnpackedArchive { manifest_dirs })
+}
+
+fn validate_archive_entry_type(entry_type: EntryType, path: &Path) -> MicrosandboxResult<()> {
+    match entry_type {
+        EntryType::Regular | EntryType::Continuous | EntryType::Directory => Ok(()),
+        _ => Err(MicrosandboxError::Custom(format!(
+            "archive contains unsupported entry type at {}",
+            path.display()
+        ))),
+    }
+}
+
+fn validate_snapshot_archive_path(path: &Path, entry_type: EntryType) -> MicrosandboxResult<()> {
+    let components = normal_utf8_components(path)?;
+    let valid = match entry_type {
+        EntryType::Directory => components.len() == 1,
+        EntryType::Regular | EntryType::Continuous => components.len() == 2,
+        _ => false,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(MicrosandboxError::Custom(format!(
+            "archive contains unsupported snapshot path: {}",
+            path.display()
+        )))
+    }
+}
+
+fn validate_cache_archive_path(path: &Path, entry_type: EntryType) -> MicrosandboxResult<()> {
+    let components = normal_utf8_components(path)?;
+    let valid = match (entry_type, components.as_slice()) {
+        (EntryType::Directory, ["cache"]) => true,
+        (EntryType::Directory, ["cache", kind]) => is_supported_cache_dir(kind),
+        (EntryType::Regular | EntryType::Continuous, ["cache", kind, file]) => {
+            is_supported_cache_file(kind, file)
+        }
+        _ => false,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(MicrosandboxError::Custom(format!(
+            "archive contains unsupported cache path: {}",
+            path.display()
+        )))
+    }
+}
+
+fn normal_utf8_components(path: &Path) -> MicrosandboxResult<Vec<&str>> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => {
+                let part = part.to_str().ok_or_else(|| {
+                    MicrosandboxError::Custom(format!(
+                        "archive contains non-utf8 path: {}",
+                        path.display()
+                    ))
+                })?;
+                components.push(part);
+            }
+            _ => {
+                return Err(MicrosandboxError::Custom(format!(
+                    "archive contains unsafe path: {}",
+                    path.display()
+                )));
+            }
+        }
+    }
+    Ok(components)
+}
+
+fn is_supported_cache_dir(kind: &str) -> bool {
+    matches!(kind, "manifests" | "layers" | "fsmeta" | "vmdk")
+}
+
+fn is_supported_cache_file(kind: &str, file: &str) -> bool {
+    match kind {
+        "manifests" => file.ends_with(".json"),
+        "layers" | "fsmeta" => file.ends_with(".erofs"),
+        "vmdk" => file.ends_with(".vmdk"),
+        _ => false,
+    }
+}
+
+async fn verify_imported_snapshots(
+    local: &LocalBackend,
+    manifest_dirs: &[PathBuf],
+) -> MicrosandboxResult<Vec<Snapshot>> {
+    if manifest_dirs.is_empty() {
+        return Err(MicrosandboxError::Custom(
+            "archive contained no snapshot manifest".into(),
+        ));
+    }
+
+    let mut seen = HashSet::new();
+    let mut snapshots = Vec::new();
+    for dir in manifest_dirs {
+        if !seen.insert(dir.clone()) {
+            continue;
+        }
+        let snap = store::open_snapshot(local, dir.to_string_lossy().as_ref()).await?;
+        snap.verify().await?;
+        snapshots.push(snap);
+    }
+
+    if snapshots.is_empty() {
+        return Err(MicrosandboxError::Custom(
+            "archive contained no snapshot manifest".into(),
+        ));
+    }
+    Ok(snapshots)
+}
+
+fn select_head_snapshot(snapshots: &[Snapshot]) -> MicrosandboxResult<usize> {
+    let imported_digests: HashSet<&str> = snapshots.iter().map(|snap| snap.digest()).collect();
+    let parent_digests: HashSet<&str> = snapshots
+        .iter()
+        .filter_map(|snap| snap.manifest().parent.as_deref())
+        .filter(|parent| imported_digests.contains(parent))
+        .collect();
+
+    snapshots
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, snap)| !parent_digests.contains(snap.digest()))
+        .map(|(index, _)| index)
+        .ok_or_else(|| MicrosandboxError::Custom("archive contained no head snapshot".into()))
+}
+
+async fn ensure_promote_targets_available(stage: &Path, dest: &Path) -> MicrosandboxResult<()> {
+    let mut entries = tokio::fs::read_dir(stage).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let target = dest.join(entry.file_name());
+        if tokio::fs::symlink_metadata(&target).await.is_ok() {
+            return Err(MicrosandboxError::SnapshotAlreadyExists(
+                target.display().to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn promote_stage(stage: &Path, dest: &Path) -> MicrosandboxResult<()> {
+    let mut entries = tokio::fs::read_dir(stage).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let target = dest.join(entry.file_name());
+        tokio::fs::rename(entry.path(), target).await?;
+    }
+    Ok(())
+}
+
+async fn install_staged_cache(
+    cache_stage: &Path,
+    cache_dir: &Path,
+    manifest: &microsandbox_image::snapshot::Manifest,
+) -> MicrosandboxResult<()> {
+    if !contains_files(cache_stage)? {
+        return Ok(());
+    }
+
+    let image_ref: microsandbox_image::Reference =
+        manifest.image.reference.parse().map_err(|e| {
+            MicrosandboxError::Custom(format!("invalid snapshot image reference: {e}"))
+        })?;
+    let pinned_digest: microsandbox_image::Digest =
+        manifest.image.manifest_digest.parse().map_err(|e| {
+            MicrosandboxError::Custom(format!("invalid snapshot image digest: {e}"))
+        })?;
+    let staged_cache = microsandbox_image::GlobalCache::new_async(cache_stage).await?;
+    let _real_cache = microsandbox_image::GlobalCache::new_async(cache_dir).await?;
+    let metadata = staged_cache
+        .read_image_metadata_async(&image_ref)
+        .await?
+        .ok_or_else(|| {
+            MicrosandboxError::Custom(format!(
+                "snapshot image cache metadata missing for {}",
+                manifest.image.reference
+            ))
+        })?;
+    validate_cached_metadata(manifest, &metadata)?;
+
+    let expected_files =
+        expected_cache_files(&staged_cache, &image_ref, &metadata, &pinned_digest)?;
+    ensure_only_expected_cache_files(cache_stage, &expected_files)?;
+    ensure_cache_targets_compatible(&expected_files, cache_stage, cache_dir).await?;
+
+    let metadata_path = staged_cache.image_metadata_path(&image_ref);
+    for source in expected_files.iter().filter(|path| **path != metadata_path) {
+        install_cache_file(source, cache_stage, cache_dir).await?;
+    }
+    install_cache_file(&metadata_path, cache_stage, cache_dir).await?;
+
+    Ok(())
+}
+
+fn validate_cached_metadata(
+    manifest: &microsandbox_image::snapshot::Manifest,
+    metadata: &microsandbox_image::CachedImageMetadata,
+) -> MicrosandboxResult<()> {
+    if metadata.manifest_digest != manifest.image.manifest_digest {
+        return Err(MicrosandboxError::Custom(format!(
+            "snapshot image metadata digest mismatch: snapshot={}, cache={}",
+            manifest.image.manifest_digest, metadata.manifest_digest
+        )));
+    }
+    verify_sha256_digest(
+        metadata.raw_manifest_json.as_bytes(),
+        &metadata.manifest_digest,
+        "raw manifest",
+    )?;
+    verify_sha256_digest(
+        metadata.raw_config_json.as_bytes(),
+        &metadata.config_digest,
+        "image config",
+    )?;
+    for layer in &metadata.layers {
+        let _: microsandbox_image::Digest = layer
+            .digest
+            .parse()
+            .map_err(|e| MicrosandboxError::Custom(format!("invalid cached layer digest: {e}")))?;
+        let _: microsandbox_image::Digest = layer
+            .diff_id
+            .parse()
+            .map_err(|e| MicrosandboxError::Custom(format!("invalid cached layer diff_id: {e}")))?;
+    }
+    Ok(())
+}
+
+fn verify_sha256_digest(bytes: &[u8], digest: &str, label: &str) -> MicrosandboxResult<()> {
+    let Some(expected) = digest.strip_prefix("sha256:") else {
+        return Err(MicrosandboxError::Custom(format!(
+            "{label} digest must use sha256: {digest}"
+        )));
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let actual = hex::encode(hasher.finalize());
+    if actual != expected {
+        return Err(MicrosandboxError::Custom(format!(
+            "{label} digest mismatch: expected sha256:{expected}, got sha256:{actual}"
+        )));
+    }
+    Ok(())
+}
+
+fn expected_cache_files(
+    cache: &microsandbox_image::GlobalCache,
+    image_ref: &microsandbox_image::Reference,
+    metadata: &microsandbox_image::CachedImageMetadata,
+    manifest_digest: &microsandbox_image::Digest,
+) -> MicrosandboxResult<HashSet<PathBuf>> {
+    let mut expected = HashSet::new();
+    let metadata_path = cache.image_metadata_path(image_ref);
+    if !metadata_path.is_file() {
+        return Err(MicrosandboxError::Custom(format!(
+            "missing staged image metadata: {}",
+            metadata_path.display()
+        )));
+    }
+    expected.insert(metadata_path);
+
+    let fsmeta = cache.fsmeta_erofs_path(manifest_digest);
+    if !cache.is_fsmeta_materialized(manifest_digest) {
+        return Err(MicrosandboxError::Custom(format!(
+            "missing staged fsmeta artifact: {}",
+            fsmeta.display()
+        )));
+    }
+    expected.insert(fsmeta);
+
+    let vmdk = cache.vmdk_path(manifest_digest);
+    if !cache.is_vmdk_materialized(manifest_digest) {
+        return Err(MicrosandboxError::Custom(format!(
+            "missing staged VMDK artifact: {}",
+            vmdk.display()
+        )));
+    }
+    expected.insert(vmdk);
+
+    for layer in &metadata.layers {
+        let diff_id: microsandbox_image::Digest = layer
+            .diff_id
+            .parse()
+            .map_err(|e| MicrosandboxError::Custom(format!("invalid cached layer diff_id: {e}")))?;
+        let layer_path = cache.layer_erofs_path(&diff_id);
+        if !cache.is_layer_materialized(&diff_id) {
+            return Err(MicrosandboxError::Custom(format!(
+                "missing staged layer artifact: {}",
+                layer_path.display()
+            )));
+        }
+        expected.insert(layer_path);
+    }
+
+    Ok(expected)
+}
+
+fn ensure_only_expected_cache_files(
+    cache_stage: &Path,
+    expected_files: &HashSet<PathBuf>,
+) -> MicrosandboxResult<()> {
+    let expected_relative = expected_files
+        .iter()
+        .map(|path| {
+            path.strip_prefix(cache_stage)
+                .map(Path::to_path_buf)
+                .map_err(|_| {
+                    MicrosandboxError::Custom(format!(
+                        "staged cache path escaped stage: {}",
+                        path.display()
+                    ))
+                })
+        })
+        .collect::<MicrosandboxResult<HashSet<_>>>()?;
+    for file in collect_files(cache_stage)? {
+        let relative = file
+            .strip_prefix(cache_stage)
+            .map(Path::to_path_buf)
+            .map_err(|_| {
+                MicrosandboxError::Custom(format!(
+                    "staged cache path escaped stage: {}",
+                    file.display()
+                ))
+            })?;
+        if !expected_relative.contains(&relative) {
+            return Err(MicrosandboxError::Custom(format!(
+                "archive contains unexpected cache artifact: {}",
+                relative.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+async fn ensure_cache_targets_compatible(
+    sources: &HashSet<PathBuf>,
+    cache_stage: &Path,
+    cache_dir: &Path,
+) -> MicrosandboxResult<()> {
+    for source in sources {
+        let target = cache_install_target(source, cache_stage, cache_dir)?;
+        ensure_cache_target_compatible(source, &target).await?;
+    }
+    Ok(())
+}
+
+async fn install_cache_file(
+    source: &Path,
+    cache_stage: &Path,
+    cache_dir: &Path,
+) -> MicrosandboxResult<()> {
+    let target = cache_install_target(source, cache_stage, cache_dir)?;
+    if tokio::fs::symlink_metadata(&target).await.is_ok() {
+        ensure_cache_target_compatible(source, &target).await?;
+        return Ok(());
+    }
+    if let Some(parent) = target.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    tokio::fs::rename(source, target).await?;
+    Ok(())
+}
+
+fn cache_install_target(
+    source: &Path,
+    cache_stage: &Path,
+    cache_dir: &Path,
+) -> MicrosandboxResult<PathBuf> {
+    let relative = source.strip_prefix(cache_stage).map_err(|_| {
+        MicrosandboxError::Custom(format!(
+            "staged cache path escaped stage: {}",
+            source.display()
+        ))
+    })?;
+    Ok(cache_dir.join(relative))
+}
+
+async fn ensure_cache_target_compatible(source: &Path, target: &Path) -> MicrosandboxResult<()> {
+    let Ok(metadata) = tokio::fs::symlink_metadata(target).await else {
+        return Ok(());
+    };
+    if !metadata.file_type().is_file() {
+        return Err(MicrosandboxError::Custom(format!(
+            "cache target is not a regular file: {}",
+            target.display()
+        )));
+    }
+    if metadata.len() != tokio::fs::metadata(source).await?.len()
+        || file_sha256(target).await? != file_sha256(source).await?
+    {
+        return Err(MicrosandboxError::Custom(format!(
+            "cache target already exists with different content: {}",
+            target.display()
+        )));
+    }
+    Ok(())
+}
+
+async fn file_sha256(path: &Path) -> MicrosandboxResult<[u8; 32]> {
+    let mut file = tokio::fs::File::open(path).await?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hasher.finalize().into())
+}
+
+fn contains_files(path: &Path) -> MicrosandboxResult<bool> {
+    Ok(!collect_files(path)?.is_empty())
+}
+
+fn collect_files(path: &Path) -> MicrosandboxResult<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    if !path.exists() {
+        return Ok(files);
+    }
+    collect_files_inner(path, &mut files)?;
+    Ok(files)
+}
+
+fn collect_files_inner(path: &Path, files: &mut Vec<PathBuf>) -> MicrosandboxResult<()> {
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_files_inner(&entry.path(), files)?;
+        } else if file_type.is_file() {
+            files.push(entry.path());
+        } else {
+            return Err(MicrosandboxError::Custom(format!(
+                "unsupported staged cache file type: {}",
+                entry.path().display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn push_required_cache_file(
+    cache_files: &mut Vec<(PathBuf, String)>,
+    path: &Path,
+    archive_dir: &str,
+) -> MicrosandboxResult<()> {
+    if !path.is_file() {
+        return Err(MicrosandboxError::Custom(format!(
+            "required image cache artifact missing: {}",
+            path.display()
+        )));
+    }
+    cache_files.push((
+        path.to_path_buf(),
+        format!("cache/{archive_dir}/{}", file_name_str(path)?),
+    ));
+    Ok(())
 }
 
 async fn tokio_stream_next<S>(s: &mut S) -> MicrosandboxResult<Option<S::Item>>

--- a/sdk/rust/lib/snapshot/store.rs
+++ b/sdk/rust/lib/snapshot/store.rs
@@ -89,7 +89,8 @@ pub(super) async fn open_snapshot(
     // index, insert it. Keeps the cache aligned with reality without
     // forcing the user to think about it. Best-effort — errors are
     // logged, not propagated.
-    if dir.starts_with(local.snapshots_dir())
+    let snapshots_dir = local.snapshots_dir();
+    if dir.parent() == Some(snapshots_dir.as_path())
         && let Ok(None) = lookup_by_digest(local, &digest).await
         && let Err(e) = index_upsert(local, snap.path(), snap.digest(), snap.manifest()).await
     {

--- a/sdk/rust/tests/snapshot_artifact.rs
+++ b/sdk/rust/tests/snapshot_artifact.rs
@@ -6,30 +6,64 @@
 //! VM live alongside the other `msb_test`-gated integration tests.
 
 use std::collections::BTreeMap;
+use std::io::Cursor;
 use std::path::Path;
+use std::sync::Arc;
 
 use microsandbox::Snapshot;
+use microsandbox::backend::{Backend, LocalBackend};
 use microsandbox_image::snapshot::{
     DEFAULT_UPPER_FILE, ImageRef, MANIFEST_FILENAME, Manifest, SCHEMA_VERSION, SnapshotFormat,
     UpperIntegrity, UpperLayer,
 };
 use sha2::{Digest, Sha256};
+use tar::{Builder, EntryType, Header};
 use tempfile::TempDir;
 
 //--------------------------------------------------------------------------------------------------
-// Helpers
+// Types
+//--------------------------------------------------------------------------------------------------
+
+struct SeededImageCache {
+    image_ref: microsandbox_image::Reference,
+    manifest_digest: String,
+    image_digest: microsandbox_image::Digest,
+    diff_id: microsandbox_image::Digest,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
 /// Build a synthetic snapshot artifact directory with a known upper
 /// file. Returns `(artifact_dir, manifest_digest)`.
 fn make_artifact(parent: &Path, name: &str, upper_bytes: &[u8]) -> (std::path::PathBuf, String) {
-    make_artifact_with_integrity(parent, name, upper_bytes, false)
+    make_artifact_with_parent_and_integrity(parent, name, upper_bytes, None, false)
 }
 
 fn make_artifact_with_integrity(
     parent: &Path,
     name: &str,
     upper_bytes: &[u8],
+    record_integrity: bool,
+) -> (std::path::PathBuf, String) {
+    make_artifact_with_parent_and_integrity(parent, name, upper_bytes, None, record_integrity)
+}
+
+fn make_artifact_with_parent(
+    parent: &Path,
+    name: &str,
+    upper_bytes: &[u8],
+    parent_digest: Option<String>,
+) -> (std::path::PathBuf, String) {
+    make_artifact_with_parent_and_integrity(parent, name, upper_bytes, parent_digest, false)
+}
+
+fn make_artifact_with_parent_and_integrity(
+    parent: &Path,
+    name: &str,
+    upper_bytes: &[u8],
+    parent_digest: Option<String>,
     record_integrity: bool,
 ) -> (std::path::PathBuf, String) {
     let dir = parent.join(name);
@@ -54,7 +88,7 @@ fn make_artifact_with_integrity(
             manifest_digest:
                 "sha256:0000000000000000000000000000000000000000000000000000000000000001".into(),
         },
-        parent: None,
+        parent: parent_digest,
         created_at: "2026-05-01T12:00:00Z".into(),
         labels: BTreeMap::new(),
         upper: UpperLayer {
@@ -68,6 +102,157 @@ fn make_artifact_with_integrity(
     let digest = manifest.digest().unwrap();
     std::fs::write(dir.join(MANIFEST_FILENAME), bytes).unwrap();
     (dir, digest)
+}
+
+fn make_artifact_with_image(
+    parent: &Path,
+    name: &str,
+    upper_bytes: &[u8],
+    image_reference: String,
+    image_manifest_digest: String,
+) -> (std::path::PathBuf, String) {
+    let dir = parent.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(DEFAULT_UPPER_FILE), upper_bytes).unwrap();
+
+    let manifest = Manifest {
+        schema: SCHEMA_VERSION,
+        format: SnapshotFormat::Raw,
+        fstype: "ext4".into(),
+        image: ImageRef {
+            reference: image_reference,
+            manifest_digest: image_manifest_digest,
+        },
+        parent: None,
+        created_at: "2026-05-01T12:00:00Z".into(),
+        labels: BTreeMap::new(),
+        upper: UpperLayer {
+            file: DEFAULT_UPPER_FILE.into(),
+            size_bytes: upper_bytes.len() as u64,
+            integrity: None,
+        },
+        source_sandbox: Some("synthetic".into()),
+    };
+    let bytes = manifest.to_canonical_bytes().unwrap();
+    let digest = manifest.digest().unwrap();
+    std::fs::write(dir.join(MANIFEST_FILENAME), bytes).unwrap();
+    (dir, digest)
+}
+
+fn sha256_digest(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{}", hex::encode(hasher.finalize()))
+}
+
+async fn seed_image_cache(cache: &microsandbox_image::GlobalCache) -> SeededImageCache {
+    let image_ref: microsandbox_image::Reference = "docker.io/library/alpine:3.20".parse().unwrap();
+    let raw_manifest = br#"{"schemaVersion":2,"layers":[]}"#;
+    let raw_config =
+        br#"{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]}}"#;
+    let manifest_digest = sha256_digest(raw_manifest);
+    let config_digest = sha256_digest(raw_config);
+    let diff_id: microsandbox_image::Digest =
+        "sha256:0000000000000000000000000000000000000000000000000000000000001000"
+            .parse()
+            .unwrap();
+    let layer_digest = "sha256:0000000000000000000000000000000000000000000000000000000000002000";
+    let metadata = microsandbox_image::CachedImageMetadata {
+        manifest_digest: manifest_digest.clone(),
+        config_digest,
+        raw_manifest_json: String::from_utf8(raw_manifest.to_vec()).unwrap(),
+        raw_config_json: String::from_utf8(raw_config.to_vec()).unwrap(),
+        config: microsandbox_image::ImageConfig::default(),
+        layers: vec![microsandbox_image::CachedLayerMetadata {
+            digest: layer_digest.into(),
+            media_type: Some("application/vnd.oci.image.layer.v1.tar+gzip".into()),
+            size_bytes: Some(10),
+            diff_id: diff_id.to_string(),
+        }],
+    };
+    cache
+        .write_image_metadata_async(&image_ref, &metadata)
+        .await
+        .unwrap();
+
+    let image_digest: microsandbox_image::Digest = manifest_digest.parse().unwrap();
+    std::fs::write(cache.layer_erofs_path(&diff_id), vec![0u8; 4096]).unwrap();
+    std::fs::write(cache.fsmeta_erofs_path(&image_digest), vec![0u8; 4096]).unwrap();
+    std::fs::write(cache.vmdk_path(&image_digest), b"# vmdk").unwrap();
+
+    SeededImageCache {
+        image_ref,
+        manifest_digest,
+        image_digest,
+        diff_id,
+    }
+}
+
+fn write_archive_from_artifacts(archive: &Path, artifacts: &[(&Path, &str)]) {
+    let file = std::fs::File::create(archive).unwrap();
+    let mut builder = Builder::new(file);
+    for (artifact, archive_name) in artifacts {
+        builder
+            .append_path_with_name(
+                artifact.join(MANIFEST_FILENAME),
+                format!("{archive_name}/{MANIFEST_FILENAME}"),
+            )
+            .unwrap();
+        builder
+            .append_path_with_name(
+                artifact.join(DEFAULT_UPPER_FILE),
+                format!("{archive_name}/{DEFAULT_UPPER_FILE}"),
+            )
+            .unwrap();
+    }
+    builder.finish().unwrap();
+}
+
+fn write_regular_file_archive(archive: &Path, path: &str, payload: &[u8]) {
+    let file = std::fs::File::create(archive).unwrap();
+    let mut builder = Builder::new(file);
+
+    let mut header = Header::new_gnu();
+    header.set_entry_type(EntryType::Regular);
+    header.set_path(path).unwrap();
+    header.set_mode(0o644);
+    header.set_size(payload.len() as u64);
+    header.set_cksum();
+    builder.append(&header, Cursor::new(payload)).unwrap();
+    builder.finish().unwrap();
+}
+
+fn write_symlink_traversal_archive(archive: &Path, escape_dir: &Path) {
+    let file = std::fs::File::create(archive).unwrap();
+    let mut builder = Builder::new(file);
+
+    let mut link_header = Header::new_gnu();
+    link_header.set_entry_type(EntryType::Symlink);
+    link_header.set_path("snap/link").unwrap();
+    link_header.set_link_name(escape_dir).unwrap();
+    link_header.set_mode(0o777);
+    link_header.set_size(0);
+    link_header.set_cksum();
+    builder
+        .append(&link_header, Cursor::new(Vec::new()))
+        .unwrap();
+
+    let payload = b"pwned via snapshot import symlink traversal\n";
+    let mut file_header = Header::new_gnu();
+    file_header.set_entry_type(EntryType::Regular);
+    file_header.set_path("snap/link/pwned.txt").unwrap();
+    file_header.set_mode(0o644);
+    file_header.set_size(payload.len() as u64);
+    file_header.set_cksum();
+    builder
+        .append(&file_header, Cursor::new(payload.as_slice()))
+        .unwrap();
+
+    builder.finish().unwrap();
+}
+
+async fn isolated_backend(home: &Path) -> Arc<dyn Backend> {
+    Arc::new(LocalBackend::builder().home(home).build().await.unwrap())
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -212,6 +397,344 @@ async fn export_then_import_round_trips_via_plain_tar() {
     let dest = tmp.path().join("imported-plain");
     let handle = Snapshot::import(&archive, Some(&dest)).await.unwrap();
     assert_eq!(handle.digest(), original_digest);
+}
+
+#[tokio::test]
+async fn export_with_image_includes_only_pinned_cache_artifacts() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let backend = isolated_backend(&home).await;
+    let cache_dir = home.join("cache");
+    let cache = microsandbox_image::GlobalCache::new(&cache_dir).unwrap();
+    let seeded = seed_image_cache(&cache).await;
+    std::fs::write(cache.layers_dir().join("unrelated.erofs"), vec![0u8; 4096]).unwrap();
+    std::fs::write(cache.fsmeta_dir().join("unrelated.erofs"), vec![0u8; 4096]).unwrap();
+
+    let (dir, _) = make_artifact_with_image(
+        tmp.path(),
+        "src-with-image",
+        b"upper",
+        seeded.image_ref.to_string(),
+        seeded.manifest_digest.clone(),
+    );
+    let archive = tmp.path().join("with-image.tar");
+
+    microsandbox::with_backend(backend, async {
+        Snapshot::export(
+            dir.to_string_lossy().as_ref(),
+            &archive,
+            microsandbox::snapshot::ExportOpts {
+                with_image: true,
+                plain_tar: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    })
+    .await;
+
+    let file = std::fs::File::open(&archive).unwrap();
+    let mut tar = tar::Archive::new(file);
+    let names = tar
+        .entries()
+        .unwrap()
+        .map(|entry| entry.unwrap().path().unwrap().to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+
+    let metadata_name = cache
+        .image_metadata_path(&seeded.image_ref)
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    assert!(
+        names
+            .iter()
+            .any(|name| name == &format!("cache/manifests/{metadata_name}")),
+        "archive did not include image metadata: {names:?}"
+    );
+    assert!(
+        names.iter().any(|name| name.starts_with("cache/layers/"))
+            && names.iter().any(|name| name.starts_with("cache/fsmeta/"))
+            && names.iter().any(|name| name.starts_with("cache/vmdk/")),
+        "archive did not include required image artifacts: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|name| name.contains("unrelated")),
+        "archive swept unrelated cache entries: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn import_rejects_symlink_entries_without_writing_outside_dest() {
+    let tmp = TempDir::new().unwrap();
+    let archive = tmp.path().join("malicious.tar");
+    let dest = tmp.path().join("dest");
+    let escape_dir = tmp.path().join("escape");
+    let escape_file = escape_dir.join("pwned.txt");
+    std::fs::create_dir_all(&escape_dir).unwrap();
+
+    write_symlink_traversal_archive(&archive, &escape_dir);
+
+    let err = Snapshot::import(&archive, Some(&dest))
+        .await
+        .expect_err("expected import to reject symlink archive entry");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unsupported entry type"),
+        "expected unsupported entry type error, got: {msg}"
+    );
+    assert!(
+        !escape_file.exists(),
+        "archive import wrote outside the destination"
+    );
+    assert!(
+        !dest.join("snap/link").exists() && !dest.join("snap/link").is_symlink(),
+        "archive import created the rejected symlink entry"
+    );
+}
+
+#[tokio::test]
+async fn import_does_not_follow_preexisting_symlink_parent() {
+    let tmp = TempDir::new().unwrap();
+    let archive = tmp.path().join("regular.tar");
+    let dest = tmp.path().join("dest");
+    let escape_dir = tmp.path().join("escape");
+    let escape_file = escape_dir.join("pwned.txt");
+    std::fs::create_dir_all(&dest).unwrap();
+    std::fs::create_dir_all(&escape_dir).unwrap();
+    std::os::unix::fs::symlink(&escape_dir, dest.join("snap")).unwrap();
+    write_regular_file_archive(&archive, "snap/pwned.txt", b"should not escape\n");
+
+    let err = Snapshot::import(&archive, Some(&dest))
+        .await
+        .expect_err("expected import without a manifest to fail");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("no snapshot manifest") || msg.contains("manifest"),
+        "unexpected error: {msg}"
+    );
+    assert!(
+        !escape_file.exists(),
+        "archive import followed a pre-existing symlink parent"
+    );
+}
+
+#[tokio::test]
+async fn open_rejects_manifest_upper_file_that_escapes_artifact() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join("bad-upper-path");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(tmp.path().join("outside.ext4"), b"data").unwrap();
+
+    let manifest = Manifest {
+        schema: SCHEMA_VERSION,
+        format: SnapshotFormat::Raw,
+        fstype: "ext4".into(),
+        image: ImageRef {
+            reference: "docker.io/library/alpine:3.20".into(),
+            manifest_digest:
+                "sha256:0000000000000000000000000000000000000000000000000000000000000001".into(),
+        },
+        parent: None,
+        created_at: "2026-05-01T12:00:00Z".into(),
+        labels: BTreeMap::new(),
+        upper: UpperLayer {
+            file: "../outside.ext4".into(),
+            size_bytes: 4,
+            integrity: None,
+        },
+        source_sandbox: Some("synthetic".into()),
+    };
+    std::fs::write(
+        dir.join(MANIFEST_FILENAME),
+        manifest.to_canonical_bytes().unwrap(),
+    )
+    .unwrap();
+
+    let err = Snapshot::open(dir.to_string_lossy().as_ref())
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("upper.file"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn import_verifies_every_snapshot_manifest_before_indexing() {
+    let tmp = TempDir::new().unwrap();
+    let (bad_dir, _) = make_artifact_with_integrity(tmp.path(), "bad-snap", b"original", true);
+    std::fs::write(bad_dir.join(DEFAULT_UPPER_FILE), b"tampered").unwrap();
+    let (good_dir, _) = make_artifact(tmp.path(), "good-snap", b"good");
+    let archive = tmp.path().join("multi.tar");
+    write_archive_from_artifacts(
+        &archive,
+        &[
+            (bad_dir.as_path(), "bad-snap"),
+            (good_dir.as_path(), "good-snap"),
+        ],
+    );
+
+    let dest = tmp.path().join("imported");
+    let err = Snapshot::import(&archive, Some(&dest))
+        .await
+        .expect_err("expected tampered sibling to fail import");
+
+    assert!(
+        err.to_string().contains("digest mismatch"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        !dest.join("bad-snap").exists() && !dest.join("good-snap").exists(),
+        "failed import promoted staged snapshots"
+    );
+}
+
+#[tokio::test]
+async fn import_detects_zstd_by_magic_bytes() {
+    let tmp = TempDir::new().unwrap();
+    let (dir, original_digest) = make_artifact(tmp.path(), "src-magic", b"magic zstd");
+
+    let archive = tmp.path().join("bundle.snapshot");
+    Snapshot::export(
+        dir.to_string_lossy().as_ref(),
+        &archive,
+        microsandbox::snapshot::ExportOpts::default(),
+    )
+    .await
+    .unwrap();
+
+    let dest = tmp.path().join("imported-magic");
+    let handle = Snapshot::import(&archive, Some(&dest)).await.unwrap();
+    assert_eq!(handle.digest(), original_digest);
+}
+
+#[tokio::test]
+async fn import_selects_child_head_when_parents_are_present() {
+    let tmp = TempDir::new().unwrap();
+    let (parent_dir, parent_digest) = make_artifact(tmp.path(), "parent", b"parent");
+    let (child_dir, child_digest) =
+        make_artifact_with_parent(tmp.path(), "child", b"child", Some(parent_digest));
+    let archive = tmp.path().join("chain.tar");
+    write_archive_from_artifacts(
+        &archive,
+        &[
+            (child_dir.as_path(), "child"),
+            (parent_dir.as_path(), "parent"),
+        ],
+    );
+
+    let dest = tmp.path().join("imported-chain");
+    let handle = Snapshot::import(&archive, Some(&dest)).await.unwrap();
+    assert_eq!(handle.digest(), child_digest);
+    assert_eq!(handle.path(), dest.join("child"));
+}
+
+#[tokio::test]
+async fn failed_import_does_not_install_staged_cache_entries() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let backend = isolated_backend(&home).await;
+    let archive = tmp.path().join("cache-poison.tar");
+    write_regular_file_archive(
+        &archive,
+        "cache/manifests/not-real.json",
+        br#"{"manifest_digest":"sha256:bad"}"#,
+    );
+    let dest = tmp.path().join("dest");
+
+    microsandbox::with_backend(backend, async {
+        let err = Snapshot::import(&archive, Some(&dest))
+            .await
+            .expect_err("expected cache-only import to fail");
+        assert!(
+            err.to_string().contains("no snapshot manifest"),
+            "unexpected error: {err}"
+        );
+    })
+    .await;
+
+    assert!(
+        !home.join("cache/manifests/not-real.json").exists(),
+        "failed import installed cache entry"
+    );
+}
+
+#[tokio::test]
+async fn failed_import_with_conflicting_cache_target_does_not_install_cache_entries() {
+    let tmp = TempDir::new().unwrap();
+    let export_home = tmp.path().join("export-home");
+    let export_backend = isolated_backend(&export_home).await;
+    let export_cache = microsandbox_image::GlobalCache::new(&export_home.join("cache")).unwrap();
+    let seeded = seed_image_cache(&export_cache).await;
+    let (dir, _) = make_artifact_with_image(
+        tmp.path(),
+        "src-cache-conflict",
+        b"upper",
+        seeded.image_ref.to_string(),
+        seeded.manifest_digest.clone(),
+    );
+    let archive = tmp.path().join("cache-conflict.tar");
+
+    microsandbox::with_backend(
+        export_backend,
+        Box::pin(async {
+            Snapshot::export(
+                dir.to_string_lossy().as_ref(),
+                &archive,
+                microsandbox::snapshot::ExportOpts {
+                    with_image: true,
+                    plain_tar: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        }),
+    )
+    .await;
+
+    let import_home = tmp.path().join("import-home");
+    let import_backend = isolated_backend(&import_home).await;
+    let import_cache = microsandbox_image::GlobalCache::new(&import_home.join("cache")).unwrap();
+    let conflicting_metadata = import_cache.image_metadata_path(&seeded.image_ref);
+    std::fs::write(&conflicting_metadata, b"conflicting metadata").unwrap();
+    let expected_layer = import_cache.layer_erofs_path(&seeded.diff_id);
+    let expected_fsmeta = import_cache.fsmeta_erofs_path(&seeded.image_digest);
+    let expected_vmdk = import_cache.vmdk_path(&seeded.image_digest);
+    let dest = tmp.path().join("cache-conflict-dest");
+
+    microsandbox::with_backend(
+        import_backend,
+        Box::pin(async {
+            let err = Snapshot::import(&archive, Some(&dest))
+                .await
+                .expect_err("expected conflicting cache target to fail import");
+            assert!(
+                err.to_string()
+                    .contains("cache target already exists with different content"),
+                "unexpected error: {err}"
+            );
+        }),
+    )
+    .await;
+
+    assert!(
+        !dest.join("src-cache-conflict").exists(),
+        "failed import promoted staged snapshot"
+    );
+    assert_eq!(
+        std::fs::read(&conflicting_metadata).unwrap(),
+        b"conflicting metadata"
+    );
+    assert!(
+        !expected_layer.exists() && !expected_fsmeta.exists() && !expected_vmdk.exists(),
+        "failed import installed cache artifacts"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## TL;DR
Harden snapshot archive import/export so malicious bundles cannot escape staging, poison cache entries, or boot with a mismatched image digest.

## Description
- Stage snapshot and cache archive contents under temporary directories, validate entry types and paths, and promote only after every snapshot manifest verifies.
- Select imported head snapshots from the parent graph and export parent artifacts before the head so chained bundles round-trip reliably.
- Restrict `with_image` exports to the snapshot's pinned metadata, fsmeta, VMDK, and layer artifacts instead of sweeping unrelated cache files.
- Validate staged image metadata, raw manifest/config digests, expected cache files, and existing cache target collisions before installing cache entries.
- Reject snapshot manifests whose `upper.file` escapes the artifact directory and reject `from_snapshot` boots when the resolved image digest differs from the snapshot pin.
- Add regression tests for traversal, cache poisoning, zstd magic detection, parent/head selection, and pinned cache exports.

## Test Plan
- [x] `cargo test -p microsandbox --test snapshot_artifact`
- [x] `cargo test -p microsandbox`
- [x] `cargo test -p microsandbox-image`
- [x] `cargo clippy -p microsandbox-image -p microsandbox -- -D warnings`
- [x] `cargo fmt --all -- --check`