### PR TITLE
docs(types): rewrite microsandbox-types readmes

### DIFF
--- a/packages/microsandbox-types/README.md
+++ b/packages/microsandbox-types/README.md
@@ -1,37 +1,49 @@
-# microsandbox-types
+# microsandbox types
 
 Shared task and wire contract types for microsandbox.
 
-This directory holds one logical type library published in two languages. It is the single, agreed-upon vocabulary that microsandbox components use to talk about sandboxes: the durable description of a sandbox task and the HTTP shapes exchanged with the cloud backend. These are contracts, not machinery. Nothing here builds, schedules, or runs a sandbox; the types only describe what a sandbox is and what the wire looks like.
+These packages define the backend-neutral shapes that describe what a sandbox should be: its rootfs source, resources, mounts, patches, network, lifecycle, and the cloud HTTP request/response bodies that carry those specs over the wire. Everything that has to agree on a sandbox's shape (the Rust SDK, the CLI, the cloud API, and the TypeScript front end) depends on these contracts instead of redefining them.
+
+This is a contract layer, not a runtime. It does not create, start, or talk to sandboxes. It only models the data those operations exchange.
 
 ## Layout
 
 ```text
-microsandbox-types/
-|-- rust/        # `microsandbox-types` crate    -> the source of truth
-`-- typescript/  # `@microsandbox/types` package  -> generated from the crate
+packages/microsandbox-types/
+├── rust/
+└── typescript/
 ```
 
-The two packages are kept structurally identical by generation, not by hand: the Rust crate defines the types, and the TypeScript declarations are produced from them. See [`rust/README.md`](rust/README.md) and [`typescript/README.md`](typescript/README.md) for the details specific to each consumer.
+- `rust/` publishes as `microsandbox-types` (crate name `microsandbox_types`). It is the source of truth for every shared type.
+- `typescript/` publishes as `@microsandbox/types`. Its `src/index.ts` is generated from the Rust types, never hand-edited.
 
-## When to use these
+## Source Of Truth
 
-Reach for these packages when you are building something that sits alongside microsandbox and needs to speak its language: an SDK, a runtime integration, a cloud client, or a contribution to microsandbox itself. They give you the exact field names, shapes, and serialization that the rest of the system expects.
+The Rust crate owns the definitions. The TypeScript bindings are derived from them with [`ts-rs`](https://github.com/Aleph-Alpha/ts-rs) behind the crate's `ts` feature, so the two stay byte-for-byte aligned.
 
-If your goal is simply to create or run sandboxes, you do not need these packages directly. Use the microsandbox SDK or CLI, which build on top of these contracts and give you the higher-level, ergonomic surface.
+```text
+rust/lib/*.rs  ──(ts-rs)──▶  typescript/src/index.ts
+```
 
-## One source of truth
-
-The Rust crate is authoritative. The TypeScript package is generated from it with [`ts-rs`](https://crates.io/crates/ts-rs) (behind the crate's optional `ts` feature), so the two never drift apart by accident and the generated bindings are never edited by hand.
-
-Regenerate the TypeScript bindings whenever the Rust types change:
+To regenerate the bindings after changing a Rust type:
 
 ```bash
 cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate
 ```
 
-CI checks that the committed bindings are current. Run the same check locally before pushing; it exits non-zero and names the stale file if the checked-in TypeScript differs from a fresh render:
+CI runs the same generator with `--check` and fails when the checked-in bindings drift:
 
 ```bash
 cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate -- --check
 ```
+
+## What Lives Here
+
+- Sandbox specs: `SandboxSpec`, `SandboxResources`, `SandboxRuntimeOptions`, rootfs sources, mounts, patches, init, lifecycle policy.
+- Networking intent: `NetworkSpec`, published ports, protocols.
+- Volumes and snapshots: `VolumeSpec`, `SnapshotSpec`, and their kinds.
+- Exec and logging: `Rlimit`, `RlimitResource`, `LogSource`, `SandboxLogLevel`.
+- Cloud wire contracts: `CloudCreateSandboxRequest`, `CloudSandbox`, paginated/message/error bodies.
+- Validation helpers: sandbox-name and hostname rules shared across SDK, CLI, and cloud.
+
+Backend-private materialized state (registry credentials, local cache paths, DB rows, resolved manifest digests, process handles) deliberately stays out of these packages. See each language's README for details.

--- a/packages/microsandbox-types/rust/README.md
+++ b/packages/microsandbox-types/rust/README.md
@@ -2,90 +2,69 @@
 
 Shared task and wire contract types for microsandbox.
 
-- Package: `microsandbox-types`
-- Library: `microsandbox_types`
+This crate is the source of truth for the backend-neutral shapes that describe a sandbox and the cloud HTTP bodies that carry them. The Rust SDK, the CLI, and the cloud backend all import these types so they agree on one definition instead of duplicating wire shapes. The generated `@microsandbox/types` TypeScript package is derived from this crate.
 
-This crate is the home of the data shapes that microsandbox components agree on, and it is the source of truth for the generated [`@microsandbox/types`](../typescript) TypeScript package. It defines a durable, backend-neutral description of a sandbox task, the HTTP wire shapes the cloud backend speaks, and a few validation helpers. It is contracts only: nothing in this crate creates, schedules, or runs a sandbox.
+It is a leaf dependency by design. It pulls in `serde`, `serde_json`, `chrono`, `sha2`, and `thiserror`, and nothing from the local VM machinery (no runtime, image, network, or database crates). That keeps it cheap enough for front-end generation, cloud API models, and SDK wrappers to all depend on.
 
-## When to reach for it
+## What This Crate Owns
 
-Depend on this crate when your code needs to construct, store, or exchange sandbox descriptions and cloud requests using the exact shapes the rest of microsandbox uses. If you only want to build and run sandboxes, use the higher-level microsandbox SDK or CLI instead; this crate is the vocabulary beneath them.
+The crate models durable user and wire intent: what the user wants to exist, not how a backend fulfills it.
 
-## What's inside
+- **Sandbox spec** (`domain` module): `SandboxSpec`, `SandboxResources`, `SandboxRuntimeOptions`, `EnvVar`, `SandboxPolicy`.
+- **Rootfs sources**: `RootfsSource` (bind, OCI, disk image), `OciRootfsSource`, `DiskImageFormat`, `PullPolicy`.
+- **Mounts and patches**: `VolumeMount`, `MountOptions`, `StatVirtualization`, `HostPermissions`, `Patch`, `SecurityProfile`.
+- **Volumes and snapshots**: `VolumeSpec`, `VolumeKind`, `NamedVolumeCreate`, `NamedVolumeMode`, `SnapshotSpec`, `SnapshotDestination`.
+- **Networking**: `NetworkSpec`, `PublishedPortSpec`, `PortProtocol`.
+- **Exec and logs**: `Rlimit`, `RlimitResource`, `SandboxLogLevel`, `LogSource`, `HandoffInit`.
+- **Cloud wire contracts** (`cloud` module): `CloudCreateSandboxRequest`, `CloudSandbox`, `CloudSandboxStatus`, `CloudPaginated`, `CloudMessageResponse`, `CloudErrorBody`, `CloudErrorDetails`.
+- **Validation** (`validation` module): `validate_sandbox_name`, `validate_hostname`, `hostname_from_sandbox_name`, and the `MAX_SANDBOX_NAME_BYTES` / `MAX_HOSTNAME_BYTES` limits.
 
-**The sandbox task contract.** [`SandboxSpec`](lib/domain.rs) is the durable, backend-neutral description of a sandbox task. It is deliberately a description and nothing more: local-only execution state such as resolved manifest digests, snapshot upper-layer paths, registry credentials, replace flags, and backend dispatch is kept out of it. Its fields pull in the surrounding domain types:
-
-- Root filesystem: `RootfsSource`, `OciRootfsSource`, `DiskImageFormat`, `PullPolicy`.
-- Resources and runtime: `SandboxResources`, `SandboxRuntimeOptions`, `EnvVar`, `SandboxLogLevel`.
-- Storage and mounts: `VolumeMount`, `VolumeSpec`, `VolumeKind`, `NamedVolumeCreate`, `NamedVolumeMode`, `MountOptions`, `StatVirtualization`, `HostPermissions`.
-- Rootfs preparation: `Patch`.
-- Networking: `NetworkSpec`, `PublishedPortSpec`, `PortProtocol`.
-- Resource limits: `Rlimit`, `RlimitResource`.
-- Init and lifecycle: `HandoffInit`, `SandboxPolicy`, `SecurityProfile`.
-- Snapshots: `SnapshotSpec`, `SnapshotDestination`.
-- Logs: `LogSource`.
-
-**Cloud wire types.** The request, response, and error shapes used by the cloud backend's sandbox HTTP endpoints: [`CloudCreateSandboxRequest`](lib/cloud.rs), [`CloudSandbox`](lib/cloud.rs), [`CloudSandboxStatus`](lib/cloud.rs), the generic page envelope `CloudPaginated<T>`, the `CloudMessageResponse` acknowledgement, and the error envelopes `CloudErrorBody` / `CloudErrorDetails`.
-
-**Validation helpers.** [`validate_sandbox_name`](lib/validation.rs), [`validate_hostname`](lib/validation.rs), and [`hostname_from_sandbox_name`](lib/validation.rs), backed by the `MAX_SANDBOX_NAME_BYTES` and `MAX_HOSTNAME_BYTES` constants and the `TypesError` / `TypesResult` error types. The crate also exposes the `DEFAULT_SANDBOX_CPUS`, `DEFAULT_SANDBOX_MEMORY_MIB`, and `DEFAULT_METRICS_SAMPLE_INTERVAL_MS` defaults that `SandboxSpec::default()` relies on.
+Backend-private materialized state stays out: registry credentials, local CA paths, replace flags, pull-discovered manifest digests, snapshot upper paths, process handles, and DB rows belong to the SDK and backends, not the contract.
 
 ## Usage
 
-Build a spec from `Default` and fill in the fields you care about, then validate the name and derive a guest hostname:
+```toml
+[dependencies]
+microsandbox-types = "0.5.7"
+```
 
 ```rust
-use microsandbox_types::{
-    RootfsSource, SandboxSpec, hostname_from_sandbox_name, validate_sandbox_name,
-};
+use microsandbox_types::{RootfsSource, SandboxResources, SandboxSpec};
 
 let spec = SandboxSpec {
-    name: "agent-1".to_string(),
-    image: RootfsSource::oci("python:3.12"),
-    ..SandboxSpec::default()
+    name: "worker".into(),
+    image: RootfsSource::oci("python"),
+    resources: SandboxResources { cpus: 2, memory_mib: 1024 },
+    ..Default::default()
 };
-
-validate_sandbox_name(&spec.name).expect("valid sandbox name");
-assert_eq!(hostname_from_sandbox_name(&spec.name), "agent-1");
 ```
 
-The validation helpers encode rules worth knowing up front:
+The Rust SDK re-exports the contract types it accepts, so most SDK users get these through `microsandbox::*` and do not depend on this crate directly.
 
-- `validate_sandbox_name` requires a non-empty name of at most 128 bytes that starts with an ASCII alphanumeric and otherwise contains only ASCII alphanumerics, dots, hyphens, and underscores.
-- `validate_hostname` accepts `None`, but rejects an empty hostname and anything longer than 64 bytes.
-- `hostname_from_sandbox_name` returns names that already fit in 64 bytes unchanged. For longer names it truncates on a UTF-8 character boundary and appends a hyphen plus 8 hex characters derived from a SHA-256 of the original name, so the result is deterministic, collision-resistant, and always within 64 bytes.
+## Serialization Notes
 
-## Wire format notes
+- `SandboxSpec`, `SandboxResources`, `SandboxRuntimeOptions`, `NetworkSpec`, and `MountOptions` use `#[serde(default)]`, so partial JSON fills missing fields from static defaults.
+- Lowercase-on-the-wire enums (`StatVirtualization`, `HostPermissions`, `SecurityProfile`, `SandboxLogLevel`, `LogSource`, `PortProtocol`) match the CLI grammar and the TypeScript string unions.
+- `VolumeMount` has hand-written `Serialize`/`Deserialize`. It tags variants with a `type` field and accepts a legacy top-level `readonly` flag, folding it into `MountOptions` on read.
+- Static defaults only. Nothing here reads process-global or profile config; the SDK and backends apply environment defaults before execution.
 
-These are the places where the serialized shape is more subtle than the Rust type suggests. They matter when you hand-write JSON or read persisted configs.
+## TypeScript Generation
 
-**Enum spellings are not uniform.** Some enums serialize as lower or snake case by serde configuration so persisted JSON lines up with the CLI grammar and the cloud wire format: `StatVirtualization` (`strict` / `relaxed` / `off`), `HostPermissions` (`private` / `mirror`), `SecurityProfile` (`default` / `restricted`), `PortProtocol` (`tcp` / `udp`), `SandboxLogLevel` (`error` / `warn` / `info` / `debug` / `trace`), `LogSource` (`stdout` / `stderr` / `output` / `system`), and `CloudSandboxStatus` (snake case). Others keep their Rust variant names on the wire: `RootfsSource` is externally tagged (`{ "Oci": ... }`), `DiskImageFormat` is `"Qcow2" | "Raw" | "Vmdk"`, `PullPolicy` is `"IfMissing" | "Always" | "Never"`, and `RlimitResource` keeps PascalCase variants. Do not assume a lowercase rule across the board.
-
-**`NetworkSpec` is partly opaque by design.** Its common, backend-visible fields (such as `enabled`, `ports`, `max_connections`, and `trust_host_cas`) are typed directly, but the rich local-engine subdocuments (`interface`, `policy`, `dns`, `tls`, `secrets`) are carried as `serde_json::Value`. That lets the shared contract round-trip those documents without depending on the local networking engine crate.
-
-**`VolumeMount::Named.create` is transient.** It is provisioning metadata used at sandbox-creation time and is intentionally skipped when a sandbox config is serialized or persisted. Restarting a sandbox mounts the already-created volume, so the field is absent from the persisted shape.
-
-## Generating the TypeScript bindings
-
-The TypeScript package is generated from this crate; this crate is the source of truth and the bindings are never hand-edited. Generation lives behind the optional `ts` feature, which pulls in `ts-rs`, and the `microsandbox-types-generate` binary requires it.
-
-Regenerate the checked-in bindings:
+The `ts` feature derives `ts_rs::TS` on every exported type and builds the `microsandbox-types-generate` binary, which writes `../typescript/src/index.ts`.
 
 ```bash
+# Regenerate the checked-in bindings.
 cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate
-```
 
-Verify they are current; this exits non-zero and names the stale target when the checked-in TypeScript differs from a fresh render:
-
-```bash
+# Verify they are current (used in CI; exits non-zero when stale).
 cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate -- --check
 ```
 
-The renderer in [`lib/typescript.rs`](lib/typescript.rs) writes [`../typescript/src/index.ts`](../typescript/src/index.ts), prefixes it with `// @generated by microsandbox-types. Do not edit by hand.`, and configures `ts-rs` to map large integers to `number`.
+A unit test (`checked_in_bindings_match_generated_output`) also fails when `typescript/src/index.ts` drifts from the generator output, so `cargo test --features ts` catches stale bindings too.
 
-## Tests
+## Testing
 
 ```bash
 cargo test -p microsandbox-types
+cargo test -p microsandbox-types --features ts
 ```
-
-The suite covers the validation rules, serde round-trips for the domain and cloud types, and an assertion that the checked-in TypeScript bindings match freshly generated output.

--- a/packages/microsandbox-types/typescript/README.md
+++ b/packages/microsandbox-types/typescript/README.md
@@ -1,14 +1,18 @@
 # @microsandbox/types
 
-Shared sandbox and cloud wire contracts for microsandbox, as TypeScript types.
+Shared task and wire contract types for microsandbox, as TypeScript.
 
-This package gives TypeScript code the same vocabulary the rest of microsandbox uses: the durable sandbox task contract (`SandboxSpec` and the domain types it composes) and the HTTP wire shapes spoken by the cloud backend (`CloudSandbox`, `CloudCreateSandboxRequest`, and the pagination and error envelopes).
+This package is the type-only mirror of the `microsandbox-types` Rust crate. It gives TypeScript consumers (the Node SDK, the cloud front end, and anything talking to the cloud API) the exact sandbox spec and cloud wire shapes the rest of microsandbox uses, so a `SandboxSpec` or `CloudCreateSandboxRequest` means the same thing on both sides of the wire.
 
-It is a declarations-only package. There is no runtime code to import. The declarations live in `dist/index.d.ts`; the compiled `dist/index.js` exists only to satisfy the module's `main` entry and is effectively empty, because the package exports types and nothing else.
+It contains no runtime code. Every export is a type or interface; importing it adds nothing to your bundle.
 
-## When to use it
+## Generated, Not Hand-Written
 
-Use `@microsandbox/types` when you are writing TypeScript that needs to exchange sandbox descriptions or cloud requests with microsandbox and you want the exact shapes the system expects: an SDK, a runtime integration, or a cloud client. If you just want to create and run sandboxes, prefer the higher-level microsandbox SDK, which builds on these types.
+`src/index.ts` is generated from the Rust crate with [`ts-rs`](https://github.com/Aleph-Alpha/ts-rs) and carries a `// @generated` header. Do not edit it. To change a shape, edit the Rust type and regenerate from the repo root:
+
+```bash
+cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate
+```
 
 ## Install
 
@@ -16,64 +20,41 @@ Use `@microsandbox/types` when you are writing TypeScript that needs to exchange
 npm install @microsandbox/types
 ```
 
-The package is ESM (`"type": "module"`) and is compiled for ES2023 with `nodenext` module resolution.
-
 ## Usage
 
-Because there are no runtime values, import everything with `import type`:
+Import the shapes you need with `import type`:
 
 ```ts
 import type {
-  CloudCreateSandboxRequest,
-  CloudSandbox,
   SandboxSpec,
+  RootfsSource,
+  CloudCreateSandboxRequest,
 } from "@microsandbox/types";
 
-const request: CloudCreateSandboxRequest = {
-  name: "agent-1",
-  image: "python:3.12",
-  vcpus: 1,
-  memory_mib: 512,
+const image: RootfsSource = { Oci: { reference: "python", upper_size_mib: null } };
+
+const req: CloudCreateSandboxRequest = {
+  name: "worker",
+  image: "python",
+  vcpus: 2,
+  memory_mib: 1024,
   env: {},
   ephemeral: true,
 };
-
-function describe(sandbox: CloudSandbox): string {
-  return `${sandbox.name} (${sandbox.status})`;
-}
-
-function rootfsLabel(spec: SandboxSpec): string {
-  return "Oci" in spec.image ? spec.image.Oci.reference : "non-OCI rootfs";
-}
 ```
 
-## Reading the generated shapes
+## Generated Shape Notes
 
-The declarations mirror the Rust serde contract exactly, including a couple of things that are easy to get wrong by hand:
+The bindings follow `ts-rs` conventions, which mirror the Rust serde representation:
 
-- String unions are not all lowercase. Some are, because the Rust type serializes that way, for example `PortProtocol` (`"tcp" | "udp"`) and `CloudSandboxStatus` (`"created" | "starting" | "running" | ...`). Others preserve the Rust variant names, for example `PullPolicy` (`"IfMissing" | "Always" | "Never"`) and `DiskImageFormat` (`"Qcow2" | "Raw" | "Vmdk"`).
-- Some unions are tagged objects rather than strings. `RootfsSource` is externally tagged (`{ "Oci": ... }`), while `VolumeMount` and `Patch` are internally or externally tagged variants. Narrow them with an `in` check or by switching on the tag, as in `rootfsLabel` above.
-- `NetworkSpec` carries its richer subdocuments (`interface`, `policy`, `dns`, `tls`, `secrets`) as the generated `JsonValue` type, because those documents are defined by the local networking engine and pass through this contract opaquely.
+- Rust enums become tagged unions or string literals. `RootfsSource` is `{ "Bind": string } | { "Oci": OciRootfsSource } | { "DiskImage": {...} }`; lowercase enums like `StatVirtualization` are `"strict" | "relaxed" | "off"`.
+- `VolumeMount` is internally tagged with a `type` field (`"Bind" | "Named" | "Tmpfs" | "DiskImage"`).
+- Optional Rust fields are `T | null`; fields skipped when absent are `?:` optional.
+- `serde_json::Value` is rendered as the `JsonValue` alias for the network subdocuments (`policy`, `dns`, `tls`, `secrets`, `interface`).
 
-## Generated, do not edit
-
-`src/index.ts` is generated from the `microsandbox-types` Rust crate with [`ts-rs`](https://crates.io/crates/ts-rs) and carries the header `// @generated by microsandbox-types. Do not edit by hand.` The Rust crate is the source of truth: change the types there and regenerate.
-
-From the repository root:
+## Build And Typecheck
 
 ```bash
-# regenerate the checked-in bindings
-cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate
-
-# verify they are current (exits non-zero if stale)
-cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate -- --check
-```
-
-## Build
-
-The published `dist/` is produced by the TypeScript compiler:
-
-```bash
-npm run build      # tsc -p tsconfig.json
-npm run typecheck  # tsc --noEmit -p tsconfig.json
+npm run build       # tsc -> dist/
+npm run typecheck   # tsc --noEmit
 ```


### PR DESCRIPTION
## TL;DR
Rewrite the three microsandbox-types READMEs so they actually match the crate source and explain how the Rust types and generated TypeScript bindings stay in sync.

## Description
- Top-level README now frames the two-package layout, the Rust-is-source-of-truth relationship, and the regenerate/`--check` binding workflow, modeled on the sibling agent-client README.
- Rust README inventories the contracts the crate owns by module (`domain`, `cloud`, `validation`), explains the leaf-dependency rationale and the spec-vs-materialized-state boundary, and documents the serde behavior (`#[serde(default)]`, lowercase enums, the hand-written `VolumeMount` codec).
- TypeScript README stresses the generated/type-only nature, shows `import type` usage, and describes the generated shapes accurately (tagged unions, `JsonValue` network subdocuments, `null` vs optional fields).
- Regenerate command stays the documented source of truth:

```bash
cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate
```

## Test Plan
- [x] `git diff --check origin/main..HEAD` exits 0
- [x] READMEs render correctly on GitHub
- [x] `cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate -- --check` exits 0 (commands cited in the docs are accurate)