### PR TITLE
fix(run): preserve detached startup semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,6 +3462,7 @@ dependencies = [
  "clap",
  "crossbeam-queue",
  "libc",
+ "microsandbox-agent-client",
  "microsandbox-db",
  "microsandbox-filesystem",
  "microsandbox-metrics",

--- a/crates/agentd/lib/config.rs
+++ b/crates/agentd/lib/config.rs
@@ -21,9 +21,9 @@ use std::path::PathBuf;
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use microsandbox_protocol::{
     ENV_BLOCK_ROOT, ENV_DIR_MOUNTS, ENV_DISK_MOUNTS, ENV_FILE_MOUNTS, ENV_HANDOFF_INIT,
-    ENV_HANDOFF_INIT_ARGS, ENV_HANDOFF_INIT_ENV, ENV_HOST_ALIAS, ENV_HOSTNAME, ENV_NET,
-    ENV_NET_IPV4, ENV_NET_IPV6, ENV_RLIMITS, ENV_SECURITY_PROFILE, ENV_TMPFS, ENV_USER,
-    HANDOFF_INIT_AUTO, exec::ExecRlimit,
+    ENV_HANDOFF_INIT_ARGS, ENV_HANDOFF_INIT_CWD, ENV_HANDOFF_INIT_ENV, ENV_HOST_ALIAS,
+    ENV_HOSTNAME, ENV_NET, ENV_NET_IPV4, ENV_NET_IPV6, ENV_RLIMITS, ENV_SECURITY_PROFILE,
+    ENV_TMPFS, ENV_USER, HANDOFF_INIT_AUTO, exec::ExecRlimit,
 };
 use serde::de::DeserializeOwned;
 
@@ -102,6 +102,9 @@ pub struct HandoffInit {
     /// argv past `argv[0]` — i.e., the supplemental arguments. Empty
     /// means the init is exec'd with `argv = [cmd]`.
     pub(crate) argv: Vec<OsString>,
+
+    /// Working directory to enter before execing the init binary.
+    pub(crate) cwd: Option<PathBuf>,
 
     /// Extra env vars merged on top of the inherited env. Empty means
     /// inherit-only.
@@ -993,6 +996,19 @@ fn parse_handoff_init() -> AgentdResult<Option<HandoffInit>> {
         _ => Vec::new(),
     };
 
+    let cwd = match read_env_raw(ENV_HANDOFF_INIT_CWD) {
+        Some(val) if !val.is_empty() => {
+            let cwd = PathBuf::from(&val);
+            if !cwd.is_absolute() {
+                return Err(AgentdError::Config(format!(
+                    "{ENV_HANDOFF_INIT_CWD} must be an absolute path, got: {val}"
+                )));
+            }
+            Some(cwd)
+        }
+        _ => None,
+    };
+
     let env = match read_env_raw(ENV_HANDOFF_INIT_ENV) {
         Some(val) if !val.is_empty() => {
             let entries = decode_handoff_json::<Vec<(String, String)>>(ENV_HANDOFF_INIT_ENV, &val)?;
@@ -1004,7 +1020,12 @@ fn parse_handoff_init() -> AgentdResult<Option<HandoffInit>> {
         _ => Vec::new(),
     };
 
-    Ok(Some(HandoffInit { cmd, argv, env }))
+    Ok(Some(HandoffInit {
+        cmd,
+        argv,
+        cwd,
+        env,
+    }))
 }
 
 fn decode_handoff_json<T: DeserializeOwned>(env_name: &str, value: &str) -> AgentdResult<T> {
@@ -1492,6 +1513,7 @@ mod tests {
     fn with_handoff_env<R>(
         cmd: Option<&str>,
         args: Option<&str>,
+        cwd: Option<&str>,
         env_var: Option<&str>,
         f: impl FnOnce() -> R,
     ) -> R {
@@ -1505,6 +1527,10 @@ mod tests {
                 Some(v) => env::set_var(ENV_HANDOFF_INIT_ARGS, v),
                 None => env::remove_var(ENV_HANDOFF_INIT_ARGS),
             }
+            match cwd {
+                Some(v) => env::set_var(ENV_HANDOFF_INIT_CWD, v),
+                None => env::remove_var(ENV_HANDOFF_INIT_CWD),
+            }
             match env_var {
                 Some(v) => env::set_var(ENV_HANDOFF_INIT_ENV, v),
                 None => env::remove_var(ENV_HANDOFF_INIT_ENV),
@@ -1514,6 +1540,7 @@ mod tests {
         unsafe {
             env::remove_var(ENV_HANDOFF_INIT);
             env::remove_var(ENV_HANDOFF_INIT_ARGS);
+            env::remove_var(ENV_HANDOFF_INIT_CWD);
             env::remove_var(ENV_HANDOFF_INIT_ENV);
         }
         out
@@ -1528,21 +1555,27 @@ mod tests {
 
     #[test]
     fn test_parse_handoff_init_unset_returns_none() {
-        let res = with_handoff_env(None, None, None, parse_handoff_init).unwrap();
+        let res = with_handoff_env(None, None, None, None, parse_handoff_init).unwrap();
         assert!(res.is_none());
     }
 
     #[test]
     fn test_parse_handoff_init_empty_returns_none() {
-        let res = with_handoff_env(Some(""), None, None, parse_handoff_init).unwrap();
+        let res = with_handoff_env(Some(""), None, None, None, parse_handoff_init).unwrap();
         assert!(res.is_none());
     }
 
     #[test]
     fn test_parse_handoff_init_cmd_only() {
-        let res = with_handoff_env(Some("/lib/systemd/systemd"), None, None, parse_handoff_init)
-            .unwrap()
-            .unwrap();
+        let res = with_handoff_env(
+            Some("/lib/systemd/systemd"),
+            None,
+            None,
+            None,
+            parse_handoff_init,
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(res.cmd, PathBuf::from("/lib/systemd/systemd"));
         assert!(res.argv.is_empty());
         assert!(res.env.is_empty());
@@ -1554,6 +1587,7 @@ mod tests {
         let res = with_handoff_env(
             Some("/lib/systemd/systemd"),
             Some(&argv),
+            None,
             None,
             parse_handoff_init,
         )
@@ -1571,9 +1605,15 @@ mod tests {
     #[test]
     fn test_parse_handoff_init_with_env() {
         let envs = encode_handoff_json(&vec![("container", "microsandbox"), ("LANG", "C.UTF-8")]);
-        let res = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
-            .unwrap()
-            .unwrap();
+        let res = with_handoff_env(
+            Some("/sbin/init"),
+            None,
+            None,
+            Some(&envs),
+            parse_handoff_init,
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(
             res.env,
             vec![
@@ -1584,15 +1624,35 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_handoff_init_with_cwd() {
+        let res = with_handoff_env(
+            Some("/sbin/init"),
+            None,
+            Some("/opt/hermes"),
+            None,
+            parse_handoff_init,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(res.cwd, Some(PathBuf::from("/opt/hermes")));
+    }
+
+    #[test]
     fn test_parse_handoff_init_argv_with_spaces_preserved() {
         let argv = encode_handoff_json(&vec![
             "--label=hello world",
             "--config=/etc/foo;bar",
             "old\x1fseparator",
         ]);
-        let res = with_handoff_env(Some("/sbin/init"), Some(&argv), None, parse_handoff_init)
-            .unwrap()
-            .unwrap();
+        let res = with_handoff_env(
+            Some("/sbin/init"),
+            Some(&argv),
+            None,
+            None,
+            parse_handoff_init,
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(
             res.argv,
             vec![
@@ -1605,7 +1665,8 @@ mod tests {
 
     #[test]
     fn test_parse_handoff_init_rejects_relative_path() {
-        let err = with_handoff_env(Some("sbin/init"), None, None, parse_handoff_init).unwrap_err();
+        let err =
+            with_handoff_env(Some("sbin/init"), None, None, None, parse_handoff_init).unwrap_err();
         assert!(err.to_string().contains("absolute path"));
     }
 
@@ -1613,6 +1674,7 @@ mod tests {
     fn test_parse_handoff_init_env_rejects_invalid_base64() {
         let err = with_handoff_env(
             Some("/sbin/init"),
+            None,
             None,
             Some("not base64!"),
             parse_handoff_init,
@@ -1622,18 +1684,43 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_handoff_init_cwd_rejects_relative_path() {
+        let err = with_handoff_env(
+            Some("/sbin/init"),
+            None,
+            Some("opt/hermes"),
+            None,
+            parse_handoff_init,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("absolute path"));
+    }
+
+    #[test]
     fn test_parse_handoff_init_env_entry_empty_key_rejected() {
         let envs = encode_handoff_json(&vec![("", "value")]);
-        let err = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
-            .unwrap_err();
+        let err = with_handoff_env(
+            Some("/sbin/init"),
+            None,
+            None,
+            Some(&envs),
+            parse_handoff_init,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("empty key"));
     }
 
     #[test]
     fn test_parse_handoff_init_arg_rejects_nul() {
         let argv = encode_handoff_json(&vec!["ok", "bad\0arg"]);
-        let err = with_handoff_env(Some("/sbin/init"), Some(&argv), None, parse_handoff_init)
-            .unwrap_err();
+        let err = with_handoff_env(
+            Some("/sbin/init"),
+            Some(&argv),
+            None,
+            None,
+            parse_handoff_init,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("entry #1"));
         assert!(err.to_string().contains("NUL"));
     }
@@ -1641,16 +1728,28 @@ mod tests {
     #[test]
     fn test_parse_handoff_init_env_key_rejects_equals() {
         let envs = encode_handoff_json(&vec![("BAD=KEY", "value")]);
-        let err = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
-            .unwrap_err();
+        let err = with_handoff_env(
+            Some("/sbin/init"),
+            None,
+            None,
+            Some(&envs),
+            parse_handoff_init,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("must not contain '='"));
     }
 
     #[test]
     fn test_parse_handoff_init_env_key_rejects_nul() {
         let envs = encode_handoff_json(&vec![("BAD\0KEY", "value")]);
-        let err = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
-            .unwrap_err();
+        let err = with_handoff_env(
+            Some("/sbin/init"),
+            None,
+            None,
+            Some(&envs),
+            parse_handoff_init,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("key"));
         assert!(err.to_string().contains("NUL"));
     }
@@ -1658,8 +1757,14 @@ mod tests {
     #[test]
     fn test_parse_handoff_init_env_value_rejects_nul() {
         let envs = encode_handoff_json(&vec![("KEY", "bad\0value")]);
-        let err = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
-            .unwrap_err();
+        let err = with_handoff_env(
+            Some("/sbin/init"),
+            None,
+            None,
+            Some(&envs),
+            parse_handoff_init,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("value for"));
         assert!(err.to_string().contains("NUL"));
     }
@@ -1667,9 +1772,15 @@ mod tests {
     #[test]
     fn test_parse_handoff_init_env_value_with_equals_is_value() {
         let envs = encode_handoff_json(&vec![("PATH", "/a:/b=/c")]);
-        let res = with_handoff_env(Some("/sbin/init"), None, Some(&envs), parse_handoff_init)
-            .unwrap()
-            .unwrap();
+        let res = with_handoff_env(
+            Some("/sbin/init"),
+            None,
+            None,
+            Some(&envs),
+            parse_handoff_init,
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(
             res.env,
             vec![(OsString::from("PATH"), OsString::from("/a:/b=/c"))]

--- a/crates/agentd/lib/handoff.rs
+++ b/crates/agentd/lib/handoff.rs
@@ -69,6 +69,9 @@ const POST_HANDOFF_STDERR: &str = "/run/microsandbox/agentd.log";
 pub fn do_handoff(spec: HandoffInit) -> AgentdResult<()> {
     let cmd = resolve_cmd(&spec.cmd)?;
     preflight(&cmd)?;
+    if let Some(ref cwd) = spec.cwd {
+        preflight_cwd(cwd)?;
+    }
 
     let argv = build_argv(&cmd, &spec.argv);
     let envp = build_envp(&spec.env);
@@ -84,6 +87,16 @@ pub fn do_handoff(spec: HandoffInit) -> AgentdResult<()> {
             // signal disposition + clear blocked mask before exec so
             // the new init starts with kernel defaults.
             reset_signals();
+            if let Some(ref cwd) = spec.cwd
+                && let Err(err) = nix::unistd::chdir(cwd)
+            {
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "agentd: chdir({}) before handoff failed: {err}",
+                    cwd.display()
+                );
+                process::exit(126);
+            }
             // SAFETY: arrays are NUL-terminated; pointers live until
             // execve consumes them or returns with an error.
             let err = nix::unistd::execve(&cmd_c, &argv, &envp).unwrap_err();
@@ -159,6 +172,22 @@ fn preflight(cmd: &Path) -> AgentdResult<()> {
     Ok(())
 }
 
+fn preflight_cwd(cwd: &Path) -> AgentdResult<()> {
+    let metadata = std::fs::metadata(cwd).map_err(|e| {
+        AgentdError::Init(format!(
+            "handoff init cwd not found at {}: {e}",
+            cwd.display()
+        ))
+    })?;
+    if !metadata.is_dir() {
+        return Err(AgentdError::Init(format!(
+            "handoff init cwd is not a directory: {}",
+            cwd.display()
+        )));
+    }
+    Ok(())
+}
+
 fn init_candidate_is_executable_file(path: &Path) -> bool {
     std::fs::metadata(path)
         .map(|metadata| metadata_is_executable_file(&metadata))
@@ -209,6 +238,7 @@ fn build_envp(extras: &[(OsString, OsString)]) -> Vec<CString> {
     for var in [
         microsandbox_protocol::ENV_HANDOFF_INIT,
         microsandbox_protocol::ENV_HANDOFF_INIT_ARGS,
+        microsandbox_protocol::ENV_HANDOFF_INIT_CWD,
         microsandbox_protocol::ENV_HANDOFF_INIT_ENV,
     ] {
         env.remove(&OsString::from(var));

--- a/crates/cli/lib/commands/create.rs
+++ b/crates/cli/lib/commands/create.rs
@@ -42,7 +42,9 @@ pub async fn run(
     let builder = Sandbox::builder(&name).image(args.image.as_str());
     let builder = apply_sandbox_opts(builder, &args.sandbox)?;
 
-    let (mut progress, task) = builder.detached(true).create_with_pull_progress()?;
+    let (mut progress, task) = builder
+        .detached(true)
+        .create_detached_with_pull_progress()?;
     let mut display = if args.sandbox.quiet {
         ui::PullProgressDisplay::quiet(&args.image)
     } else {

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -1,24 +1,13 @@
 //! `msb run` command — create and start a new sandbox.
 
 use std::io::{IsTerminal, Write};
-use std::pin::pin;
 use std::time::Duration;
 
-use chrono::{DateTime, Utc};
 use clap::Args;
-use futures::StreamExt;
-use microsandbox::MicrosandboxError;
-use microsandbox::logs::{self, LogOptions, LogSource, LogStreamOptions, LogStreamStart};
 use microsandbox::sandbox::{ExecOutput, RlimitResource, Sandbox};
 
 use super::common::{SandboxOpts, apply_sandbox_opts};
 use crate::ui;
-
-//--------------------------------------------------------------------------------------------------
-// Constants
-//--------------------------------------------------------------------------------------------------
-
-const INIT_ENTRYPOINT_STOP_TIMEOUT: Duration = Duration::from_secs(10);
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -188,7 +177,12 @@ async fn run_new(
     }
 
     // Create sandbox with pull progress — select attached vs detached mode.
-    let (mut progress, task) = builder.detached(args.detach).create_with_pull_progress()?;
+    let builder = builder.detached(args.detach);
+    let (mut progress, task) = if args.detach {
+        builder.create_detached_with_pull_progress()?
+    } else {
+        builder.create_with_pull_progress()?
+    };
 
     let display_label = args
         .snapshot
@@ -212,23 +206,12 @@ async fn run_new(
 
     // Detach mode: just print the name and exit.
     if args.detach {
-        if !sandbox.config().initial_command_consumed_by_init() {
-            warn_detached_command_ignored(&name, &args);
-        }
         sandbox.detach().await;
         println!("{name}");
         return Ok(());
     }
 
     let exec_opts = ExecOpts::parse(&args)?;
-    if sandbox.config().initial_command_consumed_by_init() {
-        let result = wait_for_init_entrypoint(&sandbox, &exec_opts).await;
-        if !is_named {
-            remove_ephemeral_sandbox(sandbox.name()).await;
-        }
-        return handle_exit(result?);
-    }
-
     let interactive = std::io::stdin().is_terminal();
 
     let (cmd, cmd_args) =
@@ -259,132 +242,6 @@ async fn run_new(
     }
 
     handle_exit(result?)
-}
-
-/// Wait for an image-declared init entrypoint to own the foreground command.
-async fn wait_for_init_entrypoint(sandbox: &Sandbox, opts: &ExecOpts) -> anyhow::Result<i32> {
-    let log_task = tokio::spawn(stream_init_entrypoint_logs(
-        sandbox.name().to_string(),
-        Utc::now(),
-    ));
-    let wait_fut = sandbox.wait();
-    let wait_result = match opts.timeout {
-        Some(duration) => match tokio::time::timeout(duration, wait_fut).await {
-            Ok(result) => result.map_err(anyhow::Error::from),
-            Err(_) => {
-                stop_init_entrypoint_after_timeout(sandbox).await;
-                Err(anyhow::anyhow!("command timed out after {duration:?}"))
-            }
-        },
-        None => wait_fut.await.map_err(anyhow::Error::from),
-    };
-    stop_init_entrypoint_log_task(log_task).await;
-
-    let status = wait_result?;
-
-    Ok(if status.success() {
-        0
-    } else {
-        status.code().unwrap_or(1)
-    })
-}
-
-/// Stream the sandbox log path while an init-owned foreground command runs.
-async fn stream_init_entrypoint_logs(name: String, since: DateTime<Utc>) -> anyhow::Result<()> {
-    let sources = vec![
-        LogSource::Stdout,
-        LogSource::Stderr,
-        LogSource::Output,
-        LogSource::System,
-    ];
-    let snapshot_opts = LogOptions {
-        tail: None,
-        since: Some(since),
-        until: None,
-        sources: sources.clone(),
-    };
-    let snapshot = logs::read_logs_snapshot(&name, &snapshot_opts).await?;
-    for entry in &snapshot.entries {
-        render_init_entrypoint_log(entry)?;
-    }
-
-    let stream_opts = LogStreamOptions {
-        sources,
-        start: LogStreamStart::From(snapshot.cursor),
-        until: None,
-        follow: true,
-    };
-    let mut stream = pin!(logs::log_stream(&name, &stream_opts).await?);
-    while let Some(item) = stream.next().await {
-        match item {
-            Ok(entry) => render_init_entrypoint_log(&entry)?,
-            Err(MicrosandboxError::MissedRotation {
-                dropped_from_offset,
-            }) => {
-                ui::warn(&format!(
-                    "log follower fell behind at offset {dropped_from_offset}; output is still available with `msb logs --source all {name}`"
-                ));
-                return Ok(());
-            }
-            Err(err) => return Err(anyhow::Error::from(err)),
-        }
-    }
-
-    Ok(())
-}
-
-async fn stop_init_entrypoint_after_timeout(sandbox: &Sandbox) {
-    match Sandbox::get(sandbox.name()).await {
-        Ok(handle) => {
-            if let Err(e) = handle.stop_with_timeout(INIT_ENTRYPOINT_STOP_TIMEOUT).await {
-                ui::warn(&format!("failed to stop sandbox after timeout: {e}"));
-            }
-        }
-        Err(_) => {
-            if let Err(e) = sandbox.stop().await {
-                ui::warn(&format!("failed to stop sandbox after timeout: {e}"));
-            }
-        }
-    }
-}
-
-async fn remove_ephemeral_sandbox(name: &str) {
-    if let Err(e) = Sandbox::remove(name).await {
-        ui::warn(&format!("failed to remove ephemeral sandbox: {e}"));
-    }
-}
-
-async fn stop_init_entrypoint_log_task(mut task: tokio::task::JoinHandle<anyhow::Result<()>>) {
-    let result = tokio::select! {
-        result = &mut task => result,
-        _ = tokio::time::sleep(Duration::from_millis(250)) => {
-            task.abort();
-            task.await
-        }
-    };
-
-    match result {
-        Ok(Ok(())) => {}
-        Ok(Err(err)) => ui::warn(&format!("failed to stream init-owned command logs: {err}")),
-        Err(err) if err.is_cancelled() => {}
-        Err(err) => ui::warn(&format!("init-owned command log task failed: {err}")),
-    }
-}
-
-fn render_init_entrypoint_log(entry: &microsandbox::logs::LogEntry) -> anyhow::Result<()> {
-    match entry.source {
-        LogSource::Stdout | LogSource::Output => {
-            let mut stdout = std::io::stdout().lock();
-            stdout.write_all(&entry.data)?;
-            stdout.flush()?;
-        }
-        LogSource::Stderr | LogSource::System => {
-            let mut stderr = std::io::stderr().lock();
-            stderr.write_all(&entry.data)?;
-            stderr.flush()?;
-        }
-    }
-    Ok(())
 }
 
 /// Execute or attach to a command in a sandbox.
@@ -482,14 +339,14 @@ fn ignored_existing_inputs(args: &RunArgs) -> Option<&'static str> {
     }
 }
 
-/// Warn when a detached run includes an explicit command.
+/// Warn when a detached run reuses an existing sandbox and includes a command.
 fn warn_detached_command_ignored(name: &str, args: &RunArgs) {
     if args.command.is_empty() {
         return;
     }
 
     ui::warn(&format!(
-        "command after -- is not run in --detach mode; sandbox '{name}' is running in the background (use `msb exec {name} -- ...`)"
+        "command after -- is not applied when reusing existing sandbox '{name}' in --detach mode (use `msb exec {name} -- ...`)"
     ));
 }
 

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -11,7 +11,7 @@ use std::{os::fd::FromRawFd, os::fd::OwnedFd};
 use clap::Args;
 use microsandbox_runtime::{
     logging::LogLevel,
-    vm::{Config, DiskMountSpec, MetricsSlotHandoff, VmConfig},
+    vm::{Config, DiskMountSpec, MetricsSlotHandoff, StartupCommand, VmConfig},
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -60,6 +60,26 @@ pub struct SandboxArgs {
     /// Write end of the startup JSON pipe.
     #[arg(long = "startup-fd", hide = true)]
     pub startup_fd: Option<i32>,
+
+    /// Startup workload command to execute after agentd is ready.
+    #[arg(long = "startup-cmd", hide = true)]
+    pub startup_cmd: Option<String>,
+
+    /// Startup workload arguments.
+    #[arg(long = "startup-arg", hide = true)]
+    pub startup_args: Vec<String>,
+
+    /// Startup workload environment variables as `KEY=VALUE`.
+    #[arg(long = "startup-env", hide = true)]
+    pub startup_env: Vec<String>,
+
+    /// Startup workload working directory.
+    #[arg(long = "startup-cwd", hide = true)]
+    pub startup_cwd: Option<String>,
+
+    /// Startup workload guest user.
+    #[arg(long = "startup-user", hide = true)]
+    pub startup_user: Option<String>,
 
     /// Forward VM console output to stdout.
     #[arg(long = "forward")]
@@ -260,6 +280,13 @@ pub fn run(args: SandboxArgs) -> ! {
         log_dir: args.log_dir,
         runtime_dir: args.runtime_dir,
         agent_sock_path: args.agent_sock,
+        startup_command: args.startup_cmd.map(|cmd| StartupCommand {
+            cmd,
+            args: args.startup_args,
+            env: args.startup_env,
+            cwd: args.startup_cwd,
+            user: args.startup_user,
+        }),
         startup_fd,
         parent_watchdog,
         forward_output: args.forward_output,
@@ -405,7 +432,15 @@ fn parse_one_disk_arg(entry: &str) -> Result<DiskMountSpec, String> {
 mod tests {
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 
+    use clap::Parser;
+
     use super::*;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: SandboxArgs,
+    }
 
     fn fmt(s: &str) -> String {
         format!(
@@ -473,6 +508,33 @@ mod tests {
         ];
         let err = parse_disk_args(&entries).unwrap_err();
         assert!(err.contains("invalid --disk entry"));
+    }
+
+    #[test]
+    fn test_hidden_startup_args_accept_hyphen_values() {
+        let parsed = TestCli::parse_from([
+            "test",
+            "--name",
+            "sandbox",
+            "--sandbox-id",
+            "7",
+            "--db-path",
+            "/tmp/msb.db",
+            "--log-dir",
+            "/tmp/logs",
+            "--runtime-dir",
+            "/tmp/runtime",
+            "--agent-sock",
+            "/tmp/agent.sock",
+            "--libkrunfw-path",
+            "/tmp/libkrunfw.dylib",
+            "--startup-cmd=/bin/sh",
+            "--startup-arg=-lc",
+            "--startup-arg=echo ok",
+        ]);
+
+        assert_eq!(parsed.args.startup_cmd.as_deref(), Some("/bin/sh"));
+        assert_eq!(parsed.args.startup_args, vec!["-lc", "echo ok"]);
     }
 
     #[test]

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -354,6 +354,16 @@ pub const HANDOFF_INIT_AUTO_CANDIDATES: &[&str] = &[
 /// - `MSB_HANDOFF_INIT_ARGS=WyItdW5pdD1tdWx0aS11c2VyLnRhcmdldCJd`
 pub const ENV_HANDOFF_INIT_ARGS: &str = "MSB_HANDOFF_INIT_ARGS";
 
+/// Working directory for the handoff init binary.
+///
+/// Docker applies `WORKDIR` before executing `ENTRYPOINT + CMD`. Init handoff
+/// uses this optional path so image-declared init entrypoints receive the same
+/// process cwd as they would under container startup.
+///
+/// Example:
+/// - `MSB_HANDOFF_INIT_CWD=/opt/app`
+pub const ENV_HANDOFF_INIT_CWD: &str = "MSB_HANDOFF_INIT_CWD";
+
 /// Extra environment variables for the handoff init binary.
 ///
 /// Format: base64url-no-padding encoded JSON array of `[key, value]`

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,6 +22,7 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
+microsandbox-agent-client = { workspace = true, features = ["uds"] }
 microsandbox-db.workspace = true
 microsandbox-filesystem.workspace = true
 microsandbox-metrics.workspace = true

--- a/crates/runtime/lib/lib.rs
+++ b/crates/runtime/lib/lib.rs
@@ -19,6 +19,7 @@ pub mod logging;
 pub mod metrics;
 pub mod policy;
 pub mod relay;
+mod startup;
 pub mod vm;
 
 pub use error::*;

--- a/crates/runtime/lib/startup.rs
+++ b/crates/runtime/lib/startup.rs
@@ -1,0 +1,77 @@
+//! Startup workload execution for detached `msb run -- CMD`.
+
+use std::path::Path;
+
+use microsandbox_agent_client::AgentClient;
+use microsandbox_protocol::{
+    exec::{ExecExited, ExecFailed, ExecRequest},
+    message::MessageType,
+};
+
+use crate::vm::StartupCommand;
+use crate::{RuntimeError, RuntimeResult};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Terminal status for the startup workload exec session.
+pub(crate) enum StartupCommandExit {
+    /// The command ran and exited with the contained status code.
+    Exited(i32),
+
+    /// agentd could not spawn the command.
+    Failed(ExecFailed),
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) async fn run_startup_command(
+    agent_sock_path: &Path,
+    command: StartupCommand,
+) -> RuntimeResult<StartupCommandExit> {
+    let client = AgentClient::connect(agent_sock_path)
+        .await
+        .map_err(|err| RuntimeError::Custom(format!("startup command connect: {err}")))?;
+
+    let request = ExecRequest {
+        cmd: command.cmd,
+        args: command.args,
+        env: command.env,
+        cwd: command.cwd,
+        user: command.user,
+        tty: false,
+        rows: 24,
+        cols: 80,
+        rlimits: Vec::new(),
+    };
+
+    let (_id, mut rx) = client
+        .stream(MessageType::ExecRequest, &request)
+        .await
+        .map_err(|err| RuntimeError::Custom(format!("startup command dispatch: {err}")))?;
+
+    while let Some(message) = rx.recv().await {
+        match message.t {
+            MessageType::ExecExited => {
+                let exited = message
+                    .payload::<ExecExited>()
+                    .map_err(|err| RuntimeError::Custom(format!("startup command exit: {err}")))?;
+                return Ok(StartupCommandExit::Exited(exited.code));
+            }
+            MessageType::ExecFailed => {
+                let failed = message.payload::<ExecFailed>().map_err(|err| {
+                    RuntimeError::Custom(format!("startup command failure: {err}"))
+                })?;
+                return Ok(StartupCommandExit::Failed(failed));
+            }
+            _ => {}
+        }
+    }
+
+    Err(RuntimeError::Custom(
+        "startup command stream ended before terminal event".into(),
+    ))
+}

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -46,6 +46,7 @@ const EXIT_REASON_SIGNAL: u8 = 3;
 const EXIT_REASON_PARENT_EXIT: u8 = 4;
 const EXIT_REASON_AGENT_UNRESPONSIVE: u8 = 5;
 const EXIT_REASON_SHUTDOWN_REQUESTED: u8 = 6;
+const EXIT_REASON_STARTUP_COMMAND_FAILED: u8 = 7;
 
 /// Host-observed stale heartbeat budget before agentd is considered unresponsive.
 const STALE_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -99,6 +100,9 @@ pub struct Config {
     /// Path to the Unix domain socket for the agent relay.
     pub agent_sock_path: PathBuf,
 
+    /// Startup command to execute after agentd reports ready.
+    pub startup_command: Option<StartupCommand>,
+
     /// Dedicated startup JSON write fd.
     ///
     /// When present, startup info is written here instead of stdout so
@@ -140,6 +144,25 @@ pub struct MetricsSlotHandoff {
     pub slot: u32,
     /// Generation paired with the reservation.
     pub generation: u64,
+}
+
+/// User workload that the sandbox process should start after boot.
+#[derive(Clone, Debug)]
+pub struct StartupCommand {
+    /// Path or command name to execute inside the guest.
+    pub cmd: String,
+
+    /// Arguments to pass to the command.
+    pub args: Vec<String>,
+
+    /// Environment variables as `KEY=VALUE` strings.
+    pub env: Vec<String>,
+
+    /// Working directory for the command.
+    pub cwd: Option<String>,
+
+    /// Guest user override for the command.
+    pub user: Option<String>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -474,6 +497,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                 EXIT_REASON_IDLE_TIMEOUT => run_entity::TerminationReason::IdleTimeout,
                 EXIT_REASON_AGENT_UNRESPONSIVE => run_entity::TerminationReason::AgentUnresponsive,
                 EXIT_REASON_SHUTDOWN_REQUESTED => run_entity::TerminationReason::ShutdownRequested,
+                EXIT_REASON_STARTUP_COMMAND_FAILED => run_entity::TerminationReason::Failed,
                 EXIT_REASON_MAX_DURATION => run_entity::TerminationReason::MaxDurationExceeded,
                 EXIT_REASON_PARENT_EXIT => run_entity::TerminationReason::Signal,
                 EXIT_REASON_SIGNAL => run_entity::TerminationReason::Signal,
@@ -692,6 +716,66 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                 tracing::info!("flush window elapsed, triggering host exit");
                 shutdown_exit_handle.trigger();
             }
+        });
+    }
+
+    // Startup workload: detached `msb run -- CMD` makes the sandbox process
+    // own the command lifecycle. Once the command terminates, stop the VM so
+    // named sandboxes become stopped and ephemeral sandboxes can self-clean.
+    if let Some(startup_command) = config.startup_command.clone() {
+        let startup_agent_sock_path = config.agent_sock_path.clone();
+        let startup_shared = Arc::clone(&shared);
+        let startup_exit_handle = exit_handle.clone();
+        let startup_reason = Arc::clone(&exit_reason);
+        tokio_rt.spawn(async move {
+            tracing::info!(
+                cmd = %startup_command.cmd,
+                args = ?startup_command.args,
+                "starting startup command"
+            );
+
+            match crate::startup::run_startup_command(&startup_agent_sock_path, startup_command)
+                .await
+            {
+                Ok(crate::startup::StartupCommandExit::Exited(0)) => {
+                    tracing::info!("startup command exited successfully");
+                }
+                Ok(crate::startup::StartupCommandExit::Exited(code)) => {
+                    startup_reason.store(
+                        EXIT_REASON_STARTUP_COMMAND_FAILED,
+                        std::sync::atomic::Ordering::SeqCst,
+                    );
+                    tracing::warn!(code, "startup command exited with non-zero status");
+                }
+                Ok(crate::startup::StartupCommandExit::Failed(failed)) => {
+                    startup_reason.store(
+                        EXIT_REASON_STARTUP_COMMAND_FAILED,
+                        std::sync::atomic::Ordering::SeqCst,
+                    );
+                    tracing::warn!(error = %failed.message, "startup command failed to spawn");
+                }
+                Err(err) => {
+                    startup_reason.store(
+                        EXIT_REASON_STARTUP_COMMAND_FAILED,
+                        std::sync::atomic::Ordering::SeqCst,
+                    );
+                    tracing::warn!(error = %err, "startup command failed");
+                }
+            }
+
+            match request_guest_shutdown(&startup_shared) {
+                Ok(()) => {
+                    tokio::time::sleep(microsandbox_protocol::SHUTDOWN_FLUSH_TIMEOUT).await;
+                    tracing::info!("startup command shutdown flush window elapsed");
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        "startup command shutdown request failed, triggering host exit"
+                    );
+                }
+            }
+            startup_exit_handle.trigger();
         });
     }
 

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -35,8 +35,8 @@ use microsandbox_image::{Digest, GlobalCache};
 use microsandbox_metrics::{MetricsRegistry, ReserveSlot, SlotReservation};
 use microsandbox_protocol::{
     ENV_BLOCK_ROOT, ENV_DIR_MOUNTS, ENV_DISK_MOUNTS, ENV_FILE_MOUNTS, ENV_HANDOFF_INIT,
-    ENV_HANDOFF_INIT_ARGS, ENV_HANDOFF_INIT_ENV, ENV_HOSTNAME, ENV_SECURITY_PROFILE, ENV_TMPFS,
-    ENV_USER,
+    ENV_HANDOFF_INIT_ARGS, ENV_HANDOFF_INIT_CWD, ENV_HANDOFF_INIT_ENV, ENV_HOSTNAME,
+    ENV_SECURITY_PROFILE, ENV_TMPFS, ENV_USER,
 };
 use microsandbox_types::SandboxLogLevel;
 use microsandbox_utils::{DB_FILENAME, DB_SUBDIR};
@@ -1084,6 +1084,7 @@ fn sandbox_cli_args(
         args.push(OsString::from("--startup-fd"));
         args.push(OsString::from(fd.to_string()));
     }
+    push_startup_command_args(&mut args, config);
 
     let sp = &config.spec.lifecycle;
     if let Some(max_dur) = sp.max_duration_secs {
@@ -1367,6 +1368,11 @@ fn sandbox_cli_args(
             )));
         }
 
+        if let Some(ref workdir) = config.spec.runtime.workdir {
+            args.push(OsString::from("--env"));
+            args.push(OsString::from(format!("{ENV_HANDOFF_INIT_CWD}={workdir}")));
+        }
+
         if !init.env.is_empty() {
             let env_val = encode_handoff_json(&init.env);
             args.push(OsString::from("--env"));
@@ -1380,6 +1386,53 @@ fn sandbox_cli_args(
     }
 
     args
+}
+
+fn push_startup_command_args(args: &mut Vec<OsString>, config: &SandboxConfig) {
+    let Some((cmd, cmd_args)) = resolve_startup_command(config) else {
+        return;
+    };
+
+    args.push(OsString::from(format!("--startup-cmd={cmd}")));
+    for arg in cmd_args {
+        args.push(OsString::from(format!("--startup-arg={arg}")));
+    }
+    for var in &config.spec.env {
+        args.push(OsString::from(format!(
+            "--startup-env={}={}",
+            var.key, var.value
+        )));
+    }
+    if let Some(workdir) = &config.spec.runtime.workdir {
+        args.push(OsString::from(format!("--startup-cwd={workdir}")));
+    }
+    if let Some(user) = &config.spec.runtime.user {
+        args.push(OsString::from(format!("--startup-user={user}")));
+    }
+}
+
+fn resolve_startup_command(config: &SandboxConfig) -> Option<(String, Vec<String>)> {
+    if !config.startup_command_requested {
+        return None;
+    }
+
+    match (&config.spec.runtime.entrypoint, &config.spec.runtime.cmd) {
+        (Some(entrypoint), cmd) if !entrypoint.is_empty() => {
+            let bin = entrypoint[0].clone();
+            let args = entrypoint[1..]
+                .iter()
+                .chain(cmd.iter().flatten())
+                .cloned()
+                .collect();
+            Some((bin, args))
+        }
+        (_, Some(cmd)) if !cmd.is_empty() => {
+            let bin = cmd[0].clone();
+            let args = cmd[1..].to_vec();
+            Some((bin, args))
+        }
+        _ => None,
+    }
 }
 
 fn sandbox_log_level_cli_flag(level: SandboxLogLevel) -> &'static str {
@@ -1403,6 +1456,7 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use microsandbox_types::HandoffInit;
     use serde::de::DeserializeOwned;
     use tempfile::tempdir;
 
@@ -1558,6 +1612,74 @@ mod tests {
                 OsString::from("--startup-fd"),
                 OsString::from(microsandbox_runtime::vm::STARTUP_FD.to_string()),
             ]));
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_cli_args_include_detached_startup_command() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .entrypoint(["/entrypoint"])
+            .env("APP_ENV", "test")
+            .workdir("/workspace")
+            .user("nobody")
+            .persistent_initial_command(["/bin/sh", "-lc", "echo detached"])
+            .build()
+            .await
+            .unwrap();
+
+        let rendered = render_args(&config);
+
+        assert!(rendered.contains(&"--startup-cmd=/entrypoint".to_string()));
+        assert!(rendered.contains(&"--startup-arg=/bin/sh".to_string()));
+        assert!(rendered.contains(&"--startup-arg=-lc".to_string()));
+        assert!(rendered.contains(&"--startup-arg=echo detached".to_string()));
+        assert!(rendered.contains(&"--startup-env=APP_ENV=test".to_string()));
+        assert!(rendered.contains(&"--startup-cwd=/workspace".to_string()));
+        assert!(rendered.contains(&"--startup-user=nobody".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_cli_args_skip_startup_exec_when_init_owns_argv() {
+        let mut config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .workdir("/opt/hermes")
+            .persistent_initial_command(["gateway", "run"])
+            .build()
+            .await
+            .unwrap();
+        config.spec.init = Some(HandoffInit {
+            cmd: PathBuf::from("/init"),
+            args: vec![
+                "/opt/hermes/docker/main-wrapper.sh".to_string(),
+                "gateway".to_string(),
+                "run".to_string(),
+            ],
+            env: Vec::new(),
+        });
+        config.startup_command_requested = false;
+
+        let rendered = render_args(&config);
+
+        assert_eq!(
+            find_env(&rendered, "MSB_HANDOFF_INIT").as_deref(),
+            Some("/init")
+        );
+        let argv = find_env(&rendered, "MSB_HANDOFF_INIT_ARGS").expect("argv env present");
+        let decoded: Vec<String> = decode_handoff_json(&argv);
+        assert_eq!(
+            decoded,
+            vec![
+                "/opt/hermes/docker/main-wrapper.sh".to_string(),
+                "gateway".to_string(),
+                "run".to_string(),
+            ]
+        );
+        assert_eq!(
+            find_env(&rendered, "MSB_HANDOFF_INIT_CWD").as_deref(),
+            Some("/opt/hermes")
+        );
+        assert!(!rendered.iter().any(|arg| arg.starts_with("--startup-cmd")));
+        assert!(!rendered.iter().any(|arg| arg.starts_with("--startup-arg")));
     }
 
     #[tokio::test]
@@ -2094,7 +2216,26 @@ mod tests {
             Some("/lib/systemd/systemd")
         );
         assert!(find_env(&args, "MSB_HANDOFF_INIT_ARGS").is_none());
+        assert!(find_env(&args, "MSB_HANDOFF_INIT_CWD").is_none());
         assert!(find_env(&args, "MSB_HANDOFF_INIT_ENV").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_handoff_init_emits_cwd_when_workdir_set() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .init("/init")
+            .workdir("/opt/hermes")
+            .build()
+            .await
+            .unwrap();
+
+        let args = render_args(&config);
+
+        assert_eq!(
+            find_env(&args, "MSB_HANDOFF_INIT_CWD").as_deref(),
+            Some("/opt/hermes")
+        );
     }
 
     #[tokio::test]

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -308,7 +308,7 @@ impl SandboxBuilder {
         self
     }
 
-    /// Set the transient initial command for attached CLI `run`.
+    /// Clear detached startup intent for attached CLI `run`.
     #[doc(hidden)]
     pub fn initial_command(mut self, command: impl IntoIterator<Item = impl Into<String>>) -> Self {
         self.config
@@ -883,24 +883,31 @@ impl SandboxBuilder {
     )> {
         let (handle, sender) = microsandbox_image::progress_channel();
         let task = tokio::spawn(async move {
+            let detached = self.detached;
             let config = self.build().await?;
             let backend = crate::backend::default_backend();
             match backend.kind() {
                 crate::backend::BackendKind::Local => {
-                    crate::sandbox::create_local(
-                        backend,
-                        config,
-                        crate::runtime::SpawnMode::Attached,
-                        Some(sender),
-                    )
-                    .await
+                    let mode = if detached {
+                        crate::runtime::SpawnMode::Detached
+                    } else {
+                        crate::runtime::SpawnMode::Attached
+                    };
+                    crate::sandbox::create_local(backend, config, mode, Some(sender)).await
                 }
                 crate::backend::BackendKind::Cloud => {
                     drop(sender);
-                    backend
-                        .sandboxes()
-                        .create(backend.clone(), config, true)
-                        .await
+                    if detached {
+                        backend
+                            .sandboxes()
+                            .create_detached(backend.clone(), config)
+                            .await
+                    } else {
+                        backend
+                            .sandboxes()
+                            .create(backend.clone(), config, true)
+                            .await
+                    }
                 }
             }
         });

--- a/sdk/rust/lib/sandbox/config.rs
+++ b/sdk/rust/lib/sandbox/config.rs
@@ -131,26 +131,13 @@ pub struct SandboxConfig {
     #[serde(skip)]
     pub(crate) snapshot_upper_source: Option<PathBuf>,
 
-    /// Initial command requested by a CLI `msb run` invocation.
-    ///
-    /// This is transient CLI intent. It lets `--init auto` decide before VM
-    /// spawn whether an image-declared init entrypoint should receive the OCI
-    /// command as argv.
+    /// Whether `runtime.cmd` should be launched by the sandbox process after boot.
+    #[serde(skip)]
+    pub(crate) startup_command_requested: bool,
+
+    /// One-shot foreground command requested by attached `msb run`.
     #[serde(skip)]
     pub(crate) initial_command: Option<Vec<String>>,
-
-    /// Whether a consumed initial command should become persisted startup argv.
-    ///
-    /// Attached `msb run` commands are one-shot foreground intent; detached
-    /// `msb run -d` commands are startup intent when an image init consumes
-    /// them.
-    #[serde(skip)]
-    pub(crate) initial_command_persistent: bool,
-
-    /// Whether [`initial_command`](Self::initial_command) was consumed by
-    /// the handoff init instead of being executed through agentd.
-    #[serde(skip)]
-    pub(crate) initial_command_consumed_by_init: bool,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -170,45 +157,33 @@ impl SandboxConfig {
         }
     }
 
-    /// Return whether the attached initial command was launched by the
-    /// handoff init rather than through agentd.
-    #[doc(hidden)]
-    pub fn initial_command_consumed_by_init(&self) -> bool {
-        self.initial_command_consumed_by_init
-    }
-
     /// Return the config shape that should be persisted for future starts.
     ///
-    /// Attached `msb run --init auto` may pass a one-off foreground command to
-    /// an image-declared init entrypoint. Detached `msb run -d --init auto`
-    /// uses the same handoff path for startup intent. Only the latter should
-    /// be replayed by `msb start`.
+    /// Attached `msb run` commands are one-shot foreground intent. Detached startup intent stays
+    /// in `runtime.cmd` and is either executed by the host runtime after agentd is ready or, for
+    /// image-declared init entrypoints, passed to the init handoff as the container startup argv.
     pub(crate) fn clone_for_persistence(&self) -> Self {
         let mut config = self.clone();
-        if config.initial_command_consumed_by_init
-            && !config.initial_command_persistent
-            && let Some(init) = &mut config.spec.init
-        {
-            init.args.clear();
-        }
+        config.startup_command_requested = false;
         config.initial_command = None;
-        config.initial_command_persistent = false;
-        config.initial_command_consumed_by_init = false;
         config
     }
 
-    /// Set one-shot initial command intent for attached `msb run`.
+    /// Clear detached startup intent for attached `msb run`.
     pub(crate) fn set_initial_command(&mut self, command: Vec<String>) {
-        self.initial_command = Some(command);
-        self.initial_command_persistent = false;
-        self.initial_command_consumed_by_init = false;
+        self.initial_command = (!command.is_empty()).then_some(command);
+        self.startup_command_requested = false;
     }
 
     /// Set startup initial command intent for detached `msb run -d`.
     pub(crate) fn set_persistent_initial_command(&mut self, command: Vec<String>) {
-        self.initial_command = Some(command);
-        self.initial_command_persistent = true;
-        self.initial_command_consumed_by_init = false;
+        if !command.is_empty() {
+            self.spec.runtime.cmd = Some(command.clone());
+            self.startup_command_requested = true;
+        } else {
+            self.startup_command_requested = false;
+        }
+        self.initial_command = None;
     }
 
     /// Apply OCI image config as defaults. User-provided values take precedence.
@@ -253,12 +228,9 @@ impl SandboxConfig {
     /// Resolve `init = "auto"` from a known init path declared as the
     /// image entrypoint.
     ///
-    /// When an attached `msb run` provided an initial command, and the
-    /// image declares a container-init entrypoint such as `/init`, the
-    /// remaining OCI process vector is passed to the init as argv. The
-    /// image init token is still stripped from the persisted workload
-    /// entrypoint so later agentd exec command resolution never tries
-    /// to direct-exec `/init`.
+    /// Docker starts containers by appending CMD to the image ENTRYPOINT. If that ENTRYPOINT is an
+    /// init binary, the init handoff must own the resolved argv; launching the same command later
+    /// through agentd skips init-established state such as s6's PATH.
     fn resolve_auto_init_from_image_entrypoint(
         &mut self,
         image_entrypoint: Option<&[String]>,
@@ -270,8 +242,6 @@ impl SandboxConfig {
         if init.cmd.as_os_str() != HANDOFF_INIT_AUTO {
             return;
         }
-        let init_args_empty = init.args.is_empty();
-
         let Some(entrypoint) = image_entrypoint else {
             return;
         };
@@ -283,25 +253,14 @@ impl SandboxConfig {
             return;
         };
 
-        let init_argv_tail = if inherited_entrypoint && init_args_empty {
-            self.image_init_entrypoint_argv_tail(init_path, entrypoint)
-        } else {
-            None
-        };
-
-        let init = self
-            .spec
-            .init
-            .as_mut()
-            .expect("init was present at start of auto resolution");
-        init.cmd = PathBuf::from(init_path);
-        init.env = merge_init_env(&self.spec.env, &init.env);
-        if let Some(argv_tail) = init_argv_tail {
-            init.args = argv_tail;
-            self.initial_command_consumed_by_init = true;
-        }
-
         if !inherited_entrypoint {
+            let init = self
+                .spec
+                .init
+                .as_mut()
+                .expect("init was present at start of auto resolution");
+            init.cmd = PathBuf::from(init_path);
+            init.env = merge_init_env(&self.spec.env, &init.env);
             return;
         }
 
@@ -314,28 +273,27 @@ impl SandboxConfig {
         {
             entrypoint.remove(0);
         }
+        let runtime_cmd = self
+            .initial_command
+            .as_deref()
+            .or(self.spec.runtime.cmd.as_deref());
+        let init_args = resolved_container_argv(&entrypoint, runtime_cmd);
+
+        let init = self
+            .spec
+            .init
+            .as_mut()
+            .expect("init was present at start of auto resolution");
+        init.cmd = PathBuf::from(init_path);
+        init.args.extend(init_args);
+        init.env = merge_init_env(&self.spec.env, &init.env);
+
+        // The startup command is now part of the PID 1 argv. Running it again through agentd would
+        // both duplicate execution and bypass any state the image init establishes before execing.
+        if self.startup_command_requested {
+            self.startup_command_requested = false;
+        }
         self.spec.runtime.entrypoint = (!entrypoint.is_empty()).then_some(entrypoint);
-    }
-
-    fn image_init_entrypoint_argv_tail(
-        &self,
-        init_path: &str,
-        image_entrypoint: &[String],
-    ) -> Option<Vec<String>> {
-        let initial_command = self.initial_command.as_ref()?;
-        if init_path != "/init" && image_entrypoint.len() <= 1 {
-            return None;
-        }
-
-        let mut process = image_entrypoint.to_vec();
-        if initial_command.is_empty() {
-            process.extend(self.spec.runtime.cmd.iter().flatten().cloned());
-        } else {
-            process.extend(initial_command.iter().cloned());
-        }
-
-        let argv_tail: Vec<_> = process.into_iter().skip(1).collect();
-        (!argv_tail.is_empty()).then_some(argv_tail)
     }
 
     /// Materialize rootfs defaults that should be persisted with the sandbox.
@@ -401,6 +359,14 @@ fn merge_init_env(base: &[EnvVar], overrides: &[(String, String)]) -> Vec<(Strin
     merge_env_pairs(base, &overrides)
         .into_iter()
         .map(Into::into)
+        .collect()
+}
+
+fn resolved_container_argv(entrypoint_tail: &[String], cmd: Option<&[String]>) -> Vec<String> {
+    entrypoint_tail
+        .iter()
+        .chain(cmd.into_iter().flatten())
+        .cloned()
         .collect()
 }
 
@@ -535,9 +501,8 @@ impl Default for SandboxConfig {
             replace_with_timeout: DEFAULT_REPLACE_TIMEOUT,
             manifest_digest: None,
             snapshot_upper_source: None,
+            startup_command_requested: false,
             initial_command: None,
-            initial_command_persistent: false,
-            initial_command_consumed_by_init: false,
         }
     }
 }
@@ -691,7 +656,10 @@ mod tests {
             .as_ref()
             .expect("init should remain configured");
         assert_eq!(init.cmd, PathBuf::from("/init"));
-        assert!(init.args.is_empty());
+        assert_eq!(
+            init.args,
+            vec!["/opt/hermes/docker/main-wrapper.sh".to_string()]
+        );
         assert_eq!(
             config.spec.runtime.entrypoint,
             Some(vec!["/opt/hermes/docker/main-wrapper.sh".to_string()])
@@ -699,7 +667,7 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_image_defaults_passes_initial_command_to_init_entrypoint() {
+    fn test_merge_image_defaults_keeps_attached_command_out_of_init_entrypoint() {
         let image = ImageConfig {
             entrypoint: Some(vec![
                 "/init".to_string(),
@@ -733,10 +701,9 @@ mod tests {
             vec![
                 "/opt/hermes/docker/main-wrapper.sh".to_string(),
                 "gateway".to_string(),
-                "run".to_string()
+                "run".to_string(),
             ]
         );
-        assert!(config.initial_command_consumed_by_init());
         assert_eq!(
             config.spec.runtime.entrypoint,
             Some(vec!["/opt/hermes/docker/main-wrapper.sh".to_string()])
@@ -797,56 +764,20 @@ mod tests {
     }
 
     #[test]
-    fn test_clone_for_persistence_drops_consumed_init_args() {
-        let mut config = SandboxConfig {
-            spec: SandboxSpec {
-                init: Some(HandoffInit {
-                    cmd: PathBuf::from("/init"),
-                    args: vec![
-                        "/opt/hermes/docker/main-wrapper.sh".to_string(),
-                        "gateway".to_string(),
-                        "run".to_string(),
-                    ],
-                    env: vec![("HERMES_DASHBOARD".to_string(), "1".to_string())],
-                }),
-                ..Default::default()
-            },
+    fn test_merge_image_defaults_passes_detached_startup_cmd_to_init_args() {
+        let image = ImageConfig {
+            entrypoint: Some(vec![
+                "/init".to_string(),
+                "/opt/hermes/docker/main-wrapper.sh".to_string(),
+            ]),
             ..Default::default()
         };
-        config.set_initial_command(vec!["gateway".to_string(), "run".to_string()]);
-        config.initial_command_consumed_by_init = true;
 
-        let persisted = config.clone_for_persistence();
-
-        let runtime_init = config.spec.init.as_ref().expect("runtime init");
-        assert_eq!(
-            runtime_init.args,
-            vec![
-                "/opt/hermes/docker/main-wrapper.sh".to_string(),
-                "gateway".to_string(),
-                "run".to_string(),
-            ]
-        );
-        let persisted_init = persisted.spec.init.as_ref().expect("persisted init");
-        assert!(persisted_init.args.is_empty());
-        assert_eq!(
-            persisted_init.env,
-            vec![("HERMES_DASHBOARD".to_string(), "1".to_string())]
-        );
-        assert!(!persisted.initial_command_consumed_by_init());
-    }
-
-    #[test]
-    fn test_clone_for_persistence_keeps_detached_startup_init_args() {
         let mut config = SandboxConfig {
             spec: SandboxSpec {
                 init: Some(HandoffInit {
-                    cmd: PathBuf::from("/init"),
-                    args: vec![
-                        "/opt/hermes/docker/main-wrapper.sh".to_string(),
-                        "gateway".to_string(),
-                        "run".to_string(),
-                    ],
+                    cmd: PathBuf::from("auto"),
+                    args: Vec::new(),
                     env: Vec::new(),
                 }),
                 ..Default::default()
@@ -854,20 +785,65 @@ mod tests {
             ..Default::default()
         };
         config.set_persistent_initial_command(vec!["gateway".to_string(), "run".to_string()]);
-        config.initial_command_consumed_by_init = true;
+        config.merge_image_defaults(&image);
 
-        let persisted = config.clone_for_persistence();
-
-        let persisted_init = persisted.spec.init.as_ref().expect("persisted init");
+        let init = config.spec.init.as_ref().expect("runtime init");
+        assert_eq!(init.cmd, PathBuf::from("/init"));
         assert_eq!(
-            persisted_init.args,
+            init.args,
             vec![
                 "/opt/hermes/docker/main-wrapper.sh".to_string(),
                 "gateway".to_string(),
                 "run".to_string(),
             ]
         );
-        assert!(!persisted.initial_command_consumed_by_init());
+        assert_eq!(
+            config.spec.runtime.entrypoint,
+            Some(vec!["/opt/hermes/docker/main-wrapper.sh".to_string()])
+        );
+        assert_eq!(
+            config.spec.runtime.cmd,
+            Some(vec!["gateway".to_string(), "run".to_string()])
+        );
+        assert!(!config.startup_command_requested);
+    }
+
+    #[test]
+    fn test_persistent_initial_command_sets_runtime_cmd() {
+        let mut config = SandboxConfig::default();
+
+        config.set_persistent_initial_command(vec![
+            "/bin/sh".to_string(),
+            "-lc".to_string(),
+            "echo detached".to_string(),
+        ]);
+
+        assert_eq!(
+            config.spec.runtime.cmd,
+            Some(vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                "echo detached".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_empty_persistent_initial_command_keeps_runtime_cmd() {
+        let mut config = SandboxConfig {
+            spec: SandboxSpec {
+                runtime: SandboxRuntimeOptions {
+                    cmd: Some(vec!["python3".to_string()]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        config.set_persistent_initial_command(Vec::new());
+
+        assert_eq!(config.spec.runtime.cmd, Some(vec!["python3".to_string()]));
     }
 
     #[test]
@@ -894,7 +870,7 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_image_defaults_passes_image_cmd_to_init_entrypoint() {
+    fn test_merge_image_defaults_passes_image_cmd_to_init_args() {
         let image = ImageConfig {
             entrypoint: Some(vec!["/init".to_string()]),
             cmd: Some(vec!["/app/server".to_string(), "--serve".to_string()]),
@@ -925,12 +901,15 @@ mod tests {
             init.args,
             vec!["/app/server".to_string(), "--serve".to_string()]
         );
-        assert!(config.initial_command_consumed_by_init());
         assert_eq!(config.spec.runtime.entrypoint, None);
+        assert_eq!(
+            config.spec.runtime.cmd,
+            Some(vec!["/app/server".to_string(), "--serve".to_string()])
+        );
     }
 
     #[test]
-    fn test_merge_image_defaults_bare_systemd_does_not_consume_initial_command() {
+    fn test_merge_image_defaults_resolves_bare_systemd_init_entrypoint() {
         let image = ImageConfig {
             entrypoint: Some(vec!["/lib/systemd/systemd".to_string()]),
             ..Default::default()
@@ -956,8 +935,7 @@ mod tests {
             .as_ref()
             .expect("init should remain configured");
         assert_eq!(init.cmd, PathBuf::from("/lib/systemd/systemd"));
-        assert!(init.args.is_empty());
-        assert!(!config.initial_command_consumed_by_init());
+        assert_eq!(init.args, vec!["bash".to_string()]);
         assert_eq!(config.spec.runtime.entrypoint, None);
     }
 
@@ -1000,7 +978,6 @@ mod tests {
             config.spec.runtime.entrypoint,
             Some(vec!["/bin/sh".to_string()])
         );
-        assert!(!config.initial_command_consumed_by_init());
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR
Make detached `msb run -- CMD` execute as runtime-owned startup intent instead of being dropped by the CLI. This also preserves Docker-style startup for known init entrypoints such as Hermes/s6 by handing `ENTRYPOINT` tail plus `CMD` to PID 1.

## Description
- Persist detached `msb run -- CMD` as `runtime.cmd` startup intent and pass it to the sandbox process with hidden runtime CLI flags.
- Execute detached startup commands from the host runtime after agentd is ready, then shut the VM down when the startup workload exits.
- Resolve known image init entrypoints under `--init auto` so `/init` receives the image entrypoint tail plus effective command, environment, and workdir.
- Add `MSB_HANDOFF_INIT_CWD` so agentd changes into the configured image workdir before execing the handoff init.
- Use detached spawn mode for `msb run -d` and `msb create` progress paths so background sandboxes survive CLI exit.
- Remove the old CLI-side init foreground wait/log handling in favor of a single runtime startup path.

Verified user-facing command:

```bash
msb run nousresearch/hermes-agent \
  --name hermes --replace -d \
  -v ~/.hermes:/opt/data \
  -p 8642:8642 \
  -p 9119:9119 \
  -e HERMES_DASHBOARD=1 \
  -e HERMES_DASHBOARD_INSECURE=1 \
  --init auto \
  -- gateway run
```

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo fmt --manifest-path crates/agentd/Cargo.toml -- --check`
- [x] `cargo check -p microsandbox-cli`
- [x] `cargo test -p microsandbox --lib handoff_init`
- [x] `cargo test -p microsandbox --lib init_entrypoint`
- [x] `cargo test -p microsandbox --lib skip_startup_exec_when_init_owns_argv`
- [x] `cargo test -p microsandbox-runtime --lib`
- [x] `cargo test -p microsandbox-cli --lib run::`
- [x] Built and codesigned `build/msb`, then ran the Hermes detached command above with a temporary `MSB_HOME`; verified `msb ps --all` showed `hermes` as `running`, kernel logs showed s6 services started, and `curl http://127.0.0.1:9119/` returned the Hermes Dashboard HTML.
- [x] Signed commit hook also passed workspace `cargo fmt`, workspace `cargo clippy`, agentd `cargo fmt`, agentd `cargo clippy`, workspace docs, and `cargo build (msb)`.
