### PR TITLE
chore(release): bump microsandbox to 0.5.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "base64",
  "chrono",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "base64",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-go"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "base64",
  "cbindgen",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "chrono",
  "libc",
@@ -3332,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics-collector"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "base64",
  "bytes",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "chrono",
  "futures",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "chrono",
  "serde",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "dirs",
  "libc",
@@ -6482,14 +6482,14 @@ dependencies = [
 
 [[package]]
 name = "test-init"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "test-macros"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6498,7 +6498,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.5.7"
+version = "0.5.8"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -61,18 +61,18 @@ panic = "abort"
 # manifest; members reference them via `{ workspace = true }`.
 # `default-features = false` on crates whose consumers opt into features
 # explicitly (see each member manifest); other consumers re-enable defaults.
-microsandbox = { version = "0.5.7", path = "sdk/rust", default-features = false }
-microsandbox-agent-client = { version = "0.5.7", path = "packages/agent-client/rust" }
-microsandbox-db = { version = "0.5.7", path = "crates/db" }
-microsandbox-filesystem = { version = "0.5.7", path = "crates/filesystem", default-features = false }
-microsandbox-image = { version = "0.5.7", path = "crates/image" }
-microsandbox-metrics = { version = "0.5.7", path = "crates/metrics" }
-microsandbox-types = { version = "0.5.7", path = "packages/microsandbox-types/rust" }
-microsandbox-migration = { version = "0.5.7", path = "crates/migration" }
-microsandbox-network = { version = "0.5.7", path = "crates/network" }
-microsandbox-protocol = { version = "0.5.7", path = "crates/protocol" }
-microsandbox-runtime = { version = "0.5.7", path = "crates/runtime", default-features = false }
-microsandbox-utils = { version = "0.5.7", path = "crates/utils" }
+microsandbox = { version = "0.5.8", path = "sdk/rust", default-features = false }
+microsandbox-agent-client = { version = "0.5.8", path = "packages/agent-client/rust" }
+microsandbox-db = { version = "0.5.8", path = "crates/db" }
+microsandbox-filesystem = { version = "0.5.8", path = "crates/filesystem", default-features = false }
+microsandbox-image = { version = "0.5.8", path = "crates/image" }
+microsandbox-metrics = { version = "0.5.8", path = "crates/metrics" }
+microsandbox-types = { version = "0.5.8", path = "packages/microsandbox-types/rust" }
+microsandbox-migration = { version = "0.5.8", path = "crates/migration" }
+microsandbox-network = { version = "0.5.8", path = "crates/network" }
+microsandbox-protocol = { version = "0.5.8", path = "crates/protocol" }
+microsandbox-runtime = { version = "0.5.8", path = "crates/runtime", default-features = false }
+microsandbox-utils = { version = "0.5.8", path = "crates/utils" }
 msb_krun = { version = "0.1.17" }
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -234,7 +234,7 @@ async fn tcp_proxy_task(
     }
 
     // Peek for HTTP CONNECT before dialing upstream; hand off if detected.
-    if let Some(tls_state) = tls_state {
+    if let Some(tls_state) = tls_state.clone() {
         if initial_buf.is_empty() {
             let (peeked, _) = peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await;
             initial_buf = peeked;
@@ -250,6 +250,7 @@ async fn tcp_proxy_task(
                 network_policy,
                 tls_state,
                 proxy_connect,
+                None,
             )
             .await;
         }
@@ -284,6 +285,32 @@ async fn tcp_proxy_task(
         (initial_buf, false)
     };
 
+    if let Some(tls_state) = tls_state.clone()
+        && could_be_connect_request(&initial_buf)
+    {
+        // The pre-connect CONNECT peek can miss a client whose first bytes arrive
+        // after we dial upstream. Once classify_first_flight has captured that
+        // request, rejoin the already-open proxy socket and use the CONNECT path
+        // so intercepted tunnels still get TLS substitution and policy checks.
+        let proxy_stream = server_rx
+            .reunite(server_tx)
+            .map_err(|_| io::Error::other("failed to reunite proxy stream halves"))?;
+        return handle_connect_tunnel(
+            guest_dst,
+            connect_dst,
+            initial_buf,
+            from_smoltcp,
+            to_smoltcp,
+            shared,
+            network_policy,
+            tls_state,
+            proxy_connect,
+            Some(proxy_stream),
+        )
+        .await;
+    }
+
+    let mut late_connect_state = tls_state;
     let mut secrets_handler: Option<SecretsHandler> = if !secrets.secrets.is_empty() && !is_tls {
         Some(match extract_http_host(&initial_buf) {
             Some(host) => SecretsHandler::new_plain_http(&secrets, &host, guest_dst.ip(), &shared),
@@ -334,6 +361,30 @@ async fn tcp_proxy_task(
             data = from_smoltcp.recv() => {
                 match data {
                     Some(bytes) => {
+                        if let Some(tls_state) = late_connect_state.take()
+                            && could_be_connect_request(&bytes)
+                        {
+                            // The first guest bytes can arrive after both peek
+                            // windows have completed. Nothing has been written
+                            // to the proxy socket yet, so this is still a valid
+                            // point to switch into CONNECT tunnel handling.
+                            let proxy_stream = server_rx
+                                .reunite(server_tx)
+                                .map_err(|_| io::Error::other("failed to reunite proxy stream halves"))?;
+                            return handle_connect_tunnel(
+                                guest_dst,
+                                connect_dst,
+                                bytes.to_vec(),
+                                from_smoltcp,
+                                to_smoltcp,
+                                shared,
+                                network_policy,
+                                tls_state,
+                                proxy_connect,
+                                Some(proxy_stream),
+                            )
+                            .await;
+                        }
                         // No handler (no secrets / TLS) is the common path: forward
                         // the chunk borrowed, with no per-chunk allocation or copy.
                         let out: Cow<[u8]> = match secrets_handler.as_mut() {
@@ -370,6 +421,9 @@ async fn tcp_proxy_task(
                 match result {
                     Ok(0) => break, // Server closed connection.
                     Ok(n) => {
+                        // A server-first byte means this is not an HTTP CONNECT
+                        // tunnel to a proxy. Keep relaying normally afterward.
+                        late_connect_state = None;
                         let data = Bytes::copy_from_slice(&server_buf[..n]);
                         if to_smoltcp.send(data).await.is_err() {
                             // Channel closed — poll loop dropped the receiver.
@@ -407,6 +461,7 @@ async fn handle_connect_tunnel(
     network_policy: Arc<NetworkPolicy>,
     tls_state: Arc<TlsState>,
     proxy_connect: Arc<ProxyConnectState>,
+    preconnected_proxy: Option<TcpStream>,
 ) -> io::Result<()> {
     let connect_req =
         parse_connect_request(buffer_connect_request(initial_buf, &mut from_smoltcp).await?)?;
@@ -426,13 +481,16 @@ async fn handle_connect_tunnel(
     };
 
     // Dial the proxy and forward the CONNECT request so it opens the tunnel.
-    let mut proxy_stream = match TcpStream::connect(proxy_dst).await {
-        Ok(s) => s,
-        Err(e) => {
-            proxy_connect.mark_upstream_connect_failed();
-            shared.proxy_wake.wake();
-            return Err(e);
-        }
+    let mut proxy_stream = match preconnected_proxy {
+        Some(stream) => stream,
+        None => match TcpStream::connect(proxy_dst).await {
+            Ok(s) => s,
+            Err(e) => {
+                proxy_connect.mark_upstream_connect_failed();
+                shared.proxy_wake.wake();
+                return Err(e);
+            }
+        },
     };
 
     if !connect_req.target.is_intercepted(&tls_state) {

--- a/examples/typescript/cloud-backend/package.json
+++ b/examples/typescript/cloud-backend/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.4"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/init-handoff/package.json
+++ b/examples/typescript/init-handoff/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/logs-read/package-lock.json
+++ b/examples/typescript/logs-read/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -32,9 +32,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.5.7",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.7",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.7"
+        "@superradcompany/microsandbox-darwin-arm64": "0.5.8",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.8",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.8"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/shell-attach/package-lock.json
+++ b/examples/typescript/shell-attach/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -32,9 +32,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.5.7",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.7",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.7"
+        "@superradcompany/microsandbox-darwin-arm64": "0.5.8",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.8",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.8"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/snapshot-fork/package.json
+++ b/examples/typescript/snapshot-fork/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.7"
+    "microsandbox": "0.5.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/packages/agent-client/rust/README.md
+++ b/packages/agent-client/rust/README.md
@@ -10,19 +10,19 @@ Use this crate when you already have an agent relay endpoint and want direct pro
 
 ```toml
 [dependencies]
-microsandbox-agent-client = "0.5.7"
-microsandbox-protocol = "0.5.7"
+microsandbox-agent-client = "0.5.8"
+microsandbox-protocol = "0.5.8"
 ```
 
 The crate is transport-agnostic by default. Enable exactly the transport adapter you need:
 
 ```toml
 # Local microsandbox relay sockets.
-microsandbox-agent-client = { version = "0.5.7", features = ["uds"] }
+microsandbox-agent-client = { version = "0.5.8", features = ["uds"] }
 
 # Any caller-owned byte-stream transport (e.g. a pre-authenticated WebSocket
 # adapted to bytes).
-microsandbox-agent-client = { version = "0.5.7", features = ["stream"] }
+microsandbox-agent-client = { version = "0.5.8", features = ["stream"] }
 ```
 
 The high-level `microsandbox` SDK enables `uds` explicitly because local sandboxes are reached through Unix domain sockets.
@@ -99,7 +99,7 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
 Enable the `stream` feature:
 
 ```toml
-microsandbox-agent-client = { version = "0.5.7", features = ["stream"] }
+microsandbox-agent-client = { version = "0.5.8", features = ["stream"] }
 ```
 
 Drive the client over any `AsyncRead + AsyncWrite` — the caller owns the dial and any authentication, then hands over the connected stream:

--- a/packages/agent-client/typescript/package-lock.json
+++ b/packages/agent-client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/agent-client",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "Apache-2.0",
       "dependencies": {
         "cbor-x": "^1.6.0"

--- a/packages/agent-client/typescript/package.json
+++ b/packages/agent-client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/microsandbox-types/rust/README.md
+++ b/packages/microsandbox-types/rust/README.md
@@ -25,7 +25,7 @@ Backend-private materialized state stays out: registry credentials, local CA pat
 
 ```toml
 [dependencies]
-microsandbox-types = "0.5.7"
+microsandbox-types = "0.5.8"
 ```
 
 ```rust

--- a/packages/microsandbox-types/typescript/package-lock.json
+++ b/packages/microsandbox-types/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/types",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6"

--- a/packages/microsandbox-types/typescript/package.json
+++ b/packages/microsandbox-types/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sdk/go/setup.go
+++ b/sdk/go/setup.go
@@ -24,7 +24,7 @@ import (
 // embedded FFI library and the downloaded msb+libkrunfw artefacts are
 // both pinned to this version. Bump when cutting a new SDK release so
 // it matches published binaries.
-const sdkVersion = "0.5.7"
+const sdkVersion = "0.5.8"
 
 // libkrunfwABI is the major SONAME version of libkrunfw that msb links
 // against.

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.5.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -662,11 +662,17 @@ module.exports.JsVolumeFsWriteSink = nativeBinding.JsVolumeFsWriteSink
 module.exports.VolumeHandle = nativeBinding.VolumeHandle
 module.exports.JsVolumeHandle = nativeBinding.JsVolumeHandle
 module.exports.allSandboxMetrics = nativeBinding.allSandboxMetrics
+module.exports.defaultBackendKind = nativeBinding.defaultBackendKind
+module.exports.imageGc = nativeBinding.imageGc
+module.exports.imageGcLayers = nativeBinding.imageGcLayers
 module.exports.imageGet = nativeBinding.imageGet
 module.exports.imageInspect = nativeBinding.imageInspect
 module.exports.imageList = nativeBinding.imageList
-module.exports.imagePrune = nativeBinding.imagePrune
 module.exports.imageRemove = nativeBinding.imageRemove
 module.exports.install = nativeBinding.install
 module.exports.isInstalled = nativeBinding.isInstalled
+module.exports.popDefaultBackend = nativeBinding.popDefaultBackend
+module.exports.pushDefaultBackend = nativeBinding.pushDefaultBackend
+module.exports.setDefaultBackend = nativeBinding.setDefaultBackend
+module.exports.setRuntimeLibkrunfwPath = nativeBinding.setRuntimeLibkrunfwPath
 module.exports.setRuntimeMsbPath = nativeBinding.setRuntimeMsbPath

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -766,12 +766,9 @@ export declare class Sandbox {
    */
   static get(name: string): Promise<JsSandboxHandle>
   /** List all sandboxes. */
-  static list(): Promise<Array<JsSandboxHandle>>
-  /**
-   * List sandboxes filtered to those carrying all of the filter's labels
-   * (AND-matched).
-   */
-  static listWith(filter: SandboxListFilter): Promise<Array<JsSandboxHandle>>
+  static list(): Promise<Array<SandboxInfo>>
+  /** List sandboxes matching a filter. */
+  static listWith(filter: SandboxListFilter): Promise<Array<SandboxInfo>>
   /**
    * Remove a stopped sandbox from the database.
    *
@@ -809,7 +806,7 @@ export declare class Sandbox {
   /** Execute a shell command with streaming I/O. */
   shellStream(script: string): Promise<ExecHandle>
   /** Get a filesystem handle for operations on the running sandbox. */
-  fs(): SandboxFsOps
+  fs(): JsSandboxFs
   /** Connect a native in-process SSH client to this sandbox. */
   sshConnect(options?: SshClientOptions | undefined | null): Promise<JsSshClient>
   /** Prepare a reusable SSH server endpoint for this sandbox. */
@@ -831,24 +828,20 @@ export declare class Sandbox {
   attachWithBuilder(cmd: string, builder: AttachOptionsBuilder): Promise<number>
   /** Attach to the sandbox's default shell. */
   attachShell(): Promise<number>
-  /** Stop the sandbox gracefully and wait until stopped state is observed. */
+  /** Stop the sandbox gracefully (SIGTERM). */
   stop(): Promise<void>
-  /** Request graceful shutdown without waiting for stopped-state observation. */
-  requestStop(): Promise<void>
-  /** Stop the sandbox gracefully with an explicit timeout in milliseconds. */
-  stopWithTimeout(timeoutMs: number): Promise<void>
-  /** Force-kill the sandbox and wait until stopped state is observed. */
+  /** Stop and wait for exit, returning the exit status. */
+  stopAndWait(): Promise<ExitStatus>
+  /** Kill the sandbox immediately (SIGKILL). */
   kill(): Promise<void>
-  /** Request force termination without waiting for stopped-state observation. */
-  requestKill(): Promise<void>
-  /** Force-kill the sandbox with an explicit observation timeout in milliseconds. */
-  killWithTimeout(timeoutMs: number): Promise<void>
-  /** Request graceful drain without waiting for completion. */
-  requestDrain(): Promise<void>
-  /** Wait until the sandbox is observed in a terminal non-running state. */
-  waitUntilStopped(): Promise<SandboxStopResult>
+  /** Graceful drain (SIGUSR1 — for load balancing). */
+  drain(): Promise<void>
+  /** Wait for the sandbox process to exit. */
+  wait(): Promise<ExitStatus>
   /** Detach from the sandbox — it will continue running after this handle is dropped. */
   detach(): Promise<void>
+  /** Remove the persisted database record after stopping. */
+  removePersisted(): Promise<void>
   /**
    * Read captured output from `exec.log` for this sandbox.
    *
@@ -941,8 +934,10 @@ export declare class SandboxBuilder {
    * Hand off PID 1 to a guest init binary after agentd's setup.
    *
    * `cmd` is either an absolute path inside the guest rootfs or
-   * the literal `"auto"`. `args` is the supplemental argv;
-   * `argv[0]` is implicitly `cmd`. For env vars, use `initWith`.
+   * the literal `"auto"`. Auto honors known image ENTRYPOINT inits,
+   * preserves attached init-entrypoint commands, then probes common
+   * guest paths. `args` is the supplemental argv; `argv[0]` is
+   * implicitly `cmd`. For env vars, use `initWith`.
    */
   init(cmd: string, args?: Array<string> | undefined | null): this
   /**
@@ -953,8 +948,6 @@ export declare class SandboxBuilder {
   initWith(cmd: string, configure: (arg: InitOptionsBuilder) => InitOptionsBuilder): this
   /** Override the guest hostname. */
   hostname(name: string): this
-  /** Override the libkrunfw shared library path for this sandbox. */
-  libkrunfwPath(path: string): this
   /** Default running user. */
   user(user: string): this
   /** Image pull policy: `"always" | "if-missing" | "never"`. */
@@ -1481,6 +1474,9 @@ export interface AttachOptions {
   rlimits: Array<JsRlimit>
 }
 
+/** Return the active default backend kind (`"local"` or `"cloud"`). */
+export declare function defaultBackendKind(): string
+
 /** DNS interception configuration produced by `DnsBuilder.build()`. */
 export interface DnsConfig {
   rebindProtection: boolean
@@ -1580,6 +1576,12 @@ export interface ImageDetailJs {
   layers: Array<ImageLayerDetail>
 }
 
+/** Garbage-collect everything reclaimable. Returns the number reclaimed. */
+export declare function imageGc(): Promise<number>
+
+/** Garbage-collect orphaned layers. Returns the number reclaimed. */
+export declare function imageGcLayers(): Promise<number>
+
 /** Look up a cached image by reference. */
 export declare function imageGet(reference: string): Promise<ImageHandle>
 
@@ -1610,19 +1612,6 @@ export interface ImageLayerDetail {
 
 /** List all cached images. */
 export declare function imageList(): Promise<Array<ImageInfo>>
-
-/** Remove cached image data that is not used by any sandbox or indexed snapshot. */
-export declare function imagePrune(): Promise<ImagePruneReportJs>
-
-/** Summary of artifacts removed by `imagePrune`. */
-export interface ImagePruneReportJs {
-  imageRefsRemoved: number
-  manifestsRemoved: number
-  layersRemoved: number
-  fsmetaRemoved: number
-  vmdkRemoved: number
-  bytesReclaimed?: number
-}
 
 /**
  * Remove a cached image. Pass `force = true` to delete even when a
@@ -1787,6 +1776,9 @@ export interface PatchReplaceOnly {
   replace?: boolean
 }
 
+/** Restore the backend saved by `pushDefaultBackend`. */
+export declare function popDefaultBackend(token: number): void
+
 /**
  * One progress event emitted during image pull and EROFS materialization.
  *
@@ -1815,6 +1807,14 @@ export interface PullProgressEvent {
   totalBytes?: number
   bytesRead?: number
 }
+
+/**
+ * Temporarily replace the process-wide default backend and return a scope token.
+ *
+ * The caller must pass the returned token to `popDefaultBackend`; concurrent
+ * JavaScript work in the same process can observe the temporary backend.
+ */
+export declare function pushDefaultBackend(kind: string, url?: string | undefined | null, apiKey?: string | undefined | null, profile?: string | undefined | null): number
 
 /**
  * A raw protocol frame: correlation id, flags, and CBOR-encoded body bytes.
@@ -1856,6 +1856,15 @@ export interface Rlimit {
   resource: string
   soft: number
   hard: number
+}
+
+/** Lightweight sandbox info returned by `Sandbox.list`. */
+export interface SandboxInfo {
+  name: string
+  status: string
+  configJson: string
+  createdAt?: number
+  updatedAt?: number
 }
 
 /**
@@ -1924,6 +1933,23 @@ export interface SecretInjection {
   queryParams: boolean
   body: boolean
 }
+
+/**
+ * Set the process-wide default backend.
+ *
+ * `kind="local"` selects the local backend. `kind="cloud"` requires either
+ * `url` + `api_key`, or `profile`.
+ */
+export declare function setDefaultBackend(kind: string, url?: string | undefined | null, apiKey?: string | undefined | null, profile?: string | undefined | null): void
+
+/**
+ * Set the `libkrunfw` shared library path resolved by the JS SDK.
+ *
+ * Process-level setter — one dylib per process address space, so this is the
+ * natural granularity. User env (`MSB_LIBKRUNFW_PATH`) still wins as tier 1.
+ * Mirrors `setRuntimeMsbPath` for libkrunfw.
+ */
+export declare function setRuntimeLibkrunfwPath(path: string): void
 
 /**
  * Set the `msb` binary path resolved by the JS SDK.

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -22,9 +22,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.5.7",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.7",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.7"
+        "@superradcompany/microsandbox-darwin-arm64": "0.5.8",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.8",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.8"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1849,52 +1849,13 @@
       "license": "MIT"
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.5.7.tgz",
-      "integrity": "sha512-/ZnoBI0l9mYvPrwS8xPQ5L+c5B6U+aescZsiGXbjIvW9m/2rvMvi+tvl/Rj/pISHME8r2/2AQTqiFk4wvVxbcQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.5.7.tgz",
-      "integrity": "sha512-OHn6eZ1eTdZxmz3cfgpQFo3wpGq1WkbyqnB5P+VQYRknl+HyBJTsGb22ayqiSpIrN07QGOGoHcOA2+43etk5fw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.5.7.tgz",
-      "integrity": "sha512-YBh0uaVG62aUHOSeKptpEQO+R2l/OZcWzE8DoCqMvyXQ9thKva9DUxP7QD439zHlteReh2Suku6DW9SRBeyqhw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -48,9 +48,9 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.5.7",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.7",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.5.7"
+    "@superradcompany/microsandbox-darwin-arm64": "0.5.8",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.8",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.5.8"
   },
   "files": [
     "dist",

--- a/sdk/rust/tests/domain_policy.rs
+++ b/sdk/rust/tests/domain_policy.rs
@@ -99,6 +99,12 @@ async fn stop_and_remove(name: &str) {
 /// Timeout is 30s rather than 10s so a slow CI runner isn't the thing
 /// tipping a probe over on the TLS handshake.
 async fn probe_https(sb: &Sandbox, url: &str) -> String {
+    probe_https_result(sb, url)
+        .await
+        .unwrap_or_else(|err| format!("{CURL_FAIL} exec={err}"))
+}
+
+async fn probe_https_result(sb: &Sandbox, url: &str) -> Result<String, String> {
     // Capture curl's exit code and stderr alongside the http_code so a
     // FAIL surfaces the specific reason (DNS, TCP, TLS, etc.) instead
     // of an opaque sentinel.
@@ -112,8 +118,12 @@ async fn probe_https(sb: &Sandbox, url: &str) -> String {
              *) printf '%s' \"$code\" ;; \
          esac"
     );
-    let out = sb.shell(&cmd).await.expect("shell");
-    out.stdout().unwrap_or_default().trim().to_string()
+    collect_probe_output(sb, &cmd).await
+}
+
+async fn collect_probe_output(sb: &Sandbox, cmd: &str) -> Result<String, String> {
+    let out = sb.shell(cmd).await.map_err(|err| err.to_string())?;
+    Ok(out.stdout().unwrap_or_default().trim().to_string())
 }
 
 /// True when `probe_https` returned a 3-digit HTTP status (i.e. curl
@@ -138,7 +148,14 @@ fn curl_failed(probe_output: &str) -> bool {
 async fn probe_https_with_retry(sb: &Sandbox, url: &str) -> String {
     let mut last = String::new();
     for _ in 0..3 {
-        last = probe_https(sb, url).await;
+        last = match probe_https_result(sb, url).await {
+            Ok(output) => output,
+            // Retryable success probes should tolerate a single dropped
+            // exec stream the same way they tolerate a dropped TLS
+            // handshake. Persistent exec failures still surface in the
+            // final assertion with the original runtime error attached.
+            Err(err) => format!("{CURL_FAIL} exec={err}"),
+        };
         if reached_server(&last) {
             return last;
         }
@@ -179,6 +196,16 @@ fn host_resolved_ipv4(name: &str) -> String {
 /// Like [`probe_https`], but force curl to connect to `ip` while still
 /// sending `host` as the HTTP Host header and TLS SNI.
 async fn probe_https_with_resolve(sb: &Sandbox, host: &str, ip: &str) -> String {
+    probe_https_with_resolve_result(sb, host, ip)
+        .await
+        .unwrap_or_else(|err| format!("{CURL_FAIL} exec={err}"))
+}
+
+async fn probe_https_with_resolve_result(
+    sb: &Sandbox,
+    host: &str,
+    ip: &str,
+) -> Result<String, String> {
     let cmd = format!(
         "tmp=$(mktemp); \
          code=$(curl -sS --max-time 30 -o /dev/null \
@@ -192,14 +219,16 @@ async fn probe_https_with_resolve(sb: &Sandbox, host: &str, ip: &str) -> String 
              *) printf '%s' \"$code\" ;; \
          esac"
     );
-    let out = sb.shell(&cmd).await.expect("curl --resolve shell");
-    out.stdout().unwrap_or_default().trim().to_string()
+    collect_probe_output(sb, &cmd).await
 }
 
 async fn probe_https_with_resolve_retry(sb: &Sandbox, host: &str, ip: &str) -> String {
     let mut last = String::new();
     for _ in 0..3 {
-        last = probe_https_with_resolve(sb, host, ip).await;
+        last = match probe_https_with_resolve_result(sb, host, ip).await {
+            Ok(output) => output,
+            Err(err) => format!("{CURL_FAIL} exec={err}"),
+        };
         if reached_server(&last) {
             return last;
         }

--- a/sdk/rust/tests/http_connect_secret.rs
+++ b/sdk/rust/tests/http_connect_secret.rs
@@ -442,10 +442,17 @@ echo "status=$?"
         .expect("curl wrong host");
 
     let stdout = out.stdout().unwrap_or_default();
-    assert!(
-        !stdout.trim_end().ends_with("status=0"),
-        "expected curl to fail when secret host does not match tunnel target; got: {stdout:?}"
-    );
+    if stdout.trim_end().ends_with("status=0") {
+        let auth =
+            tokio::time::timeout(std::time::Duration::from_secs(5), target.received_auth()).await;
+        let auth_val = match auth {
+            Ok(Ok(a)) => a,
+            _ => String::new(),
+        };
+        panic!(
+            "expected curl to fail when secret host does not match tunnel target; got: {stdout:?}; target auth: {auth_val:?}"
+        );
+    }
 
     let auth =
         tokio::time::timeout(std::time::Duration::from_secs(5), target.received_auth()).await;


### PR DESCRIPTION
## TL;DR
Prepare the 0.5.8 release train across Rust crates, SDK packages, shared TypeScript packages, examples, and agent submodules.

## Description
- Bump the Rust workspace version, internal microsandbox dependency versions, Cargo.lock entries, and TypeScript example pins from 0.5.7 to 0.5.8.
- Refresh shared package versions and lockfiles for @microsandbox/agent-client and @microsandbox/types.
- Bump the Node SDK package, native platform package versions, package lock, generated native binding files, and Go sdkVersion constant to 0.5.8.
- Refresh the logs-read and shell-attach example lockfiles, which track the local file-linked Node SDK metadata.
- Advance mcp and skills submodule pointers to their 0.5.8 release-ref commits, with submodule PRs open in superradcompany/microsandbox-mcp#10 and superradcompany/skills#8.
- Since 0.5.7, this release includes shared microsandbox-types contracts, local/cloud backend routing, the Rust SDK move to sdk/rust, HTTP CONNECT and plain HTTP secret hardening, detached auto init entrypoints, hostname and volume fixes, and docs/dependency refreshes.
- A plain cargo check without local artifacts is expected to fail before v0.5.8 release assets exist, so validation used isolated CI=1 MSB_HOME paths where build scripts need local runtime artifacts.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `CI=1 MSB_HOME=/tmp/msb-0-5-8-check cargo check --workspace`
- [x] `CI=1 MSB_HOME=/tmp/msb-0-5-8-test cargo test --workspace`
- [x] `CI=1 MSB_HOME=/tmp/msb-0-5-8-clippy cargo clippy --workspace -- -D warnings`
- [x] `cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate -- --check`
- [x] `(cd sdk/node-ts && CI=1 MSB_HOME=/tmp/msb-node-0-5-8 npm run build && CI=1 MSB_HOME=/tmp/msb-node-0-5-8 npm test && npm run typecheck)`
- [x] `(cd sdk/python && uv sync --group dev && CI=1 MSB_HOME=/tmp/msb-py-0-5-8 uv run maturin develop --release && CI=1 MSB_HOME=/tmp/msb-py-0-5-8 uv run pytest && uv run ruff check .)`