### PR TITLE
docs(sdk): redesign rust sandbox reference page

### DIFF
--- a/docs/sdk/go/agent-client.mdx
+++ b/docs/sdk/go/agent-client.mdx
@@ -3,15 +3,153 @@ title: Agent client
 description: Go SDK - Low-level agentd client reference
 ---
 
-`AgentClient` is the low-level raw transport for talking to `agentd` through a running sandbox's relay socket. Most applications should use [`Sandbox`](/sdk/go/sandbox), [`Exec`](/sdk/go/execution), and filesystem helpers instead. Use this API when you are building protocol-level tools or higher-level SDK helpers.
+`AgentClient` is the low-level raw transport for talking to `agentd` through a running sandbox's relay socket. Most applications should use [`Sandbox`](/sdk/go/sandbox), [`Exec`](/sdk/go/execution), and filesystem helpers instead. Reach for this API when you are building protocol-level tools or higher-level SDK helpers.
 
-All request bodies and response bodies are raw CBOR bytes. The SDK handles framing and correlation ids, but it does not encode or decode the CBOR message body for you.
+All request and response bodies are raw CBOR bytes. The SDK handles framing and correlation ids, but it does not encode or decode the CBOR message body for you: decode it with a library such as `fxamacker/cbor`. The raw body is the full CBOR-encoded protocol `Message` body (`v`, `t`, `p`), not just the inner payload.
 
-The raw body is the full CBOR-encoded protocol `Message` body: `v`, `t`, and `p`. It is not just the inner payload.
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Constants<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#flagterminal"><span className="msb-rn">FlagTerminal</span><span className="msb-rg">last frame for a correlation id</span></a>
+  <a className="msb-row" href="#flagsessionstart"><span className="msb-rn">FlagSessionStart</span><span className="msb-rg">first frame of a session</span></a>
+  <a className="msb-row" href="#flagshutdown"><span className="msb-rn">FlagShutdown</span><span className="msb-rg">request sandbox shutdown</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Functions<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#m-connectagentsandbox"><span className="msb-rn">m.ConnectAgentSandbox()</span><span className="msb-rg">connect by sandbox name</span></a>
+  <a className="msb-row" href="#m-connectagentpath"><span className="msb-rn">m.ConnectAgentPath()</span><span className="msb-rg">connect by socket path</span></a>
+  <a className="msb-row" href="#m-agentsocketpath"><span className="msb-rn">m.AgentSocketPath()</span><span className="msb-rg">resolve socket path only</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · AgentClient<span className="msb-ct">6</span></p>
+  <a className="msb-row" href="#c-request"><span className="msb-rn">c.Request()</span><span className="msb-rg">one frame, one response</span></a>
+  <a className="msb-row" href="#c-stream"><span className="msb-rn">c.Stream()</span><span className="msb-rg">open a streaming session</span></a>
+  <a className="msb-row" href="#c-send"><span className="msb-rn">c.Send()</span><span className="msb-rg">follow-up frame on an id</span></a>
+  <a className="msb-row" href="#c-readybytes"><span className="msb-rn">c.ReadyBytes()</span><span className="msb-rg">cached handshake frame</span></a>
+  <a className="msb-row" href="#c-close"><span className="msb-rn">c.Close()</span><span className="msb-rg">close the connection</span></a>
+  <a className="msb-row" href="#c-closectx"><span className="msb-rn">c.CloseCtx()</span><span className="msb-rg">close with a context</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · AgentStream<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#s-next"><span className="msb-rn">s.Next()</span><span className="msb-rg">pull the next frame</span></a>
+  <a className="msb-row" href="#s-id"><span className="msb-rn">s.ID()</span><span className="msb-rg">protocol correlation id</span></a>
+  <a className="msb-row" href="#s-close"><span className="msb-rn">s.Close()</span><span className="msb-rg">release the stream handle</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#agentclient">AgentClient</a>
+    <a className="msb-typepill" href="#agentstream">AgentStream</a>
+    <a className="msb-typepill" href="#rawframe">RawFrame</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```go
-import m "github.com/superradcompany/microsandbox/sdk/go"
+import (
+    "context"
+
+    "github.com/fxamacker/cbor/v2"
+    m "github.com/superradcompany/microsandbox/sdk/go"
+)
+
+ctx := context.Background()
+
+client, err := m.ConnectAgentSandbox(ctx, "dev")   // 1. connect
+if err != nil {
+    return err
+}
+defer client.Close()
+
+body, err := cbor.Marshal(map[string]any{          // 2. build a CBOR Message
+    "v": 1,
+    "t": "core.fs.request",
+    "p": fsRequestBytes,
+})
+if err != nil {
+    return err
+}
+
+frame, err := client.Request(ctx, m.FlagSessionStart, body)  // 3. request / response
+if err != nil {
+    return err
+}
+_ = frame.Body
 ```
+
+## Constants
+
+---
+
+#### <span className="msb-hn">FlagTerminal</span>
+<div className="msb-tags"><span className="msb-tag is-static">const</span></div>
+
+```go
+const FlagTerminal uint8 = 0b0000_0001
+```
+
+Frame flag: this is the last message for the given correlation id. When a frame on an open stream carries this bit, no further frames will arrive for that id. Also available as `FLAG_TERMINAL`, the cross-SDK constant spelling.
+
+---
+
+#### <span className="msb-hn">FlagSessionStart</span>
+<div className="msb-tags"><span className="msb-tag is-static">const</span></div>
+
+```go
+const FlagSessionStart uint8 = 0b0000_0010
+```
+
+Frame flag: this is the first message of a new session. Set it on the opening frame of a request/response RPC or a streaming session. Also available as `FLAG_SESSION_START`.
+
+---
+
+#### <span className="msb-hn">FlagShutdown</span>
+<div className="msb-tags"><span className="msb-tag is-static">const</span></div>
+
+```go
+const FlagShutdown uint8 = 0b0000_0100
+```
+
+Frame flag: this message requests sandbox shutdown. Also available as `FLAG_SHUTDOWN`.
+
+## Functions
+
+---
+
+#### <span className="msb-recv">m.</span><span className="msb-hn">ConnectAgentSandbox()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func ConnectAgentSandbox(ctx context.Context, name string) (*AgentClient, error)
+```
+
+Connect to a running sandbox by name. Resolves the sandbox's relay socket path and performs the `core.ready` handshake. Sandbox names are limited to 128 UTF-8 bytes. Use `context.WithTimeout` to override the default 10s handshake timeout.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Bounds the handshake; defaults to a 10s timeout if none is set.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentclient">*AgentClient</a></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 client, err := m.ConnectAgentSandbox(ctx, "dev")
@@ -19,73 +157,202 @@ if err != nil {
     return err
 }
 defer client.Close()
-
-ready, err := client.ReadyBytes()
-if err != nil {
-    return err
-}
-_ = ready
 ```
 
 ---
 
-## Constants
-
-| Name | Type | Description |
-|------|------|-------------|
-| `FlagTerminal` / `FLAG_TERMINAL` | `uint8` | Last frame for a correlation id |
-| `FlagSessionStart` / `FLAG_SESSION_START` | `uint8` | First frame of a streaming session |
-| `FlagShutdown` / `FLAG_SHUTDOWN` | `uint8` | Shutdown frame |
-
----
-
-#### ConnectAgentSandbox()
-
-```go
-func ConnectAgentSandbox(ctx context.Context, name string) (*AgentClient, error)
-```
-
-Connect to a running sandbox by name. Sandbox names are limited to 128 UTF-8 bytes.
-
----
-
-#### ConnectAgentPath()
+#### <span className="msb-recv">m.</span><span className="msb-hn">ConnectAgentPath()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func ConnectAgentPath(ctx context.Context, path string) (*AgentClient, error)
 ```
 
-Connect to an agent relay socket by path.
+Connect to an `agentd` relay socket by path. Use this when you already have the socket path, for example one returned by [`AgentSocketPath()`](#m-agentsocketpath). Use `context.WithTimeout` to override the default 10s handshake timeout.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Bounds the handshake; defaults to a 10s timeout if none is set.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Filesystem path of the relay socket.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentclient">*AgentClient</a></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+path, err := m.AgentSocketPath("dev")
+if err != nil {
+    return err
+}
+
+client, err := m.ConnectAgentPath(ctx, path)
+if err != nil {
+    return err
+}
+defer client.Close()
+```
 
 ---
 
-#### AgentSocketPath()
+#### <span className="msb-recv">m.</span><span className="msb-hn">AgentSocketPath()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func AgentSocketPath(name string) (string, error)
 ```
 
-Resolve a sandbox's `agentd` relay socket path **without connecting**. Returns the same path `ConnectAgentSandbox` would dial, so you can talk to `agentd` over a raw byte transport (e.g. a transparent relay that splices bytes to and from the socket) instead of this frame client. The sandbox need not be running. Sandbox names are limited to 128 UTF-8 bytes.
+Resolve a sandbox's `agentd` relay socket path **without connecting**. Returns the same path [`ConnectAgentSandbox()`](#m-connectagentsandbox) would dial internally (preferring the hashed path, falling back to the legacy name-derived path), so you can talk to `agentd` over a raw byte transport (for example a transparent relay that splices bytes between a WebSocket and the socket) instead of this frame client. The sandbox need not be running; the path is derived from the name and the configured home directory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Relay socket path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+path, err := m.AgentSocketPath("dev")
+if err != nil {
+    return err
+}
+fmt.Println(path)
+```
+
+## AgentClient methods
 
 ---
 
-#### Request()
+#### <span className="msb-recv">c.</span><span className="msb-hn">Request()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (c *AgentClient) Request(ctx context.Context, flags uint8, body []byte) (*RawFrame, error)
 ```
 
-Send one raw frame and wait for one response frame.
+Send one frame and await a single response frame. Use for request/response RPCs that produce exactly one terminal response (for example a `core.fs.request` to its `core.fs.response`).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the request.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">uint8</span></div>
+    <div className="msb-param-desc">Frame flag byte, e.g. <code>FlagSessionStart</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#rawframe">*RawFrame</a></div>
+    <div className="msb-param-desc">The single response frame.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+frame, err := client.Request(ctx, m.FlagSessionStart, body)
+if err != nil {
+    return err
+}
+
+var msg map[string]any
+if err := cbor.Unmarshal(frame.Body, &msg); err != nil {
+    return err
+}
+```
 
 ---
 
-#### Stream()
+#### <span className="msb-recv">c.</span><span className="msb-hn">Stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (c *AgentClient) Stream(ctx context.Context, flags uint8, body []byte) (*AgentStream, error)
 ```
 
-Open a raw streaming session.
+Open a streaming session. The returned [`AgentStream`](#agentstream) carries the protocol correlation id (read it with [`ID()`](#s-id) and pass it to [`Send()`](#c-send) for follow-up frames), and yields frames one at a time via [`Next()`](#s-next).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels opening the stream.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">uint8</span></div>
+    <div className="msb-param-desc">Frame flag byte for the opening frame, e.g. <code>FlagSessionStart</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentstream">*AgentStream</a></div>
+    <div className="msb-param-desc">Open stream of raw frames.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 stream, err := client.Stream(ctx, m.FlagSessionStart, body)
@@ -107,66 +374,310 @@ for {
 
 ---
 
-#### Send()
+#### <span className="msb-recv">c.</span><span className="msb-hn">Send()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (c *AgentClient) Send(ctx context.Context, id uint32, flags uint8, body []byte) error
 ```
 
-Send a follow-up frame on an existing correlation id. Use this with the id returned by `AgentStream.ID()`.
+Send a follow-up frame on an existing correlation id (for example stdin, a signal, a resize, or data chunks on an open session). Use the id returned by [`AgentStream.ID()`](#s-id).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the send.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>id</code><span className="msb-type">uint32</span></div>
+    <div className="msb-param-desc">Correlation id of an open session.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">uint8</span></div>
+    <div className="msb-param-desc">Frame flag byte.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+if err := client.Send(ctx, stream.ID(), 0, stdinBytes); err != nil {
+    return err
+}
+```
 
 ---
 
-#### ReadyBytes()
+#### <span className="msb-recv">c.</span><span className="msb-hn">ReadyBytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (c *AgentClient) ReadyBytes() ([]byte, error)
 ```
 
-Return the cached handshake `core.ready` frame body as CBOR bytes.
+Return the cached handshake `core.ready` frame body as CBOR bytes. Captured during connect, so this reads from the cached handshake rather than producing protocol traffic.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">CBOR-encoded <code>core.ready</code> frame body.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+ready, err := client.ReadyBytes()
+if err != nil {
+    return err
+}
+
+var msg map[string]any
+if err := cbor.Unmarshal(ready, &msg); err != nil {
+    return err
+}
+```
 
 ---
 
-#### Close()
+#### <span className="msb-recv">c.</span><span className="msb-hn">Close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (c *AgentClient) Close() error
 ```
 
-Release the client handle. Calling it more than once is safe.
+Release the client handle. Idempotent: calling it more than once is safe.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+defer client.Close()
+```
 
 ---
 
-#### CloseCtx()
+#### <span className="msb-recv">c.</span><span className="msb-hn">CloseCtx()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (c *AgentClient) CloseCtx(ctx context.Context) error
 ```
 
-Release the client handle with a caller-controlled context.
+Release the client handle with a caller-controlled context. Like [`Close()`](#c-close), but lets you bound or cancel the teardown.
 
----
+<p className="msb-label">Parameters</p>
 
-## RawFrame
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the close.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
-type RawFrame struct {
-    ID    uint32
-    Flags uint8
-    Body  []byte
+if err := client.CloseCtx(ctx); err != nil {
+    return err
 }
 ```
 
-`ID` is the protocol correlation id, `Flags` is the frame flag byte, and `Body` is the CBOR-encoded protocol message body.
+## AgentStream methods
 
 ---
 
-## AgentStream
+#### <span className="msb-recv">s.</span><span className="msb-hn">Next()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *AgentStream) Next(ctx context.Context) (*RawFrame, error)
+```
+
+Pull the next frame from the stream. Returns `nil, nil` at EOF, so loop until the frame is `nil` or carries [`FlagTerminal`](#flagterminal).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels waiting for the next frame.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#rawframe">*RawFrame</a></div>
+    <div className="msb-param-desc">Next frame, or <code>nil</code> at EOF.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+for {
+    frame, err := stream.Next(ctx)
+    if err != nil {
+        return err
+    }
+    if frame == nil {
+        break
+    }
+}
+```
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">ID()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (s *AgentStream) ID() uint32
-func (s *AgentStream) Next(ctx context.Context) (*RawFrame, error)
+```
+
+Return the protocol correlation id for this stream. Pass it to [`AgentClient.Send()`](#c-send) for follow-up frames in the session.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">uint32</span></div>
+    <div className="msb-param-desc">Correlation id for this session.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+id := stream.ID()
+if err := client.Send(ctx, id, 0, stdinBytes); err != nil {
+    return err
+}
+```
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">Close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
 func (s *AgentStream) Close(ctx context.Context) error
 ```
 
-`ID()` returns the protocol correlation id. Pass it to [`AgentClient.Send()`](#send) for follow-up frames in the same session. `Next()` returns `nil, nil` at EOF.
+Release the stream handle.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the close.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+defer stream.Close(ctx)
+```
+
+## Types
+
+### AgentClient
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#m-connectagentsandbox">ConnectAgentSandbox()</a> · <a href="#m-connectagentpath">ConnectAgentPath()</a></p>
+
+Low-level client for talking to `agentd` through the sandbox relay socket. All bodies are raw CBOR bytes: encode and decode them in your code with a library like `fxamacker/cbor`, and build typed convenience methods on top of this client. Construct it with one of the package-level connect functions.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`Request(ctx, flags, body)`](#c-request) | `(`[`*RawFrame`](#rawframe)`, error)` | Send one frame, await one response |
+| [`Stream(ctx, flags, body)`](#c-stream) | `(`[`*AgentStream`](#agentstream)`, error)` | Open a streaming session |
+| [`Send(ctx, id, flags, body)`](#c-send) | `error` | Send a follow-up frame on a correlation id |
+| [`ReadyBytes()`](#c-readybytes) | `([]byte, error)` | Cached `core.ready` handshake frame body |
+| [`Close()`](#c-close) | `error` | Release the handle (idempotent) |
+| [`CloseCtx(ctx)`](#c-closectx) | `error` | Release the handle with a context |
+
+### AgentStream
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#c-stream">Stream()</a></p>
+
+An open raw agent streaming session. Drive it by calling [`Next()`](#s-next) until it returns `nil`, which happens after a frame carrying [`FlagTerminal`](#flagterminal) or when the underlying stream is exhausted.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`Next(ctx)`](#s-next) | `(`[`*RawFrame`](#rawframe)`, error)` | Pull the next frame; `nil` at EOF |
+| [`ID()`](#s-id) | `uint32` | Protocol correlation id; pass to [`Send()`](#c-send) for follow-up frames |
+| [`Close(ctx)`](#s-close) | `error` | Release the stream handle |
+
+### RawFrame
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#c-request">Request()</a> · yielded by <a href="#s-next">Next()</a></p>
+
+A raw protocol frame. `Body` is the CBOR-encoded `Message` body (`v`, `t`, `p`) as it appeared on the wire; decode it with a CBOR library such as `fxamacker/cbor`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| ID | `uint32` | Correlation id from the frame header |
+| Flags | `uint8` | Frame flags (`FlagTerminal`, `FlagSessionStart`, ...) |
+| Body | `[]byte` | Raw CBOR-encoded body bytes |

--- a/docs/sdk/go/execution.mdx
+++ b/docs/sdk/go/execution.mdx
@@ -3,113 +3,271 @@ title: Execution
 description: Go SDK - Command execution API reference
 ---
 
-See [Commands](/sandboxes/commands) for usage examples.
+Run commands inside a running sandbox, collect their output, or stream events live. See [Commands](/sandboxes/commands) for usage examples.
 
-The Go SDK's exec API mirrors `os/exec` conventions: a **non-zero exit code is not a Go error**. Transport, timeout, and spawn-failure paths return an `error`; a program that ran and exited non-zero is a normal `*ExecOutput` result — inspect [`Success()`](#success) or [`ExitCode()`](#exitcode).
+The exec API mirrors `os/exec` conventions: a **non-zero exit code is not a Go error**. Transport, timeout, and spawn-failure paths return an `error`; a program that ran and exited non-zero is a normal [`*ExecOutput`](#execoutput) result, inspect [`Success()`](#out-success) or [`ExitCode()`](#out-exitcode).
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *Sandbox<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#sb-exec"><span className="msb-rn">sb.Exec()</span><span className="msb-rg">run a command, collect output</span></a>
+  <a className="msb-row" href="#sb-shell"><span className="msb-rn">sb.Shell()</span><span className="msb-rg">run via /bin/sh -c</span></a>
+  <a className="msb-row" href="#sb-execstream"><span className="msb-rn">sb.ExecStream()</span><span className="msb-rg">run with streaming events</span></a>
+  <a className="msb-row" href="#sb-shellstream"><span className="msb-rn">sb.ShellStream()</span><span className="msb-rg">streaming shell</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *ExecHandle<span className="msb-ct">8</span></p>
+  <a className="msb-row" href="#h-recv"><span className="msb-rn">h.Recv()</span><span className="msb-rg">next streamed event</span></a>
+  <a className="msb-row" href="#h-collect"><span className="msb-rn">h.Collect()</span><span className="msb-rg">drain into ExecOutput</span></a>
+  <a className="msb-row" href="#h-wait"><span className="msb-rn">h.Wait()</span><span className="msb-rg">wait for exit code</span></a>
+  <a className="msb-row" href="#h-takestdin"><span className="msb-rn">h.TakeStdin()</span><span className="msb-rg">take the stdin pipe</span></a>
+  <a className="msb-row" href="#h-id"><span className="msb-rn">h.ID()</span><span className="msb-rg">session correlation id</span></a>
+  <a className="msb-row" href="#h-signal"><span className="msb-rn">h.Signal()</span><span className="msb-rg">send a Unix signal</span></a>
+  <a className="msb-row" href="#h-kill"><span className="msb-rn">h.Kill()</span><span className="msb-rg">send SIGKILL</span></a>
+  <a className="msb-row" href="#h-close"><span className="msb-rn">h.Close()</span><span className="msb-rg">release the handle</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *ExecOutput<span className="msb-ct">6</span></p>
+  <a className="msb-row" href="#out-stdout"><span className="msb-rn">out.Stdout()</span><span className="msb-rg">stdout as string</span></a>
+  <a className="msb-row" href="#out-stderr"><span className="msb-rn">out.Stderr()</span><span className="msb-rg">stderr as string</span></a>
+  <a className="msb-row" href="#out-stdoutbytes"><span className="msb-rn">out.StdoutBytes()</span><span className="msb-rg">raw stdout bytes</span></a>
+  <a className="msb-row" href="#out-stderrbytes"><span className="msb-rn">out.StderrBytes()</span><span className="msb-rg">raw stderr bytes</span></a>
+  <a className="msb-row" href="#out-exitcode"><span className="msb-rn">out.ExitCode()</span><span className="msb-rg">exit code, or -1</span></a>
+  <a className="msb-row" href="#out-success"><span className="msb-rn">out.Success()</span><span className="msb-rg">exited with code 0</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *ExecSink<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#sink-write"><span className="msb-rn">sink.Write()</span><span className="msb-rg">write to stdin (io.Writer)</span></a>
+  <a className="msb-row" href="#sink-writectx"><span className="msb-rn">sink.WriteCtx()</span><span className="msb-rg">write with explicit ctx</span></a>
+  <a className="msb-row" href="#sink-close"><span className="msb-rn">sink.Close()</span><span className="msb-rg">send EOF, finalize</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Options · ExecOption<span className="msb-ct">5</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#withexeccwd">WithExecCwd()</a>
+    <a className="msb-chip" href="#withexectimeout">WithExecTimeout()</a>
+    <a className="msb-chip" href="#withexecstdinpipe">WithExecStdinPipe()</a>
+    <a className="msb-chip" href="#withexecuser">WithExecUser()</a>
+    <a className="msb-chip" href="#withexecenv">WithExecEnv()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#execoutput">ExecOutput</a>
+    <a className="msb-typepill" href="#exechandle">ExecHandle</a>
+    <a className="msb-typepill" href="#execsink">ExecSink</a>
+    <a className="msb-typepill" href="#execevent">ExecEvent</a>
+    <a className="msb-typepill" href="#execeventkind">ExecEventKind</a>
+    <a className="msb-typepill" href="#execfailure">ExecFailure</a>
+    <a className="msb-typepill" href="#execconfig">ExecConfig</a>
+    <a className="msb-typepill" href="#execoption">ExecOption</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```go
-out, err := sb.Exec(ctx, "python3", []string{"-c", "print(1+1)"})
+import m "github.com/superradcompany/microsandbox/sdk/go"
+
+out, err := sb.Exec(ctx, "python3", []string{"-c", "print(1 + 1)"})
 if err != nil {
     return err // transport / timeout / spawn failure
 }
 if !out.Success() {
-    log.Printf("program exited %d: %s", out.ExitCode(), out.Stderr())
+    log.Printf("exited %d: %s", out.ExitCode(), out.Stderr())
 }
+fmt.Print(out.Stdout())
 ```
 
 ## Sandbox methods
 
-The exec surface lives on [`*Sandbox`](/sdk/go/sandbox#instance-methods):
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `Exec(ctx, cmd, args, opts...)` | `(*ExecOutput, error)` | Run a command and collect output |
-| `ExecStream(ctx, cmd, args, opts...)` | `(*ExecHandle, error)` | Run a command with streaming events |
-| `Shell(ctx, command, opts...)` | `(*ExecOutput, error)` | Run via `/bin/sh -c` |
-| `ShellStream(ctx, command, opts...)` | `(*ExecHandle, error)` | Streaming shell |
-| `Attach(ctx, cmd, args...)` | `(int, error)` | Interactive PTY session |
-| `AttachShell(ctx)` | `(int, error)` | Interactive PTY session in the default shell |
+The exec entry points live on [`*Sandbox`](/sdk/go/sandbox#instance-methods).
 
 ---
 
-## Types
-
-### ExecOutput
-
-The result of a completed command execution.
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `Stdout()` | `string` | Collected stdout decoded as UTF-8 |
-| `Stderr()` | `string` | Collected stderr decoded as UTF-8 |
-| `StdoutBytes()` | `[]byte` | Raw stdout bytes |
-| `StderrBytes()` | `[]byte` | Raw stderr bytes |
-| `ExitCode()` | `int` | Exit code, or `-1` if the guest did not report one (e.g. killed by signal) |
-| `Success()` | `bool` | `true` if `ExitCode()` is `0` |
-
-#### Stdout()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">Exec()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
-func (e *ExecOutput) Stdout() string
+func (s *Sandbox) Exec(ctx context.Context, cmd string, args []string, opts ...ExecOption) (*ExecOutput, error)
 ```
 
-Captured standard output as a UTF-8 string.
+Run a command in the sandbox and return its collected output. Blocks until the command exits. The returned error is non-nil only on transport or runtime failures; a non-zero exit code is reported via [`ExecOutput.ExitCode`](#out-exitcode), not as an error.
 
----
+<p className="msb-label">Parameters</p>
 
-#### Stderr()
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the wait. The guest process may continue in the background.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Program to run. Passed literally to the guest agent (the image ENTRYPOINT is not consulted).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">[]string</span></div>
+    <div className="msb-param-desc">Command arguments. May be <code>nil</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#execoption">...ExecOption</a></div>
+    <div className="msb-param-desc">Per-command cwd, timeout, user, and env.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">*ExecOutput</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit code.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
-func (e *ExecOutput) Stderr() string
+out, err := sb.Exec(ctx, "make", []string{"build"},
+    m.WithExecCwd("/app"),
+    m.WithExecEnv(map[string]string{"DEBUG": "1"}),
+)
 ```
-
-Captured standard error as a UTF-8 string.
 
 ---
 
-#### StdoutBytes()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">Shell()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
-func (e *ExecOutput) StdoutBytes() []byte
+func (s *Sandbox) Shell(ctx context.Context, command string, opts ...ExecOption) (*ExecOutput, error)
 ```
 
-Raw stdout bytes — use when the output may not be valid UTF-8.
+Run `/bin/sh -c command` in the sandbox and collect its output. Blocks until the command exits. A convenience wrapper over [`Exec`](#sb-exec) for shell one-liners.
 
----
+<p className="msb-label">Parameters</p>
 
-#### StderrBytes()
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the wait.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>command</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Shell command line passed to <code>/bin/sh -c</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#execoption">...ExecOption</a></div>
+    <div className="msb-param-desc">Per-command cwd, timeout, user, and env.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">*ExecOutput</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit code.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
-func (e *ExecOutput) StderrBytes() []byte
+out, err := sb.Shell(ctx, "echo $HOME && ls /tmp")
+if err != nil {
+    return err
+}
+fmt.Print(out.Stdout())
 ```
-
-Raw stderr bytes.
 
 ---
 
-#### ExitCode()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">ExecStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
-func (e *ExecOutput) ExitCode() int
+func (s *Sandbox) ExecStream(ctx context.Context, cmd string, args []string, opts ...ExecOption) (*ExecHandle, error)
 ```
 
-The process's exit code, or `-1` if the guest did not report one (e.g. the process was killed by a signal).
+Start a streaming exec session and return an [`*ExecHandle`](#exechandle). The handle MUST be closed with [`Close`](#h-close) when the stream is no longer needed. Nonblocking: the handle returns immediately and the stream starts in the background.
 
----
+`ctx` controls only the start handshake; individual [`Recv`](#h-recv) calls take their own `ctx`. Non-zero exit codes are not errors, inspect [`ExecEventExited`](#execeventkind).
 
-#### Success()
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Controls the start handshake only.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Program to run.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">[]string</span></div>
+    <div className="msb-param-desc">Command arguments. May be <code>nil</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#execoption">...ExecOption</a></div>
+    <div className="msb-param-desc">Per-command options; add <a className="msb-type" href="#withexecstdinpipe">WithExecStdinPipe()</a> to enable stdin.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#exechandle">*ExecHandle</a></div>
+    <div className="msb-param-desc">Live exec session. Close it when done.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
-func (e *ExecOutput) Success() bool
+h, err := sb.ExecStream(ctx, "cat", nil, m.WithExecStdinPipe())
+if err != nil {
+    return err
+}
+defer h.Close()
 ```
-
-`true` if the process exited with code `0`.
 
 ---
 
-### ExecHandle
+#### <span className="msb-recv">sb.</span><span className="msb-hn">ShellStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
-A live streaming exec session returned by [`ExecStream`](/sdk/go/sandbox#execstream) and [`ShellStream`](/sdk/go/sandbox#shellstream). The handle MUST be closed with `Close` when done. **Not safe for concurrent use from multiple goroutines.**
+```go
+func (s *Sandbox) ShellStream(ctx context.Context, command string, opts ...ExecOption) (*ExecHandle, error)
+```
+
+Run `/bin/sh -c command` with streaming output. A convenience wrapper over [`ExecStream`](#sb-execstream). Nonblocking: the handle returns immediately and the stream starts in the background.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Controls the start handshake only.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>command</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Shell command line passed to <code>/bin/sh -c</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#execoption">...ExecOption</a></div>
+    <div className="msb-param-desc">Per-command options.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#exechandle">*ExecHandle</a></div>
+    <div className="msb-param-desc">Live exec session. Close it when done.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 h, err := sb.ShellStream(ctx, "tail -f /var/log/app.log")
@@ -124,6 +282,104 @@ for {
         return err
     }
     switch ev.Kind {
+    case m.ExecEventStdout:
+        os.Stdout.Write(ev.Data)
+    case m.ExecEventDone:
+        return nil
+    }
+}
+```
+
+## ExecHandle methods
+
+A live streaming exec session returned by [`ExecStream`](#sb-execstream) and [`ShellStream`](#sb-shellstream). Not safe for concurrent use from multiple goroutines.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">ID()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ExecHandle) ID() (string, error)
+```
+
+Return the unique identifier for this exec session, assigned by the guest agent. Useful for correlating log entries or referencing the session from external tooling.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Session correlation id.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">TakeStdin()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ExecHandle) TakeStdin() *ExecSink
+```
+
+Return the stdin sink for this exec session. Single-take: returns `nil` if the session was not started with [`WithExecStdinPipe`](#withexecstdinpipe), or if `TakeStdin` was already called on this handle (matching the Node and Python SDKs). The caller is responsible for closing the sink when done writing; closing the sink without closing the exec handle is fine, they own different Rust-side resources.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execsink">*ExecSink</a></div>
+    <div className="msb-param-desc">Stdin writer, or <code>nil</code> if unavailable.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sink := h.TakeStdin()
+sink.Write([]byte("hello\n"))
+sink.Close()
+```
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Recv()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ExecHandle) Recv(ctx context.Context) (*ExecEvent, error)
+```
+
+Block until the next event arrives or the stream ends. Returns an event with `Kind == ExecEventDone` when all events have been consumed. `ctx` controls the wait; cancellation causes `Recv` to return `ctx.Err()` immediately. The underlying Rust call may continue to completion in the background.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the wait for the next event.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execevent">*ExecEvent</a></div>
+    <div className="msb-param-desc">The next streamed event.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+for {
+    ev, err := h.Recv(ctx)
+    if err != nil {
+        return err
+    }
+    switch ev.Kind {
     case m.ExecEventStarted:
         fmt.Printf("started pid=%d\n", ev.PID)
     case m.ExecEventStdout:
@@ -132,83 +388,84 @@ for {
         os.Stderr.Write(ev.Data)
     case m.ExecEventExited:
         fmt.Printf("exited code=%d\n", ev.ExitCode)
-    case m.ExecEventStdinError:
-        fmt.Printf("stdin error: %s\n", ev.Failure.Message)
     case m.ExecEventDone:
         return nil
     }
 }
 ```
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `ID()` | `(string, error)` | Correlation ID assigned by the guest agent |
-| `Recv(ctx)` | `(*ExecEvent, error)` | Block until the next event arrives |
-| `TakeStdin()` | `*ExecSink` | Take the stdin writer (single-take; only with [`WithExecStdinPipe`](#withexecstdinpipe)) |
-| `Collect(ctx)` | `(*ExecOutput, error)` | Drain remaining output and assemble into an `ExecOutput` |
-| `Wait(ctx)` | `(int, error)` | Wait for exit, discarding output; returns the exit code |
-| `Kill(ctx)` | `error` | Send SIGKILL |
-| `Signal(ctx, sig)` | `error` | Send a Unix signal (e.g. `syscall.SIGTERM`) |
-| `Close()` | `error` | Release the Rust-side handle |
-
-#### ID()
-
-```go
-func (h *ExecHandle) ID() (string, error)
-```
-
-Return the unique identifier for this exec session, assigned by the guest agent. Useful for correlating log entries.
-
 ---
 
-#### Recv()
-
-```go
-func (h *ExecHandle) Recv(ctx context.Context) (*ExecEvent, error)
-```
-
-Block until the next event arrives or the stream ends. Returns an event with `Kind == ExecEventDone` when all events have been consumed.
-
-`ctx` controls the wait; cancellation causes `Recv` to return `ctx.Err()` immediately. The underlying Rust call may continue to completion in the background.
-
----
-
-#### TakeStdin()
-
-```go
-func (h *ExecHandle) TakeStdin() *ExecSink
-```
-
-Return the stdin writer for this exec session. Returns `nil` if:
-
-- the session was not started with [`WithExecStdinPipe`](#withexecstdinpipe), or
-- `TakeStdin` has already been called on this handle (single-take semantics, matching Node and Python).
-
-The caller is responsible for closing the sink when done writing. Closing the sink without closing the exec handle is fine — they own different Rust-side resources.
-
----
-
-#### Collect()
+#### <span className="msb-recv">h.</span><span className="msb-hn">Collect()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (h *ExecHandle) Collect(ctx context.Context) (*ExecOutput, error)
 ```
 
-Drain the stream, accumulate all output, and return it as an [`*ExecOutput`](#execoutput). Equivalent to calling `Recv` in a loop and assembling the result.
+Drain the stream, accumulate all output, and return it as an [`*ExecOutput`](#execoutput). Equivalent to calling [`Recv`](#h-recv) in a loop and assembling the result. The handle should be closed after `Collect` returns.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the drain.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">*ExecOutput</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit code.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+out, err := h.Collect(ctx)
+if err != nil {
+    return err
+}
+fmt.Print(out.Stdout())
+```
 
 ---
 
-#### Wait()
+#### <span className="msb-recv">h.</span><span className="msb-hn">Wait()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (h *ExecHandle) Wait(ctx context.Context) (int, error)
 ```
 
-Block until the process exits and return its exit code. Unlike `Collect`, stdout and stderr are discarded.
+Block until the process exits and return its exit code. Unlike [`Collect`](#h-collect), stdout and stderr are discarded. The handle should be closed after `Wait` returns.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the wait.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Process exit code.</div>
+  </div>
+</div>
 
 ---
 
-#### Kill()
+#### <span className="msb-recv">h.</span><span className="msb-hn">Kill()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (h *ExecHandle) Kill(ctx context.Context) error
@@ -216,9 +473,19 @@ func (h *ExecHandle) Kill(ctx context.Context) error
 
 Send SIGKILL to the running process.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the call.</div>
+  </div>
+</div>
+
 ---
 
-#### Signal()
+#### <span className="msb-recv">h.</span><span className="msb-hn">Signal()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (h *ExecHandle) Signal(ctx context.Context, signal int) error
@@ -226,21 +493,204 @@ func (h *ExecHandle) Signal(ctx context.Context, signal int) error
 
 Send a Unix signal to the running process. Pass values from `syscall` (e.g. `int(syscall.SIGTERM)`).
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the call.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>signal</code><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Signal number, e.g. <code>int(syscall.SIGTERM)</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+import "syscall"
+
+if err := h.Signal(ctx, int(syscall.SIGTERM)); err != nil {
+    return err
+}
+```
+
 ---
 
-#### Close()
+#### <span className="msb-recv">h.</span><span className="msb-hn">Close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (h *ExecHandle) Close() error
 ```
 
-Release the Rust-side exec handle. Does not kill the running process; call `Signal(ctx, 9)` or `Kill` first if you need to terminate it. Safe to call after `ExecEventDone` has been received.
+Release the Rust-side exec handle. Does not kill the running process; call [`Signal`](#h-signal) or [`Kill`](#h-kill) first if you need to terminate it. Safe to call after `ExecEventDone` has been received.
+
+<p className="msb-label">Example</p>
+
+```go
+defer h.Close()
+```
+
+## ExecOutput methods
+
+The collected result of a completed command execution, returned by [`Exec`](#sb-exec), [`Shell`](#sb-shell), and [`Collect`](#h-collect).
 
 ---
 
-### ExecSink
+#### <span className="msb-recv">out.</span><span className="msb-hn">Stdout()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
-A write-only pipe to a running process's stdin, obtained from [`ExecHandle.TakeStdin`](#takestdin). Implements `io.WriteCloser`.
+```go
+func (e *ExecOutput) Stdout() string
+```
+
+Captured standard output as a string.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Collected stdout.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">out.</span><span className="msb-hn">StdoutBytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (e *ExecOutput) StdoutBytes() []byte
+```
+
+Captured standard output as raw bytes. Use when the output may not be valid UTF-8.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">Raw stdout bytes.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">out.</span><span className="msb-hn">Stderr()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (e *ExecOutput) Stderr() string
+```
+
+Captured standard error as a string.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Collected stderr.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">out.</span><span className="msb-hn">StderrBytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (e *ExecOutput) StderrBytes() []byte
+```
+
+Captured standard error as raw bytes.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">Raw stderr bytes.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">out.</span><span className="msb-hn">ExitCode()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (e *ExecOutput) ExitCode() int
+```
+
+The process's exit code, or `-1` if the guest did not report one (e.g. the process was killed by a signal).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Exit code, or <code>-1</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">out.</span><span className="msb-hn">Success()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (e *ExecOutput) Success() bool
+```
+
+Reports whether the command exited with code `0`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> if <code>ExitCode()</code> is <code>0</code>.</div>
+  </div>
+</div>
+
+## ExecSink methods
+
+A write-only pipe to a running process's stdin, obtained from [`ExecHandle.TakeStdin`](#h-takestdin). Implements `io.WriteCloser`. `Write` and `Close` use `context.Background()` under the hood; for caller-controlled cancellation use [`WriteCtx`](#sink-writectx), or tear the session down via [`ExecHandle.Kill`](#h-kill) / [`Close`](#h-close).
+
+---
+
+#### <span className="msb-recv">sink.</span><span className="msb-hn">Write()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (sk *ExecSink) Write(p []byte) (int, error)
+```
+
+Send data to the process stdin. Implements `io.Writer`. Uses `context.Background()` internally, there is no way to cancel a stuck write through this method alone.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>p</code><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">Bytes to write to stdin.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Number of bytes written.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 h, err := sb.ExecStream(ctx, "cat", nil, m.WithExecStdinPipe())
@@ -254,38 +704,152 @@ sink.Write([]byte("hello\n"))
 sink.Close()
 
 out, _ := h.Collect(ctx)
-fmt.Println(out.Stdout()) // "hello\n"
+fmt.Print(out.Stdout()) // "hello\n"
 ```
 
-`Write` and `Close` use `context.Background()` under the hood. For caller-controlled cancellation use `WriteCtx`, or tear the session down via `ExecHandle.Kill` / `Close`.
+---
+
+#### <span className="msb-recv">sink.</span><span className="msb-hn">WriteCtx()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (sk *ExecSink) WriteCtx(ctx context.Context, p []byte) (int, error)
+```
+
+Like [`Write`](#sink-write), but with a caller-controlled context, so a stuck stdin write can be cancelled.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the write.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>p</code><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">Bytes to write to stdin.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Number of bytes written.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">sink.</span><span className="msb-hn">Close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (sk *ExecSink) Close() error
+```
+
+Close the stdin pipe, sending EOF to the process. Implements `io.Closer`.
+
+<p className="msb-label">Example</p>
+
+```go
+sink.Close()
+```
+
+## Types
+
+---
+
+### ExecOutput
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-exec">sb.Exec()</a> · <a href="#sb-shell">sb.Shell()</a> · <a href="#h-collect">h.Collect()</a></p>
+
+The collected result of a command execution. A non-zero `ExitCode` is not treated as a Go error, callers inspect [`Success`](#out-success) or [`ExitCode`](#out-exitcode) explicitly, matching how `os/exec.Cmd.Output` works against a script that exits non-zero.
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `Write(p []byte)` | `(int, error)` | Implements `io.Writer` |
-| `WriteCtx(ctx, data)` | `error` | Write with explicit context |
-| `Close()` | `error` | Send EOF and finalise |
+| [`Stdout()`](#out-stdout) | `string` | Captured stdout as a string |
+| [`StdoutBytes()`](#out-stdoutbytes) | `[]byte` | Raw stdout bytes |
+| [`Stderr()`](#out-stderr) | `string` | Captured stderr as a string |
+| [`StderrBytes()`](#out-stderrbytes) | `[]byte` | Raw stderr bytes |
+| [`ExitCode()`](#out-exitcode) | `int` | Exit code, or `-1` if the guest did not report one |
+| [`Success()`](#out-success) | `bool` | `true` if `ExitCode()` is `0` |
+
+---
+
+### ExecHandle
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-execstream">sb.ExecStream()</a> · <a href="#sb-shellstream">sb.ShellStream()</a></p>
+
+A live streaming exec session. Must be closed with [`Close`](#h-close) when done to release Rust-side resources. Not safe for concurrent use from multiple goroutines.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`ID()`](#h-id) | `(string, error)` | Session correlation id assigned by the guest agent |
+| [`TakeStdin()`](#h-takestdin) | [`*ExecSink`](#execsink) | Take the stdin writer (single-take; only with `WithExecStdinPipe`) |
+| [`Recv(ctx)`](#h-recv) | [`(*ExecEvent, error)`](#execevent) | Block until the next event arrives |
+| [`Collect(ctx)`](#h-collect) | [`(*ExecOutput, error)`](#execoutput) | Drain remaining output into an `ExecOutput` |
+| [`Wait(ctx)`](#h-wait) | `(int, error)` | Wait for exit, discarding output; returns the exit code |
+| [`Kill(ctx)`](#h-kill) | `error` | Send SIGKILL |
+| [`Signal(ctx, signal)`](#h-signal) | `error` | Send a Unix signal |
+| [`Close()`](#h-close) | `error` | Release the Rust-side handle |
+
+---
+
+### ExecSink
+
+<div className="msb-tags"><span className="msb-tag is-type">type alias</span></div>
+
+<p className="msb-backref">Returned by <a href="#h-takestdin">h.TakeStdin()</a></p>
+
+```go
+type ExecSink = ffi.ExecSink
+```
+
+A write-only pipe to a running process's stdin. Implements `io.WriteCloser`.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`Write(p)`](#sink-write) | `(int, error)` | Implements `io.Writer` |
+| [`WriteCtx(ctx, p)`](#sink-writectx) | `(int, error)` | Write with explicit context |
+| [`Close()`](#sink-close) | `error` | Send EOF and finalize |
 
 ---
 
 ### ExecEvent
 
-One event emitted by [`ExecHandle.Recv`](#recv).
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#h-recv">h.Recv()</a></p>
+
+One event from a streaming exec session. [`Kind`](#execeventkind) identifies which fields are populated.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| Kind | [`ExecEventKind`](#execeventkind) | Identifies which fields are populated |
-| PID | `uint32` | Guest process ID — set on `ExecEventStarted` |
-| Data | `[]byte` | Chunk of stdout or stderr — set on `ExecEventStdout` / `ExecEventStderr` |
-| ExitCode | `int` | Process exit code — set on `ExecEventExited` |
-| Failure | [`*ExecFailure`](#execfailure) | Structured spawn-failure detail — set on `ExecEventFailed` |
+| `Kind` | [`ExecEventKind`](#execeventkind) | Identifies which fields are populated |
+| `PID` | `uint32` | Guest process id, set on `ExecEventStarted` |
+| `Data` | `[]byte` | Chunk of stdout or stderr, set on `ExecEventStdout` / `ExecEventStderr` |
+| `ExitCode` | `int` | Process exit code, set on `ExecEventExited` |
+| `Failure` | [`*ExecFailure`](#execfailure) | Failure detail, set on `ExecEventFailed` and `ExecEventStdinError` |
 
 ---
 
 ### ExecEventKind
 
+<div className="msb-tags"><span className="msb-tag is-type">type alias</span></div>
+
+<p className="msb-backref">Field of <a href="#execevent">ExecEvent</a></p>
+
 ```go
 type ExecEventKind = ffi.ExecEventKind
 ```
+
+Identifies what an [`ExecEvent`](#execevent) carries.
 
 | Constant | Description |
 |----------|-------------|
@@ -293,63 +857,105 @@ type ExecEventKind = ffi.ExecEventKind
 | `ExecEventStdout` | A chunk of stdout; `Data` is valid |
 | `ExecEventStderr` | A chunk of stderr; `Data` is valid |
 | `ExecEventExited` | The process exited; `ExitCode` is valid |
-| `ExecEventFailed` | The user program never started (binary missing, permission denied, ...); `Failure` is valid |
-| `ExecEventStdinError` | A stdin write failed; `Failure` is valid. Non-terminal: the process may still emit output and exit normally |
+| `ExecEventFailed` | The user program never started (binary missing, permission denied, ...); `Failure` is valid and `ExitCode` is not meaningful |
+| `ExecEventStdinError` | A stdin write failed; `Failure` is valid. Non-terminal: the process may still exit normally |
 | `ExecEventDone` | All events have been consumed |
 
 ---
 
 ### ExecFailure
 
+<div className="msb-tags"><span className="msb-tag is-type">type alias</span></div>
+
+<p className="msb-backref">Field of <a href="#execevent">ExecEvent</a></p>
+
 ```go
 type ExecFailure = ffi.ExecFailure
 ```
 
-Structured detail about a failed-to-start exec. Populated on `ExecEventFailed`. See [Error Handling](/sdk/errors#spawn-time-exec-failures) for the kinds it carries (`not_found`, `permission_denied`, etc.) and how to branch on them.
+Structured detail about a failed-to-start exec, populated on `ExecEventFailed` and `ExecEventStdinError`. See [Error Handling](/sdk/errors#spawn-time-exec-failures) for the kinds it carries (`not_found`, `permission_denied`, etc.) and how to branch on them.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Kind` | `string` | Failure category, e.g. `not_found`, `permission_denied` |
+| `Errno` | `*int` | Underlying errno, if known |
+| `ErrnoName` | `string` | Symbolic errno name, if known |
+| `Message` | `string` | Human-readable failure message |
+| `Path` | `string` | Offending path, if applicable |
 
 ---
 
 ### ExecConfig
 
-The config struct populated by [`ExecOption`](#execoption) functions. Most callers go through `Exec(ctx, cmd, args, ...opts)`; `ExecConfig` is exported for callers that prefer to construct one directly.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Populated by <a href="#execoption">ExecOption</a></p>
+
+Configures a single [`Exec`](#sb-exec) or [`ExecStream`](#sb-execstream) call. Most callers set fields through the `WithExec*` functional options; `ExecConfig` is exported for parity with the other SDKs' config types.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| Cwd | `string` | Working directory inside the guest |
-| Timeout | `time.Duration` | Kill the process after this duration. Sub-second precision is rounded up |
-| StdinPipe | `bool` | Enable a stdin pipe; required for [`TakeStdin`](#takestdin) |
-| User | `string` | Guest user (UID or name) |
-| Env | `map[string]string` | Per-command environment variables |
+| `Cwd` | `string` | Working directory inside the guest |
+| `Timeout` | `time.Duration` | Kill the process after this duration; sub-second precision is rounded up |
+| `StdinPipe` | `bool` | Enable a stdin pipe; required for [`TakeStdin`](#h-takestdin) |
+| `User` | `string` | Guest user (UID or name) |
+| `Env` | `map[string]string` | Per-command environment variables |
 
 ---
 
 ### ExecOption
 
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+<p className="msb-backref">Accepted by <a href="#sb-exec">sb.Exec()</a> · <a href="#sb-shell">sb.Shell()</a> · <a href="#sb-execstream">sb.ExecStream()</a> · <a href="#sb-shellstream">sb.ShellStream()</a></p>
+
 ```go
 type ExecOption func(*ExecConfig)
 ```
 
-A functional option for [`Exec`](/sdk/go/sandbox#exec), [`Shell`](/sdk/go/sandbox#shell), [`ExecStream`](/sdk/go/sandbox#execstream), and [`ShellStream`](/sdk/go/sandbox#shellstream).
+A functional option that mutates an [`ExecConfig`](#execconfig). Construct them with the `WithExec*` functions below.
 
 ---
 
-#### WithExecCwd()
+#### <span className="msb-hn">WithExecCwd()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
 func WithExecCwd(path string) ExecOption
 ```
 
-Working directory for a single command.
+Set the working directory for a single command.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
 
 ---
 
-#### WithExecTimeout()
+#### <span className="msb-hn">WithExecTimeout()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
 func WithExecTimeout(d time.Duration) ExecOption
 ```
 
-Per-command timeout. When exceeded, the guest terminates the process and the call returns an error with `Kind == ErrExecTimeout`. Sub-second precision rounds up to whole seconds; pass at least 1 second.
+Set a per-command timeout. When exceeded, the guest terminates the process and the call returns an error with `Kind == ErrExecTimeout`. Sub-second precision rounds up to whole seconds; pass at least 1 second.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>d</code><span className="msb-type">time.Duration</span></div>
+    <div className="msb-param-desc">Timeout duration, rounded up to whole seconds.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 out, err := sb.Shell(ctx, "long-running-task",
@@ -361,17 +967,19 @@ if m.IsKind(err, m.ErrExecTimeout) {
 
 ---
 
-#### WithExecStdinPipe()
+#### <span className="msb-hn">WithExecStdinPipe()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
 func WithExecStdinPipe() ExecOption
 ```
 
-Enable a stdin pipe for the exec session, allowing data to be written via [`ExecHandle.TakeStdin`](#takestdin).
+Enable a stdin pipe for the exec session, allowing data to be written via [`ExecHandle.TakeStdin`](#h-takestdin).
 
 ---
 
-#### WithExecUser()
+#### <span className="msb-hn">WithExecUser()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
 func WithExecUser(user string) ExecOption
@@ -379,15 +987,36 @@ func WithExecUser(user string) ExecOption
 
 Run the command as the given guest user (UID or name).
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>user</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Guest user, as a UID or name.</div>
+  </div>
+</div>
+
 ---
 
-#### WithExecEnv()
+#### <span className="msb-hn">WithExecEnv()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
 func WithExecEnv(env map[string]string) ExecOption
 ```
 
-Per-command environment variables. Called repeatedly, maps merge; later keys overwrite earlier ones.
+Add per-command environment variables. Called repeatedly, maps merge; later keys overwrite earlier ones.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>env</code><span className="msb-type">map[string]string</span></div>
+    <div className="msb-param-desc">Environment variables for this command.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 out, err := sb.Exec(ctx, "make", []string{"build"},

--- a/docs/sdk/go/filesystem.mdx
+++ b/docs/sdk/go/filesystem.mdx
@@ -3,94 +3,252 @@ title: Filesystem
 description: Go SDK - Filesystem API reference
 ---
 
-See [Filesystem](/sandboxes/filesystem) for usage examples.
+Read and write files inside a running sandbox over the same host-guest channel as command execution: no SSH, no network. See [Filesystem](/sandboxes/filesystem) for usage examples. For bulk file transfer, prefer a [volume](/sdk/go/volumes).
 
-## SandboxFsOps
+<div className="msb-glance">
 
-Filesystem accessor for a running sandbox. Obtained via [`Sandbox.FS()`](/sdk/go/sandbox#fs). All operations go through the same host-guest channel as command execution — no SSH, no network involved. For bulk file operations, consider using a [volume](/sdk/go/volumes) instead.
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · SandboxFSOps<span className="msb-ct">16</span></p>
+  <a className="msb-row" href="#fs-read"><span className="msb-rn">fs.Read()</span><span className="msb-rg">read a file as bytes</span></a>
+  <a className="msb-row" href="#fs-readstring"><span className="msb-rn">fs.ReadString()</span><span className="msb-rg">read a file as a string</span></a>
+  <a className="msb-row" href="#fs-write"><span className="msb-rn">fs.Write()</span><span className="msb-rg">write bytes</span></a>
+  <a className="msb-row" href="#fs-writestring"><span className="msb-rn">fs.WriteString()</span><span className="msb-rg">write a string</span></a>
+  <a className="msb-row" href="#fs-list"><span className="msb-rn">fs.List()</span><span className="msb-rg">list a directory</span></a>
+  <a className="msb-row" href="#fs-stat"><span className="msb-rn">fs.Stat()</span><span className="msb-rg">file metadata</span></a>
+  <a className="msb-row" href="#fs-mkdir"><span className="msb-rn">fs.Mkdir()</span><span className="msb-rg">create a directory</span></a>
+  <a className="msb-row" href="#fs-remove"><span className="msb-rn">fs.Remove()</span><span className="msb-rg">delete a file</span></a>
+  <a className="msb-row" href="#fs-removedir"><span className="msb-rn">fs.RemoveDir()</span><span className="msb-rg">delete a directory</span></a>
+  <a className="msb-row" href="#fs-copy"><span className="msb-rn">fs.Copy()</span><span className="msb-rg">copy within the guest</span></a>
+  <a className="msb-row" href="#fs-rename"><span className="msb-rn">fs.Rename()</span><span className="msb-rg">rename / move</span></a>
+  <a className="msb-row" href="#fs-exists"><span className="msb-rn">fs.Exists()</span><span className="msb-rg">test a path</span></a>
+  <a className="msb-row" href="#fs-copyfromhost"><span className="msb-rn">fs.CopyFromHost()</span><span className="msb-rg">host file into guest</span></a>
+  <a className="msb-row" href="#fs-copytohost"><span className="msb-rn">fs.CopyToHost()</span><span className="msb-rg">guest file to host</span></a>
+  <a className="msb-row" href="#fs-readstream"><span className="msb-rn">fs.ReadStream()</span><span className="msb-rg">stream a large read</span></a>
+  <a className="msb-row" href="#fs-writestream"><span className="msb-rn">fs.WriteStream()</span><span className="msb-rg">stream a large write</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#fsentry">FsEntry</a>
+    <a className="msb-typepill" href="#fsentrykind">FsEntryKind</a>
+    <a className="msb-typepill" href="#fsstat">FsStat</a>
+    <a className="msb-typepill" href="#fsreadstream">FsReadStream</a>
+    <a className="msb-typepill" href="#fswritestream">FsWriteStream</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```go
-fs := sb.FS()
+import m "github.com/superradcompany/microsandbox/sdk/go"
 
-if err := fs.WriteString(ctx, "/tmp/config.json", `{"debug": true}`); err != nil {
+fs := sb.FS()                                              // 1. get the accessor
+
+err := fs.WriteString(ctx, "/tmp/config.json", `{"debug":true}`)  // 2. write
+if err != nil {
     return err
 }
-content, err := fs.ReadString(ctx, "/tmp/config.json")
+
+content, err := fs.ReadString(ctx, "/tmp/config.json")    // 3. read back
+if err != nil {
+    return err
+}
+fmt.Println(content)
 ```
+
+## Methods
+
+The accessor is obtained from a running sandbox via [`sb.FS()`](/sdk/go/sandbox#fs). Every method takes a `context.Context` first and returns an `error` (wrapped, inspectable with `m.IsKind`).
 
 ---
 
-#### Read()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">Read()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) Read(ctx context.Context, path string) ([]byte, error)
 ```
 
-Read the entire contents of a file as raw bytes.
+Read the entire contents of a file as raw bytes. The default FFI buffer is 1 MiB; for files larger than ~750 KiB (after base64 inflation) the runtime returns `BufferTooSmall` on the single-shot path, and this method transparently falls back to [`ReadStream`](#fs-readstream) so callers get a uniform bytes-returning interface up to runtime memory limits.
 
-The default FFI buffer is 1 MiB. For files larger than ~750 KiB (after base64 inflation) the runtime returns `BufferTooSmall` on the single-shot path; this method transparently falls back to `ReadStream` so callers get a uniform "Read returns bytes" interface up to runtime memory limits.
+<p className="msb-label">Parameters</p>
 
-**Parameters**
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the read.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest, e.g. <code>"/app/config.json"</code>.</div>
+  </div>
+</div>
 
-| Name | Type | Description |
-|------|------|-------------|
-| ctx | `context.Context` | Cancels the read |
-| path | `string` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+<p className="msb-label">Returns</p>
 
-**Returns**
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">File contents.</div>
+  </div>
+</div>
 
-| Type | Description |
-|------|-------------|
-| `[]byte` | File contents |
+<p className="msb-label">Example</p>
+
+```go
+data, err := fs.Read(ctx, "/etc/hostname")
+if err != nil {
+    return err
+}
+fmt.Printf("%d bytes\n", len(data))
+```
 
 ---
 
-#### ReadString()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">ReadString()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) ReadString(ctx context.Context, path string) (string, error)
 ```
 
-Read the entire contents of a file and return as a string (UTF-8 reinterpretation of the bytes; no validation).
+Read a file and return its contents as a string. The bytes are reinterpreted as UTF-8 without validation.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the read.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">File contents.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+content, err := fs.ReadString(ctx, "/tmp/config.json")
+```
 
 ---
 
-#### Write()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">Write()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) Write(ctx context.Context, path string, data []byte) error
 ```
 
-Write bytes to a file, creating it if it doesn't exist and truncating if it does.
+Write bytes to a file, creating it if it does not exist and truncating it if it does.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the write.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>data</code><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">Bytes to write.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := fs.Write(ctx, "/tmp/data.bin", []byte{0x00, 0x01, 0x02})
+```
 
 ---
 
-#### WriteString()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">WriteString()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) WriteString(ctx context.Context, path, content string) error
 ```
 
-Write a UTF-8 string to a file.
+Write a UTF-8 string to a file. Convenience wrapper over [`Write`](#fs-write).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the write.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Text to write.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := fs.WriteString(ctx, "/tmp/hello.txt", "hi")
+```
 
 ---
 
-#### List()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">List()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) List(ctx context.Context, path string) ([]FsEntry, error)
 ```
 
-List the entries in a directory.
+List the entries in a directory inside the sandbox.
 
-**Returns**
+<p className="msb-label">Parameters</p>
 
-| Type | Description |
-|------|-------------|
-| `[]`[`FsEntry`](#fsentry) | Directory entries |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the listing.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute directory path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsentry">[]FsEntry</a></div>
+    <div className="msb-param-desc">Directory entries.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 entries, err := fs.List(ctx, "/etc")
+if err != nil {
+    return err
+}
 for _, e := range entries {
     fmt.Printf("%s (%s, %d bytes)\n", e.Path, e.Kind, e.Size)
 }
@@ -98,7 +256,8 @@ for _, e := range entries {
 
 ---
 
-#### Stat()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">Stat()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) Stat(ctx context.Context, path string) (*FsStat, error)
@@ -106,35 +265,102 @@ func (fs *SandboxFSOps) Stat(ctx context.Context, path string) (*FsStat, error)
 
 Get detailed metadata for a file or directory.
 
-**Returns**
+<p className="msb-label">Parameters</p>
 
-| Type | Description |
-|------|-------------|
-| [`*FsStat`](#fsstat) | File metadata |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the stat.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsstat">*FsStat</a></div>
+    <div className="msb-param-desc">File metadata.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+st, err := fs.Stat(ctx, "/etc/hosts")
+if err != nil {
+    return err
+}
+fmt.Printf("%d bytes, dir=%v\n", st.Size, st.IsDir)
+```
 
 ---
 
-#### Mkdir()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">Mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) Mkdir(ctx context.Context, path string) error
 ```
 
-Create a directory and all missing parents.
+Create a directory and any missing parents inside the sandbox.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the operation.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute directory path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := fs.Mkdir(ctx, "/app/cache/sessions")
+```
 
 ---
 
-#### Remove()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">Remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) Remove(ctx context.Context, path string) error
 ```
 
-Remove a single file. Use [`RemoveDir`](#removedir) for directories.
+Delete a single file. Use [`RemoveDir`](#fs-removedir) for directories.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the operation.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute file path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := fs.Remove(ctx, "/tmp/scratch.txt")
+```
 
 ---
 
-#### RemoveDir()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">RemoveDir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) RemoveDir(ctx context.Context, path string) error
@@ -142,9 +368,29 @@ func (fs *SandboxFSOps) RemoveDir(ctx context.Context, path string) error
 
 Remove a directory recursively.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the operation.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute directory path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := fs.RemoveDir(ctx, "/app/cache")
+```
+
 ---
 
-#### Copy()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">Copy()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) Copy(ctx context.Context, src, dst string) error
@@ -152,9 +398,33 @@ func (fs *SandboxFSOps) Copy(ctx context.Context, src, dst string) error
 
 Copy a file within the sandbox.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the operation.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Source path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := fs.Copy(ctx, "/etc/hosts", "/tmp/hosts.bak")
+```
+
 ---
 
-#### Rename()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">Rename()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) Rename(ctx context.Context, src, dst string) error
@@ -162,19 +432,78 @@ func (fs *SandboxFSOps) Rename(ctx context.Context, src, dst string) error
 
 Rename or move a file or directory within the sandbox.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the operation.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Current path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">New path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := fs.Rename(ctx, "/tmp/old.log", "/tmp/archive/old.log")
+```
+
 ---
 
-#### Exists()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">Exists()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) Exists(ctx context.Context, path string) (bool, error)
 ```
 
-Report whether a path exists inside the sandbox.
+Report whether a file or directory exists at the given path.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the check.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> if the path exists.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+ok, err := fs.Exists(ctx, "/app/.initialized")
+if err != nil {
+    return err
+}
+if !ok {
+    // first boot
+}
+```
 
 ---
 
-#### CopyFromHost()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">CopyFromHost()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) CopyFromHost(ctx context.Context, hostPath, guestPath string) error
@@ -182,9 +511,33 @@ func (fs *SandboxFSOps) CopyFromHost(ctx context.Context, hostPath, guestPath st
 
 Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sdk/go/volumes#mountbind) instead.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the copy.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hostPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Source path on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guestPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := fs.CopyFromHost(ctx, "./seed.db", "/app/data/seed.db")
+```
+
 ---
 
-#### CopyToHost()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">CopyToHost()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) CopyToHost(ctx context.Context, guestPath, hostPath string) error
@@ -192,15 +545,63 @@ func (fs *SandboxFSOps) CopyToHost(ctx context.Context, guestPath, hostPath stri
 
 Copy a file from the sandbox to the host machine.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the copy.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guestPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Source path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hostPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination path on the host.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := fs.CopyToHost(ctx, "/app/output/report.csv", "./report.csv")
+```
+
 ---
 
-#### ReadStream()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">ReadStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) ReadStream(ctx context.Context, path string) (*FsReadStream, error)
 ```
 
-Open a streaming reader for a file. Data is transferred in chunks (~3 MiB each). Use this for files too large to fit in memory. The caller must `Close` the returned [`*FsReadStream`](#fsreadstream).
+Open a streaming reader for a file. Use this for files too large to fit in memory; data is delivered in chunks. The caller must `Close` the returned [`*FsReadStream`](#fsreadstream). [`Read`](#fs-read) falls back to this automatically when a file exceeds the single-shot buffer.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels opening the stream.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsreadstream">*FsReadStream</a></div>
+    <div className="msb-param-desc">Open read stream; close it when done.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 rs, err := fs.ReadStream(ctx, "/var/log/syslog")
@@ -209,7 +610,6 @@ if err != nil {
 }
 defer rs.Close()
 
-// Streaming pattern.
 for {
     chunk, err := rs.Recv(ctx)
     if err != nil {
@@ -221,19 +621,44 @@ for {
     os.Stdout.Write(chunk)
 }
 
-// Or as an io.WriterTo.
+// Or drain it as an io.WriterTo.
 _, err = rs.WriteTo(os.Stdout)
 ```
 
 ---
 
-#### WriteStream()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">WriteStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *SandboxFSOps) WriteStream(ctx context.Context, path string) (*FsWriteStream, error)
 ```
 
-Open a streaming writer for a file. Use this for files too large to fit in memory. The caller must call `Close(ctx)` on the returned [`*FsWriteStream`](#fswritestream) to finalise the operation.
+Open a streaming writer for a file. Use this for files too large to fit in memory. The caller must call `Close(ctx)` on the returned [`*FsWriteStream`](#fswritestream) to finalise the write.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels opening the stream.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fswritestream">*FsWriteStream</a></div>
+    <div className="msb-param-desc">Open write stream; <code>Close(ctx)</code> it to finalise.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 ws, err := fs.WriteStream(ctx, "/tmp/big.bin")
@@ -255,7 +680,11 @@ if err := ws.Close(ctx); err != nil {
 
 ### FsEntry
 
-A single directory listing entry returned by [`List`](#list).
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#fs-list">List()</a></p>
+
+A single directory listing entry.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -266,9 +695,11 @@ A single directory listing entry returned by [`List`](#list).
 
 ### FsEntryKind
 
-```go
-type FsEntryKind string
-```
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+<p className="msb-backref">Used by <a href="#fsentry">FsEntry.Kind</a></p>
+
+Classifies a directory listing entry. Defined as `type FsEntryKind string`.
 
 | Constant | Value | Description |
 |----------|-------|-------------|
@@ -279,43 +710,47 @@ type FsEntryKind string
 
 ### FsStat
 
-Detailed file metadata returned by [`Stat`](#stat).
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#fs-stat">Stat()</a></p>
+
+Detailed file metadata.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | Path | `string` | File path |
 | Size | `int64` | File size in bytes |
 | Mode | `uint32` | Unix permission bits |
-| ModTime | `time.Time` | Last modified timestamp (zero value if the guest did not report one) |
+| ModTime | `time.Time` | Last modified timestamp; zero value if the guest did not report one |
 | IsDir | `bool` | Whether the path is a directory |
 
 ### FsReadStream
 
-Streaming file read returned by [`ReadStream`](#readstream). Must be closed when done.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-```go
-type FsReadStream struct { /* ... */ }
-```
+<p className="msb-backref">Returned by <a href="#fs-readstream">ReadStream()</a></p>
+
+An open streaming read from a guest file. Must be closed with `Close` when done.
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `Recv(ctx)` | `([]byte, error)` | Receive the next chunk. Returns `(nil, nil)` at EOF |
-| `WriteTo(w io.Writer)` | `(int64, error)` | Drain the stream into `w` using `context.Background()` — implements `io.WriterTo` |
-| `CopyTo(ctx, w io.Writer)` | `(int64, error)` | Drain into `w` with caller-supplied context |
+| `Recv(ctx context.Context)` | `([]byte, error)` | Receive the next chunk; returns `(nil, nil)` at EOF |
+| `WriteTo(w io.Writer)` | `(int64, error)` | Drain the stream into `w` using `context.Background()`; implements `io.WriterTo` |
+| `CopyTo(ctx context.Context, w io.Writer)` | `(int64, error)` | Drain into `w` honouring `ctx` for per-chunk cancellation |
 | `Close()` | `error` | Release the read stream handle |
 
-`WriteTo` and `CopyTo` leave the stream open on error and partial writes so the caller can decide how to recover; close it explicitly in either case.
+On a write error or partial write, `WriteTo` and `CopyTo` return the partial byte count and leave the stream open so the caller can recover; close it explicitly in either case.
 
 ### FsWriteStream
 
-Streaming file write returned by [`WriteStream`](#writestream). Must be closed via `Close(ctx)` to finalise.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-```go
-type FsWriteStream struct { /* ... */ }
-```
+<p className="msb-backref">Returned by <a href="#fs-writestream">WriteStream()</a></p>
+
+An open streaming write to a guest file. Must be closed with `Close(ctx)` to finalise the write.
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `Write(p []byte)` | `(int, error)` | Implements `io.Writer`. Uses `context.Background()` internally |
-| `WriteCtx(ctx, data []byte)` | `error` | Write with explicit context |
-| `Close(ctx)` | `error` | Send EOF and finalise the file |
+| `Write(p []byte)` | `(int, error)` | Send a chunk; implements `io.Writer`, uses `context.Background()` internally |
+| `WriteCtx(ctx context.Context, data []byte)` | `error` | Send a chunk with explicit context control |
+| `Close(ctx context.Context)` | `error` | Send the EOF marker and wait for the guest to confirm; must be called to complete the write |

--- a/docs/sdk/go/images.mdx
+++ b/docs/sdk/go/images.mdx
@@ -3,33 +3,147 @@ title: Images
 description: Go SDK - Image cache API reference
 ---
 
-The Go SDK exposes local OCI image-cache operations through the package-level `Image` value. These APIs inspect and prune images that have already been pulled by sandbox creation.
+Inspect and prune the local OCI image cache: the images that sandbox creation has already pulled. Everything is reached through the package-level `Image` value, or through an [`ImageHandle`](#imagehandle) once you hold one.
 
 ```go
 import m "github.com/superradcompany/microsandbox/sdk/go"
 ```
 
-## Image
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Functions<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#image-get"><span className="msb-rn">Image.Get()</span><span className="msb-rg">one cached image by reference</span></a>
+  <a className="msb-row" href="#image-list"><span className="msb-rn">Image.List()</span><span className="msb-rg">every cached image</span></a>
+  <a className="msb-row" href="#image-inspect"><span className="msb-rn">Image.Inspect()</span><span className="msb-rg">handle + config + layers</span></a>
+  <a className="msb-row" href="#image-remove"><span className="msb-rn">Image.Remove()</span><span className="msb-rg">delete a cached image</span></a>
+  <a className="msb-row" href="#image-prune"><span className="msb-rn">Image.Prune()</span><span className="msb-rg">reclaim unused image data</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · ImageHandle<span className="msb-ct">10</span></p>
+  <a className="msb-row" href="#h-reference"><span className="msb-rn">h.Reference()</span><span className="msb-rg">image reference</span></a>
+  <a className="msb-row" href="#h-manifestdigest"><span className="msb-rn">h.ManifestDigest()</span><span className="msb-rg">manifest digest</span></a>
+  <a className="msb-row" href="#h-architecture"><span className="msb-rn">h.Architecture()</span><span className="msb-rg">resolved architecture</span></a>
+  <a className="msb-row" href="#h-os"><span className="msb-rn">h.OS()</span><span className="msb-rg">resolved operating system</span></a>
+  <a className="msb-row" href="#h-layercount"><span className="msb-rn">h.LayerCount()</span><span className="msb-rg">number of layers</span></a>
+  <a className="msb-row" href="#h-sizebytes"><span className="msb-rn">h.SizeBytes()</span><span className="msb-rg">total size in bytes</span></a>
+  <a className="msb-row" href="#h-createdat"><span className="msb-rn">h.CreatedAt()</span><span className="msb-rg">first-pulled time</span></a>
+  <a className="msb-row" href="#h-lastusedat"><span className="msb-rn">h.LastUsedAt()</span><span className="msb-rg">last-referenced time</span></a>
+  <a className="msb-row" href="#h-remove"><span className="msb-rn">h.Remove()</span><span className="msb-rg">delete this image</span></a>
+  <a className="msb-row" href="#h-inspect"><span className="msb-rn">h.Inspect()</span><span className="msb-rg">full detail for this image</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#imagehandle">ImageHandle</a>
+    <a className="msb-typepill" href="#imagedetail">ImageDetail</a>
+    <a className="msb-typepill" href="#imageconfig">ImageConfig</a>
+    <a className="msb-typepill" href="#imagelayer">ImageLayer</a>
+    <a className="msb-typepill" href="#imageprunereport">ImagePruneReport</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```go
+import m "github.com/superradcompany/microsandbox/sdk/go"
+
+images, err := m.Image.List(ctx)        // 1. enumerate the cache
+if err != nil {
+    return err
+}
+for _, img := range images {
+    fmt.Println(img.Reference(), img.LayerCount())
+}
+
+report, err := m.Image.Prune(ctx)       // 2. reclaim unused data
+if err != nil {
+    return err
+}
+fmt.Println(report.LayersRemoved, "layers removed")
+```
+
+## Functions
 
 ---
 
-#### Image.Get()
+#### <span className="msb-recv">Image.</span><span className="msb-hn">Get()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func (imageFactory) Get(ctx context.Context, reference string) (*ImageHandle, error)
 ```
 
-Fetch one cached image by reference. Returns `ErrImageNotFound` when the image is not present in the local cache.
+Fetch one cached image by reference. Returns `ErrImageNotFound` when no image with that reference is present in the local cache.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the lookup.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>reference</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Image reference, e.g. <code>"python:3.12"</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imagehandle">*ImageHandle</a></div>
+    <div className="msb-param-desc">Metadata handle for the cached image.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc"><code>ErrImageNotFound</code> when the reference is not cached.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+img, err := m.Image.Get(ctx, "python:3.12")
+if err != nil {
+    return err
+}
+fmt.Println(img.ManifestDigest())
+```
 
 ---
 
-#### Image.List()
+#### <span className="msb-recv">Image.</span><span className="msb-hn">List()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func (imageFactory) List(ctx context.Context) ([]*ImageHandle, error)
 ```
 
-Return every cached image, ordered newest first.
+Return every cached image, ordered by creation time (newest first).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the listing.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imagehandle">[]*ImageHandle</a></div>
+    <div className="msb-param-desc">All cached image handles, newest first.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Non-nil on failure.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 images, err := m.Image.List(ctx)
@@ -43,52 +157,429 @@ for _, img := range images {
 
 ---
 
-#### Image.Inspect()
+#### <span className="msb-recv">Image.</span><span className="msb-hn">Inspect()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func (imageFactory) Inspect(ctx context.Context, reference string) (*ImageDetail, error)
 ```
 
-Return handle metadata plus parsed OCI config and layer details.
+Return the full detail for a cached image: the [`ImageHandle`](#imagehandle) plus the parsed OCI config and the layer list.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the inspection.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>reference</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Image reference, e.g. <code>"python:3.12"</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imagedetail">*ImageDetail</a></div>
+    <div className="msb-param-desc">Handle, OCI config, and layers.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc"><code>ErrImageNotFound</code> when the reference is not cached.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+detail, err := m.Image.Inspect(ctx, "python:3.12")
+if err != nil {
+    return err
+}
+fmt.Println(detail.Config.Entrypoint, len(detail.Layers), "layers")
+```
 
 ---
 
-#### Image.Remove()
+#### <span className="msb-recv">Image.</span><span className="msb-hn">Remove()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func (imageFactory) Remove(ctx context.Context, reference string, force bool) error
 ```
 
-Delete a cached image. When `force` is false, sandboxes still referencing the image cause `ErrImageInUse`.
+Delete a cached image. When `force` is false, sandboxes that still reference the image cause the call to fail with `ErrImageInUse`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the removal.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>reference</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Image reference to delete.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>force</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>true</code>, remove even if sandboxes still reference it.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc"><code>ErrImageInUse</code> when in use and <code>force</code> is false.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+if err := m.Image.Remove(ctx, "old:tag", false); err != nil {
+    return err
+}
+```
 
 ---
 
-#### Image.Prune()
+#### <span className="msb-recv">Image.</span><span className="msb-hn">Prune()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func (imageFactory) Prune(ctx context.Context) (*ImagePruneReport, error)
 ```
 
-Remove cached image data that is not used by sandboxes and return a report with the number of image refs, manifests, layers, fsmeta files, VMDK files, and bytes reclaimed.
+Remove cached image data that is not used by any sandbox. Returns a report tallying the image refs, manifests, layers, fsmeta files, and VMDK files removed, plus bytes reclaimed.
 
-## ImageHandle
+<p className="msb-label">Parameters</p>
 
-Returned by `Image.Get` and `Image.List`.
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the prune.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imageprunereport">*ImagePruneReport</a></div>
+    <div className="msb-param-desc">Summary of what was reclaimed.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Non-nil on failure.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+report, err := m.Image.Prune(ctx)
+if err != nil {
+    return err
+}
+fmt.Println(report.LayersRemoved, "layers removed")
+```
+
+---
+
+## Methods
+
+Instance methods on [`*ImageHandle`](#imagehandle), the metadata reference returned by [`Image.Get`](#image-get) and [`Image.List`](#image-list). The accessors are pure reads of cached metadata; only `Remove` and `Inspect` take a context and reach the runtime.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Reference()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ImageHandle) Reference() string
+```
+
+The image reference, e.g. `"docker.io/library/python:3.12"`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Image reference.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">ManifestDigest()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ImageHandle) ManifestDigest() string
+```
+
+The content-addressable manifest digest, or empty when unknown.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Manifest digest, or empty.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Architecture()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ImageHandle) Architecture() string
+```
+
+The architecture resolved during the pull, or empty.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Architecture, or empty.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">OS()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ImageHandle) OS() string
+```
+
+The operating system resolved during the pull, or empty.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Operating system, or empty.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">LayerCount()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ImageHandle) LayerCount() uint
+```
+
+The number of layers in the image.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">uint</span></div>
+    <div className="msb-param-desc">Layer count.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">SizeBytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ImageHandle) SizeBytes() *int64
+```
+
+The total image size in bytes, or `nil` when unknown.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">*int64</span></div>
+    <div className="msb-param-desc">Total size in bytes, or <code>nil</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">CreatedAt()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ImageHandle) CreatedAt() time.Time
+```
+
+When this image was first pulled. Returns the zero `time.Time` when unknown.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">time.Time</span></div>
+    <div className="msb-param-desc">First-pulled time, or the zero value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">LastUsedAt()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ImageHandle) LastUsedAt() time.Time
+```
+
+When this image was last referenced. Returns the zero `time.Time` when unknown.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">time.Time</span></div>
+    <div className="msb-param-desc">Last-referenced time, or the zero value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ImageHandle) Remove(ctx context.Context, force bool) error
+```
+
+Delete this image. Equivalent to [`Image.Remove(ctx, h.Reference(), force)`](#image-remove). When `force` is false, sandboxes that still reference the image cause the call to fail with `ErrImageInUse`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the removal.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>force</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>true</code>, remove even if sandboxes still reference it.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc"><code>ErrImageInUse</code> when in use and <code>force</code> is false.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+img, err := m.Image.Get(ctx, "old:tag")
+if err != nil {
+    return err
+}
+if err := img.Remove(ctx, false); err != nil {
+    return err
+}
+```
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Inspect()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *ImageHandle) Inspect(ctx context.Context) (*ImageDetail, error)
+```
+
+Return the full detail for this image. Equivalent to [`Image.Inspect(ctx, h.Reference())`](#image-inspect).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the inspection.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imagedetail">*ImageDetail</a></div>
+    <div className="msb-param-desc">Handle, OCI config, and layers.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Non-nil on failure.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+img, err := m.Image.Get(ctx, "python:3.12")
+if err != nil {
+    return err
+}
+detail, err := img.Inspect(ctx)
+if err != nil {
+    return err
+}
+fmt.Println(detail.Config.WorkingDir)
+```
+
+---
+
+## Types
+
+### ImageHandle
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#image-get">Image.Get()</a> · <a href="#image-list">Image.List()</a></p>
+
+A lightweight metadata reference to a cached OCI image. Fields are unexported; read them through the accessor methods below. Embedded in [`ImageDetail`](#imagedetail).
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `Reference()` | `string` | Image reference |
-| `ManifestDigest()` | `string` | Content-addressable manifest digest, or empty |
-| `Architecture()` | `string` | Resolved architecture, or empty |
-| `OS()` | `string` | Resolved operating system, or empty |
-| `LayerCount()` | `uint` | Number of layers |
-| `SizeBytes()` | `*int64` | Total size, or nil when unknown |
-| `CreatedAt()` | `time.Time` | First-pulled time, or zero |
-| `LastUsedAt()` | `time.Time` | Last referenced time, or zero |
-| `Remove(ctx, force)` | `error` | Delete this image |
-| `Inspect(ctx)` | `(*ImageDetail, error)` | Fetch full detail for this image |
+| [Reference()](#h-reference) | `string` | Image reference |
+| [ManifestDigest()](#h-manifestdigest) | `string` | Content-addressable manifest digest, or empty |
+| [Architecture()](#h-architecture) | `string` | Resolved architecture, or empty |
+| [OS()](#h-os) | `string` | Resolved operating system, or empty |
+| [LayerCount()](#h-layercount) | `uint` | Number of layers |
+| [SizeBytes()](#h-sizebytes) | `*int64` | Total size in bytes, or `nil` when unknown |
+| [CreatedAt()](#h-createdat) | `time.Time` | First-pulled time, or the zero value |
+| [LastUsedAt()](#h-lastusedat) | `time.Time` | Last-referenced time, or the zero value |
+| [Remove(ctx, force)](#h-remove) | `error` | Delete this image |
+| [Inspect(ctx)](#h-inspect) | `(*ImageDetail, error)` | Fetch full detail for this image |
 
-## ImageDetail
+### ImageDetail
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#image-inspect">Image.Inspect()</a> · <a href="#h-inspect">Inspect()</a></p>
+
+Bundles an [`ImageHandle`](#imagehandle) (embedded, so all its accessors are promoted) with the parsed OCI config and layer list.
 
 ```go
 type ImageDetail struct {
@@ -98,30 +589,61 @@ type ImageDetail struct {
 }
 ```
 
+| Field | Type | Description |
+|-------|------|-------------|
+| `*ImageHandle` | [`*ImageHandle`](#imagehandle) | Embedded metadata handle (accessors promoted) |
+| Config | [`*ImageConfig`](#imageconfig) | Parsed OCI config block |
+| Layers | `[]`[`ImageLayer`](#imagelayer) | Layers in manifest order |
+
 ### ImageConfig
 
-Parsed OCI config block.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-| Field | Type |
-|-------|------|
-| Digest | `string` |
-| Env | `[]string` |
-| Cmd | `[]string` |
-| Entrypoint | `[]string` |
-| WorkingDir | `string` |
-| User | `string` |
-| Labels | `map[string]string` |
-| StopSignal | `string` |
+<p className="msb-backref">Used by <a href="#imagedetail">ImageDetail.Config</a></p>
+
+The parsed OCI config block.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Digest | `string` | Config blob digest |
+| Env | `[]string` | Environment variables (`KEY=VALUE`) |
+| Cmd | `[]string` | Default command |
+| Entrypoint | `[]string` | Entrypoint |
+| WorkingDir | `string` | Working directory |
+| User | `string` | Default user |
+| Labels | `map[string]string` | OCI labels |
+| StopSignal | `string` | Stop signal |
 
 ### ImageLayer
 
-One layer in the image manifest.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-| Field | Type |
-|-------|------|
-| DiffID | `string` |
-| BlobDigest | `string` |
-| MediaType | `string` |
-| CompressedSizeBytes | `*int64` |
-| ErofsSizeBytes | `*int64` |
-| Position | `int32` |
+<p className="msb-backref">Used by <a href="#imagedetail">ImageDetail.Layers</a></p>
+
+One layer of an image manifest.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| DiffID | `string` | Uncompressed layer diff ID |
+| BlobDigest | `string` | Compressed blob digest |
+| MediaType | `string` | Layer media type |
+| CompressedSizeBytes | `*int64` | Compressed size in bytes, or `nil` |
+| ErofsSizeBytes | `*int64` | EROFS size in bytes, or `nil` |
+| Position | `int32` | Index in the layer stack |
+
+### ImagePruneReport
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#image-prune">Image.Prune()</a></p>
+
+Summarizes the artifacts removed by [`Image.Prune`](#image-prune).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| ImageRefsRemoved | `uint32` | Image references removed |
+| ManifestsRemoved | `uint32` | Manifests removed |
+| LayersRemoved | `uint32` | Layers removed |
+| FsmetaRemoved | `uint32` | Fsmeta files removed |
+| VMDKRemoved | `uint32` | VMDK files removed |
+| BytesReclaimed | `*uint64` | Bytes reclaimed, or `nil` when unknown |

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -3,69 +3,54 @@ title: Networking
 description: Go SDK - Network API reference
 ---
 
-See [Networking](/networking/overview) for the conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+Configure a sandbox's network stack: a first-match-wins egress/ingress policy, published ports, DNS interception, TLS interception, and secret-violation handling. See [Networking](/networking/overview) for the conceptual overview and [TLS Interception](/networking/tls) for proxy details.
 
-The Go SDK's network surface is a single [`NetworkConfig`](#networkconfig) struct passed via [`WithNetwork`](/sdk/go/sandbox#withnetwork). Common shapes come from [`NetworkPolicy`](#networkpolicy); custom rule sets are built by populating `NetworkConfig.Rules` directly.
+The Go SDK exposes networking as a single [`NetworkConfig`](#networkconfig) struct passed to [`WithNetwork`](#m-withnetwork). Common shapes come from the [`NetworkPolicy`](#networkpolicy) factory; custom firewalls are built by populating `NetworkConfig.Rules` directly.
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Functions<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#m-withnetwork"><span className="msb-rn">m.WithNetwork()</span><span className="msb-rg">attach a network config</span></a>
+  <a className="msb-row" href="#m-withports"><span className="msb-rn">m.WithPorts()</span><span className="msb-rg">publish TCP ports</span></a>
+  <a className="msb-row" href="#m-withportsudp"><span className="msb-rn">m.WithPortsUDP()</span><span className="msb-rg">publish UDP ports</span></a>
+  <a className="msb-row" href="#m-withportbindings"><span className="msb-rn">m.WithPortBindings()</span><span className="msb-rg">publish on explicit binds</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Factory · NetworkPolicy<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#networkpolicy-publiconly"><span className="msb-rn">NetworkPolicy.PublicOnly()</span><span className="msb-rg">public internet only (default)</span></a>
+  <a className="msb-row" href="#networkpolicy-none"><span className="msb-rn">NetworkPolicy.None()</span><span className="msb-rg">deny everything</span></a>
+  <a className="msb-row" href="#networkpolicy-allowall"><span className="msb-rn">NetworkPolicy.AllowAll()</span><span className="msb-rg">allow everything</span></a>
+  <a className="msb-row" href="#networkpolicy-nonlocal"><span className="msb-rn">NetworkPolicy.NonLocal()</span><span className="msb-rg">public + private, no local</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#networkconfig">NetworkConfig</a>
+    <a className="msb-typepill" href="#policyrule">PolicyRule</a>
+    <a className="msb-typepill" href="#dnsconfig">DNSConfig</a>
+    <a className="msb-typepill" href="#tlsconfig">TLSConfig</a>
+    <a className="msb-typepill" href="#portbinding">PortBinding</a>
+    <a className="msb-typepill" href="#portprotocol">PortProtocol</a>
+    <a className="msb-typepill" href="#policyaction">PolicyAction</a>
+    <a className="msb-typepill" href="#policydirection">PolicyDirection</a>
+    <a className="msb-typepill" href="#policyprotocol">PolicyProtocol</a>
+    <a className="msb-typepill" href="#networkpolicypreset">NetworkPolicyPreset</a>
+    <a className="msb-typepill" href="#destination-groups">Destination groups</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```go
+import m "github.com/superradcompany/microsandbox/sdk/go"
+
+// Preset — public internet only
 sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("alpine"),
     m.WithNetwork(m.NetworkPolicy.PublicOnly()),
 )
-```
 
-## NetworkPolicy
-
-Helpers that return common preset [`*NetworkConfig`](#networkconfig) values. Access via the package-level `NetworkPolicy` value.
-
----
-
-#### NetworkPolicy.PublicOnly()
-
-```go
-func (networkPolicyFactory) PublicOnly() *NetworkConfig
-```
-
-Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** when no network configuration is supplied.
-
----
-
-#### NetworkPolicy.None()
-
-```go
-func (networkPolicyFactory) None() *NetworkConfig
-```
-
-Deny all traffic. No network interface is created; the guest is fully offline. `Exec` and `FS` still work — they use the host-guest channel, not the network.
-
----
-
-#### NetworkPolicy.AllowAll()
-
-```go
-func (networkPolicyFactory) AllowAll() *NetworkConfig
-```
-
-Unrestricted network access, including private addresses and the host machine.
-
----
-
-#### NetworkPolicy.NonLocal()
-
-```go
-func (networkPolicyFactory) NonLocal() *NetworkConfig
-```
-
-Allow public + private (LAN) destinations; ingress allowed by default. Blocks loopback, link-local, and metadata.
-
----
-
-## Custom rules
-
-Build a custom firewall by populating [`NetworkConfig.Rules`](#networkconfig). Rules are evaluated **first-match-wins** per direction. `DefaultEgress` and `DefaultIngress` set the fall-through action.
-
-```go
-sb, err := m.CreateSandbox(ctx, "ci-runner",
+// Or a custom first-match-wins firewall
+sb, err = m.CreateSandbox(ctx, "ci-runner",
     m.WithImage("python:3.12"),
     m.WithNetwork(&m.NetworkConfig{
         DefaultEgress:  m.PolicyActionDeny,
@@ -78,6 +63,293 @@ sb, err := m.CreateSandbox(ctx, "ci-runner",
                 Protocol:    m.PolicyProtocolTCP,
                 Port:        "443",
             },
+        },
+    }),
+)
+```
+
+## Functions
+
+---
+
+#### <span className="msb-recv">m.</span><span className="msb-hn">WithNetwork()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func WithNetwork(net *NetworkConfig) SandboxOption
+```
+
+Set the network configuration for the sandbox. Pass a preset from the [`NetworkPolicy`](#networkpolicy) factory, or a custom [`NetworkConfig`](#networkconfig) value with your own rules, DNS, TLS, and port settings.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>net</code><a className="msb-type" href="#networkconfig">*NetworkConfig</a></div>
+    <div className="msb-param-desc">Network stack configuration.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">SandboxOption</span></div>
+    <div className="msb-param-desc">Option to pass to <a className="msb-type" href="/sdk/go/sandbox#createsandbox">CreateSandbox</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sb, err := m.CreateSandbox(ctx, "worker",
+    m.WithImage("alpine"),
+    m.WithNetwork(m.NetworkPolicy.PublicOnly()),
+)
+```
+
+---
+
+#### <span className="msb-recv">m.</span><span className="msb-hn">WithPorts()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func WithPorts(ports map[uint16]uint16) SandboxOption
+```
+
+Make TCP services running in the sandbox reachable on localhost ports on the host. Each map entry exposes the guest port (value) on the host port (key), bound to `127.0.0.1`. Called multiple times, the maps merge.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ports</code><span className="msb-type">map[uint16]uint16</span></div>
+    <div className="msb-param-desc">Host port to guest port (TCP).</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">SandboxOption</span></div>
+    <div className="msb-param-desc">Option to pass to <a className="msb-type" href="/sdk/go/sandbox#createsandbox">CreateSandbox</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sb, err := m.CreateSandbox(ctx, "api",
+    m.WithImage("python:3.12"),
+    m.WithPorts(map[uint16]uint16{8080: 8080}),
+)
+```
+
+---
+
+#### <span className="msb-recv">m.</span><span className="msb-hn">WithPortsUDP()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func WithPortsUDP(ports map[uint16]uint16) SandboxOption
+```
+
+Make UDP services running in the sandbox reachable on localhost ports on the host. Each map entry exposes the guest port (value) on the host port (key), bound to `127.0.0.1`. Called multiple times, the maps merge.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ports</code><span className="msb-type">map[uint16]uint16</span></div>
+    <div className="msb-param-desc">Host port to guest port (UDP).</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">SandboxOption</span></div>
+    <div className="msb-param-desc">Option to pass to <a className="msb-type" href="/sdk/go/sandbox#createsandbox">CreateSandbox</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sb, err := m.CreateSandbox(ctx, "dns",
+    m.WithImage("alpine"),
+    m.WithPortsUDP(map[uint16]uint16{5353: 53}),
+)
+```
+
+---
+
+#### <span className="msb-recv">m.</span><span className="msb-hn">WithPortBindings()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func WithPortBindings(bindings ...PortBinding) SandboxOption
+```
+
+Make services running in the sandbox reachable on explicit host addresses and ports. Use this when the default `127.0.0.1` bind is too restrictive, for example to expose a port on `0.0.0.0`. Accepts one or more [`PortBinding`](#portbinding) values.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>bindings</code><a className="msb-type" href="#portbinding">...PortBinding</a></div>
+    <div className="msb-param-desc">Explicit bind address, host port, guest port, and protocol.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">SandboxOption</span></div>
+    <div className="msb-param-desc">Option to pass to <a className="msb-type" href="/sdk/go/sandbox#createsandbox">CreateSandbox</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sb, err := m.CreateSandbox(ctx, "api",
+    m.WithImage("python:3.12"),
+    m.WithPortBindings(
+        m.PortBinding{Bind: "0.0.0.0", HostPort: 8001, GuestPort: 8001},
+        m.PortBinding{Bind: "127.0.0.1", HostPort: 5353, GuestPort: 53, Protocol: m.PortProtocolUDP},
+    ),
+)
+```
+
+---
+
+## NetworkPolicy
+
+Factory namespace returning common preset [`*NetworkConfig`](#networkconfig) values. Access through the package-level `NetworkPolicy` value, for example `m.NetworkPolicy.PublicOnly()`.
+
+---
+
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">PublicOnly()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func (networkPolicyFactory) PublicOnly() *NetworkConfig
+```
+
+Allow only public internet traffic; RFC-1918 private ranges are blocked. This is the **default** when no network configuration is supplied.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#networkconfig">*NetworkConfig</a></div>
+    <div className="msb-param-desc">Preset config with <code>Policy: "public-only"</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+m.WithNetwork(m.NetworkPolicy.PublicOnly())
+```
+
+---
+
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">None()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func (networkPolicyFactory) None() *NetworkConfig
+```
+
+Block all network access. No network interface is created; the guest is fully offline. `Exec` and `FS` still work, since they use the host-guest channel rather than the network.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#networkconfig">*NetworkConfig</a></div>
+    <div className="msb-param-desc">Preset config with <code>Policy: "none"</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+m.WithNetwork(m.NetworkPolicy.None())
+```
+
+---
+
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">AllowAll()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func (networkPolicyFactory) AllowAll() *NetworkConfig
+```
+
+Permit all network traffic, including private addresses and the host machine.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#networkconfig">*NetworkConfig</a></div>
+    <div className="msb-param-desc">Preset config with <code>Policy: "allow-all"</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+m.WithNetwork(m.NetworkPolicy.AllowAll())
+```
+
+---
+
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">NonLocal()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func (networkPolicyFactory) NonLocal() *NetworkConfig
+```
+
+Allow public internet plus private/LAN egress; block loopback, link-local, and metadata.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#networkconfig">*NetworkConfig</a></div>
+    <div className="msb-param-desc">Preset config with <code>Policy: "non-local"</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+m.WithNetwork(m.NetworkPolicy.NonLocal())
+```
+
+---
+
+## Custom rules
+
+Build a custom firewall by populating [`NetworkConfig.Rules`](#networkconfig). Rules are evaluated **first-match-wins** per direction; `DefaultEgress` and `DefaultIngress` set the fall-through action. A broad rule placed before a narrow one swallows it, so put specific rules first.
+
+```go
+sb, err := m.CreateSandbox(ctx, "ci-runner",
+    m.WithImage("python:3.12"),
+    m.WithNetwork(&m.NetworkConfig{
+        DefaultEgress:  m.PolicyActionDeny,
+        DefaultIngress: m.PolicyActionAllow,
+        Rules: []m.PolicyRule{
+            {Action: m.PolicyActionDeny, Destination: "10.0.0.5"},      // specific first
+            {Action: m.PolicyActionAllow, Destination: "10.0.0.0/8"},   // broad fallthrough
             {
                 Action:      m.PolicyActionAllow,
                 Direction:   m.PolicyDirectionEgress,
@@ -90,143 +362,81 @@ sb, err := m.CreateSandbox(ctx, "ci-runner",
 )
 ```
 
-### Rule order matters
-
-The first matching rule wins, so a broad rule placed before a narrow one swallows it:
-
-```go
-Rules: []m.PolicyRule{
-    {Action: m.PolicyActionAllow, Destination: "10.0.0.0/8"},  // matches everything in 10.x
-    {Action: m.PolicyActionDeny,  Destination: "10.0.0.5"},    // never reached
-},
-```
-
-Put specific rules before general ones.
-
----
-
 ## Types
 
 ### NetworkConfig
 
-The configuration struct passed via [`WithNetwork`](/sdk/go/sandbox#withnetwork).
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#m-withnetwork">WithNetwork()</a> · returned by <a href="#networkpolicy">NetworkPolicy</a></p>
+
+The full network stack configuration passed via [`WithNetwork`](#m-withnetwork).
 
 | Field | Type | Description |
 |-------|------|-------------|
-| Policy | [`NetworkPolicyPreset`](#networkpolicypreset) | Preset name. Mutually exclusive with `Rules` for canned configurations; set via [`NetworkPolicy`](#networkpolicy) |
+| Policy | [`NetworkPolicyPreset`](#networkpolicypreset) | Preset name. Mutually exclusive with custom rules for canned configs; set via [`NetworkPolicy`](#networkpolicy). When set alongside `Rules`, preset rules come first and custom rules follow |
 | Rules | `[]`[`PolicyRule`](#policyrule) | Ordered custom rules (first match wins) |
 | DefaultEgress | [`PolicyAction`](#policyaction) | Fall-through action for outbound when no rule matches. Defaults to `"deny"` |
 | DefaultIngress | [`PolicyAction`](#policyaction) | Fall-through action for inbound when no rule matches. Defaults to `"allow"` |
-| DenyDomains | `[]string` | Exact-match domains to refuse DNS resolution for. Adds high-priority `deny Domain("...")` policy rules that fire at DNS (NXDOMAIN), TLS first-flight (SNI), and TCP egress (cache fallback) |
-| DenyDomainSuffixes | `[]string` | Domain suffixes (e.g. `.ads`) — denies the apex and any subdomain |
-| DNS | [`*DNSConfig`](#dnsconfig) | DNS interception settings |
+| DenyDomains | `[]string` | Exact domain names to refuse DNS resolution for |
+| DenyDomainSuffixes | `[]string` | Domain suffixes (e.g. `.ads`) to block, including the apex and any subdomain |
+| DNS | [`*DNSConfig`](#dnsconfig) | In-VM DNS proxy settings |
 | DNSRebindProtection | `*bool` | Legacy convenience for `DNS.RebindProtection`. When `DNS` is also set, the nested value wins |
-| TLS | [`*TLSConfig`](#tlsconfig) | TLS interception settings |
-| Ports | `map[uint16]uint16` | Host→guest TCP port mappings bound to `127.0.0.1` |
-| PortBindings | `[]`[`PortBinding`](#portbinding) | Host→guest port mappings with explicit bind addresses |
-| IPv4Pool | `string` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12` |
-| IPv6Pool | `string` | IPv6 pool used for per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48` |
-| MaxConnections | `*uint` | Cap concurrent network connections from the sandbox |
-| OnSecretViolation | [`ViolationAction`](/sdk/go/secrets#violationaction) | Sandbox-wide action when a secret is sent to a disallowed host |
-| TrustHostCAs | `*bool` | Ship the host's trusted root CAs into the guest at boot. Opt-in for corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, ...) whose gateway CA is unknown to the guest's stock Mozilla bundle |
-
-### PortBinding
-
-```go
-type PortBinding struct {
-    Bind      string
-    HostPort  uint16
-    GuestPort uint16
-    Protocol  PortProtocol
-}
-```
-
-A host-to-guest port mapping with an explicit host bind address. Use it with [`WithPortBindings`](/sdk/go/sandbox#withportbindings) or `NetworkConfig.PortBindings` when the default `127.0.0.1` bind is too restrictive.
-
-```go
-sb, err := m.CreateSandbox(ctx, "api",
-    m.WithImage("python:3.12"),
-    m.WithPortBindings(
-        m.PortBinding{Bind: "0.0.0.0", HostPort: 8001, GuestPort: 8001},
-        m.PortBinding{Bind: "127.0.0.1", HostPort: 5353, GuestPort: 53, Protocol: m.PortProtocolUDP},
-    ),
-)
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| Bind | `string` | Host IP address to bind, such as `127.0.0.1`, `0.0.0.0`, or `::` |
-| HostPort | `uint16` | Port on the host |
-| GuestPort | `uint16` | Port inside the sandbox |
-| Protocol | [`PortProtocol`](#portprotocol) | `PortProtocolTCP` or `PortProtocolUDP`. Empty defaults to TCP |
-
-### PortProtocol
-
-```go
-type PortProtocol string
-```
-
-| Constant | Value | Description |
-|----------|-------|-------------|
-| `PortProtocolTCP` | `"tcp"` | TCP port mapping |
-| `PortProtocolUDP` | `"udp"` | UDP port mapping |
+| TLS | [`*TLSConfig`](#tlsconfig) | Transparent TLS interception proxy settings |
+| Ports | `map[uint16]uint16` | Host to guest TCP port mappings bound to `127.0.0.1` |
+| PortBindings | `[]`[`PortBinding`](#portbinding) | Host to guest mappings with explicit bind addresses |
+| IPv4Pool | `string` | Pool used to derive per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12` |
+| IPv6Pool | `string` | Pool used to derive per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48` |
+| MaxConnections | `*uint` | Cap on concurrent network connections from the sandbox |
+| OnSecretViolation | [`ViolationAction`](/sdk/go/secrets#violationaction) | Sandbox-wide action when a secret is sent to a disallowed host. Per-secret overrides via `SecretEntry.OnViolation` |
+| TrustHostCAs | `*bool` | Ship the host's extra CA bundles into the guest. Opt-in for corporate MITM proxies whose gateway CA is unknown to the guest's stock bundle |
 
 ### PolicyRule
 
-A single firewall rule.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#networkconfig">NetworkConfig.Rules</a></p>
+
+A single firewall rule. Ingress rules carrying ICMP protocols are rejected at sandbox creation, since the host has no inbound ICMP path; use `PolicyDirectionEgress` for ICMP.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | Action | [`PolicyAction`](#policyaction) | `allow` or `deny` |
 | Direction | [`PolicyDirection`](#policydirection) | Direction this rule considers. `PolicyDirectionAny` matches in either |
-| Destination | `string` | Target filter: a [destination group](#destgroups), domain, domain suffix (prefixed with `.`), CIDR (`10.0.0.0/8`), exact IP, or `"*"`. Domain and suffix strings are validated at sandbox creation |
-| Protocol | [`PolicyProtocol`](#policyprotocol) | Legacy single-protocol field. Prefer `Protocols` when matching multiple |
+| Destination | `string` | Target filter: a [destination group](#destination-groups), domain, domain suffix (prefixed with `.`), CIDR (`10.0.0.0/8`), exact IP, or `"*"` |
+| Protocol | [`PolicyProtocol`](#policyprotocol) | Legacy single-protocol field. The empty string means any. Prefer `Protocols` when matching multiple |
 | Protocols | `[]`[`PolicyProtocol`](#policyprotocol) | Protocol set. Empty means any |
 | Port | `string` | Single port (`"443"`) or range (`"8000-9000"`) |
-| Ports | `[]string` | Multiple port values at once |
-
-Ingress rules carrying ICMP protocols are rejected at sandbox creation — the host has no inbound ICMP path. Use `PolicyDirectionEgress` for ICMP allow/deny.
+| Ports | `[]string` | Several port values at once |
 
 ### DNSConfig
 
-```go
-type DNSConfig struct {
-    RebindProtection *bool
-    Nameservers      []string
-    QueryTimeoutMs   *uint64
-}
-```
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#networkconfig">NetworkConfig.DNS</a></p>
 
 In-VM DNS proxy configuration.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| RebindProtection | `*bool` | Block DNS responses resolving to private IPs. Default `true` when unset |
-| Nameservers | `[]string` | Upstream resolvers. Each entry is `IP`, `IP:PORT`, `HOST`, or `HOST:PORT`. Replaces `/etc/resolv.conf` when non-empty |
+| RebindProtection | `*bool` | Block DNS responses resolving to private IPs. Defaults to `true` when unset |
+| Nameservers | `[]string` | Upstream resolvers (e.g. `"1.1.1.1:53"`). Replaces `/etc/resolv.conf` when non-empty |
 | QueryTimeoutMs | `*uint64` | Per-DNS-query timeout in milliseconds |
 
 ### TLSConfig
 
-```go
-type TLSConfig struct {
-    Bypass           []string
-    VerifyUpstream   *bool
-    InterceptedPorts []uint16
-    BlockQUIC        *bool
-    CACert           string
-    CAKey            string
-    UpstreamCACerts  []string
-}
-```
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#networkconfig">NetworkConfig.TLS</a></p>
 
 Transparent HTTPS inspection proxy configuration.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| Bypass | `[]string` | Domains to skip interception (supports `*.suffix` globs). Use for domains with certificate pinning |
-| VerifyUpstream | `*bool` | Verify upstream server certificates. Default `true`. Set `false` only for self-signed servers |
-| InterceptedPorts | `[]uint16` | TCP ports where TLS interception is active. Default `[443]` |
-| BlockQUIC | `*bool` | Block QUIC/HTTP3 (UDP) on intercepted ports, forcing TCP/TLS fallback |
+| Bypass | `[]string` | Domain patterns (supports `*.suffix`) to skip MITM. Use for domains with certificate pinning |
+| VerifyUpstream | `*bool` | Verify upstream server certificates. Defaults to `true`. Set `false` only for self-signed servers |
+| InterceptedPorts | `[]uint16` | TCP ports where TLS is intercepted. Defaults to `[443]` |
+| BlockQUIC | `*bool` | Block QUIC on intercepted ports to force TLS fallback |
 | CACert | `string` | Path to a custom interception CA certificate PEM file |
 | CAKey | `string` | Path to a custom interception CA private key PEM file |
 | UpstreamCACerts | `[]string` | Paths to additional CA bundles trusted for upstream verification |
@@ -243,11 +453,41 @@ sb, err := m.CreateSandbox(ctx, "inspect",
 )
 ```
 
+### PortBinding
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#m-withportbindings">WithPortBindings()</a> · <a href="#networkconfig">NetworkConfig.PortBindings</a></p>
+
+A host-to-guest port mapping with an explicit host bind address. `Protocol` defaults to TCP when empty. Use `Bind: "0.0.0.0"` to expose the published port on all IPv4 interfaces.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Bind | `string` | Host IP address to bind, such as `127.0.0.1`, `0.0.0.0`, or `::` |
+| HostPort | `uint16` | Port on the host |
+| GuestPort | `uint16` | Port inside the sandbox |
+| Protocol | [`PortProtocol`](#portprotocol) | `PortProtocolTCP` or `PortProtocolUDP`. Empty defaults to TCP |
+
+### PortProtocol
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#portbinding">PortBinding.Protocol</a></p>
+
+Identifies the protocol for an exposed sandbox service.
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `PortProtocolTCP` | `"tcp"` | TCP port mapping |
+| `PortProtocolUDP` | `"udp"` | UDP port mapping |
+
 ### PolicyAction
 
-```go
-type PolicyAction string
-```
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#policyrule">PolicyRule.Action</a> · <a href="#networkconfig">NetworkConfig.DefaultEgress</a></p>
+
+The action half of a [`PolicyRule`](#policyrule).
 
 | Constant | Value | Description |
 |----------|-------|-------------|
@@ -256,9 +496,11 @@ type PolicyAction string
 
 ### PolicyDirection
 
-```go
-type PolicyDirection string
-```
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#policyrule">PolicyRule.Direction</a></p>
+
+The direction half of a [`PolicyRule`](#policyrule). The Go SDK follows the Python naming (`egress`/`ingress`); the wire format carries these values.
 
 | Constant | Value | Description |
 |----------|-------|-------------|
@@ -268,9 +510,11 @@ type PolicyDirection string
 
 ### PolicyProtocol
 
-```go
-type PolicyProtocol string
-```
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#policyrule">PolicyRule.Protocol</a> · <a href="#policyrule">PolicyRule.Protocols</a></p>
+
+The protocol half of a [`PolicyRule`](#policyrule).
 
 | Constant | Value | Description |
 |----------|-------|-------------|
@@ -281,11 +525,11 @@ type PolicyProtocol string
 
 ### NetworkPolicyPreset
 
-```go
-type NetworkPolicyPreset string
-```
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
 
-Preset names accepted by [`NetworkConfig.Policy`](#networkconfig). Prefer [`NetworkPolicy`](#networkpolicy), which returns a preconfigured `*NetworkConfig`.
+<p className="msb-backref">Used by <a href="#networkconfig">NetworkConfig.Policy</a></p>
+
+Preset names accepted by [`NetworkConfig.Policy`](#networkconfig). Prefer the [`NetworkPolicy`](#networkpolicy) factory, which returns a preconfigured `*NetworkConfig`.
 
 | Constant | Value | Description |
 |----------|-------|-------------|
@@ -296,16 +540,18 @@ Preset names accepted by [`NetworkConfig.Policy`](#networkconfig). Prefer [`Netw
 
 ### Destination groups
 
-The `Destination` field on [`PolicyRule`](#policyrule) accepts these well-known group names alongside literal CIDRs and domains:
+<div className="msb-tags"><span className="msb-tag is-type">reference</span></div>
+
+<p className="msb-backref">Used by <a href="#policyrule">PolicyRule.Destination</a></p>
+
+The `Destination` field on [`PolicyRule`](#policyrule) accepts these well-known group names alongside literal CIDRs and domains. A domain prefixed with `.` becomes a suffix match: `.example.com` matches `api.example.com` but not `example.com`.
 
 | Value | Description |
 |-------|-------------|
-| `"public"` | Complement of the named categories: every address not in any other group |
+| `"public"` | Every address not in any other group |
 | `"private"` | Private/RFC 1918 addresses + ULA + CGN (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7`) |
-| `"loopback"` | Loopback addresses (`127.0.0.0/8`, `::1`); the **guest's own** loopback, not the host. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap) |
+| `"loopback"` | Loopback addresses (`127.0.0.0/8`, `::1`); the **guest's own** loopback, not the host. See [Reaching the host](/networking/overview#reaching-the-host) |
 | `"link-local"` | Link-local addresses (`169.254.0.0/16`, `fe80::/10`) excluding metadata |
 | `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
 | `"multicast"` | Multicast addresses (`224.0.0.0/4`, `ff00::/8`) |
 | `"host"` | The host machine, reached via `host.microsandbox.internal`. The right group for "let the sandbox reach my host's localhost", not `"loopback"` |
-
-A domain prefixed with `.` becomes a suffix match: `.example.com` matches `api.example.com` but not `example.com`.

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -3,112 +3,164 @@ title: Sandbox
 description: Go SDK - Sandbox API reference
 ---
 
-See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management. Examples assume the package is imported as `m "github.com/superradcompany/microsandbox/sdk/go"`.
 
-## Setup
+<div className="msb-glance">
 
----
+  <p className="msb-gl"><span className="msb-dot static"></span>Functions<span className="msb-ct">13</span></p>
+  <a className="msb-row" href="#m-createsandbox"><span className="msb-rn">m.CreateSandbox()</span><span className="msb-rg">configure and boot a new sandbox</span></a>
+  <a className="msb-row" href="#m-getsandbox"><span className="msb-rn">m.GetSandbox()</span><span className="msb-rg">handle to an existing one</span></a>
+  <a className="msb-row" href="#m-listsandboxes"><span className="msb-rn">m.ListSandboxes()</span><span className="msb-rg">all sandboxes</span></a>
+  <a className="msb-row" href="#m-listsandboxeswith"><span className="msb-rn">m.ListSandboxesWith()</span><span className="msb-rg">filter by labels</span></a>
+  <a className="msb-row" href="#m-newsandboxfilter"><span className="msb-rn">m.NewSandboxFilter()</span><span className="msb-rg">build a label filter</span></a>
+  <a className="msb-row" href="#m-startsandbox"><span className="msb-rn">m.StartSandbox()</span><span className="msb-rg">restart a stopped one</span></a>
+  <a className="msb-row" href="#m-startsandboxdetached"><span className="msb-rn">m.StartSandboxDetached()</span><span className="msb-rg">restart detached</span></a>
+  <a className="msb-row" href="#m-removesandbox"><span className="msb-rn">m.RemoveSandbox()</span><span className="msb-rg">delete a stopped one</span></a>
+  <a className="msb-row" href="#m-allsandboxmetrics"><span className="msb-rn">m.AllSandboxMetrics()</span><span className="msb-rg">metrics for every sandbox</span></a>
+  <a className="msb-row" href="#m-ensureinstalled"><span className="msb-rn">m.EnsureInstalled()</span><span className="msb-rg">install the runtime up front</span></a>
+  <a className="msb-row" href="#m-isinstalled"><span className="msb-rn">m.IsInstalled()</span><span className="msb-rg">is the runtime present</span></a>
+  <a className="msb-row" href="#m-sdkversion"><span className="msb-rn">m.SDKVersion()</span><span className="msb-rg">pinned release version</span></a>
+  <a className="msb-row" href="#m-runtimeversion"><span className="msb-rn">m.RuntimeVersion()</span><span className="msb-rg">loaded FFI version</span></a>
 
-#### EnsureInstalled()
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *Sandbox<span className="msb-ct">21</span></p>
+  <a className="msb-row" href="#sb-name"><span className="msb-rn">sb.Name()</span><span className="msb-rg">sandbox name</span></a>
+  <a className="msb-row" href="/sdk/go/execution"><span className="msb-rn">sb.Exec()</span><span className="msb-rg">run a command</span></a>
+  <a className="msb-row" href="/sdk/go/execution"><span className="msb-rn">sb.Shell()</span><span className="msb-rg">run via /bin/sh -c</span></a>
+  <a className="msb-row" href="#sb-fs"><span className="msb-rn">sb.FS()</span><span className="msb-rg">read / write files</span></a>
+  <a className="msb-row" href="/sdk/go/ssh"><span className="msb-rn">sb.SSH()</span><span className="msb-rg">SSH client / server</span></a>
+  <a className="msb-row" href="#sb-logs"><span className="msb-rn">sb.Logs()</span><span className="msb-rg">captured output</span></a>
+  <a className="msb-row" href="#sb-logstream"><span className="msb-rn">sb.LogStream()</span><span className="msb-rg">stream output</span></a>
+  <a className="msb-row" href="#sb-metrics"><span className="msb-rn">sb.Metrics()</span><span className="msb-rg">resource snapshot</span></a>
+  <a className="msb-row" href="#sb-metricsstream"><span className="msb-rn">sb.MetricsStream()</span><span className="msb-rg">stream metrics</span></a>
+  <a className="msb-row" href="#sb-attach"><span className="msb-rn">sb.Attach()</span><span className="msb-rg">interactive PTY</span></a>
+  <a className="msb-row" href="#sb-attachshell"><span className="msb-rn">sb.AttachShell()</span><span className="msb-rg">interactive shell</span></a>
+  <a className="msb-row" href="#sb-stop"><span className="msb-rn">sb.Stop()</span><span className="msb-rg">graceful shutdown</span></a>
+  <a className="msb-row" href="#sb-requeststop"><span className="msb-rn">sb.RequestStop()</span><span className="msb-rg">async stop request</span></a>
+  <a className="msb-row" href="#sb-kill"><span className="msb-rn">sb.Kill()</span><span className="msb-rg">force terminate</span></a>
+  <a className="msb-row" href="#sb-requestkill"><span className="msb-rn">sb.RequestKill()</span><span className="msb-rg">async kill request</span></a>
+  <a className="msb-row" href="#sb-requestdrain"><span className="msb-rn">sb.RequestDrain()</span><span className="msb-rg">async drain request</span></a>
+  <a className="msb-row" href="#sb-waituntilstopped"><span className="msb-rn">sb.WaitUntilStopped()</span><span className="msb-rg">block until it exits</span></a>
+  <a className="msb-row" href="#sb-detach"><span className="msb-rn">sb.Detach()</span><span className="msb-rg">release, keep running</span></a>
+  <a className="msb-row" href="#sb-close"><span className="msb-rn">sb.Close()</span><span className="msb-rg">release the handle</span></a>
+  <a className="msb-row" href="#sb-ownslifecycle"><span className="msb-rn">sb.OwnsLifecycle()</span><span className="msb-rg">attached vs detached</span></a>
+  <a className="msb-row" href="#sb-ownslifecycleorfalse"><span className="msb-rn">sb.OwnsLifecycleOrFalse()</span><span className="msb-rg">attached, false on error</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Options<span className="msb-ct">37</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#withimage">WithImage()</a>
+    <a className="msb-chip" href="#withmemory">WithMemory()</a>
+    <a className="msb-chip" href="#withcpus">WithCPUs()</a>
+    <a className="msb-chip" href="#withenv">WithEnv()</a>
+    <a className="msb-chip" href="#withports">WithPorts()</a>
+    <a className="msb-chip" href="#withmounts">WithMounts()</a>
+    <a className="msb-chip" href="#withnetwork">WithNetwork()</a>
+    <a className="msb-chip" href="#withsecrets">WithSecrets()</a>
+    <a className="msb-chip" href="#withinit">WithInit()</a>
+    <a className="msb-chip" href="#withpatches">WithPatches()</a>
+    <a className="msb-chip" href="#withdetached">WithDetached()</a>
+    <a className="msb-chip" href="#withreplace">WithReplace()</a>
+    <a className="msb-more" href="#options">+ 25 more in the Options section</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#sandboxhandle">SandboxHandle</a>
+    <a className="msb-typepill" href="#sandboxfilter">SandboxFilter</a>
+    <a className="msb-typepill" href="#sandboxconfig">SandboxConfig</a>
+    <a className="msb-typepill" href="#sandboxoption">SandboxOption</a>
+    <a className="msb-typepill" href="#metrics">Metrics</a>
+    <a className="msb-typepill" href="#metricsstreamhandle">MetricsStreamHandle</a>
+    <a className="msb-typepill" href="#sandboxstopresult">SandboxStopResult</a>
+    <a className="msb-typepill" href="#sandboxstatus">SandboxStatus</a>
+    <a className="msb-typepill" href="#logentry">LogEntry</a>
+    <a className="msb-typepill" href="#logoptions">LogOptions</a>
+    <a className="msb-typepill" href="#logstreamoptions">LogStreamOptions</a>
+    <a className="msb-typepill" href="#logstreamhandle">LogStreamHandle</a>
+    <a className="msb-typepill" href="#logsource">LogSource</a>
+    <a className="msb-typepill" href="#loglevel">LogLevel</a>
+    <a className="msb-typepill" href="#pullpolicy">PullPolicy</a>
+    <a className="msb-typepill" href="#securityprofile">SecurityProfile</a>
+    <a className="msb-typepill" href="#registryauth">RegistryAuth</a>
+    <a className="msb-typepill" href="#initconfig">InitConfig</a>
+    <a className="msb-typepill" href="#initoptions">InitOptions</a>
+    <a className="msb-typepill" href="#init">Init</a>
+    <a className="msb-typepill" href="#patchconfig">PatchConfig</a>
+    <a className="msb-typepill" href="#patchoptions">PatchOptions</a>
+    <a className="msb-typepill" href="#patchkind">PatchKind</a>
+    <a className="msb-typepill" href="#patch">Patch</a>
+    <a className="msb-typepill" href="#setupoption">SetupOption</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```go
-func EnsureInstalled(ctx context.Context, opts ...SetupOption) error
+import m "github.com/superradcompany/microsandbox/sdk/go"
+
+sb, err := m.CreateSandbox(ctx, "api",   // 1. configure + boot
+    m.WithImage("python"),
+    m.WithMemory(1024),
+)
+if err != nil {
+    return err
+}
+defer sb.Close()                         // 4. shut down
+
+out, err := sb.Exec(ctx, "python", []string{"-V"})  // 2. run
+if err != nil {
+    return err
+}
+fmt.Println(out.Stdout())                // 3. read output
 ```
 
-Optional. Ensure msb + libkrunfw are present at `~/.microsandbox/`, downloading them from the matching GitHub release if not. Call at startup to surface install errors up front; otherwise the first sandbox call handles it. The FFI library is embedded in the Go binary and loads automatically — `EnsureInstalled` does not govern it. Idempotent.
-
-**Parameters**
-
-| Name | Type              | Description                                              |
-| ---- | ----------------- | -------------------------------------------------------- |
-| ctx  | `context.Context` | Cancels an in-flight msb + libkrunfw download            |
-| opts | `...SetupOption`  | See [`SetupOption`](#setupoption) for the available knobs |
+## Functions
 
 ---
 
-#### IsInstalled()
+#### <span className="msb-recv">m.</span><span className="msb-hn">CreateSandbox()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
-func IsInstalled() bool
+func CreateSandbox(ctx context.Context, name string, opts ...SandboxOption) (*Sandbox, error)
 ```
 
-Report whether msb + libkrunfw are present on disk at the SDK's pinned version. Does **not** dlopen the FFI library (which ships embedded).
+Create and boot a new sandbox. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes. The returned [`*Sandbox`](#methods) owns the VM process, call `Close` (or `Stop` + `Close`) when done. See [Options](#options) for all configuration knobs.
 
----
+<p className="msb-label">Parameters</p>
 
-#### SDKVersion()
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the boot operation only. Cancelling after this function returns has no effect on the running sandbox.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#options">...SandboxOption</a></div>
+    <div className="msb-param-desc">Functional options applied in order.</div>
+  </div>
+</div>
 
-```go
-func SDKVersion() string
-```
+<p className="msb-label">Returns</p>
 
-Return the microsandbox release version this SDK was compiled against.
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#methods">*Sandbox</a></div>
+    <div className="msb-param-desc">Running sandbox. Safe for concurrent use from multiple goroutines.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed <code>*Error</code>, see <a href="/sdk/errors">Error Handling</a>.</div>
+  </div>
+</div>
 
----
-
-#### RuntimeVersion()
-
-```go
-func RuntimeVersion() (string, error)
-```
-
-Return the version reported by the loaded FFI library. Auto-loads the library on first use; returns `ErrLibraryNotLoaded` only if loading fails (e.g. unsupported platform or GLIBC mismatch).
-
----
-
-## SetupOption
-
-Configures [`EnsureInstalled`](#ensureinstalled). Pass any of the options below as variadic arguments. Options apply only to the first call; subsequent calls are no-ops.
-
-| Option | Effect |
-|--------|--------|
-| [`WithSkipDownload()`](#withskipdownload) | Refuse to download msb + libkrunfw — require them to be pre-installed |
-
----
-
-#### WithSkipDownload()
+<p className="msb-label">Example</p>
 
 ```go
-func WithSkipDownload() SetupOption
-```
-
-Prevent `EnsureInstalled` from fetching the msb + libkrunfw bundle from GitHub. Use when the runtime is already on disk at the install path (e.g. air-gapped CI). The embedded FFI library is unaffected — it ships with the SDK.
-
----
-
-## Top-level functions
-
----
-
-#### CreateSandbox()
-
-```go
-func CreateSandbox(
-    ctx context.Context,
-    name string,
-    opts ...SandboxOption,
-) (*Sandbox, error)
-```
-
-Create and boot a new sandbox. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes. The returned [`*Sandbox`](#instance-methods) owns the VM process — call `Close` (or `Stop` + `Close`) when done.
-
-**Parameters**
-
-| Name | Type               | Description                                                                                             |
-| ---- | ------------------ | ------------------------------------------------------------------------------------------------------- |
-| ctx  | `context.Context`  | Cancels the boot operation. Cancelling after this function returns has no effect on the running sandbox |
-| name | `string`           | Sandbox name, up to 128 UTF-8 bytes                                                                    |
-| opts | `...SandboxOption` | Functional options — see [Options](#options)                                                            |
-
-**Returns**
-
-| Type                            | Description                                        |
-| ------------------------------- | -------------------------------------------------- |
-| [`*Sandbox`](#instance-methods) | Running sandbox                                    |
-| `error`                         | Typed `*Error` — see [Error Handling](/sdk/errors) |
-
-```go
-sb, err := m.CreateSandbox(ctx, "my-sandbox",
+sb, err := m.CreateSandbox(ctx, "api",
     m.WithImage("python:3.12"),
     m.WithMemory(512),
     m.WithCPUs(2),
@@ -125,362 +177,564 @@ defer func() {
 
 ---
 
-#### StartSandbox()
-
-```go
-func StartSandbox(ctx context.Context, name string) (*Sandbox, error)
-```
-
-Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
-
-**Parameters**
-
-| Name | Type              | Description                |
-| ---- | ----------------- | -------------------------- |
-| ctx  | `context.Context` | Cancels the boot operation |
-| name | `string`          | Name of a stopped sandbox, up to 128 UTF-8 bytes |
-
-**Returns**
-
-| Type                            | Description     |
-| ------------------------------- | --------------- |
-| [`*Sandbox`](#instance-methods) | Running sandbox |
-
----
-
-#### StartSandboxDetached()
-
-```go
-func StartSandboxDetached(ctx context.Context, name string) (*Sandbox, error)
-```
-
-Boot a stopped sandbox in detached mode.
-
----
-
-#### GetSandbox()
+#### <span className="msb-recv">m.</span><span className="msb-hn">GetSandbox()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func GetSandbox(ctx context.Context, name string) (*SandboxHandle, error)
 ```
 
-Look up a sandbox by name and return a metadata handle without connecting to it. Sandbox names are limited to 128 UTF-8 bytes. Returns `ErrSandboxNotFound` if no such sandbox exists. The returned [`*SandboxHandle`](#sandboxhandle) exposes `Connect`, `Start`, `Stop`, `Kill`, `Remove`, `Metrics`, and `Logs`.
+Look up a sandbox by name and return a metadata handle without connecting to it. Returns an error with `Kind == ErrSandboxNotFound` if no such sandbox exists. The returned [`*SandboxHandle`](#sandboxhandle) exposes `Connect`, `Start`, `Stop`, `Kill`, `Remove`, `Metrics`, `Logs`, and snapshot methods.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxhandle">*SandboxHandle</a></div>
+    <div className="msb-param-desc">Metadata handle with status and lifecycle control.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+h, err := m.GetSandbox(ctx, "api")
+if err != nil {
+    return err
+}
+fmt.Println(h.Status())
+```
 
 ---
 
-#### ListSandboxes()
+#### <span className="msb-recv">m.</span><span className="msb-hn">ListSandboxes()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func ListSandboxes(ctx context.Context) ([]*SandboxHandle, error)
 ```
 
-Return metadata for every known sandbox (running, stopped, draining, crashed) ordered by creation time, newest first.
+Return metadata for every known sandbox (running, stopped, draining, crashed), ordered by creation time, newest first.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxhandle">[]*SandboxHandle</a></div>
+    <div className="msb-param-desc">All sandbox handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+handles, err := m.ListSandboxes(ctx)
+if err != nil {
+    return err
+}
+for _, h := range handles {
+    fmt.Printf("%s — %s\n", h.Name(), h.Status())
+}
+```
 
 ---
 
-#### RemoveSandbox()
+#### <span className="msb-recv">m.</span><span className="msb-hn">ListSandboxesWith()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func ListSandboxesWith(ctx context.Context, filter SandboxFilter) ([]*SandboxHandle, error)
+```
+
+Return sandbox metadata narrowed by a [`SandboxFilter`](#sandboxfilter). Label selectors are AND-matched: a sandbox matches only if it carries every label in the filter.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>filter</code><a className="msb-type" href="#sandboxfilter">SandboxFilter</a></div>
+    <div className="msb-param-desc">Label selector. The zero value matches every sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxhandle">[]*SandboxHandle</a></div>
+    <div className="msb-param-desc">Matching sandbox handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+filter := m.NewSandboxFilter().WithLabels(map[string]string{"user.id": "alice"})
+handles, err := m.ListSandboxesWith(ctx, filter)
+```
+
+---
+
+#### <span className="msb-recv">m.</span><span className="msb-hn">NewSandboxFilter()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func NewSandboxFilter() SandboxFilter
+```
+
+Return an empty [`SandboxFilter`](#sandboxfilter) that matches every sandbox. Chain [`WithLabels`](#sandboxfilter) to narrow the results passed to [`ListSandboxesWith`](#m-listsandboxeswith).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxfilter">SandboxFilter</a></div>
+    <div className="msb-param-desc">Empty filter.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">m.</span><span className="msb-hn">StartSandbox()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func StartSandbox(ctx context.Context, name string) (*Sandbox, error)
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration and returns a live [`*Sandbox`](#methods).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Name of a stopped sandbox, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#methods">*Sandbox</a></div>
+    <div className="msb-param-desc">Running sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sb, err := m.StartSandbox(ctx, "api")
+```
+
+---
+
+#### <span className="msb-recv">m.</span><span className="msb-hn">StartSandboxDetached()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func StartSandboxDetached(ctx context.Context, name string) (*Sandbox, error)
+```
+
+Boot a stopped sandbox in detached mode. The VM keeps running after the returned handle is released.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Name of a stopped sandbox, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#methods">*Sandbox</a></div>
+    <div className="msb-param-desc">Running sandbox in detached mode.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">m.</span><span className="msb-hn">RemoveSandbox()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func RemoveSandbox(ctx context.Context, name string) error
 ```
 
-Delete a stopped sandbox and all its persisted state from disk. Fails with `ErrSandboxStillRunning` if the sandbox is still running.
+Delete a stopped sandbox and all its persisted state from disk. Fails if the sandbox is still running, stop it first.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := m.RemoveSandbox(ctx, "api")
+```
 
 ---
 
-#### AllSandboxMetrics()
+#### <span className="msb-recv">m.</span><span className="msb-hn">AllSandboxMetrics()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func AllSandboxMetrics(ctx context.Context) (map[string]*Metrics, error)
 ```
 
-Return a point-in-time metrics snapshot for every running sandbox, keyed by sandbox name. Only running and draining sandboxes appear.
+Return a point-in-time [`Metrics`](#metrics) snapshot for every running sandbox, keyed by sandbox name. Only running and draining sandboxes appear.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#metrics">map[string]*Metrics</a></div>
+    <div className="msb-param-desc">Per-sandbox metrics keyed by name.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+all, err := m.AllSandboxMetrics(ctx)
+for name, metrics := range all {
+    fmt.Printf("%s: %.1f%% CPU\n", name, metrics.CPUPercent)
+}
+```
 
 ---
 
-## Instance methods
+#### <span className="msb-recv">m.</span><span className="msb-hn">EnsureInstalled()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
-The `*Sandbox` returned by [`CreateSandbox`](#createsandbox) and friends has the following methods. `*Sandbox` is **safe for concurrent use** from multiple goroutines.
+```go
+func EnsureInstalled(ctx context.Context, opts ...SetupOption) error
+```
+
+Optional. Ensure msb + libkrunfw are present under `~/.microsandbox/`, downloading them from the matching GitHub release if not. Call at startup to surface install errors up front; otherwise the first sandbox call handles it. The FFI library is embedded in the Go binary and loads automatically, `EnsureInstalled` does not govern it. Idempotent; options apply only to the first call.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels an in-flight msb + libkrunfw download.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#setupoption">...SetupOption</a></div>
+    <div className="msb-param-desc">Install knobs, e.g. <a href="#withskipdownload">WithSkipDownload()</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+if err := m.EnsureInstalled(ctx); err != nil {
+    log.Fatal(err)
+}
+```
 
 ---
 
-#### Name()
+#### <span className="msb-recv">m.</span><span className="msb-hn">IsInstalled()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func IsInstalled() bool
+```
+
+Report whether msb + libkrunfw are present on disk at the SDK's pinned version. Does **not** dlopen the FFI library (which ships embedded).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> if the runtime is present at the expected version.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">m.</span><span className="msb-hn">SDKVersion()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func SDKVersion() string
+```
+
+Return the microsandbox release version this SDK was compiled against.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Pinned release version, e.g. <code>"0.5.8"</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">m.</span><span className="msb-hn">RuntimeVersion()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func RuntimeVersion() (string, error)
+```
+
+Return the version reported by the loaded FFI library. Auto-loads the library on first use; returns an error with `Kind == ErrLibraryNotLoaded` only if loading fails (e.g. unsupported platform or GLIBC mismatch).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">FFI library version.</div>
+  </div>
+</div>
+
+---
+
+## Methods
+
+The `*Sandbox` returned by [`CreateSandbox`](#m-createsandbox), [`StartSandbox`](#m-startsandbox), and [`SandboxHandle.Connect`](#sandboxhandle) carries the methods below. `*Sandbox` is **safe for concurrent use** from multiple goroutines. The command-execution methods, `Exec`, `ExecStream`, `Shell`, and `ShellStream`, live on the same value and are documented under [Execution](/sdk/go/execution).
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">Name()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (s *Sandbox) Name() string
 ```
 
-Return the sandbox's name.
+Return the sandbox name.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
 
 ---
 
-#### FS()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">FS()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
-func (s *Sandbox) FS() *SandboxFsOps
+func (s *Sandbox) FS() *SandboxFSOps
 ```
 
-Return a filesystem accessor for reading and writing files inside the running sandbox. See [Filesystem](/sdk/go/filesystem) for API details.
+Return a filesystem accessor for reading and writing files inside the running sandbox. See [Filesystem](/sdk/go/filesystem) for the API.
 
----
+<p className="msb-label">Returns</p>
 
-#### Exec()
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/go/filesystem">*SandboxFSOps</a></div>
+    <div className="msb-param-desc">Filesystem accessor.</div>
+  </div>
+</div>
 
-```go
-func (s *Sandbox) Exec(
-    ctx context.Context,
-    cmd string,
-    args []string,
-    opts ...ExecOption,
-) (*ExecOutput, error)
-```
-
-Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`ExecStream`](#execstream).
-
-A **non-zero exit code is not a Go error** — inspect [`ExecOutput.Success`](/sdk/go/execution#success) or [`ExecOutput.ExitCode`](/sdk/go/execution#exitcode) instead. Transport, timeout, and spawn failures are returned as errors.
+<p className="msb-label">Example</p>
 
 ```go
-out, err := sb.Exec(ctx, "python3", []string{"-c", "print(1 + 1)"})
-if err != nil {
-    return err
-}
-fmt.Println(out.Stdout())    // "2\n"
-fmt.Println(out.ExitCode())  // 0
-```
-
-See [Execution](/sdk/go/execution) for `ExecOption` details.
-
----
-
-#### ExecStream()
-
-```go
-func (s *Sandbox) ExecStream(
-    ctx context.Context,
-    cmd string,
-    args []string,
-    opts ...ExecOption,
-) (*ExecHandle, error)
-```
-
-Run a command with streaming output. Returns a handle that emits `Started`, `Stdout`, `Stderr`, `Exited`, and `Done` events as they happen. The handle MUST be closed with `Close` when done.
-
-See [`ExecHandle`](/sdk/go/execution#exechandle) for the event loop.
-
----
-
-#### Shell()
-
-```go
-func (s *Sandbox) Shell(
-    ctx context.Context,
-    command string,
-    opts ...ExecOption,
-) (*ExecOutput, error)
-```
-
-Run a command through `/bin/sh -c`. Shell syntax like pipes, redirects, and `&&` chains works.
-
-```go
-out, err := sb.Shell(ctx, "ls -la /app && echo done")
+err := sb.FS().Write(ctx, "/tmp/hello.txt", []byte("hi"))
 ```
 
 ---
 
-#### ShellStream()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">SSH()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
-func (s *Sandbox) ShellStream(
-    ctx context.Context,
-    command string,
-    opts ...ExecOption,
-) (*ExecHandle, error)
+func (s *Sandbox) SSH() *SandboxSSHOps
 ```
 
-Shell command with streaming output.
+Return an SSH accessor for opening a native in-process SSH client or preparing a reusable SSH server endpoint against the running sandbox. See [SSH](/sdk/go/ssh) for the API.
 
----
+<p className="msb-label">Returns</p>
 
-#### Attach()
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/go/ssh">*SandboxSSHOps</a></div>
+    <div className="msb-param-desc">SSH accessor.</div>
+  </div>
+</div>
 
-```go
-func (s *Sandbox) Attach(ctx context.Context, cmd string, args ...string) (int, error)
-```
-
-Bridge the caller's terminal directly to a process inside the sandbox for a fully interactive PTY session. The caller's terminal must be a real TTY; primarily useful for CLI tools, not library code.
-
-**Returns**
-
-| Type  | Description              |
-| ----- | ------------------------ |
-| `int` | Exit code of the process |
-
----
-
-#### AttachShell()
+<p className="msb-label">Example</p>
 
 ```go
-func (s *Sandbox) AttachShell(ctx context.Context) (int, error)
-```
-
-Attach to the sandbox's default shell (configured via [`WithShell`](#withshell), defaults to `/bin/sh`).
-
----
-
-#### Stop()
-
-```go
-func (s *Sandbox) Stop(ctx context.Context) error
-```
-
-Gracefully shut down the sandbox and wait until stopped state is observed. Pass `WithStopTimeout(...)` to control the graceful shutdown window before force-kill.
-
----
-
-#### RequestStop()
-
-```go
-func (s *Sandbox) RequestStop(ctx context.Context) error
-```
-
-Request graceful shutdown and return once the request is sent.
-
----
-
-#### Kill()
-
-```go
-func (s *Sandbox) Kill(ctx context.Context) error
-```
-
-Force-terminate the sandbox and wait until stopped state is observed. Pass `WithKillTimeout(...)` to control the observation timeout.
-
----
-
-#### RequestKill()
-
-```go
-func (s *Sandbox) RequestKill(ctx context.Context) error
-```
-
-Request force termination and return once the request is sent.
-
----
-
-#### RequestDrain()
-
-```go
-func (s *Sandbox) RequestDrain(ctx context.Context) error
-```
-
-Request graceful drain and return once the request is sent.
-
----
-
-#### WaitUntilStopped()
-
-```go
-func (s *Sandbox) WaitUntilStopped(ctx context.Context) (*SandboxStopResult, error)
-```
-
-Block until the sandbox is observed in terminal state.
-
----
-
-#### Detach()
-
-```go
-func (s *Sandbox) Detach(ctx context.Context) error
-```
-
-Release the Rust-side handle **without** stopping the VM. Use on sandboxes created with [`WithDetached`](#withdetached) once the caller is done with the handle but the sandbox should keep running. After `Detach`, the handle is invalid; a subsequent `Close` returns `ErrInvalidHandle`.
-
----
-
-#### Close()
-
-```go
-func (s *Sandbox) Close() error
-```
-
-Release the Rust-side handle. Safe to call multiple times; the second call returns `ErrInvalidHandle`.
-
-For a sandbox created with `WithDetached`, `Close` will stop the VM — use [`Detach`](#detach) instead if the intent is to leave it running.
-
----
-
-#### OwnsLifecycle()
-
-```go
-func (s *Sandbox) OwnsLifecycle() (bool, error)
-```
-
-Report whether this handle owns the VM process. When `true`, closing or stopping the handle terminates the sandbox; when `false` the sandbox is detached.
-
----
-
-#### OwnsLifecycleOrFalse()
-
-```go
-func (s *Sandbox) OwnsLifecycleOrFalse() bool
-```
-
-Convenience that swallows the error and returns `false` on any failure. Suitable for log lines and best-effort branching.
-
----
-
-#### RemoveSandbox()
-
-```go
-func RemoveSandbox(ctx context.Context, name string) error
-```
-
-Remove a stopped sandbox's persisted state by name.
-
----
-
-#### Metrics()
-
-```go
-func (s *Sandbox) Metrics(ctx context.Context) (*Metrics, error)
-```
-
-Get a point-in-time snapshot of the sandbox's resource usage.
-
-```go
-metrics, err := sb.Metrics(ctx)
-fmt.Printf("CPU: %.1f%% Mem: %d bytes Uptime: %s\n",
-    metrics.CPUPercent, metrics.MemoryBytes, metrics.Uptime)
+client, err := sb.SSH().OpenClient(ctx)
 ```
 
 ---
 
-#### Logs()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">Logs()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (s *Sandbox) Logs(ctx context.Context, opts LogOptions) ([]LogEntry, error)
 ```
 
-Read persisted sandbox output. Works for running and stopped sandboxes.
+Read persisted output from the sandbox's `exec.log`. Backed by an on-disk file, so it works for running and stopped sandboxes alike without guest-agent protocol traffic. The default sources are stdout and stderr; add `LogSourceOutput` for PTY-merged output or `LogSourceSystem` for runtime and kernel diagnostics. The same method exists on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#logoptions">LogOptions</a></div>
+    <div className="msb-param-desc">Filters: <code>Tail</code>, <code>Since</code>, <code>Until</code>, <code>Sources</code>. The zero value returns everything for the default stdout and stderr sources.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#logentry">[]LogEntry</a></div>
+    <div className="msb-param-desc">Matching entries in chronological order.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 entries, err := sb.Logs(ctx, m.LogOptions{
     Sources: []m.LogSource{m.LogSourceStdout, m.LogSourceStderr},
 })
+for _, e := range entries {
+    fmt.Printf("[%s] %s", e.Source, e.Text())
+}
 ```
 
 ---
 
-#### MetricsStream()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">LogStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
-func (s *Sandbox) MetricsStream(
-    ctx context.Context,
-    interval time.Duration,
-) (*MetricsStreamHandle, error)
+func (s *Sandbox) LogStream(ctx context.Context, opts LogStreamOptions) (*LogStreamHandle, error)
 ```
 
-Start a streaming metrics subscription that delivers a snapshot every `interval`. Sub-millisecond precision is rounded up. Close the returned handle when done.
+Start a streaming log subscription against a live sandbox. Pass `LogStreamOptions{Follow: true}` to keep the stream open past current EOF and pick up new entries as they are written. Close the returned [`*LogStreamHandle`](#logstreamhandle) when done. Also available on [`SandboxHandle`](#sandboxhandle).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#logstreamoptions">LogStreamOptions</a></div>
+    <div className="msb-param-desc">Sources, follow mode, and a <code>Since</code> or <code>FromCursor</code> start point.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#logstreamhandle">*LogStreamHandle</a></div>
+    <div className="msb-param-desc">Live subscription; call <code>Recv</code> in a loop.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+stream, err := sb.LogStream(ctx, m.LogStreamOptions{Follow: true})
+if err != nil {
+    return err
+}
+defer stream.Close()
+for {
+    entry, err := stream.Recv(ctx)
+    if err != nil || entry == nil {
+        break
+    }
+    fmt.Print(entry.Text())
+}
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">Metrics()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) Metrics(ctx context.Context) (*Metrics, error)
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk I/O, network I/O, optional upper-disk usage, and uptime.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#metrics">*Metrics</a></div>
+    <div className="msb-param-desc">Resource snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+metrics, err := sb.Metrics(ctx)
+fmt.Printf("cpu %.1f%% · mem %d MiB\n",
+    metrics.CPUPercent, metrics.MemoryBytes/(1<<20))
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">MetricsStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) MetricsStream(ctx context.Context, interval time.Duration) (*MetricsStreamHandle, error)
+```
+
+Start a streaming metrics subscription that delivers a [`Metrics`](#metrics) snapshot every `interval`. Sub-millisecond precision is rounded up; a zero or negative value uses the runtime minimum (~1 ms). Close the returned [`*MetricsStreamHandle`](#metricsstreamhandle) when done.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>interval</code><span className="msb-type">time.Duration</span></div>
+    <div className="msb-param-desc">Time between snapshots.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#metricsstreamhandle">*MetricsStreamHandle</a></div>
+    <div className="msb-param-desc">Live subscription; call <code>Recv</code> in a loop.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 stream, err := sb.MetricsStream(ctx, 500*time.Millisecond)
@@ -488,27 +742,1024 @@ if err != nil {
     return err
 }
 defer stream.Close()
-
 for {
     metrics, err := stream.Recv(ctx)
     if err != nil || metrics == nil {
         break
     }
-    fmt.Printf("CPU: %.1f%%  Mem: %d bytes\n", metrics.CPUPercent, metrics.MemoryBytes)
+    fmt.Printf("CPU: %.1f%%\n", metrics.CPUPercent)
 }
 ```
 
 ---
 
-## Patch
+#### <span className="msb-recv">sb.</span><span className="msb-hn">Attach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
-Helpers that construct rootfs patches for [`WithPatches`](#withpatches). Access via the package-level `Patch` value. Each method returns a [`PatchConfig`](#patchconfig). `Mkdir` and `Remove` are idempotent; other operations error at boot when targeting a path already present in the image unless `Replace: true` is passed in [`PatchOptions`](#patchoptions).
+```go
+func (s *Sandbox) Attach(ctx context.Context, cmd string, args ...string) (int, error)
+```
 
-See [Patches](/sandboxes/customize#patches) for conceptual context.
+Bridge the caller's terminal to a process inside the sandbox for a fully interactive PTY session. Blocks until the process exits and returns its exit code. The caller's terminal must be a real TTY, so this is primarily useful for CLI tools, not library code.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Command to run.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">...string</span></div>
+    <div className="msb-param-desc">Command arguments.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Exit code of the process.</div>
+  </div>
+</div>
 
 ---
 
-#### Patch.Text()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">AttachShell()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) AttachShell(ctx context.Context) (int, error)
+```
+
+Attach to the sandbox's default shell (configured via [`WithShell`](#withshell), defaults to `/bin/sh`). Blocks until the shell exits and returns its exit code.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Exit code of the shell.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">Stop()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) Stop(ctx context.Context, opts ...StopOption) error
+```
+
+Gracefully shut down the sandbox and wait until stopped state is observed. Lets the workload finish writing any pending data to disk before it exits. Defaults to a ten-second graceful window before force-kill; pass [`WithStopTimeout`](#withstoptimeout) to change it.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#withstoptimeout">...StopOption</a></div>
+    <div className="msb-param-desc">Graceful shutdown window, e.g. <code>WithStopTimeout(30 * time.Second)</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := sb.Stop(ctx, m.WithStopTimeout(30*time.Second))
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">RequestStop()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) RequestStop(ctx context.Context) error
+```
+
+Request graceful shutdown and return once the request is sent, without waiting for the sandbox to reach stopped state. Pair with [`WaitUntilStopped`](#sb-waituntilstopped) to await termination.
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">Kill()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) Kill(ctx context.Context, opts ...KillOption) error
+```
+
+Force-terminate the sandbox with SIGKILL and wait until stopped state is observed. No graceful shutdown, so pending writes the workload hasn't `fsync`'d may be lost. Prefer [`Stop`](#sb-stop) for graceful shutdown. Defaults to a five-second observation window; pass [`WithKillTimeout`](#withkilltimeout) to change it.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#withkilltimeout">...KillOption</a></div>
+    <div className="msb-param-desc">Stopped-state observation window.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := sb.Kill(ctx)
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">RequestKill()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) RequestKill(ctx context.Context) error
+```
+
+Request force termination and return once the request is sent, without waiting for the sandbox to reach stopped state.
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">RequestDrain()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) RequestDrain(ctx context.Context) error
+```
+
+Request a graceful drain and return once the request is sent. Existing commands run to completion while new exec calls are rejected; the sandbox transitions to stopped when all in-flight commands finish. Useful for zero-downtime rotation of worker sandboxes.
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">WaitUntilStopped()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) WaitUntilStopped(ctx context.Context) (*SandboxStopResult, error)
+```
+
+Block until the sandbox is observed in a terminal state, then return how it ended.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxstopresult">*SandboxStopResult</a></div>
+    <div className="msb-param-desc">Terminal status, exit code, and signal.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+result, err := sb.WaitUntilStopped(ctx)
+fmt.Printf("ended as %s\n", result.Status)
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">Detach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) Detach(ctx context.Context) error
+```
+
+Release the Rust-side handle **without** stopping the VM. Use on sandboxes created with [`WithDetached`](#withdetached) once the caller is done with the handle but the sandbox should keep running in the background. After `Detach`, the handle is invalid; a subsequent `Close` returns an error with `Kind == ErrInvalidHandle`. Reconnect later with [`GetSandbox`](#m-getsandbox).
+
+<p className="msb-label">Example</p>
+
+```go
+err := sb.Detach(ctx) // keeps running in the background
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">Close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) Close() error
+```
+
+Release the Rust-side handle. Safe to call multiple times; the second call returns an error with `Kind == ErrInvalidHandle`. For a sandbox created with [`WithDetached`](#withdetached), `Close` stops the VM, use [`Detach`](#sb-detach) instead to leave it running.
+
+<p className="msb-label">Example</p>
+
+```go
+defer sb.Close()
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">OwnsLifecycle()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) OwnsLifecycle() (bool, error)
+```
+
+Report whether this handle owns the VM process. When `true`, closing or stopping the handle terminates the sandbox (attached mode); `false` means it is detached. The error return covers stale handles and FFI failures; use [`OwnsLifecycleOrFalse`](#sb-ownslifecycleorfalse) when you don't care.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> if attached.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">OwnsLifecycleOrFalse()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *Sandbox) OwnsLifecycleOrFalse() bool
+```
+
+Convenience wrapper around [`OwnsLifecycle`](#sb-ownslifecycle) that swallows the error and returns `false` on any failure. Suitable for log lines and best-effort branching.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> if attached, <code>false</code> on detach or error.</div>
+  </div>
+</div>
+
+---
+
+## Options
+
+Functional options for [`CreateSandbox`](#m-createsandbox). Map and slice options merge across repeated calls; single-value setters like [`WithImage`](#withimage) replace. Simple setters are demonstrated by the [Typical flow](#typical-flow) above.
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithImage()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithImage(image string) SandboxOption
+```
+
+Set the root filesystem source: an OCI image name, local directory path, or disk image path (e.g. `"python:3.12"`, `"docker.io/library/alpine"`). Required unless [`WithSnapshot`](#withsnapshot) is used. Use [`WithImageDisk`](#withimagedisk) when a disk-image root needs an explicit filesystem type.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>image</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">OCI image, local path, or disk image.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithOCIUpperSize()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithOCIUpperSize(mebibytes uint32) SandboxOption
+```
+
+Set the writable overlay upper size for an OCI image, in MiB. Valid only with an OCI image rootfs, not disk images or snapshots.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mebibytes</code><span className="msb-type">uint32</span></div>
+    <div className="msb-param-desc">Upper layer size in MiB.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithImageDisk()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithImageDisk(path string, fstype string) SandboxOption
+```
+
+Use a disk image as the root filesystem and optionally provide the inner filesystem type, e.g. `"ext4"`. The disk format is inferred from the path extension (`.qcow2`, `.raw`, or `.vmdk`).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Host path to the disk image.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>fstype</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Inner filesystem hint, empty to auto-detect.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithSnapshot()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithSnapshot(pathOrName string) SandboxOption
+```
+
+Boot from a snapshot artifact by bare name or filesystem path. Mutually exclusive with [`WithImage`](#withimage). See [Snapshots](/sdk/go/snapshots).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pathOrName</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Snapshot artifact path or bare name.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithMemory()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithMemory(mebibytes uint32) SandboxOption
+```
+
+Set the guest memory limit in MiB. This is a limit, not an upfront reservation. Default: `512` MiB.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mebibytes</code><span className="msb-type">uint32</span></div>
+    <div className="msb-param-desc">Memory in MiB.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithCPUs()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithCPUs(cpus uint8) SandboxOption
+```
+
+Set the number of virtual CPUs. This is a limit, not a reservation. Default: `1`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cpus</code><span className="msb-type">uint8</span></div>
+    <div className="msb-param-desc">Number of vCPUs.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithWorkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithWorkdir(path string) SandboxOption
+```
+
+Set the default working directory for all commands.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithShell()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithShell(shell string) SandboxOption
+```
+
+Set the shell used by [`Shell`](/sdk/go/execution) and [`AttachShell`](#sb-attachshell). Defaults to `/bin/sh` on most images.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>shell</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Shell path, e.g. <code>"/bin/bash"</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithSecurityProfile()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithSecurityProfile(profile SecurityProfile) SandboxOption
+```
+
+Set the in-guest security profile. [`SecurityProfileRestricted`](#securityprofile) applies stronger hardening: sets `no_new_privs`, drops mount-admin capability from user commands, and forces `nosuid,nodev` on user mounts.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>profile</code><a className="msb-type" href="#securityprofile">SecurityProfile</a></div>
+    <div className="msb-param-desc">Security profile.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithEnv()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithEnv(env map[string]string) SandboxOption
+```
+
+Set environment variables visible to all commands. Called repeatedly, the maps merge; later keys overwrite earlier ones.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>env</code><span className="msb-type">map[string]string</span></div>
+    <div className="msb-param-desc">Environment variables.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithLabels()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithLabels(labels map[string]string) SandboxOption
+```
+
+Attach labels to the sandbox for metrics attribution and [`ListSandboxesWith`](#m-listsandboxeswith) filtering. Called repeatedly, the maps merge; later keys overwrite earlier ones. Keys must not use the reserved prefixes `sandbox.`, `microsandbox.`, or `service.`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>labels</code><span className="msb-type">map[string]string</span></div>
+    <div className="msb-param-desc">Label key-value pairs.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithLabel()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithLabel(key, value string) SandboxOption
+```
+
+Attach a single label. Shorthand for [`WithLabels`](#withlabels) with one entry.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Label key.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Label value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithHostname()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithHostname(hostname string) SandboxOption
+```
+
+Set the guest hostname.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hostname</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Hostname.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithUser()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithUser(user string) SandboxOption
+```
+
+Set the default guest user (UID or name) for all commands.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>user</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">User name or UID.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithReplace()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithReplace() SandboxOption
+```
+
+Replace any existing sandbox with the same name. Sends SIGTERM, waits up to 10s for graceful exit, then escalates to SIGKILL. Without this, creation fails on name conflict. Use [`WithReplaceWithTimeout`](#withreplacewithtimeout) to set a different window.
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithReplaceWithTimeout()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithReplaceWithTimeout(timeout time.Duration) SandboxOption
+```
+
+Like [`WithReplace`](#withreplace) but with a caller-specified timeout between SIGTERM and SIGKILL. Implies `WithReplace`, calling this alone is enough. A zero duration skips SIGTERM and SIGKILLs immediately.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">time.Duration</span></div>
+    <div className="msb-param-desc">Grace period before SIGKILL.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithDetached()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithDetached() SandboxOption
+```
+
+Create the sandbox in detached mode. The VM continues running after the Go process exits; reattach via [`GetSandbox`](#m-getsandbox). Note that [`Close`](#sb-close) stops a detached sandbox, use [`Detach`](#sb-detach) to leave it running.
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithEphemeral()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithEphemeral(ephemeral bool) SandboxOption
+```
+
+Mark whether the runtime should remove the sandbox's DB row, on-disk state, logs, and captured output after it reaches a terminal status.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ephemeral</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> to delete all state on termination.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithEntrypoint()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithEntrypoint(cmd ...string) SandboxOption
+```
+
+Override the user-workload entrypoint baked into the image: the command the agent execs per request. This is the user workload, **not** the guest PID 1, for that, use [`WithInit`](#withinit) instead.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">...string</span></div>
+    <div className="msb-param-desc">Entrypoint command and arguments.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithInit()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithInit(cfg InitConfig) SandboxOption
+```
+
+Hand off PID 1 inside the guest to a custom init binary after agentd finishes boot-time setup. Construct `cfg` via the [`Init`](#init) factory. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks and shutdown semantics.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cfg</code><a className="msb-type" href="#initconfig">InitConfig</a></div>
+    <div className="msb-param-desc">Init specification.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sb, err := m.CreateSandbox(ctx, "worker",
+    m.WithImage("jrei/systemd-debian:12"),
+    m.WithInit(m.Init.Auto()),
+)
+```
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithLogLevel()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithLogLevel(level LogLevel) SandboxOption
+```
+
+Override the sandbox process's log verbosity. See [`LogLevel`](#loglevel).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>level</code><a className="msb-type" href="#loglevel">LogLevel</a></div>
+    <div className="msb-param-desc">Log level.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithQuietLogs()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithQuietLogs() SandboxOption
+```
+
+Suppress sandbox-level log output entirely.
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithScripts()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithScripts(scripts map[string]string) SandboxOption
+```
+
+Add named scripts mounted at `/.msb/scripts/<name>` inside the guest. Scripts are added to `PATH` and can be called by name. Called repeatedly, entries merge; later names overwrite earlier ones.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>scripts</code><span className="msb-type">map[string]string</span></div>
+    <div className="msb-param-desc">Script name to script content.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithPullPolicy()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithPullPolicy(p PullPolicy) SandboxOption
+```
+
+Control when the OCI image is pulled from the registry. See [`PullPolicy`](#pullpolicy).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>p</code><a className="msb-type" href="#pullpolicy">PullPolicy</a></div>
+    <div className="msb-param-desc">Pull behavior.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithMaxDuration()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithMaxDuration(d time.Duration) SandboxOption
+```
+
+Cap the sandbox's total runtime. When exceeded, the sandbox is drained and stopped. Zero means unlimited. Sub-second precision is rounded up to whole seconds. Enforced on the host side.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>d</code><span className="msb-type">time.Duration</span></div>
+    <div className="msb-param-desc">Maximum lifetime.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithIdleTimeout()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithIdleTimeout(d time.Duration) SandboxOption
+```
+
+Stop the sandbox after this much wall-clock time without exec activity. Zero means unlimited. Sub-second precision is rounded up to whole seconds.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>d</code><span className="msb-type">time.Duration</span></div>
+    <div className="msb-param-desc">Idle timeout.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithRegistryAuth()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithRegistryAuth(auth RegistryAuth) SandboxOption
+```
+
+Set credentials for pulling from a private OCI registry. See [`RegistryAuth`](#registryauth).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>auth</code><a className="msb-type" href="#registryauth">RegistryAuth</a></div>
+    <div className="msb-param-desc">Registry credentials.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithPorts()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithPorts(ports map[uint16]uint16) SandboxOption
+```
+
+Publish guest TCP ports onto host ports (map key = host port, value = guest port). The default host bind address is `127.0.0.1`. Called repeatedly, the maps merge.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ports</code><span className="msb-type">map[uint16]uint16</span></div>
+    <div className="msb-param-desc">Host port to guest port.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithPortsUDP()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithPortsUDP(ports map[uint16]uint16) SandboxOption
+```
+
+Publish guest UDP ports onto host ports. The default host bind address is `127.0.0.1`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ports</code><span className="msb-type">map[uint16]uint16</span></div>
+    <div className="msb-param-desc">Host port to guest port.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithPortBindings()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithPortBindings(bindings ...PortBinding) SandboxOption
+```
+
+Publish ports on explicit host bind addresses, such as `0.0.0.0`. See [`PortBinding`](/sdk/go/networking#portbinding) for the type definition and UDP examples.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>bindings</code><a className="msb-type" href="/sdk/go/networking#portbinding">...PortBinding</a></div>
+    <div className="msb-param-desc">Explicit bind-address port mappings.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithNetwork()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithNetwork(net *NetworkConfig) SandboxOption
+```
+
+Configure the network stack: preset, custom rules, DNS, and TLS interception. Build via the [`NetworkPolicy`](/sdk/go/networking) factory or a [`*NetworkConfig`](/sdk/go/networking#networkconfig) literal. See [Networking](/sdk/go/networking).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>net</code><a className="msb-type" href="/sdk/go/networking#networkconfig">*NetworkConfig</a></div>
+    <div className="msb-param-desc">Network configuration.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sb, err := m.CreateSandbox(ctx, "api",
+    m.WithImage("python"),
+    m.WithNetwork(m.NetworkPolicy.PublicOnly()),
+)
+```
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithSecrets()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithSecrets(secrets ...SecretEntry) SandboxOption
+```
+
+Append credential secrets to the sandbox. Secrets never enter the VM; the network proxy substitutes them at the transport layer. Build entries via the [`Secret`](/sdk/go/secrets) factory. See [Secrets](/sdk/go/secrets).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>secrets</code><a className="msb-type" href="/sdk/go/secrets#secretentry">...SecretEntry</a></div>
+    <div className="msb-param-desc">Secret injection entries.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithPatches()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithPatches(patches ...PatchConfig) SandboxOption
+```
+
+Append rootfs patches applied before the VM boots. Patches go into the writable layer; the base image is untouched. Only compatible with OverlayFS rootfs (not disk images). Build entries via the [`Patch`](#patch) factory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>patches</code><a className="msb-type" href="#patchconfig">...PatchConfig</a></div>
+    <div className="msb-param-desc">Ordered rootfs patches.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sb, err := m.CreateSandbox(ctx, "api",
+    m.WithImage("python"),
+    m.WithPatches(
+        m.Patch.Mkdir("/app", m.PatchOptions{}),
+        m.Patch.Text("/app/config.txt", "ready\n", m.PatchOptions{}),
+    ),
+)
+```
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithMounts()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithMounts(mounts map[string]MountConfig) SandboxOption
+```
+
+Add volume mount configurations keyed by guest path. Build values via the [`Mount`](/sdk/go/volumes) factory. Called repeatedly, the maps merge; later entries overwrite earlier ones for the same guest path. See [Volumes](/sdk/go/volumes).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mounts</code><span className="msb-type">map[string]MountConfig</span></div>
+    <div className="msb-param-desc">Guest path to mount config.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sb, err := m.CreateSandbox(ctx, "api",
+    m.WithImage("python"),
+    m.WithMounts(map[string]m.MountConfig{
+        "/data": m.Mount.Named("my-vol", m.MountOptions{}),
+        "/tmp":  m.Mount.Tmpfs(m.TmpfsOptions{SizeMiB: 256}),
+    }),
+)
+```
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithStopTimeout()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithStopTimeout(timeout time.Duration) StopOption
+```
+
+Set how long [`Stop`](#sb-stop) waits for graceful shutdown before force-killing. Default: 10 seconds. This is a `StopOption`, not a `SandboxOption`, pass it to [`Stop`](#sb-stop).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">time.Duration</span></div>
+    <div className="msb-param-desc">Graceful shutdown window.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithKillTimeout()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithKillTimeout(timeout time.Duration) KillOption
+```
+
+Set how long [`Kill`](#sb-kill) waits for stopped-state observation. Default: 5 seconds. This is a `KillOption`, pass it to [`Kill`](#sb-kill).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">time.Duration</span></div>
+    <div className="msb-param-desc">Observation window.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithSkipDownload()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithSkipDownload() SetupOption
+```
+
+Prevent [`EnsureInstalled`](#m-ensureinstalled) from fetching the msb + libkrunfw bundle from GitHub. Use when the runtime is already on disk at the install path (e.g. air-gapped CI). The embedded FFI library is unaffected. This is a [`SetupOption`](#setupoption), pass it to `EnsureInstalled`.
+
+---
+
+## Patch
+
+Factory that constructs rootfs patches for [`WithPatches`](#withpatches). Access via the package-level `Patch` value. Each method returns a [`PatchConfig`](#patchconfig). `Mkdir` and `Remove` are idempotent; other operations error at boot when targeting a path already present in the image unless `Replace: true` is passed in [`PatchOptions`](#patchoptions). See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">Text()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span></div>
 
 ```go
 func (patchFactory) Text(path, content string, opts PatchOptions) PatchConfig
@@ -516,9 +1767,27 @@ func (patchFactory) Text(path, content string, opts PatchOptions) PatchConfig
 
 Write UTF-8 text content at `path`.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Text content.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#patchoptions">PatchOptions</a></div>
+    <div className="msb-param-desc"><code>Mode</code> and <code>Replace</code>.</div>
+  </div>
+</div>
+
 ---
 
-#### Patch.Append()
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">Append()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span></div>
 
 ```go
 func (patchFactory) Append(path, content string) PatchConfig
@@ -526,39 +1795,95 @@ func (patchFactory) Append(path, content string) PatchConfig
 
 Append `content` to an existing file at `path`. If the file lives in a lower image layer, it is copied up first.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Text to append.</div>
+  </div>
+</div>
+
 ---
 
-#### Patch.Mkdir()
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">Mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span></div>
 
 ```go
 func (patchFactory) Mkdir(path string, opts PatchOptions) PatchConfig
 ```
 
-Create a directory. Only `opts.Mode` is honoured; `Replace` is ignored (the operation is idempotent).
+Create a directory. Idempotent. Only `opts.Mode` is honored; `Replace` is ignored.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#patchoptions">PatchOptions</a></div>
+    <div className="msb-param-desc">Only <code>Mode</code> applies.</div>
+  </div>
+</div>
 
 ---
 
-#### Patch.Remove()
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">Remove()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span></div>
 
 ```go
 func (patchFactory) Remove(path string) PatchConfig
 ```
 
-Delete a file or directory. Idempotent.
+Delete a file or directory at `path`. Idempotent.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
 
 ---
 
-#### Patch.Symlink()
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">Symlink()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span></div>
 
 ```go
 func (patchFactory) Symlink(target, link string, opts PatchOptions) PatchConfig
 ```
 
-Create a symlink at `link` pointing to `target`. Only `opts.Replace` is honoured.
+Create a symlink at `link` pointing to `target`. Only `opts.Replace` is honored.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>target</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">What the symlink points to.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>link</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path of the symlink itself.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#patchoptions">PatchOptions</a></div>
+    <div className="msb-param-desc">Only <code>Replace</code> applies.</div>
+  </div>
+</div>
 
 ---
 
-#### Patch.CopyFile()
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">CopyFile()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span></div>
 
 ```go
 func (patchFactory) CopyFile(src, dst string, opts PatchOptions) PatchConfig
@@ -566,31 +1891,78 @@ func (patchFactory) CopyFile(src, dst string, opts PatchOptions) PatchConfig
 
 Copy a single host file at `src` into the guest rootfs at `dst`.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Host source file.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute destination path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#patchoptions">PatchOptions</a></div>
+    <div className="msb-param-desc"><code>Mode</code> and <code>Replace</code>.</div>
+  </div>
+</div>
+
 ---
 
-#### Patch.CopyDir()
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">CopyDir()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span></div>
 
 ```go
 func (patchFactory) CopyDir(src, dst string, opts PatchOptions) PatchConfig
 ```
 
-Recursively copy a host directory at `src` into the guest rootfs at `dst`. Only `opts.Replace` is honoured.
+Recursively copy a host directory at `src` into the guest rootfs at `dst`. Only `opts.Replace` is honored.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Host source directory.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute destination path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#patchoptions">PatchOptions</a></div>
+    <div className="msb-param-desc">Only <code>Replace</code> applies.</div>
+  </div>
+</div>
 
 ---
 
 ## Init
 
-Helpers that construct [`InitConfig`](#initconfig) values for [`WithInit`](#withinit) to hand off PID 1 inside the guest after agentd setup. Access via the package-level `Init` value. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks and shutdown semantics.
+Factory that constructs [`InitConfig`](#initconfig) values for [`WithInit`](#withinit), handing off PID 1 inside the guest after agentd setup. Access via the package-level `Init` value. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks and shutdown semantics.
 
 ---
 
-#### Init.Auto()
+#### <span className="msb-recv">Init.</span><span className="msb-hn">Auto()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span></div>
 
 ```go
 func (initFactory) Auto() InitConfig
 ```
 
-Use a known init at the start of the image ENTRYPOINT when present, or probe common init paths inside the guest (`/sbin/init`, `/lib/systemd/systemd`, ...). For attached `msb run` against image-declared init entrypoints, microsandbox passes the remaining ENTRYPOINT plus CMD or trailing command to that init instead of direct-executing the wrapper through agentd.
+Use a known init at the start of the image ENTRYPOINT when present, preserving attached init-entrypoint commands; otherwise delegate to agentd to probe common init paths (`/sbin/init`, `/lib/systemd/systemd`, ...) inside the guest.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#initconfig">InitConfig</a></div>
+    <div className="msb-param-desc">Auto-detect init config.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 m.WithInit(m.Init.Auto())
@@ -598,13 +1970,29 @@ m.WithInit(m.Init.Auto())
 
 ---
 
-#### Init.Cmd()
+#### <span className="msb-recv">Init.</span><span className="msb-hn">Cmd()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span></div>
 
 ```go
 func (initFactory) Cmd(cmd string, opts InitOptions) InitConfig
 ```
 
-Specify the init binary explicitly with optional argv/env. `cmd` must be an absolute path inside the guest rootfs.
+Specify the init binary explicitly with optional argv and env. `cmd` must be an absolute path inside the guest rootfs.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path to the init binary inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#initoptions">InitOptions</a></div>
+    <div className="msb-param-desc">Argv and env.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 m.WithInit(m.Init.Cmd(
@@ -618,532 +2006,269 @@ m.WithInit(m.Init.Cmd(
 
 ---
 
-## Options
-
-Functional options for [`CreateSandbox`](#createsandbox). Most options merge across repeated calls; `WithImage` and similar single-value setters replace.
-
----
-
-#### WithImage()
-
-```go
-func WithImage(image string) SandboxOption
-```
-
-OCI image, local path, or disk image (e.g. `"python:3.12"`, `"docker.io/library/alpine"`). Use [`WithImageDisk`](#withimagedisk) when a disk-image root needs an explicit filesystem type. Required unless [`WithSnapshot`](#withsnapshot) is used.
-
----
-
-#### WithOCIUpperSize()
-
-```go
-func WithOCIUpperSize(mebibytes uint32) SandboxOption
-```
-
-Set the writable overlay upper size for an OCI image, in MiB. Valid only with an OCI image rootfs, not disk images or snapshots.
-
----
-
-#### WithImageDisk()
-
-```go
-func WithImageDisk(path string, fstype string) SandboxOption
-```
-
-Use a disk image as the root filesystem and optionally provide the inner filesystem type, for example `"ext4"`. The disk format is inferred from the path extension (`.qcow2`, `.raw`, or `.vmdk`).
-
----
-
-#### WithSnapshot()
-
-```go
-func WithSnapshot(pathOrName string) SandboxOption
-```
-
-Boot from a snapshot artifact by bare name or filesystem path. Mutually exclusive with [`WithImage`](#withimage). See [Snapshots](/sdk/go/snapshots).
-
----
-
-#### WithMemory()
-
-```go
-func WithMemory(mebibytes uint32) SandboxOption
-```
-
-Guest memory in MiB. This is a limit, not a reservation.
-
----
-
-#### WithCPUs()
-
-```go
-func WithCPUs(cpus uint8) SandboxOption
-```
-
-Virtual CPUs.
-
----
-
-#### WithWorkdir()
-
-```go
-func WithWorkdir(path string) SandboxOption
-```
-
-Default working directory for commands.
-
----
-
-#### WithShell()
-
-```go
-func WithShell(shell string) SandboxOption
-```
-
-Shell binary used by [`Sandbox.Shell`](#shell) and [`Sandbox.AttachShell`](#attachshell). Defaults to `/bin/sh` on most images.
-
----
-
-#### WithSecurityProfile()
-
-```go
-func WithSecurityProfile(profile SecurityProfile) SandboxOption
-```
-
-Set the in-guest security profile. Use `SecurityProfileRestricted` for stronger hardening that sets `no_new_privs`, drops mount-admin capability from user commands, and forces `nosuid,nodev` on user mounts.
-
----
-
-#### WithEnv()
-
-```go
-func WithEnv(env map[string]string) SandboxOption
-```
-
-Environment variables visible to all commands. Called repeatedly, the maps merge; later keys overwrite earlier ones.
-
----
-
-#### WithHostname()
-
-```go
-func WithHostname(hostname string) SandboxOption
-```
-
-Guest hostname.
-
----
-
-#### WithUser()
-
-```go
-func WithUser(user string) SandboxOption
-```
-
-Default user (UID or name) to run sandbox commands as.
-
----
-
-#### WithReplace()
-
-```go
-func WithReplace() SandboxOption
-```
-
-Replace any existing sandbox with the same name. Sends SIGTERM, waits up to 10s for graceful exit, then escalates to SIGKILL.
-
----
-
-#### WithReplaceWithTimeout()
-
-```go
-func WithReplaceWithTimeout(timeout time.Duration) SandboxOption
-```
-
-Like [`WithReplace`](#withreplace) but with a caller-specified timeout between SIGTERM and SIGKILL. Implies `WithReplace`. A zero duration skips SIGTERM and SIGKILLs immediately.
-
----
-
-#### WithDetached()
-
-```go
-func WithDetached() SandboxOption
-```
-
-Create the sandbox in detached mode. The VM continues running after the Go process exits.
-
----
-
-#### WithEntrypoint()
-
-```go
-func WithEntrypoint(cmd ...string) SandboxOption
-```
-
-Override the image's stored ENTRYPOINT. Consulted by `msb exec` / `msb run` (CLI command resolution against this sandbox), **not** by [`Sandbox.Exec`](#exec) / [`Sandbox.Shell`](#shell) — those pass `cmd` literally to the guest agent. Use this when configuring sandboxes via the SDK for later CLI attachment. For PID 1 handoff, use [`WithInit`](#withinit) instead.
-
----
-
-#### WithInit()
-
-```go
-func WithInit(cfg InitConfig) SandboxOption
-```
-
-Hand off PID 1 to a guest init binary. Construct `cfg` via [`Init`](#init).
-
----
-
-#### WithLogLevel()
-
-```go
-func WithLogLevel(level LogLevel) SandboxOption
-```
-
-Override the sandbox process log verbosity. See [`LogLevel`](#loglevel).
-
----
-
-#### WithQuietLogs()
-
-```go
-func WithQuietLogs() SandboxOption
-```
-
-Suppress sandbox-level log output entirely.
-
----
-
-#### WithScripts()
-
-```go
-func WithScripts(scripts map[string]string) SandboxOption
-```
-
-Named scripts mounted at `/.msb/scripts/<name>`. Called repeatedly, entries merge.
-
----
-
-#### WithPullPolicy()
-
-```go
-func WithPullPolicy(p PullPolicy) SandboxOption
-```
-
-Image pull behaviour. See [`PullPolicy`](#pullpolicy).
-
----
-
-#### WithMaxDuration()
-
-```go
-func WithMaxDuration(d time.Duration) SandboxOption
-```
-
-Maximum sandbox lifetime. Zero means unlimited. Sub-second precision is rounded up to whole seconds.
-
----
-
-#### WithIdleTimeout()
-
-```go
-func WithIdleTimeout(d time.Duration) SandboxOption
-```
-
-Stop the sandbox after this much wall-clock time without exec activity. Zero means unlimited.
-
----
-
-#### WithRegistryAuth()
-
-```go
-func WithRegistryAuth(auth RegistryAuth) SandboxOption
-```
-
-Credentials for pulling from a private OCI registry. See [`RegistryAuth`](#registryauth).
-
----
-
-#### WithPorts()
-
-```go
-func WithPorts(ports map[uint16]uint16) SandboxOption
-```
-
-Publish host TCP ports into the sandbox (map key = host port, value = guest port).
-The default host bind address is `127.0.0.1`.
-
----
-
-#### WithPortBindings()
-
-```go
-func WithPortBindings(bindings ...PortBinding) SandboxOption
-```
-
-Publish host ports on explicit host bind addresses, such as `0.0.0.0`. See [`PortBinding`](/sdk/go/networking#portbinding) for the type definition and UDP examples.
-
----
-
-#### WithPortsUDP()
-
-```go
-func WithPortsUDP(ports map[uint16]uint16) SandboxOption
-```
-
-Publish host UDP ports into the sandbox. The default host bind address is `127.0.0.1`.
-
----
-
-#### WithNetwork()
-
-```go
-func WithNetwork(net *NetworkConfig) SandboxOption
-```
-
-Configure the network stack — preset, custom rules, DNS, TLS interception. See [Networking](/sdk/go/networking).
-
----
-
-#### WithSecrets()
-
-```go
-func WithSecrets(secrets ...SecretEntry) SandboxOption
-```
-
-Append credential secrets to the sandbox. Secrets never enter the VM; the network proxy substitutes them at the transport layer. See [Secrets](/sdk/go/secrets).
-
----
-
-#### WithPatches()
-
-```go
-func WithPatches(patches ...PatchConfig) SandboxOption
-```
-
-Append rootfs patches applied before the VM boots. Patches are only compatible with OverlayFS rootfs (not disk images). Construct via [`Patch`](#patch).
-
----
-
-#### WithMounts()
-
-```go
-func WithMounts(mounts map[string]MountConfig) SandboxOption
-```
-
-Volume mount configurations keyed by guest path. See [Volumes](/sdk/go/volumes).
-
----
-
-## SandboxHandle
-
-A lightweight metadata reference to a sandbox returned by [`GetSandbox`](#getsandbox) and [`ListSandboxes`](#listsandboxes). Holds last-known name, status, config JSON, and timestamps; offers lifecycle methods that operate on the sandbox without an active connection. Call [`Connect`](#sandboxhandle-connect) or [`Start`](#sandboxhandle-start) to upgrade to a full `*Sandbox`.
-
-| Method                  | Returns                           | Description                                       |
-| ----------------------- | --------------------------------- | ------------------------------------------------- |
-| `Name()`                | `string`                          | Sandbox name, up to 128 UTF-8 bytes              |
-| `Status()`              | [`SandboxStatus`](#sandboxstatus) | Last-known lifecycle status                       |
-| `ConfigJSON()`          | `string`                          | Raw JSON configuration                            |
-| `CreatedAt()`           | `time.Time`                       | Creation time, zero value if unknown              |
-| `UpdatedAt()`           | `time.Time`                       | Last-update time, zero value if unknown           |
-| `Metrics(ctx)`          | `(*Metrics, error)`               | Point-in-time resource metrics                    |
-| `Logs(ctx, opts)`       | `([]LogEntry, error)`             | Persisted sandbox logs                            |
-| `Connect(ctx)`          | `(*Sandbox, error)`               | Reattach to the running sandbox                   |
-| `Start(ctx)`            | `(*Sandbox, error)`               | Boot a stopped sandbox in attached mode           |
-| `StartDetached(ctx)`    | `(*Sandbox, error)`               | Boot a stopped sandbox in detached mode           |
-| `Stop(ctx)`             | `error`                           | Graceful shutdown                                 |
-| `Kill(ctx)`             | `error`                           | Force terminate                                   |
-| `Remove(ctx)`           | `error`                           | Delete sandbox and persisted state                |
-| `Snapshot(ctx, name)`   | `(*SnapshotArtifact, error)`      | Snapshot stopped/crashed sandbox under a bare name |
-| `SnapshotTo(ctx, path)` | `(*SnapshotArtifact, error)`      | Snapshot stopped/crashed sandbox to an explicit path |
-
----
-
 ## Types
+
+### SandboxHandle
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#m-getsandbox">GetSandbox()</a> · <a href="#m-listsandboxes">ListSandboxes()</a> · <a href="#m-listsandboxeswith">ListSandboxesWith()</a></p>
+
+A lightweight reference to a sandbox's persisted state. Carries metadata (name, status, config JSON, timestamps) and offers lifecycle methods that operate on the sandbox **without** an active guest-agent connection. You cannot `Exec` or `FS` on a handle, call `Connect` or `Start` to upgrade to a full [`*Sandbox`](#methods).
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `Name()` | `string` | Sandbox name, up to 128 UTF-8 bytes |
+| `Status()` | [`SandboxStatus`](#sandboxstatus) | Last-known lifecycle status |
+| `ConfigJSON()` | `string` | Raw JSON configuration |
+| `Config()` | `(*`[`SandboxConfig`](#sandboxconfig)`, error)` | Parsed configuration |
+| `CreatedAt()` | `time.Time` | Creation time, zero value if unknown |
+| `UpdatedAt()` | `time.Time` | Last-update time, zero value if unknown |
+| `Refresh(ctx)` | `(*SandboxHandle, error)` | Fresh handle for the same name |
+| `Metrics(ctx)` | `(*`[`Metrics`](#metrics)`, error)` | Point-in-time resource metrics |
+| `Logs(ctx, opts)` | `([]`[`LogEntry`](#logentry)`, error)` | Read captured `exec.log` (works without starting) |
+| `LogStream(ctx, opts)` | `(*`[`LogStreamHandle`](#logstreamhandle)`, error)` | Stream captured output |
+| `Connect(ctx)` | `(*`[`Sandbox`](#methods)`, error)` | Reattach to the running sandbox |
+| `Start(ctx)` | `(*`[`Sandbox`](#methods)`, error)` | Boot a stopped sandbox in attached mode |
+| `StartDetached(ctx)` | `(*`[`Sandbox`](#methods)`, error)` | Boot a stopped sandbox in detached mode |
+| `Stop(ctx, opts...)` | `error` | Graceful shutdown; accepts [`StopOption`](#withstoptimeout) |
+| `RequestStop(ctx)` | `error` | Async stop request |
+| `Kill(ctx, opts...)` | `error` | Force terminate; accepts [`KillOption`](#withkilltimeout) |
+| `RequestKill(ctx)` | `error` | Async kill request |
+| `RequestDrain(ctx)` | `error` | Async drain request |
+| `WaitUntilStopped(ctx)` | `(*`[`SandboxStopResult`](#sandboxstopresult)`, error)` | Block until terminal state |
+| `Remove(ctx)` | `error` | Delete sandbox and persisted state |
+| `Snapshot(ctx, name)` | `(*SnapshotArtifact, error)` | Snapshot a stopped sandbox under a bare name |
+| `SnapshotTo(ctx, path)` | `(*SnapshotArtifact, error)` | Snapshot a stopped sandbox to an explicit path |
+
+### SandboxFilter
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Built by <a href="#m-newsandboxfilter">NewSandboxFilter()</a> · used by <a href="#m-listsandboxeswith">ListSandboxesWith()</a></p>
+
+Narrows the results of [`ListSandboxesWith`](#m-listsandboxeswith). The zero value matches every sandbox. Built fluently; `WithLabels` returns a new value so calls chain.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `WithLabels(labels)` | `SandboxFilter` | Require all of these labels (AND-matched). Repeated calls merge; later keys overwrite earlier ones |
 
 ### SandboxConfig
 
-The config struct populated by [`SandboxOption`](#sandboxoption) functions. Most callers build a sandbox via `CreateSandbox(ctx, name, ...opts)`; `SandboxConfig` is exported for callers that prefer to construct a value directly and pass its fields explicitly.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-| Field            | Type                                                 | Description                                                          |
-| ---------------- | ---------------------------------------------------- | -------------------------------------------------------------------- |
-| Image            | `string`                                             | OCI image, local path, or disk image                                 |
-| ImageFstype      | `string`                                             | Optional inner filesystem type for disk-image roots                  |
-| OCIUpperSizeMiB  | `uint32`                                             | Writable overlay upper size for OCI image roots                      |
-| Snapshot         | `string`                                             | Snapshot artifact path or bare name; mutually exclusive with `Image` |
-| MemoryMiB        | `uint32`                                             | Guest memory in MiB                                                  |
-| CPUs             | `uint8`                                              | Virtual CPUs                                                         |
-| Workdir          | `string`                                             | Default working directory                                            |
-| Shell            | `string`                                             | Shell binary used by `Shell` calls                                   |
-| SecurityProfile  | [`SecurityProfile`](#securityprofile)                | In-guest security profile                                            |
-| Hostname         | `string`                                             | Guest hostname                                                       |
-| User             | `string`                                             | Default guest user                                                   |
-| Replace          | `bool`                                               | Replace existing sandbox with same name                              |
-| ReplaceWithTimeout | `*time.Duration`                                   | Timeout between SIGTERM and SIGKILL (implies `Replace`)              |
-| Env              | `map[string]string`                                  | Environment variables                                                |
-| Detached         | `bool`                                               | If `true`, sandbox survives after process exits                      |
-| Entrypoint       | `[]string`                                           | Override image entrypoint                                            |
-| Init             | [`*InitConfig`](#initconfig)                         | Hand PID 1 off to a guest init binary                                |
-| LogLevel         | [`LogLevel`](#loglevel)                              | Sandbox log verbosity override                                       |
-| QuietLogs        | `bool`                                               | Suppress sandbox-level log output                                    |
-| Scripts          | `map[string]string`                                  | Named scripts mounted at `/.msb/scripts/`                            |
-| PullPolicy       | [`PullPolicy`](#pullpolicy)                          | Image pull behaviour                                                 |
-| MaxDuration      | `time.Duration`                                      | Maximum sandbox lifetime                                             |
-| IdleTimeout      | `time.Duration`                                      | Idle timeout                                                         |
-| RegistryAuth     | [`*RegistryAuth`](#registryauth)                     | Private registry credentials                                         |
-| Ports            | `map[uint16]uint16`                                  | Host→guest TCP port mappings                                         |
-| PortsUDP         | `map[uint16]uint16`                                  | Host→guest UDP port mappings                                         |
-| PortBindings     | [`[]PortBinding`](/sdk/go/networking#portbinding)    | Host→guest port mappings with explicit bind addresses                |
-| Network          | [`*NetworkConfig`](/sdk/go/networking#networkconfig) | Network policy and configuration                                     |
-| Secrets          | [`[]SecretEntry`](/sdk/go/secrets#secretentry)       | Secret injection entries                                             |
-| Patches          | [`[]PatchConfig`](#patchconfig)                      | Rootfs modifications applied before boot                             |
-| Volumes          | `map[string]MountConfig`                             | Volume mounts keyed by guest path                                    |
+<p className="msb-backref">Populated by <a href="#options">SandboxOption</a> · parsed by <a href="#sandboxhandle">SandboxHandle.Config()</a></p>
+
+The full configuration of a sandbox. Most callers build a sandbox via `CreateSandbox(ctx, name, ...opts)`; `SandboxConfig` is exported for callers that prefer to construct a value directly.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Name | `string` | Sandbox name, up to 128 UTF-8 bytes |
+| Image | `string` | OCI image, local path, or disk image |
+| ImageFstype | `string` | Optional inner filesystem type for disk-image roots |
+| OCIUpperSizeMiB | `uint32` | Writable overlay upper size for OCI image roots |
+| Snapshot | `string` | Snapshot artifact path or bare name; mutually exclusive with `Image` |
+| MemoryMiB | `uint32` | Guest memory in MiB |
+| CPUs | `uint8` | Virtual CPUs |
+| Workdir | `string` | Default working directory |
+| Shell | `string` | Shell binary used by `Shell` calls |
+| SecurityProfile | [`SecurityProfile`](#securityprofile) | In-guest security profile |
+| Hostname | `string` | Guest hostname |
+| User | `string` | Default guest user |
+| Replace | `bool` | Replace existing sandbox with same name |
+| ReplaceWithTimeout | `*time.Duration` | Timeout between SIGTERM and SIGKILL (implies `Replace`) |
+| Env | `map[string]string` | Environment variables |
+| Labels | `map[string]string` | Labels for metrics attribution and filtering |
+| Detached | `bool` | If `true`, sandbox survives after the process exits |
+| Ephemeral | `bool` | If `true`, all state is removed on termination |
+| Entrypoint | `[]string` | Override image entrypoint |
+| Init | [`*InitConfig`](#initconfig) | Hand PID 1 off to a guest init binary |
+| LogLevel | [`LogLevel`](#loglevel) | Sandbox log verbosity override |
+| QuietLogs | `bool` | Suppress sandbox-level log output |
+| Scripts | `map[string]string` | Named scripts mounted at `/.msb/scripts/` |
+| PullPolicy | [`PullPolicy`](#pullpolicy) | Image pull behaviour |
+| MaxDuration | `time.Duration` | Maximum sandbox lifetime |
+| IdleTimeout | `time.Duration` | Idle timeout |
+| RegistryAuth | [`*RegistryAuth`](#registryauth) | Private registry credentials |
+| Ports | `map[uint16]uint16` | Host to guest TCP port mappings |
+| PortsUDP | `map[uint16]uint16` | Host to guest UDP port mappings |
+| PortBindings | [`[]PortBinding`](/sdk/go/networking#portbinding) | Port mappings with explicit bind addresses |
+| Network | [`*NetworkConfig`](/sdk/go/networking#networkconfig) | Network policy and configuration |
+| Secrets | [`[]SecretEntry`](/sdk/go/secrets#secretentry) | Secret injection entries |
+| Patches | [`[]PatchConfig`](#patchconfig) | Rootfs modifications applied before boot |
+| Volumes | `map[string]MountConfig` | Volume mounts keyed by guest path |
 
 ### SandboxOption
+
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+<p className="msb-backref">Consumed by <a href="#m-createsandbox">CreateSandbox()</a></p>
 
 ```go
 type SandboxOption func(*SandboxConfig)
 ```
 
-A functional option for [`CreateSandbox`](#createsandbox). All `WithX` helpers listed above return a `SandboxOption`.
+A functional option for [`CreateSandbox`](#m-createsandbox). Every `WithX` helper in the [Options](#options) section returns one. The lifecycle setters [`WithStopTimeout`](#withstoptimeout) and [`WithKillTimeout`](#withkilltimeout) return distinct `StopOption` / `KillOption` types passed to [`Stop`](#sb-stop) and [`Kill`](#sb-kill) instead.
 
-### SecurityProfile
+### Metrics
 
-```go
-type SecurityProfile string
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-const (
-    SecurityProfileDefault    SecurityProfile = "default"
-    SecurityProfileRestricted SecurityProfile = "restricted"
-)
-```
+<p className="msb-backref">Returned by <a href="#sb-metrics">Metrics()</a> · <a href="#sb-metricsstream">MetricsStream()</a> · <a href="#m-allsandboxmetrics">AllSandboxMetrics()</a></p>
 
-Sandbox-wide in-guest security profile.
+Point-in-time resource usage snapshot.
 
-### InitConfig
+| Field | Type | Description |
+|-------|------|-------------|
+| CPUPercent | `float64` | CPU usage as a percentage |
+| VCPUTimeNs | `uint64` | Cumulative vCPU time in nanoseconds |
+| MemoryBytes | `uint64` | Current memory usage in bytes |
+| MemoryAvailableBytes | `*uint64` | Guest-reported available memory when known |
+| MemoryHostResidentBytes | `*uint64` | Host RSS backing the guest when known |
+| MemoryLimitBytes | `uint64` | Memory limit in bytes |
+| DiskReadBytes | `uint64` | Total bytes read from disk since boot |
+| DiskWriteBytes | `uint64` | Total bytes written to disk since boot |
+| NetRxBytes | `uint64` | Total bytes received over the network since boot |
+| NetTxBytes | `uint64` | Total bytes sent over the network since boot |
+| UpperUsedBytes | `*uint64` | Guest-visible OCI upper filesystem used bytes when the protected reporter is available and fresh |
+| UpperFreeBytes | `*uint64` | Guest-visible OCI upper filesystem free bytes when the protected reporter is available and fresh |
+| UpperHostAllocatedBytes | `*uint64` | Host-allocated bytes for the writable OCI upper image when available |
+| Uptime | `time.Duration` | Time since the sandbox was created |
 
-Custom init specification.
+### MetricsStreamHandle
 
-| Field | Type                | Description                                                          |
-| ----- | ------------------- | -------------------------------------------------------------------- |
-| Cmd   | `string`            | Absolute path or `"auto"` to the init binary. Auto honors known image ENTRYPOINT inits before probing common guest paths and preserves attached init-entrypoint commands |
-| Args  | `[]string`          | Supplemental argv (`argv[0]` is implicitly `Cmd`)                    |
-| Env   | `map[string]string` | Extra env vars merged on top of the inherited env                    |
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-### InitOptions
+<p className="msb-backref">Returned by <a href="#sb-metricsstream">MetricsStream()</a></p>
 
-Tuning struct for [`Init.Cmd`](#initcmd).
+Live metrics subscription. Call `Close` to release Rust-side resources.
 
-| Field | Type                | Description       |
-| ----- | ------------------- | ----------------- |
-| Args  | `[]string`          | Supplemental argv |
-| Env   | `map[string]string` | Extra env vars    |
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `Recv(ctx)` | `(*`[`Metrics`](#metrics)`, error)` | Block until the next snapshot arrives. Returns `(nil, nil)` when the stream ends (sandbox exited) |
+| `Close()` | `error` | Stop the stream and release Rust-side resources |
 
-### RegistryAuth
+### SandboxStopResult
 
-Private registry credentials.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-| Field    | Type     | Description       |
-| -------- | -------- | ----------------- |
-| Username | `string` | Registry username |
-| Password | `string` | Registry password |
+<p className="msb-backref">Returned by <a href="#sb-waituntilstopped">WaitUntilStopped()</a></p>
 
-### PatchConfig
+Describes a terminal sandbox state observed by [`WaitUntilStopped`](#sb-waituntilstopped).
 
-A single rootfs patch produced by [`Patch`](#patch).
+| Field | Type | Description |
+|-------|------|-------------|
+| Name | `string` | Sandbox name |
+| Status | [`SandboxStatus`](#sandboxstatus) | Terminal status (`stopped` or `crashed`) |
+| ExitCode | `*int` | Process exit code when known |
+| Signal | `*int` | Terminating signal when known |
+| ObservedAt | `time.Time` | When the terminal state was observed |
+| Source | `*string` | Origin of the stop observation when known |
 
-| Field   | Type                      | Description                                                 |
-| ------- | ------------------------- | ----------------------------------------------------------- |
-| Kind    | [`PatchKind`](#patchkind) | Patch flavour                                               |
-| Path    | `string`                  | Absolute guest path (text / file / mkdir / remove / append) |
-| Content | `string`                  | Text content (text / append)                                |
-| Mode    | `*uint32`                 | File or directory mode, e.g. `0o644`                        |
-| Replace | `bool`                    | When `true`, overwrite an existing path at the destination  |
-| Src     | `string`                  | Host source path (copy_file / copy_dir)                     |
-| Dst     | `string`                  | Guest destination path (copy_file / copy_dir)               |
-| Target  | `string`                  | Symlink target                                              |
-| Link    | `string`                  | Symlink path                                                |
+### SandboxStatus
 
-### PatchOptions
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
 
-Tuning struct passed to [`Patch`](#patch) methods.
-
-| Field   | Type      | Description                |
-| ------- | --------- | -------------------------- |
-| Mode    | `*uint32` | File or directory mode     |
-| Replace | `bool`    | Overwrite an existing path |
-
-### PatchKind
+<p className="msb-backref">Used by <a href="#sandboxhandle">SandboxHandle.Status()</a> · <a href="#sandboxstopresult">SandboxStopResult.Status</a></p>
 
 ```go
-type PatchKind string
+type SandboxStatus string
 ```
 
-| Constant            | Value         |
-| ------------------- | ------------- |
-| `PatchKindText`     | `"text"`      |
-| `PatchKindAppend`   | `"append"`    |
-| `PatchKindMkdir`    | `"mkdir"`     |
-| `PatchKindRemove`   | `"remove"`    |
-| `PatchKindSymlink`  | `"symlink"`   |
-| `PatchKindCopyFile` | `"copy_file"` |
-| `PatchKindCopyDir`  | `"copy_dir"`  |
-
-### PullPolicy
-
-```go
-type PullPolicy string
-```
-
-Controls when the SDK fetches an OCI image from the registry.
-
-| Constant              | Value          | Description                                       |
-| --------------------- | -------------- | ------------------------------------------------- |
-| `PullPolicyDefault`   | `""`           | Runtime default (currently `PullPolicyIfMissing`) |
-| `PullPolicyAlways`    | `"always"`     | Pull every time, even if cached locally           |
-| `PullPolicyIfMissing` | `"if-missing"` | Pull only if not already cached                   |
-| `PullPolicyNever`     | `"never"`      | Never pull; fail if missing                       |
-
-### LogOptions
-
-Filters for [`Logs`](#logs).
-
-| Field   | Type          | Description                                        |
-| ------- | ------------- | -------------------------------------------------- |
-| Tail    | `uint64`      | Keep only the last N matching entries              |
-| Since   | `time.Time`   | Inclusive lower timestamp bound                    |
-| Until   | `time.Time`   | Exclusive upper timestamp bound                    |
-| Sources | `[]LogSource` | Sources to include; empty uses the runtime default |
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `SandboxStatusRunning` | `"running"` | Guest agent is ready; `Exec`, `Shell`, `FS` work |
+| `SandboxStatusStopped` | `"stopped"` | VM shut down; configuration persisted; can be restarted |
+| `SandboxStatusCrashed` | `"crashed"` | VM exited unexpectedly (kernel panic, OOM, etc.) |
+| `SandboxStatusDraining` | `"draining"` | Graceful shutdown in progress; existing commands finish, new ones rejected |
+| `SandboxStatusPaused` | `"paused"` | VM is paused |
 
 ### LogEntry
 
-One persisted log entry.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-| Field     | Type                      | Description                              |
-| --------- | ------------------------- | ---------------------------------------- |
-| Source    | [`LogSource`](#logsource) | Origin of the captured data              |
-| SessionID | `*uint64`                 | Relay session ID, nil for system entries |
-| Timestamp | `time.Time`               | Capture timestamp                        |
-| Data      | `[]byte`                  | Captured bytes                           |
+<p className="msb-backref">Returned by <a href="#sb-logs">Logs()</a> · <a href="#sb-logstream">LogStream()</a></p>
 
-| Method   | Returns  | Description                |
-| -------- | -------- | -------------------------- |
+A single captured log entry.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Source | [`LogSource`](#logsource) | Origin of the captured data |
+| SessionID | `*uint64` | Relay-monotonic session id; nil for system entries |
+| Timestamp | `time.Time` | Wall-clock capture time on the host |
+| Data | `[]byte` | The captured bytes |
+| Cursor | `string` | Opaque resume token; pass to [`LogStreamOptions.FromCursor`](#logstreamoptions) |
+
+| Method | Returns | Description |
+|--------|---------|-------------|
 | `Text()` | `string` | Captured bytes as a string |
 
+### LogOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#sb-logs">Logs()</a></p>
+
+Filters passed to [`Logs`](#sb-logs). The zero value returns everything for the default sources (stdout + stderr).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Tail | `uint64` | Keep only the last N matching entries |
+| Since | `time.Time` | Inclusive lower timestamp bound |
+| Until | `time.Time` | Exclusive upper timestamp bound |
+| Sources | `[]`[`LogSource`](#logsource) | Sources to include; empty = stdout + stderr. Add `LogSourceOutput` or `LogSourceSystem` for PTY-merged output or runtime/kernel diagnostics |
+
+### LogStreamOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#sb-logstream">LogStream()</a></p>
+
+Configures a live log stream. The zero value reads the default sources from the beginning with follow off. `Since` and `FromCursor` are mutually exclusive.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Sources | `[]`[`LogSource`](#logsource) | Sources to include; empty = stdout + stderr + output |
+| Since | `time.Time` | Start at the first entry with timestamp >= this; mutually exclusive with `FromCursor` |
+| FromCursor | `string` | Resume strictly after the entry whose `Cursor` matches; mutually exclusive with `Since` |
+| Until | `time.Time` | Stop at the first entry with timestamp >= this |
+| Follow | `bool` | Keep the stream open past EOF and yield new entries as written |
+
+### LogStreamHandle
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-logstream">LogStream()</a></p>
+
+Live log subscription. Call `Close` to release Rust-side resources.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `Recv(ctx)` | `(*`[`LogEntry`](#logentry)`, error)` | Block until the next entry arrives. Returns `(nil, nil)` when the stream ends |
+| `Close()` | `error` | Stop the stream and release Rust-side resources |
+
 ### LogSource
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#logentry">LogEntry.Source</a> · <a href="#logoptions">LogOptions.Sources</a> · <a href="#logstreamoptions">LogStreamOptions.Sources</a></p>
 
 ```go
 type LogSource string
 ```
 
-| Constant          | Value      |
-| ----------------- | ---------- |
-| `LogSourceStdout` | `"stdout"` |
-| `LogSourceStderr` | `"stderr"` |
-| `LogSourceOutput` | `"output"` |
-| `LogSourceSystem` | `"system"` |
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `LogSourceStdout` | `"stdout"` | Captured stdout (pipe mode, streams stayed separated) |
+| `LogSourceStderr` | `"stderr"` | Captured stderr (pipe mode) |
+| `LogSourceOutput` | `"output"` | PTY-merged stdout and stderr from a session running in pty mode |
+| `LogSourceSystem` | `"system"` | Synthetic lifecycle markers plus runtime/kernel diagnostic lines |
 
 ### LogLevel
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#withloglevel">WithLogLevel()</a></p>
 
 ```go
 type LogLevel string
@@ -1151,52 +2276,185 @@ type LogLevel string
 
 Sandbox process log verbosity.
 
-| Constant          | Value     | Description                          |
-| ----------------- | --------- | ------------------------------------ |
-| `LogLevelDefault` | `""`      | Runtime default                      |
-| `LogLevelTrace`   | `"trace"` | Most verbose — all diagnostic output |
-| `LogLevelDebug`   | `"debug"` | Debug and higher                     |
-| `LogLevelInfo`    | `"info"`  | Info and higher                      |
-| `LogLevelWarn`    | `"warn"`  | Warnings and errors only             |
-| `LogLevelError`   | `"error"` | Errors only                          |
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `LogLevelDefault` | `""` | Runtime default |
+| `LogLevelTrace` | `"trace"` | Most verbose, all diagnostic output |
+| `LogLevelDebug` | `"debug"` | Debug and higher |
+| `LogLevelInfo` | `"info"` | Info and higher |
+| `LogLevelWarn` | `"warn"` | Warnings and errors only |
+| `LogLevelError` | `"error"` | Errors only |
 
-### SandboxStatus
+### PullPolicy
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#withpullpolicy">WithPullPolicy()</a></p>
 
 ```go
-type SandboxStatus string
+type PullPolicy string
 ```
 
-| Constant                | Value        | Description                    |
-| ----------------------- | ------------ | ------------------------------ |
-| `SandboxStatusRunning`  | `"running"`  | Guest agent is ready           |
-| `SandboxStatusStopped`  | `"stopped"`  | VM shut down; can be restarted |
-| `SandboxStatusCrashed`  | `"crashed"`  | VM exited unexpectedly         |
-| `SandboxStatusDraining` | `"draining"` | Graceful shutdown in progress  |
-| `SandboxStatusPaused`   | `"paused"`   | VM is paused                   |
+Controls when the SDK fetches an OCI image from the registry.
 
-### Metrics
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `PullPolicyDefault` | `""` | Runtime default (currently `PullPolicyIfMissing`) |
+| `PullPolicyAlways` | `"always"` | Pull every time, even if cached locally |
+| `PullPolicyIfMissing` | `"if-missing"` | Pull only if not already cached |
+| `PullPolicyNever` | `"never"` | Never pull; fail if missing |
 
-Point-in-time resource usage snapshot returned by [`Metrics`](#metrics).
+### SecurityProfile
 
-| Field            | Type            | Description                                      |
-| ---------------- | --------------- | ------------------------------------------------ |
-| CPUPercent       | `float64`       | CPU usage as a percentage                        |
-| MemoryBytes      | `uint64`        | Current memory usage in bytes                    |
-| MemoryLimitBytes | `uint64`        | Memory limit in bytes                            |
-| DiskReadBytes    | `uint64`        | Total bytes read from disk since boot            |
-| DiskWriteBytes   | `uint64`        | Total bytes written to disk since boot           |
-| NetRxBytes       | `uint64`        | Total bytes received over the network since boot |
-| NetTxBytes       | `uint64`        | Total bytes sent over the network since boot     |
-| UpperUsedBytes   | `*uint64`       | Guest-visible OCI upper filesystem used bytes when the protected reporter is available and fresh |
-| UpperFreeBytes   | `*uint64`       | Guest-visible OCI upper filesystem free bytes when the protected reporter is available and fresh |
-| UpperHostAllocatedBytes | `*uint64` | Host-allocated bytes for the writable OCI upper image when available |
-| Uptime           | `time.Duration` | Time since the sandbox was created               |
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
 
-### MetricsStreamHandle
+<p className="msb-backref">Used by <a href="#withsecurityprofile">WithSecurityProfile()</a></p>
 
-Live metrics subscription returned by [`MetricsStream`](#metricsstream).
+```go
+type SecurityProfile string
+```
 
-| Method      | Returns             | Description                                                                      |
-| ----------- | ------------------- | -------------------------------------------------------------------------------- |
-| `Recv(ctx)` | `(*Metrics, error)` | Block until the next snapshot arrives. Returns `(nil, nil)` when the stream ends |
-| `Close()`   | `error`             | Stop the stream and release Rust-side resources                                  |
+Sandbox-wide in-guest security profile.
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `SecurityProfileDefault` | `"default"` | Normal guest-root semantics |
+| `SecurityProfileRestricted` | `"restricted"` | Stronger hardening: `no_new_privs`, dropped mount-admin capability, forced `nosuid,nodev` on user mounts |
+
+### RegistryAuth
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#withregistryauth">WithRegistryAuth()</a></p>
+
+Credentials for a private OCI registry.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Username | `string` | Registry username |
+| Password | `string` | Registry password |
+
+### InitConfig
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Built by <a href="#init">Init</a> · used by <a href="#withinit">WithInit()</a></p>
+
+Custom guest PID-1 init specification. Construct via the [`Init`](#init) factory rather than building the struct directly.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Cmd | `string` | Absolute path inside the guest, or `"auto"` |
+| Args | `[]string` | Supplemental argv (`argv[0]` is implicitly `Cmd`) |
+| Env | `map[string]string` | Extra env vars merged on top of the inherited env |
+
+### InitOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#init-cmd">Init.Cmd()</a></p>
+
+Tuning struct for [`Init.Cmd`](#init-cmd) beyond the required cmd.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Args | `[]string` | Supplemental argv |
+| Env | `map[string]string` | Extra env vars |
+
+### Init
+
+<div className="msb-tags"><span className="msb-tag is-type">factory</span></div>
+
+<p className="msb-backref">Produces <a href="#initconfig">InitConfig</a> for <a href="#withinit">WithInit()</a></p>
+
+Package-level factory namespace for [`InitConfig`](#initconfig) values. See the [Init](#init) section for its methods.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`Auto()`](#init-auto) | [`InitConfig`](#initconfig) | Auto-detect a guest init |
+| [`Cmd(cmd, opts)`](#init-cmd) | [`InitConfig`](#initconfig) | Explicit init binary with argv and env |
+
+### PatchConfig
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Built by <a href="#patch">Patch</a> · used by <a href="#withpatches">WithPatches()</a></p>
+
+A single rootfs patch. Construct via the [`Patch`](#patch) factory; the fields populated depend on the [`PatchKind`](#patchkind).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Kind | [`PatchKind`](#patchkind) | Patch flavour |
+| Path | `string` | Absolute guest path (text / append / mkdir / remove) |
+| Content | `string` | Text content (text / append) |
+| Mode | `*uint32` | File or directory mode, e.g. `0o644` |
+| Replace | `bool` | When `true`, overwrite an existing path at the destination |
+| Src | `string` | Host source path (copy_file / copy_dir) |
+| Dst | `string` | Guest destination path (copy_file / copy_dir) |
+| Target | `string` | Symlink target |
+| Link | `string` | Symlink path |
+
+### PatchOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#patch">Patch</a> methods</p>
+
+Tuning struct passed to [`Patch`](#patch) methods that accept a mode and replace flag.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Mode | `*uint32` | File or directory mode |
+| Replace | `bool` | Overwrite an existing path |
+
+### PatchKind
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#patchconfig">PatchConfig.Kind</a></p>
+
+```go
+type PatchKind string
+```
+
+Discriminator for [`PatchConfig`](#patchconfig). Prefer the [`Patch`](#patch) factory.
+
+| Constant | Value |
+|----------|-------|
+| `PatchKindText` | `"text"` |
+| `PatchKindAppend` | `"append"` |
+| `PatchKindMkdir` | `"mkdir"` |
+| `PatchKindRemove` | `"remove"` |
+| `PatchKindSymlink` | `"symlink"` |
+| `PatchKindCopyFile` | `"copy_file"` |
+| `PatchKindCopyDir` | `"copy_dir"` |
+
+### Patch
+
+<div className="msb-tags"><span className="msb-tag is-type">factory</span></div>
+
+<p className="msb-backref">Produces <a href="#patchconfig">PatchConfig</a> for <a href="#withpatches">WithPatches()</a></p>
+
+Package-level factory namespace for [`PatchConfig`](#patchconfig) values. See the [Patch](#patch) section for its methods.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`Text(path, content, opts)`](#patch-text) | [`PatchConfig`](#patchconfig) | Write UTF-8 text |
+| [`Append(path, content)`](#patch-append) | [`PatchConfig`](#patchconfig) | Append to an existing file |
+| [`Mkdir(path, opts)`](#patch-mkdir) | [`PatchConfig`](#patchconfig) | Create a directory (idempotent) |
+| [`Remove(path)`](#patch-remove) | [`PatchConfig`](#patchconfig) | Delete a file or directory (idempotent) |
+| [`Symlink(target, link, opts)`](#patch-symlink) | [`PatchConfig`](#patchconfig) | Create a symlink |
+| [`CopyFile(src, dst, opts)`](#patch-copyfile) | [`PatchConfig`](#patchconfig) | Copy a host file into the rootfs |
+| [`CopyDir(src, dst, opts)`](#patch-copydir) | [`PatchConfig`](#patchconfig) | Copy a host directory into the rootfs |
+
+### SetupOption
+
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+<p className="msb-backref">Consumed by <a href="#m-ensureinstalled">EnsureInstalled()</a></p>
+
+```go
+type SetupOption func(*setupConfig)
+```
+
+A functional option for [`EnsureInstalled`](#m-ensureinstalled). The only helper is [`WithSkipDownload`](#withskipdownload).

--- a/docs/sdk/go/secrets.mdx
+++ b/docs/sdk/go/secrets.mdx
@@ -5,9 +5,30 @@ description: Go SDK - Secret injection API reference
 
 See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
 
-Secrets never enter the VM. The Go SDK passes each [`SecretEntry`](#secretentry) to the runtime, which exposes a placeholder string inside the guest (e.g. `$MSB_SERVICE_API_KEY`) and substitutes the real value at the network layer only when traffic reaches an allowed host.
+Secrets never enter the VM. The Go SDK passes each [`SecretEntry`](#secretentrystruct) to the runtime, which exposes a placeholder string inside the guest (e.g. `$MSB_SERVICE_API_KEY`) and substitutes the real value at the network layer only when traffic reaches an allowed host.
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Functions<span className="msb-ct">1</span></p>
+  <a className="msb-row" href="#withsecrets"><span className="msb-rn">WithSecrets()</span><span className="msb-rg">attach secrets to a sandbox</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · Secret<span className="msb-ct">1</span></p>
+  <a className="msb-row" href="#secret-env"><span className="msb-rn">Secret.Env()</span><span className="msb-rg">build a SecretEntry from an env var</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#secretentrystruct">SecretEntry</a>
+    <a className="msb-typepill" href="#secretenvoptionsstruct">SecretEnvOptions</a>
+    <a className="msb-typepill" href="#violationactionstring-enum">ViolationAction</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```go
+import m "github.com/superradcompany/microsandbox/sdk/go"
+
 sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("python:3.12"),
     m.WithSecrets(m.Secret.Env(
@@ -20,46 +41,104 @@ sb, err := m.CreateSandbox(ctx, "worker",
 )
 ```
 
-## Host Matching
+## Host matching
 
-Go does not expose the Rust `HostPattern` enum directly. Instead, exact and wildcard host patterns are represented with fields on `SecretEntry` and `SecretEnvOptions`.
+Go does not expose the Rust `HostPattern` enum directly. Exact and wildcard host patterns are represented with the `AllowHosts` and `AllowHostPatterns` fields on [`SecretEntry`](#secretentrystruct) and [`SecretEnvOptions`](#secretenvoptionsstruct).
 
 | Runtime pattern | Go API | Matches |
 |-----------------|--------|---------|
 | `HostPattern::Exact("api.example.com")` | `AllowHosts: []string{"api.example.com"}` | That exact SNI host |
 | `HostPattern::Wildcard("*.example.com")` | `AllowHostPatterns: []string{"*.example.com"}` | Hosts matching the wildcard pattern |
 
-These fields decide where the real secret value may be substituted. A host that is not matched by either field is disallowed for that secret, so sending its placeholder to that host triggers the configured [`ViolationAction`](#violationaction).
+These fields decide where the real secret value may be substituted. A host that is not matched by either field is disallowed for that secret, so sending its placeholder there triggers the configured [`ViolationAction`](#violationactionstring-enum). Allow-list entries are pinned to observed DNS answers and TLS identity. At least one exact or wildcard host is required.
 
-Exact and wildcard allow-list entries are pinned to observed DNS answers and TLS identity. At least one exact or wildcard host is required.
-
-## Secret
-
-Helpers that construct [`SecretEntry`](#secretentry) values. Access via the package-level `Secret` value.
+## Functions
 
 ---
 
-#### Secret.Env()
+#### <span className="msb-hn">WithSecrets()</span>
+<div className="msb-tags"><span className="msb-tag is-static">func</span></div>
+
+```go
+func WithSecrets(secrets ...SecretEntry) SandboxOption
+```
+
+Append credential secrets to the sandbox. Each call appends, so multiple calls accumulate. Secrets never enter the VM; the network proxy substitutes them at the transport layer. Pass to [`CreateSandbox`](/sdk/go/sandbox#createsandbox) alongside the other options.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>secrets</code><a className="msb-type" href="#secretentrystruct">...SecretEntry</a></div>
+    <div className="msb-param-desc">Secret entries to attach, usually built with <a className="msb-type" href="#secret-env">Secret.Env</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">SandboxOption</span></div>
+    <div className="msb-param-desc">Functional option for <a className="msb-type" href="/sdk/go/sandbox#createsandbox">CreateSandbox</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sb, err := m.CreateSandbox(ctx, "worker",
+    m.WithImage("python:3.12"),
+    m.WithSecrets(
+        m.Secret.Env("STRIPE_KEY", os.Getenv("STRIPE_KEY"),
+            m.SecretEnvOptions{AllowHosts: []string{"api.stripe.com"}}),
+        m.Secret.Env("OPENAI_API_KEY", os.Getenv("OPENAI_API_KEY"),
+            m.SecretEnvOptions{AllowHostPatterns: []string{"*.openai.com"}}),
+    ),
+)
+```
+
+## Methods
+
+The [`Secret`](#secret-env) factory is a package-level value. Call its methods to build [`SecretEntry`](#secretentrystruct) values without populating struct literals by hand.
+
+---
+
+#### <span className="msb-recv">Secret.</span><span className="msb-hn">Env()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (secretFactory) Env(envVar, value string, opts SecretEnvOptions) SecretEntry
 ```
 
-Create a secret entry that maps an environment variable to a real value. The guest sees a placeholder; the real value is only substituted by the TLS proxy when traffic goes to an allowed host.
+Build a [`SecretEntry`](#secretentrystruct) that maps an environment variable to a real value. The guest sees a placeholder; the real value is substituted by the TLS proxy only when traffic goes to an allowed host. Pass an empty [`SecretEnvOptions`](#secretenvoptionsstruct)`{}` when no extra tuning is needed.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| envVar | `string` | Environment variable name. Must be non-empty and cannot contain `=` or NUL; shell-identifier syntax is not required |
-| value | `string` | The real secret value. Never enters the guest VM |
-| opts | [`SecretEnvOptions`](#secretenvoptions) | Allowed hosts, placeholder override, TLS requirement, violation action. Pass `SecretEnvOptions{}` for defaults |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>envVar</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Environment variable name holding the placeholder inside the sandbox. Must be non-empty and cannot contain <code>=</code> or NUL; shell-identifier syntax is not required.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">The real secret value. Never crosses the FFI into the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#secretenvoptionsstruct">SecretEnvOptions</a></div>
+    <div className="msb-param-desc">Allowed hosts, placeholder override, TLS requirement, and violation action.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SecretEntry`](#secretentry) | Pass to [`WithSecrets`](/sdk/go/sandbox#withsecrets) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#secretentrystruct">SecretEntry</a></div>
+    <div className="msb-param-desc">Pass to <a className="msb-type" href="#withsecrets">WithSecrets</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 m.Secret.Env("STRIPE_KEY", os.Getenv("STRIPE_KEY"),
@@ -71,47 +150,57 @@ m.Secret.Env("STRIPE_KEY", os.Getenv("STRIPE_KEY"),
 )
 ```
 
----
-
 ## Types
 
-### SecretEntry
+---
 
-The value passed to [`WithSecrets`](/sdk/go/sandbox#withsecrets). Usually produced by [`Secret.Env`](#secretenv); exported for callers that prefer struct literals.
+### SecretEntry<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
 
-| Field | Type | Description |
-|-------|------|-------------|
-| EnvVar | `string` | Environment variable name holding the placeholder inside the sandbox. Must be non-empty and cannot contain `=` or NUL; shell-identifier syntax is not required |
-| Value | `string` | Real secret value (stays on the host) |
-| AllowHosts | `[]string` | Hosts allowed to receive the real value (exact match) |
-| AllowHostPatterns | `[]string` | Wildcard host patterns (e.g. `"*.googleapis.com"`) |
-| Placeholder | `string` | Custom placeholder: non-empty, up to 1024 bytes, no NUL/CR/LF. Auto-generated as `$MSB_<env_var>` when empty |
-| RequireTLS | `*bool` | Require a verified TLS identity before substituting. Default `true` when `nil` |
-| OnViolation | [`ViolationAction`](#violationaction) | Override the sandbox-wide action when this secret is sent to a disallowed host. The last non-empty `OnViolation` across all secrets wins (the runtime applies it network-wide) |
+<p className="msb-backref">accepted by <a href="#withsecrets">WithSecrets()</a> · returned by <a href="#secret-env">Secret.Env()</a></p>
 
-### SecretEnvOptions
-
-Tuning struct for [`Secret.Env`](#secretenv).
+A single credential the network proxy substitutes at the transport layer. The value never reaches the guest VM. Usually produced by [`Secret.Env`](#secret-env); exported for callers that prefer struct literals.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| AllowHosts | `[]string` | Allowed hosts (exact match) |
-| AllowHostPatterns | `[]string` | Wildcard patterns |
-| Placeholder | `string` | Custom placeholder: non-empty, up to 1024 bytes, no NUL/CR/LF |
-| RequireTLS | `*bool` | TLS-identity requirement |
-| OnViolation | [`ViolationAction`](#violationaction) | Per-secret violation action |
+| `EnvVar` | `string` | Environment variable name holding the placeholder inside the sandbox. Must be non-empty and cannot contain `=` or NUL; shell-identifier syntax is not required |
+| `Value` | `string` | Real secret value; never crosses the FFI into the guest |
+| `AllowHosts` | `[]string` | Hosts allowed to receive the real value (exact match) |
+| `AllowHostPatterns` | `[]string` | Wildcard host patterns, e.g. `"*.openai.com"` |
+| `Placeholder` | `string` | Custom placeholder shown inside the sandbox in place of the secret. Auto-generated from `EnvVar` when empty. Custom values must be non-empty, at most 1024 bytes, and cannot contain NUL, CR, or LF |
+| `RequireTLS` | `*bool` | Require a verified TLS identity before substituting. Defaults to `true` when `nil` |
+| `OnViolation` | [`ViolationAction`](#violationactionstring-enum) | Override the sandbox-wide action when this secret is detected going to a disallowed host. The last non-empty value across all secrets wins, since the runtime applies it network-wide |
 
-### ViolationAction
+---
+
+### SecretEnvOptions<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
+
+<p className="msb-backref">accepted by <a href="#secret-env">Secret.Env()</a></p>
+
+Tunes [`Secret.Env`](#secret-env) beyond the required `envVar` and `value`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `AllowHosts` | `[]string` | Allowed hosts (exact match) |
+| `AllowHostPatterns` | `[]string` | Wildcard host patterns |
+| `Placeholder` | `string` | Custom placeholder: non-empty, up to 1024 bytes, no NUL/CR/LF |
+| `RequireTLS` | `*bool` | Require a verified TLS identity before substituting. Defaults to `true` when `nil` |
+| `OnViolation` | [`ViolationAction`](#violationactionstring-enum) | Per-secret violation action |
+
+---
+
+### ViolationAction<span className="msb-tag is-type" style={{marginLeft: "8px"}}>string enum</span>
+
+<p className="msb-backref">field of <a href="#secretentrystruct">SecretEntry</a> · <a href="/sdk/go/networking#networkconfig">NetworkConfig</a></p>
 
 ```go
 type ViolationAction string
 ```
 
-Action taken when a secret placeholder is detected going to a disallowed host. Configure the sandbox-wide default on [`NetworkConfig.OnSecretViolation`](/sdk/go/networking#networkconfig); override per-secret with [`SecretEntry.OnViolation`](#secretentry).
+What happens when a secret placeholder is detected going to a host the secret isn't allowed to talk to. Configure the sandbox-wide default on [`NetworkConfig.OnSecretViolation`](/sdk/go/networking#networkconfig); override per-secret with [`SecretEntry.OnViolation`](#secretentrystruct).
 
 | Constant | Value | Description |
 |----------|-------|-------------|
-| `ViolationActionDefault` | `""` | Runtime default (currently `block-and-log`) |
+| `ViolationActionDefault` | `""` | Leave the runtime default in place (currently `block-and-log`) |
 | `ViolationActionBlock` | `"block"` | Silently drop the request. The guest sees a connection reset |
 | `ViolationActionBlockAndLog` | `"block-and-log"` | Drop the request and emit a warning log on the host side |
 | `ViolationActionBlockAndTerminate` | `"block-and-terminate"` | Drop the request, log an error, and shut down the entire sandbox |

--- a/docs/sdk/go/snapshots.mdx
+++ b/docs/sdk/go/snapshots.mdx
@@ -3,35 +3,443 @@ title: Snapshots
 description: Go SDK - Snapshot API reference
 ---
 
-Disk-only snapshots of a sandbox that is not running. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Go SDK reference.
+Disk-only snapshots of a sandbox that is not running. Create artifacts from a stopped sandbox, list and verify them, export to an archive, and import elsewhere. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Go SDK reference.
+
+<Note>
+  Snapshots are **disk-only** and require a sandbox that is stopped or crashed.
+</Note>
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Functions · Snapshot<span className="msb-ct">9</span></p>
+  <a className="msb-row" href="#snapshot-create"><span className="msb-rn">Snapshot.Create()</span><span className="msb-rg">snapshot a stopped sandbox</span></a>
+  <a className="msb-row" href="#snapshot-open"><span className="msb-rn">Snapshot.Open()</span><span className="msb-rg">open an artifact by name/path</span></a>
+  <a className="msb-row" href="#snapshot-get"><span className="msb-rn">Snapshot.Get()</span><span className="msb-rg">index handle by name/digest</span></a>
+  <a className="msb-row" href="#snapshot-list"><span className="msb-rn">Snapshot.List()</span><span className="msb-rg">indexed snapshots</span></a>
+  <a className="msb-row" href="#snapshot-listdir"><span className="msb-rn">Snapshot.ListDir()</span><span className="msb-rg">walk a directory</span></a>
+  <a className="msb-row" href="#snapshot-remove"><span className="msb-rn">Snapshot.Remove()</span><span className="msb-rg">delete artifact + index row</span></a>
+  <a className="msb-row" href="#snapshot-reindex"><span className="msb-rn">Snapshot.Reindex()</span><span className="msb-rg">rebuild the local index</span></a>
+  <a className="msb-row" href="#snapshot-export"><span className="msb-rn">Snapshot.Export()</span><span className="msb-rg">bundle into an archive</span></a>
+  <a className="msb-row" href="#snapshot-import"><span className="msb-rn">Snapshot.Import()</span><span className="msb-rg">unpack an archive</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *SandboxHandle<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#h-snapshot"><span className="msb-rn">h.Snapshot()</span><span className="msb-rg">snapshot to a bare name</span></a>
+  <a className="msb-row" href="#h-snapshotto"><span className="msb-rn">h.SnapshotTo()</span><span className="msb-rg">snapshot to a directory</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *SnapshotArtifact<span className="msb-ct">12</span></p>
+  <a className="msb-row" href="#s-verify"><span className="msb-rn">s.Verify()</span><span className="msb-rg">recompute content integrity</span></a>
+  <a className="msb-row" href="#s-path"><span className="msb-rn">s.Path()</span><span className="msb-rg">artifact directory</span></a>
+  <a className="msb-row" href="#s-digest"><span className="msb-rn">s.Digest()</span><span className="msb-rg">manifest digest</span></a>
+  <a className="msb-row" href="#s-sizebytes"><span className="msb-rn">s.SizeBytes()</span><span className="msb-rg">upper-layer size</span></a>
+  <a className="msb-row" href="#s-imageref"><span className="msb-rn">s.ImageRef()</span><span className="msb-rg">source image reference</span></a>
+  <a className="msb-row" href="#s-imagemanifestdigest"><span className="msb-rn">s.ImageManifestDigest()</span><span className="msb-rg">pinned OCI manifest digest</span></a>
+  <a className="msb-row" href="#s-format"><span className="msb-rn">s.Format()</span><span className="msb-rg">raw or qcow2</span></a>
+  <a className="msb-row" href="#s-fstype"><span className="msb-rn">s.Fstype()</span><span className="msb-rg">upper filesystem type</span></a>
+  <a className="msb-row" href="#s-parent"><span className="msb-rn">s.Parent()</span><span className="msb-rg">parent digest, or nil</span></a>
+  <a className="msb-row" href="#s-createdat"><span className="msb-rn">s.CreatedAt()</span><span className="msb-rg">RFC 3339 timestamp</span></a>
+  <a className="msb-row" href="#s-labels"><span className="msb-rn">s.Labels()</span><span className="msb-rg">user labels</span></a>
+  <a className="msb-row" href="#s-sourcesandbox"><span className="msb-rn">s.SourceSandbox()</span><span className="msb-rg">source sandbox name</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *SnapshotHandle<span className="msb-ct">10</span></p>
+  <a className="msb-row" href="#h-open"><span className="msb-rn">h.Open()</span><span className="msb-rg">open the artifact</span></a>
+  <a className="msb-row" href="#h-remove"><span className="msb-rn">h.Remove()</span><span className="msb-rg">delete this snapshot</span></a>
+  <a className="msb-row" href="#h-digest"><span className="msb-rn">h.Digest()</span><span className="msb-rg">manifest digest</span></a>
+  <a className="msb-row" href="#h-name"><span className="msb-rn">h.Name()</span><span className="msb-rg">bare-name alias, or nil</span></a>
+  <a className="msb-row" href="#h-parentdigest"><span className="msb-rn">h.ParentDigest()</span><span className="msb-rg">parent digest, or nil</span></a>
+  <a className="msb-row" href="#h-imageref"><span className="msb-rn">h.ImageRef()</span><span className="msb-rg">pinned image reference</span></a>
+  <a className="msb-row" href="#h-format"><span className="msb-rn">h.Format()</span><span className="msb-rg">raw or qcow2</span></a>
+  <a className="msb-row" href="#h-sizebytes"><span className="msb-rn">h.SizeBytes()</span><span className="msb-rg">upper size at index time</span></a>
+  <a className="msb-row" href="#h-path"><span className="msb-rn">h.Path()</span><span className="msb-rg">artifact directory</span></a>
+  <a className="msb-row" href="#h-createdat"><span className="msb-rn">h.CreatedAt()</span><span className="msb-rg">creation time</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Options<span className="msb-ct">1</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="/sdk/go/sandbox#withsnapshot">WithSnapshot()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#snapshotartifactstruct">SnapshotArtifact</a>
+    <a className="msb-typepill" href="#snapshothandlestruct">SnapshotHandle</a>
+    <a className="msb-typepill" href="#snapshotcreateoptionsstruct">SnapshotCreateOptions</a>
+    <a className="msb-typepill" href="#snapshotexportoptionsstruct">SnapshotExportOptions</a>
+    <a className="msb-typepill" href="#snapshotverifyreportstruct">SnapshotVerifyReport</a>
+    <a className="msb-typepill" href="#snapshotupperverifystatusstruct">SnapshotUpperVerifyStatus</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```go
 import m "github.com/superradcompany/microsandbox/sdk/go"
+
+// 1. stop the sandbox; snapshots are disk-only
+_ = sb.Stop(ctx)
+_ = sb.Close()
+
+// 2. snapshot it under a bare name
+snap, err := m.Snapshot.Create(ctx, "baseline", m.SnapshotCreateOptions{
+    Name:            "after-pip-install",
+    RecordIntegrity: true,
+})
+if err != nil {
+    return err
+}
+
+// 3. boot a fresh sandbox from the snapshot
+sb2, err := m.CreateSandbox(ctx, "worker",
+    m.WithSnapshot("after-pip-install"),
+)
 ```
 
-<Note>
-  Snapshots are **disk-only** and require a sandbox that is not running.
-</Note>
+## Snapshot functions
 
-## Boot from snapshot
+Package-level helpers for snapshot artifacts. Access them through the exported `Snapshot` value, e.g. `m.Snapshot.Create(ctx, ...)`.
 
-Pass [`WithSnapshot`](#withsnapshot) to [`CreateSandbox`](/sdk/go/sandbox#createsandbox). It is mutually exclusive with [`WithImage`](/sdk/go/sandbox#withimage).
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">Create()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
-sb, err := m.CreateSandbox(ctx, "worker",
-    m.WithSnapshot("after-pip-install"),
+func (snapshotFactory) Create(ctx context.Context, sourceSandbox string, opts SnapshotCreateOptions) (*SnapshotArtifact, error)
+```
+
+Create a snapshot from a stopped or crashed sandbox. Set exactly one of [`SnapshotCreateOptions.Name`](#snapshotcreateoptionsstruct) (resolved under the default snapshots directory) or [`SnapshotCreateOptions.Path`](#snapshotcreateoptionsstruct) (an explicit artifact directory).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancellation and deadline.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>sourceSandbox</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Name of the stopped or crashed sandbox to snapshot.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#snapshotcreateoptionsstruct">SnapshotCreateOptions</a></div>
+    <div className="msb-param-desc">Destination, labels, and integrity options.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotartifactstruct">*SnapshotArtifact</a></div>
+    <div className="msb-param-desc">The created artifact on disk.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+snap, err := m.Snapshot.Create(ctx, "baseline", m.SnapshotCreateOptions{
+    Name:            "after-pip-install",
+    Labels:          map[string]string{"stage": "post-deps"},
+    RecordIntegrity: true,
+})
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">Open()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func (snapshotFactory) Open(ctx context.Context, pathOrName string) (*SnapshotArtifact, error)
+```
+
+Open an existing artifact by bare name or filesystem path. This validates metadata only; call [`s.Verify()`](#s-verify) for content checks.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancellation and deadline.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pathOrName</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Bare name (resolved under the default snapshots directory) or artifact directory path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotartifactstruct">*SnapshotArtifact</a></div>
+    <div className="msb-param-desc">The artifact on disk.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+snap, err := m.Snapshot.Open(ctx, "after-pip-install")
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">Get()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func (snapshotFactory) Get(ctx context.Context, nameOrDigest string) (*SnapshotHandle, error)
+```
+
+Look up a lightweight handle in the local index by name, digest, or path.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancellation and deadline.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nameOrDigest</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Bare name, manifest digest, or artifact path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandlestruct">*SnapshotHandle</a></div>
+    <div className="msb-param-desc">Index-backed handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+h, err := m.Snapshot.Get(ctx, "after-pip-install")
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">List()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func (snapshotFactory) List(ctx context.Context) ([]*SnapshotHandle, error)
+```
+
+List indexed snapshots from the local DB cache.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandlestruct">[]*SnapshotHandle</a></div>
+    <div className="msb-param-desc">All indexed handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+handles, err := m.Snapshot.List(ctx)
+for _, h := range handles {
+    fmt.Println(h.Digest(), h.ImageRef())
+}
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">ListDir()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func (snapshotFactory) ListDir(ctx context.Context, dir string) ([]*SnapshotArtifact, error)
+```
+
+Walk a directory and parse each subdirectory's manifest without touching the index.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancellation and deadline.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dir</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Directory holding snapshot artifact subdirectories.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotartifactstruct">[]*SnapshotArtifact</a></div>
+    <div className="msb-param-desc">One artifact per parsed subdirectory.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">Remove()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func (snapshotFactory) Remove(ctx context.Context, pathOrName string, force bool) error
+```
+
+Remove a snapshot artifact and its index row. Refuses to delete a snapshot with indexed children unless `force` is true.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancellation and deadline.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pathOrName</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Bare name or artifact path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>force</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Delete even if the snapshot has indexed children.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := m.Snapshot.Remove(ctx, "after-pip-install", false)
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">Reindex()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func (snapshotFactory) Reindex(ctx context.Context, dir string) (uint32, error)
+```
+
+Walk `dir` and rebuild the local index from the artifacts it finds.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancellation and deadline.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dir</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Directory to scan for snapshot artifacts.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">uint32</span></div>
+    <div className="msb-param-desc">Number of artifacts indexed.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+n, err := m.Snapshot.Reindex(ctx, "/srv/snapshots")
+fmt.Printf("indexed %d snapshots\n", n)
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">Export()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
+
+```go
+func (snapshotFactory) Export(ctx context.Context, nameOrPath, outPath string, opts SnapshotExportOptions) error
+```
+
+Bundle a snapshot into a `.tar.zst` archive at `outPath`. Set [`SnapshotExportOptions.PlainTar`](#snapshotexportoptionsstruct) to skip compression.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancellation and deadline.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nameOrPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Bare name or artifact path to export.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>outPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination archive path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#snapshotexportoptionsstruct">SnapshotExportOptions</a></div>
+    <div className="msb-param-desc">Whether to include parents, the base image, and compression.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := m.Snapshot.Export(ctx, "after-pip-install", "/tmp/snap.tar.zst",
+    m.SnapshotExportOptions{WithParents: true},
 )
 ```
 
 ---
 
-#### WithSnapshot()
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">Import()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
-func WithSnapshot(pathOrName string) SandboxOption
+func (snapshotFactory) Import(ctx context.Context, archive, dest string) (*SnapshotHandle, error)
 ```
 
-Boot from a snapshot artifact by bare name (resolved under `~/.microsandbox/snapshots/`) or filesystem path.
+Unpack a snapshot archive into the snapshots directory or an explicit `dest` directory. Pass `""` for the default destination.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancellation and deadline.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>archive</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path to the snapshot archive.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dest</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination directory, or <code>""</code> for the default snapshots directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandlestruct">*SnapshotHandle</a></div>
+    <div className="msb-param-desc">Handle to the imported snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+h, err := m.Snapshot.Import(ctx, "/tmp/snap.tar.zst", "")
+```
 
 ## SandboxHandle methods
 
@@ -50,7 +458,8 @@ snap, err := h.Snapshot(ctx, "after-pip-install")
 
 ---
 
-#### Snapshot()
+#### <span className="msb-recv">h.</span><span className="msb-hn">Snapshot()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (h *SandboxHandle) Snapshot(ctx context.Context, name string) (*SnapshotArtifact, error)
@@ -58,9 +467,38 @@ func (h *SandboxHandle) Snapshot(ctx context.Context, name string) (*SnapshotArt
 
 Snapshot this sandbox under a bare name in the default snapshots directory. The sandbox must be stopped or crashed.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancellation and deadline.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Bare name for the artifact.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotartifactstruct">*SnapshotArtifact</a></div>
+    <div className="msb-param-desc">The created artifact.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+snap, err := h.Snapshot(ctx, "after-pip-install")
+```
+
 ---
 
-#### SnapshotTo()
+#### <span className="msb-recv">h.</span><span className="msb-hn">SnapshotTo()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (h *SandboxHandle) SnapshotTo(ctx context.Context, path string) (*SnapshotArtifact, error)
@@ -68,190 +506,425 @@ func (h *SandboxHandle) SnapshotTo(ctx context.Context, path string) (*SnapshotA
 
 Snapshot this sandbox to an explicit artifact directory. The sandbox must be stopped or crashed.
 
-## Snapshot
+<p className="msb-label">Parameters</p>
 
-Helpers for snapshot artifact operations. Access via the package-level `Snapshot` value.
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancellation and deadline.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination artifact directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotartifactstruct">*SnapshotArtifact</a></div>
+    <div className="msb-param-desc">The created artifact.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+snap, err := h.SnapshotTo(ctx, "/srv/snapshots/baseline")
+```
+
+## SnapshotArtifact methods
+
+An artifact on disk. The accessors below are plain field reads; only [`Verify`](#s-verify) touches the filesystem.
 
 ---
 
-#### Snapshot.Create()
-
-```go
-func (snapshotFactory) Create(
-    ctx context.Context,
-    sourceSandbox string,
-    opts SnapshotCreateOptions,
-) (*SnapshotArtifact, error)
-```
-
-Create a snapshot from a stopped or crashed sandbox. Set exactly one of `SnapshotCreateOptions.Name` or `SnapshotCreateOptions.Path`.
-
-```go
-snap, err := m.Snapshot.Create(ctx, "baseline",
-    m.SnapshotCreateOptions{
-        Name:            "after-pip-install",
-        Labels:          map[string]string{"stage": "post-deps"},
-        RecordIntegrity: true,
-    },
-)
-```
-
----
-
-#### Snapshot.Open()
-
-```go
-func (snapshotFactory) Open(ctx context.Context, pathOrName string) (*SnapshotArtifact, error)
-```
-
-Open an existing artifact by bare name or path. This validates metadata only; call [`Verify`](#verify) for content checks.
-
----
-
-#### Snapshot.Get()
-
-```go
-func (snapshotFactory) Get(ctx context.Context, nameOrDigest string) (*SnapshotHandle, error)
-```
-
-Look up a handle in the local index by name, digest, or path.
-
----
-
-#### Snapshot.List()
-
-```go
-func (snapshotFactory) List(ctx context.Context) ([]*SnapshotHandle, error)
-```
-
-List indexed snapshots from the local DB cache.
-
----
-
-#### Snapshot.ListDir()
-
-```go
-func (snapshotFactory) ListDir(ctx context.Context, dir string) ([]*SnapshotArtifact, error)
-```
-
-Walk a directory and parse each subdirectory's manifest without touching the index.
-
----
-
-#### Snapshot.Remove()
-
-```go
-func (snapshotFactory) Remove(ctx context.Context, pathOrName string, force bool) error
-```
-
-Remove a snapshot artifact and its index row. Refuses indexed children unless `force` is true.
-
----
-
-#### Snapshot.Reindex()
-
-```go
-func (snapshotFactory) Reindex(ctx context.Context, dir string) (uint32, error)
-```
-
-Walk `dir` and rebuild the local index. Returns the number of artifacts indexed.
-
----
-
-#### Snapshot.Export()
-
-```go
-func (snapshotFactory) Export(
-    ctx context.Context,
-    nameOrPath string,
-    outPath string,
-    opts SnapshotExportOptions,
-) error
-```
-
-Bundle a snapshot into a `.tar.zst` archive. Set `PlainTar` to skip compression.
-
----
-
-#### Snapshot.Import()
-
-```go
-func (snapshotFactory) Import(ctx context.Context, archive, dest string) (*SnapshotHandle, error)
-```
-
-Unpack a snapshot archive into the snapshots directory or an explicit `dest` directory. Pass `""` for the default destination.
-
-## SnapshotArtifact
-
-An artifact on disk, returned by `Snapshot.Create`, `Snapshot.Open`, `Snapshot.ListDir`, and `SandboxHandle.Snapshot`.
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `Path()` | `string` | Artifact directory |
-| `Digest()` | `string` | Canonical manifest digest (`sha256:...`) |
-| `SizeBytes()` | `uint64` | Apparent upper-layer size |
-| `ImageRef()` | `string` | Image reference the snapshot was taken from |
-| `ImageManifestDigest()` | `string` | Pinned OCI manifest digest |
-| `Format()` | `string` | `"raw"` or `"qcow2"` |
-| `Fstype()` | `string` | Filesystem type inside the upper layer |
-| `Parent()` | `*string` | Parent digest, or nil |
-| `CreatedAt()` | `string` | RFC 3339 timestamp |
-| `Labels()` | `map[string]string` | User labels |
-| `SourceSandbox()` | `*string` | Best-effort source sandbox name |
-
----
-
-#### Verify()
+#### <span className="msb-recv">s.</span><span className="msb-hn">Verify()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (s *SnapshotArtifact) Verify(ctx context.Context) (*SnapshotVerifyReport, error)
 ```
 
-Recompute recorded content integrity for this snapshot.
+Recompute recorded content integrity for this snapshot. Requires that the artifact was created with [`RecordIntegrity`](#snapshotcreateoptionsstruct) set.
 
-## SnapshotHandle
+<p className="msb-label">Returns</p>
 
-Lightweight handle backed by the local index. Returned by `Snapshot.Get`, `Snapshot.List`, and `Snapshot.Import`.
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotverifyreportstruct">*SnapshotVerifyReport</a></div>
+    <div className="msb-param-desc">Recomputed digest and upper-layer status.</div>
+  </div>
+</div>
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `Digest()` | `string` | Manifest digest |
-| `Name()` | `*string` | Bare-name alias, if indexed with one |
-| `ParentDigest()` | `*string` | Parent digest, or nil |
-| `ImageRef()` | `string` | Pinned image reference |
-| `Format()` | `string` | `"raw"` or `"qcow2"` |
-| `SizeBytes()` | `*uint64` | Apparent upper size at index time |
-| `CreatedAt()` | `time.Time` | Snapshot creation time |
-| `Path()` | `string` | Artifact directory |
-| `Open(ctx)` | `(*SnapshotArtifact, error)` | Open the artifact metadata |
-| `Remove(ctx, force)` | `error` | Remove this snapshot |
+<p className="msb-label">Example</p>
+
+```go
+report, err := snap.Verify(ctx)
+if err != nil {
+    return err
+}
+fmt.Println(report.Upper.Digest)
+```
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">Path()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) Path() string
+```
+
+Artifact directory on disk.
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">Digest()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) Digest() string
+```
+
+Canonical manifest digest (`sha256:...`).
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">SizeBytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) SizeBytes() uint64
+```
+
+Apparent upper-layer size in bytes.
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">ImageRef()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) ImageRef() string
+```
+
+Image reference the snapshot was taken from.
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">ImageManifestDigest()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) ImageManifestDigest() string
+```
+
+Pinned OCI manifest digest of the base image.
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">Format()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) Format() string
+```
+
+Upper-layer disk format: `"raw"` or `"qcow2"`.
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">Fstype()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) Fstype() string
+```
+
+Filesystem type inside the upper layer.
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">Parent()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) Parent() *string
+```
+
+Parent digest, or `nil` if this snapshot has no parent. Returns a defensive copy.
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">CreatedAt()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) CreatedAt() string
+```
+
+RFC 3339 creation timestamp.
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">Labels()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) Labels() map[string]string
+```
+
+User labels recorded at creation. Returns a defensive copy.
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">SourceSandbox()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) SourceSandbox() *string
+```
+
+Best-effort source sandbox name, or `nil`. Returns a defensive copy.
+
+## SnapshotHandle methods
+
+A lightweight handle backed by the local index. The accessors below are plain field reads; [`Open`](#h-open) and [`Remove`](#h-remove) take a context.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Open()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *SnapshotHandle) Open(ctx context.Context) (*SnapshotArtifact, error)
+```
+
+Open the underlying artifact metadata. Equivalent to [`Snapshot.Open`](#snapshot-open) on this handle's path.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotartifactstruct">*SnapshotArtifact</a></div>
+    <div className="msb-param-desc">The opened artifact.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+snap, err := h.Open(ctx)
+```
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *SnapshotHandle) Remove(ctx context.Context, force bool) error
+```
+
+Remove this snapshot. Equivalent to [`Snapshot.Remove`](#snapshot-remove) on this handle's digest.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancellation and deadline.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>force</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Delete even if the snapshot has indexed children.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+err := h.Remove(ctx, false)
+```
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Digest()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *SnapshotHandle) Digest() string
+```
+
+Manifest digest.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Name()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *SnapshotHandle) Name() *string
+```
+
+Bare-name alias, if the snapshot was indexed with one; otherwise `nil`. Returns a defensive copy.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">ParentDigest()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *SnapshotHandle) ParentDigest() *string
+```
+
+Parent digest, or `nil`. Returns a defensive copy.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">ImageRef()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *SnapshotHandle) ImageRef() string
+```
+
+Pinned image reference.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Format()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *SnapshotHandle) Format() string
+```
+
+Upper-layer disk format: `"raw"` or `"qcow2"`.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">SizeBytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *SnapshotHandle) SizeBytes() *uint64
+```
+
+Apparent upper size at index time, or `nil` if unknown. Returns a defensive copy.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Path()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *SnapshotHandle) Path() string
+```
+
+Artifact directory on disk.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">CreatedAt()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *SnapshotHandle) CreatedAt() time.Time
+```
+
+Snapshot creation time, decoded from the index's Unix timestamp.
 
 ## Types
 
-```go
-type SnapshotCreateOptions struct {
-    Name            string
-    Path            string
-    Labels          map[string]string
-    Force           bool
-    RecordIntegrity bool
-}
+### SnapshotArtifact<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
 
-type SnapshotExportOptions struct {
-    WithParents bool
-    WithImage   bool
-    PlainTar    bool
-}
+<p className="msb-backref">Returned by <a href="#snapshot-create">Snapshot.Create()</a> · <a href="#snapshot-open">Snapshot.Open()</a> · <a href="#snapshot-listdir">Snapshot.ListDir()</a> · <a href="#h-snapshot">h.Snapshot()</a> · <a href="#h-snapshotto">h.SnapshotTo()</a> · <a href="#h-open">h.Open()</a></p>
 
-type SnapshotVerifyReport struct {
-    Digest string
-    Path   string
-    Upper  SnapshotUpperVerifyStatus
-}
+A snapshot artifact on disk. Fields are unexported; read them through the accessor methods below.
 
-type SnapshotUpperVerifyStatus struct {
-    Kind      string
-    Algorithm string
-    Digest    string
-}
-```
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`Path()`](#s-path) | `string` | Artifact directory |
+| [`Digest()`](#s-digest) | `string` | Canonical manifest digest (`sha256:...`) |
+| [`SizeBytes()`](#s-sizebytes) | `uint64` | Apparent upper-layer size |
+| [`ImageRef()`](#s-imageref) | `string` | Image reference the snapshot was taken from |
+| [`ImageManifestDigest()`](#s-imagemanifestdigest) | `string` | Pinned OCI manifest digest |
+| [`Format()`](#s-format) | `string` | `"raw"` or `"qcow2"` |
+| [`Fstype()`](#s-fstype) | `string` | Filesystem type inside the upper layer |
+| [`Parent()`](#s-parent) | `*string` | Parent digest, or nil |
+| [`CreatedAt()`](#s-createdat) | `string` | RFC 3339 timestamp |
+| [`Labels()`](#s-labels) | `map[string]string` | User labels |
+| [`SourceSandbox()`](#s-sourcesandbox) | `*string` | Best-effort source sandbox name |
+| [`Verify(ctx)`](#s-verify) | `(*SnapshotVerifyReport, error)` | Recompute content integrity |
+
+### SnapshotHandle<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
+
+<p className="msb-backref">Returned by <a href="#snapshot-get">Snapshot.Get()</a> · <a href="#snapshot-list">Snapshot.List()</a> · <a href="#snapshot-import">Snapshot.Import()</a></p>
+
+A lightweight handle backed by the local snapshot index. Fields are unexported; read them through the accessor methods below.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`Digest()`](#h-digest) | `string` | Manifest digest |
+| [`Name()`](#h-name) | `*string` | Bare-name alias, if indexed with one |
+| [`ParentDigest()`](#h-parentdigest) | `*string` | Parent digest, or nil |
+| [`ImageRef()`](#h-imageref) | `string` | Pinned image reference |
+| [`Format()`](#h-format) | `string` | `"raw"` or `"qcow2"` |
+| [`SizeBytes()`](#h-sizebytes) | `*uint64` | Apparent upper size at index time |
+| [`Path()`](#h-path) | `string` | Artifact directory |
+| [`CreatedAt()`](#h-createdat) | `time.Time` | Snapshot creation time |
+| [`Open(ctx)`](#h-open) | `(*SnapshotArtifact, error)` | Open the artifact metadata |
+| [`Remove(ctx, force)`](#h-remove) | `error` | Remove this snapshot |
+
+### SnapshotCreateOptions<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
+
+<p className="msb-backref">Accepted by <a href="#snapshot-create">Snapshot.Create()</a></p>
+
+Configures [`Snapshot.Create`](#snapshot-create). Set exactly one of `Name` or `Path`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Name | `string` | Bare name; the artifact is written under the default snapshots directory |
+| Path | `string` | Explicit artifact directory (mutually exclusive with `Name`) |
+| Labels | `map[string]string` | Arbitrary user labels recorded in the manifest |
+| Force | `bool` | Overwrite an existing artifact at the destination |
+| RecordIntegrity | `bool` | Record content hashes so [`Verify`](#s-verify) can recompute them later |
+
+### SnapshotExportOptions<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
+
+<p className="msb-backref">Accepted by <a href="#snapshot-export">Snapshot.Export()</a></p>
+
+Configures [`Snapshot.Export`](#snapshot-export).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| WithParents | `bool` | Include the snapshot's parent chain in the archive |
+| WithImage | `bool` | Include the base OCI image in the archive |
+| PlainTar | `bool` | Write an uncompressed `.tar` instead of `.tar.zst` |
+
+### SnapshotVerifyReport<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
+
+<p className="msb-backref">Returned by <a href="#s-verify">s.Verify()</a></p>
+
+Result of [`Verify`](#s-verify).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Digest | `string` | Recomputed manifest digest |
+| Path | `string` | Artifact directory that was verified |
+| Upper | [`SnapshotUpperVerifyStatus`](#snapshotupperverifystatusstruct) | Upper-layer integrity status |
+
+### SnapshotUpperVerifyStatus<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
+
+<p className="msb-backref">Field of <a href="#snapshotverifyreportstruct">SnapshotVerifyReport</a></p>
+
+Upper-layer integrity details inside a [`SnapshotVerifyReport`](#snapshotverifyreportstruct).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Kind | `string` | Integrity record kind |
+| Algorithm | `string` | Hash algorithm used |
+| Digest | `string` | Recomputed upper-layer digest |

--- a/docs/sdk/go/ssh.mdx
+++ b/docs/sdk/go/ssh.mdx
@@ -3,211 +3,606 @@ title: SSH
 description: Go SDK - SSH API reference
 ---
 
-See [SSH](/sandboxes/ssh) for usage flows.
+Reach a running sandbox over SSH: open a native in-process SSH client, run exec requests, attach an interactive shell, transfer files over SFTP, or stand up a reusable SSH server endpoint. See [SSH](/sandboxes/ssh) for usage flows.
 
-## Sandbox
+<div className="msb-glance">
 
----
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods<span className="msb-ct">20</span></p>
+  <a className="msb-row" href="#sb-ssh"><span className="msb-rn">sb.SSH()</span><span className="msb-rg">SSH namespace for this sandbox</span></a>
+  <a className="msb-row" href="#ssh-openclient"><span className="msb-rn">ssh.OpenClient()</span><span className="msb-rg">open a native client</span></a>
+  <a className="msb-row" href="#ssh-prepareserver"><span className="msb-rn">ssh.PrepareServer()</span><span className="msb-rg">prepare a server endpoint</span></a>
+  <a className="msb-row" href="#c-exec"><span className="msb-rn">c.Exec()</span><span className="msb-rg">run a command</span></a>
+  <a className="msb-row" href="#c-attach"><span className="msb-rn">c.Attach()</span><span className="msb-rg">interactive shell</span></a>
+  <a className="msb-row" href="#c-sftp"><span className="msb-rn">c.SFTP()</span><span className="msb-rg">open an SFTP session</span></a>
+  <a className="msb-row" href="#c-close"><span className="msb-rn">c.Close()</span><span className="msb-rg">close the client</span></a>
+  <a className="msb-row" href="#srv-serveconnection"><span className="msb-rn">srv.ServeConnection()</span><span className="msb-rg">serve one connection</span></a>
+  <a className="msb-row" href="#srv-close"><span className="msb-rn">srv.Close()</span><span className="msb-rg">release the endpoint</span></a>
+  <a className="msb-row" href="#o-success"><span className="msb-rn">o.Success()</span><span className="msb-rg">exit status was 0</span></a>
+  <a className="msb-row" href="#sftpclient"><span className="msb-rn">sftp.Read()</span><span className="msb-rg">read a file</span></a>
+  <a className="msb-row" href="#sftpclient"><span className="msb-rn">sftp.Write()</span><span className="msb-rg">write a file</span></a>
+  <a className="msb-row" href="#sftpclient"><span className="msb-rn">sftp.Mkdir()</span><span className="msb-rg">create a directory</span></a>
+  <a className="msb-row" href="#sftpclient"><span className="msb-rn">sftp.Rename()</span><span className="msb-rg">rename a path</span></a>
+  <a className="msb-row" href="#sftpclient"><span className="msb-rn">sftp.RealPath()</span><span className="msb-rg">resolve a canonical path</span></a>
+  <a className="msb-row" href="#sftpclient"><span className="msb-rn">sftp.Symlink()</span><span className="msb-rg">create a symlink</span></a>
+  <a className="msb-row" href="#sftpclient"><span className="msb-rn">sftp.Close()</span><span className="msb-rg">+ 3 more in SFTPClient</span></a>
 
-#### SSH()
+  <p className="msb-gl"><span className="msb-dot builder"></span>Options<span className="msb-ct">10</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#sshclientoption">WithSSHUser()</a>
+    <a className="msb-chip" href="#sshclientoption">WithSSHTerm()</a>
+    <a className="msb-chip" href="#sshclientoption">WithSSHClientSFTP()</a>
+    <a className="msb-chip" href="#sshexecoption">WithSSHTTY()</a>
+    <a className="msb-chip" href="#sshattachoption">WithSSHAttachTerm()</a>
+    <a className="msb-chip" href="#sshattachoption">WithSSHDetachKeys()</a>
+    <a className="msb-chip" href="#sshserveroption">WithSSHHostKeyPath()</a>
+    <a className="msb-chip" href="#sshserveroption">WithSSHAuthorizedKeysPath()</a>
+    <a className="msb-chip" href="#sshserveroption">WithSSHServerUser()</a>
+    <a className="msb-chip" href="#sshserveroption">WithSSHServerSFTP()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#sandboxsshops">SandboxSSHOps</a>
+    <a className="msb-typepill" href="#sshclient">SSHClient</a>
+    <a className="msb-typepill" href="#sftpclient">SFTPClient</a>
+    <a className="msb-typepill" href="#sshserver">SSHServer</a>
+    <a className="msb-typepill" href="#sshoutput">SSHOutput</a>
+    <a className="msb-typepill" href="#sshclientoption">SSHClientOption</a>
+    <a className="msb-typepill" href="#sshexecoption">SSHExecOption</a>
+    <a className="msb-typepill" href="#sshattachoption">SSHAttachOption</a>
+    <a className="msb-typepill" href="#sshserveroption">SSHServerOption</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```go
-func (s *Sandbox) SSH() *SSH
+import (
+    "context"
+
+    m "github.com/superradcompany/microsandbox/sdk/go"
+)
+
+ctx := context.Background()
+
+client, err := sb.SSH().OpenClient(ctx)   // 1. open a native client
+if err != nil {
+    return err
+}
+defer client.Close(ctx)
+
+out, err := client.Exec(ctx, "uname -a")  // 2. run a command
+if err != nil {
+    return err
+}
+fmt.Printf("%s (exit %d)\n", out.Stdout, out.Status)
 ```
 
-Return the SSH namespace for this sandbox.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `*SSH` | SSH client and server helpers |
-
-## SSH
+## Methods
 
 ---
 
-#### Connect()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">SSH()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
-func (ssh *SSH) Connect(ctx context.Context, opts ...SSHClientOption) (*SSHClient, error)
+func (s *Sandbox) SSH() *SandboxSSHOps
 ```
 
-Connect a native in-process SSH client to the sandbox.
+Return the SSH operations namespace for this sandbox. The namespace groups the client and server helpers; it holds no resources of its own.
 
-**Parameters**
+<p className="msb-label">Returns</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| ctx | `context.Context` | Cancels the connection attempt |
-| opts | `...SSHClientOption` | Client options |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxsshops">*SandboxSSHOps</a></div>
+    <div className="msb-param-desc">SSH client and server helpers for this sandbox.</div>
+  </div>
+</div>
 
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `*SSHClient` | Native SSH client session |
-| `error` | Typed microsandbox error |
-
----
-
-#### Server()
+<p className="msb-label">Example</p>
 
 ```go
-func (ssh *SSH) Server(ctx context.Context, opts ...SSHServerOption) (*SSHServer, error)
+ssh := sb.SSH()
+client, err := ssh.OpenClient(ctx)
 ```
-
-Prepare a reusable SSH server endpoint.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| ctx | `context.Context` | Cancels server preparation |
-| opts | `...SSHServerOption` | Server options |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `*SSHServer` | Server endpoint |
-| `error` | Typed microsandbox error |
-
-## SSHClient
 
 ---
 
-#### Exec()
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">OpenClient()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (ssh *SandboxSSHOps) OpenClient(ctx context.Context, opts ...SSHClientOption) (*SSHClient, error)
+```
+
+Open a native in-process SSH client to this sandbox. Generates an ephemeral Ed25519 client and host key pair, stands up an internal server bound to a duplex stream, and authenticates over public key. With no options it uses login user `root`, terminal from `$TERM` (falling back to `xterm`), and SFTP enabled.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the connection attempt.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshclientoption">...SSHClientOption</a></div>
+    <div className="msb-param-desc">Login user, terminal name, and SFTP toggle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshclient">*SSHClient</a></div>
+    <div className="msb-param-desc">Native SSH client session.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+client, err := sb.SSH().OpenClient(ctx,
+    m.WithSSHUser("app"),
+    m.WithSSHTerm("xterm-256color"),
+)
+if err != nil {
+    return err
+}
+defer client.Close(ctx)
+```
+
+---
+
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">PrepareServer()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (ssh *SandboxSSHOps) PrepareServer(ctx context.Context, opts ...SSHServerOption) (*SSHServer, error)
+```
+
+Prepare a reusable SSH server endpoint for this sandbox. Loads or creates the host key and resolves authorized keys from the default authorized-keys file unless overridden. The returned [`SSHServer`](#sshserver) can serve connections one at a time over the process's standard streams.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels server preparation.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshserveroption">...SSHServerOption</a></div>
+    <div className="msb-param-desc">Host key, authorized keys, guest user, and SFTP toggle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshserver">*SSHServer</a></div>
+    <div className="msb-param-desc">Prepared server endpoint.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+srv, err := sb.SSH().PrepareServer(ctx,
+    m.WithSSHAuthorizedKeysPath("/etc/msb/authorized_keys"),
+)
+if err != nil {
+    return err
+}
+defer srv.Close(ctx)
+```
+
+---
+
+#### <span className="msb-recv">c.</span><span className="msb-hn">Exec()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (c *SSHClient) Exec(ctx context.Context, command string, opts ...SSHExecOption) (*SSHOutput, error)
 ```
 
-Run an SSH exec request and collect stdout, stderr, and exit status.
+Run an SSH exec request and collect stdout, stderr, and the exit status. The command is run through the sandbox's configured shell. No PTY is requested unless [`WithSSHTTY`](#sshexecoption) is passed.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| ctx | `context.Context` | Cancels the exec request |
-| command | `string` | Command string sent through SSH |
-| opts | `...SSHExecOption` | Exec options |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the exec request.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>command</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Command string sent through SSH.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshexecoption">...SSHExecOption</a></div>
+    <div className="msb-param-desc">PTY toggle for the exec channel.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `*SSHOutput` | Captured output and status |
-| `error` | Typed microsandbox error |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshoutput">*SSHOutput</a></div>
+    <div className="msb-param-desc">Captured stdout, stderr, and exit status.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+out, err := client.Exec(ctx, "python -V")
+if err != nil {
+    return err
+}
+if !out.Success() {
+    return fmt.Errorf("exit %d: %s", out.Status, out.Stderr)
+}
+fmt.Printf("%s", out.Stdout)
+```
 
 ---
 
-#### Attach()
+#### <span className="msb-recv">c.</span><span className="msb-hn">Attach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (c *SSHClient) Attach(ctx context.Context, opts ...SSHAttachOption) (int, error)
 ```
 
-Attach the local terminal to an interactive SSH shell.
+Bridge the local terminal to an interactive SSH shell. Requests a PTY sized to the current terminal, puts the terminal into raw mode, forwards keystrokes, relays window-resize events, and returns when the shell exits or the detach key sequence is typed.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| ctx | `context.Context` | Cancels the attach session |
-| opts | `...SSHAttachOption` | Attach options |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the attach session.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshattachoption">...SSHAttachOption</a></div>
+    <div className="msb-param-desc">Terminal name and detach key sequence.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `int` | Exit code |
-| `error` | Typed microsandbox error |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Shell exit code (128 if terminated by signal).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+code, err := client.Attach(ctx,
+    m.WithSSHAttachTerm("xterm-256color"),
+    m.WithSSHDetachKeys("ctrl-p,ctrl-q"),
+)
+if err != nil {
+    return err
+}
+fmt.Printf("shell exited with %d\n", code)
+```
 
 ---
 
-#### SFTP()
+#### <span className="msb-recv">c.</span><span className="msb-hn">SFTP()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (c *SSHClient) SFTP(ctx context.Context) (*SFTPClient, error)
 ```
 
-Open an SFTP session over this SSH connection.
+Open an SFTP session over this SSH connection. Returns a high-level SFTP client for reading, writing, and managing files inside the guest. Requires SFTP enabled on the client (the default).
 
-**Returns**
+<p className="msb-label">Parameters</p>
 
-| Type | Description |
-|------|-------------|
-| `*SFTPClient` | SFTP client session |
-| `error` | Typed microsandbox error |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels opening the SFTP session.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sftpclient">*SFTPClient</a></div>
+    <div className="msb-param-desc">SFTP client session.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+sftp, err := client.SFTP(ctx)
+if err != nil {
+    return err
+}
+defer sftp.Close(ctx)
+
+if err := sftp.Write(ctx, "/tmp/hello.txt", []byte("hi")); err != nil {
+    return err
+}
+```
 
 ---
 
-#### Close()
+#### <span className="msb-recv">c.</span><span className="msb-hn">Close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (c *SSHClient) Close(ctx context.Context) error
 ```
 
-Close the native SSH client session. The handle is consumed.
+Close this SSH client session. The handle is consumed; do not use it after closing.
 
-## SFTPClient
+<p className="msb-label">Parameters</p>
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| Read(ctx, path) | `([]byte, error)` | Read a file into memory |
-| Write(ctx, path, data) | `error` | Create or truncate a file |
-| Mkdir(ctx, path) | `error` | Create a directory |
-| RemoveFile(ctx, path) | `error` | Remove a file |
-| RemoveDir(ctx, path) | `error` | Remove an empty directory |
-| Rename(ctx, oldPath, newPath) | `error` | Rename a file or directory |
-| RealPath(ctx, path) | `(string, error)` | Resolve a canonical path |
-| ReadLink(ctx, path) | `(string, error)` | Read a symlink target |
-| Symlink(ctx, target, linkPath) | `error` | Create a symlink |
-| Close(ctx) | `error` | Close the SFTP session |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the close.</div>
+  </div>
+</div>
 
-## SSHServer
+<p className="msb-label">Returns</p>
 
----
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
 
-#### ServeStdio()
+<p className="msb-label">Example</p>
 
 ```go
-func (srv *SSHServer) ServeStdio(ctx context.Context) error
+defer client.Close(ctx)
 ```
-
-Serve one SSH transport over stdin/stdout.
 
 ---
 
-#### Close()
+#### <span className="msb-recv">srv.</span><span className="msb-hn">ServeConnection()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (srv *SSHServer) ServeConnection(ctx context.Context) error
+```
+
+Serve one SSH transport over this process's stdin and stdout. Returns when the connection ends. Call again on the same [`SSHServer`](#sshserver) to serve another connection.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels serving the connection.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+srv, err := sb.SSH().PrepareServer(ctx)
+if err != nil {
+    return err
+}
+defer srv.Close(ctx)
+
+if err := srv.ServeConnection(ctx); err != nil {
+    return err
+}
+```
+
+---
+
+#### <span className="msb-recv">srv.</span><span className="msb-hn">Close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (srv *SSHServer) Close(ctx context.Context) error
 ```
 
-Release the prepared server endpoint. The handle is consumed.
+Release this prepared server endpoint. The handle is consumed; do not use it after closing.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the close.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Typed microsandbox error.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+defer srv.Close(ctx)
+```
+
+---
+
+#### <span className="msb-recv">o.</span><span className="msb-hn">Success()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (o SSHOutput) Success() bool
+```
+
+Report whether the command exited with status `0`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> when <code>Status</code> is <code>0</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+out, err := client.Exec(ctx, "test -f /etc/passwd")
+if err != nil {
+    return err
+}
+fmt.Println("present:", out.Success())
+```
+
+---
 
 ## Types
 
+### SandboxSSHOps
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-ssh">SSH()</a></p>
+
+SSH operations namespace for a sandbox. Obtained via [`sb.SSH()`](#sb-ssh). Holds no resources; it groups the client and server entry points.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`OpenClient(ctx, opts...)`](#ssh-openclient) | `(`[`*SSHClient`](#sshclient)`, error)` | Open a native in-process SSH client |
+| [`PrepareServer(ctx, opts...)`](#ssh-prepareserver) | `(`[`*SSHServer`](#sshserver)`, error)` | Prepare a reusable SSH server endpoint |
+
+### SSHClient
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#ssh-openclient">OpenClient()</a></p>
+
+A native in-process SSH client session. Obtained via [`OpenClient()`](#ssh-openclient).
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`Exec(ctx, command, opts...)`](#c-exec) | `(`[`*SSHOutput`](#sshoutput)`, error)` | Run a command and collect output |
+| [`Attach(ctx, opts...)`](#c-attach) | `(int, error)` | Bridge the local terminal to an interactive shell |
+| [`SFTP(ctx)`](#c-sftp) | `(`[`*SFTPClient`](#sftpclient)`, error)` | Open an SFTP session over this connection |
+| [`Close(ctx)`](#c-close) | `error` | Close the session (consumes the handle) |
+
+### SFTPClient
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#c-sftp">SFTP()</a></p>
+
+A high-level SFTP client session over an SSH connection. Obtained via [`SFTP()`](#c-sftp).
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| Read(ctx, path) | `([]byte, error)` | Read a file into memory |
+| Write(ctx, path, data) | `error` | Write a file, creating or truncating it |
+| Mkdir(ctx, path) | `error` | Create a directory |
+| RemoveFile(ctx, path) | `error` | Remove a file |
+| RemoveDir(ctx, path) | `error` | Remove an empty directory |
+| Rename(ctx, oldPath, newPath) | `error` | Rename a file or directory |
+| RealPath(ctx, path) | `(string, error)` | Resolve a path to its canonical absolute form |
+| ReadLink(ctx, path) | `(string, error)` | Read a symlink target |
+| Symlink(ctx, target, linkPath) | `error` | Create a symlink |
+| Close(ctx) | `error` | Close the session (consumes the handle) |
+
+### SSHServer
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#ssh-prepareserver">PrepareServer()</a></p>
+
+A prepared SSH server endpoint for a sandbox. Obtained via [`PrepareServer()`](#ssh-prepareserver).
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`ServeConnection(ctx)`](#srv-serveconnection) | `error` | Serve one SSH transport over stdin/stdout |
+| [`Close(ctx)`](#srv-close) | `error` | Release the endpoint (consumes the handle) |
+
 ### SSHOutput
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#c-exec">Exec()</a></p>
+
+The output from an SSH exec request.
 
 | Field / Method | Type | Description |
 |----------------|------|-------------|
 | Status | `int` | Exit status code |
 | Stdout | `[]byte` | Captured stdout bytes |
 | Stderr | `[]byte` | Captured stderr bytes |
-| Success() | `bool` | `true` if status is `0` |
+| [`Success()`](#o-success) | `bool` | `true` when `Status` is `0` |
 
 ### SSHClientOption
 
+<div className="msb-tags"><span className="msb-tag is-type">option</span></div>
+
+<p className="msb-backref">Used by <a href="#ssh-openclient">OpenClient()</a></p>
+
+Functional option for [`OpenClient()`](#ssh-openclient). Defaults: user `root`, terminal from `$TERM` (falling back to `xterm`), SFTP enabled.
+
 | Option | Description |
 |--------|-------------|
-| WithSSHUser(user) | SSH login user. Defaults to `root` |
+| WithSSHUser(user) | SSH login user. Default `root` |
 | WithSSHTerm(term) | Terminal name for interactive sessions |
-| WithSSHClientSFTP(enabled) | Enable or disable SFTP on the internal server |
+| WithSSHClientSFTP(enabled) | Enable or disable SFTP on the internal server. Default `true` |
 
 ### SSHExecOption
+
+<div className="msb-tags"><span className="msb-tag is-type">option</span></div>
+
+<p className="msb-backref">Used by <a href="#c-exec">Exec()</a></p>
+
+Functional option for [`Exec()`](#c-exec).
 
 | Option | Description |
 |--------|-------------|
@@ -215,16 +610,28 @@ Release the prepared server endpoint. The handle is consumed.
 
 ### SSHAttachOption
 
+<div className="msb-tags"><span className="msb-tag is-type">option</span></div>
+
+<p className="msb-backref">Used by <a href="#c-attach">Attach()</a></p>
+
+Functional option for [`Attach()`](#c-attach). The default terminal comes from `$TERM` (falling back to `xterm`); detach keys default to the standard sequence.
+
 | Option | Description |
 |--------|-------------|
-| WithSSHAttachTerm(term) | Terminal name for the shell |
+| WithSSHAttachTerm(term) | Terminal name for the interactive shell |
 | WithSSHDetachKeys(keys) | Detach key sequence |
 
 ### SSHServerOption
+
+<div className="msb-tags"><span className="msb-tag is-type">option</span></div>
+
+<p className="msb-backref">Used by <a href="#ssh-prepareserver">PrepareServer()</a></p>
+
+Functional option for [`PrepareServer()`](#ssh-prepareserver). SFTP is enabled by default; when no authorized-keys path is provided, the default authorized-keys file is loaded.
 
 | Option | Description |
 |--------|-------------|
 | WithSSHHostKeyPath(path) | Override the host private key path |
 | WithSSHAuthorizedKeysPath(path) | Override the authorized-keys path |
-| WithSSHServerUser(user) | Override the guest user used for exec requests |
-| WithSSHServerSFTP(enabled) | Enable or disable SFTP |
+| WithSSHServerUser(user) | Override the guest user used for SSH exec requests |
+| WithSSHServerSFTP(enabled) | Enable or disable SFTP on the server endpoint. Default `true` |

--- a/docs/sdk/go/volumes.mdx
+++ b/docs/sdk/go/volumes.mdx
@@ -3,81 +3,194 @@ title: Volumes
 description: Go SDK - Volume API reference
 ---
 
-See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+Create and manage named persistent volumes, read and write their data directly on the host, and attach them (or bind mounts, tmpfs, and disk images) to sandboxes. See [Volumes](/sandboxes/volumes) for usage examples and patterns.
 
-## Volume
+<div className="msb-glance">
 
-Named volumes are managed by microsandbox and stored by default under `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+  <p className="msb-gl"><span className="msb-dot static"></span>Functions<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#createvolume"><span className="msb-rn">CreateVolume()</span><span className="msb-rg">create a named volume</span></a>
+  <a className="msb-row" href="#getvolume"><span className="msb-rn">GetVolume()</span><span className="msb-rg">look up one by name</span></a>
+  <a className="msb-row" href="#listvolumes"><span className="msb-rn">ListVolumes()</span><span className="msb-rg">all volumes on the host</span></a>
+  <a className="msb-row" href="#removevolume"><span className="msb-rn">RemoveVolume()</span><span className="msb-rg">delete one by name</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · Volume<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#v-name"><span className="msb-rn">v.Name()</span><span className="msb-rg">volume name</span></a>
+  <a className="msb-row" href="#v-path"><span className="msb-rn">v.Path()</span><span className="msb-rg">host data directory path</span></a>
+  <a className="msb-row" href="#v-fs"><span className="msb-rn">v.FS()</span><span className="msb-rg">host-side file access</span></a>
+  <a className="msb-row" href="#v-remove"><span className="msb-rn">v.Remove()</span><span className="msb-rg">delete this volume</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · VolumeHandle<span className="msb-ct">12</span></p>
+  <a className="msb-row" href="#h-name"><span className="msb-rn">h.Name()</span><span className="msb-rg">volume name</span></a>
+  <a className="msb-row" href="#h-path"><span className="msb-rn">h.Path()</span><span className="msb-rg">host data directory path</span></a>
+  <a className="msb-row" href="#h-kind"><span className="msb-rn">h.Kind()</span><span className="msb-rg">dir or disk backing</span></a>
+  <a className="msb-row" href="#h-quotamib"><span className="msb-rn">h.QuotaMiB()</span><span className="msb-rg">quota in MiB, or nil</span></a>
+  <a className="msb-row" href="#h-usedbytes"><span className="msb-rn">h.UsedBytes()</span><span className="msb-rg">space used in bytes</span></a>
+  <a className="msb-row" href="#h-capacitybytes"><span className="msb-rn">h.CapacityBytes()</span><span className="msb-rg">disk capacity in bytes</span></a>
+  <a className="msb-row" href="#h-diskformat"><span className="msb-rn">h.DiskFormat()</span><span className="msb-rg">disk image format</span></a>
+  <a className="msb-row" href="#h-diskfstype"><span className="msb-rn">h.DiskFstype()</span><span className="msb-rg">inner filesystem type</span></a>
+  <a className="msb-row" href="#h-labels"><span className="msb-rn">h.Labels()</span><span className="msb-rg">metadata labels</span></a>
+  <a className="msb-row" href="#h-createdat"><span className="msb-rn">h.CreatedAt()</span><span className="msb-rg">creation timestamp</span></a>
+  <a className="msb-row" href="#h-fs"><span className="msb-rn">h.FS()</span><span className="msb-rg">host-side file access</span></a>
+  <a className="msb-row" href="#h-remove"><span className="msb-rn">h.Remove()</span><span className="msb-rg">delete this volume</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · VolumeFs<span className="msb-ct">9</span></p>
+  <a className="msb-row" href="#vfs-root"><span className="msb-rn">vfs.Root()</span><span className="msb-rg">absolute root path</span></a>
+  <a className="msb-row" href="#vfs-read"><span className="msb-rn">vfs.Read()</span><span className="msb-rg">read file bytes</span></a>
+  <a className="msb-row" href="#vfs-readstring"><span className="msb-rn">vfs.ReadString()</span><span className="msb-rg">read file as string</span></a>
+  <a className="msb-row" href="#vfs-write"><span className="msb-rn">vfs.Write()</span><span className="msb-rg">write bytes to a file</span></a>
+  <a className="msb-row" href="#vfs-writestring"><span className="msb-rn">vfs.WriteString()</span><span className="msb-rg">write a string</span></a>
+  <a className="msb-row" href="#vfs-mkdir"><span className="msb-rn">vfs.Mkdir()</span><span className="msb-rg">create directory tree</span></a>
+  <a className="msb-row" href="#vfs-remove"><span className="msb-rn">vfs.Remove()</span><span className="msb-rg">delete file or empty dir</span></a>
+  <a className="msb-row" href="#vfs-removeall"><span className="msb-rn">vfs.RemoveAll()</span><span className="msb-rg">recursive delete</span></a>
+  <a className="msb-row" href="#vfs-exists"><span className="msb-rn">vfs.Exists()</span><span className="msb-rg">check for existence</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Options<span className="msb-ct">9</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#withvolumekind">WithVolumeKind()</a>
+    <a className="msb-chip" href="#withvolumesize">WithVolumeSize()</a>
+    <a className="msb-chip" href="#withvolumequota">WithVolumeQuota()</a>
+    <a className="msb-chip" href="#withvolumelabels">WithVolumeLabels()</a>
+    <a className="msb-chip" href="#mount-bind">Mount.Bind()</a>
+    <a className="msb-chip" href="#mount-named">Mount.Named()</a>
+    <a className="msb-chip" href="#mount-namedwith">Mount.NamedWith()</a>
+    <a className="msb-chip" href="#mount-tmpfs">Mount.Tmpfs()</a>
+    <a className="msb-chip" href="#mount-disk">Mount.Disk()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#volume">Volume</a>
+    <a className="msb-typepill" href="#volumehandle">VolumeHandle</a>
+    <a className="msb-typepill" href="#volumefs">VolumeFs</a>
+    <a className="msb-typepill" href="#errpathescape">ErrPathEscape</a>
+    <a className="msb-typepill" href="#volumeconfig">VolumeConfig</a>
+    <a className="msb-typepill" href="#volumeoption">VolumeOption</a>
+    <a className="msb-typepill" href="#volumekind">VolumeKind</a>
+    <a className="msb-typepill" href="#mountconfig">MountConfig</a>
+    <a className="msb-typepill" href="#mountkind">MountKind</a>
+    <a className="msb-typepill" href="#mountoptions">MountOptions</a>
+    <a className="msb-typepill" href="#namedvolumeoptions">NamedVolumeOptions</a>
+    <a className="msb-typepill" href="#tmpfsoptions">TmpfsOptions</a>
+    <a className="msb-typepill" href="#diskoptions">DiskOptions</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```go
-vol, err := m.CreateVolume(ctx, "my-data",
+import m "github.com/superradcompany/microsandbox/sdk/go"
+
+vol, err := m.CreateVolume(ctx, "my-data",        // 1. create a named volume
+    m.WithVolumeQuota(64),
     m.WithVolumeLabels(map[string]string{"env": "prod"}),
 )
 
-dockerData, err := m.CreateVolume(ctx, "docker-data",
-    m.WithVolumeKind(m.VolumeKindDisk),
-    m.WithVolumeSize(20 * 1024),
+vfs := vol.FS()                                    // 2. seed it from the host
+err = vfs.WriteString("seed.txt", "hello")
+
+sb, err := m.CreateSandbox(ctx, "worker",          // 3. attach it to a sandbox
+    m.WithImage("alpine"),
+    m.WithMounts(map[string]m.MountConfig{
+        "/data": m.Mount.Named("my-data", m.MountOptions{}),
+    }),
 )
 ```
 
-There is no Rust-side resource to release — `Remove` deletes the on-disk state and the DB record.
+Named volumes are managed by microsandbox and stored by default under `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox. There is no Rust-side resource to release: `Remove` deletes the on-disk state and the DB record.
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `Name()` | `string` | Volume name |
-| `Path()` | `string` | Host filesystem path of the volume's data directory |
-| `FS()` | [`*VolumeFs`](#volumefs) | Host-side filesystem accessor |
-| `Remove(ctx)` | `error` | Delete this volume (all sandboxes using it must be stopped) |
+## Functions
 
 ---
 
-## Top-level functions
-
----
-
-#### CreateVolume()
+#### <span className="msb-recv"></span><span className="msb-hn">CreateVolume()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
-func CreateVolume(
-    ctx context.Context,
-    name string,
-    opts ...VolumeOption,
-) (*Volume, error)
+func CreateVolume(ctx context.Context, name string, opts ...VolumeOption) (*Volume, error)
 ```
 
-Create a named volume.
+Create a named volume and return a populated [`*Volume`](#volume) with its name and host path. Configure the kind, quota, disk size, and labels with [option functions](#options). Returns `ErrVolumeAlreadyExists` if a volume with the given name already exists.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| ctx | `context.Context` | Cancels the create |
-| name | `string` | Volume name |
-| opts | `...VolumeOption` | Functional options — see [Options](#options) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the create.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#volumeoption">...VolumeOption</a></div>
+    <div className="msb-param-desc">Functional options, see <a href="#options">Options</a>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`*Volume`](#volume) | Newly created volume with `Name` and `Path` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volume">*Volume</a></div>
+    <div className="msb-param-desc">Newly created volume with <code>Name</code> and <code>Path</code>.</div>
+  </div>
+</div>
 
-Returns `ErrVolumeAlreadyExists` if a volume with the given name already exists.
+<p className="msb-label">Example</p>
+
+```go
+vol, err := m.CreateVolume(ctx, "docker-data",
+    m.WithVolumeKind(m.VolumeKindDisk),
+    m.WithVolumeSize(20*1024),
+)
+```
 
 ---
 
-#### GetVolume()
+#### <span className="msb-recv"></span><span className="msb-hn">GetVolume()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func GetVolume(ctx context.Context, name string) (*VolumeHandle, error)
 ```
 
-Look up a volume by name and return its metadata.
+Look up a volume by name and return its metadata. Returns `ErrVolumeNotFound` if no such volume exists.
 
-Returns `ErrVolumeNotFound` if no such volume exists.
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the lookup.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumehandle">*VolumeHandle</a></div>
+    <div className="msb-param-desc">Metadata reference for the volume.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+h, err := m.GetVolume(ctx, "my-data")
+fmt.Println(h.Path(), h.UsedBytes())
+```
 
 ---
 
-#### ListVolumes()
+#### <span className="msb-recv"></span><span className="msb-hn">ListVolumes()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func ListVolumes(ctx context.Context) ([]*VolumeHandle, error)
@@ -85,88 +198,292 @@ func ListVolumes(ctx context.Context) ([]*VolumeHandle, error)
 
 Return metadata for every named volume on the host.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the listing.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumehandle">[]*VolumeHandle</a></div>
+    <div className="msb-param-desc">All volume metadata handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+vols, err := m.ListVolumes(ctx)
+for _, h := range vols {
+    fmt.Printf("%s — %s\n", h.Name(), h.Kind())
+}
+```
+
 ---
 
-#### RemoveVolume()
+#### <span className="msb-recv"></span><span className="msb-hn">RemoveVolume()</span>
+<div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
 func RemoveVolume(ctx context.Context, name string) error
 ```
 
-Delete a volume by name. All sandboxes referencing the volume must be stopped.
+Delete a volume by name. All sandboxes referencing the volume must be stopped first.
 
----
+<p className="msb-label">Parameters</p>
 
-## Options
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
+    <div className="msb-param-desc">Cancels the removal.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
 
----
-
-#### WithVolumeQuota()
-
-```go
-func WithVolumeQuota(mebibytes uint32) VolumeOption
-```
-
-Set recorded quota metadata for directory volumes. Zero means unlimited.
-
----
-
-#### WithVolumeKind()
+<p className="msb-label">Example</p>
 
 ```go
-func WithVolumeKind(kind VolumeKind) VolumeOption
+err := m.RemoveVolume(ctx, "my-data")
 ```
 
-Select the volume kind. Valid values are `VolumeKindDir` and `VolumeKindDisk`.
+## Volume methods
+
+A `Volume` is returned by [`CreateVolume`](#createvolume) and carries the volume's name and host path.
 
 ---
 
-#### WithVolumeSize()
+#### <span className="msb-recv">v.</span><span className="msb-hn">Name()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
-func WithVolumeSize(mebibytes uint32) VolumeOption
+func (v *Volume) Name() string
 ```
 
-Set disk volume capacity in MiB. Required with `VolumeKindDisk`.
+Return the volume's name.
 
 ---
 
-#### WithVolumeLabels()
+#### <span className="msb-recv">v.</span><span className="msb-hn">Path()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
-func WithVolumeLabels(labels map[string]string) VolumeOption
+func (v *Volume) Path() string
 ```
 
-Attach key-value labels to the volume. Called repeatedly, maps merge; later keys overwrite earlier ones.
+Return the host filesystem path of the volume's data directory.
 
 ---
 
-## VolumeHandle
+#### <span className="msb-recv">v.</span><span className="msb-hn">FS()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
-Metadata reference returned by [`GetVolume`](#getvolume) and [`ListVolumes`](#listvolumes).
+```go
+func (v *Volume) FS() *VolumeFs
+```
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `Name()` | `string` | Volume name |
-| `Path()` | `string` | Host filesystem path of the volume's data directory |
-| `Kind()` | `VolumeKind` | Volume kind: `VolumeKindDir` or `VolumeKindDisk` |
-| `QuotaMiB()` | `*uint32` | Quota in MiB, or `nil` if unlimited |
-| `UsedBytes()` | `uint64` | Current disk usage in bytes |
-| `CapacityBytes()` | `*uint64` | Disk capacity in bytes |
-| `DiskFormat()` | `*string` | Disk image format |
-| `DiskFstype()` | `*string` | Disk filesystem type |
-| `Labels()` | `map[string]string` | Metadata labels |
-| `CreatedAt()` | `time.Time` | Creation timestamp, zero value if unknown |
-| `FS()` | [`*VolumeFs`](#volumefs) | Host-side filesystem accessor |
-| `Remove(ctx)` | `error` | Delete this volume |
+Return a [`*VolumeFs`](#volumefs) for direct host-side file operations on this volume.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumefs">*VolumeFs</a></div>
+    <div className="msb-param-desc">Host-side filesystem accessor rooted at the volume directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+vfs := vol.FS()
+err := vfs.WriteString("seed.txt", "hello")
+```
 
 ---
 
-## VolumeFs
+#### <span className="msb-recv">v.</span><span className="msb-hn">Remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
-Host-side filesystem operations on a named volume's data directory. Obtained via [`Volume.FS()`](#volume) or [`VolumeHandle.FS()`](#volumehandle). These operations run directly on the host filesystem — no running sandbox is required and no agent protocol is involved.
+```go
+func (v *Volume) Remove(ctx context.Context) error
+```
 
-All path arguments are **relative to the volume root**. Paths that would escape the root via `..`, absolute components, or stray symlink chains are rejected with [`ErrPathEscape`](#errpathescape).
+Delete this volume. All sandboxes using it must be stopped. Equivalent to [`RemoveVolume(ctx, v.Name())`](#removevolume).
+
+<p className="msb-label">Example</p>
+
+```go
+err := vol.Remove(ctx)
+```
+
+## VolumeHandle methods
+
+A `VolumeHandle` is the metadata reference returned by [`GetVolume`](#getvolume) and [`ListVolumes`](#listvolumes).
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Name()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) Name() string
+```
+
+Return the volume name.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Path()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) Path() string
+```
+
+Return the host filesystem path of the volume's data directory.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Kind()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) Kind() VolumeKind
+```
+
+Return the volume storage kind: [`VolumeKindDir`](#volumekind) or [`VolumeKindDisk`](#volumekind).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumekind">VolumeKind</a></div>
+    <div className="msb-param-desc">Storage backing for the volume.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">QuotaMiB()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) QuotaMiB() *uint32
+```
+
+Return the quota in MiB, or `nil` if unlimited.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">UsedBytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) UsedBytes() uint64
+```
+
+Return the amount of space used by the volume, in bytes.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">CapacityBytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) CapacityBytes() *uint64
+```
+
+Return the disk capacity in bytes for disk volumes, or `nil` for directory volumes.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">DiskFormat()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) DiskFormat() *string
+```
+
+Return the disk image format for disk volumes, or `nil` for directory volumes.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">DiskFstype()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) DiskFstype() *string
+```
+
+Return the inner filesystem type for disk volumes, or `nil` for directory volumes.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Labels()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) Labels() map[string]string
+```
+
+Return the labels attached to this volume.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">CreatedAt()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) CreatedAt() time.Time
+```
+
+Return the creation timestamp, or the zero `time.Time` value if unknown.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">FS()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) FS() *VolumeFs
+```
+
+Return a [`*VolumeFs`](#volumefs) for direct host-side file operations on this volume.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumefs">*VolumeFs</a></div>
+    <div className="msb-param-desc">Host-side filesystem accessor rooted at the volume directory.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">Remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *VolumeHandle) Remove(ctx context.Context) error
+```
+
+Delete this volume. All sandboxes using it must be stopped. Equivalent to [`RemoveVolume(ctx, h.Name())`](#removevolume).
+
+## VolumeFs methods
+
+Host-side filesystem operations on a named volume's data directory. Obtain via [`Volume.FS()`](#v-fs) or [`VolumeHandle.FS()`](#h-fs). These operations run directly on the host filesystem: no running sandbox is required and no agent protocol is involved.
+
+All path arguments are relative to the volume root. Paths that would escape the root via `..`, absolute components, or stray symlink chains are rejected with [`ErrPathEscape`](#errpathescape).
 
 ```go
 vfs := vol.FS()
@@ -179,7 +496,8 @@ content, err := vfs.ReadString("seed.txt")
 
 ---
 
-#### Root()
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">Root()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *VolumeFs) Root() string
@@ -189,7 +507,8 @@ Return the absolute host path of the volume's data directory.
 
 ---
 
-#### Read()
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">Read()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *VolumeFs) Read(relPath string) ([]byte, error)
@@ -197,9 +516,28 @@ func (fs *VolumeFs) Read(relPath string) ([]byte, error)
 
 Read the contents of a file relative to the volume root.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>relPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">File contents.</div>
+  </div>
+</div>
+
 ---
 
-#### ReadString()
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">ReadString()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *VolumeFs) ReadString(relPath string) (string, error)
@@ -209,7 +547,8 @@ Read a file and return its contents as a UTF-8 string.
 
 ---
 
-#### Write()
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">Write()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *VolumeFs) Write(relPath string, data []byte) error
@@ -217,19 +556,34 @@ func (fs *VolumeFs) Write(relPath string, data []byte) error
 
 Write data to a file, creating or truncating it. Created files use mode `0o644`.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>relPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>data</code><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">Bytes to write.</div>
+  </div>
+</div>
+
 ---
 
-#### WriteString()
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">WriteString()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *VolumeFs) WriteString(relPath, content string) error
 ```
 
-Write a string to a file.
+Write a string to a file. Created files use mode `0o644`.
 
 ---
 
-#### Mkdir()
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">Mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *VolumeFs) Mkdir(relPath string) error
@@ -239,7 +593,8 @@ Create a directory and all missing parents (mode `0o755`).
 
 ---
 
-#### Remove()
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">Remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *VolumeFs) Remove(relPath string) error
@@ -249,7 +604,8 @@ Delete a single file or empty directory.
 
 ---
 
-#### RemoveAll()
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">RemoveAll()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *VolumeFs) RemoveAll(relPath string) error
@@ -259,7 +615,8 @@ Delete a path and any children it contains (recursive).
 
 ---
 
-#### Exists()
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">Exists()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
 ```go
 func (fs *VolumeFs) Exists(relPath string) (bool, error)
@@ -267,75 +624,188 @@ func (fs *VolumeFs) Exists(relPath string) (bool, error)
 
 Report whether a file or directory exists at the given path.
 
----
+<p className="msb-label">Returns</p>
 
-#### ErrPathEscape
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> if a file or directory exists at the path.</div>
+  </div>
+</div>
 
-```go
-var ErrPathEscape = errors.New("microsandbox: path escapes volume root")
-```
+## Options
 
-Returned by every `VolumeFs` method when `relPath` is absolute, contains a `..` sequence that resolves outside the volume root, or otherwise escapes the volume's directory after `filepath.Clean`.
-
-```go
-if _, err := vfs.Read("../etc/passwd"); errors.Is(err, m.ErrPathEscape) {
-    log.Println("nice try")
-}
-```
+Functional options passed to [`CreateVolume`](#createvolume), plus the [`Mount`](#mountconfig) factory helpers that attach a volume, bind mount, tmpfs, or disk image to a sandbox via [`WithMounts`](/sdk/go/sandbox#withmounts).
 
 ---
 
-## Mounts
-
-Volume mounts attach a host directory, named volume, tmpfs, or disk image to a guest path. Configure them via [`WithMounts`](/sdk/go/sandbox#withmounts) on the sandbox:
+#### <span className="msb-recv"></span><span className="msb-hn">WithVolumeKind()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
-sb, err := m.CreateSandbox(ctx, "worker",
-    m.WithImage("alpine"),
-    m.WithMounts(map[string]m.MountConfig{
-        "/host":    m.Mount.Bind("/var/data", m.MountOptions{}),
-        "/data":    m.Mount.Named("my-data", m.MountOptions{}),
-        "/scratch": m.Mount.Tmpfs(m.TmpfsOptions{SizeMiB: 128}),
-        "/img":     m.Mount.Disk("./data.qcow2", m.DiskOptions{
-            Format:   "qcow2",
-            Fstype:   "ext4",
-            Readonly: true,
-        }),
-    }),
-)
+func WithVolumeKind(kind VolumeKind) VolumeOption
 ```
 
-Each `Mount.X(...)` helper returns a [`MountConfig`](#mountconfig). The `kind` discriminator is set internally; callers should always use these helpers rather than constructing the struct manually.
+Select the volume kind. Valid values are [`VolumeKindDir`](#volumekind) (default) and [`VolumeKindDisk`](#volumekind).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>kind</code><a className="msb-type" href="#volumekind">VolumeKind</a></div>
+    <div className="msb-param-desc">Storage backing for the volume.</div>
+  </div>
+</div>
 
 ---
 
-#### Mount.Bind()
+#### <span className="msb-recv"></span><span className="msb-hn">WithVolumeSize()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithVolumeSize(mebibytes uint32) VolumeOption
+```
+
+Set disk volume capacity in MiB. Required when the kind is [`VolumeKindDisk`](#volumekind).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mebibytes</code><span className="msb-type">uint32</span></div>
+    <div className="msb-param-desc">Disk capacity in MiB.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithVolumeQuota()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithVolumeQuota(mebibytes uint32) VolumeOption
+```
+
+Set the recorded quota in MiB for directory volumes. Zero means unlimited.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mebibytes</code><span className="msb-type">uint32</span></div>
+    <div className="msb-param-desc">Quota in MiB; zero means unlimited.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithVolumeLabels()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
+
+```go
+func WithVolumeLabels(labels map[string]string) VolumeOption
+```
+
+Attach key-value labels to the volume. When called repeatedly, the maps merge; later keys overwrite earlier ones.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>labels</code><span className="msb-type">map[string]string</span></div>
+    <div className="msb-param-desc">Metadata labels to attach.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Mount.</span><span className="msb-hn">Bind()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
 func (mountFactory) Bind(hostPath string, opts MountOptions) MountConfig
 ```
 
-Bind-mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
+Bind-mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa. Returns a [`MountConfig`](#mountconfig) for use with [`WithMounts`](/sdk/go/sandbox#withmounts).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hostPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Host directory to bind.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#mountoptions">MountOptions</a></div>
+    <div className="msb-param-desc">Mount tuning (read-only, noexec, and so on).</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+"/host": m.Mount.Bind("/var/data", m.MountOptions{Readonly: true})
+```
 
 ---
 
-#### Mount.Named()
+#### <span className="msb-recv">Mount.</span><span className="msb-hn">Named()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
 func (mountFactory) Named(name string, opts MountOptions) MountConfig
 ```
 
-Mount an existing named persistent volume. The volume must already exist (create it with [`CreateVolume`](#createvolume)).
+Mount an existing named persistent volume. The volume must already exist (create it with [`CreateVolume`](#createvolume)). Returns a [`MountConfig`](#mountconfig).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Name of an existing volume.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#mountoptions">MountOptions</a></div>
+    <div className="msb-param-desc">Mount tuning.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+"/data": m.Mount.Named("my-data", m.MountOptions{})
+```
 
 ---
 
-#### Mount.NamedWith()
+#### <span className="msb-recv">Mount.</span><span className="msb-hn">NamedWith()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
 func (mountFactory) NamedWith(name string, opts MountOptions, namedOpts NamedVolumeOptions) MountConfig
 ```
 
-Mount a named persistent volume with explicit sandbox-time existence behavior. `NamedVolumeOptions.Mode` accepts `"existing"` (default), `"create"`, or `"ensure-exists"`. `NamedVolumeOptions.Kind` accepts `"dir"` (default) or `"disk"`.
+Mount a named persistent volume with explicit sandbox-time existence behavior. [`NamedVolumeOptions.Mode`](#namedvolumeoptions) accepts `"existing"` (default), `"create"`, or `"ensure-exists"`. `Mode: "create"` fails when the named volume already exists. `Mode: "ensure-exists"` creates the volume if it is missing and reuses a compatible existing volume; it errors when the existing volume has a different kind, quota, or capacity than requested, and never mutates existing volume metadata.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#mountoptions">MountOptions</a></div>
+    <div className="msb-param-desc">Mount tuning.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>namedOpts</code><a className="msb-type" href="#namedvolumeoptions">NamedVolumeOptions</a></div>
+    <div className="msb-param-desc">Provisioning mode, kind, size, and quota.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```go
 sb, err := m.CreateSandbox(ctx, "worker",
@@ -353,100 +823,248 @@ sb, err := m.CreateSandbox(ctx, "worker",
 )
 ```
 
-`Mode: "create"` fails when the named volume already exists. `Mode: "ensure-exists"` creates the volume if it is missing and reuses a compatible existing volume. The ensure-exists mode errors when the existing volume has a different kind, quota, or capacity than the requested configuration; it does not mutate existing volume metadata.
-
-**NamedVolumeOptions**
-
-| Field | Description |
-|-------|-------------|
-| `Mode` | `"existing"`, `"create"`, or `"ensure-exists"`; empty means `"existing"` |
-| `Kind` | `"dir"` or `"disk"`; empty means `"dir"` |
-| `SizeMiB` | Disk capacity in MiB; required when creating or ensuring a missing disk volume |
-| `QuotaMiB` | Directory volume quota in MiB |
-
 ---
 
-#### Mount.Tmpfs()
+#### <span className="msb-recv">Mount.</span><span className="msb-hn">Tmpfs()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
 func (mountFactory) Tmpfs(opts TmpfsOptions) MountConfig
 ```
 
-Mount an ephemeral in-memory filesystem. Contents are discarded when the sandbox stops.
+Mount an ephemeral in-memory filesystem. Contents are discarded when the sandbox stops. Returns a [`MountConfig`](#mountconfig).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#tmpfsoptions">TmpfsOptions</a></div>
+    <div className="msb-param-desc">Size limit and mount flags.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+"/scratch": m.Mount.Tmpfs(m.TmpfsOptions{SizeMiB: 128})
+```
 
 ---
 
-#### Mount.Disk()
+#### <span className="msb-recv">Mount.</span><span className="msb-hn">Disk()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
 func (mountFactory) Disk(hostPath string, opts DiskOptions) MountConfig
 ```
 
-Mount a host disk image as a virtio-blk device. Supports raw, qcow2, and vmdk formats.
+Mount a host disk image as a virtio-blk device. Supports raw, qcow2, and vmdk formats. Returns a [`MountConfig`](#mountconfig).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hostPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Host path to the disk image.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#diskoptions">DiskOptions</a></div>
+    <div className="msb-param-desc">Format, inner filesystem, and mount flags.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```go
+"/img": m.Mount.Disk("./data.qcow2", m.DiskOptions{
+    Format:   "qcow2",
+    Fstype:   "ext4",
+    Readonly: true,
+})
+```
+
+## Types
 
 ---
 
-## Mount option types
+### Volume
 
-### MountOptions
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-Tuning struct for `Mount.Bind` and `Mount.Named`.
+A named persistent volume carrying its host-side path. Returned by [`CreateVolume`](#createvolume). Lookups via [`GetVolume`](#getvolume) and [`ListVolumes`](#listvolumes) yield richer [`VolumeHandle`](#volumehandle) values instead.
+
+<p className="msb-backref">Returned by <a href="#createvolume">CreateVolume()</a></p>
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`Name()`](#v-name) | `string` | Volume name |
+| [`Path()`](#v-path) | `string` | Host filesystem path of the data directory |
+| [`FS()`](#v-fs) | [`*VolumeFs`](#volumefs) | Host-side filesystem accessor |
+| [`Remove(ctx)`](#v-remove) | `error` | Delete this volume (all sandboxes using it must be stopped) |
+
+---
+
+### VolumeHandle
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Metadata reference for a named volume. Obtain via [`GetVolume`](#getvolume) or [`ListVolumes`](#listvolumes).
+
+<p className="msb-backref">Returned by <a href="#getvolume">GetVolume()</a> · <a href="#listvolumes">ListVolumes()</a></p>
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`Name()`](#h-name) | `string` | Volume name |
+| [`Path()`](#h-path) | `string` | Host filesystem path of the data directory |
+| [`Kind()`](#h-kind) | [`VolumeKind`](#volumekind) | Volume kind: `VolumeKindDir` or `VolumeKindDisk` |
+| [`QuotaMiB()`](#h-quotamib) | `*uint32` | Quota in MiB, or `nil` if unlimited |
+| [`UsedBytes()`](#h-usedbytes) | `uint64` | Current disk usage in bytes |
+| [`CapacityBytes()`](#h-capacitybytes) | `*uint64` | Disk capacity in bytes, or `nil` |
+| [`DiskFormat()`](#h-diskformat) | `*string` | Disk image format, or `nil` |
+| [`DiskFstype()`](#h-diskfstype) | `*string` | Disk filesystem type, or `nil` |
+| [`Labels()`](#h-labels) | `map[string]string` | Metadata labels |
+| [`CreatedAt()`](#h-createdat) | `time.Time` | Creation timestamp, zero value if unknown |
+| [`FS()`](#h-fs) | [`*VolumeFs`](#volumefs) | Host-side filesystem accessor |
+| [`Remove(ctx)`](#h-remove) | `error` | Delete this volume |
+
+---
+
+### VolumeFs
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Host-side filesystem operations on a volume's data directory. Obtain via [`Volume.FS()`](#v-fs) or [`VolumeHandle.FS()`](#h-fs). All path arguments are relative to the volume root; escaping paths are rejected with [`ErrPathEscape`](#errpathescape).
+
+<p className="msb-backref">Returned by <a href="#v-fs">Volume.FS()</a> · <a href="#h-fs">VolumeHandle.FS()</a></p>
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`Root()`](#vfs-root) | `string` | Absolute host path of the data directory |
+| [`Read(relPath)`](#vfs-read) | `([]byte, error)` | Read file bytes |
+| [`ReadString(relPath)`](#vfs-readstring) | `(string, error)` | Read file as a UTF-8 string |
+| [`Write(relPath, data)`](#vfs-write) | `error` | Write bytes, creating or truncating |
+| [`WriteString(relPath, content)`](#vfs-writestring) | `error` | Write a string |
+| [`Mkdir(relPath)`](#vfs-mkdir) | `error` | Create a directory tree |
+| [`Remove(relPath)`](#vfs-remove) | `error` | Delete a file or empty directory |
+| [`RemoveAll(relPath)`](#vfs-removeall) | `error` | Recursive delete |
+| [`Exists(relPath)`](#vfs-exists) | `(bool, error)` | Check for existence |
+
+---
+
+### ErrPathEscape
+
+<div className="msb-tags"><span className="msb-tag is-type">error</span></div>
+
+```go
+var ErrPathEscape = errors.New("microsandbox: path escapes volume root")
+```
+
+Returned by every [`VolumeFs`](#volumefs) method when `relPath` is absolute, contains a `..` sequence that resolves outside the volume root, or otherwise escapes the volume's directory after `filepath.Clean`.
+
+<p className="msb-backref">Returned by <a href="#volumefs">VolumeFs</a> methods</p>
+
+```go
+if _, err := vfs.Read("../etc/passwd"); errors.Is(err, m.ErrPathEscape) {
+    log.Println("nice try")
+}
+```
+
+---
+
+### VolumeConfig
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+The config struct populated by [`VolumeOption`](#volumeoption) functions. Most callers go through `CreateVolume(ctx, name, opts...)`; `VolumeConfig` is exported for callers that prefer to construct one directly.
+
+<p className="msb-backref">Mutated by <a href="#volumeoption">VolumeOption</a></p>
 
 | Field | Type | Description |
 |-------|------|-------------|
-| Readonly | `bool` | Mount as read-only; virtiofs-backed mounts also reject writes in the host filesystem server |
-| Noexec | `bool` | Prevent direct execution from the mount |
-| Nosuid | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
-| Nodev | `bool` | Ignore device files on the mount |
+| `QuotaMiB` | `uint32` | Maximum storage size in MiB (zero = unlimited) |
+| `Kind` | [`VolumeKind`](#volumekind) | Volume kind (`VolumeKindDir` by default) |
+| `SizeMiB` | `uint32` | Disk capacity in MiB for `VolumeKindDisk` |
+| `Labels` | `map[string]string` | Metadata labels |
 
-### TmpfsOptions
+---
 
-Tuning struct for `Mount.Tmpfs`.
+### VolumeOption
 
-| Field | Type | Description |
-|-------|------|-------------|
-| SizeMiB | `uint32` | Maximum size in MiB |
-| Readonly | `bool` | Mount as read-only |
-| Noexec | `bool` | Prevent direct execution from the mount |
-| Nosuid | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
-| Nodev | `bool` | Ignore device files on the mount |
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
 
-### DiskOptions
+```go
+type VolumeOption func(*VolumeConfig)
+```
 
-Tuning struct for `Mount.Disk`.
+A functional option for [`CreateVolume`](#createvolume). Constructed by the [`WithVolume*`](#options) helpers.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| Format | `string` | Format hint (`"raw"`, `"qcow2"`, `"vmdk"`). Optional; defaults from the file extension |
-| Fstype | `string` | Inner filesystem type (e.g. `"ext4"`, `"xfs"`). Optional; omitted means auto-detect |
-| Readonly | `bool` | Mount as read-only |
-| Noexec | `bool` | Prevent direct execution from the mount |
-| Nosuid | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
-| Nodev | `bool` | Ignore device files on the mount |
+<p className="msb-backref">Used by <a href="#createvolume">CreateVolume()</a></p>
+
+---
+
+### VolumeKind
+
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+```go
+type VolumeKind string
+```
+
+Describes the storage backing for a named volume.
+
+<p className="msb-backref">Used by <a href="#volumeconfig">VolumeConfig</a> · <a href="#withvolumekind">WithVolumeKind()</a> · <a href="#h-kind">VolumeHandle.Kind()</a></p>
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `VolumeKindDir` | `"dir"` | Directory-backed named volume |
+| `VolumeKindDisk` | `"disk"` | Raw ext4 disk-backed named volume |
+
+---
 
 ### MountConfig
 
-Discriminated mount configuration produced by `Mount` helpers. Inspect the kind via `Kind()`.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Discriminated mount configuration produced by the [`Mount`](#options) factory helpers and passed to [`WithMounts`](/sdk/go/sandbox#withmounts). Construct it with the factory rather than by hand: the factory sets the internal `kind` discriminator and enforces the mutually-exclusive flavours. Inspect the flavour via `Kind()`.
+
+<p className="msb-backref">Returned by <a href="#mount-bind">Mount.Bind()</a> · <a href="#mount-named">Mount.Named()</a> · <a href="#mount-namedwith">Mount.NamedWith()</a> · <a href="#mount-tmpfs">Mount.Tmpfs()</a> · <a href="#mount-disk">Mount.Disk()</a></p>
 
 | Field | Type | Description |
 |-------|------|-------------|
-| Bind | `string` | Host path for bind mounts |
-| Named | `string` | Volume name for named mounts |
-| Tmpfs | `bool` | Set for tmpfs mounts |
-| Disk | `string` | Host path for disk images |
-| Format | `string` | Disk format |
-| Fstype | `string` | Inner filesystem type |
-| Readonly | `bool` | Whether the mount is read-only |
-| Noexec | `bool` | Whether direct execution from the mount is disabled |
-| Nosuid | `bool` | Whether setuid/setgid privilege elevation from files on the mount is ignored |
-| Nodev | `bool` | Whether device files on the mount are ignored |
-| SizeMiB | `uint32` | Size limit for tmpfs mounts |
+| `Bind` | `string` | Host path for bind mounts |
+| `Named` | `string` | Volume name for named mounts |
+| `NamedMode` | `string` | Provisioning mode for named mounts (`"existing"`, `"create"`, `"ensure-exists"`) |
+| `NamedKind` | `string` | Kind for provisioned named mounts (`"dir"` or `"disk"`) |
+| `QuotaMiB` | `uint32` | Quota in MiB for provisioned directory volumes |
+| `Tmpfs` | `bool` | Set for tmpfs mounts |
+| `Disk` | `string` | Host path for disk images |
+| `Format` | `string` | Disk format |
+| `Fstype` | `string` | Inner filesystem type |
+| `Readonly` | `bool` | Whether the mount is read-only |
+| `Noexec` | `bool` | Whether direct execution from the mount is disabled |
+| `Nosuid` | `bool` | Whether setuid/setgid elevation from files on the mount is ignored |
+| `Nodev` | `bool` | Whether device files on the mount are ignored |
+| `SizeMiB` | `uint32` | Size limit for tmpfs / capacity for provisioned disk volumes |
+| `StatVirtualization` | `StatVirtualization` | Per-mount stat-virtualization policy (bind / named only) |
+| `HostPermissions` | `HostPermissions` | Per-mount host-permission propagation policy (bind / named only) |
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `Kind()` | [`MountKind`](#mountkind) | Which mount flavour this is |
+
+---
 
 ### MountKind
+
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
 
 ```go
 type MountKind uint8
 ```
+
+Discriminates between the four mount flavours. Inspect via `mount.Kind()`.
+
+<p className="msb-backref">Returned by <a href="#mountconfig">MountConfig.Kind()</a></p>
 
 | Constant | Description |
 |----------|-------------|
@@ -455,27 +1073,75 @@ type MountKind uint8
 | `MountKindTmpfs` | In-memory tmpfs |
 | `MountKindDisk` | Host disk image |
 
-Inspect via `mount.Kind()`.
-
 ---
 
-## Types
+### MountOptions
 
-### VolumeConfig
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-The config struct populated by [`VolumeOption`](#volumeoption) functions. Most callers go through `CreateVolume(ctx, name, ...opts)`; `VolumeConfig` is exported for callers that prefer to construct one directly.
+Tuning struct for [`Mount.Bind`](#mount-bind), [`Mount.Named`](#mount-named), and [`Mount.NamedWith`](#mount-namedwith). `StatVirtualization` and `HostPermissions` are virtiofs-only and rejected at build time if combined with a tmpfs or disk-image mount; their zero values preserve the conservative defaults (strict, private).
+
+<p className="msb-backref">Used by <a href="#mount-bind">Mount.Bind()</a> · <a href="#mount-named">Mount.Named()</a> · <a href="#mount-namedwith">Mount.NamedWith()</a></p>
 
 | Field | Type | Description |
 |-------|------|-------------|
-| Kind | `VolumeKind` | Volume kind (`VolumeKindDir` by default) |
-| QuotaMiB | `uint32` | Maximum storage size in MiB (zero = unlimited) |
-| SizeMiB | `uint32` | Disk capacity in MiB for `VolumeKindDisk` |
-| Labels | `map[string]string` | Metadata labels |
+| `Readonly` | `bool` | Mount as read-only; virtiofs-backed mounts also reject writes in the host filesystem server |
+| `Noexec` | `bool` | Prevent direct execution from the mount |
+| `Nosuid` | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
+| `Nodev` | `bool` | Ignore device files on the mount |
+| `StatVirtualization` | `StatVirtualization` | Per-mount stat-virtualization policy (virtiofs only) |
+| `HostPermissions` | `HostPermissions` | Per-mount host-permission propagation policy (virtiofs only) |
 
-### VolumeOption
+---
 
-```go
-type VolumeOption func(*VolumeConfig)
-```
+### NamedVolumeOptions
 
-A functional option for [`CreateVolume`](#createvolume).
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Tunes sandbox-time named volume provisioning for [`Mount.NamedWith`](#mount-namedwith).
+
+<p className="msb-backref">Used by <a href="#mount-namedwith">Mount.NamedWith()</a></p>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Mode` | `string` | `"existing"`, `"create"`, or `"ensure-exists"`; empty means `"existing"` |
+| `Kind` | `string` | `"dir"` or `"disk"`; empty means `"dir"` |
+| `SizeMiB` | `uint32` | Disk capacity in MiB; required when creating or ensuring a missing disk volume |
+| `QuotaMiB` | `uint32` | Directory volume quota in MiB |
+
+---
+
+### TmpfsOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Tuning struct for [`Mount.Tmpfs`](#mount-tmpfs).
+
+<p className="msb-backref">Used by <a href="#mount-tmpfs">Mount.Tmpfs()</a></p>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SizeMiB` | `uint32` | Maximum size in MiB |
+| `Readonly` | `bool` | Mount as read-only |
+| `Noexec` | `bool` | Prevent direct execution from the mount |
+| `Nosuid` | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
+| `Nodev` | `bool` | Ignore device files on the mount |
+
+---
+
+### DiskOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Tuning struct for [`Mount.Disk`](#mount-disk).
+
+<p className="msb-backref">Used by <a href="#mount-disk">Mount.Disk()</a></p>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Format` | `string` | Format hint (`"raw"`, `"qcow2"`, `"vmdk"`). Optional; the runtime can usually probe |
+| `Fstype` | `string` | Inner filesystem type (e.g. `"ext4"`, `"xfs"`). Optional; omitted means auto-detect |
+| `Readonly` | `bool` | Mount as read-only |
+| `Noexec` | `bool` | Prevent direct execution from the mount |
+| `Nosuid` | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
+| `Nodev` | `bool` | Ignore device files on the mount |

--- a/docs/sdk/python/agent-client.mdx
+++ b/docs/sdk/python/agent-client.mdx
@@ -3,21 +3,49 @@ title: Agent client
 description: Python SDK - Low-level agentd client reference
 ---
 
-`AgentClient` is the low-level raw transport for talking to `agentd` through a running sandbox's relay socket. Most applications should use [`Sandbox`](/sdk/python/sandbox), [`exec`](/sdk/python/execution), and [`fs`](/sdk/python/filesystem) instead. Use this API when you are building protocol-level tools or higher-level SDK helpers.
+`AgentClient` is the low-level raw transport for talking to `agentd` through a running sandbox's relay socket. Most applications should use [`Sandbox`](/sdk/python/sandbox), [`exec`](/sdk/python/execution), and [`fs`](/sdk/python/filesystem) instead. Reach for this API when you are building protocol-level tools or higher-level SDK helpers.
 
-All request bodies and response bodies are raw CBOR bytes. The SDK handles framing and correlation ids, but it does not encode or decode the CBOR message body for you.
+All request and response bodies are raw CBOR bytes. The SDK handles framing and correlation ids, but it does not encode or decode the CBOR message body for you. The raw body is the full CBOR-encoded protocol `Message` body (`v`, `t`, and `p`), not just the inner payload.
 
-The raw body is the full CBOR-encoded protocol `Message` body: `v`, `t`, and `p`. It is not just the inner payload.
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Constructors<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#agentclient-connect_sandbox"><span className="msb-rn">AgentClient.connect_sandbox()</span><span className="msb-rg">connect to a running sandbox by name</span></a>
+  <a className="msb-row" href="#agentclient-connect"><span className="msb-rn">AgentClient.connect()</span><span className="msb-rg">connect to a relay socket by path</span></a>
+  <a className="msb-row" href="#agentclient-socket_path"><span className="msb-rn">AgentClient.socket_path()</span><span className="msb-rg">resolve the socket path, don't connect</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#client-request"><span className="msb-rn">client.request()</span><span className="msb-rg">one frame, one response</span></a>
+  <a className="msb-row" href="#client-stream"><span className="msb-rn">client.stream()</span><span className="msb-rg">open a streaming session</span></a>
+  <a className="msb-row" href="#client-send"><span className="msb-rn">client.send()</span><span className="msb-rg">follow-up frame on a session</span></a>
+  <a className="msb-row" href="#client-ready_bytes"><span className="msb-rn">client.ready_bytes()</span><span className="msb-rg">cached handshake frame</span></a>
+  <a className="msb-row" href="#client-close"><span className="msb-rn">client.close()</span><span className="msb-rg">close the client</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Constants</p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#constants">FLAG_TERMINAL</a>
+    <a className="msb-chip" href="#constants">FLAG_SESSION_START</a>
+    <a className="msb-chip" href="#constants">FLAG_SHUTDOWN</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#rawframe">RawFrame</a>
+    <a className="msb-typepill" href="#agentstream">AgentStream</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```python
 from microsandbox import AgentClient
 
-client = await AgentClient.connect_sandbox("dev")
-ready = client.ready_bytes()
-await client.close()
+client = await AgentClient.connect_sandbox("dev")  # 1. connect
+ready = client.ready_bytes()                        # 2. inspect handshake
+frame = await client.request(0, body)               # 3. raw request/response
+await client.close()                                # 4. close
 ```
-
----
 
 ## Constants
 
@@ -27,42 +55,133 @@ await client.close()
 | `FLAG_SESSION_START` | `0b0000_0010` | First frame of a streaming session |
 | `FLAG_SHUTDOWN` | `0b0000_0100` | Shutdown frame |
 
+## Constructors
+
 ---
 
-#### AgentClient.connect_sandbox()
+#### <span className="msb-recv">AgentClient.</span><span className="msb-hn">connect_sandbox()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @classmethod
-async def connect_sandbox(cls, name: str) -> AgentClient
+async def connect_sandbox(cls, name: str, *, timeout: float | None = None) -> AgentClient
 ```
 
 Connect to a running sandbox by name. Sandbox names are limited to 128 UTF-8 bytes.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Connection timeout in seconds. <code>None</code> uses the default.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">AgentClient</span></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+client = await AgentClient.connect_sandbox("dev", timeout=5.0)
+```
+
 ---
 
-#### AgentClient.connect()
+#### <span className="msb-recv">AgentClient.</span><span className="msb-hn">connect()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @classmethod
-async def connect(cls, path: str) -> AgentClient
+async def connect(cls, path: str, *, timeout: float | None = None) -> AgentClient
 ```
 
-Connect to an agent relay socket by path.
+Connect to an agent relay socket by path. Use this when you already know the socket path, for example one returned by [`socket_path()`](#agentclient-socket_path).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Path to the agentd relay socket.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Connection timeout in seconds. <code>None</code> uses the default.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">AgentClient</span></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+path = AgentClient.socket_path("dev")
+client = await AgentClient.connect(path)
+```
 
 ---
 
-#### AgentClient.socket_path()
+#### <span className="msb-recv">AgentClient.</span><span className="msb-hn">socket_path()</span>
+<div className="msb-tags"><span className="msb-tag is-static">staticmethod</span></div>
 
 ```python
 @staticmethod
 def socket_path(name: str) -> str
 ```
 
-Resolve a sandbox's `agentd` relay socket path **without connecting**. Returns the same path `connect_sandbox` would dial, so you can talk to `agentd` over a raw byte transport (e.g. a transparent relay that splices bytes to and from the socket) instead of this frame client. The sandbox need not be running. Sandbox names are limited to 128 UTF-8 bytes.
+Resolve a sandbox's `agentd` relay socket path **without connecting**. Returns the same path [`connect_sandbox()`](#agentclient-connect_sandbox) would dial, so you can talk to `agentd` over a raw byte transport (for example a transparent relay that splices bytes to and from the socket) instead of this frame client. The sandbox need not be running. Sandbox names are limited to 128 UTF-8 bytes.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Filesystem path to the relay socket.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+path = AgentClient.socket_path("dev")
+```
 
 ---
 
-#### request()
+## Instance methods
+
+---
+
+#### <span className="msb-recv">client.</span><span className="msb-hn">request()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def request(self, flags: int, body: bytes) -> RawFrame
@@ -70,17 +189,73 @@ async def request(self, flags: int, body: bytes) -> RawFrame
 
 Send one raw frame and wait for one response frame.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Frame flag byte, e.g. a combination of <code>FLAG_*</code> constants.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">bytes</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#rawframe">RawFrame</a></div>
+    <div className="msb-param-desc">The response frame.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+frame = await client.request(0, body)
+print(frame["id"], frame["flags"])
+```
+
 ---
 
-#### stream()
+#### <span className="msb-recv">client.</span><span className="msb-hn">stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def stream(self, flags: int, body: bytes) -> AgentStream
 ```
 
-Open a raw streaming session. The returned stream carries the protocol correlation id and is also an async iterator of raw frames.
+Open a raw streaming session. The returned [`AgentStream`](#agentstream) carries the protocol correlation id and is also an async iterator of raw frames.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Frame flag byte; pass <code>FLAG_SESSION_START</code> to open a session.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">bytes</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentstream">AgentStream</a></div>
+    <div className="msb-param-desc">Open streaming session.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```python
+from microsandbox import FLAG_SESSION_START, FLAG_TERMINAL
+
 stream = await client.stream(FLAG_SESSION_START, body)
 async for frame in stream:
     if frame["flags"] & FLAG_TERMINAL:
@@ -89,17 +264,43 @@ async for frame in stream:
 
 ---
 
-#### send()
+#### <span className="msb-recv">client.</span><span className="msb-hn">send()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def send(self, id: int, flags: int, body: bytes) -> None
 ```
 
-Send a follow-up frame on an existing correlation id. Use this with the `id` on the [`AgentStream`](#agentstream) returned by [`stream()`](#stream).
+Send a follow-up frame on an existing correlation id. Use the `id` from the [`AgentStream`](#agentstream) returned by [`stream()`](#client-stream).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>id</code><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Correlation id of an open session, from <code>stream.id</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Frame flag byte.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">bytes</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+stream = await client.stream(FLAG_SESSION_START, body)
+await client.send(stream.id, 0, follow_up_body)
+```
 
 ---
 
-#### ready_bytes()
+#### <span className="msb-recv">client.</span><span className="msb-hn">ready_bytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```python
 def ready_bytes(self) -> bytes
@@ -107,9 +308,25 @@ def ready_bytes(self) -> bytes
 
 Return the cached handshake `core.ready` frame body as CBOR bytes.
 
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bytes</span></div>
+    <div className="msb-param-desc">CBOR-encoded <code>core.ready</code> frame body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+ready = client.ready_bytes()
+```
+
 ---
 
-#### close()
+#### <span className="msb-recv">client.</span><span className="msb-hn">close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def close(self) -> None
@@ -117,9 +334,23 @@ async def close(self) -> None
 
 Close the client. Calling it more than once is safe.
 
+<p className="msb-label">Example</p>
+
+```python
+await client.close()
+```
+
 ---
 
-## RawFrame
+## Types
+
+### RawFrame
+
+<div className="msb-tags"><span className="msb-tag is-type">TypedDict</span></div>
+
+<p className="msb-backref">Returned by <a href="#client-request">request()</a> · yielded by <a href="#agentstream">AgentStream</a></p>
+
+A raw protocol frame with a CBOR-encoded body.
 
 ```python
 class RawFrame(TypedDict):
@@ -128,17 +359,35 @@ class RawFrame(TypedDict):
     body: bytes
 ```
 
-`id` is the protocol correlation id, `flags` is the frame flag byte, and `body` is the CBOR-encoded protocol message body.
+| Field | Type | Description |
+|-------|------|-------------|
+| id | `int` | Protocol correlation id |
+| flags | `int` | Frame flag byte (combination of `FLAG_*` constants) |
+| body | `bytes` | CBOR-encoded protocol message body |
 
----
+### AgentStream
 
-## AgentStream
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#client-stream">stream()</a></p>
+
+An open raw agent stream. Carries the protocol correlation id and is both an async context manager and an async iterator of [`RawFrame`](#rawframe). Iteration stops once a frame with `FLAG_TERMINAL` set is delivered or the stream reaches EOF.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| id | `int` | Protocol correlation id; pass to [`send()`](#client-send) for follow-up frames |
+| next() | `Awaitable[`[`RawFrame`](#rawframe)` \| None]` | Read the next frame; returns `None` at EOF |
+| close() | `Awaitable[None]` | Release the stream handle early; safe to call more than once |
+| `async with` | [`AgentStream`](#agentstream) | Async context manager; closes the stream on exit |
+| `async for` | [`RawFrame`](#rawframe) | Async iterator over frames until terminal or EOF |
+
+<p className="msb-label">Example</p>
 
 ```python
-class AgentStream:
-    id: int
-    async def next(self) -> RawFrame | None: ...
-    async def close(self) -> None: ...
-```
+from microsandbox import FLAG_SESSION_START, FLAG_TERMINAL
 
-`id` is the protocol correlation id. Pass it to [`AgentClient.send()`](#send) for follow-up frames in the same session. `close()` releases the stream handle early. `next()` returns `None` at EOF.
+async with await client.stream(FLAG_SESSION_START, body) as stream:
+    async for frame in stream:
+        if frame["flags"] & FLAG_TERMINAL:
+            break
+```

--- a/docs/sdk/python/execution.mdx
+++ b/docs/sdk/python/execution.mdx
@@ -3,147 +3,553 @@ title: Execution
 description: Python SDK - Command execution API reference
 ---
 
-See [Commands](/sandboxes/commands) for usage examples.
+Run commands inside a running sandbox: collect output in one shot, stream events as they arrive, or bridge your terminal to an interactive PTY. These methods live on a running [`Sandbox`](/sdk/python/sandbox). See [Commands](/sandboxes/commands) for usage examples.
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Run &amp; collect<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#sandbox-exec"><span className="msb-rn">sandbox.exec()</span><span className="msb-rg">run, buffer output</span></a>
+  <a className="msb-row" href="#sandbox-shell"><span className="msb-rn">sandbox.shell()</span><span className="msb-rg">run through the shell</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Stream<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#sandbox-exec_stream"><span className="msb-rn">sandbox.exec_stream()</span><span className="msb-rg">stream events live</span></a>
+  <a className="msb-row" href="#sandbox-shell_stream"><span className="msb-rn">sandbox.shell_stream()</span><span className="msb-rg">stream through the shell</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Attach<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#sandbox-attach"><span className="msb-rn">sandbox.attach()</span><span className="msb-rg">interactive PTY bridge</span></a>
+  <a className="msb-row" href="#sandbox-attach_shell"><span className="msb-rn">sandbox.attach_shell()</span><span className="msb-rg">attach the default shell</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#execoutput">ExecOutput</a>
+    <a className="msb-typepill" href="#exechandle">ExecHandle</a>
+    <a className="msb-typepill" href="#execsink">ExecSink</a>
+    <a className="msb-typepill" href="#execevent">ExecEvent</a>
+    <a className="msb-typepill" href="#exitstatus">ExitStatus</a>
+    <a className="msb-typepill" href="#stdin">Stdin</a>
+    <a className="msb-typepill" href="#rlimit">Rlimit</a>
+    <a className="msb-typepill" href="#rlimitresource">RlimitResource</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```python
+import sys
+
+from microsandbox import Sandbox
+
+sandbox = await Sandbox.create("api", image="python")
+
+# 1. one-shot
+out = await sandbox.exec("python3", ["-c", "print(1 + 1)"])
+print(out.stdout_text)  # "2\n"
+
+# 2. stream
+handle = await sandbox.exec_stream("tail", ["-f", "/var/log/app.log"])
+async for event in handle:
+    if event.event_type == "stdout":
+        sys.stdout.buffer.write(event.data)
+    elif event.event_type == "exited":
+        break
+
+await sandbox.stop()
+```
+
+## Run and collect
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">exec()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def exec(
+    cmd: str,
+    args: list[str] | Mapping[str, Any] | None = None,
+    *,
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+    stdin: Stdin | bytes | str | None = None,
+    tty: bool = False,
+    rlimits: list[Rlimit] | None = None,
+) -> ExecOutput
+```
+
+Run a command inside the sandbox and wait for it to complete, buffering all stdout and stderr into memory. The keyword-only options apply to this call alone and don't change the sandbox's defaults. For long-running processes or large output, use [`exec_stream()`](#sandbox-exec_stream) instead. Raises [`ExecTimeoutError`](/sdk/python/sandbox) if `timeout` elapses and [`ExecFailedError`](/sdk/python/sandbox) if the process can't be spawned.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Command to execute (e.g. <code>"python3"</code>, <code>"/usr/bin/node"</code>).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">list[str] | Mapping[str, Any] | None</span></div>
+    <div className="msb-param-desc">Command arguments. A mapping is accepted as a shorthand for the keyword-only options below.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cwd</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Working directory for this command.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>user</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Guest user to run as.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>env</code><span className="msb-type">Mapping[str, str] | None</span></div>
+    <div className="msb-param-desc">Environment variables, merged on top of the sandbox defaults.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Seconds before the process is killed.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>stdin</code><a className="msb-type" href="#stdin">Stdin | bytes | str | None</a></div>
+    <div className="msb-param-desc">Stdin mode. Raw <code>bytes</code> / <code>str</code> are sent inline; default is <code>/dev/null</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>tty</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Allocate a pseudo-terminal, merging stdout and stderr.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>rlimits</code><a className="msb-type" href="#rlimit">list[Rlimit] | None</a></div>
+    <div className="msb-param-desc">POSIX resource limits applied to the process.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">ExecOutput</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+out = await sandbox.exec(
+    "python3",
+    ["script.py"],
+    cwd="/app",
+    env={"PYTHONPATH": "/app/lib"},
+    timeout=30.0,
+)
+print(out.stdout_text)
+print(out.exit_code)  # 0
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">shell()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def shell(
+    script: str,
+    *,
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+    stdin: Stdin | bytes | str | None = None,
+    tty: bool = False,
+    rlimits: list[Rlimit] | None = None,
+) -> ExecOutput
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works. Accepts the same keyword-only options as [`exec()`](#sandbox-exec).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>script</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Shell command string (e.g. <code>"ls -la /app &amp;&amp; echo done"</code>).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cwd, user, env, timeout, stdin, tty, rlimits</code></div>
+    <div className="msb-param-desc">Same per-call options as <a className="msb-type" href="#sandbox-exec">exec()</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">ExecOutput</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+out = await sandbox.shell("ls -la /app && echo done")
+print(out.stdout_text)
+```
+
+---
+
+## Stream
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">exec_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def exec_stream(
+    cmd: str,
+    args: list[str] | Mapping[str, Any] | None = None,
+    *,
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+    stdin: Stdin | bytes | str | None = None,
+    tty: bool = False,
+    rlimits: list[Rlimit] | None = None,
+) -> ExecHandle
+```
+
+Run a command with streaming output. Returns an [`ExecHandle`](#exechandle) that emits stdout, stderr, and exit events as they happen rather than buffering everything. Takes the same per-call options as [`exec()`](#sandbox-exec). Pass `stdin=Stdin.pipe()` to write to the process while it runs via [`take_stdin()`](#exechandle).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Command to execute.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">list[str] | Mapping[str, Any] | None</span></div>
+    <div className="msb-param-desc">Command arguments.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cwd, user, env, timeout, stdin, tty, rlimits</code></div>
+    <div className="msb-param-desc">Same per-call options as <a className="msb-type" href="#sandbox-exec">exec()</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#exechandle">ExecHandle</a></div>
+    <div className="msb-param-desc">Streaming handle for receiving events and controlling the process.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+import sys
+
+handle = await sandbox.exec_stream("tail", ["-f", "/var/log/app.log"])
+async for event in handle:
+    if event.event_type == "stdout":
+        sys.stdout.buffer.write(event.data)
+    elif event.event_type == "exited":
+        break
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">shell_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def shell_stream(
+    script: str,
+    *,
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+    stdin: Stdin | bytes | str | None = None,
+    tty: bool = False,
+    rlimits: list[Rlimit] | None = None,
+) -> ExecHandle
+```
+
+Streaming variant of [`shell()`](#sandbox-shell): runs `script` through the configured shell but returns an [`ExecHandle`](#exechandle) instead of buffering output.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>script</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Shell command string.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cwd, user, env, timeout, stdin, tty, rlimits</code></div>
+    <div className="msb-param-desc">Same per-call options as <a className="msb-type" href="#sandbox-exec">exec()</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#exechandle">ExecHandle</a></div>
+    <div className="msb-param-desc">Streaming handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+import sys
+
+handle = await sandbox.shell_stream("for i in 1 2 3; do echo $i; sleep 1; done")
+async for event in handle:
+    if event.event_type == "stdout":
+        sys.stdout.buffer.write(event.data)
+```
+
+---
+
+## Attach
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">attach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def attach(
+    cmd: str,
+    args: list[str] | None = None,
+    *,
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] | None = None,
+    detach_keys: str | None = None,
+) -> int
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Press the configured detach key sequence (default `Ctrl+]`) to disconnect without stopping the process. Returns the process exit code.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Command to run.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">list[str] | None</span></div>
+    <div className="msb-param-desc">Command arguments.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cwd</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Working directory.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>user</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Guest user to run as.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>env</code><span className="msb-type">Mapping[str, str] | None</span></div>
+    <div className="msb-param-desc">Environment variables for the session.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>detach_keys</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Detach key sequence (e.g. <code>"ctrl-]"</code> or <code>"ctrl-p,ctrl-q"</code>).</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Exit code of the process.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+code = await sandbox.attach("bash", cwd="/app", env={"EDITOR": "vim"})
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">attach_shell()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def attach_shell() -> int
+```
+
+Bridge your terminal to the sandbox's default shell in a fully interactive PTY session. Returns the shell's exit code.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Exit code of the shell process.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+code = await sandbox.attach_shell()
+```
+
+---
 
 ## Types
 
 ### ExecOutput
 
-The result of a completed command execution.
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sandbox-exec">exec()</a> · <a href="#sandbox-shell">shell()</a> · <a href="#exechandle">ExecHandle.collect()</a></p>
+
+The result of a completed command execution: collected output plus exit status. All members are properties.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| exit_code | `int` | Exit code |
-| success | `bool` | `True` if exit_code is `0` |
-| stdout_text | `str` | Collected stdout decoded as UTF-8. Raises on invalid encoding. |
-| stderr_text | `str` | Collected stderr decoded as UTF-8 |
+| exit_code | `int` | Process exit code |
+| success | `bool` | `True` when `exit_code == 0` |
+| stdout_text | `str` | Collected stdout decoded as UTF-8. Raises on invalid encoding |
+| stderr_text | `str` | Collected stderr decoded as UTF-8. Raises on invalid encoding |
 | stdout_bytes | `bytes` | Raw stdout bytes |
 | stderr_bytes | `bytes` | Raw stderr bytes |
 
----
-
 ### ExecHandle
 
-A handle to a running streaming execution. Supports `async for event in handle:` to iterate over events until the stream ends.
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sandbox-exec_stream">exec_stream()</a> · <a href="#sandbox-shell_stream">shell_stream()</a></p>
+
+A handle to a running streaming execution. It is an async iterator, so `async for event in handle:` yields each [`ExecEvent`](#execevent) until the stream ends.
 
 | Property / Method | Type | Description |
 |-------------------|------|-------------|
 | id | `str` | Correlation ID for this execution |
-| take_stdin() | [`ExecSink`](#execsink) ` \| None` | Take the stdin writer. Returns `None` after first call. |
-| recv() | `ExecEvent \| None` | *(async)* Receive the next event. Returns `None` when done. |
-| wait() | `tuple[int, bool]` | *(async)* Wait for the process to exit. Returns `(code, success)`. |
-| collect() | [`ExecOutput`](#execoutput) | *(async)* Wait and collect all remaining output |
-| signal(sig) | `None` | *(async)* Send a POSIX signal to the process |
-| kill() | `None` | *(async)* Send SIGKILL |
-
----
+| take_stdin() | [`ExecSink`](#execsink) ` \| None` | Take the stdin writer. Returns `None` after the first call, or when stdin wasn't piped |
+| recv() | [`ExecEvent`](#execevent) ` \| None` | *(async)* Receive the next event. Returns `None` when the stream ends |
+| wait() | `tuple[int, bool]` | *(async)* Wait for the process to exit. Returns `(code, success)` |
+| collect() | [`ExecOutput`](#execoutput) | *(async)* Drain remaining output and wait for exit |
+| signal(sig) | `None` | *(async)* Send a POSIX signal (numeric) to the process |
+| kill() | `None` | *(async)* Send SIGKILL to the process |
 
 ### ExecSink
 
-Writer for sending data to a running process's stdin.
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#exechandle">ExecHandle.take_stdin()</a></p>
+
+Writer for sending data to a running process's stdin. Obtained from [`ExecHandle.take_stdin()`](#exechandle) when the execution was configured with `stdin=Stdin.pipe()`.
 
 | Method | Parameters | Description |
 |--------|-----------|-------------|
-| write() | `data: bytes` | *(async)* Write bytes to the process's stdin |
-| close() | - | *(async)* Close stdin. The process sees EOF. |
-
----
+| write(data) | `data: bytes` | *(async)* Write bytes to the process's stdin |
+| close() | - | *(async)* Close stdin. The process sees EOF |
 
 ### ExecEvent
 
-Native event object emitted by streaming execution methods.
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Emitted by <a href="#exechandle">ExecHandle</a></p>
+
+Native event object emitted by [`recv()`](#exechandle) and by iterating an [`ExecHandle`](#exechandle). Fields that don't apply to a given event are `None`.
 
 | Property | Type | Description |
 |----------|------|-------------|
 | event_type | `str` | `"started"`, `"stdout"`, `"stderr"`, `"exited"`, `"failed"`, or `"stdin_error"` |
-| pid | `int \| None` | Guest PID (on `"started"`) |
-| data | `bytes \| None` | Output data on `"stdout"` / `"stderr"`, or a UTF-8 failure message on `"failed"` / `"stdin_error"` |
+| pid | `int \| None` | Guest PID, set on `"started"` |
+| data | `bytes \| None` | Output bytes on `"stdout"` / `"stderr"`, or a UTF-8 failure message on `"failed"` / `"stdin_error"` |
 | code | `int \| None` | Exit code on `"exited"`, or errno when available on `"failed"` / `"stdin_error"` |
 
-Fields that do not apply to a particular event are `None`.
+### ExitStatus
+
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
+
+<p className="msb-backref">Used by <a href="#exechandle">ExecHandle.wait()</a></p>
+
+Frozen dataclass describing a process exit result. [`ExecHandle.wait()`](#exechandle) returns the same information as a `(code, success)` tuple.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| code | `int` | Process exit code |
+| success | `bool` | `True` when `code == 0` |
 
 ### Stdin
 
-Frozen dataclass with factory methods for configuring process stdin.
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
+
+<p className="msb-backref">Used by <a href="#sandbox-exec">exec()</a> · <a href="#sandbox-shell">shell()</a> · <a href="#sandbox-exec_stream">exec_stream()</a> · <a href="#sandbox-shell_stream">shell_stream()</a></p>
+
+Frozen dataclass with factory methods for configuring process stdin. Pass the result as the `stdin` argument to an exec or shell method. Raw `bytes` and `str` are also accepted directly and are sent inline.
 
 | Factory | Parameters | Description |
 |---------|-----------|-------------|
-| Stdin.null() | - | `/dev/null` (default) |
-| Stdin.pipe() | - | Piped stdin. Use [`take_stdin()`](#exechandle) on the handle to write. |
-| Stdin.bytes() | `data: bytes` | Inline data sent before the process starts |
-
----
+| Stdin.null() | - | Connect stdin to `/dev/null` (default) |
+| Stdin.pipe() | - | Open a writable pipe. Write via [`take_stdin()`](#exechandle) on the handle |
+| Stdin.bytes(data) | `data: bytes` | Inline data sent before the process starts, then EOF |
 
 ### Rlimit
 
-Frozen dataclass with factory methods for POSIX resource limits.
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
+
+<p className="msb-backref">Used by <a href="#sandbox-exec">exec()</a> · <a href="#sandbox-shell">shell()</a> · <a href="#sandbox-exec_stream">exec_stream()</a> · <a href="#sandbox-shell_stream">shell_stream()</a></p>
+
+Frozen dataclass describing a POSIX resource limit. Construct one directly or via a factory, then pass a list as the `rlimits` argument.
 
 | Factory | Parameters | Description |
 |---------|-----------|-------------|
 | Rlimit.nofile(limit) | `limit: int` | Max open file descriptors |
 | Rlimit.cpu(secs) | `secs: int` | CPU time limit in seconds |
-| Rlimit.as_(*, soft, hard) | `soft: int, hard: int` | Virtual memory size |
+| Rlimit.as_(\*, soft, hard) | `soft: int, hard: int` | Virtual memory size |
 | Rlimit.nproc(limit) | `limit: int` | Max number of processes |
 | Rlimit.fsize(limit) | `limit: int` | Max file size |
 | Rlimit.memlock(limit) | `limit: int` | Max locked memory |
 | Rlimit.stack(limit) | `limit: int` | Max stack size |
 
-**Properties**
+**Fields**
 
-| Property | Type | Description |
-|----------|------|-------------|
-| resource | [`RlimitResource`](#rlimitresource) | Resource type |
+| Field | Type | Description |
+|-------|------|-------------|
+| resource | [`RlimitResource`](#rlimitresource) | Which resource is limited |
 | soft | `int` | Soft limit |
 | hard | `int` | Hard limit |
 
----
-
 ### RlimitResource
 
-Enum of POSIX resource types.
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#rlimit">Rlimit.resource</a></p>
+
+String enum (`enum.StrEnum`) naming a limitable POSIX resource.
 
 | Value | Description |
 |-------|-------------|
-| `cpu` | CPU time |
-| `fsize` | File size |
-| `data` | Data segment size |
-| `stack` | Stack size |
-| `core` | Core file size |
-| `rss` | Resident set size |
-| `nproc` | Number of processes |
-| `nofile` | Open file descriptors |
-| `memlock` | Locked memory |
-| `as` | Virtual memory |
-| `locks` | File locks |
-| `sigpending` | Pending signals |
-| `msgqueue` | Message queue size |
-| `nice` | Nice priority ceiling |
-| `rtprio` | Real-time priority ceiling |
-| `rttime` | Real-time CPU time |
-
----
-
-### SandboxMetrics
-
-Metrics snapshot for a running sandbox.
-
-| Property | Type | Description |
-|----------|------|-------------|
-| cpu_percent | `float` | CPU utilization percentage |
-| memory_bytes | `int` | Current memory usage in bytes |
-| memory_limit_bytes | `int` | Memory limit in bytes |
-| disk_read_bytes | `int` | Total bytes read from disk |
-| disk_write_bytes | `int` | Total bytes written to disk |
-| net_rx_bytes | `int` | Total bytes received over the network |
-| net_tx_bytes | `int` | Total bytes sent over the network |
-| upper_used_bytes | `int \| None` | Guest-visible OCI upper filesystem used bytes when the protected reporter is available and fresh |
-| upper_free_bytes | `int \| None` | Guest-visible OCI upper filesystem free bytes when the protected reporter is available and fresh |
-| upper_host_allocated_bytes | `int \| None` | Host-allocated bytes for the writable OCI upper image when available |
-| uptime_ms | `int` | Sandbox uptime in milliseconds |
-| timestamp_ms | `float` | Timestamp of the snapshot in milliseconds |
-
----
-
-### MetricsStream
-
-Async iterator yielding [`SandboxMetrics`](#sandboxmetrics). Use `async for metrics in stream:` to consume.
+| `CPU` | CPU time |
+| `FSIZE` | File size |
+| `DATA` | Data segment size |
+| `STACK` | Stack size |
+| `CORE` | Core file size |
+| `RSS` | Resident set size |
+| `NPROC` | Number of processes |
+| `NOFILE` | Open file descriptors |
+| `MEMLOCK` | Locked memory |
+| `AS` | Virtual memory |
+| `LOCKS` | File locks |
+| `SIGPENDING` | Pending signals |
+| `MSGQUEUE` | Message queue size |
+| `NICE` | Nice priority ceiling |
+| `RTPRIO` | Real-time priority ceiling |
+| `RTTIME` | Real-time CPU time |

--- a/docs/sdk/python/filesystem.mdx
+++ b/docs/sdk/python/filesystem.mdx
@@ -3,126 +3,67 @@ title: Filesystem
 description: Python SDK - Filesystem API reference
 ---
 
-See [Filesystem](/sandboxes/filesystem) for usage examples.
+Read, write, and manage files inside a running sandbox. Operations go through the same host-guest channel as command execution: no SSH, no network. See [Filesystem](/sandboxes/filesystem) for usage examples. For bulk file movement, prefer a [volume](/sandboxes/volumes).
 
-## SandboxFsOps
+<div className="msb-glance">
 
-Filesystem handle for a running sandbox. Obtained via the `sandbox.fs` property. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
+  <p className="msb-gl"><span className="msb-dot instance"></span>Read<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#fs-read"><span className="msb-rn">fs.read()</span><span className="msb-rg">whole file as bytes</span></a>
+  <a className="msb-row" href="#fs-read_text"><span className="msb-rn">fs.read_text()</span><span className="msb-rg">whole file as UTF-8 text</span></a>
+  <a className="msb-row" href="#fs-read_stream"><span className="msb-rn">fs.read_stream()</span><span className="msb-rg">stream a large file in chunks</span></a>
 
----
+  <p className="msb-gl"><span className="msb-dot instance"></span>Write<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#fs-write"><span className="msb-rn">fs.write()</span><span className="msb-rg">overwrite a file with bytes</span></a>
+  <a className="msb-row" href="#fs-write_stream"><span className="msb-rn">fs.write_stream()</span><span className="msb-rg">stream a large file in chunks</span></a>
 
-#### copy()
+  <p className="msb-gl"><span className="msb-dot instance"></span>Directories &amp; metadata<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#fs-list"><span className="msb-rn">fs.list()</span><span className="msb-rg">directory entries</span></a>
+  <a className="msb-row" href="#fs-mkdir"><span className="msb-rn">fs.mkdir()</span><span className="msb-rg">create a directory and parents</span></a>
+  <a className="msb-row" href="#fs-stat"><span className="msb-rn">fs.stat()</span><span className="msb-rg">file metadata</span></a>
+  <a className="msb-row" href="#fs-exists"><span className="msb-rn">fs.exists()</span><span className="msb-rg">check a path exists</span></a>
+  <a className="msb-row" href="#fs-remove_dir"><span className="msb-rn">fs.remove_dir()</span><span className="msb-rg">remove a directory recursively</span></a>
 
-```python
-async def copy(src: str, dst: str) -> None
-```
+  <p className="msb-gl"><span className="msb-dot instance"></span>Move, copy &amp; remove<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#fs-copy"><span className="msb-rn">fs.copy()</span><span className="msb-rg">copy a file in the sandbox</span></a>
+  <a className="msb-row" href="#fs-rename"><span className="msb-rn">fs.rename()</span><span className="msb-rg">rename / move a path</span></a>
+  <a className="msb-row" href="#fs-remove"><span className="msb-rn">fs.remove()</span><span className="msb-rg">remove a file</span></a>
+  <a className="msb-row" href="#fs-copy_from_host"><span className="msb-rn">fs.copy_from_host()</span><span className="msb-rg">host file into sandbox</span></a>
+  <a className="msb-row" href="#fs-copy_to_host"><span className="msb-rn">fs.copy_to_host()</span><span className="msb-rg">sandbox file out to host</span></a>
 
-Copy a file within the sandbox.
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#fsentry">FsEntry</a>
+    <a className="msb-typepill" href="#fsentrykind">FsEntryKind</a>
+    <a className="msb-typepill" href="#fsmetadata">FsMetadata</a>
+    <a className="msb-typepill" href="#fsreadstream">FsReadStream</a>
+    <a className="msb-typepill" href="#fswritesink">FsWriteSink</a>
+  </div>
 
-**Parameters**
+</div>
 
-| Name | Type | Description |
-|------|------|-------------|
-| src | `str` | Source path |
-| dst | `str` | Destination path |
-
----
-
-#### copy_from_host()
-
-```python
-async def copy_from_host(host_path: str, guest_path: str) -> None
-```
-
-Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| host_path | `str` | Path on the host filesystem |
-| guest_path | `str` | Destination path inside the sandbox |
-
----
-
-#### copy_to_host()
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```python
-async def copy_to_host(guest_path: str, host_path: str) -> None
+from microsandbox import Sandbox
+
+async with await Sandbox.create("api", image="python") as sb:
+    fs = sb.fs                                   # 1. grab the handle
+
+    await fs.mkdir("/app")                        # 2. set up
+    await fs.write("/app/config.json", b'{"ok": true}')
+
+    data = await fs.read_text("/app/config.json")  # 3. read it back
+    print(data)
 ```
 
-Copy a file from the sandbox to the host machine.
+The handle is reached through the `sb.fs` property on a running [`Sandbox`](/sdk/python/sandbox). All methods are coroutines, so `await` each call.
 
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| guest_path | `str` | Path inside the sandbox |
-| host_path | `str` | Destination path on the host |
+## Methods
 
 ---
 
-#### exists()
-
-```python
-async def exists(path: str) -> bool
-```
-
-Check whether a path exists inside the sandbox.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute path inside the guest |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `bool` | `True` if the path exists |
-
----
-
-#### list()
-
-```python
-async def list(path: str) -> list[FsEntry]
-```
-
-List the entries in a directory.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute directory path inside the guest |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `list[`[`FsEntry`](#fsentry)`]` | Directory entries |
-
----
-
-#### mkdir()
-
-```python
-async def mkdir(path: str) -> None
-```
-
-Create a directory and all parent directories.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute directory path |
-
----
-
-#### read()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def read(path: str) -> bytes
@@ -130,114 +71,236 @@ async def read(path: str) -> bytes
 
 Read the entire contents of a file as raw bytes.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest, e.g. <code>"/app/config.json"</code>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `bytes` | File contents as raw bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bytes</span></div>
+    <div className="msb-param-desc">File contents as raw bytes.</div>
+  </div>
+</div>
 
----
-
-#### read_stream()
+<p className="msb-label">Example</p>
 
 ```python
-async def read_stream(path: str) -> FsReadStream
+raw = await sb.fs.read("/app/data.bin")
+print(len(raw))
 ```
-
-Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute path inside the guest |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`FsReadStream`](#fsreadstream) | Async iterator that yields chunks of file data |
 
 ---
 
-#### read_text()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read_text()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def read_text(path: str) -> str
 ```
 
-Read the entire contents of a file and decode as UTF-8.
+Read the entire contents of a file and decode it as UTF-8.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute path inside the guest |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `str` | File contents as a string |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">File contents decoded as UTF-8.</div>
+  </div>
+</div>
 
----
-
-#### remove()
-
-```python
-async def remove(path: str) -> None
-```
-
-Remove a file.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute file path |
-
----
-
-#### remove_dir()
+<p className="msb-label">Example</p>
 
 ```python
-async def remove_dir(path: str) -> None
+config = await sb.fs.read_text("/app/config.json")
 ```
-
-Remove a directory recursively.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute directory path |
 
 ---
 
-#### rename()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def rename(src: str, dst: str) -> None
+async def read_stream(path: str) -> FsReadStream
 ```
 
-Rename or move a file or directory within the sandbox.
+Open a streaming reader for a file. Use this for files too large to hold in memory. The returned [`FsReadStream`](#fsreadstream) is an async iterator that yields chunks of bytes, or call its `collect()` to gather everything into one `bytes`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| src | `str` | Current path |
-| dst | `str` | New path |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsreadstream">FsReadStream</a></div>
+    <div className="msb-param-desc">Async iterator yielding chunks of file data.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+stream = await sb.fs.read_stream("/app/large.log")
+async for chunk in stream:
+    process(chunk)
+```
 
 ---
 
-#### stat()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">write()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting it if it does.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>data</code><span className="msb-type">bytes</span></div>
+    <div className="msb-param-desc">File content.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.fs.write("/app/hello.txt", b"hi\n")
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">write_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def write_stream(path: str) -> FsWriteSink
+```
+
+Open a streaming writer for a file. Use this for files too large to hold in memory. The returned [`FsWriteSink`](#fswritesink) supports the async context manager protocol, so `async with` closes and finalizes the file automatically.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fswritesink">FsWriteSink</a></div>
+    <div className="msb-param-desc">Async writer that accepts chunks of bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+async with await sb.fs.write_stream("/app/out.bin") as sink:
+    await sink.write(b"chunk one")
+    await sink.write(b"chunk two")
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute directory path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsentry">list[FsEntry]</a></div>
+    <div className="msb-param-desc">Directory entries.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+for entry in await sb.fs.list("/app"):
+    print(entry.kind, entry.path)
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory, including any missing parent directories.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute directory path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.fs.mkdir("/app/data/cache")
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">stat()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def stat(path: str) -> FsMetadata
@@ -245,56 +308,238 @@ async def stat(path: str) -> FsMetadata
 
 Get detailed metadata for a file or directory.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute path inside the guest |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`FsMetadata`](#fsmetadata) | File metadata |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsmetadata">FsMetadata</a></div>
+    <div className="msb-param-desc">File metadata.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+meta = await sb.fs.stat("/app/config.json")
+print(meta.kind, meta.size, meta.readonly)
+```
 
 ---
 
-#### write()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">exists()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def write(path: str, data: bytes) -> None
+async def exists(path: str) -> bool
 ```
 
-Write content to a file, creating it if it doesn't exist and overwriting if it does.
+Check whether a path exists inside the sandbox.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute path inside the guest |
-| data | `bytes` | File content |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>True</code> if the path exists.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+if not await sb.fs.exists("/app/config.json"):
+    await sb.fs.write("/app/config.json", b"{}")
+```
 
 ---
 
-#### write_stream()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">remove_dir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def write_stream(path: str) -> FsWriteSink
+async def remove_dir(path: str) -> None
 ```
 
-Open a streaming writer for a file. Use this for files too large to fit in memory.
+Remove a directory and its contents recursively.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute path inside the guest |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute directory path inside the guest.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Example</p>
 
-| Type | Description |
-|------|-------------|
-| [`FsWriteSink`](#fswritesink) | Async writer that accepts chunks of data |
+```python
+await sb.fs.remove_dir("/app/data/cache")
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">copy()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def copy(src: str, dst: str) -> None
+```
+
+Copy a file within the sandbox.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Source path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Destination path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.fs.copy("/app/config.json", "/app/config.bak.json")
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">rename()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def rename(src: str, dst: str) -> None
+```
+
+Rename or move a file or directory within the sandbox.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Current path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">New path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.fs.rename("/app/tmp.txt", "/app/final.txt")
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def remove(path: str) -> None
+```
+
+Remove a file. Use [`remove_dir()`](#fs-remove_dir) for directories.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute file path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.fs.remove("/app/config.bak.json")
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">copy_from_host()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def copy_from_host(host_path: str, guest_path: str) -> None
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Path on the host filesystem.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Destination path inside the sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.fs.copy_from_host("./local/seed.csv", "/app/seed.csv")
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">copy_to_host()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def copy_to_host(guest_path: str, host_path: str) -> None
+```
+
+Copy a file from the sandbox out to the host machine.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Path inside the sandbox.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Destination path on the host.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.fs.copy_to_host("/app/report.pdf", "./report.pdf")
+```
 
 ---
 
@@ -302,55 +547,75 @@ Open a streaming writer for a file. Use this for files too large to fit in memor
 
 ### FsEntry
 
-Metadata for a single directory entry, returned by [`list()`](#list).
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#fs-list">list()</a></p>
+
+Metadata for a single directory entry, returned by [`list()`](#fs-list).
 
 | Property | Type | Description |
 |----------|------|-------------|
-| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
-| mode | `int` | Unix permission bits |
-| modified | `float \| None` | Last modified timestamp (ms since epoch) |
-| path | `str` | File path |
+| path | `str` | Full path of the entry |
+| kind | `str` | Entry type: `"file"`, `"directory"`, `"symlink"`, or `"other"` (see [`FsEntryKind`](#fsentrykind)) |
 | size | `int` | File size in bytes |
+| mode | `int` | Unix permission bits |
+| modified | `float \| None` | Last-modified time, milliseconds since the Unix epoch |
 
 ### FsEntryKind
 
-String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) representing the type of a filesystem entry.
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Describes <a href="#fsentry">FsEntry.kind</a> · <a href="#fsmetadata">FsMetadata.kind</a></p>
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) of filesystem entry types. The `kind` fields on [`FsEntry`](#fsentry) and [`FsMetadata`](#fsmetadata) carry these string values.
 
 | Value | Description |
 |-------|-------------|
-| `"directory"` | Directory |
 | `"file"` | Regular file |
-| `"other"` | Other entry type |
+| `"directory"` | Directory |
 | `"symlink"` | Symbolic link |
+| `"other"` | Other entry type |
 
 ### FsMetadata
 
-Detailed file metadata, returned by [`stat()`](#stat).
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#fs-stat">stat()</a></p>
+
+Detailed file metadata, returned by [`stat()`](#fs-stat).
 
 | Property | Type | Description |
 |----------|------|-------------|
-| created | `float \| None` | Creation timestamp (ms since epoch) |
-| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
-| mode | `int` | Unix permission bits |
-| modified | `float \| None` | Last modified timestamp (ms since epoch) |
-| readonly | `bool` | Whether the file is read-only |
+| kind | `str` | Entry type: `"file"`, `"directory"`, `"symlink"`, or `"other"` (see [`FsEntryKind`](#fsentrykind)) |
 | size | `int` | File size in bytes |
+| mode | `int` | Unix permission bits |
+| readonly | `bool` | Whether the file is read-only |
+| modified | `float \| None` | Last-modified time, milliseconds since the Unix epoch |
+| created | `float \| None` | Creation time, milliseconds since the Unix epoch |
 
 ### FsReadStream
 
-Async stream for reading a file in chunks. Obtained via [`read_stream()`](#read_stream).
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#fs-read_stream">read_stream()</a></p>
+
+Async stream for reading a file in chunks. Obtained via [`read_stream()`](#fs-read_stream). Iterate it with `async for chunk in stream:`, or call `collect()` to gather everything at once.
 
 | Method / Protocol | Returns | Description |
 |-------------------|---------|-------------|
-| `__aiter__` / `__anext__` | `bytes` | Async iterator - use with `async for chunk in stream:` |
-| `collect()` | `bytes` | Collect all remaining data into a single `bytes` object |
+| `__aiter__` / `__anext__` | `bytes` | Async iterator. Use `async for chunk in stream:`. |
+| collect() | `bytes` | *(async)* Collect all remaining data into a single `bytes` object |
 
 ### FsWriteSink
 
-Async writer for streaming data into a file. Obtained via [`write_stream()`](#write_stream). Supports the async context manager protocol (`async with`).
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#fs-write_stream">write_stream()</a></p>
+
+Async writer for streaming data into a file. Obtained via [`write_stream()`](#fs-write_stream). Supports the async context manager protocol, so `async with` closes the sink on exit.
 
 | Method / Protocol | Returns | Description |
 |-------------------|---------|-------------|
-| `write(data)` | `None` | Write a chunk of `bytes` to the file |
-| `close()` | `None` | Send EOF and finalize the file |
-| `__aenter__` / `__aexit__` | `FsWriteSink` | Use with `async with` for automatic close on exit |
+| write(data) | `None` | *(async)* Write a chunk of `bytes` to the file |
+| close() | `None` | *(async)* Send EOF and finalize the file |
+| `__aenter__` / `__aexit__` | `FsWriteSink` | *(async)* Use with `async with` for automatic close on exit |

--- a/docs/sdk/python/images.mdx
+++ b/docs/sdk/python/images.mdx
@@ -3,133 +3,477 @@ title: Images
 description: Python SDK - Image cache API reference
 ---
 
-The Python SDK exposes local OCI image-cache operations through `Image`.
-These APIs inspect and prune images that have already been pulled by sandbox
-creation. `Image` also remains the namespace for explicit rootfs source
-configuration such as `Image.oci(...)`, `Image.bind(...)`, and `Image.disk(...)`.
+`Image` is the static namespace for two related things: configuring an explicit rootfs source for a sandbox (`Image.oci`, `Image.bind`, `Image.disk`), and managing the local OCI image cache that sandbox creation pulls into (`get`, `list`, `inspect`, `remove`, `prune`). Cache operations require a local backend. See [Sandbox](/sdk/python/sandbox) for the `image=` and `pull_policy=` creation kwargs.
 
 ```python
 from microsandbox import Image
 ```
 
-## Image
+<div className="msb-glance">
 
----
+  <p className="msb-gl"><span className="msb-dot static"></span>Source factory<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#image-oci"><span className="msb-rn">Image.oci()</span><span className="msb-rg">OCI image rootfs source</span></a>
+  <a className="msb-row" href="#image-bind"><span className="msb-rn">Image.bind()</span><span className="msb-rg">bind a host directory</span></a>
+  <a className="msb-row" href="#image-disk"><span className="msb-rn">Image.disk()</span><span className="msb-rg">boot from a disk image</span></a>
 
-#### Image.get()
+  <p className="msb-gl"><span className="msb-dot static"></span>Cache management<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#image-get"><span className="msb-rn">Image.get()</span><span className="msb-rg">one cached image</span></a>
+  <a className="msb-row" href="#image-list"><span className="msb-rn">Image.list()</span><span className="msb-rg">all cached images</span></a>
+  <a className="msb-row" href="#image-inspect"><span className="msb-rn">Image.inspect()</span><span className="msb-rg">config + layer detail</span></a>
+  <a className="msb-row" href="#image-remove"><span className="msb-rn">Image.remove()</span><span className="msb-rg">delete a cached image</span></a>
+  <a className="msb-row" href="#image-prune"><span className="msb-rn">Image.prune()</span><span className="msb-rg">reclaim unused data</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#imagesource">ImageSource</a>
+    <a className="msb-typepill" href="#imagehandle">ImageHandle</a>
+    <a className="msb-typepill" href="#imagedetail">ImageDetail</a>
+    <a className="msb-typepill" href="#imageconfigdetail">ImageConfigDetail</a>
+    <a className="msb-typepill" href="#imagelayerdetail">ImageLayerDetail</a>
+    <a className="msb-typepill" href="#imageprunereport">ImagePruneReport</a>
+    <a className="msb-typepill" href="#diskimageformat">DiskImageFormat</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```python
-async def Image.get(reference: str) -> ImageHandle
-```
+from microsandbox import Image, Sandbox
 
-Fetch one cached image by reference. Raises `ImageNotFoundError` when the image
-is not present in the local cache.
+# Pull happens implicitly on creation
+async with await Sandbox.create("api", image="python:3.12") as sb:
+    await sb.exec("python", ["-V"])
 
----
-
-#### Image.list()
-
-```python
-async def Image.list() -> list[ImageHandle]
-```
-
-Return every cached image, ordered newest first.
-
-```python
-images = await Image.list()
-for image in images:
+# Later, inspect and prune the local cache
+for image in await Image.list():
     print(image.reference, image.layer_count)
+
+report = await Image.prune()
+print(f"reclaimed {report.bytes_reclaimed} bytes")
+```
+
+## Source factory
+
+These static methods return an [`ImageSource`](#imagesource) you can pass as the `image=` kwarg to [`Sandbox.create()`](/sdk/python/sandbox). A plain string also works (`image="python:3.12"`); use the factory when you need OCI-only options like the writable upper size, or to be explicit about a bind or disk source.
+
+---
+
+#### <span className="msb-recv">Image.</span><span className="msb-hn">oci()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
+
+```python
+@staticmethod
+def oci(reference: str, *, upper_size_mib: int | None = None) -> ImageSource
+```
+
+Create an OCI image rootfs source. Use `upper_size_mib` to size the writable overlay upper layer; otherwise the default applies.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>reference</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">OCI image reference, e.g. <code>"python:3.12"</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>upper_size_mib</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Writable overlay upper size in MiB. <code>None</code> keeps the default.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imagesource">ImageSource</a></div>
+    <div className="msb-param-desc">Rootfs source for <code>image=</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+sb = await Sandbox.create(
+    "api",
+    image=Image.oci("python:3.12", upper_size_mib=8192),
+)
 ```
 
 ---
 
-#### Image.inspect()
+#### <span className="msb-recv">Image.</span><span className="msb-hn">bind()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```python
-async def Image.inspect(reference: str) -> ImageDetail
+@staticmethod
+def bind(path: str) -> ImageSource
 ```
 
-Return handle metadata plus parsed OCI config and layer details.
+Create a rootfs source that binds a host directory as the guest root filesystem.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Host directory to use as the rootfs.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imagesource">ImageSource</a></div>
+    <div className="msb-param-desc">Rootfs source for <code>image=</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+sb = await Sandbox.create("api", image=Image.bind("/srv/rootfs"))
+```
 
 ---
 
-#### Image.remove()
+#### <span className="msb-recv">Image.</span><span className="msb-hn">disk()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```python
-async def Image.remove(reference: str, *, force: bool = False) -> None
+@staticmethod
+def disk(path: str, *, fstype: str | None = None) -> ImageSource
 ```
 
-Delete a cached image. When `force` is false, sandboxes still referencing the
-image raise `ImageInUseError`.
+Create a rootfs source backed by a disk image. The format is inferred from the file extension. Pass `fstype` when the filesystem type cannot be auto-detected.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Path to the disk image (e.g. <code>.qcow2</code>, <code>.raw</code>, <code>.vmdk</code>).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>fstype</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Filesystem type, e.g. <code>"ext4"</code>. <code>None</code> auto-detects.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imagesource">ImageSource</a></div>
+    <div className="msb-param-desc">Rootfs source for <code>image=</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+sb = await Sandbox.create(
+    "api",
+    image=Image.disk("/data/root.qcow2", fstype="ext4"),
+)
+```
+
+## Cache management
+
+These static methods inspect and prune images already pulled into the local OCI cache. They require a local backend; on a cloud backend they raise `UnsupportedError`.
 
 ---
 
-#### Image.prune()
+#### <span className="msb-recv">Image.</span><span className="msb-hn">get()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def Image.prune() -> ImagePruneReport
+@staticmethod
+async def get(reference: str) -> ImageHandle
 ```
 
-Remove cached image data that is not used by any sandbox or indexed snapshot.
-The returned report includes the count of removed refs, manifests, layers,
-fsmeta files, VMDK files, and any measured bytes reclaimed.
+Fetch one cached image by reference. Raises [`ImageNotFoundError`](#errors) when the image is not present in the local cache.
 
-## ImageHandle
+<p className="msb-label">Parameters</p>
 
-Returned by `Image.get()` and `Image.list()`.
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>reference</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Image reference to look up.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imagehandle">ImageHandle</a></div>
+    <div className="msb-param-desc">Handle to the cached image.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+handle = await Image.get("python:3.12")
+print(handle.reference, handle.layer_count)
+```
+
+---
+
+#### <span className="msb-recv">Image.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def list() -> list[ImageHandle]
+```
+
+Return every cached image.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imagehandle">list[ImageHandle]</a></div>
+    <div className="msb-param-desc">All cached image handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+for image in await Image.list():
+    print(image.reference, image.size_bytes)
+```
+
+---
+
+#### <span className="msb-recv">Image.</span><span className="msb-hn">inspect()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def inspect(reference: str) -> ImageDetail
+```
+
+Return handle metadata plus the parsed OCI config and per-layer detail.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>reference</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Image reference to inspect.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imagedetail">ImageDetail</a></div>
+    <div className="msb-param-desc">Handle, OCI config, and layers.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+detail = await Image.inspect("python:3.12")
+print(detail.handle.reference)
+for layer in detail.layers:
+    print(layer.position, layer.diff_id)
+```
+
+---
+
+#### <span className="msb-recv">Image.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def remove(reference: str, *, force: bool = False) -> None
+```
+
+Delete a cached image. When `force` is `False`, an image still referenced by one or more sandboxes raises [`ImageInUseError`](#errors); pass `force=True` to remove it anyway.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>reference</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Image reference to delete.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>force</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Remove even if still referenced. Default <code>False</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await Image.remove("python:3.12", force=True)
+```
+
+---
+
+#### <span className="msb-recv">Image.</span><span className="msb-hn">prune()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def prune() -> ImagePruneReport
+```
+
+Remove cached image data that is not used by any sandbox or indexed snapshot. The returned report counts the removed refs, manifests, layers, fsmeta files, and VMDK files, plus any measured bytes reclaimed.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#imageprunereport">ImagePruneReport</a></div>
+    <div className="msb-param-desc">Counts of removed data and bytes reclaimed.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+report = await Image.prune()
+print(f"{report.layers_removed} layers, {report.bytes_reclaimed} bytes")
+```
+
+## Types
+
+### ImageSource
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#image-oci">oci()</a> · <a href="#image-bind">bind()</a> · <a href="#image-disk">disk()</a></p>
+
+Explicit rootfs image source. Build one with [`Image.oci()`](#image-oci), [`Image.bind()`](#image-bind), or [`Image.disk()`](#image-disk), then pass it as the `image=` kwarg to [`Sandbox.create()`](/sdk/python/sandbox). A frozen dataclass; treat its fields as opaque.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_type` | `str` | Source kind: `"oci"`, `"bind"`, or `"disk"` |
+| `_path` | `str \| None` | Host path for `bind` / `disk` sources |
+| `_reference` | `str \| None` | OCI reference for `oci` sources |
+| `_upper_size_mib` | `int \| None` | Writable overlay upper size in MiB (OCI only) |
+| `_fstype` | `str \| None` | Filesystem type for `disk` sources |
+| `_format` | [`DiskImageFormat`](#diskimageformat)` \| None` | Disk image format (inferred from extension) |
+
+### ImageHandle
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#image-get">get()</a> · <a href="#image-list">list()</a></p>
+
+A lightweight handle to a cached OCI image, returned by [`Image.get()`](#image-get) and [`Image.list()`](#image-list). Properties are read-only attributes; the two methods are async.
 
 | Property / Method | Type | Description |
 |-------------------|------|-------------|
 | `reference` | `str` | Image reference |
+| `size_bytes` | `int \| None` | Total size in bytes, or `None` when unknown |
 | `manifest_digest` | `str \| None` | Content-addressable manifest digest |
 | `architecture` | `str \| None` | Resolved architecture |
 | `os` | `str \| None` | Resolved operating system |
 | `layer_count` | `int` | Number of layers |
-| `size_bytes` | `int \| None` | Total size, or `None` when unknown |
-| `created_at` | `float \| None` | First-pulled time as milliseconds since epoch |
-| `last_used_at` | `float \| None` | Last referenced time as milliseconds since epoch |
-| `await remove(force=False)` | `None` | Delete this image |
-| `await inspect()` | `ImageDetail` | Fetch full detail for this image |
+| `last_used_at` | `float \| None` | Last referenced time, milliseconds since epoch |
+| `created_at` | `float \| None` | First-pulled time, milliseconds since epoch |
+| `await inspect()` | [`ImageDetail`](#imagedetail) | Fetch full detail for this image |
+| `await remove(*, force=False)` | `None` | Delete this image (raises [`ImageInUseError`](#errors) unless `force`) |
 
-## ImageDetail
+### ImageDetail
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#image-inspect">inspect()</a> · <a href="#imagehandle">ImageHandle.inspect()</a></p>
+
+Full detail for a cached image: the core handle, the parsed OCI config block, and per-layer metadata.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `handle` | `ImageHandle` | Core cached image metadata |
-| `config` | `ImageConfigDetail \| None` | Parsed OCI config block |
-| `layers` | `list[ImageLayerDetail]` | Layers in bottom-to-top order |
+| `handle` | [`ImageHandle`](#imagehandle) | Core cached image metadata |
+| `config` | [`ImageConfigDetail`](#imageconfigdetail)` \| None` | Parsed OCI config block |
+| `layers` | `list[`[`ImageLayerDetail`](#imagelayerdetail)`]` | Layers in bottom-to-top order |
 
 ### ImageConfigDetail
 
-| Property | Type |
-|----------|------|
-| `digest` | `str` |
-| `env` | `list[str]` |
-| `cmd` | `list[str] \| None` |
-| `entrypoint` | `list[str] \| None` |
-| `working_dir` | `str \| None` |
-| `user` | `str \| None` |
-| `labels` | `dict[str, Any] \| None` |
-| `stop_signal` | `str \| None` |
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Used by <a href="#imagedetail">ImageDetail.config</a></p>
+
+OCI image config fields extracted from the local cache.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `digest` | `str` | Config blob digest |
+| `env` | `list[str]` | Environment variables (`KEY=value`) |
+| `cmd` | `list[str] \| None` | Default command |
+| `entrypoint` | `list[str] \| None` | Image entrypoint |
+| `working_dir` | `str \| None` | Default working directory |
+| `user` | `str \| None` | Default user |
+| `labels` | `dict[str, Any] \| None` | OCI labels |
+| `stop_signal` | `str \| None` | Configured stop signal |
 
 ### ImageLayerDetail
 
-| Property | Type |
-|----------|------|
-| `diff_id` | `str` |
-| `blob_digest` | `str` |
-| `media_type` | `str \| None` |
-| `compressed_size_bytes` | `int \| None` |
-| `erofs_size_bytes` | `int \| None` |
-| `position` | `int` |
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Used by <a href="#imagedetail">ImageDetail.layers</a></p>
+
+Metadata for a single image layer.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `diff_id` | `str` | Uncompressed layer diff id |
+| `blob_digest` | `str` | Compressed blob digest |
+| `media_type` | `str \| None` | Layer media type |
+| `compressed_size_bytes` | `int \| None` | Compressed size in bytes |
+| `erofs_size_bytes` | `int \| None` | Size of the generated EROFS sidecar in bytes |
+| `position` | `int` | Layer position (bottom to top) |
 
 ### ImagePruneReport
 
-| Property | Type |
-|----------|------|
-| `image_refs_removed` | `int` |
-| `manifests_removed` | `int` |
-| `layers_removed` | `int` |
-| `fsmeta_removed` | `int` |
-| `vmdk_removed` | `int` |
-| `bytes_reclaimed` | `int \| None` |
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#image-prune">prune()</a></p>
+
+Summary of cached image data removed by [`Image.prune()`](#image-prune).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `image_refs_removed` | `int` | Number of image refs removed |
+| `manifests_removed` | `int` | Number of manifests removed |
+| `layers_removed` | `int` | Number of layer blobs removed |
+| `fsmeta_removed` | `int` | Number of fsmeta sidecar files removed |
+| `vmdk_removed` | `int` | Number of VMDK files removed |
+| `bytes_reclaimed` | `int \| None` | Measured bytes reclaimed, or `None` when not measured |
+
+### DiskImageFormat
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#imagesource">ImageSource._format</a></p>
+
+Disk image container format. A `StrEnum`, so the string values are accepted directly.
+
+| Value | Description |
+|-------|-------------|
+| `"qcow2"` | QEMU copy-on-write v2 |
+| `"raw"` | Raw block image |
+| `"vmdk"` | VMware disk image |
+
+### Errors
+
+Image operations raise these typed exceptions, all subclasses of `MicrosandboxError`.
+
+| Exception | Raised when |
+|-----------|-------------|
+| `ImageNotFoundError` | The image reference could not be resolved in the local cache |
+| `ImageInUseError` | The image is still referenced by one or more sandboxes (and `force` was not set) |
+| `ImagePullFailedError` | An image pull failed |
+| `UnsupportedError` | Cache operations were attempted on a backend that lacks a local cache |

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -3,62 +3,100 @@ title: Networking
 description: Python SDK - Network API reference
 ---
 
-See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+Configure a sandbox's network stack: a first-match-wins egress/ingress policy, published ports, DNS interception, TLS interception, and secret-violation handling. Pass a [`Network`](#network) as the `network=` kwarg to [`Sandbox.create()`](/sdk/python/sandbox#sandbox-create). See [Networking](/networking/overview) for the conceptual overview and [TLS Interception](/networking/tls) for proxy details.
 
-## Network
+<div className="msb-glance">
 
-Frozen dataclass for sandbox network configuration. Use a class-method preset for the common cases, or construct directly with custom options.
+  <p className="msb-gl"><span className="msb-dot static"></span>Factory · Network<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#network-none"><span className="msb-rn">Network.none()</span><span className="msb-rg">deny everything, no interface</span></a>
+  <a className="msb-row" href="#network-public_only"><span className="msb-rn">Network.public_only()</span><span className="msb-rg">public internet only (default)</span></a>
+  <a className="msb-row" href="#network-allow_all"><span className="msb-rn">Network.allow_all()</span><span className="msb-rg">allow everything</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Factory · Rule<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#rule-allow"><span className="msb-rn">Rule.allow()</span><span className="msb-rg">permit matching traffic</span></a>
+  <a className="msb-row" href="#rule-deny"><span className="msb-rn">Rule.deny()</span><span className="msb-rg">block matching traffic</span></a>
+  <a className="msb-row" href="#rule-allow_dns"><span className="msb-rn">Rule.allow_dns()</span><span className="msb-rg">open plain DNS to gateway</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Factory · Destination<span className="msb-ct">6</span></p>
+  <a className="msb-row" href="#destination-any"><span className="msb-rn">Destination.any()</span><span className="msb-rg">match any destination</span></a>
+  <a className="msb-row" href="#destination-ip"><span className="msb-rn">Destination.ip()</span><span className="msb-rg">match an exact IP</span></a>
+  <a className="msb-row" href="#destination-cidr"><span className="msb-rn">Destination.cidr()</span><span className="msb-rg">match an IP range</span></a>
+  <a className="msb-row" href="#destination-domain"><span className="msb-rn">Destination.domain()</span><span className="msb-rg">match an exact domain</span></a>
+  <a className="msb-row" href="#destination-domain_suffix"><span className="msb-rn">Destination.domain_suffix()</span><span className="msb-rg">match apex + subdomains</span></a>
+  <a className="msb-row" href="#destination-group"><span className="msb-rn">Destination.group()</span><span className="msb-rg">match an address group</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Factory · PortBinding<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#portbinding-tcp"><span className="msb-rn">PortBinding.tcp()</span><span className="msb-rg">published TCP port</span></a>
+  <a className="msb-row" href="#portbinding-udp"><span className="msb-rn">PortBinding.udp()</span><span className="msb-rg">published UDP port</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#network">Network</a>
+    <a className="msb-typepill" href="#networkpolicy">NetworkPolicy</a>
+    <a className="msb-typepill" href="#rule">Rule</a>
+    <a className="msb-typepill" href="#destination">Destination</a>
+    <a className="msb-typepill" href="#networkdestination">NetworkDestination</a>
+    <a className="msb-typepill" href="#portbinding">PortBinding</a>
+    <a className="msb-typepill" href="#dnsconfig">DnsConfig</a>
+    <a className="msb-typepill" href="#tlsconfig">TlsConfig</a>
+    <a className="msb-typepill" href="#action">Action</a>
+    <a className="msb-typepill" href="#direction">Direction</a>
+    <a className="msb-typepill" href="#protocol">Protocol</a>
+    <a className="msb-typepill" href="#portprotocol">PortProtocol</a>
+    <a className="msb-typepill" href="#destgroup">DestGroup</a>
+    <a className="msb-typepill" href="/sdk/python/secrets#violationaction">ViolationAction</a>
+    <a className="msb-typepill" href="/sdk/python/secrets#violationpolicy">ViolationPolicy</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```python
-Network(
-    policy: str | NetworkPolicy | None = None,
-    ports: Mapping[int, int] | Sequence[PortBinding] = {},
-    deny_domains: tuple[str, ...] = (),
-    deny_domain_suffixes: tuple[str, ...] = (),
-    dns: DnsConfig | None = None,
-    tls: TlsConfig | None = None,
-    ipv4_pool: str | None = None,
-    ipv6_pool: str | None = None,
-    max_connections: int | None = None,
-    on_secret_violation: ViolationAction | ViolationPolicy = ViolationAction.BLOCK_AND_LOG,
-    trust_host_cas: bool | None = None,
+from microsandbox import (
+    Action,
+    DestGroup,
+    Destination,
+    Network,
+    NetworkPolicy,
+    PortBinding,
+    Protocol,
+    Rule,
+    Sandbox,
+)
+
+policy = NetworkPolicy(                            # 1. compose a policy
+    default_egress=Action.DENY,
+    rules=(
+        *Rule.allow_dns(),
+        Rule.allow(
+            protocol=Protocol.TCP,
+            port=443,
+            destination=Destination.group(DestGroup.PUBLIC),
+        ),
+    ),
+)
+
+sb = await Sandbox.create(                          # 2. wire it into the sandbox
+    "api",
+    image="python",
+    network=Network(
+        policy=policy,
+        ports=(PortBinding.tcp(8080, 80),),
+    ),
 )
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| policy | `str \| NetworkPolicy \| None` | Preset name (`"none"`, `"public_only"`, `"allow_all"`) or custom [`NetworkPolicy`](#networkpolicy) |
-| ports | `Mapping[int, int] \| Sequence[PortBinding]` | Port mappings from host to guest. Mapping form binds to `127.0.0.1`; `PortBinding` can set an explicit bind address |
-| deny_domains | `tuple[str, ...]` | Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (NXDOMAIN), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy so it takes precedence over later allow rules |
-| deny_domain_suffixes | `tuple[str, ...]` | Deny egress to all subdomains of these suffixes. Adds `deny DomainSuffix("...")` rules; same enforcement layers as `deny_domains` |
-| dns | [`DnsConfig`](#dnsconfig) ` \| None` | DNS interception configuration |
-| tls | [`TlsConfig`](#tlsconfig) ` \| None` | TLS interception configuration |
-| ipv4_pool | `str \| None` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12` |
-| ipv6_pool | `str \| None` | IPv6 pool used for per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48` |
-| max_connections | `int \| None` | Maximum concurrent connections |
-| on_secret_violation | [`ViolationAction`](/sdk/python/secrets#violationaction) `\|` [`ViolationPolicy`](/sdk/python/secrets#violationpolicy) | Sandbox-wide action when a secret placeholder reaches a disallowed host |
-| trust_host_cas | `bool \| None` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle. Opt-in |
+The default policy denies egress except for an implicit allow-public rule, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry. `Network`, `Rule`, `Destination`, and `PortBinding` are all frozen dataclasses re-exported from `microsandbox`, each carrying class-method or static-method constructors for the common cases.
+
+## Network factory
+
+[`Network`](#network) is a frozen dataclass. The presets below return a `Network` for the common policy shapes; construct one directly for custom policies, ports, DNS, or TLS.
 
 ---
 
-#### Network.allow_all()
-
-```python
-@classmethod
-def allow_all() -> Network
-```
-
-Unrestricted network access, including to private addresses and the host machine.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`Network`](#network) | Unrestricted network configuration |
-
----
-
-#### Network.none()
+#### <span className="msb-recv">Network.</span><span className="msb-hn">none()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
 
 ```python
 @classmethod
@@ -67,15 +105,25 @@ def none() -> Network
 
 Deny all traffic. No network interface is created; the guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`Network`](#network) | Fully airgapped network configuration |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#network">Network</a></div>
+    <div className="msb-param-desc">Fully airgapped network configuration.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+sb = await Sandbox.create("offline", image="python", network=Network.none())
+```
 
 ---
 
-#### Network.public_only()
+#### <span className="msb-recv">Network.</span><span className="msb-hn">public_only()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
 
 ```python
 @classmethod
@@ -84,90 +132,52 @@ def public_only() -> Network
 
 Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`Network`](#network) | Public-only network configuration |
-
----
-
-## PortBinding
-
-Frozen dataclass for published ports that need an explicit host bind address or UDP.
-
-```python
-PortBinding(
-    host_port: int,
-    guest_port: int,
-    bind: str = "127.0.0.1",
-    protocol: PortProtocol = PortProtocol.TCP,
-)
-```
-
-Prefer the protocol-specific constructors:
-
-```python
-PortBinding.tcp(8001, 8001, bind="0.0.0.0")
-PortBinding.udp(5353, 5353, bind="0.0.0.0")
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| host_port | `int` | Port on the host |
-| guest_port | `int` | Port inside the sandbox |
-| bind | `str` | Host address to bind. Defaults to `127.0.0.1`; use `0.0.0.0` for all IPv4 interfaces |
-| protocol | [`PortProtocol`](#portprotocol) | Published port protocol |
-
-`PortBinding.tcp()` maps to the Rust `port_bind(...)` path; `PortBinding.udp()` maps to `port_udp_bind(...)`.
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#network">Network</a></div>
+    <div className="msb-param-desc">Public-only network configuration.</div>
+  </div>
+</div>
 
 ---
 
-## NetworkPolicy
-
-A list of rules plus two per-direction defaults, evaluated first-match-wins. Pass to `Network(policy=...)` for custom policies:
+#### <span className="msb-recv">Network.</span><span className="msb-hn">allow_all()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
 
 ```python
-from microsandbox import (
-    Action,
-    DestGroup,
-    Destination,
-    Direction,
-    NetworkPolicy,
-    Protocol,
-    Rule,
-)
+@classmethod
+def allow_all() -> Network
+```
+
+Unrestricted network access, including to private addresses and the host machine.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#network">Network</a></div>
+    <div className="msb-param-desc">Unrestricted network configuration.</div>
+  </div>
+</div>
+
+## Rule factory
+
+A [`NetworkPolicy`](#networkpolicy) is an ordered list of [`Rule`](#rule) values plus two per-direction defaults, evaluated first-match-wins per direction. The class methods below build rules; assemble them into `NetworkPolicy(rules=(...))` and pass it as `Network(policy=...)`.
+
+```python
+from microsandbox import Action, Destination, NetworkPolicy, Protocol, Rule
 
 policy = NetworkPolicy(
     default_egress=Action.DENY,
     default_ingress=Action.ALLOW,
     rules=(
-        Rule.allow(
-            protocol=Protocol.TCP,
-            port=443,
-            destination=Destination.ip("1.1.1.1"),
-        ),
-        Rule.allow(destination=Destination.group(DestGroup.LINK_LOCAL)),
+        Rule.allow(protocol=Protocol.TCP, port=443, destination=Destination.ip("1.1.1.1")),
         Rule.deny(destination=Destination.domain("api.example.com")),
     ),
 )
 ```
-
-The default policy denies egress except for an implicit `allow public`, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry.
-
-```python
-NetworkPolicy(
-    default_egress: Action = Action.DENY,
-    default_ingress: Action = Action.ALLOW,
-    rules: tuple[Rule, ...] = (),
-)
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
-| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
-| rules | `tuple[`[`Rule`](#rule)`, ...]` | Rules evaluated first-match-wins per direction |
 
 ### Rule order matters
 
@@ -188,33 +198,8 @@ Put specific rules before general ones.
 
 ---
 
-## Rule
-
-Frozen dataclass for a single network policy rule.
-
-```python
-Rule(
-    action: Action,
-    direction: Direction = Direction.EGRESS,
-    destination: str | NetworkDestination | None = None,
-    protocol: Protocol | None = None,
-    port: int | str | None = None,
-)
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| action | [`Action`](#action) | What to do when this rule matches |
-| direction | [`Direction`](#direction) | Which evaluator considers this rule. `Direction.ANY` matches in either direction |
-| destination | `str \| NetworkDestination \| None` | Target filter. Prefer typed [`Destination`](#destination) helpers for new code. String shorthand remains supported: [`DestGroup`](#destgroup) values, exact IPs, domains, CIDR ranges, domain suffixes prefixed with `"."`, or `"*"` for any. Domain and suffix strings are validated at sandbox creation; invalid names raise `ValueError` |
-| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
-| port | `int \| str \| None` | Single port (`443`) or range (`"8000-9000"`) |
-
-Ingress rules carrying ICMP protocols are rejected at sandbox creation; the host has no inbound ICMP path. Use `Direction.EGRESS` for ICMP allow/deny.
-
----
-
-#### Rule.allow()
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">allow()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
 
 ```python
 @classmethod
@@ -227,26 +212,50 @@ def allow(
 ) -> Rule
 ```
 
-Create a rule that permits matching traffic.
+Create a rule that permits matching traffic. All filters are keyword-only.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| direction | [`Direction`](#direction) | Traffic direction |
-| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
-| port | `int \| str \| None` | Port or port range |
-| destination | `str \| NetworkDestination \| None` | Destination filter |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>direction</code><a className="msb-type" href="#direction">Direction</a></div>
+    <div className="msb-param-desc">Which evaluator considers the rule. Defaults to <code>EGRESS</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>protocol</code><a className="msb-type" href="#protocol">Protocol | None</a></div>
+    <div className="msb-param-desc">Protocol filter.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>port</code><span className="msb-type">int | str | None</span></div>
+    <div className="msb-param-desc">Single port (<code>443</code>) or range (<code>"8000-9000"</code>).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>destination</code><a className="msb-type" href="#networkdestination">str | NetworkDestination | None</a></div>
+    <div className="msb-param-desc">Target filter. Prefer the typed <a className="msb-type" href="#destination">Destination</a> helpers; string shorthand is also accepted.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`Rule`](#rule) | An allow rule |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#rule">Rule</a></div>
+    <div className="msb-param-desc">An allow rule.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+from microsandbox import Destination, Protocol, Rule
+
+r = Rule.allow(protocol=Protocol.TCP, port=443, destination=Destination.domain("api.example.com"))
+```
 
 ---
 
-#### Rule.deny()
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">deny()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
 
 ```python
 @classmethod
@@ -259,26 +268,42 @@ def deny(
 ) -> Rule
 ```
 
-Create a rule that blocks matching traffic.
+Create a rule that blocks matching traffic. Same keyword-only filters as [`allow()`](#rule-allow).
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| direction | [`Direction`](#direction) | Traffic direction |
-| protocol | [`Protocol`](#protocol) ` \| None` | Protocol filter |
-| port | `int \| str \| None` | Port or port range |
-| destination | `str \| NetworkDestination \| None` | Destination filter |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>direction</code><a className="msb-type" href="#direction">Direction</a></div>
+    <div className="msb-param-desc">Which evaluator considers the rule. Defaults to <code>EGRESS</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>protocol</code><a className="msb-type" href="#protocol">Protocol | None</a></div>
+    <div className="msb-param-desc">Protocol filter.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>port</code><span className="msb-type">int | str | None</span></div>
+    <div className="msb-param-desc">Single port or port range.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>destination</code><a className="msb-type" href="#networkdestination">str | NetworkDestination | None</a></div>
+    <div className="msb-param-desc">Target filter.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`Rule`](#rule) | A deny rule |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#rule">Rule</a></div>
+    <div className="msb-param-desc">A deny rule.</div>
+  </div>
+</div>
 
 ---
 
-#### Rule.allow_dns()
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">allow_dns()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
 
 ```python
 @classmethod
@@ -287,9 +312,22 @@ def allow_dns() -> tuple[Rule, Rule]
 
 Allow plain DNS (UDP/53 and TCP/53) to the sandbox gateway, i.e. the in-process DNS forwarder. The standard one-liner for opening DNS under a deny-by-default policy. See [DNS as egress](/networking/dns#dns-as-egress) for the underlying semantics.
 
-Returns the pair `(udp_rule, tcp_rule)` since this SDK's `Rule` shape carries a single protocol; splat into `NetworkPolicy.rules`:
+Returns the pair `(udp_rule, tcp_rule)` since this SDK's [`Rule`](#rule) shape carries a single protocol; splat into `NetworkPolicy.rules`. DoT (TCP/853) is intentionally not included; add an explicit `Rule.allow(destination=Destination.group(DestGroup.HOST), protocol=Protocol.TCP, port=853)` if needed (and pair with TLS interception).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#rule">tuple[Rule, Rule]</a></div>
+    <div className="msb-param-desc"><code>(udp_rule, tcp_rule)</code> for <code>DestGroup.HOST</code> on port 53.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```python
+from microsandbox import Action, DestGroup, Destination, NetworkPolicy, Protocol, Rule
+
 policy = NetworkPolicy(
     default_egress=Action.DENY,
     rules=(
@@ -303,19 +341,9 @@ policy = NetworkPolicy(
 )
 ```
 
-DoT (TCP/853) is intentionally not included; add an explicit `Rule.allow(destination=Destination.group(DestGroup.HOST), protocol=Protocol.TCP, port=853)` if needed (and pair with TLS interception).
+## Destination factory
 
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `tuple[`[`Rule`](#rule)`, `[`Rule`](#rule)`]` | `(udp_rule, tcp_rule)` for `Group::Host` on port 53 |
-
----
-
-## Destination
-
-Factory namespace for typed network policy destinations. Typed destinations avoid string-shorthand ambiguity and match the TypeScript SDK shape.
+Factory namespace for typed network policy destinations. Typed destinations avoid string-shorthand ambiguity and match the TypeScript SDK shape. Each method returns a [`NetworkDestination`](#networkdestination).
 
 ```python
 from microsandbox import DestGroup, Destination
@@ -328,20 +356,334 @@ Destination.domain_suffix(".example.com")
 Destination.group(DestGroup.LINK_LOCAL)
 ```
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `Destination.any()` | [`NetworkDestination`](#networkdestination) | Match any destination |
-| `Destination.ip(ip)` | [`NetworkDestination`](#networkdestination) | Match an exact IPv4 or IPv6 address. Stored as `/32` for IPv4 or `/128` for IPv6 |
-| `Destination.cidr(cidr)` | [`NetworkDestination`](#networkdestination) | Match a CIDR range |
-| `Destination.domain(domain)` | [`NetworkDestination`](#networkdestination) | Match an exact domain |
-| `Destination.domain_suffix(suffix)` | [`NetworkDestination`](#networkdestination) | Match the apex domain and all subdomains |
-| `Destination.group(group)` | [`NetworkDestination`](#networkdestination) | Match a [`DestGroup`](#destgroup) value |
-
-Bare IP strings such as `"1.1.1.1"` remain supported and are parsed like `Destination.ip("1.1.1.1")`. Prefer `Destination.ip(...)` when the value is known to be an IP address.
+Bare IP strings such as `"1.1.1.1"` remain supported on [`Rule`](#rule) destinations and are parsed like `Destination.ip("1.1.1.1")`. Prefer the typed helper when the value is known to be an IP.
 
 ---
 
+#### <span className="msb-recv">Destination.</span><span className="msb-hn">any()</span>
+<div className="msb-tags"><span className="msb-tag is-static">staticmethod</span></div>
+
+```python
+@staticmethod
+def any() -> NetworkDestination
+```
+
+Match any destination.
+
+---
+
+#### <span className="msb-recv">Destination.</span><span className="msb-hn">ip()</span>
+<div className="msb-tags"><span className="msb-tag is-static">staticmethod</span></div>
+
+```python
+@staticmethod
+def ip(ip: str) -> NetworkDestination
+```
+
+Match an exact IPv4 or IPv6 address. Stored as `/32` for IPv4 or `/128` for IPv6.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ip</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">IPv4 or IPv6 address.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Destination.</span><span className="msb-hn">cidr()</span>
+<div className="msb-tags"><span className="msb-tag is-static">staticmethod</span></div>
+
+```python
+@staticmethod
+def cidr(cidr: str) -> NetworkDestination
+```
+
+Match a CIDR range.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cidr</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">CIDR notation, e.g. <code>"10.0.0.0/8"</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Destination.</span><span className="msb-hn">domain()</span>
+<div className="msb-tags"><span className="msb-tag is-static">staticmethod</span></div>
+
+```python
+@staticmethod
+def domain(domain: str) -> NetworkDestination
+```
+
+Match an exact domain. Domain strings are validated at sandbox creation; invalid names raise `ValueError`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>domain</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Fully qualified domain name.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Destination.</span><span className="msb-hn">domain_suffix()</span>
+<div className="msb-tags"><span className="msb-tag is-static">staticmethod</span></div>
+
+```python
+@staticmethod
+def domain_suffix(suffix: str) -> NetworkDestination
+```
+
+Match the apex domain and all subdomains.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>suffix</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Domain suffix, e.g. <code>".example.com"</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Destination.</span><span className="msb-hn">group()</span>
+<div className="msb-tags"><span className="msb-tag is-static">staticmethod</span></div>
+
+```python
+@staticmethod
+def group(group: DestGroup | str) -> NetworkDestination
+```
+
+Match a well-known [`DestGroup`](#destgroup) address group.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>group</code><a className="msb-type" href="#destgroup">DestGroup | str</a></div>
+    <div className="msb-param-desc">Group keyword.</div>
+  </div>
+</div>
+
+## PortBinding factory
+
+[`PortBinding`](#portbinding) is a frozen dataclass for published ports that need an explicit host bind address or UDP. Prefer the protocol-specific constructors over building one by hand.
+
+```python
+PortBinding.tcp(8001, 8001, bind="0.0.0.0")
+PortBinding.udp(5353, 5353, bind="0.0.0.0")
+```
+
+Pass them to `Network(ports=(...))`. A plain `dict[int, int]` is also accepted for the common case, binding TCP to `127.0.0.1`.
+
+---
+
+#### <span className="msb-recv">PortBinding.</span><span className="msb-hn">tcp()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
+
+```python
+@classmethod
+def tcp(cls, host_port: int, guest_port: int, *, bind: str = "127.0.0.1") -> PortBinding
+```
+
+Publish a TCP port from the sandbox to the host.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_port</code><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_port</code><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>bind</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Host bind address. Defaults to <code>127.0.0.1</code>; use <code>0.0.0.0</code> for all IPv4 interfaces.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#portbinding">PortBinding</a></div>
+    <div className="msb-param-desc">A TCP port binding.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">PortBinding.</span><span className="msb-hn">udp()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
+
+```python
+@classmethod
+def udp(cls, host_port: int, guest_port: int, *, bind: str = "127.0.0.1") -> PortBinding
+```
+
+Publish a UDP port from the sandbox to the host.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_port</code><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_port</code><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>bind</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Host bind address. Defaults to <code>127.0.0.1</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#portbinding">PortBinding</a></div>
+    <div className="msb-param-desc">A UDP port binding.</div>
+  </div>
+</div>
+
+## Types
+
+### Network
+
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
+
+<p className="msb-backref">Used by <a href="/sdk/python/sandbox#sandbox-create">Sandbox.create(network=...)</a></p>
+
+Frozen dataclass for sandbox network configuration. Use a [class-method preset](#network-factory) for the common cases, or construct directly with custom options.
+
+```python
+Network(
+    policy: str | NetworkPolicy | None = None,
+    ports: Mapping[int, int] | Sequence[PortBinding] = {},
+    deny_domains: tuple[str, ...] = (),
+    deny_domain_suffixes: tuple[str, ...] = (),
+    dns: DnsConfig | None = None,
+    tls: TlsConfig | None = None,
+    ipv4_pool: str | None = None,
+    ipv6_pool: str | None = None,
+    max_connections: int | None = None,
+    on_secret_violation: ViolationAction | ViolationPolicy = ViolationAction.BLOCK_AND_LOG,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| policy | `str \| `[`NetworkPolicy`](#networkpolicy)` \| None` | `None` | Preset name (`"none"`, `"public_only"`, `"allow_all"`) or a custom [`NetworkPolicy`](#networkpolicy) |
+| ports | `Mapping[int, int] \| Sequence[`[`PortBinding`](#portbinding)`]` | `{}` | Port mappings from host to guest. Mapping form binds TCP to `127.0.0.1`; [`PortBinding`](#portbinding) can set an explicit bind address or UDP |
+| deny_domains | `tuple[str, ...]` | `()` | Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (NXDOMAIN), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy so it takes precedence over later allow rules |
+| deny_domain_suffixes | `tuple[str, ...]` | `()` | Deny egress to all subdomains of these suffixes. Adds `deny DomainSuffix("...")` rules; same enforcement layers as `deny_domains` |
+| dns | [`DnsConfig`](#dnsconfig)` \| None` | `None` | DNS interception configuration |
+| tls | [`TlsConfig`](#tlsconfig)` \| None` | `None` | TLS interception configuration |
+| ipv4_pool | `str \| None` | `None` | IPv4 pool used for per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12` |
+| ipv6_pool | `str \| None` | `None` | IPv6 pool used for per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48` |
+| max_connections | `int \| None` | `None` | Maximum concurrent connections |
+| on_secret_violation | [`ViolationAction`](/sdk/python/secrets#violationaction)` \| `[`ViolationPolicy`](/sdk/python/secrets#violationpolicy) | `BLOCK_AND_LOG` | Sandbox-wide action when a secret placeholder reaches a disallowed host |
+
+| Class method | Returns | Description |
+|--------------|---------|-------------|
+| [none()](#network-none) | [`Network`](#network) | Deny all traffic, no interface |
+| [public_only()](#network-public_only) | [`Network`](#network) | Public destinations only (default) |
+| [allow_all()](#network-allow_all) | [`Network`](#network) | Unrestricted access |
+
+### NetworkPolicy
+
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
+
+<p className="msb-backref">Used by <a href="#network">Network(policy=...)</a></p>
+
+Frozen dataclass: an ordered list of [`Rule`](#rule) values plus two per-direction defaults, evaluated first-match-wins. The defaults are asymmetric to preserve today's behavior: egress falls through to deny (public_only reachability when paired with the implicit allow-public rule); ingress falls through to allow (unfiltered published-port behavior).
+
+```python
+NetworkPolicy(
+    default_egress: Action = Action.DENY,
+    default_ingress: Action = Action.ALLOW,
+    rules: tuple[Rule, ...] = (),
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| default_egress | [`Action`](#action) | `DENY` | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | `ALLOW` | Action when no ingress-applicable rule matches |
+| rules | `tuple[`[`Rule`](#rule)`, ...]` | `()` | Rules evaluated first-match-wins per direction |
+
+### Rule
+
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
+
+<p className="msb-backref">Used by <a href="#networkpolicy">NetworkPolicy(rules=...)</a></p>
+
+Frozen dataclass for a single network policy rule. Prefer the [`Rule.allow()`](#rule-allow) / [`Rule.deny()`](#rule-deny) class methods over the positional constructor.
+
+```python
+Rule(
+    action: Action,
+    direction: Direction = Direction.EGRESS,
+    destination: str | NetworkDestination | None = None,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| action | [`Action`](#action) | - | What to do when this rule matches |
+| direction | [`Direction`](#direction) | `EGRESS` | Which evaluator considers this rule. `Direction.ANY` matches in either direction |
+| destination | `str \| `[`NetworkDestination`](#networkdestination)` \| None` | `None` | Target filter. Prefer typed [`Destination`](#destination) helpers; string shorthand also works ([`DestGroup`](#destgroup) values, exact IPs, domains, CIDR ranges, domain suffixes prefixed with `"."`, or `"*"` for any). Domain and suffix strings are validated at sandbox creation; invalid names raise `ValueError` |
+| protocol | [`Protocol`](#protocol)` \| None` | `None` | Protocol filter |
+| port | `int \| str \| None` | `None` | Single port (`443`) or range (`"8000-9000"`) |
+
+Ingress rules carrying ICMP protocols are rejected at sandbox creation; the host has no inbound ICMP path. Use `Direction.EGRESS` for ICMP allow/deny.
+
+| Class method | Returns | Description |
+|--------------|---------|-------------|
+| [allow(...)](#rule-allow) | [`Rule`](#rule) | Permit matching traffic |
+| [deny(...)](#rule-deny) | [`Rule`](#rule) | Block matching traffic |
+| [allow_dns()](#rule-allow_dns) | `tuple[`[`Rule`](#rule)`, `[`Rule`](#rule)`]` | Open plain DNS to the gateway |
+
+### Destination
+
+<div className="msb-tags"><span className="msb-tag is-type">factory</span></div>
+
+<p className="msb-backref">Returns <a href="#networkdestination">NetworkDestination</a> · used by <a href="#rule">Rule.allow() / Rule.deny()</a></p>
+
+Factory namespace ([static methods](#destination-factory)) producing typed [`NetworkDestination`](#networkdestination) values.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [any()](#destination-any) | [`NetworkDestination`](#networkdestination) | Match any destination |
+| [ip(ip)](#destination-ip) | [`NetworkDestination`](#networkdestination) | Match an exact IPv4 or IPv6 address (`/32` or `/128`) |
+| [cidr(cidr)](#destination-cidr) | [`NetworkDestination`](#networkdestination) | Match a CIDR range |
+| [domain(domain)](#destination-domain) | [`NetworkDestination`](#networkdestination) | Match an exact domain |
+| [domain_suffix(suffix)](#destination-domain_suffix) | [`NetworkDestination`](#networkdestination) | Match the apex domain and all subdomains |
+| [group(group)](#destination-group) | [`NetworkDestination`](#networkdestination) | Match a [`DestGroup`](#destgroup) value |
+
 ### NetworkDestination
+
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
+
+<p className="msb-backref">Produced by <a href="#destination">Destination</a> helpers</p>
 
 Frozen dataclass produced by [`Destination`](#destination) helpers.
 
@@ -352,16 +694,47 @@ NetworkDestination(
 )
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| kind | `Literal["any", "ip", "cidr", "domain", "domain_suffix", "group"]` | Destination variant |
-| value | `str \| None` | Variant value, omitted for `Destination.any()` |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| kind | `Literal["any", "ip", "cidr", "domain", "domain_suffix", "group"]` | - | Destination variant |
+| value | `str \| None` | `None` | Variant value, omitted for `Destination.any()` |
 
----
+### PortBinding
 
-## DnsConfig
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
 
-Frozen dataclass for DNS interception settings.
+<p className="msb-backref">Used by <a href="#network">Network(ports=...)</a></p>
+
+Frozen dataclass for a published host-to-guest port with an optional host bind address. Prefer the [`PortBinding.tcp()`](#portbinding-tcp) / [`PortBinding.udp()`](#portbinding-udp) class methods.
+
+```python
+PortBinding(
+    host_port: int,
+    guest_port: int,
+    bind: str = "127.0.0.1",
+    protocol: PortProtocol = PortProtocol.TCP,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| host_port | `int` | - | Port on the host |
+| guest_port | `int` | - | Port inside the sandbox |
+| bind | `str` | `"127.0.0.1"` | Host address to bind. Use `0.0.0.0` for all IPv4 interfaces |
+| protocol | [`PortProtocol`](#portprotocol) | `TCP` | Published port protocol |
+
+| Class method | Returns | Description |
+|--------------|---------|-------------|
+| [tcp(host_port, guest_port, *, bind)](#portbinding-tcp) | [`PortBinding`](#portbinding) | A TCP port binding |
+| [udp(host_port, guest_port, *, bind)](#portbinding-udp) | [`PortBinding`](#portbinding) | A UDP port binding |
+
+### DnsConfig
+
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
+
+<p className="msb-backref">Used by <a href="#network">Network(dns=...)</a></p>
+
+Frozen dataclass for DNS interception settings. The value type of [`Network.dns`](#network); import it from `microsandbox.types`.
 
 ```python
 DnsConfig(
@@ -371,15 +744,17 @@ DnsConfig(
 )
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| nameservers | `tuple[str, ...]` | Nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). Overrides the host's `/etc/resolv.conf` when set. Hostnames are resolved once at startup via the host's OS resolver |
-| query_timeout_ms | `int \| None` | Per-DNS-query timeout in milliseconds |
-| rebind_protection | `bool` | Block DNS responses resolving to private IPs |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| rebind_protection | `bool` | `True` | Block DNS responses resolving to private IPs |
+| nameservers | `tuple[str, ...]` | `()` | Nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). Overrides the host's `/etc/resolv.conf` when set. Hostnames are resolved once at startup via the host's OS resolver |
+| query_timeout_ms | `int \| None` | `None` | Per-DNS-query timeout in milliseconds. Defaults to `5000` |
 
----
+### TlsConfig
 
-## TlsConfig
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
+
+<p className="msb-backref">Used by <a href="#network">Network(tls=...)</a></p>
 
 Frozen dataclass for TLS interception settings within [`Network`](#network).
 
@@ -395,23 +770,23 @@ TlsConfig(
 )
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| block_quic | `bool` | Block QUIC/HTTP3 (UDP) on intercepted ports, forcing TCP/TLS fallback |
-| bypass | `tuple[str, ...]` | Domains to skip interception. Use for domains with certificate pinning |
-| ca_cert | `str \| None` | Path to a custom interception CA certificate PEM file |
-| ca_cn | `str \| None` | Common name for the generated interception CA |
-| ca_key | `str \| None` | Path to a custom interception CA private key PEM file |
-| intercepted_ports | `tuple[int, ...]` | TCP ports where TLS interception is active |
-| verify_upstream | `bool` | Verify upstream server certificates. Set to `False` only for self-signed servers |
-
----
-
-## Types
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| bypass | `tuple[str, ...]` | `()` | Domains to skip interception. Use for domains with certificate pinning |
+| verify_upstream | `bool` | `True` | Verify upstream server certificates. Set to `False` only for self-signed servers |
+| intercepted_ports | `tuple[int, ...]` | `(443,)` | TCP ports where TLS interception is active |
+| block_quic | `bool` | `False` | Block QUIC/HTTP3 (UDP) on intercepted ports, forcing TCP/TLS fallback |
+| ca_cert | `str \| None` | `None` | Path to a custom interception CA certificate PEM file |
+| ca_key | `str \| None` | `None` | Path to a custom interception CA private key PEM file |
+| ca_cn | `str \| None` | `None` | Common name for the generated interception CA |
 
 ### Action
 
-String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) for policy actions.
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#networkpolicy">NetworkPolicy</a> · <a href="#rule">Rule</a></p>
+
+String enum (`StrEnum`) for policy actions, so the string values are accepted directly.
 
 | Value | Description |
 |-------|-------------|
@@ -419,6 +794,10 @@ String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnu
 | `"deny"` | Drop the traffic silently |
 
 ### Direction
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#rule">Rule</a></p>
 
 String enum for traffic direction.
 
@@ -429,6 +808,10 @@ String enum for traffic direction.
 | `"any"` | Rule applies in either direction |
 
 ### Protocol
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#rule">Rule</a></p>
 
 String enum for network protocols in policy rules.
 
@@ -441,6 +824,10 @@ String enum for network protocols in policy rules.
 
 ### PortProtocol
 
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#portbinding">PortBinding</a></p>
+
 String enum for port-level protocol selection.
 
 | Value | Description |
@@ -450,7 +837,11 @@ String enum for port-level protocol selection.
 
 ### DestGroup
 
-String enum for well-known destination groups used in [`Destination.group()`](#destination) or string-shorthand [`Rule.destination`](#rule).
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#destination">Destination.group()</a></p>
+
+String enum for well-known destination groups used in [`Destination.group()`](#destination-group) or string-shorthand [`Rule.destination`](#rule).
 
 | Value | Description |
 |-------|-------------|

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -3,60 +3,130 @@ title: Sandbox
 description: Python SDK - Sandbox API reference
 ---
 
-See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Static<span className="msb-ct">7</span></p>
+  <a className="msb-row" href="#sandbox-create"><span className="msb-rn">Sandbox.create()</span><span className="msb-rg">configure and boot a sandbox</span></a>
+  <a className="msb-row" href="#sandbox-create_with_progress"><span className="msb-rn">Sandbox.create_with_progress()</span><span className="msb-rg">boot with pull progress</span></a>
+  <a className="msb-row" href="#sandbox-start"><span className="msb-rn">Sandbox.start()</span><span className="msb-rg">restart a stopped one</span></a>
+  <a className="msb-row" href="#sandbox-get"><span className="msb-rn">Sandbox.get()</span><span className="msb-rg">handle to an existing one</span></a>
+  <a className="msb-row" href="#sandbox-list"><span className="msb-rn">Sandbox.list()</span><span className="msb-rg">all sandboxes</span></a>
+  <a className="msb-row" href="#sandbox-list_with"><span className="msb-rn">Sandbox.list_with()</span><span className="msb-rg">filter by labels</span></a>
+  <a className="msb-row" href="#sandbox-remove"><span className="msb-rn">Sandbox.remove()</span><span className="msb-rg">delete a stopped one</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Properties<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#sb-name"><span className="msb-rn">sb.name()</span><span className="msb-rg">sandbox name (async method)</span></a>
+  <a className="msb-row" href="#sb-owns_lifecycle"><span className="msb-rn">sb.owns_lifecycle</span><span className="msb-rg">attached vs detached (async)</span></a>
+  <a className="msb-row" href="#sb-fs"><span className="msb-rn">sb.fs</span><span className="msb-rg">read / write files</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance<span className="msb-ct">18</span></p>
+  <a className="msb-row" href="/sdk/python/execution"><span className="msb-rn">sb.exec()</span><span className="msb-rg">run a command</span></a>
+  <a className="msb-row" href="/sdk/python/execution"><span className="msb-rn">sb.exec_stream()</span><span className="msb-rg">run, stream events</span></a>
+  <a className="msb-row" href="/sdk/python/execution"><span className="msb-rn">sb.shell()</span><span className="msb-rg">run through a shell</span></a>
+  <a className="msb-row" href="/sdk/python/execution"><span className="msb-rn">sb.shell_stream()</span><span className="msb-rg">shell, stream events</span></a>
+  <a className="msb-row" href="/sdk/python/ssh"><span className="msb-rn">sb.ssh()</span><span className="msb-rg">SSH client / server</span></a>
+  <a className="msb-row" href="#sb-attach"><span className="msb-rn">sb.attach()</span><span className="msb-rg">interactive PTY session</span></a>
+  <a className="msb-row" href="#sb-attach_shell"><span className="msb-rn">sb.attach_shell()</span><span className="msb-rg">attach to the shell</span></a>
+  <a className="msb-row" href="#sb-metrics"><span className="msb-rn">sb.metrics()</span><span className="msb-rg">resource snapshot</span></a>
+  <a className="msb-row" href="#sb-metrics_stream"><span className="msb-rn">sb.metrics_stream()</span><span className="msb-rg">stream metrics</span></a>
+  <a className="msb-row" href="#sb-logs"><span className="msb-rn">sb.logs()</span><span className="msb-rg">captured output</span></a>
+  <a className="msb-row" href="#sb-log_stream"><span className="msb-rn">sb.log_stream()</span><span className="msb-rg">stream / follow logs</span></a>
+  <a className="msb-row" href="#sb-stop"><span className="msb-rn">sb.stop()</span><span className="msb-rg">graceful shutdown</span></a>
+  <a className="msb-row" href="#sb-request_stop"><span className="msb-rn">sb.request_stop()</span><span className="msb-rg">request stop, don't wait</span></a>
+  <a className="msb-row" href="#sb-kill"><span className="msb-rn">sb.kill()</span><span className="msb-rg">force terminate</span></a>
+  <a className="msb-row" href="#sb-request_kill"><span className="msb-rn">sb.request_kill()</span><span className="msb-rg">signal kill, don't wait</span></a>
+  <a className="msb-row" href="#sb-request_drain"><span className="msb-rn">sb.request_drain()</span><span className="msb-rg">graceful drain</span></a>
+  <a className="msb-row" href="#sb-wait_until_stopped"><span className="msb-rn">sb.wait_until_stopped()</span><span className="msb-rg">block until it exits</span></a>
+  <a className="msb-row" href="#sb-detach"><span className="msb-rn">sb.detach()</span><span className="msb-rg">release, keep running</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Patch factory · Patch<span className="msb-ct">7</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#patch-text">Patch.text()</a>
+    <a className="msb-chip" href="#patch-append">Patch.append()</a>
+    <a className="msb-chip" href="#patch-mkdir">Patch.mkdir()</a>
+    <a className="msb-chip" href="#patch-remove">Patch.remove()</a>
+    <a className="msb-chip" href="#patch-copy_file">Patch.copy_file()</a>
+    <a className="msb-chip" href="#patch-copy_dir">Patch.copy_dir()</a>
+    <a className="msb-chip" href="#patch-symlink">Patch.symlink()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#sandboxconfig">SandboxConfig</a>
+    <a className="msb-typepill" href="#initconfig">InitConfig</a>
+    <a className="msb-typepill" href="#securityprofile">SecurityProfile</a>
+    <a className="msb-typepill" href="#sandboxhandle">SandboxHandle</a>
+    <a className="msb-typepill" href="#sandboxstopresult">SandboxStopResult</a>
+    <a className="msb-typepill" href="#sandboxstatus">SandboxStatus</a>
+    <a className="msb-typepill" href="#sandboxmetrics">SandboxMetrics</a>
+    <a className="msb-typepill" href="#metricsstream">MetricsStream</a>
+    <a className="msb-typepill" href="#logentry">LogEntry</a>
+    <a className="msb-typepill" href="#logstream">LogStream</a>
+    <a className="msb-typepill" href="#logsource">LogSource</a>
+    <a className="msb-typepill" href="#loglevel">LogLevel</a>
+    <a className="msb-typepill" href="#pullpolicy">PullPolicy</a>
+    <a className="msb-typepill" href="#registryauth">RegistryAuth</a>
+    <a className="msb-typepill" href="#patchconfig">PatchConfig</a>
+    <a className="msb-typepill" href="#pullsession">PullSession</a>
+    <a className="msb-typepill" href="#pullevent">PullEvent</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```python
+from microsandbox import Sandbox
+
+# 1. configure + 2. boot the microVM
+async with await Sandbox.create("api", image="python", memory=1024) as sb:
+    # 3. run
+    out = await sb.exec("python", ["-V"])
+    print(out.stdout_text)
+# 4. on exit the sandbox is killed and its state removed
+```
 
 ## Static methods
 
 ---
 
-#### Sandbox.create()
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @staticmethod
 async def create(name: str, **kwargs) -> Sandbox
 ```
 
-Create and boot a sandbox. Keyword arguments provide individual config fields. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes.
+Create and boot a sandbox. Keyword arguments provide individual config fields; see [`SandboxConfig`](#sandboxconfig) for the full set. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes.
 
-**Parameters**
+The returned `Sandbox` is an async context manager. Use `async with` to guarantee cleanup; on exit the sandbox is killed and its persisted state removed.
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `str` | Sandbox name, up to 128 UTF-8 bytes |
-| image | `str \| ImageSource` | OCI image, local path, or disk image. Required unless `snapshot=` is passed. Use `Image.oci("python:3.12", upper_size_mib=8192)` to set an OCI upper size |
-| snapshot | `str \| os.PathLike` | Snapshot artifact to boot from instead of `image=`. Mutually exclusive with `image=` |
-| cpus | `int` | Virtual CPUs (default `1`) |
-| memory | `int` | Guest memory in MiB (default `512`) |
-| workdir | `str` | Default working directory for commands |
-| shell | `str` | Shell for `shell()` calls (default `"/bin/sh"`) |
-| security | [`SecurityProfile`](#securityprofile) \| `str` | In-guest security profile. `RESTRICTED` sets `no_new_privs`, drops mount-admin capability from user commands, and forces `nosuid,nodev` on user mounts |
-| hostname | `str` | Guest hostname |
-| user | `str` | Default guest user |
-| entrypoint | `list[str]` | Override the image's stored ENTRYPOINT. Consulted by `msb exec` / `msb run` (CLI command resolution), **not** by `sb.exec` / `sb.shell` — those pass `cmd` literally |
-| init | `str \| dict \|` [`InitConfig`](#initconfig) | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) and [`InitConfig`](#initconfig) for accepted shapes |
-| replace | `bool` | Replace existing sandbox with same name (10s SIGTERM grace, then SIGKILL) |
-| replace_with_timeout | `float` | Seconds to wait after `SIGTERM` before escalating to `SIGKILL` (default `10`; `0` skips `SIGTERM`). Implies `replace=True` |
-| max_duration | `float` | Maximum sandbox lifetime in seconds |
-| idle_timeout | `float` | Idle timeout in seconds |
-| env | `dict[str, str]` | Environment variables visible to all commands |
-| scripts | `dict[str, str]` | Named scripts mounted at `/.msb/scripts/` and added to `PATH` |
-| pull_policy | `str \| PullPolicy` | Image pull behavior |
-| log_level | `str \| LogLevel` | Override log verbosity |
-| registry_auth | [`RegistryAuth`](#registryauth) | Private registry credentials |
-| volumes | `dict[str, MountConfig]` | Volume mounts. See [Volumes](/sdk/python/volumes). |
-| patches | `list[PatchConfig]` | Rootfs modifications applied before boot |
-| ports | `dict[int, int] \| Sequence[PortBinding]` | Port mappings. Dict form is TCP and binds to `127.0.0.1`; use [`PortBinding`](/sdk/python/networking#portbinding) for explicit bind addresses or UDP |
-| network | [`Network`](/sdk/python/networking#network) | Network policy and configuration |
-| secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | Secret injection |
-| detached | `bool` | If `True`, spawn the sandbox in detached mode; call [`detach()`](#detach) before dropping the returned handle when it should keep running |
+<p className="msb-label">Parameters</p>
 
-**Returns**
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>**kwargs</code><a className="msb-type" href="#sandboxconfig">SandboxConfig</a></div>
+    <div className="msb-param-desc">Configuration fields: <code>image</code>, <code>cpus</code>, <code>memory</code>, <code>volumes</code>, <code>ports</code>, <code>network</code>, <code>secrets</code>, <code>detached</code>, and more.</div>
+  </div>
+</div>
 
-| Type | Description |
-|------|-------------|
-| [`Sandbox`](#instance-methods) | Running sandbox |
+<p className="msb-label">Returns</p>
 
-The returned `Sandbox` is an async context manager. Use `async with` to guarantee cleanup; on exit the sandbox is killed and its persisted state removed:
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Sandbox</a></div>
+    <div className="msb-param-desc">Running sandbox, usable as an async context manager.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```python
 async with await Sandbox.create("my-sandbox", image="alpine") as sb:
@@ -67,28 +137,52 @@ async with await Sandbox.create("my-sandbox", image="alpine") as sb:
 
 ---
 
-#### Sandbox.create_with_progress()
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">create_with_progress()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```python
 @staticmethod
 def create_with_progress(name: str, **kwargs) -> PullSession
 ```
 
-Same parameters as [`Sandbox.create()`](#sandboxcreate) but returns a [`PullSession`](#pullsession) that lets you track image pull progress before the sandbox is ready. This method is synchronous (not awaitable) -- the async work happens through the `PullSession`.
+Same parameters as [`create()`](#sandbox-create) but returns a [`PullSession`](#pullsession) that lets you track image pull progress before the sandbox is ready. This method is synchronous (not awaitable); the async work happens through the `PullSession`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-Same as [`Sandbox.create()`](#sandboxcreate).
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>**kwargs</code><a className="msb-type" href="#sandboxconfig">SandboxConfig</a></div>
+    <div className="msb-param-desc">Same configuration fields as <a href="#sandbox-create">create()</a>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`PullSession`](#pullsession) | Session for tracking pull progress and obtaining the final sandbox |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#pullsession">PullSession</a></div>
+    <div className="msb-param-desc">Session for tracking pull progress and obtaining the final sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+session = Sandbox.create_with_progress("my-sandbox", image="ubuntu:latest")
+async with session:
+    async for event in session.progress:
+        print(event.event_type)
+    sb = await session.result()
+```
 
 ---
 
-#### Sandbox.start()
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">start()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @staticmethod
@@ -97,45 +191,75 @@ async def start(name: str, *, detached: bool = False) -> Sandbox
 
 Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `str` | Name of a stopped sandbox, up to 128 UTF-8 bytes |
-| detached | `bool` | If `True`, sandbox survives after your process exits (default `False`) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Name of a stopped sandbox, up to 128 UTF-8 bytes.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>detached</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>True</code>, the sandbox survives after your process exits. Default <code>False</code>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`Sandbox`](#instance-methods) | Running sandbox |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Sandbox</a></div>
+    <div className="msb-param-desc">Running sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+sb = await Sandbox.start("api")
+```
 
 ---
 
-#### Sandbox.get()
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">get()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @staticmethod
 async def get(name: str) -> SandboxHandle
 ```
 
-Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control.
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control without requiring a full connection to the guest agent.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `str` | Sandbox name, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxhandle">SandboxHandle</a></div>
+    <div className="msb-param-desc">Handle with status and lifecycle control.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+handle = await Sandbox.get("api")
+print(handle.status)
+```
 
 ---
 
-#### Sandbox.list()
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @staticmethod
@@ -144,28 +268,84 @@ async def list() -> list[SandboxHandle]
 
 List all sandboxes (running, stopped, and crashed).
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `list[`[`SandboxHandle`](#sandboxhandle)`]` | All sandboxes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxhandle">list[SandboxHandle]</a></div>
+    <div className="msb-param-desc">All sandbox handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+for h in await Sandbox.list():
+    print(h.name, h.status)
+```
 
 ---
 
-#### Sandbox.remove()
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">list_with()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def list_with(*, labels: Mapping[str, str] | None = None) -> list[SandboxHandle]
+```
+
+List sandboxes filtered by label. Only sandboxes whose labels match every supplied key/value pair are returned.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>labels</code><span className="msb-type">Mapping[str, str] | None</span></div>
+    <div className="msb-param-desc">Label key/value pairs to match. <code>None</code> returns every sandbox, like <a href="#sandbox-list">list()</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxhandle">list[SandboxHandle]</a></div>
+    <div className="msb-param-desc">Matching sandbox handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+workers = await Sandbox.list_with(labels={"role": "worker"})
+```
+
+---
+
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @staticmethod
 async def remove(name: str) -> None
 ```
 
-Delete a stopped sandbox and all its state from disk. Fails if the sandbox is still running.
+Delete a stopped sandbox and all its state from disk (configuration, logs, runtime directory). Fails if the sandbox is still running; stop it first.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `str` | Sandbox name, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await Sandbox.remove("api")
+```
 
 ---
 
@@ -173,53 +353,92 @@ Delete a stopped sandbox and all its state from disk. Fails if the sandbox is st
 
 ---
 
-#### name
+#### <span className="msb-recv">sb.</span><span className="msb-hn">name</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-@property
 async def name(self) -> str
 ```
 
-Sandbox name. Names are limited to 128 UTF-8 bytes. This is an async property -- use `await sb.name`.
+The sandbox name. This is an async method; call `await sb.name()`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+print(await sb.name())
+```
 
 ---
 
-#### owns_lifecycle
+#### <span className="msb-recv">sb.</span><span className="msb-hn">owns_lifecycle</span>
+<div className="msb-tags"><span className="msb-tag is-instance">property</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @property
 async def owns_lifecycle(self) -> bool
 ```
 
-Whether this handle owns the sandbox lifecycle. A sandbox returned directly by [`create()`](#sandboxcreate) or [`start()`](#sandboxstart) owns lifecycle, including when created with `detached=True`, until you call [`detach()`](#detach). Handles returned by [`connect()`](#connect) do not own lifecycle. This is an async property -- use `await sb.owns_lifecycle`.
+Whether this handle owns the sandbox lifecycle. A sandbox returned directly by [`create()`](#sandbox-create) or [`start()`](#sandbox-start) owns lifecycle, including when created with `detached=True`, until you call [`detach()`](#sb-detach). Handles upgraded via [`SandboxHandle.connect()`](#sandboxhandle) do not own lifecycle. This is an async property; use `await sb.owns_lifecycle`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>True</code> if this handle owns the lifecycle.</div>
+  </div>
+</div>
 
 ---
 
-#### fs
+#### <span className="msb-recv">sb.</span><span className="msb-hn">fs</span>
+<div className="msb-tags"><span className="msb-tag is-instance">property</span></div>
 
 ```python
 @property
 def fs(self) -> SandboxFsOps
 ```
 
-Get a filesystem handle for reading and writing files inside the running sandbox. This is a synchronous property -- use `sb.fs` (no `await`). See [Filesystem](/sdk/python/filesystem) for API details.
+Get a filesystem handle for reading and writing files inside the running sandbox. This is a synchronous property; use `sb.fs` (no `await`). See [Filesystem](/sdk/python/filesystem) for API details.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxFsOps`](/sdk/python/filesystem) | Filesystem handle |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/python/filesystem">SandboxFsOps</a></div>
+    <div className="msb-param-desc">Filesystem handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.fs.write("/tmp/hello.txt", b"hi")
+```
 
 ---
 
 ## Instance methods
 
+Command execution (`exec`, `exec_stream`, `shell`, `shell_stream`) is documented on the [Execution](/sdk/python/execution) page; SSH (`ssh`) on the [SSH](/sdk/python/ssh) page. The lifecycle, attach, metrics, and logs methods follow.
+
 ---
 
-#### attach()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">attach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def attach(
+    self,
     cmd: str,
     args: list[str] | None = None,
     *,
@@ -230,405 +449,476 @@ async def attach(
 ) -> int
 ```
 
-Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session.
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Returns the process exit code once the session ends.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `str` | Command to run |
-| args | `list[str] \| None` | Command arguments |
-| cwd | `str \| None` | Working directory |
-| user | `str \| None` | Guest user |
-| env | `Mapping[str, str] \| None` | Environment variables |
-| detach_keys | `str \| None` | Custom detach key sequence |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Command to run.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">list[str] | None</span></div>
+    <div className="msb-param-desc">Command arguments.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cwd</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Working directory.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>user</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Guest user.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>env</code><span className="msb-type">Mapping[str, str] | None</span></div>
+    <div className="msb-param-desc">Environment variables.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>detach_keys</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Custom detach key sequence.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `int` | Exit code of the process |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Exit code of the process.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+code = await sb.attach("python", ["-i"])
+```
 
 ---
 
-#### attach_shell()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">attach_shell()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def attach_shell() -> int
+async def attach_shell(self) -> int
 ```
 
-Attach to the sandbox's default shell.
+Attach your terminal to the sandbox's default shell for an interactive session.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `int` | Exit code |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Exit code.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.attach_shell()
+```
 
 ---
 
-#### detach()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">metrics()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def detach() -> None
+async def metrics(self) -> SandboxMetrics
 ```
 
-Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.get()`](#sandboxget).
+Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk I/O, network I/O, optional upper disk usage, and uptime.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxmetrics">SandboxMetrics</a></div>
+    <div className="msb-param-desc">Resource metrics.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+m = await sb.metrics()
+print(f"cpu {m.cpu_percent:.1f}% · mem {m.memory_bytes // 1_048_576} MiB")
+```
 
 ---
 
-#### request_drain()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">metrics_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def request_drain() -> None
+async def metrics_stream(self, interval: float = 1.0) -> MetricsStream
 ```
 
-Request a graceful drain and return once the request is sent. Existing commands run to completion, but new `exec` calls are rejected. Use [`wait_until_stopped()`](#wait_until_stopped) when the caller needs stopped-state observation.
+Stream resource metrics at a regular interval. The returned [`MetricsStream`](#metricsstream) supports both `recv()` and `async for`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>interval</code><span className="msb-type">float</span></div>
+    <div className="msb-param-desc">Seconds between metric snapshots. Default <code>1.0</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#metricsstream">MetricsStream</a></div>
+    <div className="msb-param-desc">Async stream yielding a snapshot each interval.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+stream = await sb.metrics_stream(1.0)
+async for snapshot in stream:
+    print(f"{snapshot.cpu_percent:.1f}%")
+```
 
 ---
 
-#### exec()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">logs()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def exec(
-    cmd: str,
-    args: list[str] | None = None,
-    *,
-    cwd: str | None = None,
-    user: str | None = None,
-    env: Mapping[str, str] | None = None,
-    timeout: float | None = None,
-    stdin: Stdin | bytes | str | None = None,
-    tty: bool = False,
-    rlimits: list[Rlimit] | None = None,
-) -> ExecOutput
+async def logs(
+    self,
+    tail: int | None = None,
+    since_ms: float | None = None,
+    until_ms: float | None = None,
+    sources: list[LogReadSource] | None = None,
+) -> list[LogEntry]
 ```
 
-Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike; there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
 
-Pass per-execution options as keyword-only arguments. The SDK still accepts the older second-positional options dict for compatibility, but prefer kwargs for new code.
+The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines, or `"all"` as shorthand for all four. Timestamps are exposed as `float` ms since the Unix epoch (UTC) for parity with [`SandboxMetrics.timestamp_ms`](#sandboxmetrics).
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `str` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
-| args | `list[str] \| None` | Command arguments |
-| cwd | `str \| None` | Working directory |
-| user | `str \| None` | Guest user |
-| env | `Mapping[str, str] \| None` | Environment variables |
-| timeout | `float \| None` | Kill the process after this many seconds |
-| stdin | [`Stdin`](/sdk/python/execution#stdin) `\| bytes \| str \| None` | Stdin source |
-| tty | `bool` | Allocate a pseudo-terminal |
-| rlimits | `list[`[`Rlimit`](/sdk/python/execution#rlimit)`] \| None` | Resource limits |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>tail</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Show only the last N entries after other filters apply.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>since_ms</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Inclusive lower bound on entry timestamp (ms since epoch).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>until_ms</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Exclusive upper bound on entry timestamp (ms since epoch).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>sources</code><a className="msb-type" href="#logsource">list[LogReadSource] | None</a></div>
+    <div className="msb-param-desc">Sources to include. <code>None</code> = <code>["stdout", "stderr", "output"]</code>. Add <code>"system"</code> to merge runtime/kernel diagnostics, or use <code>"all"</code> for all four.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#logentry">list[LogEntry]</a></div>
+    <div className="msb-param-desc">Matching entries in chronological order.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```python
-output = await sb.exec(
-    "python",
-    ["compute.py"],
-    cwd="/app",
-    env={"PYTHONPATH": "/app/lib"},
-    timeout=30.0,
+import time
+from microsandbox import Sandbox
+
+handle = await Sandbox.get("web")
+
+# Default — all user-program output, regardless of pipe/pty mode
+entries = await handle.logs()
+for e in entries:
+    label = {"stdout": "OUT", "stderr": "ERR", "output": "PTY", "system": "SYS"}[e.source]
+    print(f"[{e.timestamp_ms / 1000:.3f}] {label} {e.session_id}: {e.text().rstrip()}")
+
+# Filtered: last 50 entries from the past hour, including system lines
+recent = await handle.logs(
+    tail=50,
+    since_ms=(time.time() - 3600) * 1000,
+    sources=["stdout", "stderr", "output", "system"],
 )
 ```
 
 ---
 
-#### exec_stream()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">log_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def exec_stream(
-    cmd: str,
-    args: list[str] | None = None,
-    *,
-    cwd: str | None = None,
-    user: str | None = None,
-    env: Mapping[str, str] | None = None,
-    timeout: float | None = None,
-    stdin: Stdin | bytes | str | None = None,
-    tty: bool = False,
-    rlimits: list[Rlimit] | None = None,
-) -> ExecHandle
-```
-
-Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
-
-Like [`exec()`](#exec), pass per-execution options as keyword-only arguments. The older second-positional options dict remains accepted for compatibility.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `str` | Command to execute |
-| args | `list[str] \| None` | Command arguments |
-| cwd | `str \| None` | Working directory |
-| user | `str \| None` | Guest user |
-| env | `Mapping[str, str] \| None` | Environment variables |
-| timeout | `float \| None` | Kill the process after this many seconds |
-| stdin | [`Stdin`](/sdk/python/execution#stdin) `\| bytes \| str \| None` | Stdin source |
-| tty | `bool` | Allocate a pseudo-terminal |
-| rlimits | `list[`[`Rlimit`](/sdk/python/execution#rlimit)`] \| None` | Resource limits |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle for receiving events and controlling the process |
-
----
-
-#### kill()
-
-```python
-async def kill(timeout: float | None = None) -> None
-```
-
-Force-terminate the sandbox and wait until stopped state is observed. Pass `timeout` to control the observation timeout. No graceful shutdown. Pending writes that the workload hasn't `fsync`'d may be lost — same durability semantics as a sudden power loss on a physical machine. Use [`stop()`](#stop) for graceful shutdown that gives the workload a chance to flush.
-
----
-
-#### metrics()
-
-```python
-async def metrics() -> SandboxMetrics
-```
-
-Get a point-in-time snapshot of the sandbox's resource usage.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network, and optional upper disk metrics |
-
----
-
-#### metrics_stream()
-
-```python
-async def metrics_stream(interval: float = 1.0) -> MetricsStream
-```
-
-Stream resource metrics at a regular interval. The returned stream supports both `recv()` and `async for`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| interval | `float` | Seconds between metric snapshots (default `1.0`) |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`MetricsStream`](#metricsstream) | Async stream of metrics |
-
----
-
-#### logs()
-
-```python
-async def logs(
-    tail: int | None = None,
+async def log_stream(
+    self,
+    sources: list[LogReadSource] | None = None,
     since_ms: float | None = None,
+    from_cursor: str | None = None,
     until_ms: float | None = None,
-    sources: list[str] | None = None,
-) -> list[LogEntry]
+    follow: bool = False,
+) -> LogStream
 ```
 
-Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+Stream captured log entries as a [`LogStream`](#logstream). With `follow=True` the stream stays open and yields new entries as they are written, like `tail -f`. Resume an earlier stream by passing the [`cursor`](#logentry) of the last entry you saw as `from_cursor`. Also available on [`SandboxHandle`](#sandboxhandle).
 
-The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>sources</code><a className="msb-type" href="#logsource">list[LogReadSource] | None</a></div>
+    <div className="msb-param-desc">Sources to include. Same semantics as <a href="#sb-logs">logs()</a>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>since_ms</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Inclusive lower bound on entry timestamp (ms since epoch).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>from_cursor</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Resume after this opaque cursor (from a prior <a href="#logentry">LogEntry.cursor</a>).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>until_ms</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Exclusive upper bound on entry timestamp (ms since epoch).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>follow</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>True</code>, keep the stream open and yield new entries as they arrive. Default <code>False</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#logstream">LogStream</a></div>
+    <div className="msb-param-desc">Async stream of log entries.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```python
-import asyncio
-import microsandbox
-
-async def main():
-    handle = await microsandbox.Sandbox.get("web")
-
-    # Default — all user-program output, regardless of pipe/pty mode
-    entries = await handle.logs()
-
-    for e in entries:
-        source = {
-            "stdout": "OUT",
-            "stderr": "ERR",
-            "output": "PTY",
-            "system": "SYS",
-        }[e.source]
-        print(
-            f"[{e.timestamp_ms / 1000:.3f}] "
-            f"{source} {e.session_id}: {e.text().rstrip()}"
-        )
-
-    # Filtered: last 50 entries from the past hour, including system lines
-    import time
-    recent = await handle.logs(
-        tail=50,
-        since_ms=(time.time() - 3600) * 1000,
-        sources=["stdout", "stderr", "output", "system"],
-    )
-
-asyncio.run(main())
+stream = await sb.log_stream(follow=True)
+async for entry in stream:
+    print(entry.text().rstrip())
 ```
-
-Timestamps are exposed as `float` ms since the Unix epoch (UTC) for parity with `SandboxMetrics.timestamp_ms`. Convert to `datetime` if needed:
-
-```python
-from datetime import datetime, timezone
-dt = datetime.fromtimestamp(e.timestamp_ms / 1000, timezone.utc)
-```
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| tail | `int \| None` | Show only the last N entries after other filters apply |
-| since_ms | `float \| None` | Inclusive lower bound on entry timestamp (ms since epoch) |
-| until_ms | `float \| None` | Exclusive upper bound on entry timestamp (ms since epoch) |
-| sources | `list[str] \| None` | Sources to include. `None` = `["stdout", "stderr", "output"]`. Add `"system"` to merge runtime/kernel diagnostics. Use `"all"` as shorthand for all four. |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `list[`[`LogEntry`](#logentry)`]` | Matching entries in chronological order |
 
 ---
 
-#### remove()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">stop()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def remove() -> None
-```
-
-Remove the sandbox and all its persisted state from disk.
-
----
-
-#### shell()
-
-```python
-async def shell(
-    script: str,
-    *,
-    cwd: str | None = None,
-    user: str | None = None,
-    env: Mapping[str, str] | None = None,
-    timeout: float | None = None,
-    stdin: Stdin | bytes | str | None = None,
-    tty: bool = False,
-    rlimits: list[Rlimit] | None = None,
-) -> ExecOutput
-```
-
-Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| script | `str` | Shell command string (e.g. `"ls -la /app && echo done"`) |
-| cwd | `str \| None` | Working directory |
-| user | `str \| None` | Guest user |
-| env | `Mapping[str, str] \| None` | Environment variables |
-| timeout | `float \| None` | Kill the process after this many seconds |
-| stdin | [`Stdin`](/sdk/python/execution#stdin) `\| bytes \| str \| None` | Stdin source |
-| tty | `bool` | Allocate a pseudo-terminal |
-| rlimits | `list[`[`Rlimit`](/sdk/python/execution#rlimit)`] \| None` | Resource limits |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
-
----
-
-#### shell_stream()
-
-```python
-async def shell_stream(script: str) -> ExecHandle
-```
-
-Shell command with streaming output.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| script | `str` | Shell command string |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle |
-
----
-
-#### stop()
-
-```python
-async def stop(timeout: float | None = None) -> None
+async def stop(self, timeout: float | None = None) -> None
 ```
 
 Gracefully shut down the sandbox and wait until stopped state is observed. Lets the sandbox finish writing any pending data to disk before it exits, so files written inside the sandbox aren't lost across a later restart. Waits up to ten seconds by default; pass `timeout` to override the graceful shutdown window before force-kill escalation.
 
----
+<p className="msb-label">Parameters</p>
 
-#### request_stop()
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Seconds to wait for graceful exit before force-kill. <code>None</code> uses the ten-second default.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```python
-async def request_stop() -> None
+await sb.stop()
 ```
 
-Request graceful shutdown and return once the request is sent.
-
 ---
 
-#### request_kill()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">request_stop()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def request_kill() -> None
+async def request_stop(self) -> None
 ```
 
-Request force termination and return once the signal is sent.
+Request graceful shutdown and return once the request is sent, without waiting for stopped state. Pair with [`wait_until_stopped()`](#sb-wait_until_stopped) when the caller needs to observe the terminal state.
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.request_stop()
+```
 
 ---
 
-#### wait_until_stopped()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">kill()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def wait_until_stopped() -> SandboxStopResult
+async def kill(self, timeout: float | None = None) -> None
+```
+
+Force-terminate the sandbox and wait until stopped state is observed. No graceful shutdown; use when the sandbox is unresponsive. Pending writes that the workload hasn't `fsync`'d may be lost, same durability semantics as a sudden power loss on a physical machine. Prefer [`stop()`](#sb-stop) for graceful shutdown that gives the workload a chance to flush.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Seconds to wait for the stopped state to be observed.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.kill()  # SIGKILL, no graceful shutdown
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">request_kill()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def request_kill(self) -> None
+```
+
+Request force termination and return once the signal is sent, without waiting for stopped state.
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.request_kill()
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">request_drain()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def request_drain(self) -> None
+```
+
+Request a graceful drain and return once the request is sent. Existing commands run to completion, but new `exec` calls are rejected; the sandbox transitions to stopped when all in-flight commands finish. Useful for zero-downtime rotation of worker sandboxes. Use [`wait_until_stopped()`](#sb-wait_until_stopped) when the caller needs stopped-state observation.
+
+<p className="msb-label">Example</p>
+
+```python
+await sb.request_drain()
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">wait_until_stopped()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def wait_until_stopped(self) -> SandboxStopResult
 ```
 
 Block until the sandbox is observed in a terminal non-running state, without triggering a stop or kill request.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxStopResult`](#sandboxstopresult) | Terminal status and optional observed exit code |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxstopresult">SandboxStopResult</a></div>
+    <div className="msb-param-desc">Terminal status and optional observed exit code.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+result = await sb.wait_until_stopped()
+print(result.status, result.exit_code)
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">detach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def detach(self) -> None
+```
+
+Release the handle without stopping the sandbox. The sandbox continues running as a background process. Reconnect later with [`Sandbox.get()`](#sandbox-get).
+
+<p className="msb-label">Example</p>
+
+```python
+sb = await Sandbox.create("worker", image="python", detached=True)
+await sb.detach()  # keeps running in the background
+```
 
 ---
 
 ## Patch
 
-Factory class for rootfs patches passed to `Sandbox.create(..., patches=[...])`. Each static method returns a [`PatchConfig`](#patchconfig). By default a patch that targets a path already present in the image errors at boot; pass `replace=True` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
-
-See [Patches](/sandboxes/customize#patches) for conceptual context.
+Factory class for rootfs patches passed to `Sandbox.create(..., patches=[...])`. Each static method returns a [`PatchConfig`](#patchconfig). By default a patch that targets a path already present in the image errors at boot; pass `replace=True` on the operation to allow overwriting. `mkdir` and `remove` are idempotent. See [Patches](/sandboxes/customize#patches) for conceptual context.
 
 ---
 
-#### Patch.append()
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">text()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span><span className="msb-tag is-static">static</span></div>
+
+```python
+@staticmethod
+def text(path: str, content: str, *, mode: int | None = None, replace: bool = False) -> PatchConfig
+```
+
+Write UTF-8 text content at `path`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Text content.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mode</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">File mode, e.g. <code>0o644</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>replace</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>True</code>, overwrite an existing path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+from microsandbox import Patch, Sandbox
+
+sb = await Sandbox.create(
+    "api",
+    image="python",
+    patches=[Patch.text("/etc/app.conf", "debug=1\n", mode=0o644)],
+)
+```
+
+---
+
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">append()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span><span className="msb-tag is-static">static</span></div>
 
 ```python
 @staticmethod
@@ -637,61 +927,23 @@ def append(path: str, content: str) -> PatchConfig
 
 Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute path inside the guest |
-| content | `str` | Text to append |
-
----
-
-#### Patch.copy_dir()
-
-```python
-@staticmethod
-def copy_dir(src: str, dst: str, *, replace: bool = False) -> PatchConfig
-```
-
-Recursively copy a host directory at `src` into the guest rootfs at `dst`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| src | `str` | Host source directory |
-| dst | `str` | Absolute destination path inside the guest |
-| replace | `bool` | When `True`, overwrite an existing path at `dst` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Text to append.</div>
+  </div>
+</div>
 
 ---
 
-#### Patch.copy_file()
-
-```python
-@staticmethod
-def copy_file(
-    src: str,
-    dst: str,
-    *,
-    mode: int | None = None,
-    replace: bool = False,
-) -> PatchConfig
-```
-
-Copy a single host file at `src` into the guest rootfs at `dst`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| src | `str` | Host source file |
-| dst | `str` | Absolute destination path inside the guest |
-| mode | `int \| None` | File mode, e.g. `0o644`. `None` keeps the source mode |
-| replace | `bool` | When `True`, overwrite an existing path at `dst` |
-
----
-
-#### Patch.mkdir()
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span><span className="msb-tag is-static">static</span></div>
 
 ```python
 @staticmethod
@@ -700,16 +952,23 @@ def mkdir(path: str, *, mode: int | None = None) -> PatchConfig
 
 Create a directory at `path`. Idempotent: a no-op if the directory already exists.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute path inside the guest |
-| mode | `int \| None` | Directory mode, e.g. `0o755` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mode</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Directory mode, e.g. <code>0o755</code>.</div>
+  </div>
+</div>
 
 ---
 
-#### Patch.remove()
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span><span className="msb-tag is-static">static</span></div>
 
 ```python
 @staticmethod
@@ -718,15 +977,81 @@ def remove(path: str) -> PatchConfig
 
 Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute path inside the guest |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
 
 ---
 
-#### Patch.symlink()
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">copy_file()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span><span className="msb-tag is-static">static</span></div>
+
+```python
+@staticmethod
+def copy_file(src: str, dst: str, *, mode: int | None = None, replace: bool = False) -> PatchConfig
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Host source file.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute destination path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mode</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">File mode, e.g. <code>0o644</code>. <code>None</code> keeps the source mode.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>replace</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>True</code>, overwrite an existing path at <code>dst</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">copy_dir()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span><span className="msb-tag is-static">static</span></div>
+
+```python
+@staticmethod
+def copy_dir(src: str, dst: str, *, replace: bool = False) -> PatchConfig
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Host source directory.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute destination path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>replace</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>True</code>, overwrite an existing path at <code>dst</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Patch.</span><span className="msb-hn">symlink()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">factory</span><span className="msb-tag is-static">static</span></div>
 
 ```python
 @staticmethod
@@ -735,242 +1060,79 @@ def symlink(target: str, link: str, *, replace: bool = False) -> PatchConfig
 
 Create a symlink at `link` pointing to `target`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| target | `str` | What the symlink points to (literal symlink target text) |
-| link | `str` | Absolute path of the symlink itself |
-| replace | `bool` | When `True`, overwrite an existing path at `link` |
-
----
-
-#### Patch.text()
-
-```python
-@staticmethod
-def text(
-    path: str,
-    content: str,
-    *,
-    mode: int | None = None,
-    replace: bool = False,
-) -> PatchConfig
-```
-
-Write UTF-8 text content at `path`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Absolute path inside the guest |
-| content | `str` | Text content |
-| mode | `int \| None` | File mode, e.g. `0o644` |
-| replace | `bool` | When `True`, overwrite an existing path |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>target</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">What the symlink points to (literal symlink target text).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>link</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Absolute path of the symlink itself.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>replace</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>True</code>, overwrite an existing path at <code>link</code>.</div>
+  </div>
+</div>
 
 ---
 
 ## Types
 
-### LogLevel
-
-Sandbox process log verbosity.
-
-| Value | Description |
-|-------|-------------|
-| `"debug"` | Debug and higher |
-| `"error"` | Errors only |
-| `"info"` | Info and higher |
-| `"trace"` | Most verbose -- all diagnostic output |
-| `"warn"` | Warnings and errors only |
-
-### SecurityProfile
-
-```python
-class SecurityProfile(StrEnum):
-    DEFAULT = "default"
-    RESTRICTED = "restricted"
-```
-
-Sandbox-wide in-guest security profile.
-
-### LogEntry
-
-A single captured log entry returned by [`logs()`](#logs).
-
-| Property / Method | Type | Description |
-|-------------------|------|-------------|
-| timestamp_ms | `float` | Wall-clock capture time (ms since Unix epoch, UTC) |
-| source | `str` | Where the chunk came from. See [LogSource](#logsource). |
-| session_id | `int \| None` | Relay-monotonic session id; `None` for `"system"` entries |
-| data | `bytes` | The chunk's bytes (UTF-8 lossy decoded by default) |
-| `text()` | `str` | Convenience: UTF-8 decode of `data` (lossy — invalid bytes are replaced) |
-
-### LogSource
-
-The string values that the `source` field on a [`LogEntry`](#logentry) can take, also accepted by `logs(sources=[...])`.
-
-| Value | Description |
-|-------|-------------|
-| `"stdout"` | Captured from a session's stdout (pipe mode — streams stayed separated) |
-| `"stderr"` | Captured from a session's stderr (pipe mode) |
-| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `"output"` rather than mislabelled as `"stdout"`. |
-| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested. |
-
-In addition, `logs(sources=["all"])` is a shorthand for all four.
-
-### MetricsStream
-
-Async stream for receiving periodic metrics snapshots.
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `__aiter__` | `AsyncIterator[`[`SandboxMetrics`](#sandboxmetrics)`]` | Use with `async for` |
-| `recv()` | [`SandboxMetrics`](#sandboxmetrics) `\| None` | Receive next snapshot. Returns `None` when the stream ends. |
-
-### PatchConfig
-
-A single rootfs patch. Produced by the [`Patch`](#patch) factory; you'd normally not construct one directly. Frozen dataclass.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| kind | `str` | One of `"text"`, `"file"`, `"copy_file"`, `"copy_dir"`, `"symlink"`, `"mkdir"`, `"remove"`, `"append"` |
-| path | `str \| None` | Absolute guest path (used by text / file / mkdir / remove / append) |
-| content | `str \| None` | Text content (text / append) |
-| src | `str \| None` | Host source path (copy_file / copy_dir) |
-| dst | `str \| None` | Guest destination path (copy_file / copy_dir) |
-| target | `str \| None` | Symlink target |
-| link | `str \| None` | Symlink path |
-| mode | `int \| None` | File / directory mode (e.g. `0o644`) |
-| replace | `bool` | When `True`, overwrite an existing path at the destination. Defaults to `False` |
-
-### PullPolicy
-
-Controls when the SDK fetches an OCI image from the registry.
-
-| Value | Description |
-|-------|-------------|
-| `"always"` | Pull the image every time, even if cached locally |
-| `"if-missing"` | Pull only if the image is not already cached. This is the default. |
-| `"never"` | Never pull; fail if the image is not cached locally |
-
-### PullEvent
-
-Native event object emitted by [`PullSession.progress`](#pullsession). Inspect `event_type` and the fields relevant to that event:
-
-| event_type | Fields |
-|------------|--------|
-| `"resolving"` | `reference` |
-| `"resolved"` | `reference`, `manifest_digest`, `layer_count`, `total_download_bytes` |
-| `"layer_download_progress"` | `layer_index`, `digest`, `downloaded_bytes`, `total_bytes` |
-| `"layer_download_complete"` | `layer_index`, `digest`, `downloaded_bytes` |
-| `"layer_download_verifying"` | `layer_index`, `digest` |
-| `"layer_materialize_started"` | `layer_index`, `diff_id` |
-| `"layer_materialize_progress"` | `layer_index`, `bytes_read`, `total_bytes` |
-| `"layer_materialize_writing"` | `layer_index` |
-| `"layer_materialize_complete"` | `layer_index`, `diff_id` |
-| `"stitch_merging_trees"` | `layer_count` |
-| `"stitch_writing_fsmeta"` | - |
-| `"stitch_writing_vmdk"` | - |
-| `"stitch_complete"` | - |
-| `"complete"` | `reference`, `layer_count` |
-
-Fields that do not apply to a particular event are `None`.
-
-```python
-from microsandbox import Sandbox
-
-session = Sandbox.create_with_progress("my-sandbox", image="ubuntu:latest")
-async with session:
-    async for event in session.progress:
-        if event.event_type == "resolved":
-            print(f"{event.layer_count} layers, {event.total_download_bytes} bytes")
-        elif event.event_type == "layer_download_progress":
-            print(f"layer {event.layer_index}: {event.downloaded_bytes}/{event.total_bytes}")
-    sb = await session.result()
-```
-
-### PullSession
-
-Returned by [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress). `Sandbox.create_with_progress()` itself is synchronous; use the returned session as an async context manager to track image pull progress.
-
-```python
-session = Sandbox.create_with_progress("my-sandbox", image="ubuntu:latest")
-async with session:
-    async for event in session.progress:
-        print(event)
-    sb = await session.result()
-```
-
-| Property / Method | Type | Description |
-|-------------------|------|-------------|
-| progress | `AsyncIterator[`[`PullEvent`](#pullevent)`]` | Async iterator of pull progress events |
-| result() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Await once to get the final running sandbox. A second call raises `RuntimeError`. |
-
-### RegistryAuth
-
-Private registry credentials.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| username | `str` | Registry username |
-| password | `str` | Registry password |
-
 ### SandboxConfig
 
-The keyword arguments accepted by [`Sandbox.create()`](#sandboxcreate) and [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress).
+<div className="msb-tags"><span className="msb-tag is-type">kwargs</span></div>
+
+<p className="msb-backref">Used by <a href="#sandbox-create">create()</a> · <a href="#sandbox-create_with_progress">create_with_progress()</a></p>
+
+The keyword arguments accepted by [`create()`](#sandbox-create) and [`create_with_progress()`](#sandbox-create_with_progress). There is no `SandboxConfig` object you construct directly; these are passed as `**kwargs`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| image | `str \| ImageSource` | - | OCI image, local path, or disk image. Required unless `snapshot=` is passed. Use `Image.oci("python:3.12", upper_size_mib=8192)` to set an OCI upper size |
+| image | `str \| `[`ImageSource`](/sdk/python/snapshots) | - | OCI image, local path, or disk image. Required unless `snapshot=` is passed. Use `Image.oci("python:3.12", upper_size_mib=8192)` to set an OCI upper size |
 | snapshot | `str \| os.PathLike` | - | Snapshot artifact to boot from instead of `image=`. Mutually exclusive with `image=` |
-| cpus | `int` | `1` | Virtual CPUs |
-| memory | `int` | `512` | Guest memory in MiB. This is a limit, not a reservation. |
+| cpus | `int` | `1` | Virtual CPUs. This is a limit, not a reservation |
+| memory | `int` | `512` | Guest memory in MiB. This is a limit, not a reservation |
 | workdir | `str` | - | Default working directory for commands |
 | shell | `str` | `"/bin/sh"` | Shell for `shell()` calls |
-| security | [`SecurityProfile`](#securityprofile) \| `str` | `SecurityProfile.DEFAULT` | In-guest security profile |
+| security | [`SecurityProfile`](#securityprofile) `\| str` | `"default"` | In-guest security profile. `"restricted"` sets `no_new_privs`, drops mount-admin capability from user commands, and forces `nosuid,nodev` on user mounts |
 | hostname | `str` | - | Guest hostname |
 | user | `str` | - | Default guest user |
-| entrypoint | `list[str]` | - | Override the image's stored ENTRYPOINT. Consulted by `msb exec` / `msb run` (CLI command resolution), **not** by `sb.exec` / `sb.shell` — those pass `cmd` literally |
-| init | `str \| dict \|` [`InitConfig`](#initconfig) | - | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) |
-| replace | `bool` | `False` | Replace existing sandbox with same name |
-| replace_with_timeout | `float` | `10` | Seconds to wait after `SIGTERM` before escalating to `SIGKILL`; implies `replace=True` |
+| entrypoint | `list[str]` | - | Override the image's stored ENTRYPOINT. Consulted by `msb exec` / `msb run` (CLI command resolution), **not** by `sb.exec` / `sb.shell` which pass `cmd` literally |
+| init | `str \| dict \| `[`InitConfig`](#initconfig) | - | Hand off PID 1 to a guest init binary. See [Custom init system](/sandboxes/customize#custom-init-system) and [`InitConfig`](#initconfig) for accepted shapes |
+| replace | `bool` | `False` | Replace an existing sandbox with the same name (10s SIGTERM grace, then SIGKILL) |
+| replace_with_timeout | `float` | `10` | Seconds to wait after `SIGTERM` before escalating to `SIGKILL` (`0` skips `SIGTERM`). Implies `replace=True` |
 | max_duration | `float` | - | Maximum sandbox lifetime in seconds |
 | idle_timeout | `float` | - | Idle timeout in seconds |
 | env | `dict[str, str]` | `{}` | Environment variables visible to all commands |
 | scripts | `dict[str, str]` | `{}` | Named scripts mounted at `/.msb/scripts/` and added to `PATH` |
-| pull_policy | `str \| PullPolicy` | `"if-missing"` | Image pull behavior |
-| log_level | `str \| LogLevel` | - | Override log verbosity |
+| pull_policy | `str \| `[`PullPolicy`](#pullpolicy) | `"if-missing"` | Image pull behavior |
+| log_level | `str \| `[`LogLevel`](#loglevel) | - | Override log verbosity |
 | registry_auth | [`RegistryAuth`](#registryauth) | - | Private registry credentials |
-| volumes | `dict[str, MountConfig]` | `{}` | Volume mounts. See [Volumes](/sdk/python/volumes). |
-| patches | `list[PatchConfig]` | `[]` | Rootfs modifications applied before boot |
-| ports | `dict[int, int] \| Sequence[PortBinding]` | `{}` | Port mappings. Dict form is TCP and binds to `127.0.0.1`; use [`PortBinding`](/sdk/python/networking#portbinding) for explicit bind addresses or UDP |
+| volumes | `dict[str, `[`MountConfig`](/sdk/python/volumes)`]` | `{}` | Volume mounts. See [Volumes](/sdk/python/volumes) |
+| patches | `list[`[`PatchConfig`](#patchconfig)`]` | `[]` | Rootfs modifications applied before boot |
+| ports | `dict[int, int] \| Sequence[`[`PortBinding`](/sdk/python/networking#portbinding)`]` | `{}` | Port mappings. Dict form is TCP and binds to `127.0.0.1`; use `PortBinding` for explicit bind addresses or UDP |
 | network | [`Network`](/sdk/python/networking#network) | `public_only` | Network policy and configuration |
 | secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | `[]` | Secret injection |
-| detached | `bool` | `False` | If `True`, spawn the sandbox in detached mode; call [`detach()`](#detach) before dropping the returned handle when it should keep running |
+| detached | `bool` | `False` | If `True`, spawn the sandbox in detached mode; call [`detach()`](#sb-detach) before dropping the returned handle when it should keep running |
 
 ### InitConfig
 
-Custom init specification. Pass it (or one of the equivalent shorthand shapes) as the `init=` kwarg to [`Sandbox.create()`](#sandboxcreate) to hand PID 1 inside the guest off to your own init binary after agentd's setup. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks, shutdown semantics, and tradeoffs.
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
 
-```python
-from dataclasses import dataclass
+<p className="msb-backref">Used by <a href="#sandboxconfig">create(init=...)</a></p>
 
-@dataclass(frozen=True, slots=True)
-class InitConfig:
-    cmd: str
-    args: tuple[str, ...] = ()
-    env: Mapping[str, str] = {}
-```
+Custom init specification. Pass it (or one of the equivalent shorthand shapes) as the `init=` kwarg to [`create()`](#sandbox-create) to hand PID 1 inside the guest off to your own init binary after agentd's setup. Frozen dataclass. See [Custom init system](/sandboxes/customize#custom-init-system) for image picks, shutdown semantics, and tradeoffs.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| cmd | `str` | Absolute path or `"auto"` to the init binary. Auto honors known image ENTRYPOINT inits before probing common guest paths and preserves attached init-entrypoint commands |
-| args | `tuple[str, ...]` | Supplemental argv (`argv[0]` is implicitly `cmd`) |
-| env | `dict[str, str]` | Extra env vars merged on top of the inherited env |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| cmd | `str` | - | Absolute path or `"auto"` to the init binary. Auto honors a known image ENTRYPOINT init before probing `/sbin/init`, `/lib/systemd/systemd`, and `/usr/lib/systemd/systemd`, and preserves attached init-entrypoint commands |
+| args | `tuple[str, ...]` | `()` | Supplemental argv (`argv[0]` is implicitly `cmd`) |
+| env | `Mapping[str, str]` | `{}` | Extra env vars merged on top of the inherited env |
 
-The `init=` kwarg follows the same shape as other `Sandbox.create` kwargs that carry structured values (`image=`, `network=`, etc.): a bare scalar for the simple case, or a dataclass / dict for the rich case.
+The `init=` kwarg follows the same shape as other structured `create` kwargs: a bare scalar for the simple case, or a dataclass / dict for the rich case.
 
 | Form | Equivalent to |
 |------|---------------|
@@ -996,17 +1158,36 @@ sb = await Sandbox.create(
 )
 ```
 
+### SecurityProfile
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#sandboxconfig">create(security=...)</a></p>
+
+Sandbox-wide in-guest security profile. A `StrEnum`, so the string values are accepted directly.
+
+| Value | Description |
+|-------|-------------|
+| `"default"` | Standard profile |
+| `"restricted"` | Sets `no_new_privs`, drops mount-admin capability from user commands, and forces `nosuid,nodev` on user mounts |
+
 ### SandboxHandle
 
-A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandboxget) or [`Sandbox.list()`](#sandboxlist). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. Call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sandbox-get">Sandbox.get()</a> · <a href="#sandbox-list">Sandbox.list()</a> · <a href="#sandbox-list_with">Sandbox.list_with()</a></p>
+
+A lightweight handle to an existing sandbox (running or stopped). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. You cannot `exec` or `fs` on a handle; call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
 
 | Property / Method | Type | Description |
 |-------------------|------|-------------|
 | name | `str` | Sandbox name, up to 128 UTF-8 bytes |
-| status | `str` | Current status (`"running"`, `"stopped"`, `"crashed"`, `"draining"`, `"paused"`) |
+| status | `str` | Current status. See [`SandboxStatus`](#sandboxstatus) |
 | config_json | `str` | Raw JSON configuration |
 | created_at | `float \| None` | Creation timestamp (ms since epoch) |
 | updated_at | `float \| None` | Last update timestamp (ms since epoch) |
+| config() | `dict[str, Any]` | Parsed configuration |
+| refresh() | `Awaitable[`[`SandboxHandle`](#sandboxhandle)`]` | Re-fetch status and metadata, returning a fresh handle |
 | connect(timeout=None) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Connect to a running sandbox, optionally with an explicit timeout in seconds |
 | start(*, detached=False) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Start in attached or detached mode |
 | stop(timeout=None) | `Awaitable[None]` | Gracefully shut down and wait until stopped state is observed |
@@ -1017,32 +1198,240 @@ A lightweight handle to an existing sandbox (running or stopped). Obtained via [
 | wait_until_stopped() | `Awaitable[`[`SandboxStopResult`](#sandboxstopresult)`]` | Block until the sandbox reaches terminal state |
 | remove() | `Awaitable[None]` | Delete sandbox and state |
 | metrics() | `Awaitable[`[`SandboxMetrics`](#sandboxmetrics)`]` | Point-in-time resource metrics |
-| logs() | `Awaitable[list[`[`LogEntry`](#logentry)`]]` | Read captured `exec.log` (works without starting) |
+| logs(...) | `Awaitable[list[`[`LogEntry`](#logentry)`]]` | Read captured `exec.log` (works without starting) |
+| log_stream(...) | `Awaitable[`[`LogStream`](#logstream)`]` | Stream captured log entries (works without starting) |
+| snapshot(name) | `Awaitable[Snapshot]` | Create a named [snapshot](/sdk/python/snapshots) of the sandbox |
+| snapshot_to(path) | `Awaitable[Snapshot]` | Create a [snapshot](/sdk/python/snapshots) at a path |
 
 ### SandboxStopResult
 
-Observed terminal sandbox state returned by [`wait_until_stopped()`](#wait_until_stopped).
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
 
-| Field | Type | Description |
-|-------|------|-------------|
-| status | `str` | Terminal status that was observed |
+<p className="msb-backref">Returned by <a href="#sb-wait_until_stopped">wait_until_stopped()</a></p>
+
+Observed terminal sandbox state returned by [`wait_until_stopped()`](#sb-wait_until_stopped).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| name | `str` | Sandbox name |
+| status | `str` | Terminal status that was observed. See [`SandboxStatus`](#sandboxstatus) |
 | exit_code | `int \| None` | Process exit code when it is available |
+| signal | `int \| None` | Terminating signal number when the sandbox was killed by a signal |
+| observed_at | `float` | When the terminal state was observed (ms since epoch) |
+| source | `str \| None` | Where the terminal observation came from |
+
+### SandboxStatus
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#sandboxhandle">SandboxHandle.status</a> · <a href="#sandboxstopresult">SandboxStopResult.status</a></p>
+
+The string status values a sandbox can report. A `StrEnum`, exposed as plain strings on `status` fields.
+
+| Value | Description |
+|-------|-------------|
+| `"running"` | Guest agent is ready; `exec`, `shell`, `fs` work |
+| `"stopped"` | VM shut down; configuration persisted; can be restarted |
+| `"crashed"` | VM exited unexpectedly (kernel panic, OOM, etc.) |
+| `"draining"` | Graceful shutdown in progress; existing commands finish, new ones rejected |
+| `"paused"` | VM paused |
 
 ### SandboxMetrics
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-metrics">metrics()</a> · <a href="#sb-metrics_stream">metrics_stream()</a></p>
 
 Point-in-time resource usage snapshot.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | cpu_percent | `float` | CPU usage as a percentage |
+| vcpu_time_ns | `int` | Cumulative vCPU time consumed since boot, in nanoseconds |
+| memory_bytes | `int` | Current memory usage in bytes |
+| memory_available_bytes | `int \| None` | Guest-reported available memory in bytes when known |
+| memory_host_resident_bytes | `int \| None` | Host-resident memory backing the guest in bytes when known |
+| memory_limit_bytes | `int` | Memory limit in bytes |
 | disk_read_bytes | `int` | Total bytes read from disk since boot |
 | disk_write_bytes | `int` | Total bytes written to disk since boot |
-| memory_bytes | `int` | Current memory usage in bytes |
-| memory_limit_bytes | `int` | Memory limit in bytes |
 | net_rx_bytes | `int` | Total bytes received over the network since boot |
 | net_tx_bytes | `int` | Total bytes sent over the network since boot |
 | upper_used_bytes | `int \| None` | Guest-visible OCI upper filesystem used bytes when the protected reporter is available and fresh |
 | upper_free_bytes | `int \| None` | Guest-visible OCI upper filesystem free bytes when the protected reporter is available and fresh |
 | upper_host_allocated_bytes | `int \| None` | Host-allocated bytes for the writable OCI upper image when available |
-| timestamp_ms | `float` | When this measurement was taken (ms since epoch) |
 | uptime_ms | `int` | Time since the sandbox was created (ms) |
+| timestamp_ms | `float` | When this measurement was taken (ms since epoch) |
+
+### MetricsStream
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-metrics_stream">metrics_stream()</a></p>
+
+Async stream for receiving periodic metrics snapshots.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `__aiter__` / `__anext__` | [`SandboxMetrics`](#sandboxmetrics) | Use with `async for` |
+
+### LogEntry
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-logs">logs()</a> · iterated from <a href="#logstream">LogStream</a></p>
+
+A single captured log entry returned by [`logs()`](#sb-logs) or iterated from a [`LogStream`](#logstream).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| timestamp_ms | `float` | Wall-clock capture time (ms since Unix epoch, UTC) |
+| source | [`LogSource`](#logsource) | Where the chunk came from |
+| session_id | `int \| None` | Relay-monotonic session id; `None` for `"system"` entries |
+| cursor | `str` | Opaque resume token; pass back via `log_stream(from_cursor=...)` |
+| data | `bytes` | The chunk's raw bytes |
+| text() | `str` | Convenience: UTF-8 decode of `data` (lossy; invalid bytes are replaced) |
+
+### LogStream
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-log_stream">log_stream()</a></p>
+
+Async stream of [`LogEntry`](#logentry) values, returned by [`log_stream()`](#sb-log_stream).
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `__aiter__` / `__anext__` | [`LogEntry`](#logentry) | Use with `async for` |
+
+### LogSource
+
+<div className="msb-tags"><span className="msb-tag is-type">literal</span></div>
+
+<p className="msb-backref">Used by <a href="#logentry">LogEntry.source</a> · <a href="#sb-logs">logs(sources=...)</a></p>
+
+The string values the `source` field on a [`LogEntry`](#logentry) can take, also accepted by `logs(sources=[...])` and `log_stream(sources=[...])`. The read form additionally accepts `"all"`.
+
+| Value | Description |
+|-------|-------------|
+| `"stdout"` | Captured from a session's stdout (pipe mode, streams stayed separated) |
+| `"stderr"` | Captured from a session's stderr (pipe mode) |
+| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream, tagged `"output"` rather than mislabelled as `"stdout"` |
+| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested |
+| `"all"` | Read shorthand for all four sources (accepted by `sources=`, never returned on an entry) |
+
+### LogLevel
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#sandboxconfig">create(log_level=...)</a></p>
+
+Sandbox process log verbosity. A `StrEnum`, so the string values are accepted directly.
+
+| Value | Description |
+|-------|-------------|
+| `"trace"` | Most verbose, all diagnostic output |
+| `"debug"` | Debug and higher |
+| `"info"` | Info and higher |
+| `"warn"` | Warnings and errors only |
+| `"error"` | Errors only |
+
+### PullPolicy
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#sandboxconfig">create(pull_policy=...)</a></p>
+
+Controls when the SDK fetches an OCI image from the registry. A `StrEnum`, so the string values are accepted directly.
+
+| Value | Description |
+|-------|-------------|
+| `"always"` | Pull the image every time, even if cached locally |
+| `"if-missing"` | Pull only if the image is not already cached. This is the default |
+| `"never"` | Never pull; fail if the image is not cached locally |
+
+### RegistryAuth
+
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
+
+<p className="msb-backref">Used by <a href="#sandboxconfig">create(registry_auth=...)</a></p>
+
+Credentials for authenticating to a private container registry. Frozen dataclass; construct directly or via `RegistryAuth.basic(username, password)`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| username | `str` | Registry username |
+| password | `str` | Registry password |
+
+### PatchConfig
+
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
+
+<p className="msb-backref">Returned by <a href="#patch-text">Patch.* factory methods</a> · used by <a href="#sandboxconfig">create(patches=...)</a></p>
+
+A single rootfs patch. Produced by the [`Patch`](#patch) factory; you'd normally not construct one directly. Frozen dataclass.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| kind | `str` | One of `"text"`, `"file"`, `"copy_file"`, `"copy_dir"`, `"symlink"`, `"mkdir"`, `"remove"`, `"append"` |
+| path | `str \| None` | Absolute guest path (text / mkdir / remove / append) |
+| content | `str \| None` | Text content (text / append) |
+| src | `str \| None` | Host source path (copy_file / copy_dir) |
+| dst | `str \| None` | Guest destination path (copy_file / copy_dir) |
+| target | `str \| None` | Symlink target |
+| link | `str \| None` | Symlink path |
+| mode | `int \| None` | File / directory mode (e.g. `0o644`) |
+| replace | `bool` | When `True`, overwrite an existing path at the destination. Defaults to `False` |
+
+### PullSession
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sandbox-create_with_progress">create_with_progress()</a></p>
+
+Returned by [`create_with_progress()`](#sandbox-create_with_progress). The factory itself is synchronous; use the returned session as an async context manager to track image pull progress.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| progress | `AsyncIterator[`[`PullEvent`](#pullevent)`]` | Async iterator of pull progress events |
+| result() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Await once to get the final running sandbox. A second call raises `RuntimeError` |
+
+```python
+session = Sandbox.create_with_progress("my-sandbox", image="ubuntu:latest")
+async with session:
+    async for event in session.progress:
+        print(event)
+    sb = await session.result()
+```
+
+### PullEvent
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Iterated from <a href="#pullsession">PullSession.progress</a></p>
+
+Native event object emitted by [`PullSession.progress`](#pullsession). Inspect `event_type` and the fields relevant to that event; fields that do not apply to a particular event are `None`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| event_type | `str` | Event tag, e.g. `"resolving"`, `"resolved"`, `"layer_download_progress"`, `"complete"` |
+| reference | `str \| None` | Image reference being pulled |
+| manifest_digest | `str \| None` | Resolved manifest digest |
+| layer_count | `int \| None` | Number of layers |
+| total_download_bytes | `int \| None` | Total bytes to download across layers |
+| layer_index | `int \| None` | Index of the layer this event concerns |
+| digest | `str \| None` | Layer blob digest |
+| diff_id | `str \| None` | Layer diff id |
+| downloaded_bytes | `int \| None` | Bytes downloaded so far for the layer |
+| total_bytes | `int \| None` | Total bytes for the layer |
+| bytes_read | `int \| None` | Bytes read during materialization |
+
+```python
+session = Sandbox.create_with_progress("my-sandbox", image="ubuntu:latest")
+async with session:
+    async for event in session.progress:
+        if event.event_type == "resolved":
+            print(f"{event.layer_count} layers, {event.total_download_bytes} bytes")
+        elif event.event_type == "layer_download_progress":
+            print(f"layer {event.layer_index}: {event.downloaded_bytes}/{event.total_bytes}")
+    sb = await session.result()
+```

--- a/docs/sdk/python/secrets.mdx
+++ b/docs/sdk/python/secrets.mdx
@@ -3,15 +3,56 @@ title: Secrets
 description: Python SDK - Secret injection API reference
 ---
 
-See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+Bind a credential to an environment variable so the guest only ever sees a placeholder: the real value is substituted by the TLS proxy when traffic reaches an allowed host, and blocked everywhere else. See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
 
-## Secret
+<div className="msb-glance">
 
-Static factory for creating secret entries used in `SandboxConfig.secrets`.
+  <p className="msb-gl"><span className="msb-dot static"></span>Factory · Secret<span className="msb-ct">1</span></p>
+  <a className="msb-row" href="#secret-env"><span className="msb-rn">Secret.env()</span><span className="msb-rg">map an env var to a secret value</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Violation policy · ViolationPolicy<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#violationpolicy-block"><span className="msb-rn">ViolationPolicy.block()</span><span className="msb-rg">silently drop on violation</span></a>
+  <a className="msb-row" href="#violationpolicy-block_and_log"><span className="msb-rn">ViolationPolicy.block_and_log()</span><span className="msb-rg">drop and warn</span></a>
+  <a className="msb-row" href="#violationpolicy-block_and_terminate"><span className="msb-rn">ViolationPolicy.block_and_terminate()</span><span className="msb-rg">drop, log, shut down</span></a>
+  <a className="msb-row" href="#violationpolicy-passthrough"><span className="msb-rn">ViolationPolicy.passthrough()</span><span className="msb-rg">forward placeholder to hosts</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#secretentry">SecretEntry</a>
+    <a className="msb-typepill" href="#secretinjection">SecretInjection</a>
+    <a className="msb-typepill" href="#violationaction">ViolationAction</a>
+    <a className="msb-typepill" href="#violationpolicy">ViolationPolicy</a>
+    <a className="msb-typepill" href="#secretviolationerror">SecretViolationError</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```python
+import os
+from microsandbox import Sandbox, Secret
+
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    secrets=[
+        Secret.env(
+            "GITHUB_TOKEN",
+            value=os.environ["GITHUB_TOKEN"],
+            allow_hosts=["api.github.com"],
+            allow_host_patterns=["*.githubusercontent.com"],
+        ),
+    ],
+)
+```
+
+## Factory methods
 
 ---
 
-#### Secret.env()
+#### <span className="msb-recv">Secret.</span><span className="msb-hn">env()</span>
+<div className="msb-tags"><span className="msb-tag is-static">staticmethod</span></div>
 
 ```python
 @staticmethod
@@ -28,42 +69,195 @@ def env(
 ) -> SecretEntry
 ```
 
-Create a secret entry that maps an environment variable to a real value. The guest sees a placeholder - the real value is only substituted by the TLS proxy when traffic goes to an allowed host.
+Create a secret entry that maps an environment variable to a real value. The guest sees a placeholder; the real value is only substituted by the TLS proxy when traffic goes to an allowed host. Pass the returned entry to `Sandbox.create(..., secrets=[...])`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Default | Description |
-|------|------|---------|-------------|
-| env_var | `str` | - | Environment variable name. Must be non-empty and cannot contain `=` or NUL; shell-identifier syntax is not required. |
-| value | `str` | - | The real secret value. Never enters the guest VM. **Required.** |
-| allow_hosts | `Sequence[str]` | `()` | Hosts allowed to receive the real value (exact match). At least one exact or wildcard host is required. |
-| allow_host_patterns | `Sequence[str]` | `()` | Wildcard host patterns (e.g. `"*.googleapis.com"`) |
-| placeholder | `str \| None` | `None` | Custom placeholder string: non-empty, up to 1024 bytes, no NUL/CR/LF. Auto-generated as `$MSB_<env_var>` if not set. |
-| require_tls | `bool` | `True` | Only substitute on TLS-intercepted connections. Disable only if you know the traffic is safe. |
-| on_violation | [`ViolationAction`](#violationaction) `\|` [`ViolationPolicy`](#violationpolicy) | `BLOCK_AND_LOG` | Per-secret violation behavior |
-| injection | [`SecretInjection`](#secretinjection) `\| None` | `None` | Where in the HTTP request to substitute. `None` uses the defaults. |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>env_var</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Environment variable name. Must be non-empty and cannot contain <code>=</code> or NUL; shell-identifier syntax is not required.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">The real secret value. Never enters the guest VM. Keyword-only and required.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>allow_hosts</code><span className="msb-type">Sequence[str]</span></div>
+    <div className="msb-param-desc">Hosts allowed to receive the real value (exact match). At least one exact or wildcard host is required. Default <code>()</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>allow_host_patterns</code><span className="msb-type">Sequence[str]</span></div>
+    <div className="msb-param-desc">Wildcard host patterns, e.g. <code>"*.googleapis.com"</code>. Default <code>()</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>placeholder</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Custom placeholder string: non-empty, up to 1024 bytes, no NUL/CR/LF. Auto-generated as <code>$MSB_&lt;env_var&gt;</code> when <code>None</code>. Default <code>None</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>require_tls</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Only substitute on TLS-intercepted connections. Disable only if you know the traffic is safe. Default <code>True</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>on_violation</code><a className="msb-type" href="#violationaction">ViolationAction</a> | <a className="msb-type" href="#violationpolicy">ViolationPolicy</a></div>
+    <div className="msb-param-desc">Per-secret violation behavior. Default <code>ViolationAction.BLOCK_AND_LOG</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>injection</code><a className="msb-type" href="#secretinjection">SecretInjection</a> | None</div>
+    <div className="msb-param-desc">Where in the HTTP request to substitute. <code>None</code> uses <code>SecretInjection()</code> defaults. Default <code>None</code>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SecretEntry`](#secretentry) | Secret entry for `SandboxConfig.secrets` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#secretentry">SecretEntry</a></div>
+    <div className="msb-param-desc">Secret entry for <code>Sandbox.create(secrets=[...])</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+from microsandbox import Secret, SecretInjection
+
+secret = Secret.env(
+    "SERVICE_API_KEY",
+    value=os.environ["SERVICE_API_KEY"],
+    allow_hosts=["api.example.com"],
+    injection=SecretInjection(query_params=True),
+)
+```
 
 ---
 
-## Host Matching
+## Violation policy
 
-Python host settings map to the runtime `HostPattern` model. Allow-list fields decide where the real secret value may be substituted; passthrough fields decide where the placeholder may be forwarded unchanged.
+`on_violation` (per secret) and `Network.on_secret_violation` (sandbox-wide default) both accept a bare [`ViolationAction`](#violationaction) or a [`ViolationPolicy`](#violationpolicy). The classmethods below construct a policy. Use [`passthrough()`](#violationpolicy-passthrough) when selected hosts should receive the placeholder unchanged; the other three mirror the plain [`ViolationAction`](#violationaction) values.
 
-| Pattern kind | Python API | Matches |
-|--------------|------------|---------|
-| Exact host | `allow_hosts=("api.example.com",)`, `ViolationPolicy.passthrough(hosts=("api.example.com",))` | That exact SNI host |
-| Wildcard host | `allow_host_patterns=("*.example.com",)`, `ViolationPolicy.passthrough(host_patterns=("*.example.com",))` | Hosts matching the wildcard pattern |
-| Any host | `ViolationPolicy.passthrough(all_hosts=True)` | Every host for passthrough |
+---
 
-Passthrough host patterns do **not** make a secret eligible for substitution. They only prevent blocking when the guest sends the placeholder to a matching host, so the request is forwarded with the placeholder unchanged.
+#### <span className="msb-recv">ViolationPolicy.</span><span className="msb-hn">block()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
 
-Exact and wildcard allow-list entries are pinned to observed DNS answers and TLS identity. Empty allow-lists are rejected when the sandbox configuration is materialized.
+```python
+@classmethod
+def block(cls) -> ViolationPolicy
+```
+
+Silently drop the request when the placeholder is sent to a disallowed host. The guest sees a connection reset. Equivalent to `ViolationAction.BLOCK`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#violationpolicy">ViolationPolicy</a></div>
+    <div className="msb-param-desc">Policy with <code>fallback = ViolationAction.BLOCK</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">ViolationPolicy.</span><span className="msb-hn">block_and_log()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
+
+```python
+@classmethod
+def block_and_log(cls) -> ViolationPolicy
+```
+
+Drop the request and emit a warning log on the host side. This is the default. Equivalent to `ViolationAction.BLOCK_AND_LOG`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#violationpolicy">ViolationPolicy</a></div>
+    <div className="msb-param-desc">Policy with <code>fallback = ViolationAction.BLOCK_AND_LOG</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">ViolationPolicy.</span><span className="msb-hn">block_and_terminate()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
+
+```python
+@classmethod
+def block_and_terminate(cls) -> ViolationPolicy
+```
+
+Drop the request, log an error, and shut down the entire sandbox. Equivalent to `ViolationAction.BLOCK_AND_TERMINATE`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#violationpolicy">ViolationPolicy</a></div>
+    <div className="msb-param-desc">Policy with <code>fallback = ViolationAction.BLOCK_AND_TERMINATE</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">ViolationPolicy.</span><span className="msb-hn">passthrough()</span>
+<div className="msb-tags"><span className="msb-tag is-static">classmethod</span></div>
+
+```python
+@classmethod
+def passthrough(
+    cls,
+    *,
+    hosts: Sequence[str] = (),
+    host_patterns: Sequence[str] = (),
+    all_hosts: bool = False,
+) -> ViolationPolicy
+```
+
+Forward the placeholder unchanged to matching hosts instead of blocking. Passthrough hosts do **not** make a secret eligible for substitution; they only prevent blocking when the guest sends the placeholder to a matching host, so the request is forwarded with the placeholder intact. Hosts outside the passthrough set fall back to `BLOCK_AND_LOG`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hosts</code><span className="msb-type">Sequence[str]</span></div>
+    <div className="msb-param-desc">Exact hosts that may receive the placeholder unchanged. Keyword-only. Default <code>()</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_patterns</code><span className="msb-type">Sequence[str]</span></div>
+    <div className="msb-param-desc">Wildcard host patterns, e.g. <code>"*.example.com"</code>. Keyword-only. Default <code>()</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>all_hosts</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Forward the placeholder unchanged to every host. Keyword-only. Default <code>False</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#violationpolicy">ViolationPolicy</a></div>
+    <div className="msb-param-desc">Passthrough policy.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+from microsandbox import Secret, ViolationPolicy
+
+secret = Secret.env(
+    "API_KEY",
+    value=os.environ["API_KEY"],
+    allow_hosts=["api.github.com"],
+    on_violation=ViolationPolicy.passthrough(
+        hosts=["api.anthropic.com"],
+        host_patterns=["*.anthropic.com"],
+    ),
+)
+```
 
 ---
 
@@ -71,22 +265,30 @@ Exact and wildcard allow-list entries are pinned to observed DNS answers and TLS
 
 ### SecretEntry
 
-Frozen dataclass returned by [`Secret.env()`](#secretenv) and used in `SandboxConfig.secrets`.
+<div className="msb-tags"><span className="msb-tag is-type">frozen dataclass</span></div>
 
-| Field | Type | Description |
-|-------|------|-------------|
-| env_var | `str` | Environment variable name (non-empty, no `=` or NUL) |
-| value | `str` | Secret value |
-| allow_hosts | `tuple[str, ...]` | Allowed hosts (exact match) |
-| allow_host_patterns | `tuple[str, ...]` | Wildcard patterns |
-| placeholder | `str \| None` | Placeholder string: non-empty, up to 1024 bytes, no NUL/CR/LF |
-| require_tls | `bool` | TLS requirement |
-| on_violation | [`ViolationAction`](#violationaction) `\|` [`ViolationPolicy`](#violationpolicy) | Per-secret violation behavior |
-| injection | [`SecretInjection`](#secretinjection) | Per-request injection scopes |
+<p className="msb-backref">Returned by <a href="#secret-env">Secret.env()</a></p>
+
+A single secret entry, used in `Sandbox.create(secrets=[...])`. Construct it with [`Secret.env()`](#secret-env) rather than directly.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| env_var | `str` | required | Environment variable name (non-empty, no `=` or NUL) |
+| value | `str` | required | Secret value. Never enters the guest |
+| allow_hosts | `tuple[str, ...]` | `()` | Allowed hosts (exact match) |
+| allow_host_patterns | `tuple[str, ...]` | `()` | Wildcard patterns |
+| placeholder | `str \| None` | `None` | Placeholder string: non-empty, up to 1024 bytes, no NUL/CR/LF. Auto-generated as `$MSB_<env_var>` when `None` |
+| require_tls | `bool` | `True` | Only substitute on TLS-intercepted connections |
+| on_violation | [`ViolationAction`](#violationaction) `\|` [`ViolationPolicy`](#violationpolicy) | `BLOCK_AND_LOG` | Per-secret violation behavior |
+| injection | [`SecretInjection`](#secretinjection) | `SecretInjection()` | Per-request injection scopes |
 
 ### SecretInjection
 
-Frozen dataclass controlling where in the HTTP request the secret value is substituted.
+<div className="msb-tags"><span className="msb-tag is-type">frozen dataclass</span></div>
+
+<p className="msb-backref">Used by <a href="#secret-env">Secret.env()</a> · <a href="#secretentry">SecretEntry.injection</a></p>
+
+Controls where in the HTTP request the secret value can be substituted.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -97,23 +299,38 @@ Frozen dataclass controlling where in the HTTP request the secret value is subst
 
 ### ViolationAction
 
+<div className="msb-tags"><span className="msb-tag is-type">StrEnum</span></div>
+
+<p className="msb-backref">Used by <a href="#secret-env">Secret.env()</a> · <a href="#secretentry">SecretEntry.on_violation</a></p>
+
 String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) defining the action taken when a secret placeholder is sent to a disallowed host.
 
-| Value | Description |
-|-------|-------------|
-| `"block"` | Silently drop the request. The guest sees a connection reset. |
-| `"block-and-log"` | Drop the request and emit a warning log on the host side. This is the default. |
-| `"block-and-terminate"` | Drop the request, log an error, and shut down the entire sandbox. |
-| `"passthrough"` | Forward matching hosts with the placeholder unchanged. Non-matching hosts use the default secret violation action. |
+| Member | Value | Description |
+|--------|-------|-------------|
+| `BLOCK` | `"block"` | Silently drop the request. The guest sees a connection reset. |
+| `BLOCK_AND_LOG` | `"block-and-log"` | Drop the request and emit a warning log on the host side. This is the default. |
+| `BLOCK_AND_TERMINATE` | `"block-and-terminate"` | Drop the request, log an error, and shut down the entire sandbox. |
+| `PASSTHROUGH` | `"passthrough"` | Forward matching hosts with the placeholder unchanged. Non-matching hosts use the default secret violation action. |
 
 ### ViolationPolicy
 
-Frozen dataclass for passthrough host policies. Use `ViolationPolicy.passthrough(...)` when selected hosts should receive placeholders unchanged.
+<div className="msb-tags"><span className="msb-tag is-type">frozen dataclass</span></div>
 
-```python
-ViolationPolicy.passthrough(
-    hosts=("api.anthropic.com",),
-    host_patterns=("*.example.com",),
-    all_hosts=False,
-)
-```
+<p className="msb-backref">Used by <a href="#secret-env">Secret.env()</a> · <a href="#secretentry">SecretEntry.on_violation</a></p>
+
+Secret violation behavior, including optional passthrough hosts. Construct it with the classmethods ([`block()`](#violationpolicy-block), [`block_and_log()`](#violationpolicy-block_and_log), [`block_and_terminate()`](#violationpolicy-block_and_terminate), [`passthrough()`](#violationpolicy-passthrough)) rather than setting fields directly.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| fallback | [`ViolationAction`](#violationaction) | `BLOCK_AND_LOG` | Action for hosts not covered by the passthrough set |
+| passthrough_hosts | `tuple[str, ...]` | `()` | Exact hosts forwarded with the placeholder unchanged |
+| passthrough_host_patterns | `tuple[str, ...]` | `()` | Wildcard patterns forwarded with the placeholder unchanged |
+| passthrough_all_hosts | `bool` | `False` | Forward the placeholder unchanged to every host |
+
+### SecretViolationError
+
+<div className="msb-tags"><span className="msb-tag is-type">exception</span></div>
+
+<p className="msb-backref">Subclass of <code>MicrosandboxError</code></p>
+
+Raised when a secret placeholder was sent to a disallowed host. Carries `code = "secret-violation"`.

--- a/docs/sdk/python/snapshots.mdx
+++ b/docs/sdk/python/snapshots.mdx
@@ -3,24 +3,244 @@ title: Snapshots
 description: Python SDK - Snapshot API reference
 ---
 
-Disk-only snapshots of a sandbox that is not running. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Python SDK reference.
+Capture the disk state of a stopped sandbox as a reusable artifact, then boot fresh sandboxes from it. Snapshots are disk-only and require a sandbox that is not running. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs.
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Take a snapshot<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#handle-snapshot"><span className="msb-rn">handle.snapshot()</span><span className="msb-rg">snapshot under a name</span></a>
+  <a className="msb-row" href="#handle-snapshot_to"><span className="msb-rn">handle.snapshot_to()</span><span className="msb-rg">snapshot to a path</span></a>
+  <a className="msb-row" href="#snapshot-create"><span className="msb-rn">Snapshot.create()</span><span className="msb-rg">snapshot a stopped sandbox by name</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Boot from a snapshot<span className="msb-ct">1</span></p>
+  <a className="msb-row" href="#sandbox-create"><span className="msb-rn">Sandbox.create(snapshot=...)</span><span className="msb-rg">boot a fresh sandbox from an artifact</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Manage artifacts<span className="msb-ct">7</span></p>
+  <a className="msb-row" href="#snapshot-open"><span className="msb-rn">Snapshot.open()</span><span className="msb-rg">open an artifact by name or path</span></a>
+  <a className="msb-row" href="#snapshot-get"><span className="msb-rn">Snapshot.get()</span><span className="msb-rg">handle from the local index</span></a>
+  <a className="msb-row" href="#snapshot-list"><span className="msb-rn">Snapshot.list()</span><span className="msb-rg">indexed snapshots</span></a>
+  <a className="msb-row" href="#snapshot-list_dir"><span className="msb-rn">Snapshot.list_dir()</span><span className="msb-rg">parse a directory of artifacts</span></a>
+  <a className="msb-row" href="#snapshot-remove"><span className="msb-rn">Snapshot.remove()</span><span className="msb-rg">delete an artifact</span></a>
+  <a className="msb-row" href="#snapshot-reindex"><span className="msb-rn">Snapshot.reindex()</span><span className="msb-rg">rebuild the local index</span></a>
+  <a className="msb-row" href="#snapshot-export"><span className="msb-rn">Snapshot.export()</span><span className="msb-rg">bundle into an archive</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Move artifacts<span className="msb-ct">1</span></p>
+  <a className="msb-row" href="#snapshot-import_"><span className="msb-rn">Snapshot.import_()</span><span className="msb-rg">unpack an archive</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Inspect<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#snap-verify"><span className="msb-rn">snap.verify()</span><span className="msb-rg">recompute and check integrity</span></a>
+  <a className="msb-row" href="#handle-open"><span className="msb-rn">handle.open()</span><span className="msb-rg">load full metadata from a handle</span></a>
+  <a className="msb-row" href="#handle-remove"><span className="msb-rn">handle.remove()</span><span className="msb-rg">delete via a handle</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#snapshot">Snapshot</a>
+    <a className="msb-typepill" href="#snapshothandle">SnapshotHandle</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```python
-from microsandbox import Sandbox, Snapshot, SnapshotHandle
+from microsandbox import Sandbox, Snapshot
+
+# Run setup work, then stop the sandbox
+async with await Sandbox.create("baseline", image="python:3.12") as sb:
+    await sb.exec("pip", ["install", "numpy"])
+    await sb.stop()
+
+# Capture its disk state under a name
+snap = await Snapshot.create("baseline", name="after-pip-install")
+print(snap.digest)
+
+# Boot a fresh sandbox from the artifact
+sb2 = await Sandbox.create("worker", snapshot="after-pip-install")
 ```
 
-<Note>
-  Snapshots are **disk-only** and require a sandbox that is not running.
-</Note>
+## Take a snapshot
 
-## Sandbox.create() — `snapshot=` kwarg
+---
+
+#### <span className="msb-recv">handle.</span><span className="msb-hn">snapshot()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">SandboxHandle</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def snapshot(self, name: str) -> Snapshot
+```
+
+Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). The sandbox must be stopped or crashed. For an explicit filesystem destination, see [`snapshot_to()`](#handle-snapshot_to). Called on a [`SandboxHandle`](/sdk/python/sandbox#sandboxhandle), obtained from [`Sandbox.get()`](/sdk/python/sandbox#sandbox-get).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Snapshot name; resolved under the default snapshots directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshot">Snapshot</a></div>
+    <div className="msb-param-desc">The captured snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+handle = await Sandbox.get("baseline")
+snap = await handle.snapshot("after-pip-install")
+print(snap.digest)
+```
+
+---
+
+#### <span className="msb-recv">handle.</span><span className="msb-hn">snapshot_to()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">SandboxHandle</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def snapshot_to(self, path: str | os.PathLike) -> Snapshot
+```
+
+Snapshot this sandbox to an explicit filesystem path. The sandbox must be stopped or crashed.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str | os.PathLike</span></div>
+    <div className="msb-param-desc">Destination artifact directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshot">Snapshot</a></div>
+    <div className="msb-param-desc">The captured snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+handle = await Sandbox.get("baseline")
+snap = await handle.snapshot_to("/data/snapshots/baseline")
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def create(
+    source_sandbox: str,
+    *,
+    name: str | None = None,
+    path: str | os.PathLike | None = None,
+    labels: dict[str, str] | None = None,
+    force: bool = False,
+    record_integrity: bool = False,
+) -> Snapshot
+```
+
+Create a snapshot from a stopped or crashed sandbox. Exactly one of `name=` (resolved under the default snapshots directory) or `path=` (explicit filesystem destination) is required.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>source_sandbox</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Name of the stopped or crashed sandbox to capture.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Snapshot name under the default snapshots directory. Mutually exclusive with <code>path</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str | os.PathLike | None</span></div>
+    <div className="msb-param-desc">Explicit destination directory. Mutually exclusive with <code>name</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>labels</code><span className="msb-type">dict[str, str] | None</span></div>
+    <div className="msb-param-desc">User-supplied labels stored in the manifest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>force</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Overwrite an existing destination. Default <code>False</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>record_integrity</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Record an integrity hash in the manifest so the artifact can be verified later. Default <code>False</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshot">Snapshot</a></div>
+    <div className="msb-param-desc">The captured snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+snap = await Snapshot.create(
+    "baseline",
+    name="after-pip-install",
+    labels={"stage": "post-deps"},
+    record_integrity=True,
+)
+```
+
+---
+
+## Boot from a snapshot
+
+---
+
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @staticmethod
 async def create(name: str, *, snapshot: str | os.PathLike | None = None, **kwargs) -> Sandbox
 ```
 
-Boot a fresh sandbox from a snapshot artifact by passing `snapshot=` as a peer of `image=`. The two are mutually exclusive — pass exactly one.
+Boot a fresh sandbox from a snapshot artifact by passing `snapshot=` as a peer of `image=`. The two are mutually exclusive: pass exactly one. See [`Sandbox.create()`](/sdk/python/sandbox#sandbox-create) for the full set of configuration kwargs.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>snapshot</code><span className="msb-type">str | os.PathLike | None</span></div>
+    <div className="msb-param-desc">Snapshot bare name or artifact path to boot from instead of <code>image=</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/python/sandbox#instance-methods">Sandbox</a></div>
+    <div className="msb-param-desc">Running sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```python
 # Boot from a snapshot
@@ -30,68 +250,345 @@ sb = await Sandbox.create("worker", snapshot="after-pip-install")
 sb = await Sandbox.create("worker", image="python:3.12")
 ```
 
-**Errors**
+---
 
-- `ValueError` — both `image=` and `snapshot=` were passed or neither, the snapshot artifact doesn't exist, or the artifact's manifest failed validation
+## Manage artifacts
 
 ---
 
-## SandboxHandle methods
-
----
-
-#### snapshot()
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">open()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def snapshot(self, name: str) -> Snapshot
+@staticmethod
+async def open(path_or_name: str) -> Snapshot
 ```
 
-Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). The sandbox must be stopped or crashed. For an explicit filesystem destination, see [`snapshot_to()`](#snapshot-to).
+Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#snap-verify) for content checks.
 
-**Errors**
+<p className="msb-label">Parameters</p>
 
-- `SnapshotSandboxRunning` — the sandbox is not stopped
-- `SnapshotAlreadyExists` — destination exists (use `Snapshot.create(..., force=True)` to overwrite)
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path_or_name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Bare snapshot name or artifact directory path.</div>
+  </div>
+</div>
 
----
+<p className="msb-label">Returns</p>
 
-#### snapshot_to()
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshot">Snapshot</a></div>
+    <div className="msb-param-desc">The opened snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```python
-async def snapshot_to(self, path: str | os.PathLike) -> Snapshot
+snap = await Snapshot.open("after-pip-install")
+print(snap.image_ref)
 ```
 
-Snapshot this sandbox to an explicit filesystem path. The sandbox must be stopped or crashed.
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">get()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def get(name_or_digest: str) -> SnapshotHandle
+```
+
+Look up a handle in the local index by name, digest, or path.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name_or_digest</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Snapshot name, digest, or path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandle">SnapshotHandle</a></div>
+    <div className="msb-param-desc">Lightweight handle backed by an index row.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+h = await Snapshot.get("after-pip-install")
+print(h.digest)
+```
 
 ---
 
-## Snapshot (instance)
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
-Properties are read-only attributes (not async).
+```python
+@staticmethod
+async def list() -> list[SnapshotHandle]
+```
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `path` | `str` | Path to the artifact directory |
-| `digest` | `str` | Canonical content digest (`sha256:hex`). The snapshot's identity. |
-| `size_bytes` | `int` | Apparent size of the captured upper layer in bytes (sparse on disk) |
-| `image_ref` | `str` | Image reference the snapshot was taken from |
-| `image_manifest_digest` | `str` | OCI manifest digest of the pinned image |
-| `format` | `str` | `"raw"` or `"qcow2"` (always `"raw"` today) |
-| `fstype` | `str` | Filesystem type inside the upper (e.g. `"ext4"`) |
-| `parent` | `str \| None` | Parent snapshot's digest, or `None` for a root |
-| `created_at` | `str` | RFC 3339 timestamp |
-| `labels` | `dict[str, str]` | User-supplied labels |
-| `source_sandbox` | `str \| None` | Best-effort source-sandbox name |
+List indexed snapshots from the local DB cache.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandle">list[SnapshotHandle]</a></div>
+    <div className="msb-param-desc">Indexed snapshot handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+for h in await Snapshot.list():
+    print(h.name, h.digest)
+```
 
 ---
 
-#### verify()
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">list_dir()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def list_dir(dir: str | os.PathLike) -> list[Snapshot]
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index, useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dir</code><span className="msb-type">str | os.PathLike</span></div>
+    <div className="msb-param-desc">Directory to scan for artifacts.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshot">list[Snapshot]</a></div>
+    <div className="msb-param-desc">One snapshot per valid artifact directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+for snap in await Snapshot.list_dir("/mnt/artifacts"):
+    print(snap.path, snap.digest)
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def remove(path_or_name: str, *, force: bool = False) -> None
+```
+
+Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force=True`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path_or_name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Bare snapshot name or artifact path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>force</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Remove even if the snapshot has indexed children. Default <code>False</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await Snapshot.remove("after-pip-install", force=True)
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">reindex()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def reindex(dir: str | os.PathLike | None = None) -> int
+```
+
+Walk `dir` (default: configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dir</code><span className="msb-type">str | os.PathLike | None</span></div>
+    <div className="msb-param-desc">Directory to scan. Default: the configured snapshots directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Number of artifacts indexed.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+count = await Snapshot.reindex()
+print(f"indexed {count} snapshots")
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">export()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def export(
+    name_or_path: str,
+    out: str | os.PathLike,
+    *,
+    with_parents: bool = False,
+    with_image: bool = False,
+    plain_tar: bool = False,
+) -> None
+```
+
+Bundle a snapshot into a `.tar.zst` archive. The existing snapshot manifest is archived as-is; create the snapshot with recorded integrity when the archive will cross a trust boundary.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name_or_path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Snapshot bare name or artifact path to export.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>out</code><span className="msb-type">str | os.PathLike</span></div>
+    <div className="msb-param-desc">Output archive path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>with_parents</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Include the snapshot's parent chain. Default <code>False</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>with_image</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Include the pinned base image. Default <code>False</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>plain_tar</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Write an uncompressed <code>.tar</code> instead of <code>.tar.zst</code>. Default <code>False</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+await Snapshot.export(
+    "after-pip-install",
+    "/tmp/after-pip-install.tar.zst",
+    with_parents=True,
+)
+```
+
+---
+
+## Move artifacts
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">import_()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```python
+@staticmethod
+async def import_(
+    archive: str | os.PathLike,
+    *,
+    dest: str | os.PathLike | None = None,
+) -> SnapshotHandle
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity when present. Compression is detected from magic bytes. The trailing underscore is intentional: `import` is a reserved Python keyword.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>archive</code><span className="msb-type">str | os.PathLike</span></div>
+    <div className="msb-param-desc">Archive path (<code>.tar.zst</code> or <code>.tar</code>).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dest</code><span className="msb-type">str | os.PathLike | None</span></div>
+    <div className="msb-param-desc">Destination directory. Default: the configured snapshots directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandle">SnapshotHandle</a></div>
+    <div className="msb-param-desc">Handle to the imported snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+h = await Snapshot.import_("/tmp/after-pip-install.tar.zst")
+print(h.path)
+```
+
+---
+
+## Inspect
+
+---
+
+#### <span className="msb-recv">snap.</span><span className="msb-hn">verify()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">Snapshot</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def verify(self) -> dict[str, Any]
 ```
 
 Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">dict[str, Any]</span></div>
+    <div className="msb-param-desc">Verification report. The <code>upper.kind</code> field is <code>"not_recorded"</code> when no integrity hash was stored, or <code>"verified"</code> with the recomputed digest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```python
 report = await snap.verify()
@@ -114,146 +611,97 @@ The report shape:
 
 ---
 
-## Snapshot (static)
-
----
-
-#### Snapshot.create()
+#### <span className="msb-recv">handle.</span><span className="msb-hn">open()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">SnapshotHandle</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-@staticmethod
-async def create(
-    source_sandbox: str,
-    *,
-    name: str | None = None,
-    path: str | os.PathLike | None = None,
-    labels: dict[str, str] | None = None,
-    force: bool = False,
-    record_integrity: bool = False,
-) -> Snapshot
+async def open(self) -> Snapshot
 ```
 
-Create a snapshot from a stopped or crashed sandbox. Exactly one of `name=` (resolved under the default snapshots directory) or `path=` (explicit filesystem destination) is required.
+Load the full [`Snapshot`](#snapshot) metadata for this handle. Metadata-validated only; does not read the upper file.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshot">Snapshot</a></div>
+    <div className="msb-param-desc">The opened snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```python
-snap = await Snapshot.create(
-    "baseline",
-    name="after-pip-install",
-    labels={"stage": "post-deps"},
-    record_integrity=True,
-)
+h = await Snapshot.get("after-pip-install")
+snap = await h.open()
+print(snap.fstype)
 ```
 
 ---
 
-#### Snapshot.open()
+#### <span className="msb-recv">handle.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">SnapshotHandle</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-@staticmethod
-async def open(path_or_name: str) -> Snapshot
+async def remove(self, *, force: bool = False) -> None
 ```
 
-Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+Remove this snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force=True`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>force</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Remove even if the snapshot has indexed children. Default <code>False</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+h = await Snapshot.get("after-pip-install")
+await h.remove(force=False)
+```
 
 ---
 
-#### Snapshot.get()
+## Types
 
-```python
-@staticmethod
-async def get(name_or_digest: str) -> SnapshotHandle
-```
+### Snapshot
 
-Look up a handle in the local index by name, digest, or path.
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
 
----
+<p className="msb-backref">Returned by <a href="#handle-snapshot">snapshot()</a> · <a href="#handle-snapshot_to">snapshot_to()</a> · <a href="#snapshot-create">Snapshot.create()</a> · <a href="#snapshot-open">Snapshot.open()</a> · <a href="#snapshot-list_dir">Snapshot.list_dir()</a> · <a href="#handle-open">handle.open()</a></p>
 
-#### Snapshot.list()
+A fully-parsed snapshot artifact. Properties are read-only attributes (not async).
 
-```python
-@staticmethod
-async def list() -> list[SnapshotHandle]
-```
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `path` | `str` | Path to the artifact directory |
+| `digest` | `str` | Canonical content digest (`sha256:hex`). The snapshot's identity |
+| `size_bytes` | `int` | Apparent size of the captured upper layer in bytes (sparse on disk) |
+| `image_ref` | `str` | Image reference the snapshot was taken from |
+| `image_manifest_digest` | `str` | OCI manifest digest of the pinned image |
+| `format` | `str` | `"raw"` or `"qcow2"` (always `"raw"` today) |
+| `fstype` | `str` | Filesystem type inside the upper (e.g. `"ext4"`) |
+| `parent` | `str \| None` | Parent snapshot's digest, or `None` for a root |
+| `created_at` | `str` | RFC 3339 timestamp |
+| `labels` | `dict[str, str]` | User-supplied labels |
+| `source_sandbox` | `str \| None` | Best-effort source-sandbox name |
+| `verify()` | `Awaitable[dict[str, Any]]` | Recompute and check the upper-layer integrity hash. See [`verify()`](#snap-verify) |
 
-List indexed snapshots from the local DB cache.
+### SnapshotHandle
 
----
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
 
-#### Snapshot.list_dir()
+<p className="msb-backref">Returned by <a href="#snapshot-get">Snapshot.get()</a> · <a href="#snapshot-list">Snapshot.list()</a> · <a href="#snapshot-import_">Snapshot.import_()</a></p>
 
-```python
-@staticmethod
-async def list_dir(dir: str | os.PathLike) -> list[Snapshot]
-```
+Lightweight handle backed by an index row. Properties are read-only attributes (not async).
 
-Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
-
----
-
-#### Snapshot.remove()
-
-```python
-@staticmethod
-async def remove(path_or_name: str, *, force: bool = False) -> None
-```
-
-Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force=True`.
-
----
-
-#### Snapshot.reindex()
-
-```python
-@staticmethod
-async def reindex(dir: str | os.PathLike | None = None) -> int
-```
-
-Walk `dir` (default: configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
-
----
-
-#### Snapshot.export()
-
-```python
-@staticmethod
-async def export(
-    name_or_path: str,
-    out: str | os.PathLike,
-    *,
-    with_parents: bool = False,
-    with_image: bool = False,
-    plain_tar: bool = False,
-) -> None
-```
-
-Bundle a snapshot into a `.tar.zst` archive. The existing snapshot manifest is archived as-is; create the snapshot with recorded integrity when the archive will cross a trust boundary.
-
----
-
-#### Snapshot.import_()
-
-```python
-@staticmethod
-async def import_(
-    archive: str | os.PathLike,
-    *,
-    dest: str | os.PathLike | None = None,
-) -> SnapshotHandle
-```
-
-Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity when present. Compression is detected from magic bytes.
-
-The trailing underscore is intentional — `import` is a reserved Python keyword.
-
----
-
-## SnapshotHandle
-
-Lightweight handle backed by an index row. Returned by [`Snapshot.list()`](#snapshot-list) and [`Snapshot.get()`](#snapshot-get).
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `digest` | `str` | Manifest digest — canonical identity |
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `digest` | `str` | Manifest digest, canonical identity |
 | `name` | `str \| None` | Convenience alias |
 | `parent_digest` | `str \| None` | Parent snapshot digest, or `None` for a root |
 | `image_ref` | `str` | Image the snapshot was taken from |
@@ -261,9 +709,5 @@ Lightweight handle backed by an index row. Returned by [`Snapshot.list()`](#snap
 | `size_bytes` | `int \| None` | Apparent upper size at index time |
 | `created_at` | `float` | ms since Unix epoch |
 | `path` | `str` | Local artifact directory path |
-
-```python
-h = await Snapshot.get("after-pip-install")
-snap = await h.open()                # metadata-validated
-await h.remove(force=False)          # refuse if has children
-```
+| `open()` | `Awaitable[`[`Snapshot`](#snapshot)`]` | Load full metadata. See [`open()`](#handle-open) |
+| `remove(force=False)` | `Awaitable[None]` | Delete the artifact and its index row. See [`remove()`](#handle-remove) |

--- a/docs/sdk/python/ssh.mdx
+++ b/docs/sdk/python/ssh.mdx
@@ -3,34 +3,104 @@ title: SSH
 description: Python SDK - SSH API reference
 ---
 
-See [SSH](/sandboxes/ssh) for usage flows.
+Reach a running sandbox over SSH: open a native in-process SSH client, run exec requests, attach an interactive shell, transfer files over SFTP, or stand up a reusable server endpoint that serves connections over stdin/stdout. See [SSH](/sandboxes/ssh) for usage flows.
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Sandbox<span className="msb-ct">1</span></p>
+  <a className="msb-row" href="#sb-ssh"><span className="msb-rn">sb.ssh()</span><span className="msb-rg">SSH namespace for this sandbox</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SandboxSshOps<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#ssh-open_client"><span className="msb-rn">ssh.open_client()</span><span className="msb-rg">open a client</span></a>
+  <a className="msb-row" href="#ssh-prepare_server"><span className="msb-rn">ssh.prepare_server()</span><span className="msb-rg">prepare a server endpoint</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SshClient<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#client-exec"><span className="msb-rn">client.exec()</span><span className="msb-rg">run a command</span></a>
+  <a className="msb-row" href="#client-attach"><span className="msb-rn">client.attach()</span><span className="msb-rg">interactive shell</span></a>
+  <a className="msb-row" href="#client-sftp"><span className="msb-rn">client.sftp()</span><span className="msb-rg">open an SFTP session</span></a>
+  <a className="msb-row" href="#client-close"><span className="msb-rn">client.close()</span><span className="msb-rg">close the session</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SshServer<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#server-serve_connection"><span className="msb-rn">server.serve_connection()</span><span className="msb-rg">serve one connection over stdin/stdout</span></a>
+  <a className="msb-row" href="#server-close"><span className="msb-rn">server.close()</span><span className="msb-rg">release the endpoint</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SftpClient<span className="msb-ct">10</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#sftpclient">read()</a>
+    <a className="msb-chip" href="#sftpclient">write()</a>
+    <a className="msb-chip" href="#sftpclient">mkdir()</a>
+    <a className="msb-chip" href="#sftpclient">remove_file()</a>
+    <a className="msb-chip" href="#sftpclient">remove_dir()</a>
+    <a className="msb-chip" href="#sftpclient">rename()</a>
+    <a className="msb-chip" href="#sftpclient">real_path()</a>
+    <a className="msb-chip" href="#sftpclient">read_link()</a>
+    <a className="msb-chip" href="#sftpclient">symlink()</a>
+    <a className="msb-chip" href="#sftpclient">close()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#sandboxsshops">SandboxSshOps</a>
+    <a className="msb-typepill" href="#sshclient">SshClient</a>
+    <a className="msb-typepill" href="#sshserver">SshServer</a>
+    <a className="msb-typepill" href="#sftpclient">SftpClient</a>
+    <a className="msb-typepill" href="#sshoutput">SshOutput</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```python
+from microsandbox import Sandbox
+
+async with await Sandbox.create("api", image="python") as sb:
+    client = await sb.ssh().open_client()      # 1. open an SSH client
+    out = await client.exec("python -V")        # 2. run a command
+    print(out.stdout_text)
+
+    await client.close()                        # 3. close the session
+```
 
 ## Sandbox
 
 ---
 
-#### ssh()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">ssh()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```python
 def ssh() -> SandboxSshOps
 ```
 
-Return the SSH namespace for this sandbox.
+Return the SSH namespace for this sandbox. The namespace holds the SSH client and server helpers; nothing connects until you call [`open_client()`](#ssh-open_client) or [`prepare_server()`](#ssh-prepare_server). This method is synchronous; the helpers it returns are async.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxSshOps`](#sandboxssh) | SSH client and server helpers |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxsshops">SandboxSshOps</a></div>
+    <div className="msb-param-desc">SSH namespace for this sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+client = await sb.ssh().open_client()
+```
 
 ## SandboxSshOps
 
+SSH namespace for a sandbox, obtained from [`sb.ssh()`](#sb-ssh). SSH is only supported on local sandboxes.
+
 ---
 
-#### connect()
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">open_client()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def connect(
+async def open_client(
     *,
     user: str = "root",
     term: str | None = None,
@@ -38,28 +108,48 @@ async def connect(
 ) -> SshClient
 ```
 
-Connect a native in-process SSH client to the sandbox.
+Connect a native in-process SSH client to this sandbox. Generates an ephemeral client and host key pair, stands up an internal server bound to an in-memory stream, and authenticates over public key.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| user | `str` | SSH login user |
-| term | `str \| None` | Terminal name for interactive sessions |
-| sftp | `bool` | Enable or disable SFTP on the internal server |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>user</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">SSH login user. Default <code>"root"</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>term</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Terminal name for interactive sessions. Defaults to <code>$TERM</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>sftp</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Enable or disable SFTP on the internal server. Default <code>True</code>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SshClient`](#sshclient) | Native SSH client session |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshclient">SshClient</a></div>
+    <div className="msb-param-desc">Connected SSH client session.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+client = await sb.ssh().open_client(user="app", term="xterm-256color")
+out = await client.exec("uname -a")
+```
 
 ---
 
-#### server()
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">prepare_server()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def server(
+async def prepare_server(
     *,
     host_key_path: str | os.PathLike[str] | None = None,
     authorized_keys_path: str | os.PathLike[str] | None = None,
@@ -68,51 +158,97 @@ async def server(
 ) -> SshServer
 ```
 
-Prepare a reusable SSH server endpoint.
+Prepare a reusable SSH server endpoint for this sandbox. Loads or creates the host key and resolves authorized keys, falling back to the default authorized-keys file when no path is given. The returned [`SshServer`](#sshserver) serves one connection over this process's stdin/stdout.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| host_key_path | `str \| os.PathLike[str] \| None` | Override the host private key path |
-| authorized_keys_path | `str \| os.PathLike[str] \| None` | Override the authorized-keys path |
-| user | `str \| None` | Override the guest user used for exec requests |
-| sftp | `bool` | Enable or disable SFTP |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_key_path</code><span className="msb-type">str | os.PathLike[str] | None</span></div>
+    <div className="msb-param-desc">Override the host private key path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>authorized_keys_path</code><span className="msb-type">str | os.PathLike[str] | None</span></div>
+    <div className="msb-param-desc">Override the authorized-keys path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>user</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Override the guest user used for exec requests.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>sftp</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Enable or disable SFTP. Default <code>True</code>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SshServer`](#sshserver) | Server endpoint |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshserver">SshServer</a></div>
+    <div className="msb-param-desc">Reusable SSH server endpoint.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+server = await sb.ssh().prepare_server(
+    authorized_keys_path="/home/me/.ssh/authorized_keys",
+    user="app",
+    sftp=False,
+)
+await server.serve_connection()
+```
 
 ## SshClient
 
+A connected, native in-process SSH client session, obtained from [`ssh.open_client()`](#ssh-open_client).
+
 ---
 
-#### exec()
+#### <span className="msb-recv">client.</span><span className="msb-hn">exec()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def exec(command: str, *, tty: bool = False) -> SshOutput
 ```
 
-Run an SSH exec request and collect stdout, stderr, and exit status.
+Run an SSH exec request and collect stdout, stderr, and the exit status. The command runs through the sandbox's configured shell. When `tty=True` a PTY is allocated and stderr is folded into stdout.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| command | `str` | Command string sent through SSH |
-| tty | `bool` | Request a PTY for the exec channel |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>command</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Command string sent through SSH.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>tty</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Request a PTY for the exec channel. Default <code>False</code>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SshOutput`](#sshoutput) | Captured output and status |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshoutput">SshOutput</a></div>
+    <div className="msb-param-desc">Captured output and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+out = await client.exec("echo hello")
+print(f"exit {out.status}: {out.stdout_text}")
+```
 
 ---
 
-#### attach()
+#### <span className="msb-recv">client.</span><span className="msb-hn">attach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def attach(
@@ -122,93 +258,193 @@ async def attach(
 ) -> int
 ```
 
-Attach the local terminal to an interactive SSH shell.
+Attach the local terminal to an interactive SSH shell. Requests a PTY sized to the current terminal, puts the terminal into raw mode, forwards keystrokes, and returns when the shell exits or the detach key sequence is typed.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| term | `str \| None` | Terminal name for the shell |
-| detach_keys | `str \| None` | Detach key sequence |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>term</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Terminal name for the shell. Defaults to <code>$TERM</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>detach_keys</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Detach key sequence, e.g. <code>"ctrl-p,ctrl-q"</code>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `int` | Exit code |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">int</span></div>
+    <div className="msb-param-desc">Shell exit code (128 if terminated by signal).</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+code = await client.attach(term="xterm-256color", detach_keys="ctrl-p,ctrl-q")
+print(f"shell exited with {code}")
+```
 
 ---
 
-#### sftp()
+#### <span className="msb-recv">client.</span><span className="msb-hn">sftp()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def sftp() -> SftpClient
 ```
 
-Open an SFTP session over this SSH connection.
+Open an SFTP client session over this SSH connection. Requests the `sftp` subsystem and returns a high-level session for reading, writing, and listing files inside the guest.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SftpClient`](#sftpclient) | SFTP client session |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sftpclient">SftpClient</a></div>
+    <div className="msb-param-desc">SFTP client session.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+sftp = await client.sftp()
+await sftp.write("/tmp/hello.txt", b"hi")
+data = await sftp.read("/tmp/hello.txt")
+```
 
 ---
 
-#### close()
+#### <span className="msb-recv">client.</span><span className="msb-hn">close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def close() -> None
 ```
 
-Close the native SSH client session.
+Close this native SSH client session. Sends a disconnect and aborts the internal server task.
 
-## SftpClient
+<p className="msb-label">Example</p>
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| read(path) | `bytes` | Read a file into memory |
-| write(path, data) | `None` | Create or truncate a file |
-| mkdir(path) | `None` | Create a directory |
-| remove_file(path) | `None` | Remove a file |
-| remove_dir(path) | `None` | Remove an empty directory |
-| rename(old_path, new_path) | `None` | Rename a file or directory |
-| real_path(path) | `str` | Resolve a canonical path |
-| read_link(path) | `str` | Read a symlink target |
-| symlink(target, link_path) | `None` | Create a symlink |
-| close() | `None` | Close the SFTP session |
+```python
+await client.close()
+```
 
 ## SshServer
 
+A reusable SSH server endpoint for a sandbox, obtained from [`ssh.prepare_server()`](#ssh-prepare_server).
+
 ---
 
-#### serve_connection()
+#### <span className="msb-recv">server.</span><span className="msb-hn">serve_connection()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 async def serve_connection() -> None
 ```
 
-Serve one SSH transport over stdin/stdout.
+Serve one SSH transport over this process's stdin/stdout. Runs the SSH handshake and session loop to completion, returning when the connection closes. Use this to bridge an SSH connection over the parent process's standard streams.
+
+<p className="msb-label">Example</p>
+
+```python
+server = await sb.ssh().prepare_server()
+await server.serve_connection()
+```
 
 ---
 
-#### close()
+#### <span className="msb-recv">server.</span><span className="msb-hn">close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```python
 def close() -> None
 ```
 
-Release the prepared server endpoint.
+Release this prepared server endpoint. This method is synchronous.
+
+<p className="msb-label">Example</p>
+
+```python
+server.close()
+```
 
 ## Types
 
+### SandboxSshOps
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-ssh">sb.ssh()</a></p>
+
+SSH namespace for a sandbox.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`open_client()`](#ssh-open_client) | [`SshClient`](#sshclient) | *(async)* Open a client. |
+| [`prepare_server()`](#ssh-prepare_server) | [`SshServer`](#sshserver) | *(async)* Prepare a server endpoint. |
+
+### SshClient
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#ssh-open_client">ssh.open_client()</a></p>
+
+Native in-process SSH client session.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`exec(command, *, tty=False)`](#client-exec) | [`SshOutput`](#sshoutput) | *(async)* Run a command. |
+| [`attach(*, term=None, detach_keys=None)`](#client-attach) | `int` | *(async)* Interactive shell. |
+| [`sftp()`](#client-sftp) | [`SftpClient`](#sftpclient) | *(async)* Open an SFTP session. |
+| [`close()`](#client-close) | `None` | *(async)* Close the session. |
+
+### SshServer
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#ssh-prepare_server">ssh.prepare_server()</a></p>
+
+Reusable SSH server endpoint for a sandbox.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`serve_connection()`](#server-serve_connection) | `None` | *(async)* Serve one connection over stdin/stdout. |
+| [`close()`](#server-close) | `None` | Release the prepared endpoint. |
+
+### SftpClient
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#client-sftp">client.sftp()</a></p>
+
+High-level SFTP client session over an SSH connection. All methods are async.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| read(path) | `bytes` | Read a file into memory. |
+| write(path, data) | `None` | Write a file, creating or truncating it. |
+| mkdir(path) | `None` | Create a directory. |
+| remove_file(path) | `None` | Remove a file. |
+| remove_dir(path) | `None` | Remove an empty directory. |
+| rename(old_path, new_path) | `None` | Rename a file or directory. |
+| real_path(path) | `str` | Resolve a path to its canonical absolute form. |
+| read_link(path) | `str` | Read a symlink target. |
+| symlink(target, link_path) | `None` | Create a symlink. |
+| close() | `None` | Close the SFTP session. |
+
 ### SshOutput
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#client-exec">client.exec()</a></p>
+
+Output from an SSH exec request.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| status | `int` | Exit status code |
-| success | `bool` | `True` if status is `0` |
-| stdout_text | `str` | Captured stdout decoded as UTF-8 |
-| stderr_text | `str` | Captured stderr decoded as UTF-8 |
-| stdout_bytes | `bytes` | Captured stdout bytes |
-| stderr_bytes | `bytes` | Captured stderr bytes |
+| status | `int` | Exit status code. |
+| success | `bool` | Whether the command exited successfully. |
+| stdout_text | `str` | Stdout as UTF-8 text. |
+| stderr_text | `str` | Stderr as UTF-8 text. |
+| stdout_bytes | `bytes` | Stdout as raw bytes. |
+| stderr_bytes | `bytes` | Stderr as raw bytes. |

--- a/docs/sdk/python/volumes.mdx
+++ b/docs/sdk/python/volumes.mdx
@@ -3,20 +3,77 @@ title: Volumes
 description: Python SDK - Volume API reference
 ---
 
-See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+Create and manage named persistent volumes, and build the mount configs that attach storage to a sandbox. See [Volumes](/sandboxes/volumes) for usage examples and patterns.
 
-## Volume
+<div className="msb-glance">
 
-Named volumes are managed by microsandbox and stored by default under `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+  <p className="msb-gl"><span className="msb-dot static"></span>Static · Volume<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#volume-create"><span className="msb-rn">Volume.create()</span><span className="msb-rg">create a named volume</span></a>
+  <a className="msb-row" href="#volume-get"><span className="msb-rn">Volume.get()</span><span className="msb-rg">handle to an existing one</span></a>
+  <a className="msb-row" href="#volume-list"><span className="msb-rn">Volume.list()</span><span className="msb-rg">all volumes</span></a>
+  <a className="msb-row" href="#volume-remove"><span className="msb-rn">Volume.remove()</span><span className="msb-rg">delete a volume</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Mount factories · Volume<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#volume-bind"><span className="msb-rn">Volume.bind()</span><span className="msb-rg">mount a host directory</span></a>
+  <a className="msb-row" href="#volume-named"><span className="msb-rn">Volume.named()</span><span className="msb-rg">mount a named volume</span></a>
+  <a className="msb-row" href="#volume-tmpfs"><span className="msb-rn">Volume.tmpfs()</span><span className="msb-rg">in-memory filesystem</span></a>
+  <a className="msb-row" href="#volume-disk"><span className="msb-rn">Volume.disk()</span><span className="msb-rg">mount a disk image</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · Volume<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#volume-name"><span className="msb-rn">volume.name</span><span className="msb-rg">volume name</span></a>
+  <a className="msb-row" href="#volume-path"><span className="msb-rn">volume.path</span><span className="msb-rg">host path</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · VolumeFs<span className="msb-ct">7</span></p>
+  <a className="msb-row" href="#fs-read"><span className="msb-rn">fs.read()</span><span className="msb-rg">read bytes</span></a>
+  <a className="msb-row" href="#fs-read_text"><span className="msb-rn">fs.read_text()</span><span className="msb-rg">read UTF-8 text</span></a>
+  <a className="msb-row" href="#fs-write"><span className="msb-rn">fs.write()</span><span className="msb-rg">write bytes</span></a>
+  <a className="msb-row" href="#fs-list"><span className="msb-rn">fs.list()</span><span className="msb-rg">list a directory</span></a>
+  <a className="msb-row" href="#fs-mkdir"><span className="msb-rn">fs.mkdir()</span><span className="msb-rg">create a directory</span></a>
+  <a className="msb-row" href="#fs-remove_file"><span className="msb-rn">fs.remove_file()</span><span className="msb-rg">remove a file</span></a>
+  <a className="msb-row" href="#fs-exists"><span className="msb-rn">fs.exists()</span><span className="msb-rg">check a path exists</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#volumehandle">VolumeHandle</a>
+    <a className="msb-typepill" href="#volumefs">VolumeFs</a>
+    <a className="msb-typepill" href="#mountconfig">MountConfig</a>
+    <a className="msb-typepill" href="#mountkind">MountKind</a>
+    <a className="msb-typepill" href="#diskimageformat">DiskImageFormat</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```python
+from microsandbox import Sandbox, Volume
+
+# 1. create a persistent named volume
+await Volume.create("pip-cache", quota_mib=2048)
+
+# 2. mount it into a sandbox via a mount factory
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    volumes={"/root/.cache/pip": Volume.named("pip-cache")},
+)
+
+# 3. inspect or edit the volume from the host, no sandbox required
+handle = await Volume.get("pip-cache")
+print(handle.used_bytes)
+```
 
 ## Static methods
 
+Static methods on `Volume` that manage named persistent volumes. Volumes live independently of any sandbox, stored by default under `~/.microsandbox/volumes/<name>/`.
+
 ---
 
-#### Volume.create()
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def Volume.create(
+async def create(
     name: str,
     *,
     kind: str = "dir",
@@ -26,224 +83,340 @@ async def Volume.create(
 ) -> Volume
 ```
 
-Create a new named volume.
+Create a new named volume. A `"dir"` volume is a host directory; a `"disk"` volume is a backing disk image that requires `size_mib`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `str` | Volume name (required) |
-| kind | `str` | Volume kind: `"dir"` or `"disk"` |
-| size_mib | `int \| None` | Disk capacity in MiB; required with `kind="disk"` |
-| quota_mib | `int \| None` | Recorded quota metadata for directory volumes |
-| labels | `dict[str, str] \| None` | Metadata labels |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>kind</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Volume kind: <code>"dir"</code> (default) or <code>"disk"</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>size_mib</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Disk capacity in MiB; required with <code>kind="disk"</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>quota_mib</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Quota in MiB recorded for directory volumes.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>labels</code><span className="msb-type">dict[str, str] | None</span></div>
+    <div className="msb-param-desc">Metadata labels.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Volume` | Created volume with `name` and `path` properties |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-properties">Volume</a></div>
+    <div className="msb-param-desc">Created volume, exposing <code>name</code> and <code>path</code>.</div>
+  </div>
+</div>
 
----
-
-#### Volume.get()
+<p className="msb-label">Example</p>
 
 ```python
-async def Volume.get(name: str) -> VolumeHandle
+await Volume.create("pip-cache", quota_mib=2048)
+await Volume.create("docker-data", kind="disk", size_mib=20 * 1024)
 ```
 
-Get a handle to an existing named volume.
+---
 
-**Parameters**
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">get()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `str` | Volume name |
+```python
+async def get(name: str) -> VolumeHandle
+```
 
-**Returns**
+Get a lightweight handle to an existing named volume, with its metadata and a host-side filesystem handle.
 
-| Type | Description |
-|------|-------------|
-| [`VolumeHandle`](#volumehandle) | Volume handle |
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumehandle">VolumeHandle</a></div>
+    <div className="msb-param-desc">Handle with metadata and a filesystem accessor.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+handle = await Volume.get("pip-cache")
+print(handle.kind, handle.used_bytes)
+```
 
 ---
 
-#### Volume.list()
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def Volume.list() -> list[VolumeHandle]
+async def list() -> list[VolumeHandle]
 ```
 
 List all named volumes.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `list[`[`VolumeHandle`](#volumehandle)`]` | All volumes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumehandle">list[VolumeHandle]</a></div>
+    <div className="msb-param-desc">All volume handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+for v in await Volume.list():
+    print(v.name, v.used_bytes)
+```
 
 ---
 
-#### Volume.remove()
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
-async def Volume.remove(name: str) -> None
+async def remove(name: str) -> None
 ```
 
 Delete a named volume and its contents. Fails if the volume is currently mounted.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `str` | Volume name |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
 
----
-
-## Volume instance properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| name | `str` | Volume name |
-| path | `str` | Host path to the volume directory |
-
----
-
-## Mount config factories
-
-Static factory methods on `Volume` for creating mount configurations used in sandbox volume config.
-
----
-
-#### Volume.bind()
+<p className="msb-label">Example</p>
 
 ```python
-def Volume.bind(
+await Volume.remove("pip-cache")
+```
+
+---
+
+## Mount factories
+
+Static factory methods on `Volume` that build a [`MountConfig`](#mountconfig). Pass the result as a value in the `volumes` dict when creating a sandbox, keyed by the guest mount point.
+
+---
+
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">bind()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
+
+```python
+def bind(
     path: str,
     *,
     readonly: bool = False,
     noexec: bool = False,
     nosuid: bool = False,
     nodev: bool = False,
-) -> dict
+) -> MountConfig
 ```
 
 Mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Directory path on the host |
-| readonly | `bool` | Mount as read-only; virtiofs-backed mounts also reject writes in the host filesystem server |
-| noexec | `bool` | Prevent direct execution from the mount |
-| nosuid | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
-| nodev | `bool` | Ignore device files on the mount |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Directory path on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>readonly</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Mount as read-only; virtiofs-backed mounts also reject writes in the host filesystem server.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>noexec</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Prevent direct execution from the mount.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nosuid</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Ignore setuid and setgid privilege elevation from files on the mount.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nodev</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Ignore device files on the mount.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `dict` | Mount configuration dictionary |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#mountconfig">MountConfig</a></div>
+    <div className="msb-param-desc">Mount configuration.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+sb = await Sandbox.create(
+    "build",
+    image="python",
+    volumes={"/src": Volume.bind("/home/me/project", readonly=True)},
+)
+```
 
 ---
 
-#### Volume.named()
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">named()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```python
-def Volume.named(
+def named(
     name: str,
     *,
-    mode: str | None = None,
-    kind: str | None = None,
-    size_mib: int | None = None,
-    quota_mib: int | None = None,
     readonly: bool = False,
     noexec: bool = False,
     nosuid: bool = False,
     nodev: bool = False,
-) -> dict
+) -> MountConfig
 ```
 
-Mount a named volume. By default, the volume must already exist (create it with [`Volume.create()`](#volumecreate)). Pass `mode="create"` to create the volume and fail if it already exists, or `mode="ensure-exists"` to create it if missing and reuse it if compatible.
+Mount an existing named volume. The volume must already exist; create it first with [`Volume.create()`](#volume-create).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>readonly</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Mount as read-only; virtiofs-backed mounts also reject writes in the host filesystem server.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>noexec</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Prevent direct execution from the mount.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nosuid</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Ignore setuid and setgid privilege elevation from files on the mount.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nodev</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Ignore device files on the mount.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#mountconfig">MountConfig</a></div>
+    <div className="msb-param-desc">Mount configuration.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```python
 sb = await Sandbox.create(
     "worker",
     image="python",
     volumes={
-        "/cache": Volume.named("pip-cache", mode="ensure-exists"),
-        "/var/lib/docker": Volume.named(
-            "docker-data",
-            mode="ensure-exists",
-            kind="disk",
-            size_mib=20 * 1024,
-        ),
+        "/root/.cache/pip": Volume.named("pip-cache"),
+        "/etc/config": Volume.named("shared-config", readonly=True),
     },
 )
 ```
 
-The ensure-exists mode validates existing volume metadata. It errors when the existing volume has a different kind, quota, or capacity than the requested configuration; it does not mutate existing volume metadata.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| name | `str` | Volume name |
-| mode | `str \| None` | Named volume behavior: `"existing"` (default), `"create"`, or `"ensure-exists"` |
-| kind | `str \| None` | Storage kind for create or ensure-exists: `"dir"` (default) or `"disk"` |
-| size_mib | `int \| None` | Disk capacity in MiB; required when creating or ensuring a missing disk volume |
-| quota_mib | `int \| None` | Directory volume quota in MiB |
-| readonly | `bool` | Mount as read-only; virtiofs-backed mounts also reject writes in the host filesystem server |
-| noexec | `bool` | Prevent direct execution from the mount |
-| nosuid | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
-| nodev | `bool` | Ignore device files on the mount |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `dict` | Mount configuration dictionary |
-
 ---
 
-#### Volume.tmpfs()
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">tmpfs()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```python
-def Volume.tmpfs(
+def tmpfs(
     *,
     size_mib: int | None = None,
     readonly: bool = False,
     noexec: bool = False,
     nosuid: bool = False,
     nodev: bool = False,
-) -> dict
+) -> MountConfig
 ```
 
 Use an in-memory filesystem. Contents are discarded when the sandbox stops.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| size_mib | `int \| None` | Maximum size in MiB |
-| readonly | `bool` | Mount as read-only |
-| noexec | `bool` | Prevent direct execution from the mount |
-| nosuid | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
-| nodev | `bool` | Ignore device files on the mount |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>size_mib</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Maximum size in MiB.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>readonly</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Mount as read-only.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>noexec</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Prevent direct execution from the mount.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nosuid</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Ignore setuid and setgid privilege elevation from files on the mount.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nodev</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Ignore device files on the mount.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `dict` | Mount configuration dictionary |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#mountconfig">MountConfig</a></div>
+    <div className="msb-param-desc">Mount configuration.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+sb = await Sandbox.create(
+    "scratch",
+    image="python",
+    volumes={"/tmp/work": Volume.tmpfs(size_mib=256)},
+)
+```
 
 ---
 
-#### Volume.disk()
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">disk()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```python
-def Volume.disk(
+def disk(
     path: str,
     *,
     format: str | None = None,
@@ -252,34 +425,302 @@ def Volume.disk(
     noexec: bool = False,
     nosuid: bool = False,
     nodev: bool = False,
-) -> dict
+) -> MountConfig
 ```
 
-Mount a host disk image as a virtio-blk device. `format` may be `"raw"`, `"qcow2"`, or `"vmdk"`; when omitted it defaults from the file extension. `fstype` is the inner filesystem type such as `"ext4"`; when omitted agentd auto-detects.
+Mount a host disk image as a virtio-blk device. `format` is the disk image format (`"qcow2"`, `"raw"`, or `"vmdk"`); when omitted it is inferred from the file extension. `fstype` (e.g. `"ext4"`) is the inner filesystem agentd mounts; when omitted, agentd probes `/proc/filesystems` for a type that mounts cleanly.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Host path to the disk image |
-| format | `str \| None` | Disk image format hint |
-| fstype | `str \| None` | Inner filesystem type |
-| readonly | `bool` | Mount as read-only |
-| noexec | `bool` | Prevent direct execution from the mount |
-| nosuid | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
-| nodev | `bool` | Ignore device files on the mount |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Host path to the disk image.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>format</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Disk image format hint. See <a href="#diskimageformat">DiskImageFormat</a>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>fstype</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Inner filesystem type.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>readonly</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Mount as read-only.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>noexec</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Prevent direct execution from the mount.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nosuid</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Ignore setuid and setgid privilege elevation from files on the mount.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nodev</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Ignore device files on the mount.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `dict` | Mount configuration dictionary |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#mountconfig">MountConfig</a></div>
+    <div className="msb-param-desc">Mount configuration.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+sb = await Sandbox.create(
+    "db",
+    image="postgres",
+    volumes={"/var/lib/postgresql": Volume.disk("/data/pg.qcow2", fstype="ext4")},
+)
+```
 
 ---
 
-## VolumeHandle
+## Instance properties
 
-Handle to an existing named volume, returned by [`Volume.get()`](#volumeget) and [`Volume.list()`](#volumelist).
+Read-only properties on a [`Volume`](#volume-create) returned by [`Volume.create()`](#volume-create).
+
+---
+
+#### <span className="msb-recv">volume.</span><span className="msb-hn">name</span>
+<div className="msb-tags"><span className="msb-tag is-instance">property</span></div>
+
+```python
+name: str
+```
+
+Volume name.
+
+---
+
+#### <span className="msb-recv">volume.</span><span className="msb-hn">path</span>
+<div className="msb-tags"><span className="msb-tag is-instance">property</span></div>
+
+```python
+path: str
+```
+
+Host path to the volume's directory.
+
+---
+
+## VolumeFs methods
+
+Host-side filesystem operations on a named volume, obtained via the `fs` property on a [`VolumeHandle`](#volumehandle). These run directly on the host filesystem; no running sandbox is required. All paths are relative to the volume root.
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def read(path: str) -> bytes
+```
+
+Read the entire contents of a file as raw bytes.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bytes</span></div>
+    <div className="msb-param-desc">File contents as raw bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+handle = await Volume.get("pip-cache")
+data = await handle.fs.read("index.json")
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read_text()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def read_text(path: str) -> str
+```
+
+Read the entire contents of a file and decode it as UTF-8.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">File contents as a string.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">write()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>data</code><span className="msb-type">bytes</span></div>
+    <div className="msb-param-desc">File content.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```python
+handle = await Volume.get("pip-cache")
+await handle.fs.write("seed.txt", b"hello")
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/python/filesystem#fsentry">list[FsEntry]</a></div>
+    <div className="msb-param-desc">Directory entries.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory and all parent directories.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">remove_file()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def remove_file(path: str) -> None
+```
+
+Remove a file.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">exists()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```python
+async def exists(path: str) -> bool
+```
+
+Check whether a path exists within the volume.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>True</code> if the path exists.</div>
+  </div>
+</div>
+
+---
+
+## Types
+
+### VolumeHandle
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#volume-get">Volume.get()</a>, <a href="#volume-list">Volume.list()</a></p>
+
+A lightweight handle to a named volume, with its database metadata and a host-side filesystem accessor.
 
 | Property / Method | Type | Description |
 |-------------------|------|-------------|
@@ -295,187 +736,76 @@ Handle to an existing named volume, returned by [`Volume.get()`](#volumeget) and
 | fs | [`VolumeFs`](#volumefs) | Host-side filesystem handle |
 | remove() | *(async)* `None` | Delete this volume |
 
----
+### VolumeFs
 
-## VolumeFs
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
 
-Host-side filesystem operations on a named volume. Obtained via the `fs` property on [`VolumeHandle`](#volumehandle). These operations run directly on the host filesystem - no running sandbox is required.
+<p className="msb-backref">Returned by <a href="#volumehandle">VolumeHandle.fs</a></p>
 
----
+Host-side filesystem operations on a named volume. No running sandbox is required. See the [VolumeFs methods](#volumefs-methods) above for the full API.
 
-#### read()
-
-```python
-async def read(path: str) -> bytes
-```
-
-Read the entire contents of a file as raw bytes.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Path relative to the volume root |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `bytes` | File contents as raw bytes |
-
----
-
-#### read_text()
-
-```python
-async def read_text(path: str) -> str
-```
-
-Read the entire contents of a file and decode as UTF-8.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Path relative to the volume root |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `str` | File contents as a string |
-
----
-
-#### write()
-
-```python
-async def write(path: str, data: bytes) -> None
-```
-
-Write content to a file, creating it if it doesn't exist and overwriting if it does.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Path relative to the volume root |
-| data | `bytes` | File content |
-
----
-
-#### list()
-
-```python
-async def list(path: str) -> list[FsEntry]
-```
-
-List the entries in a directory.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Path relative to the volume root |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `list[`[`FsEntry`](/sdk/python/filesystem#fsentry)`]` | Directory entries |
-
----
-
-#### mkdir()
-
-```python
-async def mkdir(path: str) -> None
-```
-
-Create a directory and all parent directories.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Path relative to the volume root |
-
----
-
-#### remove_file()
-
-```python
-async def remove_file(path: str) -> None
-```
-
-Remove a file.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Path relative to the volume root |
-
----
-
-#### exists()
-
-```python
-async def exists(path: str) -> bool
-```
-
-Check whether a path exists within the volume.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `str` | Path relative to the volume root |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `bool` | `True` if the path exists |
-
----
-
-## Types
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| [read](#fs-read) | `read(path) -> bytes` | Read a file as raw bytes |
+| [read_text](#fs-read_text) | `read_text(path) -> str` | Read a file as UTF-8 text |
+| [write](#fs-write) | `write(path, data) -> None` | Write bytes to a file |
+| [list](#fs-list) | `list(path) -> list[FsEntry]` | List a directory |
+| [mkdir](#fs-mkdir) | `mkdir(path) -> None` | Create a directory |
+| [remove_file](#fs-remove_file) | `remove_file(path) -> None` | Remove a file |
+| [exists](#fs-exists) | `exists(path) -> bool` | Check a path exists |
 
 ### MountConfig
 
-Frozen dataclass representing a mount configuration.
+<div className="msb-tags"><span className="msb-tag is-type">dataclass</span></div>
 
-```python
-MountConfig(
-    kind: MountKind,
-    bind: str | None = None,
-    named: str | None = None,
-    size_mib: int | None = None,
-    readonly: bool = False,
-    noexec: bool = False,
-    nosuid: bool = False,
-    nodev: bool = False,
-)
-```
+<p className="msb-backref">Returned by <a href="#volume-bind">Volume.bind()</a>, <a href="#volume-named">Volume.named()</a>, <a href="#volume-tmpfs">Volume.tmpfs()</a>, <a href="#volume-disk">Volume.disk()</a></p>
+
+Frozen dataclass representing a mount configuration. Build one with a [mount factory](#mount-factories) and pass it as a value in the sandbox `volumes` dict. `stat_virtualization` and `host_permissions` apply only to virtiofs-backed mounts (`BIND` and `NAMED`); setting either on a `TMPFS` or `DISK` mount raises `ValueError`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | kind | [`MountKind`](#mountkind) | - | Type of mount (required) |
 | bind | `str \| None` | `None` | Host path for bind mounts |
 | named | `str \| None` | `None` | Volume name for named mounts |
-| size_mib | `int \| None` | `None` | Size limit for tmpfs mounts |
+| named_mode | `"existing" \| "create" \| "ensure-exists" \| None` | `None` | Named-volume creation behavior |
+| named_kind | `"dir" \| "directory" \| "disk" \| None` | `None` | Storage kind for created named volumes |
+| quota_mib | `int \| None` | `None` | Quota in MiB for directory named volumes |
+| size_mib | `int \| None` | `None` | Size limit for tmpfs, or capacity for disk named volumes |
 | readonly | `bool` | `False` | Whether the mount is read-only |
 | noexec | `bool` | `False` | Whether direct execution from the mount is disabled |
-| nosuid | `bool` | `False` | Whether setuid/setgid privilege elevation from files on the mount is ignored |
+| nosuid | `bool` | `False` | Whether setuid/setgid privilege elevation is ignored |
 | nodev | `bool` | `False` | Whether device files on the mount are ignored |
+| disk | `str \| None` | `None` | Host path to a disk image for disk mounts |
+| format | [`DiskImageFormat`](#diskimageformat)` \| str \| None` | `None` | Disk image format for disk mounts |
+| fstype | `str \| None` | `None` | Inner filesystem type for disk mounts |
+| stat_virtualization | `StatVirtualization \| str \| None` | `None` | Per-mount stat-virtualization policy (virtiofs-backed only) |
+| host_permissions | `HostPermissions \| str \| None` | `None` | Per-mount host-permission policy (virtiofs-backed only) |
 
 ### MountKind
 
-String enum representing the type of mount.
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#mountconfig">MountConfig</a></p>
+
+String enum (`StrEnum`) for the type of mount.
 
 | Value | Description |
 |-------|-------------|
 | `"bind"` | Host bind mount |
 | `"named"` | Named volume mount |
 | `"tmpfs"` | In-memory filesystem |
+| `"disk"` | Host disk image mount |
+
+### DiskImageFormat
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#volume-disk">Volume.disk()</a>, <a href="#mountconfig">MountConfig</a></p>
+
+String enum (`StrEnum`) for the format of a backing disk image.
+
+| Value | Description |
+|-------|-------------|
+| `"qcow2"` | QEMU copy-on-write v2 image |
+| `"raw"` | Raw disk image |
+| `"vmdk"` | VMware disk image |

--- a/docs/sdk/rust/agent-client.mdx
+++ b/docs/sdk/rust/agent-client.mdx
@@ -3,14 +3,77 @@ title: Agent client
 description: Rust SDK - Low-level agentd client reference
 ---
 
-`AgentClient` is the low-level transport for talking to `agentd` through a running sandbox's relay socket. Most applications should use [`Sandbox`](/sdk/rust/sandbox), [`exec`](/sdk/rust/execution), and [`fs`](/sdk/rust/filesystem) instead. Use `AgentClient` when you are building a protocol-level integration or an SDK layer.
+`AgentClient` is the low-level transport for talking to `agentd` through a running sandbox's relay socket. Most applications should use [`Sandbox`](/sdk/rust/sandbox), [`exec`](/sdk/rust/execution), and [`fs`](/sdk/rust/filesystem) instead. Reach for `AgentClient` when you are building a protocol-level integration or an SDK layer. [`AgentBridge`](#agentbridge) wraps the same connection in concrete, FFI-shaped types for the Node, Python, and Go bindings.
 
-The Rust client has two tiers:
+The client has two tiers that share one socket and one background reader task:
 
 - **Typed** methods encode and decode microsandbox protocol messages for you.
 - **Raw** methods move framed CBOR bytes without decoding the message body.
 
-The raw body is the full CBOR-encoded protocol `Message` body: `v`, `t`, and `p`. It is not just the inner payload.
+The raw body is the full CBOR-encoded protocol `Message` body (`v`, `t`, and `p`), not just the inner payload. The typed and raw methods reach the connection through `Deref` to the underlying client; everything below is callable directly on the value `connect_sandbox` returns.
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Module functions<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#agentconnect_sandbox"><span className="msb-rn">agent::connect_sandbox()</span><span className="msb-rg">resolve a name and connect</span></a>
+  <a className="msb-row" href="#agentconnect_sandbox_with_timeout"><span className="msb-rn">agent::connect_sandbox_with_timeout()</span><span className="msb-rg">connect with a handshake timeout</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Static · AgentClient<span className="msb-ct">7</span></p>
+  <a className="msb-row" href="#agentclientconnect"><span className="msb-rn">AgentClient::connect()</span><span className="msb-rg">dial a socket path</span></a>
+  <a className="msb-row" href="#agentclientconnect_with_timeout"><span className="msb-rn">AgentClient::connect_with_timeout()</span><span className="msb-rg">dial with a timeout</span></a>
+  <a className="msb-row" href="#agentclientconnect_with_deadline"><span className="msb-rn">AgentClient::connect_with_deadline()</span><span className="msb-rg">dial with a deadline</span></a>
+  <a className="msb-row" href="#agentclientconnect_sandbox"><span className="msb-rn">AgentClient::connect_sandbox()</span><span className="msb-rg">resolve a name and connect</span></a>
+  <a className="msb-row" href="#agentclientconnect_sandbox_with_timeout"><span className="msb-rn">AgentClient::connect_sandbox_with_timeout()</span><span className="msb-rg">resolve a name, with timeout</span></a>
+  <a className="msb-row" href="#agentclientsocket_path"><span className="msb-rn">AgentClient::socket_path()</span><span className="msb-rg">resolve a path without connecting</span></a>
+  <a className="msb-row" href="#agentclientensure_version_compat_for"><span className="msb-rn">AgentClient::ensure_version_compat_for()</span><span className="msb-rg">gate a type at a generation</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · AgentClient<span className="msb-ct">15</span></p>
+  <a className="msb-row" href="#client-request"><span className="msb-rn">client.request()</span><span className="msb-rg">one-shot typed RPC</span></a>
+  <a className="msb-row" href="#client-stream"><span className="msb-rn">client.stream()</span><span className="msb-rg">open a typed stream</span></a>
+  <a className="msb-row" href="#client-send"><span className="msb-rn">client.send()</span><span className="msb-rg">typed follow-up message</span></a>
+  <a className="msb-row" href="#client-request_raw"><span className="msb-rn">client.request_raw()</span><span className="msb-rg">one-shot raw RPC</span></a>
+  <a className="msb-row" href="#client-stream_raw"><span className="msb-rn">client.stream_raw()</span><span className="msb-rg">open a raw stream</span></a>
+  <a className="msb-row" href="#client-send_raw"><span className="msb-rn">client.send_raw()</span><span className="msb-rg">raw follow-up frame</span></a>
+  <a className="msb-row" href="#client-ready"><span className="msb-rn">client.ready()</span><span className="msb-rg">decoded handshake payload</span></a>
+  <a className="msb-row" href="#client-ready_bytes"><span className="msb-rn">client.ready_bytes()</span><span className="msb-rg">raw handshake CBOR</span></a>
+  <a className="msb-row" href="#client-protocol"><span className="msb-rn">client.protocol()</span><span className="msb-rg">codec generation</span></a>
+  <a className="msb-row" href="#client-is_legacy_protocol"><span className="msb-rn">client.is_legacy_protocol()</span><span className="msb-rg">pre-0.5 relay?</span></a>
+  <a className="msb-row" href="#client-negotiated_version"><span className="msb-rn">client.negotiated_version()</span><span className="msb-rg">negotiated capability generation</span></a>
+  <a className="msb-row" href="#client-agent_version"><span className="msb-rn">client.agent_version()</span><span className="msb-rg">runtime package version</span></a>
+  <a className="msb-row" href="#client-supports"><span className="msb-rn">client.supports()</span><span className="msb-rg">message type available?</span></a>
+  <a className="msb-row" href="#client-ensure_version_compat"><span className="msb-rn">client.ensure_version_compat()</span><span className="msb-rg">gate a type, error if too old</span></a>
+  <a className="msb-row" href="#client-close"><span className="msb-rn">client.close()</span><span className="msb-rg">close the connection</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Static · AgentBridge<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#agentbridgeconnect_sandbox"><span className="msb-rn">AgentBridge::connect_sandbox()</span><span className="msb-rg">connect by sandbox name</span></a>
+  <a className="msb-row" href="#agentbridgeconnect_sandbox_with_timeout"><span className="msb-rn">AgentBridge::connect_sandbox_with_timeout()</span><span className="msb-rg">connect by name, with timeout</span></a>
+  <a className="msb-row" href="#agentbridgeconnect_path"><span className="msb-rn">AgentBridge::connect_path()</span><span className="msb-rg">connect to a socket path</span></a>
+  <a className="msb-row" href="#agentbridgeconnect_path_with_timeout"><span className="msb-rn">AgentBridge::connect_path_with_timeout()</span><span className="msb-rg">connect to a path, with timeout</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · AgentBridge<span className="msb-ct">7</span></p>
+  <a className="msb-row" href="#bridge-request"><span className="msb-rn">bridge.request()</span><span className="msb-rg">one-shot raw request</span></a>
+  <a className="msb-row" href="#bridge-send"><span className="msb-rn">bridge.send()</span><span className="msb-rg">follow-up frame</span></a>
+  <a className="msb-row" href="#bridge-stream_open"><span className="msb-rn">bridge.stream_open()</span><span className="msb-rg">open a stream</span></a>
+  <a className="msb-row" href="#bridge-stream_next"><span className="msb-rn">bridge.stream_next()</span><span className="msb-rg">pull the next frame</span></a>
+  <a className="msb-row" href="#bridge-stream_close"><span className="msb-rn">bridge.stream_close()</span><span className="msb-rg">close a stream</span></a>
+  <a className="msb-row" href="#bridge-ready_bytes"><span className="msb-rn">bridge.ready_bytes()</span><span className="msb-rg">raw handshake CBOR</span></a>
+  <a className="msb-row" href="#bridge-close"><span className="msb-rn">bridge.close()</span><span className="msb-rg">close the connection</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#agentclient">AgentClient</a>
+    <a className="msb-typepill" href="#agentbridge">AgentBridge</a>
+    <a className="msb-typepill" href="#bridgeframe">BridgeFrame</a>
+    <a className="msb-typepill" href="#streamhandle">StreamHandle</a>
+    <a className="msb-typepill" href="#agentprotocol">AgentProtocol</a>
+    <a className="msb-typepill" href="#rawframe">RawFrame</a>
+    <a className="msb-typepill" href="#agentclienterror">AgentClientError</a>
+    <a className="msb-typepill" href="#agentclientresult">AgentClientResult</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```rust
 use microsandbox::{
@@ -21,7 +84,386 @@ use microsandbox::{
     },
 };
 
+let client = agent::connect_sandbox("dev").await?;   // 1. resolve name + connect
+
+let response = client                                // 2. one-shot typed RPC
+    .request(
+        MessageType::FsRequest,
+        &FsRequest {
+            op: FsOp::Stat {
+                path: "/etc/os-release".to_string(),
+                follow_symlink: true,
+            },
+        },
+    )
+    .await?;
+
+let fs_response: FsResponse = response.payload()?;   // 3. decode the payload
+client.close().await;                                // 4. close
+```
+
+## Module functions
+
+---
+
+#### <span className="msb-recv">agent::</span><span className="msb-hn">connect_sandbox()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn connect_sandbox(name: &str) -> AgentClientResult<AgentClient>
+```
+
+Resolve a sandbox name to its agent relay socket path and connect, using the default ten-second handshake timeout. The socket lives under the SDK's configured runtime directory at a short, name-derived path. Sandbox names are limited to 128 UTF-8 bytes.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentclient">AgentClient</a></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::agent;
+
 let client = agent::connect_sandbox("dev").await?;
+```
+
+---
+
+#### <span className="msb-recv">agent::</span><span className="msb-hn">connect_sandbox_with_timeout()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn connect_sandbox_with_timeout(name: &str, timeout: Duration) -> AgentClientResult<AgentClient>
+```
+
+Like [`connect_sandbox`](#agentconnect_sandbox), but with an explicit handshake timeout instead of the ten-second default.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">Duration</span></div>
+    <div className="msb-param-desc">Maximum time to wait for the relay handshake.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentclient">AgentClient</a></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use std::time::Duration;
+use microsandbox::agent;
+
+let client = agent::connect_sandbox_with_timeout("dev", Duration::from_secs(2)).await?;
+```
+
+## AgentClient: static methods
+
+---
+
+#### <span className="msb-recv">AgentClient::</span><span className="msb-hn">connect()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn connect(sock_path: impl AsRef<Path>) -> AgentClientResult<AgentClient>
+```
+
+Connect to an arbitrary agent relay socket by path, using the default ten-second handshake timeout. The connection performs the relay handshake, validates the cached `core.ready` frame, and starts one background reader task.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>sock_path</code><span className="msb-type">impl AsRef&lt;Path&gt;</span></div>
+    <div className="msb-param-desc">Path to the agent relay socket.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentclient">AgentClient</a></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::agent::AgentClient;
+
+let path = AgentClient::socket_path("dev")?;
+let client = AgentClient::connect(&path).await?;
+```
+
+---
+
+#### <span className="msb-recv">AgentClient::</span><span className="msb-hn">connect_with_timeout()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn connect_with_timeout(sock_path: impl AsRef<Path>, timeout: Duration) -> AgentClientResult<AgentClient>
+```
+
+Connect to an arbitrary agent relay socket by path with an explicit handshake timeout.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>sock_path</code><span className="msb-type">impl AsRef&lt;Path&gt;</span></div>
+    <div className="msb-param-desc">Path to the agent relay socket.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">Duration</span></div>
+    <div className="msb-param-desc">Maximum time to wait for the relay handshake.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentclient">AgentClient</a></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">AgentClient::</span><span className="msb-hn">connect_with_deadline()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn connect_with_deadline(sock_path: impl AsRef<Path>, deadline: Instant) -> AgentClientResult<AgentClient>
+```
+
+Connect to an arbitrary agent relay socket by path with an explicit handshake deadline. The deadline bounds both handshake reads, so an accepted connection that stalls before writing the handshake bytes cannot block this call indefinitely.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>sock_path</code><span className="msb-type">impl AsRef&lt;Path&gt;</span></div>
+    <div className="msb-param-desc">Path to the agent relay socket.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>deadline</code><span className="msb-type">Instant</span></div>
+    <div className="msb-param-desc">Tokio instant by which the handshake must complete.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentclient">AgentClient</a></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">AgentClient::</span><span className="msb-hn">connect_sandbox()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn connect_sandbox(name: &str) -> AgentClientResult<AgentClient>
+```
+
+Resolve a sandbox name to its agent socket path and connect. Equivalent to the module-level [`agent::connect_sandbox`](#agentconnect_sandbox).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentclient">AgentClient</a></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">AgentClient::</span><span className="msb-hn">connect_sandbox_with_timeout()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn connect_sandbox_with_timeout(name: &str, timeout: Duration) -> AgentClientResult<AgentClient>
+```
+
+Resolve a sandbox name to its agent socket path and connect with an explicit handshake timeout. Equivalent to the module-level [`agent::connect_sandbox_with_timeout`](#agentconnect_sandbox_with_timeout).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">Duration</span></div>
+    <div className="msb-param-desc">Maximum time to wait for the relay handshake.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentclient">AgentClient</a></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">AgentClient::</span><span className="msb-hn">socket_path()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
+
+```rust
+fn socket_path(name: &str) -> MicrosandboxResult<PathBuf>
+```
+
+Resolve a sandbox's relay socket path **without connecting**. Returns the same path [`connect_sandbox`](#agentconnect_sandbox) would dial: the hashed path under the runtime directory when it fits the platform's Unix-socket length limit, and the legacy name-derived path otherwise. Useful for talking to `agentd` over a raw byte transport (for example a transparent relay that splices bytes to and from the socket) instead of this frame client. The sandbox need not be running.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">PathBuf</span></div>
+    <div className="msb-param-desc">Relay socket path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::agent::AgentClient;
+
+let path = AgentClient::socket_path("dev")?;
+println!("{}", path.display());
+```
+
+---
+
+#### <span className="msb-recv">AgentClient::</span><span className="msb-hn">ensure_version_compat_for()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
+
+```rust
+fn ensure_version_compat_for(t: MessageType, negotiated: u8) -> AgentClientResult<()>
+```
+
+Check a message type against an explicit negotiated generation. The single place the rule lives, exposed for callers that hold the negotiated generation but not a live client. Returns [`AgentClientError::UnsupportedOperation`](#agentclienterror) if the type was introduced after the given generation.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>t</code><span className="msb-type">MessageType</span></div>
+    <div className="msb-param-desc">Protocol message type to gate.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>negotiated</code><span className="msb-type">u8</span></div>
+    <div className="msb-param-desc">Protocol generation to check against.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::{agent::AgentClient, protocol::message::MessageType};
+
+AgentClient::ensure_version_compat_for(MessageType::FsRequest, 2)?;
+```
+
+## AgentClient: instance methods
+
+---
+
+#### <span className="msb-recv">client.</span><span className="msb-hn">request()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn request<T: Serialize>(&self, t: MessageType, payload: &T) -> AgentClientResult<Message>
+```
+
+Send one typed protocol message and wait for one response frame with the same correlation id. Flags are derived from the message type. Use this for one-shot RPCs such as filesystem stat or list requests. Fails fast with [`AgentClientError::UnsupportedOperation`](#agentclienterror) if the connected sandbox is too old for the message type.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>t</code><span className="msb-type">MessageType</span></div>
+    <div className="msb-param-desc">Protocol message type.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>payload</code><span className="msb-type">&amp;T: Serialize</span></div>
+    <div className="msb-param-desc">Message payload, serialized with CBOR.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Message</span></div>
+    <div className="msb-param-desc">Decoded response message.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::protocol::{
+    fs::{FsOp, FsRequest, FsResponse},
+    message::MessageType,
+};
+
 let response = client
     .request(
         MessageType::FsRequest,
@@ -38,136 +480,828 @@ let fs_response: FsResponse = response.payload()?;
 
 ---
 
-#### connect()
-
-```rust
-async fn connect(sock_path: impl AsRef<Path>) -> AgentClientResult<AgentClient>
-```
-
-Connect to an agent relay socket by path. The connection performs the relay handshake, validates the cached `core.ready` frame, and starts one background reader task.
-
----
-
-#### agent::connect_sandbox()
-
-```rust
-async fn agent::connect_sandbox(name: &str) -> AgentClientResult<AgentClient>
-```
-
-Resolve a sandbox name to its relay socket path and connect to it. Sandbox names are limited to 128 UTF-8 bytes.
-
----
-
-#### AgentClient::socket_path()
-
-```rust
-fn AgentClient::socket_path(name: &str) -> MicrosandboxResult<PathBuf>
-```
-
-Resolve a sandbox's relay socket path **without connecting**. Returns the same path `connect_sandbox` would dial, so you can talk to `agentd` over a raw byte transport (e.g. a transparent relay that splices bytes to and from the socket) instead of this frame client. The sandbox need not be running.
-
----
-
-#### request()
-
-```rust
-async fn request<T: Serialize>(&self, t: MessageType, payload: &T) -> AgentClientResult<Message>
-```
-
-Send one typed protocol message and wait for one response frame with the same correlation id. Use this for one-shot RPCs such as filesystem stat/list requests.
-
----
-
-#### stream()
+#### <span className="msb-recv">client.</span><span className="msb-hn">stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn stream<T: Serialize>(&self, t: MessageType, payload: &T) -> AgentClientResult<(u32, Receiver<Message>)>
 ```
 
-Open a typed streaming session. The returned id is the protocol correlation id. Use it with [`send()`](#send) for follow-up messages such as stdin, resize, signal, or file data chunks.
+Open a typed streaming session. The returned id is the protocol correlation id. Use it with [`send()`](#client-send) for follow-up messages such as stdin, resize, signal, or file data chunks. The receiver yields messages until a terminal frame is delivered or the connection closes.
 
-The receiver yields messages until a terminal frame is delivered or the connection closes.
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>t</code><span className="msb-type">MessageType</span></div>
+    <div className="msb-param-desc">Protocol message type for the opening frame.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>payload</code><span className="msb-type">&amp;T: Serialize</span></div>
+    <div className="msb-param-desc">Opening message payload, serialized with CBOR.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">(u32, Receiver&lt;Message&gt;)</span></div>
+    <div className="msb-param-desc">Correlation id and a typed message receiver.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::protocol::{exec::ExecRequest, message::MessageType};
+
+let (id, mut rx) = client
+    .stream(MessageType::ExecRequest, &ExecRequest {
+        cmd: "echo".into(),
+        args: vec!["hi".into()],
+        env: Vec::new(),
+        cwd: None,
+        user: None,
+        tty: false,
+        rows: 24,
+        cols: 80,
+        rlimits: Vec::new(),
+    })
+    .await?;
+
+while let Some(msg) = rx.recv().await {
+    println!("{:?}", msg.t);
+}
+```
 
 ---
 
-#### send()
+#### <span className="msb-recv">client.</span><span className="msb-hn">send()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn send<T: Serialize>(&self, id: u32, t: MessageType, payload: &T) -> AgentClientResult<()>
 ```
 
-Send a typed follow-up message on an existing correlation id.
+Send a typed follow-up message on an existing correlation id (the id returned by [`stream()`](#client-stream)).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>id</code><span className="msb-type">u32</span></div>
+    <div className="msb-param-desc">Correlation id from the open stream.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>t</code><span className="msb-type">MessageType</span></div>
+    <div className="msb-param-desc">Protocol message type.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>payload</code><span className="msb-type">&amp;T: Serialize</span></div>
+    <div className="msb-param-desc">Message payload, serialized with CBOR.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::protocol::{exec::ExecStdin, message::MessageType};
+
+client.send(id, MessageType::ExecStdin, &ExecStdin { data: b"input\n".to_vec() }).await?;
+```
 
 ---
 
-#### request_raw()
+#### <span className="msb-recv">client.</span><span className="msb-hn">request_raw()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn request_raw(&self, flags: u8, body: Vec<u8>) -> AgentClientResult<RawFrame>
 ```
 
-Allocate a correlation id, send one raw frame, and wait for one raw response frame.
+Allocate a correlation id, send one raw frame with `(flags, body)`, and wait for one raw response frame with the matching id. CBOR encoding and decoding are left to the caller.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">u8</span></div>
+    <div className="msb-param-desc">Frame flag byte.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">Vec&lt;u8&gt;</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#rawframe">RawFrame</a></div>
+    <div className="msb-param-desc">Raw response frame.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let frame = client.request_raw(flags, body).await?;
+println!("id={} flags={}", frame.id, frame.flags);
+```
 
 ---
 
-#### stream_raw()
+#### <span className="msb-recv">client.</span><span className="msb-hn">stream_raw()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn stream_raw(&self, flags: u8, body: Vec<u8>) -> AgentClientResult<(u32, Receiver<RawFrame>)>
 ```
 
-Open a raw streaming session. The receiver yields raw frames for the returned correlation id until a terminal frame is delivered or the receiver is dropped.
+Open a raw streaming session. The receiver yields raw frames for the returned correlation id until a frame with the terminal flag arrives or the receiver is dropped. Use [`send_raw()`](#client-send_raw) with the returned id to send follow-up frames.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">u8</span></div>
+    <div className="msb-param-desc">Frame flag byte for the opening frame.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">Vec&lt;u8&gt;</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">(u32, Receiver&lt;RawFrame&gt;)</span></div>
+    <div className="msb-param-desc">Correlation id and a raw frame receiver.</div>
+  </div>
+</div>
 
 ---
 
-#### send_raw()
+#### <span className="msb-recv">client.</span><span className="msb-hn">send_raw()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn send_raw(&self, id: u32, flags: u8, body: &[u8]) -> AgentClientResult<()>
 ```
 
-Send a raw follow-up frame on an existing correlation id.
+Send a raw follow-up frame on an existing correlation id (the id returned by [`stream_raw()`](#client-stream_raw)).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>id</code><span className="msb-type">u32</span></div>
+    <div className="msb-param-desc">Correlation id from the open raw stream.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">u8</span></div>
+    <div className="msb-param-desc">Frame flag byte.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">&amp;[u8]</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
 
 ---
 
-#### ready()
+#### <span className="msb-recv">client.</span><span className="msb-hn">ready()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
 fn ready(&self) -> AgentClientResult<Ready>
 ```
 
-Return the decoded `core.ready` payload from the handshake.
+Return the decoded `core.ready` payload captured during the handshake (boot timings and the runtime's self-reported version).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Ready</span></div>
+    <div className="msb-param-desc">Decoded handshake payload.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let ready = client.ready()?;
+println!("boot {} ns", ready.boot_time_ns);
+```
 
 ---
 
-#### ready_bytes()
+#### <span className="msb-recv">client.</span><span className="msb-hn">ready_bytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
 fn ready_bytes(&self) -> &[u8]
 ```
 
-Return the cached handshake `core.ready` frame body as CBOR bytes.
+Return the cached handshake `core.ready` frame body as CBOR bytes. Useful for bindings that want to deserialize the ready payload with their own CBOR tooling. For typed access, use [`ready()`](#client-ready).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">&amp;[u8]</span></div>
+    <div className="msb-param-desc">CBOR-encoded ready frame body.</div>
+  </div>
+</div>
 
 ---
 
-#### close()
+#### <span className="msb-recv">client.</span><span className="msb-hn">protocol()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn protocol(&self) -> AgentProtocol
+```
+
+The agent protocol generation (wire codec) negotiated for this connection.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentprotocol">AgentProtocol</a></div>
+    <div className="msb-param-desc">Codec generation: <code>Current</code> or <code>LegacyV1</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">client.</span><span className="msb-hn">is_legacy_protocol()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn is_legacy_protocol(&self) -> bool
+```
+
+Whether this connection is using the legacy pre-0.5 protocol.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> if the relay speaks the pre-0.5 protocol.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">client.</span><span className="msb-hn">negotiated_version()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn negotiated_version(&self) -> u8
+```
+
+The negotiated protocol generation for this connection: the lower of what this client speaks and what the sandbox advertised at handshake. This is the capability gate that drives [`supports()`](#client-supports) and the typed send path, and it is distinct from [`protocol()`](#client-protocol), which selects the wire codec.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">u8</span></div>
+    <div className="msb-param-desc">Negotiated capability generation.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">client.</span><span className="msb-hn">agent_version()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn agent_version(&self) -> &str
+```
+
+The runtime's self-reported package version, taken from its `core.ready` frame. Empty when the runtime predates this field (an older agent), in which case fall back to the generation for diagnostics.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Runtime package version, or empty if unknown.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">client.</span><span className="msb-hn">supports()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn supports(&self, t: MessageType) -> bool
+```
+
+Whether the connected sandbox is new enough to handle the given message type. The single source of truth for feature gating: callers that cannot gate by sending (for example the SSH/SFTP layer) consult this instead of inspecting the protocol generation directly.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>t</code><span className="msb-type">MessageType</span></div>
+    <div className="msb-param-desc">Protocol message type to check.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> if the runtime can handle the type.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::protocol::message::MessageType;
+
+if client.supports(MessageType::FsRequest) {
+    // safe to issue filesystem RPCs
+}
+```
+
+---
+
+#### <span className="msb-recv">client.</span><span className="msb-hn">ensure_version_compat()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn ensure_version_compat(&self, t: MessageType) -> AgentClientResult<()>
+```
+
+Reject a message type the connected sandbox is too old to handle, against this connection's negotiated generation. Fails before any bytes are sent, so only that one operation fails and the session continues. The typed [`request()`](#client-request), [`stream()`](#client-stream), and [`send()`](#client-send) methods call this internally.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>t</code><span className="msb-type">MessageType</span></div>
+    <div className="msb-param-desc">Protocol message type to gate.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::protocol::message::MessageType;
+
+client.ensure_version_compat(MessageType::TcpConnect)?;
+```
+
+---
+
+#### <span className="msb-recv">client.</span><span className="msb-hn">close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn close(self)
 ```
 
-Close the client by consuming it. Dropping the client has the same effect.
+Close the client by consuming it. Drops the writer and aborts the reader task; any in-flight requests resolve with [`AgentClientError::Closed`](#agentclienterror). Dropping the client has the same effect.
+
+<p className="msb-label">Example</p>
+
+```rust
+client.close().await;
+```
+
+## AgentBridge
+
+Bytes-in/bytes-out wrapper around [`AgentClient`](#agentclient), with concrete, monomorphic types suitable for crossing FFI boundaries. The Node, Python, and Go bindings build on it. No generics, no consuming-`self` methods, no callbacks across FFI: each method takes `&self` and is idempotent where the underlying operation allows. CBOR (de)serialization happens entirely in the caller's language; the bridge only moves bytes. One instance owns one Unix-socket connection; multiple concurrent streams are supported, each identified by an opaque [`StreamHandle`](#streamhandle).
 
 ---
 
-## RawFrame
+#### <span className="msb-recv">AgentBridge::</span><span className="msb-hn">connect_sandbox()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
-pub struct RawFrame {
-    pub id: u32,
-    pub flags: u8,
-    pub body: Vec<u8>,
+async fn connect_sandbox(name: &str) -> AgentClientResult<AgentBridge>
+```
+
+Connect to a sandbox by name, resolving the socket path from SDK config. Sandbox names are limited to 128 UTF-8 bytes.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentbridge">AgentBridge</a></div>
+    <div className="msb-param-desc">Connected bridge.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">AgentBridge::</span><span className="msb-hn">connect_sandbox_with_timeout()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn connect_sandbox_with_timeout(name: &str, timeout: Duration) -> AgentClientResult<AgentBridge>
+```
+
+Connect to a sandbox by name with an explicit handshake timeout.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">Duration</span></div>
+    <div className="msb-param-desc">Maximum time to wait for the relay handshake.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentbridge">AgentBridge</a></div>
+    <div className="msb-param-desc">Connected bridge.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">AgentBridge::</span><span className="msb-hn">connect_path()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn connect_path(path: &str) -> AgentClientResult<AgentBridge>
+```
+
+Connect to an arbitrary agentd relay socket by path.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Path to the agent relay socket.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentbridge">AgentBridge</a></div>
+    <div className="msb-param-desc">Connected bridge.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">AgentBridge::</span><span className="msb-hn">connect_path_with_timeout()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn connect_path_with_timeout(path: &str, timeout: Duration) -> AgentClientResult<AgentBridge>
+```
+
+Connect to an arbitrary agentd relay socket by path with an explicit handshake timeout.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Path to the agent relay socket.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">Duration</span></div>
+    <div className="msb-param-desc">Maximum time to wait for the relay handshake.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentbridge">AgentBridge</a></div>
+    <div className="msb-param-desc">Connected bridge.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">bridge.</span><span className="msb-hn">request()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn request(&self, flags: u8, body: Vec<u8>) -> AgentClientResult<BridgeFrame>
+```
+
+One-shot request: send `(flags, body)` and wait for one response frame.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">u8</span></div>
+    <div className="msb-param-desc">Frame flag byte.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">Vec&lt;u8&gt;</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#bridgeframe">BridgeFrame</a></div>
+    <div className="msb-param-desc">Response frame.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">bridge.</span><span className="msb-hn">send()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn send(&self, id: u32, flags: u8, body: Vec<u8>) -> AgentClientResult<()>
+```
+
+Send a follow-up frame on an existing correlation id.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>id</code><span className="msb-type">u32</span></div>
+    <div className="msb-param-desc">Correlation id from an open stream.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">u8</span></div>
+    <div className="msb-param-desc">Frame flag byte.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">Vec&lt;u8&gt;</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">bridge.</span><span className="msb-hn">stream_open()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn stream_open(&self, flags: u8, body: Vec<u8>) -> AgentClientResult<(u32, StreamHandle)>
+```
+
+Open a streaming session. Returns the protocol correlation id (for follow-up sends via [`send()`](#bridge-send)) and an opaque stream handle (for [`stream_next()`](#bridge-stream_next) and [`stream_close()`](#bridge-stream_close)).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">u8</span></div>
+    <div className="msb-param-desc">Frame flag byte for the opening frame.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">Vec&lt;u8&gt;</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">(u32, <a className="msb-type" href="#streamhandle">StreamHandle</a>)</span></div>
+    <div className="msb-param-desc">Correlation id and an opaque stream handle.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">bridge.</span><span className="msb-hn">stream_next()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn stream_next(&self, handle: StreamHandle) -> AgentClientResult<Option<BridgeFrame>>
+```
+
+Pull the next frame from a stream. Returns `None` when the stream has ended (the terminal frame was already delivered, or the stream was closed or dropped).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>handle</code><a className="msb-type" href="#streamhandle">StreamHandle</a></div>
+    <div className="msb-param-desc">Handle returned by <a href="#bridge-stream_open"><code>stream_open()</code></a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;<a className="msb-type" href="#bridgeframe">BridgeFrame</a>&gt;</span></div>
+    <div className="msb-param-desc">Next frame, or <code>None</code> at end of stream.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let (id, handle) = bridge.stream_open(flags, body).await?;
+while let Some(frame) = bridge.stream_next(handle).await? {
+    // decode frame.body with your own CBOR tooling
 }
 ```
 
-`id` is the protocol correlation id, `flags` is the frame flag byte, and `body` is the CBOR-encoded protocol message body.
+---
+
+#### <span className="msb-recv">bridge.</span><span className="msb-hn">stream_close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn stream_close(&self, handle: StreamHandle)
+```
+
+Close a stream and drop its handle. Idempotent.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>handle</code><a className="msb-type" href="#streamhandle">StreamHandle</a></div>
+    <div className="msb-param-desc">Handle returned by <a href="#bridge-stream_open"><code>stream_open()</code></a>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">bridge.</span><span className="msb-hn">ready_bytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn ready_bytes(&self) -> AgentClientResult<Vec<u8>>
+```
+
+The cached handshake `core.ready` frame body bytes (CBOR). Errors with [`AgentClientError::Closed`](#agentclienterror) if the bridge has been closed.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Vec&lt;u8&gt;</span></div>
+    <div className="msb-param-desc">CBOR-encoded ready frame body.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">bridge.</span><span className="msb-hn">close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn close(&self)
+```
+
+Close the connection. Idempotent. After close, every operation except another close returns [`AgentClientError::Closed`](#agentclienterror).
+
+<p className="msb-label">Example</p>
+
+```rust
+bridge.close().await;
+```
+
+## Types
+
+---
+
+### AgentClient
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#agentconnect_sandbox">agent::connect_sandbox()</a>, <a href="#agentclientconnect">AgentClient::connect()</a> · wrapped by <a href="#agentbridge">AgentBridge</a></p>
+
+Client for communicating with `agentd` through a running sandbox's relay. A newtype over the underlying `microsandbox_agent_client::AgentClient`; the typed and raw transport methods reach the inner client through `Deref`. See the [static](#agentclient-static-methods) and [instance](#agentclient-instance-methods) method sections above.
+
+---
+
+### BridgeFrame
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#bridge-request">bridge.request()</a>, <a href="#bridge-stream_next">bridge.stream_next()</a></p>
+
+FFI-friendly view of a [`RawFrame`](#rawframe): id, flags, body bytes.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `u32` | Correlation ID from the frame header. |
+| `flags` | `u8` | Frame flags from the frame header. |
+| `body` | `Vec<u8>` | Raw CBOR-encoded body bytes. |
+
+---
+
+### StreamHandle
+<div className="msb-tags"><span className="msb-tag is-type">type alias</span></div>
+
+<p className="msb-backref">Returned by <a href="#bridge-stream_open">bridge.stream_open()</a> · used by <a href="#bridge-stream_next">bridge.stream_next()</a>, <a href="#bridge-stream_close">bridge.stream_close()</a></p>
+
+```rust
+pub type StreamHandle = u64;
+```
+
+Opaque handle identifying an open stream on an [`AgentBridge`](#agentbridge). Foreign-language wrappers reference streams by this `u64` instead of owning a tokio receiver.
+
+---
+
+### AgentProtocol
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Returned by <a href="#client-protocol">client.protocol()</a></p>
+
+Agent protocol generation (wire codec) spoken by a connected sandbox relay.
+
+| Variant | Description |
+| --- | --- |
+| `Current` | Current protocol generation. |
+| `LegacyV1` | Pre-0.5 microsandbox relay handshake and agent protocol. |
+
+---
+
+### RawFrame
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#client-request_raw">client.request_raw()</a>, <a href="#client-stream_raw">client.stream_raw()</a></p>
+
+A framed protocol message at the byte level. `id` is the protocol correlation id, `flags` is the frame flag byte, and `body` is the CBOR-encoded protocol message body. Re-exported from `microsandbox::protocol::codec`.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `u32` | Protocol correlation id. |
+| `flags` | `u8` | Frame flag byte. |
+| `body` | `Vec<u8>` | CBOR-encoded protocol message body. |
+
+---
+
+### AgentClientError
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Error variant of <a href="#agentclientresult">AgentClientResult</a></p>
+
+Errors raised by [`AgentClient`](#agentclient) and [`AgentBridge`](#agentbridge).
+
+| Variant | Description |
+| --- | --- |
+| `Connect { path, source }` | Failed to open the Unix socket connection to the relay. |
+| `Handshake(String)` | Handshake with the relay failed (timeout, EOF, or malformed frame). |
+| `SandboxNotFound(String)` | Sandbox name could not be resolved to an agent socket path. |
+| `InvalidSandboxName(String)` | Sandbox name failed SDK validation before socket resolution. |
+| `Io(std::io::Error)` | An I/O error occurred on the socket after connect. |
+| `Protocol(ProtocolError)` | A wire-protocol error (framing, CBOR, oversize frame). |
+| `Cbor(String)` | CBOR encoding or decoding failed. |
+| `InvalidPacket(String)` | The supplied packet did not contain exactly one complete transport frame. |
+| `UnsupportedOperation { msg_type, needs, peer }` | The connected sandbox's runtime is older than the requested feature needs; restart the sandbox to update its runtime. |
+| `ReaderClosed(u32)` | The reader task closed before the in-flight request received its response. |
+| `Closed` | The client has been closed. |
+| `IdRangeExhausted` | The relay-assigned correlation ID range has no available IDs. |
+| `NotImplemented(&'static str)` | The operation is not implemented yet. |
+
+---
+
+### AgentClientResult
+<div className="msb-tags"><span className="msb-tag is-type">type alias</span></div>
+
+<p className="msb-backref">Returned by most <a href="#agentclient">AgentClient</a> and <a href="#agentbridge">AgentBridge</a> methods</p>
+
+```rust
+pub type AgentClientResult<T> = Result<T, AgentClientError>;
+```
+
+Result alias for agent client operations. The error is [`AgentClientError`](#agentclienterror).

--- a/docs/sdk/rust/execution.mdx
+++ b/docs/sdk/rust/execution.mdx
@@ -3,303 +3,1222 @@ title: Execution
 description: Rust SDK - Command execution API reference
 ---
 
-See [Commands](/sandboxes/commands) for usage examples.
+Run commands inside a running sandbox: buffer the output in one call, stream it event by event, drive a shell, or bridge your terminal to an interactive PTY session. See [Commands](/sandboxes/commands) for usage examples.
 
----
+<div className="msb-glance">
 
-#### attach()
+  <p className="msb-gl"><span className="msb-dot instance"></span>Run · buffered<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#sb-exec"><span className="msb-rn">sb.exec()</span><span className="msb-rg">run, wait, collect output</span></a>
+  <a className="msb-row" href="#sb-exec_with"><span className="msb-rn">sb.exec_with()</span><span className="msb-rg">run with per-exec options</span></a>
+  <a className="msb-row" href="#sb-shell"><span className="msb-rn">sb.shell()</span><span className="msb-rg">run through the shell</span></a>
+  <a className="msb-row" href="#sb-shell_with"><span className="msb-rn">sb.shell_with()</span><span className="msb-rg">shell with options</span></a>
 
-```rust
-async fn attach(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<i32>
-```
+  <p className="msb-gl"><span className="msb-dot instance"></span>Run · streaming<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#sb-exec_stream"><span className="msb-rn">sb.exec_stream()</span><span className="msb-rg">stream stdout/stderr events</span></a>
+  <a className="msb-row" href="#sb-exec_stream_with"><span className="msb-rn">sb.exec_stream_with()</span><span className="msb-rg">stream with options</span></a>
+  <a className="msb-row" href="#sb-shell_stream"><span className="msb-rn">sb.shell_stream()</span><span className="msb-rg">stream a shell command</span></a>
+  <a className="msb-row" href="#sb-shell_stream_with"><span className="msb-rn">sb.shell_stream_with()</span><span className="msb-rg">stream shell with options</span></a>
 
-Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Your terminal's stdin, stdout, and stderr are connected to the guest process. Press `Ctrl+]` (or configured detach keys) to disconnect without stopping the process - it keeps running and can be reattached via its session ID.
+  <p className="msb-gl"><span className="msb-dot instance"></span>Attach · interactive<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#sb-attach"><span className="msb-rn">sb.attach()</span><span className="msb-rg">bridge terminal to a process</span></a>
+  <a className="msb-row" href="#sb-attach_with"><span className="msb-rn">sb.attach_with()</span><span className="msb-rg">attach with options</span></a>
+  <a className="msb-row" href="#sb-attach_shell"><span className="msb-rn">sb.attach_shell()</span><span className="msb-rg">attach to the default shell</span></a>
 
-**Parameters**
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · ExecOptionsBuilder<span className="msb-ct">14</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#arg">.arg()</a>
+    <a className="msb-chip" href="#args">.args()</a>
+    <a className="msb-chip" href="#cwd">.cwd()</a>
+    <a className="msb-chip" href="#user">.user()</a>
+    <a className="msb-chip" href="#env">.env()</a>
+    <a className="msb-chip" href="#envs">.envs()</a>
+    <a className="msb-chip" href="#timeout">.timeout()</a>
+    <a className="msb-chip" href="#tty">.tty()</a>
+    <a className="msb-chip" href="#stdin_null">.stdin_null()</a>
+    <a className="msb-chip" href="#stdin_pipe">.stdin_pipe()</a>
+    <a className="msb-chip" href="#stdin_bytes">.stdin_bytes()</a>
+    <a className="msb-chip" href="#rlimit">.rlimit()</a>
+    <a className="msb-chip" href="#rlimit_range">.rlimit_range()</a>
+    <a className="msb-chip" href="#build">.build()</a>
+  </div>
 
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `impl Into<String>` | Command to run |
-| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments |
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · AttachOptionsBuilder<span className="msb-ct">10</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#arg-2">.arg()</a>
+    <a className="msb-chip" href="#args-2">.args()</a>
+    <a className="msb-chip" href="#cwd-2">.cwd()</a>
+    <a className="msb-chip" href="#user-2">.user()</a>
+    <a className="msb-chip" href="#env-2">.env()</a>
+    <a className="msb-chip" href="#envs-2">.envs()</a>
+    <a className="msb-chip" href="#detach_keys">.detach_keys()</a>
+    <a className="msb-chip" href="#rlimit-3">.rlimit()</a>
+    <a className="msb-chip" href="#rlimit_range-2">.rlimit_range()</a>
+    <a className="msb-chip" href="#build-2">.build()</a>
+  </div>
 
-**Returns**
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#exechandle">ExecHandle</a>
+    <a className="msb-typepill" href="#execcontrol">ExecControl</a>
+    <a className="msb-typepill" href="#execsink">ExecSink</a>
+    <a className="msb-typepill" href="#execevent">ExecEvent</a>
+    <a className="msb-typepill" href="#execoutput">ExecOutput</a>
+    <a className="msb-typepill" href="#exitstatus">ExitStatus</a>
+    <a className="msb-typepill" href="#rlimit-2">Rlimit</a>
+    <a className="msb-typepill" href="#rlimitresource">RlimitResource</a>
+  </div>
 
-| Type | Description |
-|------|-------------|
-| `i32` | Exit code of the process |
+</div>
 
----
-
-#### attach_shell()
-
-```rust
-async fn attach_shell(&self) -> MicrosandboxResult<i32>
-```
-
-Attach to the sandbox's default shell (configured via `SandboxBuilder::shell()`, defaults to `/bin/sh`).
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `i32` | Exit code |
-
----
-
-#### attach_with()
-
-```rust
-async fn attach_with(&self, cmd: impl Into<String>, f: impl FnOnce(AttachOptionsBuilder) -> AttachOptionsBuilder) -> MicrosandboxResult<i32>
-```
-
-Interactive PTY attach with options for environment variables, working directory, user, and custom detach keys.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `impl Into<String>` | Command to run |
-| f | `AttachOptionsBuilder` | Configure attach options (env, cwd, user, detach keys). |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `i32` | Exit code of the process |
-
----
-
-#### exec()
-
-```rust
-async fn exec(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<ExecOutput>
-```
-
-Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `impl Into<String>` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
-| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments (e.g. `["-c", "print('hello')"]`) |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
-
----
-
-#### exec_stream()
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```rust
-async fn exec_stream(&self, cmd: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> MicrosandboxResult<ExecHandle>
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("api").image("python").create().await?;
+
+// Buffered: run and collect everything
+let out = sb.exec("python", ["-c", "print('hi')"]).await?;
+println!("{}", out.stdout()?);
+
+// Streaming: process output as it arrives
+let mut handle = sb.exec_stream("tail", ["-f", "/var/log/app.log"]).await?;
+while let Some(event) = handle.recv().await {
+    if let microsandbox::ExecEvent::Stdout(chunk) = event {
+        print!("{}", String::from_utf8_lossy(&chunk));
+    }
+}
+
+sb.stop().await?;
 ```
 
-Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything until the command finishes. Use this for long-running processes, large output, or when you need to process output incrementally.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `impl Into<String>` | Command to execute |
-| args | `impl IntoIterator<Item = impl Into<String>>` | Command arguments |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`ExecHandle`](#exechandle) | Streaming handle for receiving events and controlling the process |
+## Run methods
 
 ---
 
-#### exec_stream_with()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">exec()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
-async fn exec_stream_with(&self, cmd: impl Into<String>, f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder) -> MicrosandboxResult<ExecHandle>
+async fn exec(
+    &self,
+    cmd: impl Into<String>,
+    args: impl IntoIterator<Item = impl Into<String>>,
+) -> MicrosandboxResult<ExecOutput>
 ```
 
-Streaming execution with per-execution overrides. Enable `stdin_pipe()` to write to the process's stdin, and `tty(true)` to allocate a pseudo-terminal for interactive programs like shells, REPLs, or editors.
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit status. `cmd` is passed literally to the guest agent: the image ENTRYPOINT is **not** consulted, and `args` are not shell-interpreted. For long-running processes or large output, use [`exec_stream()`](#sb-exec_stream); for shell syntax like pipes and redirects, use [`shell()`](#sb-shell).
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `impl Into<String>` | Command to execute |
-| f | [`ExecOptionsBuilder`](#execoptionsbuilder) | Configure execution options. |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Command to execute, e.g. <code>"python"</code> or <code>"/usr/bin/node"</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">impl IntoIterator</span></div>
+    <div className="msb-param-desc">Command arguments, e.g. <code>["-c", "print('hi')"]</code>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`ExecHandle`](#exechandle) | Streaming handle |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">ExecOutput</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit status.</div>
+  </div>
+</div>
 
----
-
-#### exec_with()
+<p className="msb-label">Example</p>
 
 ```rust
-async fn exec_with(&self, cmd: impl Into<String>, f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder) -> MicrosandboxResult<ExecOutput>
+let out = sb.exec("python", ["-V"]).await?;
+println!("{}", out.stdout()?);
 ```
-
-Run a command with per-execution overrides. The closure receives an [`ExecOptionsBuilder`](#execoptionsbuilder) to configure working directory, environment variables, timeout, resource limits, stdin mode, and TTY allocation. These overrides apply only to this execution and don't change the sandbox's defaults.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `impl Into<String>` | Command to execute |
-| f | [`ExecOptionsBuilder`](#execoptionsbuilder) | Configure execution options. |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
 
 ---
 
-#### shell()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">exec_with()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn exec_with(
+    &self,
+    cmd: impl Into<String>,
+    f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder,
+) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a command with per-execution overrides and wait for completion. The closure receives an [`ExecOptionsBuilder`](#execoptionsbuilder) to set args, working directory, environment variables, user, timeout, resource limits, stdin mode, and TTY allocation. These overrides apply only to this execution and don't change the sandbox's defaults.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Command to execute.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#execoptionsbuilder">FnOnce(ExecOptionsBuilder)</a></div>
+    <div className="msb-param-desc">Configure execution options.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">ExecOutput</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use std::time::Duration;
+
+let out = sb.exec_with("python", |e| e
+    .args(["compute.py"])
+    .cwd("/app")
+    .env("LOG_LEVEL", "debug")
+    .timeout(Duration::from_secs(30)))
+    .await?;
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">shell()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn shell(&self, script: impl Into<String>) -> MicrosandboxResult<ExecOutput>
 ```
 
-Run a command through the sandbox's configured shell (defaults to `/bin/sh`). The script is passed as `sh -c "<script>"`, so shell syntax like pipes, redirects, and `&&` chains works.
+Run a command through the sandbox's configured shell (default: `/bin/sh`, set via [`SandboxBuilder::shell()`](/sdk/rust/sandbox#shell)). The script is run as `<shell> -c "<script>"`, so shell syntax like pipes, redirects, and `&&` chains works.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| script | `impl Into<String>` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>script</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Shell command string, e.g. <code>"ls -la /app && echo done"</code>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`ExecOutput`](#execoutput) | Collected stdout, stderr, and exit status |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">ExecOutput</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let out = sb.shell("cat /etc/os-release | grep PRETTY_NAME").await?;
+println!("{}", out.stdout()?);
+```
 
 ---
 
-#### shell_stream()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">shell_with()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn shell_with(
+    &self,
+    script: impl Into<String>,
+    f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder,
+) -> MicrosandboxResult<ExecOutput>
+```
+
+Run a shell command with per-execution overrides and wait for completion. The `-c <script>` arguments are prepended to whatever the [`ExecOptionsBuilder`](#execoptionsbuilder) configures, so use the builder for env, cwd, user, timeout, and resource limits rather than for positional args.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>script</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Shell command string.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#execoptionsbuilder">FnOnce(ExecOptionsBuilder)</a></div>
+    <div className="msb-param-desc">Configure execution options.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">ExecOutput</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let out = sb.shell_with("env | sort", |e| e.env("STAGE", "build")).await?;
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">exec_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn exec_stream(
+    &self,
+    cmd: impl Into<String>,
+    args: impl IntoIterator<Item = impl Into<String>>,
+) -> MicrosandboxResult<ExecHandle>
+```
+
+Run a command with streaming output. Returns an [`ExecHandle`](#exechandle) that emits stdout, stderr, started, and exit events as they happen, rather than buffering everything until the command finishes. Use this for long-running processes, large output, or when you need to process output incrementally.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Command to execute.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">impl IntoIterator</span></div>
+    <div className="msb-param-desc">Command arguments.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#exechandle">ExecHandle</a></div>
+    <div className="msb-param-desc">Streaming handle for receiving events and controlling the process.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::ExecEvent;
+
+let mut handle = sb.exec_stream("tail", ["-f", "/var/log/app.log"]).await?;
+while let Some(event) = handle.recv().await {
+    match event {
+        ExecEvent::Stdout(chunk) => print!("{}", String::from_utf8_lossy(&chunk)),
+        ExecEvent::Exited { code } => { println!("exited {code}"); break; }
+        _ => {}
+    }
+}
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">exec_stream_with()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn exec_stream_with(
+    &self,
+    cmd: impl Into<String>,
+    f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder,
+) -> MicrosandboxResult<ExecHandle>
+```
+
+Streaming execution with per-execution overrides. Enable [`stdin_pipe()`](#stdin_pipe) to write to the process's stdin via [`ExecHandle::take_stdin()`](#exechandle), and [`tty(true)`](#tty) to allocate a pseudo-terminal for interactive programs like shells, REPLs, or editors.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Command to execute.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#execoptionsbuilder">FnOnce(ExecOptionsBuilder)</a></div>
+    <div className="msb-param-desc">Configure execution options.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#exechandle">ExecHandle</a></div>
+    <div className="msb-param-desc">Streaming handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let mut handle = sb.exec_stream_with("python", |e| e.stdin_pipe().tty(true)).await?;
+if let Some(stdin) = handle.take_stdin() {
+    stdin.write(b"print(2 + 2)\n").await?;
+    stdin.close().await?;
+}
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">shell_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn shell_stream(&self, script: impl Into<String>) -> MicrosandboxResult<ExecHandle>
 ```
 
-Shell command with streaming output.
+Like [`shell()`](#sb-shell), but returns a streaming [`ExecHandle`](#exechandle) instead of waiting for completion.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| script | `impl Into<String>` | Shell command string |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>script</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Shell command string.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`ExecHandle`](#exechandle) | Streaming handle |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#exechandle">ExecHandle</a></div>
+    <div className="msb-param-desc">Streaming handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let mut handle = sb.shell_stream("for i in 1 2 3; do echo $i; sleep 1; done").await?;
+let out = handle.collect().await?;
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">shell_stream_with()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn shell_stream_with(
+    &self,
+    script: impl Into<String>,
+    f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder,
+) -> MicrosandboxResult<ExecHandle>
+```
+
+Run a shell command with per-execution overrides and streaming I/O. As with [`shell_with()`](#sb-shell_with), the `-c <script>` arguments are prepended to whatever the builder configures.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>script</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Shell command string.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#execoptionsbuilder">FnOnce(ExecOptionsBuilder)</a></div>
+    <div className="msb-param-desc">Configure execution options.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#exechandle">ExecHandle</a></div>
+    <div className="msb-param-desc">Streaming handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let mut handle = sb.shell_stream_with("npm run build", |e| e.cwd("/app")).await?;
+```
+
+---
+
+## Attach methods
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">attach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn attach(
+    &self,
+    cmd: impl Into<String>,
+    args: impl IntoIterator<Item = impl Into<String>>,
+) -> MicrosandboxResult<i32>
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. The host terminal is put into raw mode and its stdin, stdout, and window-size changes are wired to the guest process. Press the detach key (default `Ctrl+]`) to disconnect without stopping the process; it keeps running in the guest. Returns when the process exits or you detach.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Command to run.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">impl IntoIterator</span></div>
+    <div className="msb-param-desc">Command arguments.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">i32</span></div>
+    <div className="msb-param-desc">Exit code of the process, or <code>-1</code> if you detached before it exited.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let exit_code = sb.attach("bash", ["-l"]).await?;
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">attach_with()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn attach_with(
+    &self,
+    cmd: impl Into<String>,
+    f: impl FnOnce(AttachOptionsBuilder) -> AttachOptionsBuilder,
+) -> MicrosandboxResult<i32>
+```
+
+Interactive PTY attach with options. The closure receives an [`AttachOptionsBuilder`](#attachoptionsbuilder) to set args, environment variables, working directory, user, custom detach keys, and resource limits.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Command to run.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#attachoptionsbuilder">FnOnce(AttachOptionsBuilder)</a></div>
+    <div className="msb-param-desc">Configure attach options.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">i32</span></div>
+    <div className="msb-param-desc">Exit code of the process, or <code>-1</code> if you detached.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let exit_code = sb.attach_with("zsh", |a| a
+    .env("TERM", "xterm-256color")
+    .detach_keys("ctrl-p,ctrl-q"))
+    .await?;
+```
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">attach_shell()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn attach_shell(&self) -> MicrosandboxResult<i32>
+```
+
+Attach to the sandbox's default shell (configured via [`SandboxBuilder::shell()`](/sdk/rust/sandbox#shell), default `/bin/sh`) with an interactive PTY session.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">i32</span></div>
+    <div className="msb-param-desc">Exit code, or <code>-1</code> if you detached.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let exit_code = sb.attach_shell().await?;
+```
+
+---
+
+## ExecOptionsBuilder
+
+Builder for per-execution overrides passed to [`exec_with()`](#sb-exec_with), [`exec_stream_with()`](#sb-exec_stream_with), [`shell_with()`](#sb-shell_with), and [`shell_stream_with()`](#sb-shell_stream_with). Does not change the sandbox's defaults. Every setter returns `Self`, so calls chain.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">arg()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn arg(self, arg: impl Into<String>) -> Self
+```
+
+Append a single command-line argument, e.g. `"-la"` or `"/tmp"`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>arg</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Argument to append.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">args()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn args(self, args: impl IntoIterator<Item = impl Into<String>>) -> Self
+```
+
+Append multiple command-line arguments.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">impl IntoIterator</span></div>
+    <div className="msb-param-desc">Arguments to append.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">cwd()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn cwd(self, cwd: impl Into<String>) -> Self
+```
+
+Override the working directory for this command. Overrides the sandbox default set via the builder's `workdir`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cwd</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">user()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn user(self, user: impl Into<String>) -> Self
+```
+
+Override the guest user for this command.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>user</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">User name or UID.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">env()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn env(self, key: impl Into<String>, value: impl Into<String>) -> Self
+```
+
+Set an environment variable for this command. Merged on top of the sandbox-level env vars.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Variable name.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Variable value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">envs()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn envs(
+    self,
+    vars: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+) -> Self
+```
+
+Set multiple environment variables for this command at once.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>vars</code><span className="msb-type">impl IntoIterator</span></div>
+    <div className="msb-param-desc">Key-value pairs to set.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">timeout()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn timeout(self, timeout: Duration) -> Self
+```
+
+Kill the process with SIGKILL if it hasn't exited within this duration.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeout</code><span className="msb-type">Duration</span></div>
+    <div className="msb-param-desc">Maximum run time before SIGKILL.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">tty()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn tty(self, enabled: bool) -> Self
+```
+
+Allocate a pseudo-terminal. Enable for interactive programs (shells, editors, `top`); disable for scripts and batch jobs. When enabled, stdout and stderr are merged at the kernel level inside the guest. Default: `false`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> to allocate a PTY.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">stdin_null()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn stdin_null(self) -> Self
+```
+
+Stdin reads from `/dev/null`. This is the default.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">stdin_pipe()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn stdin_pipe(self) -> Self
+```
+
+Enable a stdin writer via [`ExecSink`](#execsink). Use with [`ExecHandle::take_stdin()`](#exechandle) on the returned streaming handle to send data to the process.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">stdin_bytes()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn stdin_bytes(self, data: impl Into<Vec<u8>>) -> Self
+```
+
+Provide fixed bytes as stdin. The process reads them and then sees EOF.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>data</code><span className="msb-type">impl Into&lt;Vec&lt;u8&gt;&gt;</span></div>
+    <div className="msb-param-desc">Bytes fed to the process's stdin.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">rlimit()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn rlimit(self, resource: RlimitResource, limit: u64) -> Self
+```
+
+Set a POSIX resource limit with soft equal to hard. Applied via `setrlimit()` before exec.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>resource</code><a className="msb-type" href="#rlimitresource">RlimitResource</a></div>
+    <div className="msb-param-desc">Which resource to limit.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>limit</code><span className="msb-type">u64</span></div>
+    <div className="msb-param-desc">Limit value (soft = hard).</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::sandbox::RlimitResource;
+
+let out = sb.exec_with("./worker", |e| e.rlimit(RlimitResource::Nofile, 1024)).await?;
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">rlimit_range()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn rlimit_range(self, resource: RlimitResource, soft: u64, hard: u64) -> Self
+```
+
+Set a resource limit with different soft and hard values. [`build()`](#build) errors if `soft > hard`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>resource</code><a className="msb-type" href="#rlimitresource">RlimitResource</a></div>
+    <div className="msb-param-desc">Which resource to limit.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>soft</code><span className="msb-type">u64</span></div>
+    <div className="msb-param-desc">Soft limit (raisable by the process up to hard).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hard</code><span className="msb-type">u64</span></div>
+    <div className="msb-param-desc">Hard ceiling.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn build(self) -> MicrosandboxResult<ExecOptions>
+```
+
+Finalize the options. Called automatically by the `*_with` methods when you use the closure form. Returns an error if any rlimit has `soft > hard`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">ExecOptions</span></div>
+    <div className="msb-param-desc">Validated execution options.</div>
+  </div>
+</div>
+
+---
+
+## AttachOptionsBuilder
+
+Builder for interactive attach options passed to [`attach_with()`](#sb-attach_with). Every setter returns `Self`, so calls chain.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">arg()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn arg(self, arg: impl Into<String>) -> Self
+```
+
+Append a single command-line argument to the attached command.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>arg</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Argument to append.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">args()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn args(self, args: impl IntoIterator<Item = impl Into<String>>) -> Self
+```
+
+Append multiple command-line arguments.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">impl IntoIterator</span></div>
+    <div className="msb-param-desc">Arguments to append.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">cwd()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn cwd(self, cwd: impl Into<String>) -> Self
+```
+
+Override the working directory for the attached session.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cwd</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">user()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn user(self, user: impl Into<String>) -> Self
+```
+
+Override the guest user for the attached session.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>user</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">User name or UID.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">env()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn env(self, key: impl Into<String>, value: impl Into<String>) -> Self
+```
+
+Set an environment variable for the attached session. Merged on top of the sandbox-level env vars.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Variable name.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Variable value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">envs()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn envs(
+    self,
+    vars: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+) -> Self
+```
+
+Set multiple environment variables for the attached session at once.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>vars</code><span className="msb-type">impl IntoIterator</span></div>
+    <div className="msb-param-desc">Key-value pairs to set.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">detach_keys()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn detach_keys(self, keys: impl Into<String>) -> Self
+```
+
+Set the key sequence that detaches from the session without stopping the process. Docker-style syntax: `"ctrl-]"` (default), `"ctrl-p,ctrl-q"` for a multi-key sequence, or a single character like `"q"`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>keys</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Detach key specification.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">rlimit()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn rlimit(self, resource: RlimitResource, limit: u64) -> Self
+```
+
+Set a POSIX resource limit with soft equal to hard for the attached process.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>resource</code><a className="msb-type" href="#rlimitresource">RlimitResource</a></div>
+    <div className="msb-param-desc">Which resource to limit.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>limit</code><span className="msb-type">u64</span></div>
+    <div className="msb-param-desc">Limit value (soft = hard).</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">rlimit_range()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn rlimit_range(self, resource: RlimitResource, soft: u64, hard: u64) -> Self
+```
+
+Set a resource limit with different soft and hard values for the attached process. [`build()`](#build-2) errors if `soft > hard`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>resource</code><a className="msb-type" href="#rlimitresource">RlimitResource</a></div>
+    <div className="msb-param-desc">Which resource to limit.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>soft</code><span className="msb-type">u64</span></div>
+    <div className="msb-param-desc">Soft limit.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hard</code><span className="msb-type">u64</span></div>
+    <div className="msb-param-desc">Hard ceiling.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn build(self) -> MicrosandboxResult<AttachOptions>
+```
+
+Finalize the options. Called automatically by [`attach_with()`](#sb-attach_with). Returns an error if any rlimit has `soft > hard`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">AttachOptions</span></div>
+    <div className="msb-param-desc">Validated attach options.</div>
+  </div>
+</div>
 
 ---
 
 ## Types
 
-### ExecEvent
-
-Events emitted by a streaming execution.
-
-| Variant | Fields | Description |
-|---------|--------|-------------|
-| `Exited` | `code: i32` | The process has exited. `code` is the exit code. |
-| `Started` | `pid: u32` | The process has started. `pid` is the guest-side PID. |
-| `Stderr` | `Bytes` | A chunk of stderr data. |
-| `Stdout` | `Bytes` | A chunk of stdout data. May arrive in arbitrary sizes. |
-
 ### ExecHandle
 
-A handle to a running streaming execution. Receives events as the process produces output, and provides control over stdin and signals.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-exec_stream">exec_stream()</a> · <a href="#sb-exec_stream_with">exec_stream_with()</a> · <a href="#sb-shell_stream">shell_stream()</a> · <a href="#sb-shell_stream_with">shell_stream_with()</a></p>
+
+A handle to a running streaming execution. Receives [`ExecEvent`](#execevent)s as the process produces output, and provides control over stdin, signals, and the PTY size.
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| collect() | [`ExecOutput`](#execoutput) | Wait for exit and collect all remaining stdout/stderr. |
+| recv() | `Option<`[`ExecEvent`](#execevent)`>` | Receive the next event. `None` when the session has ended and all output has been delivered. |
+| wait() | `Result<`[`ExitStatus`](#exitstatus)`>` | Wait for the process to exit, discarding any remaining output. |
+| collect() | `Result<`[`ExecOutput`](#execoutput)`>` | Wait for exit and collect all remaining stdout/stderr. |
 | id() | `String` | Session ID for this execution. Can be used to reattach later. |
-| kill() | `()` | Send SIGKILL to the process. |
-| recv() | `Option<`[`ExecEvent`](#execevent)`>` | Receive the next event. Returns `None` when the process has exited and all output has been delivered. |
-| signal(signal) | `()` | Send a POSIX signal to the process (e.g. `libc::SIGTERM`). |
-| take_stdin() | `Option<`[`ExecSink`](#execsink)`>` | Take the stdin writer. Only available if `stdin_pipe()` was enabled. Returns `None` after the first call. |
-| wait() | [`ExitStatus`](#exitstatus) | Wait for the process to exit, discarding any remaining output. |
+| control() | [`ExecControl`](#execcontrol) | A cloneable control handle for sending signals and resizes from another task. |
+| take_stdin() | `Option<`[`ExecSink`](#execsink)`>` | Take the stdin writer. Only available if `stdin_pipe()` was set; returns `None` after the first call. |
+| signal(signal) | `Result<()>` | Send a POSIX signal to the process (e.g. `libc::SIGTERM`). |
+| kill() | `Result<()>` | Send SIGKILL to the process. |
+| resize(rows, cols) | `Result<()>` | Resize the PTY for this session. |
 
-### ExecOptionsBuilder
+### ExecControl
 
-Builder for per-execution overrides. Does not change the sandbox's defaults.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-| Method | Parameters | Description |
-|--------|-----------|-------------|
-| args() | `impl IntoIterator<Item = impl Into<String>>` | Append command-line arguments. |
-| cwd() | `impl Into<String>` | Override the working directory for this command. |
-| env() | - `key: impl Into<String>` <br/> - `value: impl Into<String>` | Set an environment variable. Merged on top of sandbox-level env vars. |
-| envs() | `impl IntoIterator<Item = (String, String)>` | Set multiple environment variables at once. |
-| rlimit() | - `resource:` [`RlimitResource`](#rlimitresource) <br/> - `limit: u64` | Set a POSIX resource limit (soft = hard). Applied via `setrlimit()` before exec. |
-| rlimit_range() | - `resource:` [`RlimitResource`](#rlimitresource) <br/> - `soft: u64` <br/> - `hard: u64` | Set a resource limit with different soft and hard values. |
-| stdin_bytes() | `impl Into<Vec<u8>>` | Provide fixed bytes as stdin. The process reads them and then sees EOF. |
-| stdin_null() | - | Stdin reads from `/dev/null`. This is the default. |
-| stdin_pipe() | - | Enable a stdin writer via [`ExecSink`](#execsink). Use with [`ExecHandle::take_stdin()`](#exechandle). |
-| timeout() | `Duration` | Kill the process with SIGKILL if it hasn't exited within this duration. |
-| tty() | `bool` | Allocate a pseudo-terminal. Enable for interactive programs (shells, editors, `top`); disable for scripts and batch jobs. Default: `false`. |
-| user() | `impl Into<String>` | Override the guest user for this command. |
+<p className="msb-backref">Returned by <a href="#exechandle">ExecHandle.control()</a></p>
 
-### ExecOutput
+A cloneable, lightweight control handle for a streaming exec session. Lets a task other than the one owning the [`ExecHandle`](#exechandle) send signals and PTY resizes. Carries no event stream.
 
-The result of a completed command execution. Holds the exit status and all captured output.
-
-| Field / Method | Type | Description |
-|----------------|------|-------------|
-| status() | [`ExitStatus`](#exitstatus) | Exit code and success flag |
-| stderr() | `Result<String>` | Collected stderr decoded as UTF-8 |
-| stderr_bytes() | `&Bytes` | Raw stderr bytes without decoding |
-| stdout() | `Result<String>` | Collected stdout decoded as UTF-8. Returns `Err` if the output is not valid UTF-8. |
-| stdout_bytes() | `&Bytes` | Raw stdout bytes without decoding |
+| Method | Returns | Description |
+|--------|---------|-------------|
+| id() | `String` | Session ID for this execution. |
+| signal(signal) | `Result<()>` | Send a POSIX signal to the process (e.g. `libc::SIGTERM`). |
+| kill() | `Result<()>` | Send SIGKILL to the process. |
+| resize(rows, cols) | `Result<()>` | Resize the PTY for this session. |
 
 ### ExecSink
 
-A writer for sending data to a running process's stdin. Obtained via [`ExecHandle::take_stdin()`](#exechandle).
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#exechandle">ExecHandle.take_stdin()</a></p>
+
+A writer for sending data to a running process's stdin. Obtained via [`ExecHandle::take_stdin()`](#exechandle) after enabling [`stdin_pipe()`](#stdin_pipe).
 
 | Method | Parameters | Description |
 |--------|-----------|-------------|
+| write(data) | `data: impl AsRef<[u8]>` | Write bytes to the process's stdin. |
 | close() | - | Close stdin. The process sees EOF on its stdin. |
-| write() | `data: impl AsRef<[u8]>` | Write bytes to the process's stdin. |
+
+### ExecEvent
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Yielded by <a href="#exechandle">ExecHandle.recv()</a></p>
+
+An event emitted by a streaming execution.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Started` | `pid: u32` | The process has started. `pid` is the guest-side PID. |
+| `Stdout` | `Bytes` | A chunk of stdout data. May arrive in arbitrary sizes. |
+| `Stderr` | `Bytes` | A chunk of stderr data. |
+| `Exited` | `code: i32` | The process exited normally. `code` is the exit code. |
+| `Failed` | `ExecFailed` | The process failed to spawn (binary not found, permission denied, etc.). The user code never ran. Terminal: no further events follow. |
+| `StdinError` | `ExecStdinError` | A stdin write to the child failed (e.g. broken pipe). Non-terminal: the session keeps running and may still emit output and an `Exited` event. |
+
+### ExecOutput
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-exec">exec()</a> · <a href="#sb-exec_with">exec_with()</a> · <a href="#sb-shell">shell()</a> · <a href="#sb-shell_with">shell_with()</a> · <a href="#exechandle">ExecHandle.collect()</a></p>
+
+The result of a completed command execution. Holds the exit status and all captured output.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| status() | [`ExitStatus`](#exitstatus) | Exit code and success flag. |
+| stdout() | `Result<String, FromUtf8Error>` | Collected stdout decoded as UTF-8. Errors if the output is not valid UTF-8. |
+| stderr() | `Result<String, FromUtf8Error>` | Collected stderr decoded as UTF-8. |
+| stdout_bytes() | `&Bytes` | Raw stdout bytes without decoding. |
+| stderr_bytes() | `&Bytes` | Raw stderr bytes without decoding. |
 
 ### ExitStatus
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#exechandle">ExecHandle.wait()</a> · <a href="#execoutput">ExecOutput.status()</a> · <a href="/sdk/rust/sandbox#sb-wait">sb.wait()</a> · <a href="/sdk/rust/sandbox#sb-stop_and_wait">sb.stop_and_wait()</a></p>
 
 The exit status of a completed process.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | code | `i32` | Exit code. `0` typically means success. |
-| success | `bool` | `true` if code is `0` |
+| success | `bool` | `true` if `code` is `0`. |
+
+### Rlimit
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Configured via <a href="#rlimit">rlimit()</a> · <a href="#rlimit_range">rlimit_range()</a></p>
+
+A POSIX resource limit. Built indirectly by [`rlimit()`](#rlimit) and [`rlimit_range()`](#rlimit_range) on the option builders; you rarely construct it by hand.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| resource | [`RlimitResource`](#rlimitresource) | Which resource to limit. |
+| soft | `u64` | Soft limit; the process may raise it up to `hard`. |
+| hard | `u64` | Hard ceiling; raising it requires privileges. |
 
 ### RlimitResource
 
-POSIX resource limit identifiers. Maps to `RLIMIT_*` constants.
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#rlimit">rlimit()</a> · <a href="#rlimit_range">rlimit_range()</a> · <a href="#rlimit-3">AttachOptionsBuilder.rlimit()</a></p>
+
+POSIX resource limit identifiers. Each maps to an `RLIMIT_*` constant.
 
 | Value | Description |
 |-------|-------------|
-| `As` | Max address space size |
-| `Core` | Max core file size |
-| `Cpu` | Max CPU time in seconds |
-| `Data` | Max data segment size |
-| `Fsize` | Max file size in bytes |
-| `Locks` | Max file locks |
-| `Memlock` | Max locked memory |
-| `Msgqueue` | Max bytes in POSIX message queues |
-| `Nice` | Max nice priority |
-| `Nofile` | Max open file descriptors |
-| `Nproc` | Max number of processes |
-| `Rss` | Max resident set size |
-| `Rtprio` | Max real-time priority |
-| `Rttime` | Max real-time timeout |
-| `Sigpending` | Max pending signals |
-| `Stack` | Max stack size |
+| `Cpu` | Max CPU time in seconds (`RLIMIT_CPU`) |
+| `Fsize` | Max file size in bytes (`RLIMIT_FSIZE`) |
+| `Data` | Max data segment size (`RLIMIT_DATA`) |
+| `Stack` | Max stack size (`RLIMIT_STACK`) |
+| `Core` | Max core file size (`RLIMIT_CORE`) |
+| `Rss` | Max resident set size (`RLIMIT_RSS`) |
+| `Nproc` | Max number of processes (`RLIMIT_NPROC`) |
+| `Nofile` | Max open file descriptors (`RLIMIT_NOFILE`) |
+| `Memlock` | Max locked memory (`RLIMIT_MEMLOCK`) |
+| `As` | Max address space size (`RLIMIT_AS`) |
+| `Locks` | Max file locks (`RLIMIT_LOCKS`) |
+| `Sigpending` | Max pending signals (`RLIMIT_SIGPENDING`) |
+| `Msgqueue` | Max bytes in POSIX message queues (`RLIMIT_MSGQUEUE`) |
+| `Nice` | Max nice priority (`RLIMIT_NICE`) |
+| `Rtprio` | Max real-time priority (`RLIMIT_RTPRIO`) |
+| `Rttime` | Max real-time timeout (`RLIMIT_RTTIME`) |

--- a/docs/sdk/rust/filesystem.mdx
+++ b/docs/sdk/rust/filesystem.mdx
@@ -3,224 +3,417 @@ title: Filesystem
 description: Rust SDK - Filesystem API reference
 ---
 
-See [Filesystem](/sandboxes/filesystem) for usage examples.
+Read, write, list, and manipulate files inside a running sandbox. Obtained via [`sb.fs()`](/sdk/rust/sandbox#sb-fs). Every op dispatches through the same host-guest channel as command execution, so there is no SSH and no network involved. For bulk file movement, prefer a [volume](/sdk/rust/volumes) that gives the guest direct filesystem access. See [Filesystem](/sandboxes/filesystem) for conceptual usage.
 
-## SandboxFsOps
+<div className="msb-glance">
 
-Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead, which give the guest direct filesystem access.
+  <p className="msb-gl"><span className="msb-dot instance"></span>Read<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#fs-read"><span className="msb-rn">fs.read()</span><span className="msb-rg">whole file as bytes</span></a>
+  <a className="msb-row" href="#fs-read_to_string"><span className="msb-rn">fs.read_to_string()</span><span className="msb-rg">whole file as UTF-8</span></a>
+  <a className="msb-row" href="#fs-read_stream"><span className="msb-rn">fs.read_stream()</span><span className="msb-rg">stream chunks in</span></a>
 
----
+  <p className="msb-gl"><span className="msb-dot instance"></span>Write<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#fs-write"><span className="msb-rn">fs.write()</span><span className="msb-rg">overwrite a file</span></a>
+  <a className="msb-row" href="#fs-write_stream"><span className="msb-rn">fs.write_stream()</span><span className="msb-rg">stream chunks out</span></a>
 
-#### copy()
+  <p className="msb-gl"><span className="msb-dot instance"></span>Directories<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#fs-list"><span className="msb-rn">fs.list()</span><span className="msb-rg">children of a dir</span></a>
+  <a className="msb-row" href="#fs-mkdir"><span className="msb-rn">fs.mkdir()</span><span className="msb-rg">create dir + parents</span></a>
+  <a className="msb-row" href="#fs-remove_dir"><span className="msb-rn">fs.remove_dir()</span><span className="msb-rg">remove dir recursively</span></a>
 
-```rust
-async fn copy(&self, from: &str, to: &str) -> MicrosandboxResult<()>
-```
+  <p className="msb-gl"><span className="msb-dot instance"></span>Files<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#fs-remove"><span className="msb-rn">fs.remove()</span><span className="msb-rg">delete a single file</span></a>
+  <a className="msb-row" href="#fs-copy"><span className="msb-rn">fs.copy()</span><span className="msb-rg">copy within sandbox</span></a>
+  <a className="msb-row" href="#fs-rename"><span className="msb-rn">fs.rename()</span><span className="msb-rg">rename / move</span></a>
 
-Copy a file within the sandbox.
+  <p className="msb-gl"><span className="msb-dot instance"></span>Metadata<span className="msb-ct">6</span></p>
+  <a className="msb-row" href="#fs-stat"><span className="msb-rn">fs.stat()</span><span className="msb-rg">file metadata</span></a>
+  <a className="msb-row" href="#fs-stat_with_follow"><span className="msb-rn">fs.stat_with_follow()</span><span className="msb-rg">stat, control symlinks</span></a>
+  <a className="msb-row" href="#fs-set_stat"><span className="msb-rn">fs.set_stat()</span><span className="msb-rg">update metadata</span></a>
+  <a className="msb-row" href="#fs-read_link"><span className="msb-rn">fs.read_link()</span><span className="msb-rg">resolve a symlink</span></a>
+  <a className="msb-row" href="#fs-symlink"><span className="msb-rn">fs.symlink()</span><span className="msb-rg">create a symlink</span></a>
+  <a className="msb-row" href="#fs-exists"><span className="msb-rn">fs.exists()</span><span className="msb-rg">does a path exist</span></a>
 
-**Parameters**
+  <p className="msb-gl"><span className="msb-dot instance"></span>Host transfer<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#fs-copy_from_host"><span className="msb-rn">fs.copy_from_host()</span><span className="msb-rg">host file -&gt; guest</span></a>
+  <a className="msb-row" href="#fs-copy_to_host"><span className="msb-rn">fs.copy_to_host()</span><span className="msb-rg">guest file -&gt; host</span></a>
 
-| Name | Type | Description |
-|------|------|-------------|
-| from | `&str` | Source path |
-| to | `&str` | Destination path |
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#sandboxfs">SandboxFs</a>
+    <a className="msb-typepill" href="#fsentry">FsEntry</a>
+    <a className="msb-typepill" href="#fsentrykind">FsEntryKind</a>
+    <a className="msb-typepill" href="#fsmetadata">FsMetadata</a>
+    <a className="msb-typepill" href="#fssetattrs">FsSetAttrs</a>
+    <a className="msb-typepill" href="#fsreadstream">FsReadStream</a>
+    <a className="msb-typepill" href="#fswritesink">FsWriteSink</a>
+    <a className="msb-typepill" href="#fshandle">FsHandle</a>
+  </div>
 
----
+</div>
 
-#### copy_from_host()
-
-```rust
-async fn copy_from_host(&self, host_path: impl AsRef<Path>, guest_path: &str) -> MicrosandboxResult<()>
-```
-
-Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| host_path | `impl AsRef<Path>` | Path on the host filesystem |
-| guest_path | `&str` | Destination path inside the sandbox |
-
----
-
-#### copy_to_host()
-
-```rust
-async fn copy_to_host(&self, guest_path: &str, host_path: impl AsRef<Path>) -> MicrosandboxResult<()>
-```
-
-Copy a file from the sandbox to the host machine.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| guest_path | `&str` | Path inside the sandbox |
-| host_path | `impl AsRef<Path>` | Destination path on the host |
-
----
-
-#### exists()
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```rust
-async fn exists(&self, path: &str) -> MicrosandboxResult<bool>
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("api").image("python").create().await?;
+let fs = sb.fs();
+
+fs.write("/tmp/config.json", r#"{"debug": true}"#).await?;
+let text = fs.read_to_string("/tmp/config.json").await?;
+println!("{text}");
+
+for entry in fs.list("/tmp").await? {
+    println!("{} ({} bytes)", entry.path, entry.size);
+}
 ```
 
-Check whether a path exists inside the sandbox.
+`sb.fs()` is synchronous and just borrows the sandbox's backend and name; the work happens on the `await`ed methods below, every one of which is `async`.
 
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `&str` | Absolute path inside the guest |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `bool` | `true` if the path exists |
+## Read operations
 
 ---
 
-#### list()
-
-```rust
-async fn list(&self, path: &str) -> MicrosandboxResult<Vec<FsEntry>>
-```
-
-List the entries in a directory. Returns metadata for each entry including name, type, size, and permissions.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `&str` | Absolute directory path inside the guest |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Vec<`[`FsEntry`](#fsentry)`>` | Directory entries |
-
----
-
-#### mkdir()
-
-```rust
-async fn mkdir(&self, path: &str) -> MicrosandboxResult<()>
-```
-
-Create a directory. Parent directories must already exist.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `&str` | Absolute directory path |
-
----
-
-#### read()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn read(&self, path: &str) -> MicrosandboxResult<Bytes>
 ```
 
-Read the entire contents of a file as raw bytes.
+Read an entire file from the guest filesystem into memory as raw bytes.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `&str` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest, e.g. <code>"/app/config.json"</code>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Bytes` | File contents as raw bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Bytes</span></div>
+    <div className="msb-param-desc">File contents as raw bytes.</div>
+  </div>
+</div>
 
----
-
-#### read_stream()
+<p className="msb-label">Example</p>
 
 ```rust
-async fn read_stream(&self, path: &str) -> MicrosandboxResult<FsReadStream>
+let bytes = sb.fs().read("/app/logo.png").await?;
+println!("{} bytes", bytes.len());
 ```
-
-Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory, or when you want to process data incrementally.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `&str` | Absolute path inside the guest |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`FsReadStream`](#fsreadstream) | Async stream that yields chunks of file data |
 
 ---
 
-#### read_to_string()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read_to_string()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn read_to_string(&self, path: &str) -> MicrosandboxResult<String>
 ```
 
-Read the entire contents of a file and decode as UTF-8. Returns an error if the file contains invalid UTF-8.
+Read an entire file and decode it as UTF-8. Errors if the contents are not valid UTF-8.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `&str` | Absolute path inside the guest |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `String` | File contents as a UTF-8 string |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">String</span></div>
+    <div className="msb-param-desc">File contents as a UTF-8 string.</div>
+  </div>
+</div>
 
----
-
-#### remove()
+<p className="msb-label">Example</p>
 
 ```rust
-async fn remove(&self, path: &str) -> MicrosandboxResult<()>
+let text = sb.fs().read_to_string("/etc/hostname").await?;
+println!("{}", text.trim());
 ```
-
-Remove a file.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `&str` | Absolute file path |
 
 ---
 
-#### remove_dir()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn read_stream(&self, path: &str) -> MicrosandboxResult<FsReadStream>
+```
+
+Open a streaming reader that yields chunks of file data as they arrive. Use this for files too large to hold in memory, or to process data incrementally.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsreadstream">FsReadStream</a></div>
+    <div className="msb-param-desc">Reader that yields chunks until the file is exhausted.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let mut stream = sb.fs().read_stream("/var/log/big.log").await?;
+let mut total = 0;
+while let Some(chunk) = stream.recv().await? {
+    total += chunk.len();
+}
+println!("read {total} bytes");
+```
+
+---
+
+## Write operations
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">write()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn write(&self, path: &str, data: impl AsRef<[u8]>) -> MicrosandboxResult<()>
+```
+
+Write data to a file in the guest, creating it if it doesn't exist and truncating it if it does. Parent directories must already exist.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>data</code><span className="msb-type">impl AsRef&lt;[u8]&gt;</span></div>
+    <div className="msb-param-desc">File content (bytes or a string).</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.fs().write("/tmp/hello.txt", "hi there").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">write_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn write_stream(&self, path: &str) -> MicrosandboxResult<FsWriteSink>
+```
+
+Open a streaming writer for large files. Write chunks incrementally, then call [`FsWriteSink::close()`](#fswritesink) to flush and finalize. The file is created if missing and truncated if it exists.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fswritesink">FsWriteSink</a></div>
+    <div className="msb-param-desc">Writer for sending chunks; must be closed to finalize.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let sink = sb.fs().write_stream("/tmp/out.bin").await?;
+sink.write(&[0u8; 4096]).await?;
+sink.write(&[1u8; 4096]).await?;
+sink.close().await?;
+```
+
+---
+
+## Directory operations
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn list(&self, path: &str) -> MicrosandboxResult<Vec<FsEntry>>
+```
+
+List the immediate children of a directory (non-recursive). Each entry carries its path, kind, size, mode, and modification time.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute directory path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsentry">Vec&lt;FsEntry&gt;</a></div>
+    <div className="msb-param-desc">Directory entries.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+for entry in sb.fs().list("/app").await? {
+    println!("{:?} {}", entry.kind, entry.path);
+}
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn mkdir(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Create a directory, including any missing parent directories.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute directory path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.fs().mkdir("/app/data/cache").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">remove_dir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn remove_dir(&self, path: &str) -> MicrosandboxResult<()>
 ```
 
-Remove a directory.
+Remove a directory and everything under it, recursively. For a single file use [`remove()`](#fs-remove).
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `&str` | Absolute directory path |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute directory path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.fs().remove_dir("/app/data/cache").await?;
+```
 
 ---
 
-#### rename()
+## File operations
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn remove(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Delete a single file. Use [`remove_dir()`](#fs-remove_dir) for directories.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute file path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.fs().remove("/tmp/hello.txt").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">copy()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn copy(&self, from: &str, to: &str) -> MicrosandboxResult<()>
+```
+
+Copy a file from one path to another within the sandbox.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>from</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Source path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>to</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Destination path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.fs().copy("/app/config.json", "/app/config.bak.json").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">rename()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn rename(&self, from: &str, to: &str) -> MicrosandboxResult<()>
@@ -228,128 +421,422 @@ async fn rename(&self, from: &str, to: &str) -> MicrosandboxResult<()>
 
 Rename or move a file or directory within the sandbox.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| from | `&str` | Current path |
-| to | `&str` | New path |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>from</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Current path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>to</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">New path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.fs().rename("/tmp/draft.txt", "/tmp/final.txt").await?;
+```
 
 ---
 
-#### stat()
+## Metadata
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">stat()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn stat(&self, path: &str) -> MicrosandboxResult<FsMetadata>
 ```
 
-Get detailed metadata for a file or directory, including type, size, permissions, and timestamps.
+Get metadata for a file or directory: kind, size, mode, read-only flag, and timestamps. A final symlink is followed (equivalent to `stat_with_follow(path, true)`); use [`stat_with_follow()`](#fs-stat_with_follow) to control that.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `&str` | Absolute path inside the guest |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`FsMetadata`](#fsmetadata) | File metadata |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsmetadata">FsMetadata</a></div>
+    <div className="msb-param-desc">File metadata.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let meta = sb.fs().stat("/app/config.json").await?;
+println!("{} bytes, mode {:o}", meta.size, meta.mode);
+```
 
 ---
 
-#### write()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">stat_with_follow()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
-async fn write(&self, path: &str, data: impl AsRef<[u8]>) -> MicrosandboxResult<()>
+async fn stat_with_follow(&self, path: &str, follow_symlink: bool) -> MicrosandboxResult<FsMetadata>
 ```
 
-Write content to a file, creating it if it doesn't exist and overwriting if it does. Parent directories must already exist.
+Get metadata, choosing whether to follow a final symlink. With `follow_symlink = false` you stat the link itself rather than its target. Local backend only; cloud returns `Unsupported`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `&str` | Absolute path inside the guest |
-| data | `impl AsRef<[u8]>` | File content |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>follow_symlink</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>false</code>, stat the symlink itself instead of its target.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsmetadata">FsMetadata</a></div>
+    <div className="msb-param-desc">File metadata.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let link_meta = sb.fs().stat_with_follow("/app/current", false).await?;
+println!("{:?}", link_meta.kind);
+```
 
 ---
 
-#### write_stream()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">set_stat()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
-async fn write_stream(&self, path: &str) -> MicrosandboxResult<FsWriteSink>
+async fn set_stat(&self, path: &str, follow_symlink: bool, attrs: FsSetAttrs) -> MicrosandboxResult<()>
 ```
 
-Open a streaming writer for large files. Write chunks incrementally and close when done.
+Update metadata on a file or directory: mode, owner uid/gid, size, and access/modification times. Only the fields you set on [`FsSetAttrs`](#fssetattrs) are applied. Local backend only; cloud returns `Unsupported`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `&str` | Absolute path inside the guest |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>follow_symlink</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>false</code>, target the symlink itself instead of its target.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>attrs</code><a className="msb-type" href="#fssetattrs">FsSetAttrs</a></div>
+    <div className="msb-param-desc">Attributes to change; unset fields are left untouched.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Example</p>
 
-| Type | Description |
-|------|-------------|
-| [`FsWriteSink`](#fswritesink) | Async writer for sending chunks |
+```rust
+use microsandbox::sandbox::FsSetAttrs;
+
+sb.fs().set_stat("/app/run.sh", true, FsSetAttrs {
+    mode: Some(0o755),
+    ..Default::default()
+}).await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read_link()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn read_link(&self, path: &str) -> MicrosandboxResult<String>
+```
+
+Read the target of a symbolic link, returning the literal target text. Local backend only; cloud returns `Unsupported`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute path of the symlink inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">String</span></div>
+    <div className="msb-param-desc">The link's target path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let target = sb.fs().read_link("/app/current").await?;
+println!("-> {target}");
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">symlink()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn symlink(&self, target: &str, link_path: &str) -> MicrosandboxResult<()>
+```
+
+Create a symbolic link at `link_path` that points to `target`. Local backend only; cloud returns `Unsupported`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>target</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">What the link points to (literal target text).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>link_path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute path of the symlink to create.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.fs().symlink("/app/releases/v2", "/app/current").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">exists()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn exists(&self, path: &str) -> MicrosandboxResult<bool>
+```
+
+Check whether a file or directory exists at the given path in the guest. Implemented as a `stat()` probe: a successful stat yields `true`, a filesystem-op error yields `false`, and transport errors still propagate.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> if the path exists.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+if sb.fs().exists("/app/config.json").await? {
+    println!("config present");
+}
+```
+
+---
+
+## Host transfer
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">copy_from_host()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn copy_from_host(&self, host_path: impl AsRef<Path>, guest_path: &str) -> MicrosandboxResult<()>
+```
+
+Copy a file from the host machine into the sandbox, streaming it in chunks. For transferring many files, consider a [bind-mounted volume](/sdk/rust/volumes) instead.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_path</code><span className="msb-type">impl AsRef&lt;Path&gt;</span></div>
+    <div className="msb-param-desc">Path on the host filesystem.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Destination path inside the sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.fs().copy_from_host("./local/model.bin", "/app/model.bin").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">copy_to_host()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn copy_to_host(&self, guest_path: &str, host_path: impl AsRef<Path>) -> MicrosandboxResult<()>
+```
+
+Copy a file from the sandbox to the host machine.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Path inside the sandbox.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_path</code><span className="msb-type">impl AsRef&lt;Path&gt;</span></div>
+    <div className="msb-param-desc">Destination path on the host.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.fs().copy_to_host("/app/out/report.pdf", "./report.pdf").await?;
+```
 
 ---
 
 ## Types
 
+### SandboxFs
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="/sdk/rust/sandbox#sb-fs">sb.fs()</a></p>
+
+Filesystem operations handle for a running sandbox, borrowing the parent sandbox's backend and name (it is generic over a lifetime, `SandboxFs<'a>`). Every method dispatches through the same host-guest channel as command execution. Local routes to `core.fs.*` agent messages; cloud returns `Unsupported` per method until cloud guest-fs lands. All operations are listed in the sections above.
+
+`with_backend(backend, name)` is a public constructor for FFI shims that re-assemble a `SandboxFs` per call; most callers obtain one via [`sb.fs()`](/sdk/rust/sandbox#sb-fs).
+
 ### FsEntry
 
-Metadata for a single directory entry, returned by [`list()`](#list).
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#fs-list">list()</a></p>
+
+Metadata for a single entry returned from a directory listing.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| path | `String` | Path of the entry |
+| kind | [`FsEntryKind`](#fsentrykind) | Kind of entry |
+| size | `u64` | Size in bytes |
 | mode | `u32` | Unix permission bits (e.g. `0o644`) |
-| modified | `Option<DateTime<Utc>>` | Last modified timestamp |
-| path | `String` | File path |
-| size | `u64` | File size in bytes |
+| modified | `Option<DateTime<Utc>>` | Last modification time |
 
 ### FsEntryKind
 
-The type of a filesystem entry.
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
 
-| Value | Description |
-|-------|-------------|
-| `Directory` | Directory |
+<p className="msb-backref">Used by <a href="#fsentry">FsEntry.kind</a> · <a href="#fsmetadata">FsMetadata.kind</a></p>
+
+The kind of a filesystem entry. Derives `Copy`, `PartialEq`, and `Eq`.
+
+| Variant | Description |
+|---------|-------------|
 | `File` | Regular file |
-| `Other` | Other entry type (device, socket, etc.) |
+| `Directory` | Directory |
 | `Symlink` | Symbolic link |
+| `Other` | Other entry type (device, socket, etc.) |
 
 ### FsMetadata
 
-Detailed file metadata, returned by [`stat()`](#stat).
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#fs-stat">stat()</a> · <a href="#fs-stat_with_follow">stat_with_follow()</a></p>
+
+Detailed metadata for a file or directory.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| created | `Option<DateTime<Utc>>` | Creation timestamp (not available on all filesystems) |
-| kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
+| kind | [`FsEntryKind`](#fsentrykind) | Kind of entry |
+| size | `u64` | Size in bytes |
 | mode | `u32` | Unix permission bits |
-| modified | `Option<DateTime<Utc>>` | Last modified timestamp |
-| readonly | `bool` | Whether the file is read-only |
-| size | `u64` | File size in bytes |
+| readonly | `bool` | Whether the entry is read-only (no owner write bit) |
+| modified | `Option<DateTime<Utc>>` | Last modification time |
+| created | `Option<DateTime<Utc>>` | Creation time (not populated by guest stat, currently always `None`) |
+
+### FsSetAttrs
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#fs-set_stat">set_stat()</a></p>
+
+Attributes accepted by `set_stat()`. Re-exported from `microsandbox_protocol::fs`. Derives `Default`, so set only the fields you want to change and spread the rest with `..Default::default()`. Each field is `Option`: `None` leaves that attribute unchanged.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| mode | `Option<u32>` | Unix permission bits |
+| uid | `Option<u32>` | Owner user ID |
+| gid | `Option<u32>` | Owner group ID |
+| size | `Option<u64>` | File size (truncate or extend) |
+| atime | `Option<i64>` | Access time as Unix timestamp seconds |
+| mtime | `Option<i64>` | Modification time as Unix timestamp seconds |
 
 ### FsReadStream
 
-Async stream for reading a file in chunks. Obtained via [`read_stream()`](#read_stream).
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| collect() | `Bytes` | Collect all remaining chunks into a single `Bytes` buffer. |
-| recv() | `Option<Bytes>` | Receive the next chunk. Returns `None` when the file has been fully read. |
+<p className="msb-backref">Returned by <a href="#fs-read_stream">read_stream()</a></p>
+
+Streaming reader for file data from the sandbox. Obtained via [`read_stream()`](#fs-read_stream).
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| recv() | `recv(&mut self) -> MicrosandboxResult<Option<Bytes>>` | Receive the next chunk; `None` once the file is fully read. Errors if the guest reports a failure. |
+| collect() | `collect(self) -> MicrosandboxResult<Bytes>` | Consume the stream and collect all remaining chunks into a single buffer. |
 
 ### FsWriteSink
 
-Async writer for streaming data into a file. Obtained via [`write_stream()`](#write_stream).
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-| Method | Parameters | Description |
+<p className="msb-backref">Returned by <a href="#fs-write_stream">write_stream()</a></p>
+
+Streaming writer for file data to the sandbox. Obtained via [`write_stream()`](#fs-write_stream).
+
+| Method | Signature | Description |
 |--------|-----------|-------------|
-| close() | - | Finalize the write and close the stream. Must be called to ensure all data is flushed. |
-| write() | `data: impl AsRef<[u8]>` | Write a chunk of data to the file. |
+| write() | `write(&self, data: impl AsRef<[u8]>) -> MicrosandboxResult<()>` | Write a chunk of data. |
+| close() | `close(self) -> MicrosandboxResult<()>` | Send EOF and wait for confirmation. Must be called to finalize the write; errors if the guest reports a write failure. |
+
+### FsHandle
+
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+Type alias for an agentd-side filesystem handle. Internal plumbing: no public method takes or returns it, and the streaming types hold one only behind their own state.
+
+```rust
+pub type FsHandle = u64;
+```

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -3,11 +3,174 @@ title: Networking
 description: Rust SDK - Network API reference
 ---
 
-See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+Configure a sandbox's network stack: a first-match-wins egress/ingress policy, published ports, DNS interception, TLS interception, and secret-violation handling. See [Networking](/networking/overview) for the conceptual overview and [TLS Interception](/networking/tls) for proxy details.
 
-## NetworkPolicy
+<div className="msb-glance">
 
-A list of rules plus two per-direction defaults, evaluated first-match-wins. Build one with [`NetworkPolicy::builder()`](#networkpolicybuilder):
+  <p className="msb-gl"><span className="msb-dot static"></span>Static · NetworkPolicy<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#networkpolicybuilder"><span className="msb-rn">NetworkPolicy::builder()</span><span className="msb-rg">start the fluent builder</span></a>
+  <a className="msb-row" href="#networkpolicynone"><span className="msb-rn">NetworkPolicy::none()</span><span className="msb-rg">deny everything</span></a>
+  <a className="msb-row" href="#networkpolicyallow_all"><span className="msb-rn">NetworkPolicy::allow_all()</span><span className="msb-rg">allow everything</span></a>
+  <a className="msb-row" href="#networkpolicypublic_only"><span className="msb-rn">NetworkPolicy::public_only()</span><span className="msb-rg">public internet only (default)</span></a>
+  <a className="msb-row" href="#networkpolicynon_local"><span className="msb-rn">NetworkPolicy::non_local()</span><span className="msb-rg">public + private, no local</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · NetworkPolicy<span className="msb-ct">8</span></p>
+  <a className="msb-row" href="#policy-allow_domain"><span className="msb-rn">policy.allow_domain()</span><span className="msb-rg">prepend an allow-Domain rule</span></a>
+  <a className="msb-row" href="#policy-deny_domain"><span className="msb-rn">policy.deny_domain()</span><span className="msb-rg">prepend a deny-Domain rule</span></a>
+  <a className="msb-row" href="#policy-allow_domains"><span className="msb-rn">policy.allow_domains()</span><span className="msb-rg">prepend allow-Domain rules</span></a>
+  <a className="msb-row" href="#policy-deny_domains"><span className="msb-rn">policy.deny_domains()</span><span className="msb-rg">prepend deny-Domain rules</span></a>
+  <a className="msb-row" href="#policy-allow_domain_suffix"><span className="msb-rn">policy.allow_domain_suffix()</span><span className="msb-rg">prepend an allow-suffix rule</span></a>
+  <a className="msb-row" href="#policy-deny_domain_suffix"><span className="msb-rn">policy.deny_domain_suffix()</span><span className="msb-rg">prepend a deny-suffix rule</span></a>
+  <a className="msb-row" href="#policy-allow_domain_suffixes"><span className="msb-rn">policy.allow_domain_suffixes()</span><span className="msb-rg">prepend allow-suffix rules</span></a>
+  <a className="msb-row" href="#policy-deny_domain_suffixes"><span className="msb-rn">policy.deny_domain_suffixes()</span><span className="msb-rg">prepend deny-suffix rules</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · NetworkBuilder<span className="msb-ct">15</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#policy">.policy()</a>
+    <a className="msb-chip" href="#nb-port">.port()</a>
+    <a className="msb-chip" href="#port_udp">.port_udp()</a>
+    <a className="msb-chip" href="#port_bind">.port_bind()</a>
+    <a className="msb-chip" href="#port_udp_bind">.port_udp_bind()</a>
+    <a className="msb-chip" href="#dns">.dns()</a>
+    <a className="msb-chip" href="#tls">.tls()</a>
+    <a className="msb-chip" href="#trust_host_cas">.trust_host_cas()</a>
+    <a className="msb-chip" href="#max_connections">.max_connections()</a>
+    <a className="msb-chip" href="#ipv4_pool">.ipv4_pool()</a>
+    <a className="msb-chip" href="#ipv6_pool">.ipv6_pool()</a>
+    <a className="msb-chip" href="#interface">.interface()</a>
+    <a className="msb-chip" href="#enabled">.enabled()</a>
+    <a className="msb-chip" href="#on_secret_violation">.on_secret_violation()</a>
+    <a className="msb-chip" href="#secret">.secret()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · NetworkPolicyBuilder<span className="msb-ct">9</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#default_deny">.default_deny()</a>
+    <a className="msb-chip" href="#default_allow">.default_allow()</a>
+    <a className="msb-chip" href="#default_egress">.default_egress()</a>
+    <a className="msb-chip" href="#default_ingress">.default_ingress()</a>
+    <a className="msb-chip" href="#egress">.egress()</a>
+    <a className="msb-chip" href="#ingress">.ingress()</a>
+    <a className="msb-chip" href="#any">.any()</a>
+    <a className="msb-chip" href="#rule">.rule()</a>
+    <a className="msb-chip" href="#build">.build()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · RuleBuilder<span className="msb-ct">32</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#rb-egress">.egress()</a>
+    <a className="msb-chip" href="#rb-ingress">.ingress()</a>
+    <a className="msb-chip" href="#rb-any">.any()</a>
+    <a className="msb-chip" href="#tcp">.tcp()</a>
+    <a className="msb-chip" href="#udp">.udp()</a>
+    <a className="msb-chip" href="#port-1">.port()</a>
+    <a className="msb-chip" href="#allow_public">.allow_public()</a>
+    <a className="msb-chip" href="#allow_private">.allow_private()</a>
+    <a className="msb-chip" href="#allow_host">.allow_host()</a>
+    <a className="msb-chip" href="#allow_local">.allow_local()</a>
+    <a className="msb-chip" href="#allow_domains-1">.allow_domains()</a>
+    <a className="msb-chip" href="#rb-allow">.allow()</a>
+    <a className="msb-chip" href="#rb-deny">.deny()</a>
+    <a className="msb-more" href="#rulebuilder">+ 19 more in the RuleBuilder section</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · RuleDestinationBuilder<span className="msb-ct">6</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#rd-ip">.ip()</a>
+    <a className="msb-chip" href="#rd-cidr">.cidr()</a>
+    <a className="msb-chip" href="#rd-domain">.domain()</a>
+    <a className="msb-chip" href="#rd-domain_suffix">.domain_suffix()</a>
+    <a className="msb-chip" href="#rd-group">.group()</a>
+    <a className="msb-chip" href="#rd-any">.any()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · DnsBuilder · TlsBuilder · ViolationActionBuilder<span className="msb-ct">16</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#nameservers">.nameservers()</a>
+    <a className="msb-chip" href="#query_timeout_ms">.query_timeout_ms()</a>
+    <a className="msb-chip" href="#rebind_protection">.rebind_protection()</a>
+    <a className="msb-chip" href="#bypass">.bypass()</a>
+    <a className="msb-chip" href="#intercepted_ports">.intercepted_ports()</a>
+    <a className="msb-chip" href="#verify_upstream">.verify_upstream()</a>
+    <a className="msb-chip" href="#block_quic">.block_quic()</a>
+    <a className="msb-chip" href="#intercept_ca_cert">.intercept_ca_cert()</a>
+    <a className="msb-chip" href="#intercept_ca_key">.intercept_ca_key()</a>
+    <a className="msb-chip" href="#upstream_ca_cert">.upstream_ca_cert()</a>
+    <a className="msb-chip" href="#block_and_log">.block_and_log()</a>
+    <a className="msb-chip" href="#passthrough_host">.passthrough_host()</a>
+    <a className="msb-chip" href="#passthrough_host_pattern">.passthrough_host_pattern()</a>
+    <a className="msb-chip" href="#passthrough_all_hosts">.passthrough_all_hosts()</a>
+    <a className="msb-more" href="#violationactionbuilder">+ 2 more in the ViolationActionBuilder section</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#networkpolicy">NetworkPolicy</a>
+    <a className="msb-typepill" href="#rule">Rule</a>
+    <a className="msb-typepill" href="#action">Action</a>
+    <a className="msb-typepill" href="#direction">Direction</a>
+    <a className="msb-typepill" href="#destination">Destination</a>
+    <a className="msb-typepill" href="#destinationgroup">DestinationGroup</a>
+    <a className="msb-typepill" href="#protocol">Protocol</a>
+    <a className="msb-typepill" href="#portrange">PortRange</a>
+    <a className="msb-typepill" href="#domainname">DomainName</a>
+    <a className="msb-typepill" href="#nameserver">Nameserver</a>
+    <a className="msb-typepill" href="#interfaceoverrides">InterfaceOverrides</a>
+    <a className="msb-typepill" href="#builderror">BuildError</a>
+    <a className="msb-typepill" href="#violationaction">ViolationAction</a>
+    <a className="msb-typepill" href="/sdk/rust/secrets#hostpattern">HostPattern</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```rust
+use microsandbox::{NetworkPolicy, Sandbox};
+
+let policy = NetworkPolicy::builder()       // 1. compose a policy
+    .default_deny()
+    .egress(|e| e.tcp().port(443).allow_public())
+    .rule(|r| r.any().deny().ip("198.51.100.5"))
+    .build()?;
+
+let sb = Sandbox::builder("api")
+    .image("python")
+    .network(|n| n                          // 2. wire it into the sandbox
+        .policy(policy)
+        .port(8080, 80)
+        .dns(|d| d.rebind_protection(true)))
+    .create()
+    .await?;
+```
+
+The default policy denies egress except for an implicit allow-public rule (plus DNS), and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry. `NetworkPolicy` and the builders live in `microsandbox_network`; `NetworkPolicy` is also re-exported from the crate root as `microsandbox::NetworkPolicy`.
+
+## NetworkPolicy static methods
+
+A [`NetworkPolicy`](#networkpolicy) is an ordered rule list plus two per-direction defaults, evaluated first-match-wins. The presets below construct common shapes directly; for anything custom, start from [`builder()`](#networkpolicybuilder).
+
+---
+
+#### <span className="msb-recv">NetworkPolicy::</span><span className="msb-hn">builder()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
+
+```rust
+fn builder() -> NetworkPolicyBuilder
+```
+
+Start the fluent [`NetworkPolicyBuilder`](#networkpolicybuilder). The primary construction path: string inputs (`.ip`, `.cidr`, `.domain`, `.domain_suffix`) are stored raw and parsed at [`build()`](#build), so the chain stays clean and the first parse or validation failure surfaces as [`BuildError`](#builderror).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#networkpolicybuilder">NetworkPolicyBuilder</a></div>
+    <div className="msb-param-desc">Empty builder.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```rust
 use microsandbox::NetworkPolicy;
@@ -15,106 +178,229 @@ use microsandbox::NetworkPolicy;
 let policy = NetworkPolicy::builder()
     .default_deny()
     .egress(|e| e.tcp().port(443).allow_public().allow_private())
-    .rule(|r| r.any().deny().ip("198.51.100.5"))
     .build()?;
 ```
 
-The default policy denies egress except for an implicit `allow public`, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry.
+---
 
-| Field | Type | Description |
-|-------|------|-------------|
-| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
-| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
-| rules | `Vec<`[`Rule`](#rule)`>` | Ordered list of rules; first match wins |
-
-### Rule order matters
-
-The first matching rule wins, so a broad rule placed before a narrow one swallows it:
+#### <span className="msb-recv">NetworkPolicy::</span><span className="msb-hn">none()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```rust
-NetworkPolicy::builder()
-    .default_deny()
-    .egress(|e| e
-        .allow().cidr("10.0.0.0/8")     // matches everything in 10.x
-        .deny().ip("10.0.0.5"))          // never reached
-    .build()?;
+fn none() -> NetworkPolicy
 ```
 
-Put specific rules before general ones.
-
-### Shadow detection
-
-`.build()` walks the rules and warns (via `tracing::warn!`) when a rule is fully covered by an earlier one in the same direction. Only `Ip`, `Cidr`, and `Group` destinations are checked; domain coverage depends on runtime DNS and is skipped. Builds still succeed:
-
-```text
-WARN rule #1 (Egress Cidr(10.0.0.5/32) Deny) is shadowed by rule #0 (Egress Cidr(10.0.0.0/8) Allow); to narrow, place the more specific rule first
-```
-
-### State accumulation
-
-State setters (`.tcp()`, `.port()`, etc.) inside a closure carry into every rule-adder that follows. State is **not reset** between adders:
-
-```rust
-.rule(|r| r.egress()
-    .tcp().port(443).allow_public()    // rule 1: egress, TCP, 443, allow Public
-    .udp().allow_private())            // rule 2: egress, [TCP, UDP], 443, allow Private
-```
-
-Use separate closures for rules that need different state.
+No network access: deny everything in both directions, no rules. This is the policy set by [`SandboxBuilder::disable_network()`](/sdk/rust/sandbox#disable_network).
 
 ---
 
-## NetworkPolicy::builder()
+#### <span className="msb-recv">NetworkPolicy::</span><span className="msb-hn">allow_all()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
-The fluent builder is the primary construction path. String inputs (`.ip(&str)`, `.cidr(&str)`, `.domain(&str)`, `.domain_suffix(&str)`) are stored raw and parsed at `.build()` time, so the chain stays clean. The first parse / validation failure surfaces as [`BuildError`](#builderror).
+```rust
+fn allow_all() -> NetworkPolicy
+```
 
-The closure signature for `.rule()` / `.egress()` / `.ingress()` / `.any()` is `FnOnce(&mut RuleBuilder) -> &mut RuleBuilder`. A chain ending in any rule-adder (`.allow_public()`, `.deny().ip(...)`, etc.) returns the builder reference and satisfies the bound. Multi-statement bodies end with an explicit `r` return.
+Unrestricted network access: allow everything in both directions, no rules.
 
 ---
 
-#### any()
+#### <span className="msb-recv">NetworkPolicy::</span><span className="msb-hn">public_only()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```rust
-fn any<F>(self, f: F) -> Self
+fn public_only() -> NetworkPolicy
+```
+
+Public internet only, and the [`Default`](#networkpolicy) policy. Egress defaults to deny but allows DNS to the gateway forwarder and any [`Public`](#destinationgroup) destination; private, loopback, link-local, and metadata are denied. Ingress defaults to allow, preserving unfiltered published-port behavior.
+
+---
+
+#### <span className="msb-recv">NetworkPolicy::</span><span className="msb-hn">non_local()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
+
+```rust
+fn non_local() -> NetworkPolicy
+```
+
+Non-local access: like [`public_only()`](#networkpolicypublic_only) but also allows egress to [`Private`](#destinationgroup) / LAN ranges. Loopback, link-local, and metadata stay denied; ingress defaults to allow.
+
+---
+
+## NetworkPolicy instance methods
+
+These methods consume `self` and return a modified policy, so they chain off a preset or a built policy. Each **prepends** its rules, so a later deny outranks a catch-all allow like `allow public` under first-match-wins. All return [`Result<NetworkPolicy, DomainNameError>`](#domainname) because the names are parsed eagerly.
+
+---
+
+#### <span className="msb-recv">policy.</span><span className="msb-hn">allow_domain()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn allow_domain<S: AsRef<str>>(self, name: S) -> Result<NetworkPolicy, DomainNameError>
+```
+
+Prepend a single allow-[`Domain`](#destination) egress rule. Single-name sugar over [`allow_domains()`](#policy-allow_domains).
+
+<p className="msb-label">Example</p>
+
+```rust
+let policy = NetworkPolicy::public_only().allow_domain("api.openai.com")?;
+```
+
+---
+
+#### <span className="msb-recv">policy.</span><span className="msb-hn">deny_domain()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn deny_domain<S: AsRef<str>>(self, name: S) -> Result<NetworkPolicy, DomainNameError>
+```
+
+Prepend a single deny-[`Domain`](#destination) egress rule. Single-name sugar over [`deny_domains()`](#policy-deny_domains).
+
+---
+
+#### <span className="msb-recv">policy.</span><span className="msb-hn">allow_domains()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn allow_domains<I, S>(self, names: I) -> Result<NetworkPolicy, DomainNameError>
 where
-    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
 ```
 
-Sugar for [`rule()`](#rule) with direction pre-set to `Any`. Rules committed inside apply in both directions.
+Prepend one allow-[`Domain`](#destination) egress rule per name.
 
----
+<p className="msb-label">Parameters</p>
 
-#### build()
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>names</code><span className="msb-type">IntoIterator&lt;Item = AsRef&lt;str&gt;&gt;</span></div>
+    <div className="msb-param-desc">Exact domain names.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```rust
-fn build(self) -> Result<NetworkPolicy, BuildError>
+let policy = NetworkPolicy::default()
+    .allow_domains(["pypi.org", "files.pythonhosted.org"])?;
 ```
-
-Consume the builder and produce a [`NetworkPolicy`](#networkpolicy). Lazy-parses every `.ip()` / `.cidr()` / `.domain()` / `.domain_suffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a `tracing::warn!` for each shadowed rule pair detected.
 
 ---
 
-#### default_allow()
+#### <span className="msb-recv">policy.</span><span className="msb-hn">deny_domains()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
-fn default_allow(self) -> Self
+fn deny_domains<I, S>(self, names: I) -> Result<NetworkPolicy, DomainNameError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
 ```
 
-Set both `default_egress` and `default_ingress` to `Allow`.
+Prepend one deny-[`Domain`](#destination) egress rule per name. Prepending lets the denies outrank catch-all allows.
+
+<p className="msb-label">Example</p>
+
+```rust
+let policy = NetworkPolicy::allow_all()
+    .deny_domains(["evil.com", "tracker.example"])?;
+```
 
 ---
 
-#### default_deny()
+#### <span className="msb-recv">policy.</span><span className="msb-hn">allow_domain_suffix()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn allow_domain_suffix<S: AsRef<str>>(self, suffix: S) -> Result<NetworkPolicy, DomainNameError>
+```
+
+Prepend a single allow-[`DomainSuffix`](#destination) egress rule. Single-suffix sugar over [`allow_domain_suffixes()`](#policy-allow_domain_suffixes).
+
+---
+
+#### <span className="msb-recv">policy.</span><span className="msb-hn">deny_domain_suffix()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn deny_domain_suffix<S: AsRef<str>>(self, suffix: S) -> Result<NetworkPolicy, DomainNameError>
+```
+
+Prepend a single deny-[`DomainSuffix`](#destination) egress rule. Single-suffix sugar over [`deny_domain_suffixes()`](#policy-deny_domain_suffixes).
+
+---
+
+#### <span className="msb-recv">policy.</span><span className="msb-hn">allow_domain_suffixes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn allow_domain_suffixes<I, S>(self, suffixes: I) -> Result<NetworkPolicy, DomainNameError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+```
+
+Prepend one allow-[`DomainSuffix`](#destination) egress rule per suffix. Suffixes match the apex domain and every subdomain (label-aligned).
+
+---
+
+#### <span className="msb-recv">policy.</span><span className="msb-hn">deny_domain_suffixes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn deny_domain_suffixes<I, S>(self, suffixes: I) -> Result<NetworkPolicy, DomainNameError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+```
+
+Prepend one deny-[`DomainSuffix`](#destination) egress rule per suffix.
+
+<p className="msb-label">Example</p>
+
+```rust
+let policy = NetworkPolicy::allow_all()
+    .deny_domain_suffixes([".ads.example", ".doubleclick.net"])?;
+```
+
+---
+
+## NetworkPolicyBuilder
+
+Fluent builder for [`NetworkPolicy`](#networkpolicy), obtained via [`NetworkPolicy::builder()`](#networkpolicybuilder). Defaults and rule-batch closures interleave; the build is deferred. The closure signature for [`rule()`](#rule) / [`egress()`](#egress) / [`ingress()`](#ingress) / [`any()`](#any) is `FnOnce(&mut RuleBuilder) -> &mut RuleBuilder`. A chain ending in any rule-adder (`.allow_public()`, `.deny().ip(...)`, etc.) returns the builder reference and satisfies the bound; multi-statement bodies end with an explicit `r` return.
+
+State setters inside a closure (`.tcp()`, `.port()`) accumulate eagerly and are **not reset** between rule-adders, so a single closure can fan one state into several rules. Use separate closures for rules that need different state. See [State accumulation](/networking/overview) for the rationale.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">default_deny()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn default_deny(self) -> Self
 ```
 
-Set both `default_egress` and `default_ingress` to `Deny`.
+Set both `default_egress` and `default_ingress` to [`Deny`](#action).
 
 ---
 
-#### default_egress()
+#### <span className="msb-recv">.</span><span className="msb-hn">default_allow()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn default_allow(self) -> Self
+```
+
+Set both `default_egress` and `default_ingress` to [`Allow`](#action).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">default_egress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn default_egress(self, action: Action) -> Self
@@ -122,15 +408,19 @@ fn default_egress(self, action: Action) -> Self
 
 Per-direction override for the egress default action.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| action | [`Action`](#action) | Default action for egress |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>action</code><a className="msb-type" href="#action">Action</a></div>
+    <div className="msb-param-desc">Default action for egress.</div>
+  </div>
+</div>
 
 ---
 
-#### default_ingress()
+#### <span className="msb-recv">.</span><span className="msb-hn">default_ingress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn default_ingress(self, action: Action) -> Self
@@ -138,15 +428,19 @@ fn default_ingress(self, action: Action) -> Self
 
 Per-direction override for the ingress default action.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| action | [`Action`](#action) | Default action for ingress |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>action</code><a className="msb-type" href="#action">Action</a></div>
+    <div className="msb-param-desc">Default action for ingress.</div>
+  </div>
+</div>
 
 ---
 
-#### egress()
+#### <span className="msb-recv">.</span><span className="msb-hn">egress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn egress<F>(self, f: F) -> Self
@@ -154,11 +448,21 @@ where
     F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
 ```
 
-Sugar for [`rule()`](#rule) with direction pre-set to `Egress`.
+Sugar for [`rule()`](#rule) with direction pre-set to [`Egress`](#direction).
+
+<p className="msb-label">Example</p>
+
+```rust
+NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.tcp().port(443).allow_public())
+    .build()?;
+```
 
 ---
 
-#### ingress()
+#### <span className="msb-recv">.</span><span className="msb-hn">ingress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn ingress<F>(self, f: F) -> Self
@@ -166,11 +470,25 @@ where
     F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
 ```
 
-Sugar for [`rule()`](#rule) with direction pre-set to `Ingress`.
+Sugar for [`rule()`](#rule) with direction pre-set to [`Ingress`](#direction).
 
 ---
 
-#### rule()
+#### <span className="msb-recv">.</span><span className="msb-hn">any()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn any<F>(self, f: F) -> Self
+where
+    F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
+```
+
+Sugar for [`rule()`](#rule) with direction pre-set to [`Any`](#direction). Rules committed inside apply in both directions.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">rule()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn rule<F>(self, f: F) -> Self
@@ -178,119 +496,151 @@ where
     F: for<'a> FnOnce(&'a mut RuleBuilder) -> &'a mut RuleBuilder
 ```
 
-Open a multi-rule batch closure. Direction must be set inside via `.egress()`, `.ingress()`, or `.any()` before any rule-adder.
+Open a multi-rule batch closure. Direction must be set inside via [`.egress()`](#rb-egress), [`.ingress()`](#rb-ingress), or [`.any()`](#rb-any) before any rule-adder, otherwise [`build()`](#build) returns [`BuildError::DirectionNotSet`](#builderror).
+
+<p className="msb-label">Example</p>
+
+```rust
+NetworkPolicy::builder()
+    .rule(|r| r.egress().tcp().port(443).allow().domain("api.example.com"))
+    .build()?;
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn build(self) -> Result<NetworkPolicy, BuildError>
+```
+
+Consume the builder and produce a [`NetworkPolicy`](#networkpolicy). Lazy-parses every `.ip()` / `.cidr()` / `.domain()` / `.domain_suffix()` input, validates the direction-set and ICMP-egress-only invariants, and emits a `tracing::warn!` for each shadowed rule pair (a rule fully covered by an earlier one in the same direction; only `Ip` / `Cidr` / `Group` destinations are checked). Builds still succeed when a shadow is detected. Returns the first [`BuildError`](#builderror) encountered.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#networkpolicy">NetworkPolicy</a></div>
+    <div className="msb-param-desc">Validated policy.</div>
+  </div>
+</div>
 
 ---
 
 ## RuleBuilder
 
-The closure passed to `.rule(...)` (or any of the direction sugar methods) gives you a `RuleBuilder`. State setters and rule-adders interleave freely. State accumulates eagerly across the closure (see [State accumulation](#state-accumulation)).
-
-### Direction setters
-
-Last-write-wins. ICMP rule-adders are egress-only at build time.
+The mutable builder handed to a [`NetworkPolicyBuilder`](#networkpolicybuilder) rule-batch closure. Direction, protocol, and port setters return `&mut Self` and accumulate eagerly; rule-adders commit one rule each using the current state. Protocols and ports have set semantics, so duplicates dedupe.
 
 ---
 
-#### any()
+#### <span className="msb-recv">.</span><span className="msb-hn">egress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
-```rust
-fn any(&mut self) -> &mut Self
-```
-
-Set direction to `Any` for subsequent rule-adders. Rules committed after this apply in both directions.
-
----
-
-#### egress()
+<a id="rb-egress"></a>
 
 ```rust
 fn egress(&mut self) -> &mut Self
 ```
 
-Set direction to `Egress` for subsequent rule-adders.
+Set direction to [`Egress`](#direction) for subsequent rule-adders. Last-write-wins.
 
 ---
 
-#### ingress()
+#### <span className="msb-recv">.</span><span className="msb-hn">ingress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="rb-ingress"></a>
 
 ```rust
 fn ingress(&mut self) -> &mut Self
 ```
 
-Set direction to `Ingress` for subsequent rule-adders.
+Set direction to [`Ingress`](#direction) for subsequent rule-adders. Last-write-wins.
 
 ---
 
-### Protocol setters
+#### <span className="msb-recv">.</span><span className="msb-hn">any()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
-Protocols accumulate as a set; duplicates dedupe.
-
----
-
-#### icmpv4()
+<a id="rb-any"></a>
 
 ```rust
-fn icmpv4(&mut self) -> &mut Self
+fn any(&mut self) -> &mut Self
 ```
 
-Add `Icmpv4` to the protocols set. Egress-only; an ICMP rule on an `Ingress` or `Any` direction fails build with [`BuildError::IngressDoesNotSupportIcmp`](#builderror).
+Set direction to [`Any`](#direction) for subsequent rule-adders. Rules committed after this apply in both directions. Last-write-wins.
 
 ---
 
-#### icmpv6()
-
-```rust
-fn icmpv6(&mut self) -> &mut Self
-```
-
-Add `Icmpv6` to the protocols set. Egress-only; same rules as [`icmpv4()`](#icmpv4).
-
----
-
-#### tcp()
+#### <span className="msb-recv">.</span><span className="msb-hn">tcp()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn tcp(&mut self) -> &mut Self
 ```
 
-Add `Tcp` to the protocols set.
+Add [`Tcp`](#protocol) to the protocols set.
 
 ---
 
-#### udp()
+#### <span className="msb-recv">.</span><span className="msb-hn">udp()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn udp(&mut self) -> &mut Self
 ```
 
-Add `Udp` to the protocols set.
+Add [`Udp`](#protocol) to the protocols set.
 
 ---
 
-### Port setters
+#### <span className="msb-recv">.</span><span className="msb-hn">icmpv4()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
-Ports accumulate as a set; duplicates dedupe. Always guest-side (egress destination port / ingress listening port).
+```rust
+fn icmpv4(&mut self) -> &mut Self
+```
+
+Add [`Icmpv4`](#protocol) to the protocols set. Egress-only: an ICMP protocol on an `Ingress` or `Any` rule fails build with [`BuildError::IngressDoesNotSupportIcmp`](#builderror).
 
 ---
 
-#### port()
+#### <span className="msb-recv">.</span><span className="msb-hn">icmpv6()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn icmpv6(&mut self) -> &mut Self
+```
+
+Add [`Icmpv6`](#protocol) to the protocols set. Egress-only; same rule as [`icmpv4()`](#icmpv4).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">port()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="port-1"></a>
 
 ```rust
 fn port(&mut self, port: u16) -> &mut Self
 ```
 
-Add a single port to the ports set.
+Add a single port to the ports set. Always guest-side (egress destination port / ingress listening port).
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| port | `u16` | Port number |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port number.</div>
+  </div>
+</div>
 
 ---
 
-#### port_range()
+#### <span className="msb-recv">.</span><span className="msb-hn">port_range()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn port_range(&mut self, lo: u16, hi: u16) -> &mut Self
@@ -298,174 +648,157 @@ fn port_range(&mut self, lo: u16, hi: u16) -> &mut Self
 
 Add an inclusive port range.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| lo | `u16` | Lower bound (inclusive) |
-| hi | `u16` | Upper bound (inclusive). `lo > hi` records [`BuildError::InvalidPortRange`](#builderror) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>lo</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Lower bound (inclusive).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hi</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Upper bound (inclusive). <code>lo &gt; hi</code> records <a href="#builderror">BuildError::InvalidPortRange</a>.</div>
+  </div>
+</div>
 
 ---
 
-#### ports()
+#### <span className="msb-recv">.</span><span className="msb-hn">ports()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn ports<I: IntoIterator<Item = u16>>(&mut self, ports: I) -> &mut Self
 ```
 
-Add multiple single ports. Equivalent to calling [`port()`](#port-setters) once per element.
+Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
 
 ---
 
-### Group rule-adders
-
-Each adder commits one rule using the current state and the named destination group.
-
----
-
-#### allow_host()
-
-```rust
-fn allow_host(&mut self) -> &mut Self
-```
-
-Allow the `Host` group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allow_loopback()`](#allow_loopback).
-
----
-
-#### allow_link_local()
-
-```rust
-fn allow_link_local(&mut self) -> &mut Self
-```
-
-Allow the `LinkLocal` group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
-
----
-
-#### allow_loopback()
-
-```rust
-fn allow_loopback(&mut self) -> &mut Self
-```
-
-Allow the `Loopback` group (`127.0.0.0/8`, `::1`). The **guest's own** loopback, not the host. To reach a service on the host's localhost, use [`allow_host()`](#allow_host) instead. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
-
----
-
-#### allow_meta()
-
-```rust
-fn allow_meta(&mut self) -> &mut Self
-```
-
-Allow the `Metadata` group (`169.254.169.254`). **Dangerous on cloud hosts** (exposes IAM credentials).
-
----
-
-#### allow_multicast()
-
-```rust
-fn allow_multicast(&mut self) -> &mut Self
-```
-
-Allow the `Multicast` group (`224.0.0.0/4`, `ff00::/8`).
-
----
-
-#### allow_private()
-
-```rust
-fn allow_private(&mut self) -> &mut Self
-```
-
-Allow the `Private` group (RFC1918 + ULA + CGN).
-
----
-
-#### allow_public()
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_public()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn allow_public(&mut self) -> &mut Self
 ```
 
-Allow the `Public` group (complement of named categories: every IP not in any other group).
+Commit an allow rule for the [`Public`](#destinationgroup) group: every IP not in another named category. A matching [`deny_public()`](#deny_public) exists for each `allow_*` group adder below.
 
 ---
 
-#### deny_host()
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_private()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn deny_host(&mut self) -> &mut Self
+fn allow_private(&mut self) -> &mut Self
 ```
 
-Deny the `Host` group.
+Allow the [`Private`](#destinationgroup) group (RFC1918 + ULA + CGN).
 
 ---
 
-#### deny_link_local()
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_loopback()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn deny_link_local(&mut self) -> &mut Self
+fn allow_loopback(&mut self) -> &mut Self
 ```
 
-Deny the `LinkLocal` group.
+Allow the [`Loopback`](#destinationgroup) group (`127.0.0.0/8`, `::1`): the **guest's own** loopback, not the host. To reach a service on the host's localhost use [`allow_host()`](#allow_host) instead. See the [loopback-vs-host trap](/networking/overview#loopback-vs-host-a-common-trap).
 
 ---
 
-#### deny_loopback()
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_link_local()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn deny_loopback(&mut self) -> &mut Self
+fn allow_link_local(&mut self) -> &mut Self
 ```
 
-Deny the `Loopback` group.
+Allow the [`LinkLocal`](#destinationgroup) group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
 
 ---
 
-#### deny_meta()
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_meta()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn deny_meta(&mut self) -> &mut Self
+fn allow_meta(&mut self) -> &mut Self
 ```
 
-Deny the `Metadata` group.
+Allow the [`Metadata`](#destinationgroup) group (`169.254.169.254`). **Dangerous on cloud hosts**: exposes IAM credentials.
 
 ---
 
-#### deny_multicast()
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_multicast()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn deny_multicast(&mut self) -> &mut Self
+fn allow_multicast(&mut self) -> &mut Self
 ```
 
-Deny the `Multicast` group.
+Allow the [`Multicast`](#destinationgroup) group (`224.0.0.0/4`, `ff00::/8`).
 
 ---
 
-#### deny_private()
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_host()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn deny_private(&mut self) -> &mut Self
+fn allow_host(&mut self) -> &mut Self
 ```
 
-Deny the `Private` group.
+Allow the [`Host`](#destinationgroup) group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allow_loopback()`](#allow_loopback).
 
 ---
 
-#### deny_public()
+#### <span className="msb-recv">.</span><span className="msb-hn">deny_public()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn deny_public(&mut self) -> &mut Self
 ```
 
-Deny the `Public` group.
+Deny the [`Public`](#destinationgroup) group. Per-group `deny_*` adders mirror the `allow_*` set: `deny_private()`, `deny_loopback()`, `deny_link_local()`, `deny_meta()`, `deny_multicast()`, and `deny_host()`.
 
 ---
 
-### Bulk-domain rule-adders
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_local()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
-Each call adds one rule per name, inheriting the current direction / protocol / port state. Lazy-parse: invalid names surface as [`BuildError::InvalidDomain`](#builderror) from `.build()`.
+```rust
+fn allow_local(&mut self) -> &mut Self
+```
+
+Commit **three** allow rules atomically: [`Loopback`](#destinationgroup) + `LinkLocal` + `Host`. Each uses the closure's current state. `Metadata` is intentionally excluded; opt in via [`allow_meta()`](#allow_meta) separately.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">deny_local()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn deny_local(&mut self) -> &mut Self
+```
+
+Commit three deny rules atomically: `Loopback` + `LinkLocal` + `Host`. `Metadata` is intentionally excluded.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_domains()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="allow_domains-1"></a>
+
+```rust
+fn allow_domains<I, S>(&mut self, names: I) -> &mut Self
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>
+```
+
+Add one allow-[`Domain`](#destination) rule per name, inheriting the closure's current direction / protocol / port state. Lazy-parse: invalid names surface as [`BuildError::InvalidDomain`](#builderror) from [`build()`](#build).
+
+<p className="msb-label">Example</p>
 
 ```rust
 NetworkPolicy::builder()
@@ -473,214 +806,197 @@ NetworkPolicy::builder()
     .egress(|e| e
         .deny_domains(["evil.com", "tracker.example"])
         .deny_domain_suffixes([".ads.example", ".doubleclick.net"]))
-    .build()?
+    .build()?;
 ```
 
 ---
 
-#### allow_domain_suffixes()
-
-```rust
-fn allow_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
-where I: IntoIterator<Item = S>, S: Into<String>
-```
-
-Add one `Destination::DomainSuffix` allow rule per suffix.
-
----
-
-#### allow_domains()
-
-```rust
-fn allow_domains<I, S>(&mut self, names: I) -> &mut Self
-where I: IntoIterator<Item = S>, S: Into<String>
-```
-
-Add one `Destination::Domain` allow rule per name.
-
----
-
-#### deny_domain_suffixes()
-
-```rust
-fn deny_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
-where I: IntoIterator<Item = S>, S: Into<String>
-```
-
-Add one `Destination::DomainSuffix` deny rule per suffix.
-
----
-
-#### deny_domains()
+#### <span className="msb-recv">.</span><span className="msb-hn">deny_domains()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn deny_domains<I, S>(&mut self, names: I) -> &mut Self
-where I: IntoIterator<Item = S>, S: Into<String>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>
 ```
 
-Add one `Destination::Domain` deny rule per name.
+Add one deny-[`Domain`](#destination) rule per name.
 
 ---
 
-### Composite rule-adders
-
----
-
-#### allow_local()
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_domain_suffixes()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn allow_local(&mut self) -> &mut Self
+fn allow_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>
 ```
 
-Add three allow rules atomically: `Loopback + LinkLocal + Host`. Each uses the closure's current state. `Metadata` is intentionally not included; opt in via [`allow_meta()`](#allow_meta) separately.
+Add one allow-[`DomainSuffix`](#destination) rule per suffix.
 
 ---
 
-#### deny_local()
+#### <span className="msb-recv">.</span><span className="msb-hn">deny_domain_suffixes()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn deny_local(&mut self) -> &mut Self
+fn deny_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>
 ```
 
-Add three deny rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is intentionally not included.
+Add one deny-[`DomainSuffix`](#destination) rule per suffix.
 
 ---
 
-### Explicit-destination rule-adders
+#### <span className="msb-recv">.</span><span className="msb-hn">allow()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
-`.allow()` / `.deny()` open an [`ExplicitRuleBuilder`](#explicitrulebuilder) that requires a destination call to commit.
+<a id="rb-allow"></a>
 
 ```rust
-.rule(|r| r.egress().tcp().port(443).allow().domain("api.example.com"))
-.rule(|r| r.any().deny().cidr("198.51.100.0/24"))
+fn allow(&mut self) -> RuleDestinationBuilder<'_>
 ```
 
-Dropping without a destination call adds no rule (the type is `#[must_use]`).
+Begin an explicit-destination rule with action [`Allow`](#action). The returned [`RuleDestinationBuilder`](#ruledestinationbuilder) requires exactly one destination call to commit; dropping it without one adds no rule.
+
+<p className="msb-label">Example</p>
+
+```rust
+NetworkPolicy::builder()
+    .egress(|e| e.tcp().port(443).allow().domain("api.example.com"))
+    .any(|a| a.deny().cidr("198.51.100.0/24"))
+    .build()?;
+```
 
 ---
 
-#### allow()
+#### <span className="msb-recv">.</span><span className="msb-hn">deny()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="rb-deny"></a>
 
 ```rust
-fn allow(&mut self) -> ExplicitRuleBuilder<'_>
+fn deny(&mut self) -> RuleDestinationBuilder<'_>
 ```
 
-Begin an explicit-destination rule with action `Allow`.
+Begin an explicit-destination rule with action [`Deny`](#action).
 
 ---
 
-#### deny()
+## RuleDestinationBuilder
+
+Returned by [`RuleBuilder::allow()`](#rb-allow) / [`RuleBuilder::deny()`](#rb-deny). Requires exactly one destination method call to commit the rule, then returns the `&mut RuleBuilder` so the chain continues. The type is `#[must_use]`: dropping it without a destination call adds no rule.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">ip()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="rd-ip"></a>
 
 ```rust
-fn deny(&mut self) -> ExplicitRuleBuilder<'_>
+fn ip(self, ip: impl Into<String>) -> &'a mut RuleBuilder
 ```
 
-Begin an explicit-destination rule with action `Deny`.
+Commit with [`Destination::Cidr`](#destination) of the IP as `/32` (v4) or `/128` (v6). The string is parsed at [`build()`](#build); invalid values surface as [`BuildError::InvalidIp`](#builderror).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">cidr()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="rd-cidr"></a>
+
+```rust
+fn cidr(self, cidr: impl Into<String>) -> &'a mut RuleBuilder
+```
+
+Commit with [`Destination::Cidr`](#destination). Invalid values surface as [`BuildError::InvalidCidr`](#builderror).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">domain()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="rd-domain"></a>
+
+```rust
+fn domain(self, domain: impl Into<String>) -> &'a mut RuleBuilder
+```
+
+Commit with [`Destination::Domain`](#destination). Matches only when a cached hostname for the remote IP equals this name (after canonicalization).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">domain_suffix()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="rd-domain_suffix"></a>
+
+```rust
+fn domain_suffix(self, suffix: impl Into<String>) -> &'a mut RuleBuilder
+```
+
+Commit with [`Destination::DomainSuffix`](#destination). Matches the apex domain itself and any subdomain. A single-label suffix (e.g. `com`) is rejected at build as [`BuildError::InvalidDomain`](#builderror).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">group()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="rd-group"></a>
+
+```rust
+fn group(self, group: DestinationGroup) -> &'a mut RuleBuilder
+```
+
+Commit with [`Destination::Group`](#destination) for callers who already hold a [`DestinationGroup`](#destinationgroup) value.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">any()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="rd-any"></a>
+
+```rust
+fn any(self) -> &'a mut RuleBuilder
+```
+
+Commit with [`Destination::Any`](#destination): matches every remote.
 
 ---
 
 ## NetworkBuilder
 
-Builder for configuring the sandbox's network stack. Used in `SandboxBuilder::network(|n| n...)`. Errors accumulated by nested builders cascade up; the outermost `SandboxBuilder::build()` surfaces them as `MicrosandboxError::NetworkBuilder(BuildError)`.
+Builder for the sandbox's network stack, used in [`SandboxBuilder::network(|n| n...)`](/sdk/rust/sandbox#network). Every setter returns `Self`, so calls chain. Errors accumulated by nested builders cascade up: the outermost `SandboxBuilder::build()` surfaces them as [`MicrosandboxError::NetworkBuilder(BuildError)`](#builderror).
 
 ---
 
-#### dns()
-
-```rust
-fn dns(self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self
-```
-
-Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
-
-```rust
-.network(|n| n
-    .dns(|d| d
-        .nameservers(["1.1.1.1".parse::<Nameserver>()?])
-        .query_timeout_ms(3000)
-    )
-)
-```
-
----
-
-#### max_connections()
-
-```rust
-fn max_connections(self, max: usize) -> Self
-```
-
-Limit the maximum number of concurrent network connections from the sandbox.
-
----
-
-#### ipv4_pool()
-
-```rust
-fn ipv4_pool(self, pool: Ipv4Network) -> Self
-```
-
-Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12`.
-
----
-
-#### ipv6_pool()
-
-```rust
-fn ipv6_pool(self, pool: Ipv6Network) -> Self
-```
-
-Set the IPv6 pool used to derive per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48`.
-
----
-
-#### on_secret_violation()
-
-```rust
-fn on_secret_violation(
-    self,
-    f: impl FnOnce(ViolationActionBuilder) -> ViolationActionBuilder,
-) -> Self
-```
-
-Set the action taken when a secret placeholder is detected in traffic destined for a host not in the secret's allow list. The builder can configure a blocking action or passthrough hosts:
-
-```rust
-.network(|n| n.on_secret_violation(|v| {
-    v.block_and_log()
-     .passthrough_host("api.anthropic.com")
-     .passthrough_host_pattern("*.example.com")
-}))
-```
-
-Passthrough hosts receive the placeholder unchanged. They do **not** receive real secret values.
-
----
-
-## ViolationActionBuilder
-
-Builder for secret violation behavior. Used by [`NetworkBuilder::on_secret_violation()`](#on_secret_violation) and `SecretBuilder::on_violation(...)`.
-
-| Method | Description |
-|--------|-------------|
-| `block()` | Block the request silently |
-| `block_and_log()` | Block the request and emit a warning log |
-| `block_and_terminate()` | Block the request and terminate the sandbox |
-| `passthrough_host(host)` | Allow placeholders to pass through unchanged to an exact host |
-| `passthrough_host_pattern(pattern)` | Allow placeholders to pass through unchanged to matching wildcard hosts |
-| `passthrough_all_hosts(true)` | Allow placeholders to pass through unchanged to any host |
-
-Passthrough host calls accumulate. When passthrough hosts are configured, non-matching hosts use the default secret violation action.
-
----
-
-#### policy()
+#### <span className="msb-recv">.</span><span className="msb-hn">policy()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn policy(self, policy: NetworkPolicy) -> Self
 ```
 
-Set the network access policy. Pass a builder-constructed [`NetworkPolicy`](#networkpolicy):
+Set the network access policy. Pass a preset or a builder-constructed [`NetworkPolicy`](#networkpolicy).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>policy</code><a className="msb-type" href="#networkpolicy">NetworkPolicy</a></div>
+    <div className="msb-param-desc">Access policy.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```rust
 .network(|n| n.policy(NetworkPolicy::builder().default_deny().build()?))
@@ -688,7 +1004,106 @@ Set the network access policy. Pass a builder-constructed [`NetworkPolicy`](#net
 
 ---
 
-#### tls()
+#### <span className="msb-recv">.</span><span className="msb-hn">port()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="nb-port"></a>
+
+```rust
+fn port(self, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a TCP port from the sandbox to the host. The default host bind address is `127.0.0.1`. Equivalent to [`SandboxBuilder::port()`](/sdk/rust/sandbox#port).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">port_udp()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn port_udp(self, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a UDP port. The default host bind address is `127.0.0.1`.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">port_bind()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn port_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a TCP port on a specific host bind address, such as `0.0.0.0`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_bind</code><span className="msb-type">IpAddr</span></div>
+    <div className="msb-param-desc">Host bind address.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">port_udp_bind()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn port_udp_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self
+```
+
+Publish a UDP port on a specific host bind address.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">dns()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn dns(self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self
+```
+
+Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox_network::dns::Nameserver;
+
+.network(|n| n
+    .dns(|d| d
+        .nameservers(["1.1.1.1".parse::<Nameserver>()?])
+        .query_timeout_ms(3000)))
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">tls()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn tls(self, f: impl FnOnce(TlsBuilder) -> TlsBuilder) -> Self
@@ -698,23 +1113,152 @@ Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
 
 ---
 
-#### trust_host_cas()
+#### <span className="msb-recv">.</span><span className="msb-hn">trust_host_cas()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn trust_host_cas(self, enabled: bool) -> Self
 ```
 
-Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in when egress HTTPS inside the sandbox needs to work behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.). These proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle.
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in when egress HTTPS inside the sandbox needs to work behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.): those proxies install a gateway CA on the host that's unknown to the guest's stock Mozilla bundle.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">max_connections()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn max_connections(self, max: usize) -> Self
+```
+
+Limit the maximum number of concurrent network connections from the sandbox. Default: `256`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>max</code><span className="msb-type">usize</span></div>
+    <div className="msb-param-desc">Maximum concurrent connections.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">ipv4_pool()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn ipv4_pool(self, pool: Ipv4Network) -> Self
+```
+
+Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12`. A pool with a prefix longer than `/30` records [`BuildError::InvalidIpv4Pool`](#builderror).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pool</code><span className="msb-type">Ipv4Network</span></div>
+    <div className="msb-param-desc">IPv4 pool, prefix <code>/30</code> or shorter.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">ipv6_pool()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn ipv6_pool(self, pool: Ipv6Network) -> Self
+```
+
+Set the IPv6 pool used to derive per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48`. A pool with a prefix longer than `/64` records [`BuildError::InvalidIpv6Pool`](#builderror).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">interface()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn interface(self, overrides: InterfaceOverrides) -> Self
+```
+
+Override the guest interface settings wholesale: MAC, MTU, IPv4/IPv6 addresses, and the derivation pools. A low-level escape hatch. For the common case of changing only the address pools, prefer [`ipv4_pool()`](#ipv4_pool) and [`ipv6_pool()`](#ipv6_pool), which validate the prefix. Unset fields fall back to values derived deterministically from the sandbox slot. See [`InterfaceOverrides`](#interfaceoverrides).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>overrides</code><a className="msb-type" href="#interfaceoverrides">InterfaceOverrides</a></div>
+    <div className="msb-param-desc">Guest interface overrides.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">enabled()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn enabled(self, enabled: bool) -> Self
+```
+
+Enable or disable networking. Default: `true`. To fully turn networking off, prefer [`SandboxBuilder::disable_network()`](/sdk/rust/sandbox#disable_network), which also sets the policy to [`NetworkPolicy::none()`](#networkpolicynone).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">on_secret_violation()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn on_secret_violation(
+    self,
+    f: impl FnOnce(ViolationActionBuilder) -> ViolationActionBuilder,
+) -> Self
+```
+
+Set the sandbox-wide action taken when a secret placeholder is detected in traffic to a host not in the secret's allow list. See [`ViolationActionBuilder`](#violationactionbuilder).
+
+<p className="msb-label">Example</p>
+
+```rust
+.network(|n| n.on_secret_violation(|v| v
+    .block_and_log()
+    .passthrough_host("api.anthropic.com")
+    .passthrough_host_pattern("*.example.com")))
+```
+
+Passthrough hosts receive the placeholder unchanged. They do **not** receive real secret values.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">secret()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn secret(self, f: impl FnOnce(SecretBuilder) -> SecretBuilder) -> Self
+```
+
+Add a secret via a closure builder. Mirrors [`SandboxBuilder::secret()`](/sdk/rust/sandbox#secret). See [`SecretBuilder`](/sdk/rust/secrets#secretbuilder) for the full API. A companion `secret_env(env_var, value, placeholder, allowed_host)` shorthand and `secret_entry(SecretEntry)` are also available on `NetworkBuilder`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="/sdk/rust/secrets#secretbuilder">SecretBuilder</a></div>
+    <div className="msb-param-desc">Configure the secret.</div>
+  </div>
+</div>
 
 ---
 
 ## DnsBuilder
 
-Builder for DNS interception settings. Used in `NetworkBuilder::dns(|d| d...)`. Owns rebind protection, nameserver pinning, and the per-query timeout.
+Builder for DNS interception, used in [`NetworkBuilder::dns(|d| d...)`](#dns). Owns rebind protection, nameserver pinning, and the per-query timeout. Every setter returns `Self`.
 
 ---
 
-#### nameservers()
+#### <span className="msb-recv">.</span><span className="msb-hn">nameservers()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn nameservers<I>(self, nameservers: I) -> Self
@@ -723,11 +1267,21 @@ where
     I::Item: Into<Nameserver>
 ```
 
-Set the upstream nameservers to forward DNS queries to. Replaces any previously-set nameservers. Each element is convertible into `Nameserver` (`SocketAddr`, `IpAddr`, or a parsed string via `"dns.google:53".parse::<Nameserver>()?`).
+Set the upstream nameservers to forward DNS queries to. Replaces any previously-set nameservers. When empty, the interceptor falls back to the host's `/etc/resolv.conf` (or, on macOS, the SystemConfiguration dynamic store). Each element converts into [`Nameserver`](#nameserver): a `SocketAddr`, an `IpAddr`, or a parsed string via `"dns.google:53".parse::<Nameserver>()?`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nameservers</code><span className="msb-type">IntoIterator&lt;Item = Into&lt;Nameserver&gt;&gt;</span></div>
+    <div className="msb-param-desc">Upstream resolvers.</div>
+  </div>
+</div>
 
 ---
 
-#### query_timeout_ms()
+#### <span className="msb-recv">.</span><span className="msb-hn">query_timeout_ms()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn query_timeout_ms(self, ms: u64) -> Self
@@ -737,63 +1291,45 @@ Set the per-DNS-query timeout in milliseconds. Default: `5000`.
 
 ---
 
-#### rebind_protection()
+#### <span className="msb-recv">.</span><span className="msb-hn">rebind_protection()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn rebind_protection(self, enabled: bool) -> Self
 ```
 
-When enabled, DNS responses that resolve to private IP addresses are blocked. Prevents DNS rebinding attacks. Default: `true`.
+When enabled, DNS responses that resolve to private IP addresses are blocked, preventing DNS rebinding attacks. Default: `true`.
 
 ---
 
 ## TlsBuilder
 
-Builder for TLS interception settings. Used in `NetworkBuilder::tls(|t| t...)`.
+Builder for TLS interception, used in [`NetworkBuilder::tls(|t| t...)`](#tls). Creating it enables interception. Every setter returns `Self`.
 
 ---
 
-#### block_quic()
-
-```rust
-fn block_quic(self, block: bool) -> Self
-```
-
-Block QUIC/HTTP3 on intercepted ports, forcing TCP/TLS fallback. Default: `true`.
-
----
-
-#### bypass()
+#### <span className="msb-recv">.</span><span className="msb-hn">bypass()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn bypass(self, pattern: impl Into<String>) -> Self
 ```
 
-Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). Use for domains with certificate pinning.
+Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). Use for domains with certificate pinning. Can be called multiple times.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pattern</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Host glob. Supports exact match and <code>*.suffix</code> wildcards.</div>
+  </div>
+</div>
 
 ---
 
-#### intercept_ca_cert()
-
-```rust
-fn intercept_ca_cert(self, path: impl Into<PathBuf>) -> Self
-```
-
-PEM file used as the intercepting CA's certificate. Pair with [`intercept_ca_key()`](#intercept_ca_key) to provide a stable CA across sandbox restarts.
-
----
-
-#### intercept_ca_key()
-
-```rust
-fn intercept_ca_key(self, path: impl Into<PathBuf>) -> Self
-```
-
-PEM file used as the intercepting CA's private key.
-
----
-
-#### intercepted_ports()
+#### <span className="msb-recv">.</span><span className="msb-hn">intercepted_ports()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn intercepted_ports(self, ports: Vec<u16>) -> Self
@@ -803,17 +1339,8 @@ TCP ports where TLS interception is active. Default: `[443]`.
 
 ---
 
-#### upstream_ca_cert()
-
-```rust
-fn upstream_ca_cert(self, path: impl Into<PathBuf>) -> Self
-```
-
-PEM file with extra root CAs the proxy should trust when verifying upstream servers.
-
----
-
-#### verify_upstream()
+#### <span className="msb-recv">.</span><span className="msb-hn">verify_upstream()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn verify_upstream(self, verify: bool) -> Self
@@ -823,9 +1350,189 @@ Whether the proxy verifies upstream server certificates. Default: `true`. Set to
 
 ---
 
+#### <span className="msb-recv">.</span><span className="msb-hn">block_quic()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn block_quic(self, block: bool) -> Self
+```
+
+Block QUIC/HTTP3 on intercepted ports, forcing TCP/TLS fallback. Default: `true`.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">intercept_ca_cert()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn intercept_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file used as the intercepting CA's certificate. Pair with [`intercept_ca_key()`](#intercept_ca_key) to provide a stable CA across sandbox restarts. If unset, a CA is auto-generated and persisted.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">intercept_ca_key()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn intercept_ca_key(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file used as the intercepting CA's private key.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">upstream_ca_cert()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn upstream_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+PEM file with extra root CAs the proxy should trust when verifying upstream servers. Useful for self-signed or private upstream CAs. Can be called multiple times.
+
+---
+
+## ViolationActionBuilder
+
+Builder for secret-violation behavior, used by [`NetworkBuilder::on_secret_violation()`](#on_secret_violation) and [`SecretBuilder::on_violation()`](/sdk/rust/secrets#on_violation). A blocking call (`block`, `block_and_log`, `block_and_terminate`) replaces any accumulated passthrough hosts; passthrough calls accumulate. When passthrough hosts are configured, non-matching hosts use the default action. Every setter returns `Self`. Produces a [`ViolationAction`](#violationaction).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">block()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn block(self) -> Self
+```
+
+Block the request silently.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">block_and_log()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn block_and_log(self) -> Self
+```
+
+Block the request and emit a warning log on the host. This is the [`ViolationAction`](#violationaction) default.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">block_and_terminate()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn block_and_terminate(self) -> Self
+```
+
+Block the request and terminate the entire sandbox.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">passthrough_host()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn passthrough_host(self, host: impl Into<String>) -> Self
+```
+
+Allow an exact host to receive secret placeholders unchanged (no substitution).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Exact host.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">passthrough_host_pattern()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn passthrough_host_pattern(self, pattern: impl Into<String>) -> Self
+```
+
+Allow hosts matching a wildcard pattern (e.g. `*.example.com`) to receive placeholders unchanged.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">passthrough_all_hosts()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn passthrough_all_hosts(self, i_understand_the_risk: bool) -> Self
+```
+
+Allow **any** host to receive placeholders unchanged. Takes effect only when `i_understand_the_risk` is `true`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>i_understand_the_risk</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Must be <code>true</code> to take effect.</div>
+  </div>
+</div>
+
+---
+
 ## Types
 
+### NetworkPolicy
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Built by <a href="#networkpolicybuilder">NetworkPolicy::builder()</a> · used by <a href="#policy">policy()</a></p>
+
+An ordered rule list plus two per-direction defaults, evaluated first-match-wins. Egress evaluation considers rules where `direction ∈ {Egress, Any}`; ingress considers `{Ingress, Any}`. If no rule matches, the direction-specific default applies. `Default` is [`public_only()`](#networkpolicypublic_only).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
+| rules | `Vec<`[`Rule`](#rule)`>` | Ordered rules; first match wins per direction |
+
+### Rule
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Held by <a href="#networkpolicy">NetworkPolicy</a></p>
+
+A single policy rule. The `destination` interpretation is direction-dependent: egress destination, or ingress peer/source. `ports` is always the guest-side port (egress destination port / ingress listening port).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| direction | [`Direction`](#direction) | Which evaluator considers this rule |
+| destination | [`Destination`](#destination) | Target filter |
+| protocols | `Vec<`[`Protocol`](#protocol)`>` | Set semantics; empty = any protocol |
+| ports | `Vec<`[`PortRange`](#portrange)`>` | Set semantics; empty = any port |
+| action | [`Action`](#action) | What to do on match |
+
+Convenience constructors build any-protocol, any-port rules:
+
+| Method | Description |
+|--------|-------------|
+| `Rule::allow_egress(destination)` | Allow rule, direction `Egress` |
+| `Rule::deny_egress(destination)` | Deny rule, direction `Egress` |
+| `Rule::allow_ingress(destination)` | Allow rule, direction `Ingress` |
+| `Rule::deny_ingress(destination)` | Deny rule, direction `Ingress` |
+| `Rule::allow_any(destination)` | Allow rule, direction `Any` |
+| `Rule::deny_any(destination)` | Deny rule, direction `Any` |
+| `Rule::allow_dns()` | Allow plain DNS (UDP/53 + TCP/53) to the gateway forwarder (`Group::Host`); the one-liner for opening DNS under deny-by-default. See [DNS as egress](/networking/dns#dns-as-egress) |
+
 ### Action
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#rule">Rule</a> · <a href="#networkpolicy">NetworkPolicy</a> · <a href="#default_egress">default_egress()</a></p>
 
 | Value | Wire format | Description |
 |-------|-------------|-------------|
@@ -833,6 +1540,10 @@ Whether the proxy verifies upstream server certificates. Default: `true`. Set to
 | `Deny` | `"deny"` | Drop the traffic silently |
 
 ### Direction
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#rule">Rule</a></p>
 
 | Value | Wire format | Description |
 |-------|-------------|-------------|
@@ -842,42 +1553,41 @@ Whether the proxy verifies upstream server certificates. Default: `true`. Set to
 
 ### Destination
 
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Held by <a href="#rule">Rule</a> · committed by <a href="#ruledestinationbuilder">RuleDestinationBuilder</a></p>
+
 | Variant | Description |
 |---------|-------------|
 | `Any` | Match any address |
 | `Cidr(IpNetwork)` | Match a CIDR range (e.g. `10.0.0.0/8`); single IPs are stored as `/32` or `/128` |
-| `Domain(`[`DomainName`](#domainname)`)` | Match an exact domain (e.g. `example.com`) |
+| `Domain(`[`DomainName`](#domainname)`)` | Match an exact domain (e.g. `example.com`) when a cached hostname for the remote IP equals it |
 | `DomainSuffix(`[`DomainName`](#domainname)`)` | Match the apex domain and every subdomain (e.g. `example.com` and `api.example.com`) |
 | `Group(`[`DestinationGroup`](#destinationgroup)`)` | Match a predefined address group |
 
 ### DestinationGroup
 
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Held by <a href="#destination">Destination</a> · committed by <a href="#allow_public">RuleBuilder group adders</a></p>
+
+Groups are disjoint with one carve-out: `Metadata` takes precedence over `LinkLocal` for `169.254.169.254`, and `Host` over `Private` when the gateway IPs sit in CGN/ULA ranges.
+
 | Value | Wire format | Matches |
 |-------|-------------|---------|
 | `Public` | `"public"` | Complement of the other categories: every address not in any other group |
-| `Private` | `"private"` | `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7` |
 | `Loopback` | `"loopback"` | `127.0.0.0/8`, `::1` (the **guest's own** loopback, not the host) |
+| `Private` | `"private"` | RFC1918 (`10/8`, `172.16/12`, `192.168/16`) + CGN (`100.64/10`) + ULA (`fc00::/7`) |
 | `LinkLocal` | `"link_local"` | `169.254.0.0/16`, `fe80::/10` (excludes metadata) |
-| `Metadata` | `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
+| `Metadata` | `"metadata"` | Cloud metadata endpoint (`169.254.169.254`) |
 | `Multicast` | `"multicast"` | `224.0.0.0/4`, `ff00::/8` |
 | `Host` | `"host"` | Per-sandbox gateway IPs that back `host.microsandbox.internal` |
 
-### DomainName
-
-A validated DNS name. Construction goes through `str::parse` (or `TryFrom<String>`), which delegates to `hickory_proto::rr::Name` and canonicalizes the input (lowercased ASCII, leading and trailing dots stripped) so rule matching is a byte-wise compare against the DNS cache. Invalid inputs return a `DomainNameError`.
-
-```rust
-use microsandbox_network::policy::{Destination, DomainName};
-
-let exact: DomainName = "PyPI.Org.".parse()?;     // -> "pypi.org"
-let suffix: DomainName = ".example.com".parse()?;  // -> "example.com"
-```
-
-Labels follow the permissive DNS grammar (RFC 2181 §11), so underscore-prefixed names like `_service._tcp.example.com` are accepted.
-
-The builder methods (`.domain(&str)`, `.domain_suffix(&str)`) take strings and parse them lazily at `.build()`; callers don't need to construct `DomainName` directly.
-
 ### Protocol
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Held by <a href="#rule">Rule</a> · set by <a href="#tcp">RuleBuilder protocol setters</a></p>
 
 | Value | Wire format |
 |-------|-------------|
@@ -890,58 +1600,84 @@ ICMP protocols are egress-only. A rule with direction `Ingress` or `Any` carryin
 
 ### PortRange
 
-```rust
-struct PortRange {
-    start: u16,  // inclusive
-    end: u16,    // inclusive
-}
-```
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Held by <a href="#rule">Rule</a> · added by <a href="#port-1">port()</a> · <a href="#port_range">port_range()</a></p>
+
+An inclusive port range.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| start | `u16` | Start port (inclusive) |
+| end | `u16` | End port (inclusive) |
 
 | Method | Description |
 |--------|-------------|
 | `PortRange::single(port)` | Match a single port |
 | `PortRange::range(start, end)` | Match an inclusive range |
+| `contains(port)` | Whether `port` falls within the range |
 
-### Rule
+### DomainName
 
-A single network policy rule.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Held by <a href="#destination">Destination::Domain / DomainSuffix</a></p>
+
+A validated DNS name. Construction goes through `str::parse` (or `TryFrom<String>`), which delegates to `hickory_proto::rr::Name` and canonicalizes the input (lowercased ASCII, leading and trailing dots stripped) so rule matching is a byte-wise compare against the DNS cache. Invalid inputs return a [`DomainNameError`](#builderror).
+
+```rust
+use microsandbox_network::policy::DomainName;
+
+let exact: DomainName = "PyPI.Org.".parse()?;      // -> "pypi.org"
+let suffix: DomainName = ".example.com".parse()?;  // -> "example.com"
+```
+
+Labels follow the permissive DNS grammar (RFC 2181 §11), so underscore-prefixed names like `_service._tcp.example.com` are accepted. The builder methods (`.domain(&str)`, `.domain_suffix(&str)`) take strings and parse them lazily at [`build()`](#build), so callers rarely construct `DomainName` directly.
+
+| Method | Description |
+|--------|-------------|
+| `as_str()` | Borrow the canonical string form |
+| `try_into_suffix()` | Validate for use as a `DomainSuffix`; single-label names (e.g. `com`) are rejected |
+
+### Nameserver
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#nameservers">nameservers()</a></p>
+
+An upstream DNS server, either a literal address or a hostname resolved at interceptor startup via the host's OS resolver. Serializes as a single string. Construct via `From<SocketAddr>`, `From<IpAddr>`, or `str::parse` (errors with `ParseNameserverError`).
+
+| Variant | Description |
+|---------|-------------|
+| `Addr(SocketAddr)` | Literal socket address, ready to use |
+| `Host { host: String, port: u16 }` | Hostname + port resolved at startup |
+
+Accepted parse forms: `1.1.1.1`, `1.1.1.1:5353`, `2606:4700:4700::1111`, `[2606:4700:4700::1111]:53`, `dns.google`, `dns.google:53`. A bare IP or hostname defaults to port `53`.
+
+### InterfaceOverrides
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#interface">interface()</a></p>
+
+Per-sandbox guest interface overrides. Every field is optional; an omitted field is derived deterministically from the sandbox slot. Most callers only touch the pools via [`ipv4_pool()`](#ipv4_pool) / [`ipv6_pool()`](#ipv6_pool) rather than constructing this directly.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| direction | [`Direction`](#direction) | Which evaluator considers this rule |
-| destination | [`Destination`](#destination) | Target filter (egress destination / ingress source) |
-| protocols | `Vec<`[`Protocol`](#protocol)`>` | Set semantics; empty = any protocol |
-| ports | `Vec<`[`PortRange`](#portrange)`>` | Set semantics; empty = any port. Always guest-side (egress destination port / ingress listening port) |
-| action | [`Action`](#action) | What to do on match |
-
-Convenience constructors:
-
-| Method | Description |
-|--------|-------------|
-| `Rule::allow_egress(destination)` | Allow rule, direction `Egress` |
-| `Rule::deny_egress(destination)` | Deny rule, direction `Egress` |
-| `Rule::allow_ingress(destination)` | Allow rule, direction `Ingress` |
-| `Rule::deny_ingress(destination)` | Deny rule, direction `Ingress` |
-| `Rule::allow_any(destination)` | Allow rule, direction `Any` |
-| `Rule::deny_any(destination)` | Deny rule, direction `Any` |
-| `Rule::allow_dns()` | Allow plain DNS (UDP/53 + TCP/53) to the gateway forwarder (`Group::Host`). The standard one-liner for opening DNS under a deny-by-default policy. See [DNS as egress](/networking/dns#dns-as-egress) |
-
-### ExplicitRuleBuilder
-
-Returned by [`RuleBuilder`](#rulebuilder)`::allow()` / `::deny()`. Requires exactly one destination method call to commit the rule. The type is `#[must_use]`; dropping without a call adds no rule.
-
-| Method | Description |
-|--------|-------------|
-| `.ip(impl Into<String>)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
-| `.cidr(impl Into<String>)` | Commit with `Destination::Cidr` |
-| `.domain(impl Into<String>)` | Commit with `Destination::Domain` |
-| `.domain_suffix(impl Into<String>)` | Commit with `Destination::DomainSuffix` |
-| `.group(DestinationGroup)` | Commit with `Destination::Group` |
-| `.any()` | Commit with `Destination::Any` |
+| mac | `Option<[u8; 6]>` | Guest MAC address. Default: derived from slot |
+| mtu | `Option<u16>` | Interface MTU. Default: `1500` |
+| ipv4_address | `Option<Ipv4Addr>` | Guest IPv4 address. Default: derived from slot within `ipv4_pool` |
+| ipv4_pool | `Option<Ipv4Network>` | IPv4 pool guest subnets are derived from. Default: `172.16.0.0/12` |
+| ipv6_address | `Option<Ipv6Addr>` | Guest IPv6 address. Default: derived from slot within `ipv6_pool` |
+| ipv6_pool | `Option<Ipv6Network>` | IPv6 pool guest prefixes are derived from. Default: `fd42:6d73:62::/48` |
 
 ### BuildError
 
-Errors surfaced by the builders' `.build()` methods. The same enum covers `NetworkPolicy::builder()`, `DnsBuilder`, and `NetworkBuilder` (the network and DNS builders accumulate errors lazily; the first failure surfaces from the outermost `.build()` in the chain).
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Returned by <a href="#build">NetworkPolicyBuilder::build()</a> · wrapped by <a href="#networkbuilder">NetworkBuilder</a></p>
+
+Errors surfaced by the builders' `build()` methods. The same enum covers [`NetworkPolicy::builder()`](#networkpolicybuilder), [`DnsBuilder`](#dnsbuilder), and [`NetworkBuilder`](#networkbuilder); the network and DNS builders accumulate lazily, so the first failure surfaces from the outermost `build()` in the chain.
 
 | Variant | Cause |
 |---------|-------|
@@ -949,19 +1685,26 @@ Errors surfaced by the builders' `.build()` methods. The same enum covers `Netwo
 | `MissingDestination { rule_index }` | `.allow()` or `.deny()` was called but no destination method followed |
 | `InvalidIp { rule_index, raw }` | `.ip(&str)` got an unparseable value |
 | `InvalidCidr { rule_index, raw }` | `.cidr(&str)` got an unparseable value |
-| `InvalidDomain { rule_index, raw, source }` | `.domain` or `.domain_suffix` got a value that failed `DomainName` parse |
+| `InvalidIpv4Pool { raw }` | `ipv4_pool()` got a pool that can't hold a `/30` sandbox subnet |
+| `InvalidIpv6Pool { raw }` | `ipv6_pool()` got a pool that can't hold a `/64` sandbox prefix |
+| `InvalidDomain { rule_index, raw, source }` | `.domain` / `.domain_suffix` got a value that failed `DomainName` parse |
 | `InvalidPortRange { rule_index, lo, hi }` | `.port_range(lo, hi)` had `lo > hi` |
 | `IngressDoesNotSupportIcmp { rule_index }` | ICMP protocol on a non-egress rule |
+| `InvalidSecretConfig { source }` | A secret entry failed validation |
 
 Inside `SandboxBuilder::build()`, `BuildError` is wrapped as `MicrosandboxError::NetworkBuilder(BuildError)`.
 
 ### ViolationAction
 
-Action taken when a secret placeholder is sent to a disallowed host.
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
 
-| Value | Description |
-|-------|-------------|
-| `Block` | Silently drop the request. The guest sees a connection reset. This is the default. |
-| `BlockAndLog` | Drop the request and emit a warning log on the host side. |
-| `BlockAndTerminate` | Drop the request, log an error, and shut down the entire sandbox. |
-| `Passthrough(Vec<HostPattern>)` | Forward matching hosts with the placeholder unchanged. Non-matching hosts use the default secret violation action. |
+<p className="msb-backref">Built by <a href="#violationactionbuilder">ViolationActionBuilder</a> · used by <a href="#on_secret_violation">on_secret_violation()</a></p>
+
+Action taken when a secret placeholder is sent to a disallowed host. Also documented on the [Secrets](/sdk/rust/secrets#violationaction) page, where it pairs with [`SecretBuilder`](/sdk/rust/secrets#secretbuilder).
+
+| Value | Wire format | Description |
+|-------|-------------|-------------|
+| `Block` | `"block"` | Silently drop the request |
+| `BlockAndLog` | `"block-and-log"` | Drop the request and emit a warning log (the default) |
+| `BlockAndTerminate` | `"block-and-terminate"` | Drop the request, log an error, and shut down the sandbox |
+| `Passthrough(Vec<`[`HostPattern`](/sdk/rust/secrets#hostpattern)`>)` | `"passthrough"` | Forward matching hosts with the placeholder unchanged; non-matching hosts use the default action |

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -6,37 +6,52 @@ description: Rust SDK - Sandbox API reference
 Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
 
 <div className="msb-glance">
-  <p className="msb-eyebrow">At a glance</p>
-  <div className="msb-glance-grid">
-    <div>
-      <p className="msb-col-title"><span className="msb-dot static"></span>Static methods</p>
-      <div className="msb-mrow"><a className="msb-m" href="#sandboxbuilder">Sandbox::builder()</a><span className="msb-gloss">configure a new sandbox</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#sandboxget">Sandbox::get()</a><span className="msb-gloss">handle to an existing one</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#sandboxlist">Sandbox::list()</a><span className="msb-gloss">all sandboxes</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#sandboxstart">Sandbox::start()</a><span className="msb-gloss">restart a stopped one</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#sandboxremove">Sandbox::remove()</a><span className="msb-gloss">delete a stopped one</span></div>
-    </div>
-    <div>
-      <p className="msb-col-title"><span className="msb-dot instance"></span>Instance methods</p>
-      <div className="msb-mrow"><a className="msb-m" href="/sdk/rust/execution">exec() · shell()</a><span className="msb-gloss">run commands</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#fs">fs()</a><span className="msb-gloss">read / write files</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#metrics">metrics()</a><span className="msb-gloss">resource snapshot</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#logs">logs()</a><span className="msb-gloss">captured output</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#stop">stop() · kill()</a><span className="msb-gloss">shut down</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#detach">detach()</a><span className="msb-gloss">release, keep running</span></div>
-    </div>
-    <div>
-      <p className="msb-col-title"><span className="msb-dot builder"></span>Builder · SandboxBuilder</p>
-      <div className="msb-mrow"><a className="msb-m" href="#image">.image() · .image_with()</a><span className="msb-gloss">rootfs source</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#memory">.memory() · .cpus()</a><span className="msb-gloss">resource limits</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#port">.port() · .volume()</a><span className="msb-gloss">networking &amp; storage</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#secret">.secret() · .env()</a><span className="msb-gloss">secrets &amp; environment</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#patch">.patch()</a><span className="msb-gloss">modify rootfs pre-boot</span></div>
-      <div className="msb-mrow"><a className="msb-m" href="#create">.create() · .build()</a><span className="msb-gloss">boot / materialize</span></div>
-    </div>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Static<span className="msb-ct">6</span></p>
+  <a className="msb-row" href="#sandboxbuilder"><span className="msb-rn">Sandbox::builder()</span><span className="msb-rg">configure a new sandbox</span></a>
+  <a className="msb-row" href="#sandboxget"><span className="msb-rn">Sandbox::get()</span><span className="msb-rg">handle to an existing one</span></a>
+  <a className="msb-row" href="#sandboxlist"><span className="msb-rn">Sandbox::list()</span><span className="msb-rg">all sandboxes</span></a>
+  <a className="msb-row" href="#sandboxstart"><span className="msb-rn">Sandbox::start()</span><span className="msb-rg">restart a stopped one</span></a>
+  <a className="msb-row" href="#sandboxstart_detached"><span className="msb-rn">Sandbox::start_detached()</span><span className="msb-rg">restart detached</span></a>
+  <a className="msb-row" href="#sandboxremove"><span className="msb-rn">Sandbox::remove()</span><span className="msb-rg">delete a stopped one</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance<span className="msb-ct">16</span></p>
+  <a className="msb-row" href="/sdk/rust/execution"><span className="msb-rn">sb.exec()</span><span className="msb-rg">run a command</span></a>
+  <a className="msb-row" href="/sdk/rust/execution"><span className="msb-rn">sb.shell()</span><span className="msb-rg">interactive shell</span></a>
+  <a className="msb-row" href="#sb-fs"><span className="msb-rn">sb.fs()</span><span className="msb-rg">read / write files</span></a>
+  <a className="msb-row" href="#sb-logs"><span className="msb-rn">sb.logs()</span><span className="msb-rg">captured output</span></a>
+  <a className="msb-row" href="#sb-metrics"><span className="msb-rn">sb.metrics()</span><span className="msb-rg">resource snapshot</span></a>
+  <a className="msb-row" href="#sb-metrics_stream"><span className="msb-rn">sb.metrics_stream()</span><span className="msb-rg">stream metrics</span></a>
+  <a className="msb-row" href="#sb-stop"><span className="msb-rn">sb.stop()</span><span className="msb-rg">graceful shutdown</span></a>
+  <a className="msb-row" href="#sb-kill"><span className="msb-rn">sb.kill()</span><span className="msb-rg">force terminate</span></a>
+  <a className="msb-row" href="#sb-drain"><span className="msb-rn">sb.drain()</span><span className="msb-rg">graceful drain</span></a>
+  <a className="msb-row" href="#sb-detach"><span className="msb-rn">sb.detach()</span><span className="msb-rg">release, keep running</span></a>
+  <a className="msb-row" href="#sb-wait"><span className="msb-rn">sb.wait()</span><span className="msb-rg">block until it exits</span></a>
+  <a className="msb-row" href="#sb-stop_and_wait"><span className="msb-rn">sb.stop_and_wait()</span><span className="msb-rg">stop, then await exit</span></a>
+  <a className="msb-row" href="#sb-config"><span className="msb-rn">sb.config()</span><span className="msb-rg">full configuration</span></a>
+  <a className="msb-row" href="#sb-name"><span className="msb-rn">sb.name()</span><span className="msb-rg">sandbox name</span></a>
+  <a className="msb-row" href="#sb-owns_lifecycle"><span className="msb-rn">sb.owns_lifecycle()</span><span className="msb-rg">attached vs detached</span></a>
+  <a className="msb-row" href="#sb-remove_persisted"><span className="msb-rn">sb.remove_persisted()</span><span className="msb-rg">delete persisted state</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SandboxBuilder<span className="msb-ct">32</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#image">.image()</a>
+    <a className="msb-chip" href="#memory">.memory()</a>
+    <a className="msb-chip" href="#cpus">.cpus()</a>
+    <a className="msb-chip" href="#port">.port()</a>
+    <a className="msb-chip" href="#volume">.volume()</a>
+    <a className="msb-chip" href="#env">.env()</a>
+    <a className="msb-chip" href="#secret">.secret()</a>
+    <a className="msb-chip" href="#network">.network()</a>
+    <a className="msb-chip" href="#init">.init()</a>
+    <a className="msb-chip" href="#patch">.patch()</a>
+    <a className="msb-chip" href="#create">.create()</a>
+    <a className="msb-chip" href="#build">.build()</a>
+    <a className="msb-more" href="#build">+ 20 more in the Builder section</a>
   </div>
-  <p className="msb-eyebrow msb-eyebrow-mt">Related types</p>
-  <div className="msb-typestrip">
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
     <a className="msb-typepill" href="#sandboxconfig">SandboxConfig</a>
     <a className="msb-typepill" href="#sandboxhandle">SandboxHandle</a>
     <a className="msb-typepill" href="#sandboxmetrics">SandboxMetrics</a>
@@ -50,6 +65,7 @@ Create and control a microVM sandbox: boot it from an image, run commands, strea
     <a className="msb-typepill" href="/sdk/rust/execution#exitstatus">ExitStatus</a>
     <a className="msb-typepill" href="#patchbuilder">PatchBuilder</a>
   </div>
+
 </div>
 
 <p className="msb-label" id="typical-flow">Typical flow</p>
@@ -73,8 +89,7 @@ sb.stop().await?;                  // 4. shut down
 
 ---
 
-#### Sandbox::builder()
-
+#### <span className="msb-recv">Sandbox::</span><span className="msb-hn">builder()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```rust
@@ -112,8 +127,7 @@ let sb = Sandbox::builder("api")
 
 ---
 
-#### Sandbox::get()
-
+#### <span className="msb-recv">Sandbox::</span><span className="msb-hn">get()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -149,8 +163,7 @@ println!("{:?}", handle.status());
 
 ---
 
-#### Sandbox::list()
-
+#### <span className="msb-recv">Sandbox::</span><span className="msb-hn">list()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -178,8 +191,7 @@ for h in Sandbox::list().await? {
 
 ---
 
-#### Sandbox::remove()
-
+#### <span className="msb-recv">Sandbox::</span><span className="msb-hn">remove()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -205,8 +217,7 @@ Sandbox::remove("api").await?;
 
 ---
 
-#### Sandbox::start()
-
+#### <span className="msb-recv">Sandbox::</span><span className="msb-hn">start()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -241,8 +252,7 @@ let sb = Sandbox::start("api").await?;
 
 ---
 
-#### Sandbox::start_detached()
-
+#### <span className="msb-recv">Sandbox::</span><span className="msb-hn">start_detached()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -275,8 +285,7 @@ Restart a stopped sandbox in detached mode. The sandbox survives after your proc
 
 ---
 
-#### config()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">config()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
@@ -302,8 +311,7 @@ println!("{} MiB", sb.config().memory_mib);
 
 ---
 
-#### detach()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">detach()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -320,8 +328,7 @@ sb.detach().await; // keeps running in the background
 
 ---
 
-#### drain()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">drain()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -338,8 +345,7 @@ sb.drain().await?;
 
 ---
 
-#### fs()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">fs()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
@@ -365,15 +371,14 @@ sb.fs().write("/tmp/hello.txt", "hi").await?;
 
 ---
 
-#### kill()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">kill()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn kill(&self) -> MicrosandboxResult<()>
 ```
 
-Force-terminate the sandbox immediately with SIGKILL. No graceful shutdown — use when the sandbox is unresponsive. Pending writes that the workload hasn't `fsync`'d may be lost, same durability semantics as a sudden power loss on a physical machine. Prefer [`stop()`](#stop) for graceful shutdown that gives the workload a chance to flush.
+Force-terminate the sandbox immediately with SIGKILL. No graceful shutdown — use when the sandbox is unresponsive. Pending writes that the workload hasn't `fsync`'d may be lost, same durability semantics as a sudden power loss on a physical machine. Prefer [`stop()`](#sb-stop) for graceful shutdown that gives the workload a chance to flush.
 
 <p className="msb-label">Example</p>
 
@@ -383,8 +388,7 @@ sb.kill().await?; // SIGKILL, no graceful shutdown
 
 ---
 
-#### metrics()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">metrics()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -411,8 +415,7 @@ println!("cpu {:.1}% · mem {} MiB", m.cpu_percent, m.memory_bytes / 1_048_576);
 
 ---
 
-#### metrics_stream()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">metrics_stream()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
@@ -452,8 +455,7 @@ while let Some(snapshot) = stream.next().await {
 
 ---
 
-#### logs()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">logs()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
@@ -524,8 +526,7 @@ let recent = handle.logs(&LogOptions {
 
 ---
 
-#### name()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">name()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
@@ -545,8 +546,7 @@ Get the sandbox name.
 
 ---
 
-#### owns_lifecycle()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">owns_lifecycle()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
@@ -566,8 +566,7 @@ Whether this handle owns the sandbox lifecycle. `true` in attached mode (sandbox
 
 ---
 
-#### remove_persisted()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">remove_persisted()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -584,8 +583,7 @@ sb.remove_persisted().await?;
 
 ---
 
-#### stop()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">stop()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -602,8 +600,7 @@ sb.stop().await?;
 
 ---
 
-#### stop_and_wait()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">stop_and_wait()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -630,8 +627,7 @@ println!("exited: {}", status.success());
 
 ---
 
-#### wait()
-
+#### <span className="msb-recv">sb.</span><span className="msb-hn">wait()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -663,15 +659,14 @@ Builder for configuring a sandbox before creation. Obtained via [`Sandbox::build
 
 ---
 
-#### build()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn build(self) -> MicrosandboxResult<SandboxConfig>
 ```
 
-Materialize the [`SandboxConfig`](#sandboxconfig) without booting the sandbox. Validates the configuration and, if [`from_snapshot`](#from_snapshot) was called, opens the snapshot manifest to pin its image reference and upper-layer source. For booting, use [`create`](#create) or [`create_detached`](#create_detached) instead — they call `build` internally.
+Materialize the [`SandboxConfig`](#sandboxconfig) without booting the sandbox. Validates the configuration and, if `from_snapshot` was called, opens the snapshot manifest to pin its image reference and upper-layer source. For booting, use [`create`](#create) or [`create_detached`](#create_detached) instead — they call `build` internally.
 
 <p className="msb-label">Returns</p>
 
@@ -684,8 +679,7 @@ Materialize the [`SandboxConfig`](#sandboxconfig) without booting the sandbox. V
 
 ---
 
-#### cpus()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">cpus()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -705,8 +699,7 @@ Set the number of virtual CPUs. This is a limit, not a reservation. Default: `1`
 
 ---
 
-#### create()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">create()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -726,8 +719,7 @@ Boot the sandbox in attached mode. The sandbox stops when your process exits.
 
 ---
 
-#### create_detached()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">create_detached()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
@@ -757,8 +749,7 @@ sb.detach().await;
 
 ---
 
-#### disable_network()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">disable_network()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -769,8 +760,7 @@ Fully disable networking. No network interface is created.
 
 ---
 
-#### entrypoint()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">entrypoint()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -790,8 +780,7 @@ Override the OCI image's stored ENTRYPOINT. The value is consulted by command-re
 
 ---
 
-#### env()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">env()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -815,8 +804,7 @@ Set an environment variable visible to all commands. Can be called multiple time
 
 ---
 
-#### hostname()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">hostname()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -836,8 +824,7 @@ Set the guest hostname.
 
 ---
 
-#### idle_timeout()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">idle_timeout()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -857,8 +844,7 @@ Auto-drain the sandbox after this many seconds of inactivity (no active exec ses
 
 ---
 
-#### init()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">init()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -890,8 +876,7 @@ let sb = Sandbox::builder("worker")
 
 ---
 
-#### init_with()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">init_with()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -931,8 +916,7 @@ let sb = Sandbox::builder("worker")
 
 ---
 
-#### image()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">image()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -952,8 +936,7 @@ Set the root filesystem source. Accepts OCI image names, local directory paths, 
 
 ---
 
-#### image_with()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">image_with()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -984,8 +967,7 @@ let sb = Sandbox::builder("worker")
 
 ---
 
-#### log_level()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">log_level()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1005,8 +987,7 @@ Override the sandbox process's log verbosity.
 
 ---
 
-#### max_duration()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">max_duration()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1026,8 +1007,7 @@ Set the maximum sandbox lifetime in seconds. When exceeded, the sandbox is drain
 
 ---
 
-#### memory()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">memory()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1047,8 +1027,7 @@ Set the guest memory size. Physical pages are only allocated as the guest touche
 
 ---
 
-#### network()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">network()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1068,8 +1047,7 @@ Configure networking. See [Networking](/sdk/rust/networking) for the full builde
 
 ---
 
-#### patch()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">patch()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1089,8 +1067,7 @@ Modify the rootfs before the VM boots. Patches go into the writable layer - the 
 
 ---
 
-#### port()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">port()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1114,8 +1091,7 @@ Publish a TCP port from the sandbox to the host. The default host bind address i
 
 ---
 
-#### port_bind()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">port_bind()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1143,8 +1119,7 @@ Publish a TCP port on a specific host bind address, such as `0.0.0.0`.
 
 ---
 
-#### port_udp()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">port_udp()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1168,8 +1143,7 @@ Publish a UDP port. The default host bind address is `127.0.0.1`.
 
 ---
 
-#### port_udp_bind()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">port_udp_bind()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1197,8 +1171,7 @@ Publish a UDP port on a specific host bind address.
 
 ---
 
-#### pull_policy()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">pull_policy()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1218,8 +1191,7 @@ Control when the OCI image is pulled from the registry.
 
 ---
 
-#### registry_auth()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">registry_auth()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1239,8 +1211,7 @@ Authenticate to a private container registry.
 
 ---
 
-#### replace()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">replace()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1251,8 +1222,7 @@ If a sandbox with the same name already exists, stop it, remove it, and create a
 
 ---
 
-#### script()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">script()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1276,8 +1246,7 @@ Add a named script at `/.msb/scripts/` inside the guest. Scripts are added to `P
 
 ---
 
-#### secret()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">secret()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1297,8 +1266,7 @@ Add a secret with full configuration. See [Secrets](/sdk/rust/secrets) for the b
 
 ---
 
-#### secret_env()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">secret_env()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1326,8 +1294,7 @@ Shorthand for adding a header-injected secret. Equivalent to `.secret(|s| s.env(
 
 ---
 
-#### shell()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">shell()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1347,8 +1314,7 @@ Set the shell used by [`Sandbox::shell()`](/sdk/rust/execution). Default: `/bin/
 
 ---
 
-#### user()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">user()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1368,8 +1334,7 @@ Set the default guest user for all commands.
 
 ---
 
-#### volume()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">volume()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1393,8 +1358,7 @@ Add a volume mount. See [Volumes](/sdk/rust/volumes) for mount types.
 
 ---
 
-#### workdir()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">workdir()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1420,8 +1384,7 @@ Fluent builder for the ordered list of pre-boot rootfs patches. Used in `Sandbox
 
 ---
 
-#### append()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">append()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1445,8 +1408,7 @@ Append `content` to an existing file at `path`. If the file lives in a lower ima
 
 ---
 
-#### copy_dir()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">copy_dir()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1474,8 +1436,7 @@ Recursively copy a host directory at `src` into the guest rootfs at `dst`.
 
 ---
 
-#### copy_file()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">copy_file()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1513,8 +1474,7 @@ Copy a single host file at `src` into the guest rootfs at `dst`.
 
 ---
 
-#### file()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">file()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1552,8 +1512,7 @@ Write raw bytes at `path`.
 
 ---
 
-#### mkdir()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">mkdir()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1577,8 +1536,7 @@ Create a directory at `path`. Idempotent: a no-op if the directory already exist
 
 ---
 
-#### remove()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">remove()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1598,8 +1556,7 @@ Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't ex
 
 ---
 
-#### symlink()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">symlink()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1627,8 +1584,7 @@ Create a symlink at `link` pointing to `target`.
 
 ---
 
-#### text()
-
+#### <span className="msb-recv">.</span><span className="msb-hn">text()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
@@ -1672,9 +1628,9 @@ Write UTF-8 text content at `path`.
 
 <div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-<p className="msb-backref">Returned by <a href="#logs">logs()</a></p>
+<p className="msb-backref">Returned by <a href="#sb-logs">logs()</a></p>
 
-A single captured log entry returned by [`logs()`](#logs).
+A single captured log entry returned by [`logs()`](#sb-logs).
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -1703,9 +1659,9 @@ Sandbox process log verbosity.
 
 <div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-<p className="msb-backref">Used by <a href="#logs">logs()</a></p>
+<p className="msb-backref">Used by <a href="#sb-logs">logs()</a></p>
 
-Filters passed to [`logs()`](#logs). All fields optional. `LogOptions::default()` returns everything for the default sources (`Stdout` + `Stderr` + `Output`).
+Filters passed to [`logs()`](#sb-logs). All fields optional. `LogOptions::default()` returns everything for the default sources (`Stdout` + `Stderr` + `Output`).
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -1759,9 +1715,9 @@ Credentials for authenticating to a private container registry.
 
 <div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-<p className="msb-backref">Returned by <a href="#config">config()</a> · <a href="#build">build()</a></p>
+<p className="msb-backref">Returned by <a href="#sb-config">config()</a> · <a href="#build">build()</a></p>
 
-The full configuration of a sandbox. Obtained via [`config()`](#config) or built via [`SandboxBuilder`](#sandboxbuilder). Contains all settings used to create the sandbox.
+The full configuration of a sandbox. Obtained via [`config()`](#sb-config) or built via [`SandboxBuilder`](#sandboxbuilder). Contains all settings used to create the sandbox.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -1809,7 +1765,7 @@ A lightweight handle to an existing sandbox (running or stopped). Obtained via [
 
 <div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-<p className="msb-backref">Returned by <a href="#metrics">metrics()</a> · <a href="#metrics_stream">metrics_stream()</a></p>
+<p className="msb-backref">Returned by <a href="#sb-metrics">metrics()</a> · <a href="#sb-metrics_stream">metrics_stream()</a></p>
 
 Point-in-time resource usage snapshot.
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -3,7 +3,71 @@ title: Sandbox
 description: Rust SDK - Sandbox API reference
 ---
 
-See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+<div className="msb-glance">
+  <p className="msb-eyebrow">At a glance</p>
+  <div className="msb-glance-grid">
+    <div>
+      <p className="msb-col-title"><span className="msb-dot static"></span>Static methods</p>
+      <div className="msb-mrow"><a className="msb-m" href="#sandboxbuilder">Sandbox::builder()</a><span className="msb-gloss">configure a new sandbox</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#sandboxget">Sandbox::get()</a><span className="msb-gloss">handle to an existing one</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#sandboxlist">Sandbox::list()</a><span className="msb-gloss">all sandboxes</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#sandboxstart">Sandbox::start()</a><span className="msb-gloss">restart a stopped one</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#sandboxremove">Sandbox::remove()</a><span className="msb-gloss">delete a stopped one</span></div>
+    </div>
+    <div>
+      <p className="msb-col-title"><span className="msb-dot instance"></span>Instance methods</p>
+      <div className="msb-mrow"><a className="msb-m" href="/sdk/rust/execution">exec() · shell()</a><span className="msb-gloss">run commands</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#fs">fs()</a><span className="msb-gloss">read / write files</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#metrics">metrics()</a><span className="msb-gloss">resource snapshot</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#logs">logs()</a><span className="msb-gloss">captured output</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#stop">stop() · kill()</a><span className="msb-gloss">shut down</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#detach">detach()</a><span className="msb-gloss">release, keep running</span></div>
+    </div>
+    <div>
+      <p className="msb-col-title"><span className="msb-dot builder"></span>Builder · SandboxBuilder</p>
+      <div className="msb-mrow"><a className="msb-m" href="#image">.image() · .image_with()</a><span className="msb-gloss">rootfs source</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#memory">.memory() · .cpus()</a><span className="msb-gloss">resource limits</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#port">.port() · .volume()</a><span className="msb-gloss">networking &amp; storage</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#secret">.secret() · .env()</a><span className="msb-gloss">secrets &amp; environment</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#patch">.patch()</a><span className="msb-gloss">modify rootfs pre-boot</span></div>
+      <div className="msb-mrow"><a className="msb-m" href="#create">.create() · .build()</a><span className="msb-gloss">boot / materialize</span></div>
+    </div>
+  </div>
+  <p className="msb-eyebrow msb-eyebrow-mt">Related types</p>
+  <div className="msb-typestrip">
+    <a className="msb-typepill" href="#sandboxconfig">SandboxConfig</a>
+    <a className="msb-typepill" href="#sandboxhandle">SandboxHandle</a>
+    <a className="msb-typepill" href="#sandboxmetrics">SandboxMetrics</a>
+    <a className="msb-typepill" href="#sandboxstatus">SandboxStatus</a>
+    <a className="msb-typepill" href="#logentry">LogEntry</a>
+    <a className="msb-typepill" href="#logoptions">LogOptions</a>
+    <a className="msb-typepill" href="#logsource">LogSource</a>
+    <a className="msb-typepill" href="#loglevel">LogLevel</a>
+    <a className="msb-typepill" href="#pullpolicy">PullPolicy</a>
+    <a className="msb-typepill" href="#registryauth">RegistryAuth</a>
+    <a className="msb-typepill" href="/sdk/rust/execution#exitstatus">ExitStatus</a>
+    <a className="msb-typepill" href="#patchbuilder">PatchBuilder</a>
+  </div>
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("api")   // 1. configure
+    .image("python")
+    .memory(1024)
+    .create()                      // 2. boot the microVM
+    .await?;
+
+let out = sb.exec("python", ["-V"]).await?;  // 3. run
+println!("{}", out.stdout()?);
+
+sb.stop().await?;                  // 4. shut down
+```
 
 ## Static methods
 
@@ -11,27 +75,46 @@ See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/
 
 #### Sandbox::builder()
 
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
+
 ```rust
 fn builder(name: impl Into<String>) -> SandboxBuilder
 ```
 
 Create a builder for configuring a new sandbox. The builder lets you set the image, resources, volumes, networking, secrets, and other options before booting the VM. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes. See [`SandboxBuilder`](#sandboxbuilder) for all available options.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `impl Into<String>` | Sandbox name - must be unique and no longer than 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Sandbox name - must be unique and no longer than 128 UTF-8 bytes.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxBuilder`](#sandboxbuilder) | Builder for configuring the sandbox |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxbuilder">SandboxBuilder</a></div>
+    <div className="msb-param-desc">Builder for configuring the sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let sb = Sandbox::builder("api")
+    .image("python")
+    .create()
+    .await?;
+```
 
 ---
 
 #### Sandbox::get()
+
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn get(name: &str) -> MicrosandboxResult<SandboxHandle>
@@ -39,21 +122,36 @@ async fn get(name: &str) -> MicrosandboxResult<SandboxHandle>
 
 Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control without requiring a full connection to the guest agent.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `&str` | Sandbox name, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxhandle">SandboxHandle</a></div>
+    <div className="msb-param-desc">Handle with status and lifecycle control.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let handle = Sandbox::get("api").await?;
+println!("{:?}", handle.status());
+```
 
 ---
 
 #### Sandbox::list()
+
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn list() -> MicrosandboxResult<Vec<SandboxHandle>>
@@ -61,15 +159,28 @@ async fn list() -> MicrosandboxResult<Vec<SandboxHandle>>
 
 List all sandboxes (running, stopped, and crashed).
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Vec<`[`SandboxHandle`](#sandboxhandle)`>` | All sandbox handles |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxhandle">Vec&lt;SandboxHandle&gt;</a></div>
+    <div className="msb-param-desc">All sandbox handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+for h in Sandbox::list().await? {
+    println!("{} — {:?}", h.name(), h.status());
+}
+```
 
 ---
 
 #### Sandbox::remove()
+
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn remove(name: &str) -> MicrosandboxResult<()>
@@ -77,15 +188,26 @@ async fn remove(name: &str) -> MicrosandboxResult<()>
 
 Delete a stopped sandbox and all its state from disk (configuration, logs, runtime directory). Fails if the sandbox is still running - stop it first.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `&str` | Sandbox name, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+Sandbox::remove("api").await?;
+```
 
 ---
 
 #### Sandbox::start()
+
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn start(name: &str) -> MicrosandboxResult<Sandbox>
@@ -93,21 +215,35 @@ async fn start(name: &str) -> MicrosandboxResult<Sandbox>
 
 Restart a previously stopped sandbox. The VM reboots using the persisted configuration. The sandbox enters attached mode - it stops when your process exits.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `&str` | Name of a stopped sandbox, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Name of a stopped sandbox, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`Sandbox`](#instance-methods) | Running sandbox |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Sandbox</a></div>
+    <div className="msb-param-desc">Running sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let sb = Sandbox::start("api").await?;
+```
 
 ---
 
 #### Sandbox::start_detached()
+
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn start_detached(name: &str) -> MicrosandboxResult<Sandbox>
@@ -115,17 +251,23 @@ async fn start_detached(name: &str) -> MicrosandboxResult<Sandbox>
 
 Restart a stopped sandbox in detached mode. The sandbox survives after your process exits.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `&str` | Name of a stopped sandbox, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Name of a stopped sandbox, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`Sandbox`](#instance-methods) | Running sandbox |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Sandbox</a></div>
+    <div className="msb-param-desc">Running sandbox.</div>
+  </div>
+</div>
 
 ---
 
@@ -135,21 +277,34 @@ Restart a stopped sandbox in detached mode. The sandbox survives after your proc
 
 #### config()
 
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
 ```rust
 fn config(&self) -> &SandboxConfig
 ```
 
 Access the sandbox's full configuration.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`&SandboxConfig`](#sandboxconfig) | Sandbox configuration |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxconfig">&amp;SandboxConfig</a></div>
+    <div className="msb-param-desc">Sandbox configuration.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+println!("{} MiB", sb.config().memory_mib);
+```
 
 ---
 
 #### detach()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn detach(self)
@@ -157,9 +312,17 @@ async fn detach(self)
 
 Release the handle without stopping the sandbox. The sandbox continues running as a background process. Reconnect later with [`Sandbox::get()`](#sandboxget).
 
+<p className="msb-label">Example</p>
+
+```rust
+sb.detach().await; // keeps running in the background
+```
+
 ---
 
 #### drain()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn drain(&self) -> MicrosandboxResult<()>
@@ -167,9 +330,17 @@ async fn drain(&self) -> MicrosandboxResult<()>
 
 Start a graceful drain. Existing commands run to completion, but new `exec` calls are rejected. The sandbox transitions to `Stopped` when all in-flight commands finish. Useful for zero-downtime rotation of worker sandboxes.
 
+<p className="msb-label">Example</p>
+
+```rust
+sb.drain().await?;
+```
+
 ---
 
 #### fs()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
 fn fs(&self) -> SandboxFs<'_>
@@ -177,30 +348,44 @@ fn fs(&self) -> SandboxFs<'_>
 
 Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/rust/filesystem) for API details.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxFs`](/sdk/rust/filesystem) | Filesystem handle |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/rust/filesystem">SandboxFs</a></div>
+    <div className="msb-param-desc">Filesystem handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.fs().write("/tmp/hello.txt", "hi").await?;
+```
 
 ---
 
 #### kill()
 
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
 ```rust
 async fn kill(&self) -> MicrosandboxResult<()>
 ```
 
-Force-terminate the sandbox immediately with SIGKILL. No graceful
-shutdown — use when the sandbox is unresponsive. Pending writes that
-the workload hasn't `fsync`'d may be lost, same durability semantics
-as a sudden power loss on a physical machine. Prefer
-[`stop()`](#stop) for graceful shutdown that gives the workload a
-chance to flush.
+Force-terminate the sandbox immediately with SIGKILL. No graceful shutdown — use when the sandbox is unresponsive. Pending writes that the workload hasn't `fsync`'d may be lost, same durability semantics as a sudden power loss on a physical machine. Prefer [`stop()`](#stop) for graceful shutdown that gives the workload a chance to flush.
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.kill().await?; // SIGKILL, no graceful shutdown
+```
 
 ---
 
 #### metrics()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn metrics(&self) -> MicrosandboxResult<SandboxMetrics>
@@ -208,15 +393,27 @@ async fn metrics(&self) -> MicrosandboxResult<SandboxMetrics>
 
 Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk I/O, network I/O, optional upper disk usage, and uptime.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxMetrics`](#sandboxmetrics) | Resource metrics |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxmetrics">SandboxMetrics</a></div>
+    <div className="msb-param-desc">Resource metrics.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let m = sb.metrics().await?;
+println!("cpu {:.1}% · mem {} MiB", m.cpu_percent, m.memory_bytes / 1_048_576);
+```
 
 ---
 
 #### metrics_stream()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
 fn metrics_stream(&self, interval: Duration) -> impl Stream<Item = MicrosandboxResult<SandboxMetrics>>
@@ -224,21 +421,40 @@ fn metrics_stream(&self, interval: Duration) -> impl Stream<Item = MicrosandboxR
 
 Stream resource metrics at a regular interval. Returns an async stream that yields a new snapshot every `interval` duration.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| interval | `Duration` | Time between metric snapshots |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>interval</code><span className="msb-type">Duration</span></div>
+    <div className="msb-param-desc">Time between metric snapshots.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `impl Stream<Item = Result<`[`SandboxMetrics`](#sandboxmetrics)`>>` | Async stream of metrics |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxmetrics">impl Stream&lt;SandboxMetrics&gt;</a></div>
+    <div className="msb-param-desc">Async stream yielding a snapshot each interval.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use futures::StreamExt;
+
+let mut stream = sb.metrics_stream(Duration::from_secs(1));
+while let Some(snapshot) = stream.next().await {
+    println!("{:.1}%", snapshot?.cpu_percent);
+}
+```
 
 ---
 
 #### logs()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
 fn logs(&self, opts: &LogOptions) -> MicrosandboxResult<Vec<LogEntry>>
@@ -246,7 +462,27 @@ fn logs(&self, opts: &LogOptions) -> MicrosandboxResult<Vec<LogEntry>>
 
 Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
 
-The default sources are `Stdout`, `Stderr`, and `Output` (PTY-merged). Pass `LogSource::System` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+The default sources are `Stdout`, `Stderr`, and `Output` (PTY-merged). Pass `LogSource::System` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines. `logs()` is **synchronous** because it's a pure file read.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#logoptions">&amp;LogOptions</a></div>
+    <div className="msb-param-desc">Filters: <code>tail</code>, <code>since</code>, <code>until</code>, <code>sources</code>. <code>LogOptions::default()</code> returns everything for the default sources.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#logentry">Vec&lt;LogEntry&gt;</a></div>
+    <div className="msb-param-desc">Matching entries in chronological order.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```rust
 use microsandbox::sandbox::{LogOptions, LogSource, Sandbox};
@@ -286,23 +522,11 @@ let recent = handle.logs(&LogOptions {
 })?;
 ```
 
-`logs()` is **synchronous** because it's a pure file read.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| opts | `&`[`LogOptions`](#logoptions) | Filters: `tail`, `since`, `until`, `sources`. `LogOptions::default()` returns everything for the default sources. |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Vec<`[`LogEntry`](#logentry)`>` | Matching entries in chronological order |
-
 ---
 
 #### name()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
 fn name(&self) -> &str
@@ -310,15 +534,20 @@ fn name(&self) -> &str
 
 Get the sandbox name.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `&str` | Sandbox name, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
 
 ---
 
 #### owns_lifecycle()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
 fn owns_lifecycle(&self) -> bool
@@ -326,15 +555,20 @@ fn owns_lifecycle(&self) -> bool
 
 Whether this handle owns the sandbox lifecycle. `true` in attached mode (sandbox stops when your process exits), `false` in detached mode.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `bool` | `true` if attached |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> if attached.</div>
+  </div>
+</div>
 
 ---
 
 #### remove_persisted()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn remove_persisted(&self) -> MicrosandboxResult<()>
@@ -342,23 +576,35 @@ async fn remove_persisted(&self) -> MicrosandboxResult<()>
 
 Remove the sandbox and all its persisted state from disk.
 
+<p className="msb-label">Example</p>
+
+```rust
+sb.remove_persisted().await?;
+```
+
 ---
 
 #### stop()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn stop(&self) -> MicrosandboxResult<()>
 ```
 
-Gracefully shut down the sandbox. Lets the sandbox finish writing
-any pending data to disk before it exits, so files written inside
-the sandbox aren't lost across a later restart. Waits up to ten
-seconds for a clean exit; if the sandbox is still running after
-that, it is force-killed.
+Gracefully shut down the sandbox. Lets the sandbox finish writing any pending data to disk before it exits, so files written inside the sandbox aren't lost across a later restart. Waits up to ten seconds for a clean exit; if the sandbox is still running after that, it is force-killed.
+
+<p className="msb-label">Example</p>
+
+```rust
+sb.stop().await?;
+```
 
 ---
 
 #### stop_and_wait()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn stop_and_wait(&self) -> MicrosandboxResult<ExitStatus>
@@ -366,15 +612,27 @@ async fn stop_and_wait(&self) -> MicrosandboxResult<ExitStatus>
 
 Stop the sandbox and wait for the exit status.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/rust/execution#exitstatus">ExitStatus</a></div>
+    <div className="msb-param-desc">Exit code and success flag.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let status = sb.stop_and_wait().await?;
+println!("exited: {}", status.success());
+```
 
 ---
 
 #### wait()
+
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn wait(&self) -> MicrosandboxResult<ExitStatus>
@@ -382,21 +640,32 @@ async fn wait(&self) -> MicrosandboxResult<ExitStatus>
 
 Block until the sandbox exits on its own (without triggering a stop). Returns the exit status.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`ExitStatus`](/sdk/rust/execution#exitstatus) | Exit code and success flag |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/rust/execution#exitstatus">ExitStatus</a></div>
+    <div className="msb-param-desc">Exit code and success flag.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let status = sb.wait().await?;
+```
 
 ---
 
 ## SandboxBuilder
 
-Builder for configuring a sandbox before creation. Obtained via [`Sandbox::builder(name)`](#sandboxbuilder).
+Builder for configuring a sandbox before creation. Obtained via [`Sandbox::builder(name)`](#sandboxbuilder). Every setter returns `Self`, so calls chain. Examples are shown on the methods where usage is non-obvious; simple setters are demonstrated by the [Typical flow](#typical-flow) above.
 
 ---
 
 #### build()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn build(self) -> MicrosandboxResult<SandboxConfig>
@@ -404,15 +673,20 @@ async fn build(self) -> MicrosandboxResult<SandboxConfig>
 
 Materialize the [`SandboxConfig`](#sandboxconfig) without booting the sandbox. Validates the configuration and, if [`from_snapshot`](#from_snapshot) was called, opens the snapshot manifest to pin its image reference and upper-layer source. For booting, use [`create`](#create) or [`create_detached`](#create_detached) instead — they call `build` internally.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxConfig`](#sandboxconfig) | Validated, ready-to-boot configuration |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxconfig">SandboxConfig</a></div>
+    <div className="msb-param-desc">Validated, ready-to-boot configuration.</div>
+  </div>
+</div>
 
 ---
 
 #### cpus()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn cpus(self, count: u8) -> Self
@@ -420,15 +694,20 @@ fn cpus(self, count: u8) -> Self
 
 Set the number of virtual CPUs. This is a limit, not a reservation. Default: `1`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| count | `u8` | Number of vCPUs |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>count</code><span className="msb-type">u8</span></div>
+    <div className="msb-param-desc">Number of vCPUs.</div>
+  </div>
+</div>
 
 ---
 
 #### create()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn create(self) -> MicrosandboxResult<Sandbox>
@@ -436,15 +715,20 @@ async fn create(self) -> MicrosandboxResult<Sandbox>
 
 Boot the sandbox in attached mode. The sandbox stops when your process exits.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`Sandbox`](#instance-methods) | Running sandbox |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Sandbox</a></div>
+    <div className="msb-param-desc">Running sandbox.</div>
+  </div>
+</div>
 
 ---
 
 #### create_detached()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn create_detached(self) -> MicrosandboxResult<Sandbox>
@@ -452,15 +736,30 @@ async fn create_detached(self) -> MicrosandboxResult<Sandbox>
 
 Boot the sandbox in detached mode. The sandbox survives after your process exits.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`Sandbox`](#instance-methods) | Running sandbox |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Sandbox</a></div>
+    <div className="msb-param-desc">Running sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .create_detached()
+    .await?;
+sb.detach().await;
+```
 
 ---
 
 #### disable_network()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn disable_network(self) -> Self
@@ -472,21 +771,28 @@ Fully disable networking. No network interface is created.
 
 #### entrypoint()
 
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
 ```rust
 fn entrypoint(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> Self
 ```
 
-Override the OCI image's stored ENTRYPOINT. The value is consulted by command-resolution paths that follow OCI semantics — specifically `msb exec` / `msb run` against this sandbox from the terminal. [`Sandbox::exec`](#exec) and [`Sandbox::shell`](#shell) do **not** consult it; they pass `cmd` literally to the guest agent. Use this when configuring a sandbox via the SDK for later CLI attachment.
+Override the OCI image's stored ENTRYPOINT. The value is consulted by command-resolution paths that follow OCI semantics — specifically `msb exec` / `msb run` against this sandbox from the terminal. [`Sandbox::exec`](/sdk/rust/execution) and [`Sandbox::shell`](/sdk/rust/execution) do **not** consult it; they pass `cmd` literally to the guest agent. Use this when configuring a sandbox via the SDK for later CLI attachment.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `impl IntoIterator<Item = impl Into<String>>` | Entrypoint command and arguments |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">impl IntoIterator</span></div>
+    <div className="msb-param-desc">Entrypoint command and arguments.</div>
+  </div>
+</div>
 
 ---
 
 #### env()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn env(self, key: impl Into<String>, value: impl Into<String>) -> Self
@@ -494,16 +800,24 @@ fn env(self, key: impl Into<String>, value: impl Into<String>) -> Self
 
 Set an environment variable visible to all commands. Can be called multiple times. Per-command env vars (via `exec_with`) are merged on top.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| key | `impl Into<String>` | Variable name |
-| value | `impl Into<String>` | Variable value |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Variable name.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Variable value.</div>
+  </div>
+</div>
 
 ---
 
 #### hostname()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn hostname(self, hostname: impl Into<String>) -> Self
@@ -511,15 +825,20 @@ fn hostname(self, hostname: impl Into<String>) -> Self
 
 Set the guest hostname.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| hostname | `impl Into<String>` | Hostname |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hostname</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Hostname.</div>
+  </div>
+</div>
 
 ---
 
 #### idle_timeout()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn idle_timeout(self, secs: u64) -> Self
@@ -527,9 +846,20 @@ fn idle_timeout(self, secs: u64) -> Self
 
 Auto-drain the sandbox after this many seconds of inactivity (no active exec sessions). Enforced on the host side.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>secs</code><span className="msb-type">u64</span></div>
+    <div className="msb-param-desc">Idle timeout in seconds.</div>
+  </div>
+</div>
+
 ---
 
 #### init()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn init(self, cmd: impl Into<PathBuf>) -> Self
@@ -539,11 +869,16 @@ Hand off PID 1 inside the guest to `cmd` after agentd finishes its boot-time set
 
 `cmd` is either an absolute path inside the guest rootfs or the literal `"auto"`. Auto first honors a known init at the start of the image ENTRYPOINT, such as `/init` in s6-overlay images, then falls back to probing `/sbin/init`, `/lib/systemd/systemd`, and `/usr/lib/systemd/systemd` inside the guest. When attached `msb run` uses an image-declared init entrypoint, the remaining ENTRYPOINT plus CMD or trailing command is passed to that init instead of direct-executed through agentd. For init binaries that take argv or extra env (rare), use [`init_with`](#init_with).
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `impl Into<PathBuf>` | Absolute path inside the guest, or `"auto"` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">impl Into&lt;PathBuf&gt;</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest, or <code>"auto"</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```rust
 let sb = Sandbox::builder("worker")
@@ -557,6 +892,8 @@ let sb = Sandbox::builder("worker")
 
 #### init_with()
 
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
 ```rust
 fn init_with(
     self,
@@ -565,16 +902,22 @@ fn init_with(
 ) -> Self
 ```
 
-Like [`init`](#init), but with a closure-builder for argv and env vars. Mirrors `exec_with` in shape.
+Like [`init`](#init), but with a closure-builder for argv and env vars. Mirrors `exec_with` in shape. The builder exposes `arg`, `args`, `env`, and `envs`. Calling `init` or `init_with` more than once overwrites — different from `env`, which appends. The init is one-shot pre-boot.
 
-The builder exposes `arg`, `args`, `env`, and `envs`.
+<p className="msb-label">Parameters</p>
 
-**Parameters**
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">impl Into&lt;PathBuf&gt;</span></div>
+    <div className="msb-param-desc">Absolute path to the init binary inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><span className="msb-type">FnOnce(InitOptionsBuilder)</span></div>
+    <div className="msb-param-desc">Closure populating argv and env.</div>
+  </div>
+</div>
 
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `impl Into<PathBuf>` | Absolute path to the init binary inside the guest |
-| f | `FnOnce(InitOptionsBuilder) -> InitOptionsBuilder` | Closure populating argv and env |
+<p className="msb-label">Example</p>
 
 ```rust
 let sb = Sandbox::builder("worker")
@@ -586,17 +929,11 @@ let sb = Sandbox::builder("worker")
     .await?;
 ```
 
-Calling `init` or `init_with` more than once overwrites — different from `env`, which appends. The init is one-shot pre-boot.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| secs | `u64` | Idle timeout in seconds |
-
 ---
 
 #### image()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn image(self, image: impl IntoImage) -> Self
@@ -604,15 +941,20 @@ fn image(self, image: impl IntoImage) -> Self
 
 Set the root filesystem source. Accepts OCI image names, local directory paths, or disk image paths. The format is auto-detected.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| image | `impl IntoImage` | OCI image name, local directory path, or disk image path |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>image</code><span className="msb-type">impl IntoImage</span></div>
+    <div className="msb-param-desc">OCI image name, local directory path, or disk image path.</div>
+  </div>
+</div>
 
 ---
 
 #### image_with()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn image_with(self, f: impl FnOnce(ImageBuilder) -> ImageBuilder) -> Self
@@ -620,11 +962,16 @@ fn image_with(self, f: impl FnOnce(ImageBuilder) -> ImageBuilder) -> Self
 
 Configure an explicit rootfs source. Use this for OCI-only settings such as the writable overlay upper size, or for disk images when the filesystem type can't be auto-detected.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| f | `ImageBuilder` | Configure the rootfs source. |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><span className="msb-type">FnOnce(ImageBuilder)</span></div>
+    <div className="msb-param-desc">Configure the rootfs source.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```rust
 use microsandbox::size::SizeExt;
@@ -639,21 +986,28 @@ let sb = Sandbox::builder("worker")
 
 #### log_level()
 
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
 ```rust
 fn log_level(self, level: LogLevel) -> Self
 ```
 
 Override the sandbox process's log verbosity.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| level | [`LogLevel`](#loglevel) | Log level |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>level</code><a className="msb-type" href="#loglevel">LogLevel</a></div>
+    <div className="msb-param-desc">Log level.</div>
+  </div>
+</div>
 
 ---
 
 #### max_duration()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn max_duration(self, secs: u64) -> Self
@@ -661,15 +1015,20 @@ fn max_duration(self, secs: u64) -> Self
 
 Set the maximum sandbox lifetime in seconds. When exceeded, the sandbox is drained and stopped. Enforced on the host side - the guest cannot override it.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| secs | `u64` | Maximum lifetime in seconds |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>secs</code><span className="msb-type">u64</span></div>
+    <div className="msb-param-desc">Maximum lifetime in seconds.</div>
+  </div>
+</div>
 
 ---
 
 #### memory()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn memory(self, size: impl Into<Mebibytes>) -> Self
@@ -677,15 +1036,20 @@ fn memory(self, size: impl Into<Mebibytes>) -> Self
 
 Set the guest memory size. Physical pages are only allocated as the guest touches them, so this is a limit, not an upfront reservation. Default: `512` MiB.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| size | `impl Into<Mebibytes>` | Memory in MiB |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>size</code><span className="msb-type">impl Into&lt;Mebibytes&gt;</span></div>
+    <div className="msb-param-desc">Memory in MiB.</div>
+  </div>
+</div>
 
 ---
 
 #### network()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn network(self, f: impl FnOnce(NetworkBuilder) -> NetworkBuilder) -> Self
@@ -693,31 +1057,41 @@ fn network(self, f: impl FnOnce(NetworkBuilder) -> NetworkBuilder) -> Self
 
 Configure networking. See [Networking](/sdk/rust/networking) for the full builder API.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| f | [`NetworkBuilder`](/sdk/rust/networking#networkbuilder) | Configure the network. |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="/sdk/rust/networking#networkbuilder">NetworkBuilder</a></div>
+    <div className="msb-param-desc">Configure the network.</div>
+  </div>
+</div>
 
 ---
 
 #### patch()
 
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
 ```rust
 fn patch(self, f: impl FnOnce(PatchBuilder) -> PatchBuilder) -> Self
 ```
 
-Modify the rootfs before the VM boots. Patches go into the writable layer - the base image is untouched.
+Modify the rootfs before the VM boots. Patches go into the writable layer - the base image is untouched. See [`PatchBuilder`](#patchbuilder) for the operations.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| f | `PatchBuilder` | Configure rootfs patches. |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#patchbuilder">FnOnce(PatchBuilder)</a></div>
+    <div className="msb-param-desc">Configure rootfs patches.</div>
+  </div>
+</div>
 
 ---
 
 #### port()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn port(self, host_port: u16, guest_port: u16) -> Self
@@ -725,16 +1099,24 @@ fn port(self, host_port: u16, guest_port: u16) -> Self
 
 Publish a TCP port from the sandbox to the host. The default host bind address is `127.0.0.1`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| host_port | `u16` | Port on the host |
-| guest_port | `u16` | Port inside the sandbox |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
 
 ---
 
 #### port_bind()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn port_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self
@@ -742,9 +1124,28 @@ fn port_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self
 
 Publish a TCP port on a specific host bind address, such as `0.0.0.0`.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_bind</code><span className="msb-type">IpAddr</span></div>
+    <div className="msb-param-desc">Host bind address.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
 ---
 
 #### port_udp()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn port_udp(self, host_port: u16, guest_port: u16) -> Self
@@ -752,16 +1153,24 @@ fn port_udp(self, host_port: u16, guest_port: u16) -> Self
 
 Publish a UDP port. The default host bind address is `127.0.0.1`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| host_port | `u16` | Port on the host |
-| guest_port | `u16` | Port inside the sandbox |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
 
 ---
 
 #### port_udp_bind()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn port_udp_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self
@@ -769,9 +1178,28 @@ fn port_udp_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Se
 
 Publish a UDP port on a specific host bind address.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_bind</code><span className="msb-type">IpAddr</span></div>
+    <div className="msb-param-desc">Host bind address.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_port</code><span className="msb-type">u16</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
 ---
 
 #### pull_policy()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn pull_policy(self, policy: PullPolicy) -> Self
@@ -779,15 +1207,20 @@ fn pull_policy(self, policy: PullPolicy) -> Self
 
 Control when the OCI image is pulled from the registry.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| policy | [`PullPolicy`](#pullpolicy) | Pull behavior |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>policy</code><a className="msb-type" href="#pullpolicy">PullPolicy</a></div>
+    <div className="msb-param-desc">Pull behavior.</div>
+  </div>
+</div>
 
 ---
 
 #### registry_auth()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn registry_auth(self, auth: RegistryAuth) -> Self
@@ -795,15 +1228,20 @@ fn registry_auth(self, auth: RegistryAuth) -> Self
 
 Authenticate to a private container registry.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| auth | [`RegistryAuth`](#registryauth) | Registry credentials |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>auth</code><a className="msb-type" href="#registryauth">RegistryAuth</a></div>
+    <div className="msb-param-desc">Registry credentials.</div>
+  </div>
+</div>
 
 ---
 
 #### replace()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn replace(self) -> Self
@@ -815,22 +1253,32 @@ If a sandbox with the same name already exists, stop it, remove it, and create a
 
 #### script()
 
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
 ```rust
 fn script(self, name: impl Into<String>, content: impl Into<String>) -> Self
 ```
 
 Add a named script at `/.msb/scripts/` inside the guest. Scripts are added to `PATH` and can be called by name via `exec()` or `shell()`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `impl Into<String>` | Script name (becomes the filename) |
-| content | `impl Into<String>` | Script content |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Script name (becomes the filename).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Script content.</div>
+  </div>
+</div>
 
 ---
 
 #### secret()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn secret(self, f: impl FnOnce(SecretBuilder) -> SecretBuilder) -> Self
@@ -838,15 +1286,20 @@ fn secret(self, f: impl FnOnce(SecretBuilder) -> SecretBuilder) -> Self
 
 Add a secret with full configuration. See [Secrets](/sdk/rust/secrets) for the builder API. Automatically enables TLS interception.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| f | [`SecretBuilder`](/sdk/rust/secrets#secretbuilder) | Configure the secret. |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="/sdk/rust/secrets#secretbuilder">SecretBuilder</a></div>
+    <div className="msb-param-desc">Configure the secret.</div>
+  </div>
+</div>
 
 ---
 
 #### secret_env()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn secret_env(self, env_var: impl Into<String>, value: impl Into<String>, allowed_host: impl Into<String>) -> Self
@@ -854,33 +1307,49 @@ fn secret_env(self, env_var: impl Into<String>, value: impl Into<String>, allowe
 
 Shorthand for adding a header-injected secret. Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| env_var | `impl Into<String>` | Environment variable name (non-empty, no `=` or NUL) |
-| value | `impl Into<String>` | Secret value |
-| allowed_host | `impl Into<String>` | Allowed destination host |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>env_var</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Environment variable name (non-empty, no <code>=</code> or NUL).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Secret value.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>allowed_host</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Allowed destination host.</div>
+  </div>
+</div>
 
 ---
 
 #### shell()
 
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
 ```rust
 fn shell(self, shell: impl Into<String>) -> Self
 ```
 
-Set the shell used by [`Sandbox::shell()`](#shell). Default: `/bin/sh`.
+Set the shell used by [`Sandbox::shell()`](/sdk/rust/execution). Default: `/bin/sh`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| shell | `impl Into<String>` | Shell path (e.g. `"/bin/bash"`) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>shell</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Shell path (e.g. <code>"/bin/bash"</code>).</div>
+  </div>
+</div>
 
 ---
 
 #### user()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn user(self, user: impl Into<String>) -> Self
@@ -888,15 +1357,20 @@ fn user(self, user: impl Into<String>) -> Self
 
 Set the default guest user for all commands.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| user | `impl Into<String>` | User name or UID |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>user</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">User name or UID.</div>
+  </div>
+</div>
 
 ---
 
 #### volume()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn volume(self, guest_path: impl Into<String>, f: impl FnOnce(MountBuilder) -> MountBuilder) -> Self
@@ -904,16 +1378,24 @@ fn volume(self, guest_path: impl Into<String>, f: impl FnOnce(MountBuilder) -> M
 
 Add a volume mount. See [Volumes](/sdk/rust/volumes) for mount types.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| guest_path | `impl Into<String>` | Mount point inside the sandbox |
-| f | [`MountBuilder`](/sdk/rust/volumes#mountbuilder) | Configure the mount. |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest_path</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Mount point inside the sandbox.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="/sdk/rust/volumes#mountbuilder">MountBuilder</a></div>
+    <div className="msb-param-desc">Configure the mount.</div>
+  </div>
+</div>
 
 ---
 
 #### workdir()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn workdir(self, path: impl Into<String>) -> Self
@@ -921,23 +1403,26 @@ fn workdir(self, path: impl Into<String>) -> Self
 
 Set the default working directory for all commands.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `impl Into<String>` | Absolute path inside the guest |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
 
 ---
 
 ## PatchBuilder
 
-Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder::patch(|p| p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `replace = true` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
-
-See [Patches](/sandboxes/customize#patches) for conceptual context.
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder::patch(|p| p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `replace = true` on the operation to allow overwriting. `mkdir` and `remove` are idempotent. See [Patches](/sandboxes/customize#patches) for conceptual context.
 
 ---
 
 #### append()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn append(self, path: impl Into<String>, content: impl Into<String>) -> Self
@@ -945,16 +1430,24 @@ fn append(self, path: impl Into<String>, content: impl Into<String>) -> Self
 
 Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `impl Into<String>` | Absolute path inside the guest |
-| content | `impl Into<String>` | Text to append |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Text to append.</div>
+  </div>
+</div>
 
 ---
 
 #### copy_dir()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn copy_dir(self, src: impl Into<PathBuf>, dst: impl Into<String>, replace: bool) -> Self
@@ -962,17 +1455,28 @@ fn copy_dir(self, src: impl Into<PathBuf>, dst: impl Into<String>, replace: bool
 
 Recursively copy a host directory at `src` into the guest rootfs at `dst`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| src | `impl Into<PathBuf>` | Host source directory |
-| dst | `impl Into<String>` | Absolute destination path inside the guest |
-| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">impl Into&lt;PathBuf&gt;</span></div>
+    <div className="msb-param-desc">Host source directory.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute destination path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>replace</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>true</code>, overwrite an existing path at <code>dst</code>.</div>
+  </div>
+</div>
 
 ---
 
 #### copy_file()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn copy_file(
@@ -986,18 +1490,32 @@ fn copy_file(
 
 Copy a single host file at `src` into the guest rootfs at `dst`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| src | `impl Into<PathBuf>` | Host source file |
-| dst | `impl Into<String>` | Absolute destination path inside the guest |
-| mode | `Option<u32>` | File mode, e.g. `Some(0o644)`. `None` keeps the source mode |
-| replace | `bool` | When `true`, overwrite an existing path at `dst` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">impl Into&lt;PathBuf&gt;</span></div>
+    <div className="msb-param-desc">Host source file.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute destination path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mode</code><span className="msb-type">Option&lt;u32&gt;</span></div>
+    <div className="msb-param-desc">File mode, e.g. <code>Some(0o644)</code>. <code>None</code> keeps the source mode.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>replace</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>true</code>, overwrite an existing path at <code>dst</code>.</div>
+  </div>
+</div>
 
 ---
 
 #### file()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn file(
@@ -1011,18 +1529,32 @@ fn file(
 
 Write raw bytes at `path`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `impl Into<String>` | Absolute path inside the guest |
-| content | `impl Into<Vec<u8>>` | Raw byte content |
-| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
-| replace | `bool` | When `true`, overwrite an existing path |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">impl Into&lt;Vec&lt;u8&gt;&gt;</span></div>
+    <div className="msb-param-desc">Raw byte content.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mode</code><span className="msb-type">Option&lt;u32&gt;</span></div>
+    <div className="msb-param-desc">File mode, e.g. <code>Some(0o644)</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>replace</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>true</code>, overwrite an existing path.</div>
+  </div>
+</div>
 
 ---
 
 #### mkdir()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn mkdir(self, path: impl Into<String>, mode: Option<u32>) -> Self
@@ -1030,16 +1562,24 @@ fn mkdir(self, path: impl Into<String>, mode: Option<u32>) -> Self
 
 Create a directory at `path`. Idempotent: a no-op if the directory already exists.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `impl Into<String>` | Absolute path inside the guest |
-| mode | `Option<u32>` | Directory mode, e.g. `Some(0o755)` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mode</code><span className="msb-type">Option&lt;u32&gt;</span></div>
+    <div className="msb-param-desc">Directory mode, e.g. <code>Some(0o755)</code>.</div>
+  </div>
+</div>
 
 ---
 
 #### remove()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn remove(self, path: impl Into<String>) -> Self
@@ -1047,15 +1587,20 @@ fn remove(self, path: impl Into<String>) -> Self
 
 Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `impl Into<String>` | Absolute path inside the guest |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
 
 ---
 
 #### symlink()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn symlink(self, target: impl Into<String>, link: impl Into<String>, replace: bool) -> Self
@@ -1063,17 +1608,28 @@ fn symlink(self, target: impl Into<String>, link: impl Into<String>, replace: bo
 
 Create a symlink at `link` pointing to `target`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| target | `impl Into<String>` | What the symlink points to (literal symlink target text) |
-| link | `impl Into<String>` | Absolute path of the symlink itself |
-| replace | `bool` | When `true`, overwrite an existing path at `link` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>target</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">What the symlink points to (literal symlink target text).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>link</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute path of the symlink itself.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>replace</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>true</code>, overwrite an existing path at <code>link</code>.</div>
+  </div>
+</div>
 
 ---
 
 #### text()
+
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn text(
@@ -1087,20 +1643,36 @@ fn text(
 
 Write UTF-8 text content at `path`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `impl Into<String>` | Absolute path inside the guest |
-| content | `impl Into<String>` | Text content |
-| mode | `Option<u32>` | File mode, e.g. `Some(0o644)` |
-| replace | `bool` | When `true`, overwrite an existing path |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Text content.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mode</code><span className="msb-type">Option&lt;u32&gt;</span></div>
+    <div className="msb-param-desc">File mode, e.g. <code>Some(0o644)</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>replace</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>true</code>, overwrite an existing path.</div>
+  </div>
+</div>
 
 ---
 
 ## Types
 
 ### LogEntry
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#logs">logs()</a></p>
 
 A single captured log entry returned by [`logs()`](#logs).
 
@@ -1112,6 +1684,10 @@ A single captured log entry returned by [`logs()`](#logs).
 | data | `Bytes` | The chunk's bytes (UTF-8 lossy decoded by default; raw bytes if `--raw` mode was used) |
 
 ### LogLevel
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#log_level">log_level()</a></p>
 
 Sandbox process log verbosity.
 
@@ -1125,6 +1701,10 @@ Sandbox process log verbosity.
 
 ### LogOptions
 
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#logs">logs()</a></p>
+
 Filters passed to [`logs()`](#logs). All fields optional. `LogOptions::default()` returns everything for the default sources (`Stdout` + `Stderr` + `Output`).
 
 | Field | Type | Description |
@@ -1135,6 +1715,10 @@ Filters passed to [`logs()`](#logs). All fields optional. `LogOptions::default()
 | sources | `Vec<`[`LogSource`](#logsource)`>` | Sources to include. Empty = `[Stdout, Stderr, Output]` (the default user-program sources). Add `System` to merge runtime/kernel diagnostics. |
 
 ### LogSource
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#logentry">LogEntry.source</a> · <a href="#logoptions">LogOptions.sources</a></p>
 
 Tag indicating where a captured log entry came from.
 
@@ -1147,6 +1731,10 @@ Tag indicating where a captured log entry came from.
 
 ### PullPolicy
 
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#pull_policy">pull_policy()</a></p>
+
 Controls when the SDK fetches an OCI image from the registry.
 
 | Value | Description |
@@ -1157,6 +1745,10 @@ Controls when the SDK fetches an OCI image from the registry.
 
 ### RegistryAuth
 
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#registry_auth">registry_auth()</a></p>
+
 Credentials for authenticating to a private container registry.
 
 | Variant | Fields | Description |
@@ -1164,6 +1756,10 @@ Credentials for authenticating to a private container registry.
 | `Basic` | - `username: String` <br/> - `password: String` | Username and password authentication |
 
 ### SandboxConfig
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#config">config()</a> · <a href="#build">build()</a></p>
 
 The full configuration of a sandbox. Obtained via [`config()`](#config) or built via [`SandboxBuilder`](#sandboxbuilder). Contains all settings used to create the sandbox.
 
@@ -1183,6 +1779,10 @@ The full configuration of a sandbox. Obtained via [`config()`](#config) or built
 | workdir | `Option<String>` | Default working directory |
 
 ### SandboxHandle
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#sandboxget">Sandbox::get()</a> · <a href="#sandboxlist">Sandbox::list()</a></p>
 
 A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox::get()`](#sandboxget) or [`Sandbox::list()`](#sandboxlist). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. You cannot `exec` or `fs` on a handle - call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
 
@@ -1207,6 +1807,10 @@ A lightweight handle to an existing sandbox (running or stopped). Obtained via [
 
 ### SandboxMetrics
 
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#metrics">metrics()</a> · <a href="#metrics_stream">metrics_stream()</a></p>
+
 Point-in-time resource usage snapshot.
 
 | Field | Type | Description |
@@ -1225,6 +1829,10 @@ Point-in-time resource usage snapshot.
 | uptime | `Duration` | Time since the sandbox was created |
 
 ### SandboxStatus
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#sandboxhandle">SandboxHandle.status()</a></p>
 
 | Value | Description |
 |-------|-------------|

--- a/docs/sdk/rust/secrets.mdx
+++ b/docs/sdk/rust/secrets.mdx
@@ -3,189 +3,241 @@ title: Secrets
 description: Rust SDK - Secret injection API reference
 ---
 
-See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+Inject credentials into outbound HTTP without ever exposing the real value to the guest. The guest only ever sees a placeholder; microsandbox's TLS proxy swaps in the real secret on connections to allowed hosts and blocks everything else. See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
 
-## HostPattern
+<div className="msb-glance">
 
-`HostPattern` is used anywhere a secret policy needs to match the destination host. Allow-list patterns decide where the real secret value may be substituted; passthrough patterns decide where the placeholder may be forwarded unchanged.
+  <p className="msb-gl"><span className="msb-dot static"></span>Static<span className="msb-ct">1</span></p>
+  <a className="msb-row" href="#secretbuildernew"><span className="msb-rn">SecretBuilder::new()</span><span className="msb-rg">start a secret builder</span></a>
 
-| Variant | Builder methods | Matches |
-|---------|-----------------|---------|
-| `HostPattern::Exact("api.example.com")` | `allow_host("api.example.com")`, `passthrough_host("api.example.com")` | That exact SNI host |
-| `HostPattern::Wildcard("*.example.com")` | `allow_host_pattern("*.example.com")`, `passthrough_host_pattern("*.example.com")` | Hosts matching the wildcard pattern |
-| `HostPattern::Any` | `allow_any_host_dangerous(true)`, `passthrough_all_hosts(true)` | Every host |
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SecretBuilder<span className="msb-ct">13</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#env">.env()</a>
+    <a className="msb-chip" href="#value">.value()</a>
+    <a className="msb-chip" href="#allow_host">.allow_host()</a>
+    <a className="msb-chip" href="#allow_host_pattern">.allow_host_pattern()</a>
+    <a className="msb-chip" href="#allow_any_host_dangerous">.allow_any_host_dangerous()</a>
+    <a className="msb-chip" href="#placeholder">.placeholder()</a>
+    <a className="msb-chip" href="#on_violation">.on_violation()</a>
+    <a className="msb-chip" href="#require_tls_identity">.require_tls_identity()</a>
+    <a className="msb-chip" href="#inject_headers">.inject_headers()</a>
+    <a className="msb-chip" href="#inject_basic_auth">.inject_basic_auth()</a>
+    <a className="msb-chip" href="#inject_query">.inject_query()</a>
+    <a className="msb-chip" href="#inject_body">.inject_body()</a>
+    <a className="msb-chip" href="#build">.build()</a>
+  </div>
 
-Passthrough host patterns do **not** make a secret eligible for substitution. They only prevent blocking when the guest sends the placeholder to a matching host, so the request is forwarded with the placeholder unchanged.
+  <p className="msb-gl"><span className="msb-dot builder"></span>Shorthand · SandboxBuilder<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#secret_env"><span className="msb-rn">.secret_env()</span><span className="msb-rg">one-line header-injected secret</span></a>
+  <a className="msb-row" href="#secret_entry"><span className="msb-rn">.secret_entry()</span><span className="msb-rg">add a prebuilt SecretEntry</span></a>
 
-Exact and wildcard allow-list entries are pinned to observed DNS answers and TLS identity. `HostPattern::Any` is the only allow-list pattern that skips this host pinning. Empty allow-lists are rejected by the builder and treated as deny-all by the runtime.
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#hostpattern">HostPattern</a>
+    <a className="msb-typepill" href="#secretentry">SecretEntry</a>
+    <a className="msb-typepill" href="#secretinjection">SecretInjection</a>
+    <a className="msb-typepill" href="#violationaction">ViolationAction</a>
+    <a className="msb-typepill" href="#secretconfigerror">SecretConfigError</a>
+    <a className="msb-typepill" href="/sdk/rust/networking#violationactionbuilder">ViolationActionBuilder</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("agent")
+    .image("python")
+    .secret(|s| s
+        .env("OPENAI_API_KEY")             // guest sees $MSB_OPENAI_API_KEY
+        .value(std::env::var("OPENAI_API_KEY")?)
+        .allow_host("api.openai.com"))     // real value only reaches this host
+    .create()
+    .await?;
+
+// In the guest, the placeholder is swapped for the real key
+// only on TLS connections to api.openai.com.
+let out = sb.exec("python", ["agent.py"]).await?;
+```
+
+## Static methods
+
+---
+
+#### <span className="msb-recv">SecretBuilder::</span><span className="msb-hn">new()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
+
+```rust
+fn new() -> SecretBuilder
+```
+
+Start building a secret with defaults: no env var, no value, no allowed hosts, the default [`SecretInjection`](#secretinjection) (headers and Basic Auth on, query and body off), no per-secret violation override, and `require_tls_identity = true`. You rarely call this yourself: [`SandboxBuilder::secret(|s| s...)`](/sdk/rust/sandbox#secret) hands you a fresh builder and calls [`build()`](#build) for you. `SecretBuilder::default()` is equivalent.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#secretbuilder">SecretBuilder</a></div>
+    <div className="msb-param-desc">A builder with default injection scopes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::sandbox::SecretBuilder;
+
+let entry = SecretBuilder::new()
+    .env("STRIPE_KEY")
+    .value(stripe_key)
+    .allow_host("api.stripe.com")
+    .build();
+```
+
+---
 
 ## SecretBuilder
 
-Builder for configuring a secret's placeholder, allowed hosts, and injection scopes. Obtained through `SandboxBuilder::secret(|s| s...)`. Each secret maps an environment variable to a real value that is only revealed when traffic goes to an allowed host via the TLS proxy.
+Builder for one secret's placeholder, allowed hosts, and injection scopes. Obtained through [`SandboxBuilder::secret(|s| s...)`](/sdk/rust/sandbox#secret) or [`SecretBuilder::new()`](#secretbuildernew); each secret maps an environment variable to a real value that is only revealed when traffic reaches an allowed host through the TLS proxy. Every setter returns `Self`, so calls chain. [`env()`](#env), [`value()`](#value), and at least one allowed host are required; [`build()`](#build) panics otherwise.
+
+Import path: `microsandbox::sandbox::SecretBuilder`. Adding any secret automatically enables TLS interception.
 
 ---
 
-#### allow_any_host_dangerous()
-
-```rust
-fn allow_any_host_dangerous(self, i_understand_the_risk: bool) -> Self
-```
-
-Allow substitution on **any** host. This means any server the guest connects to will receive the real secret - effectively disabling host-based protection. Only use this when the secret is not sensitive or the sandbox network is fully locked down.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| i_understand_the_risk | `bool` | Must be `true` to take effect |
-
----
-
-#### allow_host()
-
-```rust
-fn allow_host(self, host: impl Into<String>) -> Self
-```
-
-Add a host that is allowed to receive the real secret value. The proxy checks the host against the connection's verified identity and observed DNS history. Can be called multiple times to allow multiple hosts.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| host | `impl Into<String>` | Exact hostname (e.g. `"api.example.com"`) |
-
----
-
-#### allow_host_pattern()
-
-```rust
-fn allow_host_pattern(self, pattern: impl Into<String>) -> Self
-```
-
-Add a wildcard host pattern. The `*` matches any subdomain prefix.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| pattern | `impl Into<String>` | Wildcard pattern (e.g. `"*.googleapis.com"`) |
-
----
-
-#### env()
+#### <span className="msb-recv">.</span><span className="msb-hn">env()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn env(self, var: impl Into<String>) -> Self
 ```
 
-Set the environment variable name that will hold the placeholder inside the guest. The guest sees `$MSB_<var>` (or a custom placeholder) - never the real value. Names must be non-empty and cannot contain `=` or NUL; shell-identifier syntax is not required. **Required.**
+Set the environment variable name that holds the placeholder inside the guest. The guest sees `$MSB_<var>` (or a custom [`placeholder`](#placeholder)), never the real value. Names must be non-empty and cannot contain `=` or NUL; shell-identifier syntax is not required since Linux only requires a `NAME=value` shape. **Required.**
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| var | `impl Into<String>` | Environment variable name (non-empty, no `=` or NUL) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>var</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Environment variable name (non-empty, no <code>=</code> or NUL).</div>
+  </div>
+</div>
 
 ---
 
-#### inject_basic_auth()
+#### <span className="msb-recv">.</span><span className="msb-hn">value()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn inject_basic_auth(self, enabled: bool) -> Self
+fn value(self, value: impl Into<String>) -> Self
 ```
 
-Control whether `Authorization: Basic <base64>` credentials are decoded, substituted in the decoded `user:password`, and re-encoded. Orthogonal to `inject_headers`: this flag handles the encoded-credentials case for Basic scheme; `inject_headers` handles literal substitution in any header line, including non-Basic Authorization schemes (`Bearer`, `Digest`).
+Set the real secret value. This is the string that replaces the placeholder when a request reaches an allowed host. It never enters the guest VM. **Required.**
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| enabled | `bool` | Default: `true` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">The actual credential or token.</div>
+  </div>
+</div>
 
 ---
 
-#### inject_body()
-
-```rust
-fn inject_body(self, enabled: bool) -> Self
-```
-
-Control whether the placeholder is replaced in HTTP request bodies. Body substitution applies only when microsandbox can inspect and rewrite the body safely. Encoded bodies are forwarded unchanged, and body placeholders in unsupported body formats are blocked instead of being leaked.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| enabled | `bool` | Default: `false` |
-
----
-
-#### inject_headers()
-
-```rust
-fn inject_headers(self, enabled: bool) -> Self
-```
-
-Control whether the placeholder is replaced anywhere in HTTP headers. This is the most common injection scope - covers `Authorization: Bearer $MSB_...` and similar patterns.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| enabled | `bool` | Default: `true` |
-
----
-
-#### inject_query()
-
-```rust
-fn inject_query(self, enabled: bool) -> Self
-```
-
-Control whether the placeholder is replaced in the URL query string (the `?key=value` portion of the request line).
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| enabled | `bool` | Default: `false` |
-
----
-
-#### placeholder()
+#### <span className="msb-recv">.</span><span className="msb-hn">placeholder()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn placeholder(self, placeholder: impl Into<String>) -> Self
 ```
 
-Override the auto-generated placeholder string. By default, microsandbox generates `$MSB_<env_var>`. Use this when you need a specific format or when the placeholder must match a particular byte length. Placeholders must be non-empty, may be up to 1024 bytes, and cannot contain NUL, CR, or LF.
+Override the auto-generated placeholder string. By default microsandbox generates `$MSB_<env_var>`. Use this when you need a specific format or when the placeholder must match a particular byte length. Placeholders must be non-empty, at most 1024 bytes ([`MAX_SECRET_PLACEHOLDER_BYTES`](#secretconfigerror)), and cannot contain NUL, CR, or LF.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| placeholder | `impl Into<String>` | Custom placeholder string: non-empty, up to 1024 bytes, no NUL/CR/LF |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>placeholder</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Custom placeholder string: non-empty, up to 1024 bytes, no NUL/CR/LF.</div>
+  </div>
+</div>
 
 ---
 
-#### require_tls_identity()
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_host()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn require_tls_identity(self, enabled: bool) -> Self
+fn allow_host(self, host: impl Into<String>) -> Self
 ```
 
-When `true`, the secret is only substituted on TLS-intercepted connections where the proxy has verified it is performing MITM. Bypassed TLS is opaque and does not receive request-body or header substitution. Disable only if you know the traffic is safe and the connection path explicitly supports non-TLS substitution.
+Add an exact host allowed to receive the real secret value. The proxy checks the host against the connection's verified TLS identity and observed DNS history. Can be called multiple times to allow several hosts. At least one allowed host (exact, pattern, or any) is required.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| enabled | `bool` | Default: `true` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Exact hostname, e.g. <code>"api.example.com"</code>. Becomes a <a className="msb-type" href="#hostpattern">HostPattern::Exact</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+.secret(|s| s
+    .env("STRIPE_KEY")
+    .value(stripe_key)
+    .allow_host("api.stripe.com")
+    .allow_host("files.stripe.com"))
+```
 
 ---
 
-#### on_violation()
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_host_pattern()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn allow_host_pattern(self, pattern: impl Into<String>) -> Self
+```
+
+Add a wildcard host pattern. A `*.suffix` pattern matches the suffix itself and any single-or-multi label subdomain of it.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pattern</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Wildcard pattern, e.g. <code>"*.googleapis.com"</code>. Becomes a <a className="msb-type" href="#hostpattern">HostPattern::Wildcard</a>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allow_any_host_dangerous()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn allow_any_host_dangerous(self, i_understand_the_risk: bool) -> Self
+```
+
+Allow substitution on **any** host. Every server the guest connects to can then receive the real secret, which effectively disables host-based protection. The call is a no-op unless `i_understand_the_risk` is `true`. Only use this when the secret is not sensitive or the sandbox network is fully locked down. Adds a [`HostPattern::Any`](#hostpattern) to the allow list, the one pattern that skips DNS and TLS-identity pinning.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>i_understand_the_risk</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Must be <code>true</code> to take effect.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">on_violation()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn on_violation(
@@ -194,79 +246,330 @@ fn on_violation(
 ) -> Self
 ```
 
-Configure violation behavior for this secret. This can override the sandbox-wide secret violation policy and can allow selected hosts to receive the placeholder unchanged:
+Configure violation behavior for this secret. Overrides the sandbox-wide secret violation policy and can let selected hosts receive the placeholder unchanged. See [`ViolationActionBuilder`](/sdk/rust/networking#violationactionbuilder) for the full set of `block_*` and `passthrough_*` methods.
+
+Passthrough hosts do **not** receive the real secret value; substitution still only happens for hosts configured with [`allow_host()`](#allow_host) or [`allow_host_pattern()`](#allow_host_pattern). When a per-secret passthrough policy does not match the request host, microsandbox falls back to the sandbox-wide secret violation action.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="/sdk/rust/networking#violationactionbuilder">FnOnce(ViolationActionBuilder)</a></div>
+    <div className="msb-param-desc">Configure the per-secret violation action.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```rust
 .secret(|s| s
     .env("API_KEY")
     .value(api_key)
     .allow_host("api.github.com")
-    .on_violation(|v| {
-        v.block_and_log()
-         .passthrough_host("api.anthropic.com")
-    })
-)
+    .on_violation(|v| v
+        .block_and_log()
+        .passthrough_host("api.anthropic.com")))
 ```
 
-Passthrough hosts do **not** receive the real secret value; substitution still only happens for hosts configured with [`allow_host()`](#allow_host) or [`allow_host_pattern()`](#allow_host_pattern).
-
-If a per-secret passthrough policy does not match the request host, microsandbox falls back to the sandbox-wide secret violation action. A per-secret passthrough rule cannot weaken a stricter global default such as `BlockAndTerminate`.
-
 ---
 
-## Request validation
-
-For intercepted HTTP traffic, each request's authority must match the TLS identity. Domain-fronting attempts are blocked before they reach upstream.
-
-Secret substitution is not performed inside TLS bypass streams, HTTP `CONNECT` tunnels, SOCKS tunnels, or plain HTTP connections. Those paths can still be constrained with network policy, and placeholder violations are enforced only where microsandbox can inspect the request bytes.
-
----
-
-#### value()
+#### <span className="msb-recv">.</span><span className="msb-hn">require_tls_identity()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn value(self, value: impl Into<String>) -> Self
+fn require_tls_identity(self, enabled: bool) -> Self
 ```
 
-Set the real secret value. This is the string that replaces the placeholder when a request reaches an allowed host. It never enters the guest VM. **Required.**
+When `true`, the secret is only substituted on TLS-intercepted connections where the proxy has verified it is performing MITM and the SNI matches an allowed host. Bypassed TLS is opaque and never receives substitution. Disable only when you know the traffic path is safe and explicitly supports non-TLS substitution. Default: `true`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| value | `impl Into<String>` | The actual credential or token |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Require verified TLS identity. Default: <code>true</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">inject_headers()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn inject_headers(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced anywhere in HTTP headers. This is the most common injection scope, covering `Authorization: Bearer $MSB_...` and similar patterns. Default: `true`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Substitute in headers. Default: <code>true</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">inject_basic_auth()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn inject_basic_auth(self, enabled: bool) -> Self
+```
+
+Control whether `Authorization: Basic <base64>` credentials are decoded, substituted in the decoded `user:password`, then re-encoded. Orthogonal to [`inject_headers`](#inject_headers): this flag handles the encoded-credentials case for the Basic scheme; `inject_headers` handles literal substitution in any header line, including non-Basic Authorization schemes (`Bearer`, `Digest`). Default: `true`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Substitute inside Basic Auth credentials. Default: <code>true</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">inject_query()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn inject_query(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced in the URL query string (the `?key=value` portion of the request line). Default: `false`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Substitute in query parameters. Default: <code>false</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">inject_body()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn inject_body(self, enabled: bool) -> Self
+```
+
+Control whether the placeholder is replaced in HTTP/1 request bodies. Fixed-length bodies up to 16 MiB are substituted and their `Content-Length` updated; larger fixed-length bodies are blocked. Chunked bodies are decoded and re-encoded with fresh chunk sizes. Encoded bodies pass through unchanged. HTTP/2 DATA-frame substitution is not supported, so matching body placeholders are blocked rather than leaked. Default: `false`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Substitute in request bodies. Default: <code>false</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn build(self) -> SecretEntry
+```
+
+Materialize the [`SecretEntry`](#secretentry). Called for you by [`SandboxBuilder::secret`](/sdk/rust/sandbox#secret), so you rarely call it directly. If [`placeholder`](#placeholder) was not set, it defaults to `$MSB_<env_var>`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#secretentry">SecretEntry</a></div>
+    <div className="msb-param-desc">The materialized secret entry.</div>
+  </div>
+</div>
+
+<p className="msb-label">Panics</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-desc">Panics if <code>env</code> or <code>value</code> was not set, or if the allow list is empty. Use <a className="msb-type" href="#allow_any_host_dangerous">allow_any_host_dangerous(true)</a> for an explicit any-host secret.</div>
+  </div>
+</div>
 
 ---
 
 ## Shorthand
 
-#### secret_env()
+Two convenience methods on [`SandboxBuilder`](/sdk/rust/sandbox#sandboxbuilder) for the common cases, so you don't have to spell out a [`SecretBuilder`](#secretbuilder) closure. Both automatically enable TLS interception.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">secret_env()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn secret_env(self, env_var: impl Into<String>, value: impl Into<String>, allowed_host: impl Into<String>) -> Self
+fn secret_env(
+    self,
+    env_var: impl Into<String>,
+    value: impl Into<String>,
+    allowed_host: impl Into<String>,
+) -> Self
 ```
 
-Convenience method on `SandboxBuilder`. Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`. Uses default injection scopes (headers enabled, body disabled).
+Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`. The placeholder is auto-generated as `$MSB_<env_var>` and the default injection scopes apply (headers and Basic Auth enabled, query and body disabled).
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| env_var | `impl Into<String>` | Environment variable name (non-empty, no `=` or NUL) |
-| value | `impl Into<String>` | Secret value |
-| allowed_host | `impl Into<String>` | Allowed destination host |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>env_var</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Environment variable name (non-empty, no <code>=</code> or NUL).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Secret value.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>allowed_host</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Allowed destination host (exact match).</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let sb = Sandbox::builder("agent")
+    .image("python")
+    .secret_env("OPENAI_API_KEY", api_key, "api.openai.com")
+    .create()
+    .await?;
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">secret_entry()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn secret_entry(self, entry: SecretEntry) -> Self
+```
+
+Add a pre-built [`SecretEntry`](#secretentry) directly. This is the escape hatch when you already have a materialized entry, for example one produced by [`SecretBuilder::build()`](#build), loaded from configuration, or constructed by hand for full control over the serialized shape. Both [`secret()`](/sdk/rust/sandbox#secret) and [`secret_env()`](#secret_env) funnel through this method. The entry is validated when the sandbox is built; an invalid one surfaces as a config error rather than a panic.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>entry</code><a className="msb-type" href="#secretentry">SecretEntry</a></div>
+    <div className="msb-param-desc">A materialized secret entry.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::sandbox::SecretBuilder;
+
+let entry = SecretBuilder::new()
+    .env("STRIPE_KEY")
+    .value(stripe_key)
+    .allow_host("api.stripe.com")
+    .build();
+
+let sb = Sandbox::builder("billing")
+    .image("python")
+    .secret_entry(entry)
+    .create()
+    .await?;
+```
 
 ---
 
 ## Types
 
+### HostPattern
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">used by <a href="#secretentry">SecretEntry</a> · <a href="#allow_host">allow_host()</a> · <a href="#allow_host_pattern">allow_host_pattern()</a> · <a href="/sdk/rust/networking#violationaction">ViolationAction</a></p>
+
+Matches a destination host anywhere a secret policy needs one. Allow-list patterns decide where the real value may be substituted; passthrough patterns (on [`ViolationAction`](#violationaction)) decide where the placeholder may be forwarded unchanged. Passthrough patterns never make a secret eligible for substitution. Exact and wildcard allow-list entries are pinned to observed DNS answers and TLS identity; `Any` is the only allow-list pattern that skips this pinning.
+
+| Variant | Builder methods | Matches |
+|---------|-----------------|---------|
+| `Exact(String)` | [`allow_host()`](#allow_host), `passthrough_host()` | That exact host, ASCII case-insensitive |
+| `Wildcard(String)` | [`allow_host_pattern()`](#allow_host_pattern), `passthrough_host_pattern()` | The suffix and its subdomains, e.g. `*.example.com` |
+| `Any` | [`allow_any_host_dangerous(true)`](#allow_any_host_dangerous), `passthrough_all_hosts(true)` | Every host |
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `matches` | `fn matches(&self, hostname: &str) -> bool` | Whether `hostname` matches this pattern (ASCII case-insensitive). |
+
+### SecretEntry
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">returned by <a href="#build">SecretBuilder::build()</a> · used by <a href="#secret_entry">secret_entry()</a></p>
+
+The materialized, serializable form of a secret that is handed to the network engine. The real `value` is redacted from the `Debug` output. Built for you by [`SecretBuilder`](#secretbuilder); construct it directly only when you need full control over the serialized shape, then pass it to [`secret_entry()`](#secret_entry).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `env_var` | `String` | Environment variable holding the placeholder. Non-empty, no `=` or NUL. |
+| `value` | `String` | The real secret value (never enters the guest). |
+| `placeholder` | `String` | What the guest sees. Non-empty, at most 1024 bytes, no NUL/CR/LF. |
+| `allowed_hosts` | `Vec<HostPattern>` | Hosts allowed to receive the real value. |
+| `injection` | [`SecretInjection`](#secretinjection) | Where in the request the value may be substituted. |
+| `on_violation` | `Option<ViolationAction>` | Per-secret violation override. `None` falls back to the sandbox-wide action. |
+| `require_tls_identity` | `bool` | Require verified TLS identity before substituting. Default: `true`. |
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `validate` | `fn validate(&self, secret_index: usize) -> Result<(), SecretConfigError>` | Validate this entry's env var, allowed hosts, and placeholder. |
+
+### SecretInjection
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">used by <a href="#secretentry">SecretEntry</a></p>
+
+Which parts of an outbound HTTP request the placeholder may be substituted in. Set through the [`inject_*`](#inject_headers) methods on [`SecretBuilder`](#secretbuilder).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `headers` | `bool` | `true` | Substitute anywhere in HTTP headers. |
+| `basic_auth` | `bool` | `true` | Substitute inside decoded `Authorization: Basic` credentials. |
+| `query_params` | `bool` | `false` | Substitute in the URL query string. |
+| `body` | `bool` | `false` | Substitute in HTTP/1 request bodies (see [`inject_body()`](#inject_body) for limits). |
+
 ### ViolationAction
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
 
-Configured globally via [`NetworkBuilder::on_secret_violation()`](/sdk/rust/networking#on_secret_violation) or per secret via [`SecretBuilder::on_violation()`](#on_violation). Determines what happens when the guest sends a request containing a secret placeholder to a host that is **not** in the secret's substitution allow list.
+<p className="msb-backref">used by <a href="#secretentry">SecretEntry</a> · <a href="#on_violation">on_violation()</a> · <a href="/sdk/rust/networking#violationactionbuilder">ViolationActionBuilder</a></p>
 
-| Value | Description |
-|-------|-------------|
-| `Block` | Silently drop the request. The guest sees a connection reset. This is the default. |
-| `BlockAndLog` | Drop the request and emit a warning log on the host side. |
+What happens when the guest sends a request containing a secret placeholder to a host that is **not** in the secret's substitution allow list. Built through [`ViolationActionBuilder`](/sdk/rust/networking#violationactionbuilder), set globally via [`NetworkBuilder::on_secret_violation()`](/sdk/rust/networking#on_secret_violation) or per secret via [`SecretBuilder::on_violation()`](#on_violation). Also documented on the [Networking](/sdk/rust/networking#violationaction) page.
+
+| Variant | Description |
+|---------|-------------|
+| `Block` | Silently drop the request. The guest sees a connection reset. |
+| `BlockAndLog` | Drop the request and emit a warning log on the host side. This is the default. |
 | `BlockAndTerminate` | Drop the request, log an error, and shut down the entire sandbox. |
-| `Passthrough(Vec<HostPattern>)` | Forward matching hosts with the placeholder unchanged. Non-matching hosts use the default secret violation action. |
+| `Passthrough(Vec<HostPattern>)` | Forward matching hosts with the placeholder unchanged. Non-matching hosts fall back to the default secret violation action. |
+
+### SecretConfigError
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">returned by <a href="#secretentry">SecretEntry::validate()</a></p>
+
+Why a secret entry failed validation. Each variant carries the offending `secret_index`. The placeholder ceiling is the public constant `MAX_SECRET_PLACEHOLDER_BYTES = 1024`.
+
+| Variant | Description |
+|---------|-------------|
+| `EmptyEnvVar` | The environment variable name is empty. |
+| `EnvVarContainsEquals` | The environment variable name contains `=`. |
+| `EnvVarContainsNul` | The environment variable name contains NUL. |
+| `MissingAllowedHosts` | No allowed hosts were configured. |
+| `EmptyPlaceholder` | The placeholder is empty. |
+| `PlaceholderTooLong` | The placeholder exceeds `MAX_SECRET_PLACEHOLDER_BYTES` (carries `actual_bytes`, `max_bytes`). |
+| `PlaceholderContainsNul` | The placeholder contains NUL. |
+| `PlaceholderContainsLineBreak` | The placeholder contains CR or LF. |

--- a/docs/sdk/rust/snapshots.mdx
+++ b/docs/sdk/rust/snapshots.mdx
@@ -3,340 +3,1184 @@ title: Snapshots
 description: Rust SDK - Snapshot API reference
 ---
 
-Disk-only snapshots of a sandbox that is not running. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Rust SDK reference.
+Capture a stopped sandbox's writable upper layer into a self-describing, content-addressed artifact on disk, then list, verify, export, import, or boot a fresh sandbox from it. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Rust SDK reference.
 
-```rust
-use microsandbox::{Sandbox, Snapshot, SnapshotHandle, SnapshotFormat};
-use microsandbox::snapshot::ExportOpts;
-```
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Static · Snapshot<span className="msb-ct">10</span></p>
+  <a className="msb-row" href="#snapshotbuilder"><span className="msb-rn">Snapshot::builder()</span><span className="msb-rg">configure a new snapshot</span></a>
+  <a className="msb-row" href="#snapshotcreate"><span className="msb-rn">Snapshot::create()</span><span className="msb-rg">create from a config</span></a>
+  <a className="msb-row" href="#snapshotopen"><span className="msb-rn">Snapshot::open()</span><span className="msb-rg">open an artifact</span></a>
+  <a className="msb-row" href="#snapshotget"><span className="msb-rn">Snapshot::get()</span><span className="msb-rg">handle from the index</span></a>
+  <a className="msb-row" href="#snapshotlist"><span className="msb-rn">Snapshot::list()</span><span className="msb-rg">indexed snapshots</span></a>
+  <a className="msb-row" href="#snapshotlist_dir"><span className="msb-rn">Snapshot::list_dir()</span><span className="msb-rg">artifacts in a directory</span></a>
+  <a className="msb-row" href="#snapshotremove"><span className="msb-rn">Snapshot::remove()</span><span className="msb-rg">delete an artifact</span></a>
+  <a className="msb-row" href="#snapshotreindex"><span className="msb-rn">Snapshot::reindex()</span><span className="msb-rg">rebuild the index</span></a>
+  <a className="msb-row" href="#snapshotexport"><span className="msb-rn">Snapshot::export()</span><span className="msb-rg">bundle to an archive</span></a>
+  <a className="msb-row" href="#snapshotimport"><span className="msb-rn">Snapshot::import()</span><span className="msb-rg">unpack an archive</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · Snapshot<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#snap-digest"><span className="msb-rn">snap.digest()</span><span className="msb-rg">content identity</span></a>
+  <a className="msb-row" href="#snap-path"><span className="msb-rn">snap.path()</span><span className="msb-rg">artifact directory</span></a>
+  <a className="msb-row" href="#snap-manifest"><span className="msb-rn">snap.manifest()</span><span className="msb-rg">parsed manifest</span></a>
+  <a className="msb-row" href="#snap-size_bytes"><span className="msb-rn">snap.size_bytes()</span><span className="msb-rg">upper-layer size</span></a>
+  <a className="msb-row" href="#snap-verify"><span className="msb-rn">snap.verify()</span><span className="msb-rg">recheck integrity</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · SnapshotHandle<span className="msb-ct">10</span></p>
+  <a className="msb-row" href="#h-digest"><span className="msb-rn">h.digest()</span><span className="msb-rg">manifest digest</span></a>
+  <a className="msb-row" href="#h-name"><span className="msb-rn">h.name()</span><span className="msb-rg">name alias</span></a>
+  <a className="msb-row" href="#h-parent_digest"><span className="msb-rn">h.parent_digest()</span><span className="msb-rg">parent snapshot</span></a>
+  <a className="msb-row" href="#h-image_ref"><span className="msb-rn">h.image_ref()</span><span className="msb-rg">source image</span></a>
+  <a className="msb-row" href="#h-format"><span className="msb-rn">h.format()</span><span className="msb-rg">upper format</span></a>
+  <a className="msb-row" href="#h-size_bytes"><span className="msb-rn">h.size_bytes()</span><span className="msb-rg">indexed size</span></a>
+  <a className="msb-row" href="#h-created_at"><span className="msb-rn">h.created_at()</span><span className="msb-rg">creation time</span></a>
+  <a className="msb-row" href="#h-path"><span className="msb-rn">h.path()</span><span className="msb-rg">artifact directory</span></a>
+  <a className="msb-row" href="#h-open"><span className="msb-rn">h.open()</span><span className="msb-rg">read the artifact</span></a>
+  <a className="msb-row" href="#h-remove"><span className="msb-rn">h.remove()</span><span className="msb-rg">delete this snapshot</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Sandbox entry points<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#from_snapshot"><span className="msb-rn">.from_snapshot()</span><span className="msb-rg">boot from a snapshot</span></a>
+  <a className="msb-row" href="#h-snapshot"><span className="msb-rn">h.snapshot()</span><span className="msb-rg">snapshot a stopped sandbox</span></a>
+  <a className="msb-row" href="#h-snapshot_to"><span className="msb-rn">h.snapshot_to()</span><span className="msb-rg">snapshot to a path</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SnapshotBuilder<span className="msb-ct">8</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#destination">.destination()</a>
+    <a className="msb-chip" href="#name">.name()</a>
+    <a className="msb-chip" href="#path">.path()</a>
+    <a className="msb-chip" href="#label">.label()</a>
+    <a className="msb-chip" href="#force">.force()</a>
+    <a className="msb-chip" href="#record_integrity">.record_integrity()</a>
+    <a className="msb-chip" href="#build">.build()</a>
+    <a className="msb-chip" href="#create">.create()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#snapshothandle">SnapshotHandle</a>
+    <a className="msb-typepill" href="#snapshotconfig">SnapshotConfig</a>
+    <a className="msb-typepill" href="#snapshotdestination">SnapshotDestination</a>
+    <a className="msb-typepill" href="#snapshotformat">SnapshotFormat</a>
+    <a className="msb-typepill" href="#exportopts">ExportOpts</a>
+    <a className="msb-typepill" href="#snapshotverifyreport">SnapshotVerifyReport</a>
+    <a className="msb-typepill" href="#upperverifystatus">UpperVerifyStatus</a>
+    <a className="msb-typepill" href="#manifest">Manifest</a>
+    <a className="msb-typepill" href="#imageref">ImageRef</a>
+    <a className="msb-typepill" href="#upperlayer">UpperLayer</a>
+    <a className="msb-typepill" href="#upperintegrity">UpperIntegrity</a>
+  </div>
+
+</div>
 
 <Note>
-  Snapshots are **disk-only** and require a sandbox that is not running.
+  Snapshots are **local-only** and **disk-only** today: they capture a sandbox that is stopped or crashed, and every operation runs against the default local backend. Cloud snapshots and qcow2 backing chains are deferred.
 </Note>
 
-## SandboxBuilder
-
----
-
-#### from_snapshot()
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```rust
-fn from_snapshot(self, src: impl Into<String>) -> Self
+use microsandbox::{Sandbox, Snapshot};
+
+// 1. stop the sandbox you want to capture
+let sb = Sandbox::get("api").await?;
+sb.stop().await?;
+
+// 2. capture its writable upper layer
+let snap = Snapshot::builder("api")
+    .name("after-pip-install")     // bare name in the default dir
+    .record_integrity()            // hash the upper layer
+    .create()
+    .await?;
+println!("{} ({} bytes)", snap.digest(), snap.size_bytes());
+
+// 3. boot a fresh sandbox from it
+let restored = Sandbox::builder("api-restored")
+    .from_snapshot("after-pip-install")
+    .create()
+    .await?;
 ```
 
-Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`image()`](/sdk/rust/sandbox#image) and [`image_with()`](/sdk/rust/sandbox#image-with) — the snapshot already pins the image.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| src | `impl Into<String>` | Bare name (resolved under `~/.microsandbox/snapshots/`) or filesystem path to an artifact directory |
+## Static methods
 
 ---
 
-## SandboxHandle methods
-
----
-
-#### snapshot()
-
-```rust
-async fn snapshot(&self, name: &str) -> MicrosandboxResult<Snapshot>
-```
-
-Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). The sandbox must be stopped or crashed. For an explicit filesystem destination see [`snapshot_to()`](#snapshot-to).
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| name | `&str` | Bare snapshot name |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Snapshot` | The created artifact handle |
-
-**Errors**
-
-- `MicrosandboxError::SnapshotSandboxRunning` — the sandbox is not stopped
-- `MicrosandboxError::SnapshotAlreadyExists` — destination already exists (use the builder with `.force()` to overwrite)
-
----
-
-#### snapshot_to()
-
-```rust
-async fn snapshot_to(&self, path: impl AsRef<Path>) -> MicrosandboxResult<Snapshot>
-```
-
-Snapshot this sandbox to an explicit filesystem path. The sandbox must be stopped or crashed. For the common case of writing under the default snapshots directory see [`snapshot()`](#snapshot).
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `impl AsRef<Path>` | Destination directory |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Snapshot` | The created artifact handle |
-
----
-
-## Snapshot (instance)
-
----
-
-#### path()
-
-```rust
-fn path(&self) -> &Path
-```
-
-Path to the artifact directory.
-
----
-
-#### digest()
-
-```rust
-fn digest(&self) -> &str
-```
-
-Canonical content digest (`sha256:hex`) over the manifest bytes. The snapshot's identity.
-
----
-
-#### manifest()
-
-```rust
-fn manifest(&self) -> &Manifest
-```
-
-Parsed manifest — image reference, image manifest digest, fstype, format, labels, upper-layer metadata, and optional integrity hash.
-
----
-
-#### size_bytes()
-
-```rust
-fn size_bytes(&self) -> u64
-```
-
-Apparent size of the captured upper layer in bytes (the ext4 virtual size, sparse on disk).
-
----
-
-#### verify()
-
-```rust
-async fn verify(&self) -> MicrosandboxResult<SnapshotVerifyReport>
-```
-
-Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds. Returns `NotRecorded` when the manifest has no integrity hash.
-
----
-
-## Snapshot::builder
-
----
-
-#### Snapshot::builder()
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">builder()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```rust
 fn builder(source_sandbox: impl Into<String>) -> SnapshotBuilder
 ```
 
-Start configuring a new snapshot. The fluent builder is the API the CLI uses internally.
+Start configuring a new snapshot of `source_sandbox`. The builder lets you set the destination, labels, and whether to record content integrity before capturing. See [`SnapshotBuilder`](#snapshotbuilder) for all options.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>source_sandbox</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Name of the source sandbox. Must be stopped or crashed, and rooted on an OCI image.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotbuilder">SnapshotBuilder</a></div>
+    <div className="msb-param-desc">Builder for configuring the snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```rust
-let snap = Snapshot::builder("baseline")
-    .name("after-pip-install")        // bare name in default dir
-    .label("stage", "post-deps")
-    .force()                           // overwrite if it exists
-    .record_integrity()                // hash the upper layer
+let snap = Snapshot::builder("api")
+    .name("baseline")
     .create()
     .await?;
 ```
 
-**Builder methods**
-
-| Method | Description |
-|--------|-------------|
-| `.destination(SnapshotDestination)` | Explicit destination variant |
-| `.name(&str)` | Convenience: bare name under the default snapshots directory |
-| `.path(PathBuf)` | Convenience: explicit filesystem path |
-| `.label(k, v)` | Add a `key=value` label (sorted in canonical form) |
-| `.force()` | Overwrite an existing artifact at the destination |
-| `.record_integrity()` | Compute and record a content-integrity hash at creation |
-
 ---
 
-## Snapshot (static)
-
----
-
-#### Snapshot::create()
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn create(config: SnapshotConfig) -> MicrosandboxResult<Snapshot>
 ```
 
-Create a snapshot from a [`SnapshotConfig`](#snapshotconfig). Equivalent to using the builder.
+Create a snapshot artifact from a stopped sandbox. Writes `manifest.json` and the captured `upper.ext4` into the destination directory atomically (the manifest is renamed into place last), then best-effort upserts a row into the local index. Index failures are logged but do not fail the call; the artifact is the source of truth. Most callers use the [builder](#snapshotbuilder)'s [`create()`](#create) instead of constructing a [`SnapshotConfig`](#snapshotconfig) by hand.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>config</code><a className="msb-type" href="#snapshotconfig">SnapshotConfig</a></div>
+    <div className="msb-param-desc">Source sandbox, destination, labels, and integrity flag.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Snapshot</a></div>
+    <div className="msb-param-desc">The created artifact handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let snap = Snapshot::create(
+    Snapshot::builder("api").name("baseline").build()?
+).await?;
+```
 
 ---
 
-#### Snapshot::open()
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">open()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn open(path_or_name: impl AsRef<str>) -> MicrosandboxResult<Snapshot>
 ```
 
-Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
+Open an existing artifact by path or bare name. Bare names (no path separator, not starting with `.` or `~`) resolve under the default snapshots directory; anything else is treated as a path. This is a fast metadata operation: it verifies the manifest structure, recomputes the manifest digest, and checks that the upper file exists with the recorded size. It does **not** read the full upper contents; use [`verify()`](#snap-verify) for that.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path_or_name</code><span className="msb-type">impl AsRef&lt;str&gt;</span></div>
+    <div className="msb-param-desc">Bare snapshot name or filesystem path to an artifact directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Snapshot</a></div>
+    <div className="msb-param-desc">The opened artifact handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let snap = Snapshot::open("baseline").await?;
+println!("{}", snap.manifest().image.reference);
+```
 
 ---
 
-#### Snapshot::get()
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">get()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn get(name_or_digest: &str) -> MicrosandboxResult<SnapshotHandle>
 ```
 
-Look up a handle in the local index by name, digest, or path.
+Look up a lightweight [`SnapshotHandle`](#snapshothandle) in the local index by name, digest (`sha256:`/`sha512:` prefix), or path.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name_or_digest</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Snapshot name, manifest digest, or artifact path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandle">SnapshotHandle</a></div>
+    <div className="msb-param-desc">Handle backed by the matching index row.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let h = Snapshot::get("after-pip-install").await?;
+println!("{} from {}", h.digest(), h.image_ref());
+```
 
 ---
 
-#### Snapshot::list()
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn list() -> MicrosandboxResult<Vec<SnapshotHandle>>
 ```
 
-List indexed snapshots from the local DB cache. External-path artifacts opened via `Snapshot::open(/some/path)` may not appear here unless they live under the configured snapshots directory.
+List indexed snapshots from the local DB cache, newest first. External-path artifacts booted by full path aren't in the index and won't appear here; use [`list_dir`](#snapshotlist_dir) to enumerate artifacts on disk directly.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandle">Vec&lt;SnapshotHandle&gt;</a></div>
+    <div className="msb-param-desc">Indexed snapshot handles, ordered by creation time descending.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+for h in Snapshot::list().await? {
+    println!("{:?} — {}", h.name(), h.digest());
+}
+```
 
 ---
 
-#### Snapshot::list_dir()
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">list_dir()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn list_dir(dir: impl AsRef<Path>) -> MicrosandboxResult<Vec<Snapshot>>
 ```
 
-Walk a directory and parse each subdirectory's manifest. Does not touch the index. Skips entries that don't look like snapshot artifacts.
+Walk a directory and parse each subdirectory's manifest. Does not touch the index. Skips entries that don't look like snapshot artifacts (no `manifest.json`) and malformed artifacts.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dir</code><span className="msb-type">impl AsRef&lt;Path&gt;</span></div>
+    <div className="msb-param-desc">Directory to scan for artifacts.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Vec&lt;Snapshot&gt;</a></div>
+    <div className="msb-param-desc">One handle per valid artifact found.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let snaps = Snapshot::list_dir("/data/snapshots").await?;
+println!("{} artifacts", snaps.len());
+```
 
 ---
 
-#### Snapshot::remove()
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn remove(path_or_name: &str, force: bool) -> MicrosandboxResult<()>
 ```
 
-Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force` is `true`.
+Remove a snapshot artifact (by digest, name, or path) and its index row. Refuses if the snapshot has indexed children unless `force` is set. The artifact directory is deleted on success and the parent's child count is decremented.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path_or_name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Snapshot digest, name, or artifact path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>force</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>true</code>, remove even if the snapshot has indexed children.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+Snapshot::remove("after-pip-install", false).await?;
+```
 
 ---
 
-#### Snapshot::reindex()
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">reindex()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn reindex(dir: impl AsRef<Path>) -> MicrosandboxResult<usize>
 ```
 
-Walk `dir`, upsert index rows for every artifact found, recompute parent-edge child counts. Returns the number of artifacts indexed.
+Rebuild the local index from the artifacts in `dir`. Upserts an index row for every artifact found, then recomputes parent-edge child counts in one pass so the cache stays honest about the current set of artifacts.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dir</code><span className="msb-type">impl AsRef&lt;Path&gt;</span></div>
+    <div className="msb-param-desc">Directory of artifacts to index.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">usize</span></div>
+    <div className="msb-param-desc">Number of artifacts indexed.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let n = Snapshot::reindex("/data/snapshots").await?;
+println!("indexed {n} snapshots");
+```
 
 ---
 
-#### Snapshot::export()
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">export()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn export(name_or_path: &str, out: &Path, opts: ExportOpts) -> MicrosandboxResult<()>
 ```
 
-Bundle a snapshot into a `.tar.zst` archive. The existing snapshot manifest is archived as-is; create the snapshot with recorded integrity when the archive will cross a trust boundary.
+Bundle a snapshot into a `.tar.zst` archive (or plain `.tar`) at `out`. The head snapshot is verified before bundling. The recorded manifest is archived as-is, so create the snapshot with [`record_integrity()`](#record_integrity) when the archive will cross a trust boundary. See [`ExportOpts`](#exportopts) to also include ancestors and the OCI image cache.
 
-**ExportOpts**
+<p className="msb-label">Parameters</p>
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `with_parents` | `bool` | Walk the parent chain and include each ancestor |
-| `with_image` | `bool` | Bundle the OCI image cache (`cache/{layers,fsmeta,vmdk}`) for offline transport |
-| `plain_tar` | `bool` | Skip zstd compression and write a plain `.tar` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name_or_path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Snapshot name or artifact path to export.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>out</code><span className="msb-type">&amp;Path</span></div>
+    <div className="msb-param-desc">Output archive path. Parent directories are created if missing.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#exportopts">ExportOpts</a></div>
+    <div className="msb-param-desc">Bundling options. <code>ExportOpts::default()</code> writes the head snapshot only, zstd-compressed.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::snapshot::ExportOpts;
+use std::path::Path;
+
+Snapshot::export(
+    "baseline",
+    Path::new("/tmp/baseline.tar.zst"),
+    ExportOpts { with_parents: true, with_image: true, ..Default::default() },
+).await?;
+```
 
 ---
 
-#### Snapshot::import()
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">import()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
-async fn import(archive: &Path, dest: Option<&Path>) -> MicrosandboxResult<SnapshotHandle>
+async fn import(archive_path: &Path, dest: Option<&Path>) -> MicrosandboxResult<SnapshotHandle>
 ```
 
-Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity when present. Compression is detected from magic bytes.
+Unpack a snapshot archive (`.tar.zst` or `.tar`, detected from magic bytes) into the snapshots directory (or `dest`), routing any bundled image-cache entries into the global cache and registering everything found in the index. Recorded integrity is verified as artifacts land. Returns a handle for the head snapshot.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>archive_path</code><span className="msb-type">&amp;Path</span></div>
+    <div className="msb-param-desc">Archive to unpack.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dest</code><span className="msb-type">Option&lt;&amp;Path&gt;</span></div>
+    <div className="msb-param-desc">Destination directory. <code>None</code> uses the default snapshots directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandle">SnapshotHandle</a></div>
+    <div className="msb-param-desc">Handle for the head (last-listed) snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use std::path::Path;
+
+let h = Snapshot::import(Path::new("/tmp/baseline.tar.zst"), None).await?;
+println!("imported {}", h.digest());
+```
 
 ---
 
-## SnapshotHandle
+## Instance methods
 
-Lightweight handle backed by an index row. Returned by [`Snapshot::list()`](#snapshotlist) and [`Snapshot::get()`](#snapshotget).
+Methods on an opened [`Snapshot`](#snapshotopen) artifact.
+
+---
+
+#### <span className="msb-recv">snap.</span><span className="msb-hn">digest()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
-let h = Snapshot::get("after-pip-install").await?;
-
-h.digest();           // &str — sha256:...
-h.name();             // Option<&str>
-h.parent_digest();    // Option<&str>
-h.image_ref();        // &str
-h.format();           // SnapshotFormat::Raw | Qcow2
-h.size_bytes();       // Option<u64>
-h.created_at();       // chrono::NaiveDateTime
-h.path();             // &Path
-
-let snap = h.open().await?;       // verify metadata, return Snapshot
-h.remove(false).await?;            // false = refuse if has children
+fn digest(&self) -> &str
 ```
+
+Canonical content digest of this snapshot's manifest (`sha256:hex`). This is the snapshot's identity.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Manifest digest in <code>sha256:hex</code> form.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">snap.</span><span className="msb-hn">path()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn path(&self) -> &Path
+```
+
+Path to the artifact directory holding the canonical `manifest.json` and the captured upper file.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">&amp;Path</span></div>
+    <div className="msb-param-desc">Artifact directory path.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">snap.</span><span className="msb-hn">manifest()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn manifest(&self) -> &Manifest
+```
+
+The parsed [`Manifest`](#manifest): schema, format, fstype, image reference, parent, creation time, labels, and upper-layer metadata.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#manifest">&amp;Manifest</a></div>
+    <div className="msb-param-desc">Parsed snapshot manifest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let snap = Snapshot::open("baseline").await?;
+let m = snap.manifest();
+println!("{} @ {}", m.image.reference, m.image.manifest_digest);
+```
+
+---
+
+#### <span className="msb-recv">snap.</span><span className="msb-hn">size_bytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn size_bytes(&self) -> u64
+```
+
+Apparent size of the captured upper layer in bytes (the ext4 virtual size; sparse on disk).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">u64</span></div>
+    <div className="msb-param-desc">Upper-layer apparent size in bytes.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">snap.</span><span className="msb-hn">verify()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn verify(&self) -> MicrosandboxResult<SnapshotVerifyReport>
+```
+
+Recompute the upper layer's content hash and compare it against the manifest. Walks data extents only, so a multi-GiB sparse file with a little data verifies in milliseconds. Returns `NotRecorded` when the manifest has no integrity descriptor; errors with `SnapshotIntegrity` on mismatch.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotverifyreport">SnapshotVerifyReport</a></div>
+    <div className="msb-param-desc">Digest, path, and upper-layer verification status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::snapshot::UpperVerifyStatus;
+
+let snap = Snapshot::open("baseline").await?;
+match snap.verify().await?.upper {
+    UpperVerifyStatus::Verified { algorithm, .. } => println!("ok via {algorithm}"),
+    UpperVerifyStatus::NotRecorded => println!("no integrity hash recorded"),
+}
+```
+
+---
+
+## SnapshotHandle methods
+
+Accessors and lifecycle on a [`SnapshotHandle`](#snapshothandle) (an index row). Returned by [`Snapshot::get()`](#snapshotget), [`Snapshot::list()`](#snapshotlist), and [`Snapshot::import()`](#snapshotimport).
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">digest()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn digest(&self) -> &str
+```
+
+Manifest digest (`sha256:hex`), the canonical identity.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">name()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn name(&self) -> Option<&str>
+```
+
+Name alias, or `None` for digest-only entries.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">parent_digest()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn parent_digest(&self) -> Option<&str>
+```
+
+The parent snapshot's digest, or `None` for a root. Always `None` today; populated once chained snapshots land.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">image_ref()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn image_ref(&self) -> &str
+```
+
+Image reference the snapshot was taken from.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">format()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn format(&self) -> SnapshotFormat
+```
+
+On-disk format of the upper layer.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotformat">SnapshotFormat</a></div>
+    <div className="msb-param-desc">Upper-layer format (<code>Raw</code> today).</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">size_bytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn size_bytes(&self) -> Option<u64>
+```
+
+Apparent size of the upper file at index time, if recorded.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">created_at()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn created_at(&self) -> chrono::NaiveDateTime
+```
+
+Snapshot creation time, parsed from the manifest.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">path()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn path(&self) -> &Path
+```
+
+Local artifact directory path.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">open()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn open(&self) -> MicrosandboxResult<Snapshot>
+```
+
+Open the underlying artifact metadata, upgrading this lightweight handle to a full [`Snapshot`](#instance-methods). Equivalent to [`Snapshot::open(self.path())`](#snapshotopen).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Snapshot</a></div>
+    <div className="msb-param-desc">The opened artifact.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let h = Snapshot::get("baseline").await?;
+let snap = h.open().await?;
+snap.verify().await?;
+```
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn remove(&self, force: bool) -> MicrosandboxResult<()>
+```
+
+Remove this snapshot. Delegates to [`Snapshot::remove(self.digest(), force)`](#snapshotremove).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>force</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>true</code>, remove even if the snapshot has indexed children.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let h = Snapshot::get("baseline").await?;
+h.remove(false).await?;
+```
+
+---
+
+## Sandbox entry points
+
+Snapshot-related methods that live on the sandbox builder and handle. See [Sandbox](/sdk/rust/sandbox) for the full sandbox API.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">from_snapshot()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn from_snapshot(self, path_or_name: impl Into<String>) -> Self
+```
+
+`SandboxBuilder` setter. Boot a fresh sandbox from a snapshot artifact. The snapshot already pins the image reference and digest, so this is mutually exclusive with [`image()`](/sdk/rust/sandbox#image) and [`image_with()`](/sdk/rust/sandbox#image_with). The artifact is opened and its integrity verified at [`create()`](/sdk/rust/sandbox#create) time, not here.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path_or_name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Bare name resolved under the default snapshots directory, or a path to an artifact directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let sb = Sandbox::builder("api-restored")
+    .from_snapshot("after-pip-install")
+    .create()
+    .await?;
+```
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">snapshot()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn snapshot(&self, name: &str) -> MicrosandboxResult<Snapshot>
+```
+
+`SandboxHandle` method. Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). The sandbox must be stopped or crashed; running sandboxes are rejected with `SnapshotSandboxRunning`. Local handles only. For an explicit destination see [`snapshot_to()`](#h-snapshot_to).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Bare snapshot name.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Snapshot</a></div>
+    <div className="msb-param-desc">The created artifact handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let h = Sandbox::get("api").await?;
+h.stop().await?;
+let snap = h.snapshot("baseline").await?;
+```
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">snapshot_to()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn snapshot_to(&self, path: impl AsRef<Path>) -> MicrosandboxResult<Snapshot>
+```
+
+`SandboxHandle` method. Snapshot this sandbox to an explicit filesystem path. The sandbox must be stopped or crashed. Local handles only. For the common case of writing under the default snapshots directory see [`snapshot()`](#h-snapshot).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">impl AsRef&lt;Path&gt;</span></div>
+    <div className="msb-param-desc">Destination artifact directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Snapshot</a></div>
+    <div className="msb-param-desc">The created artifact handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let h = Sandbox::get("api").await?;
+h.stop().await?;
+let snap = h.snapshot_to("/data/snapshots/baseline").await?;
+```
+
+---
+
+## SnapshotBuilder
+
+Builder for a [`SnapshotConfig`](#snapshotconfig). Obtained via [`Snapshot::builder(source_sandbox)`](#snapshotbuilder). A destination is required ([`name`](#name) or [`path`](#path)); the other setters are optional. Every setter returns `Self`, so calls chain.
+
+```rust
+let snap = Snapshot::builder("api")
+    .name("after-pip-install")     // bare name in default dir
+    .label("stage", "post-deps")
+    .force()                       // overwrite if it exists
+    .record_integrity()            // hash the upper layer
+    .create()
+    .await?;
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">destination()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn destination(self, dest: SnapshotDestination) -> Self
+```
+
+Set the artifact destination explicitly. The [`name`](#name) and [`path`](#path) setters are convenience wrappers over this.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dest</code><a className="msb-type" href="#snapshotdestination">SnapshotDestination</a></div>
+    <div className="msb-param-desc">Name- or path-based destination.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">name()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn name(self, name: impl Into<String>) -> Self
+```
+
+Convenience: use a bare name resolved under the default snapshots directory. Sets the destination to [`SnapshotDestination::Name`](#snapshotdestination).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Bare snapshot name. Must not be empty, contain <code>/</code>, or start with <code>.</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">path()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn path(self, path: impl Into<PathBuf>) -> Self
+```
+
+Convenience: write the artifact to an explicit path. Sets the destination to [`SnapshotDestination::Path`](#snapshotdestination).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">impl Into&lt;PathBuf&gt;</span></div>
+    <div className="msb-param-desc">Destination artifact directory.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">label()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn label(self, key: impl Into<String>, value: impl Into<String>) -> Self
+```
+
+Add a user label. Can be called multiple times. Labels are sorted by key in the manifest's canonical form.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Label key.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Label value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">force()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn force(self) -> Self
+```
+
+Overwrite an existing artifact at the destination. Without this, creation fails with `SnapshotAlreadyExists` if the destination directory exists.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">record_integrity()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn record_integrity(self) -> Self
+```
+
+Compute and record an upper-layer content-integrity hash during creation. Recorded integrity is what [`verify()`](#snap-verify) checks and what import/export rely on when crossing a trust boundary.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn build(self) -> MicrosandboxResult<SnapshotConfig>
+```
+
+Materialize the [`SnapshotConfig`](#snapshotconfig) without creating the snapshot. Errors with `InvalidConfig` if no destination was set. For capturing, use [`create`](#create) instead; it calls `build` internally.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotconfig">SnapshotConfig</a></div>
+    <div className="msb-param-desc">Validated snapshot configuration.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn create(self) -> MicrosandboxResult<Snapshot>
+```
+
+Build and execute the snapshot in one step. Equivalent to [`Snapshot::create(self.build()?)`](#snapshotcreate).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Snapshot</a></div>
+    <div className="msb-param-desc">The created artifact handle.</div>
+  </div>
+</div>
 
 ---
 
 ## Types
 
-#### SnapshotDestination
+### SnapshotHandle
 
-```rust
-pub enum SnapshotDestination {
-    Name(String),
-    Path(PathBuf),
-}
-```
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-Used by [`SnapshotBuilder::destination()`](#snapshotbuilder). The handle methods [`snapshot()`](#snapshot) and [`snapshot_to()`](#snapshot-to) construct this enum internally so callers don't need to import it.
+<p className="msb-backref">Returned by <a href="#snapshotget">Snapshot::get()</a> · <a href="#snapshotlist">Snapshot::list()</a> · <a href="#snapshotimport">Snapshot::import()</a></p>
 
-#### SnapshotFormat
+A lightweight handle backed by a local index row. Use [`open()`](#h-open) to read the artifact metadata, and [`Snapshot::verify()`](#snap-verify) for explicit content verification. All accessors are listed under [SnapshotHandle methods](#snapshothandle-methods).
 
-```rust
-pub enum SnapshotFormat {
-    Raw,
-    Qcow2,
-}
-```
+| Method | Type | Description |
+|--------|------|-------------|
+| digest() | `&str` | Manifest digest (`sha256:hex`) |
+| name() | `Option<&str>` | Name alias; `None` for digest-only entries |
+| parent_digest() | `Option<&str>` | Parent snapshot digest, or `None` for a root |
+| image_ref() | `&str` | Source image reference |
+| format() | [`SnapshotFormat`](#snapshotformat) | On-disk upper format |
+| size_bytes() | `Option<u64>` | Upper file size at index time |
+| created_at() | `chrono::NaiveDateTime` | Creation time from the manifest |
+| path() | `&Path` | Local artifact directory |
+| open() | `Result<`[`Snapshot`](#instance-methods)`>` | Open the underlying artifact |
+| remove(force) | `Result<()>` | Remove this snapshot |
 
-Snapshots currently emit `Raw`.
+### SnapshotConfig
 
-#### SnapshotVerifyReport
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-```rust
-pub struct SnapshotVerifyReport {
-    pub digest: String,
-    pub path: PathBuf,
-    pub upper: UpperVerifyStatus,
-}
+<p className="msb-backref">Used by <a href="#snapshotcreate">Snapshot::create()</a> · returned by <a href="#build">build()</a></p>
 
-pub enum UpperVerifyStatus {
-    NotRecorded,
-    Verified { algorithm: String, digest: String },
-}
-```
+Inputs to create a snapshot. A type alias for `SnapshotSpec`. Usually built via [`SnapshotBuilder`](#snapshotbuilder) rather than constructed directly.
 
-Returned by [`Snapshot::verify()`](#verify).
+| Field | Type | Description |
+|-------|------|-------------|
+| source_sandbox | `String` | Name of the source sandbox; must be stopped |
+| destination | [`SnapshotDestination`](#snapshotdestination) | Where to write the artifact |
+| labels | `Vec<(String, String)>` | User-supplied labels |
+| force | `bool` | Overwrite an existing artifact at the destination |
+| record_integrity | `bool` | Compute and record upper-layer integrity at creation |
+
+### SnapshotDestination
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#destination">destination()</a> · <a href="#snapshotconfig">SnapshotConfig.destination</a></p>
+
+Where to place a new snapshot artifact. The builder's [`name()`](#name) and [`path()`](#path), and the handle's [`snapshot()`](#h-snapshot) / [`snapshot_to()`](#h-snapshot_to), construct this enum internally so callers rarely import it.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Name` | `String` | Bare name resolved under the default snapshots directory |
+| `Path` | `PathBuf` | Explicit absolute or relative path to the artifact directory |
+
+### SnapshotFormat
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#h-format">format()</a> · <a href="#manifest">Manifest.format</a></p>
+
+On-disk format of the captured upper layer. Today only `Raw` is produced; the variant exists so qcow2 chains drop in later without a schema migration.
+
+| Value | Description |
+|-------|-------------|
+| `Raw` | Raw ext4 image, sparse on disk |
+| `Qcow2` | qcow2 with optional backing chain (future) |
+
+### ExportOpts
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#snapshotexport">Snapshot::export()</a></p>
+
+Options for [`Snapshot::export()`](#snapshotexport). Implements `Default`; `ExportOpts::default()` writes the head snapshot only, zstd-compressed.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| with_parents | `bool` | Walk the parent chain and include each ancestor in the archive |
+| with_image | `bool` | Bundle the OCI image artifacts (EROFS layers, fsmeta, VMDK descriptor) from the global cache so the archive boots offline |
+| plain_tar | `bool` | Skip zstd compression and write a plain `.tar`. Default: zstd |
+
+### SnapshotVerifyReport
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#snap-verify">verify()</a></p>
+
+Result of explicit snapshot verification.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| digest | `String` | Snapshot manifest digest |
+| path | `PathBuf` | Artifact directory |
+| upper | [`UpperVerifyStatus`](#upperverifystatus) | Upper-layer content verification result |
+
+### UpperVerifyStatus
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#snapshotverifyreport">SnapshotVerifyReport.upper</a></p>
+
+Upper-layer content verification result.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `NotRecorded` | - | No content integrity descriptor was recorded in the manifest |
+| `Verified` | - `algorithm: String` <br/> - `digest: String` | Recorded integrity matched the computed digest |
+
+### Manifest
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#snap-manifest">manifest()</a></p>
+
+The snapshot artifact manifest, the source of truth for an artifact. Re-exported as `microsandbox::snapshot::Manifest`. Its SHA-256 digest over the canonical byte form is the snapshot's identity. Field order is load-bearing (it determines the canonical byte layout) and must not be reordered.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| schema | `u32` | Manifest schema version; readers reject unknown values |
+| format | [`SnapshotFormat`](#snapshotformat) | On-disk format of the upper layer |
+| fstype | `String` | Filesystem type inside the upper (e.g. `ext4`) |
+| image | [`ImageRef`](#imageref) | Image the snapshot was taken from |
+| parent | `Option<String>` | Parent snapshot digest, or `None` for a root |
+| created_at | `String` | RFC 3339 creation timestamp |
+| labels | `BTreeMap<String, String>` | User-supplied labels, sorted by key in canonical form |
+| upper | [`UpperLayer`](#upperlayer) | The captured upper layer |
+| source_sandbox | `Option<String>` | Best-effort name of the source sandbox (informational) |
+
+### ImageRef
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#manifest">Manifest.image</a></p>
+
+Reference to the OCI image the snapshot was taken from. Re-exported as `microsandbox::snapshot::ImageRef`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| reference | `String` | Human-readable image reference (e.g. `docker.io/library/python:3.12`) |
+| manifest_digest | `String` | Digest of the OCI manifest, in `sha256:hex` form |
+
+### UpperLayer
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#manifest">Manifest.upper</a></p>
+
+Captured upper-layer file metadata. Re-exported as `microsandbox::snapshot::UpperLayer`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| file | `String` | Filename inside the artifact directory (e.g. `upper.ext4`) |
+| size_bytes | `u64` | Apparent size in bytes (ext4 virtual size; sparse on disk) |
+| integrity | `Option<`[`UpperIntegrity`](#upperintegrity)`>` | Optional content integrity descriptor; `None` on local hot paths |
+
+### UpperIntegrity
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#upperlayer">UpperLayer.integrity</a></p>
+
+Content integrity descriptor for the captured upper layer.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| algorithm | `String` | Digest algorithm name (e.g. `msb-sparse-sha256-v1`) |
+| digest | `String` | Algorithm output, in `sha256:hex` form for current algorithms |

--- a/docs/sdk/rust/ssh.mdx
+++ b/docs/sdk/rust/ssh.mdx
@@ -3,51 +3,177 @@ title: SSH
 description: Rust SDK - SSH API reference
 ---
 
-See [SSH](/sandboxes/ssh) for usage flows.
+Reach a running sandbox over SSH: open a native in-process SSH client, run exec requests, attach an interactive shell, transfer files over SFTP, or stand up a reusable SSH server endpoint. Requires the `ssh` feature. See [SSH](/sandboxes/ssh) for usage flows.
 
 ```toml
-microsandbox = { version = "0.4.6", features = ["ssh"] }
+microsandbox = { version = "0.5.8", features = ["ssh"] }
+```
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Sandbox<span className="msb-ct">1</span></p>
+  <a className="msb-row" href="#sb-ssh"><span className="msb-rn">sb.ssh()</span><span className="msb-rg">SSH namespace for this sandbox</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SandboxSsh<span className="msb-ct">8</span></p>
+  <a className="msb-row" href="#ssh-connect"><span className="msb-rn">ssh.connect()</span><span className="msb-rg">open a client</span></a>
+  <a className="msb-row" href="#ssh-open_client"><span className="msb-rn">ssh.open_client()</span><span className="msb-rg">alias of connect()</span></a>
+  <a className="msb-row" href="#ssh-connect_with"><span className="msb-rn">ssh.connect_with()</span><span className="msb-rg">open a client with options</span></a>
+  <a className="msb-row" href="#ssh-open_client_with"><span className="msb-rn">ssh.open_client_with()</span><span className="msb-rg">alias of connect_with()</span></a>
+  <a className="msb-row" href="#ssh-server"><span className="msb-rn">ssh.server()</span><span className="msb-rg">prepare a server endpoint</span></a>
+  <a className="msb-row" href="#ssh-prepare_server"><span className="msb-rn">ssh.prepare_server()</span><span className="msb-rg">alias of server()</span></a>
+  <a className="msb-row" href="#ssh-server_with"><span className="msb-rn">ssh.server_with()</span><span className="msb-rg">server endpoint with options</span></a>
+  <a className="msb-row" href="#ssh-prepare_server_with"><span className="msb-rn">ssh.prepare_server_with()</span><span className="msb-rg">alias of server_with()</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SshClient<span className="msb-ct">6</span></p>
+  <a className="msb-row" href="#client-exec"><span className="msb-rn">client.exec()</span><span className="msb-rg">run a command</span></a>
+  <a className="msb-row" href="#client-exec_with"><span className="msb-rn">client.exec_with()</span><span className="msb-rg">run with options</span></a>
+  <a className="msb-row" href="#client-attach"><span className="msb-rn">client.attach()</span><span className="msb-rg">interactive shell</span></a>
+  <a className="msb-row" href="#client-attach_with"><span className="msb-rn">client.attach_with()</span><span className="msb-rg">attach with options</span></a>
+  <a className="msb-row" href="#client-sftp"><span className="msb-rn">client.sftp()</span><span className="msb-rg">open an SFTP session</span></a>
+  <a className="msb-row" href="#client-close"><span className="msb-rn">client.close()</span><span className="msb-rg">close the session</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SshServer · SshStdioStream<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#server-serve"><span className="msb-rn">server.serve()</span><span className="msb-rg">serve one connection</span></a>
+  <a className="msb-row" href="#server-serve_connection"><span className="msb-rn">server.serve_connection()</span><span className="msb-rg">alias of serve()</span></a>
+  <a className="msb-row" href="#sshstdiostreamnew"><span className="msb-rn">SshStdioStream::new()</span><span className="msb-rg">stdin/stdout transport</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Option builders<span className="msb-ct">16</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#sshclientoptionsbuilder">client.user()</a>
+    <a className="msb-chip" href="#sshclientoptionsbuilder">client.term()</a>
+    <a className="msb-chip" href="#sshclientoptionsbuilder">client.sftp()</a>
+    <a className="msb-chip" href="#sshexecoptionsbuilder">exec.tty()</a>
+    <a className="msb-chip" href="#sshattachoptionsbuilder">attach.term()</a>
+    <a className="msb-chip" href="#sshattachoptionsbuilder">attach.detach_keys()</a>
+    <a className="msb-chip" href="#sshserveroptionsbuilder">srv.host_key_path()</a>
+    <a className="msb-chip" href="#sshserveroptionsbuilder">srv.host_key()</a>
+    <a className="msb-chip" href="#sshserveroptionsbuilder">srv.authorized_keys_path()</a>
+    <a className="msb-chip" href="#sshserveroptionsbuilder">srv.authorized_key()</a>
+    <a className="msb-chip" href="#sshserveroptionsbuilder">srv.user()</a>
+    <a className="msb-chip" href="#sshserveroptionsbuilder">srv.sftp()</a>
+    <a className="msb-more" href="#sshserveroptionsbuilder">+ build() on each builder</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Constants<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#default_ssh_host"><span className="msb-rn">DEFAULT_SSH_HOST</span><span className="msb-rg">default listener host</span></a>
+  <a className="msb-row" href="#default_ssh_port"><span className="msb-rn">DEFAULT_SSH_PORT</span><span className="msb-rg">default listener port</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#sandboxssh">SandboxSsh</a>
+    <a className="msb-typepill" href="#sshclient">SshClient</a>
+    <a className="msb-typepill" href="#sshserver">SshServer</a>
+    <a className="msb-typepill" href="#sshoutput">SshOutput</a>
+    <a className="msb-typepill" href="#sftpclient">SftpClient</a>
+    <a className="msb-typepill" href="#sshstdiostream">SshStdioStream</a>
+    <a className="msb-typepill" href="#sshclientoptionsbuilder">SshClientOptionsBuilder</a>
+    <a className="msb-typepill" href="#sshexecoptionsbuilder">SshExecOptionsBuilder</a>
+    <a className="msb-typepill" href="#sshattachoptionsbuilder">SshAttachOptionsBuilder</a>
+    <a className="msb-typepill" href="#sshserveroptionsbuilder">SshServerOptionsBuilder</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("api")
+    .image("python")
+    .create()
+    .await?;
+
+let client = sb.ssh().connect().await?;     // 1. open an SSH client
+let out = client.exec("python -V").await?;   // 2. run a command
+println!("{}", String::from_utf8_lossy(&out.stdout));
+
+client.close().await?;                       // 3. close the session
 ```
 
 ## Sandbox
 
 ---
 
-#### ssh()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">ssh()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```rust
-fn ssh(&self) -> SandboxSshOps
+fn ssh(&self) -> SandboxSsh
 ```
 
-Return the SSH namespace for this sandbox.
+Return the SSH namespace for this sandbox. The namespace holds the SSH client and server helpers; nothing connects until you call [`connect`](#ssh-connect) or [`server`](#ssh-server).
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxSshOps`](#sandboxssh) | SSH client and server helpers |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxssh">SandboxSsh</a></div>
+    <div className="msb-param-desc">SSH namespace for this sandbox.</div>
+  </div>
+</div>
 
-## SandboxSshOps
+<p className="msb-label">Example</p>
+
+```rust
+let client = sb.ssh().connect().await?;
+```
+
+## SandboxSsh
+
+SSH namespace for a sandbox, obtained from [`sb.ssh()`](#sb-ssh). SSH is only supported on local sandboxes; calls error with `Unsupported` against a cloud backend.
 
 ---
 
-#### connect()
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">connect()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn connect(&self) -> MicrosandboxResult<SshClient>
 ```
 
-Connect a native in-process SSH client to the sandbox.
+Connect a native in-process SSH client to this sandbox. Generates an ephemeral Ed25519 client and host key pair, stands up an internal server bound to a duplex stream, and authenticates over public key. Uses default client options (user `root`, terminal from `$TERM`, SFTP enabled).
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SshClient`](#sshclient) | Native SSH client session |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshclient">SshClient</a></div>
+    <div className="msb-param-desc">Connected SSH client session.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let client = sb.ssh().connect().await?;
+let out = client.exec("uname -a").await?;
+```
 
 ---
 
-#### connect_with()
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">open_client()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn open_client(&self) -> MicrosandboxResult<SshClient>
+```
+
+Alias for [`connect`](#ssh-connect).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshclient">SshClient</a></div>
+    <div className="msb-param-desc">Connected SSH client session.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">connect_with()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn connect_with(
@@ -56,39 +182,118 @@ async fn connect_with(
 ) -> MicrosandboxResult<SshClient>
 ```
 
-Connect a native SSH client with custom client options.
+Connect a native in-process SSH client with custom options. The closure configures the login user, terminal name, and whether SFTP is enabled on the internal server.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| f | `FnOnce(SshClientOptionsBuilder) -> SshClientOptionsBuilder` | Configure user, terminal, and SFTP support |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#sshclientoptionsbuilder">FnOnce(SshClientOptionsBuilder)</a></div>
+    <div className="msb-param-desc">Configure user, terminal, and SFTP support.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SshClient`](#sshclient) | Native SSH client session |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshclient">SshClient</a></div>
+    <div className="msb-param-desc">Connected SSH client session.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let client = sb.ssh().connect_with(|opts| opts
+    .user("app")
+    .term("xterm-256color")).await?;
+```
 
 ---
 
-#### server()
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">open_client_with()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn open_client_with(
+    &self,
+    f: impl FnOnce(SshClientOptionsBuilder) -> SshClientOptionsBuilder,
+) -> MicrosandboxResult<SshClient>
+```
+
+Alias for [`connect_with`](#ssh-connect_with).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#sshclientoptionsbuilder">FnOnce(SshClientOptionsBuilder)</a></div>
+    <div className="msb-param-desc">Configure user, terminal, and SFTP support.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshclient">SshClient</a></div>
+    <div className="msb-param-desc">Connected SSH client session.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">server()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn server(&self) -> MicrosandboxResult<SshServer>
 ```
 
-Prepare a reusable SSH server endpoint for this sandbox.
+Prepare a reusable SSH server endpoint for this sandbox. Loads or creates the host key and resolves authorized keys from the default authorized-keys file. The returned [`SshServer`](#sshserver) is cloneable and can serve many connections.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SshServer`](#sshserver) | Reusable SSH server endpoint |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshserver">SshServer</a></div>
+    <div className="msb-param-desc">Reusable SSH server endpoint.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let server = sb.ssh().server().await?;
+let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+server.serve(server_io).await?;
+```
 
 ---
 
-#### server_with()
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">prepare_server()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn prepare_server(&self) -> MicrosandboxResult<SshServer>
+```
+
+Alias for [`server`](#ssh-server).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshserver">SshServer</a></div>
+    <div className="msb-param-desc">Reusable SSH server endpoint.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">server_with()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn server_with(
@@ -97,47 +302,111 @@ async fn server_with(
 ) -> MicrosandboxResult<SshServer>
 ```
 
-Prepare a server endpoint with custom host-key, authorization, user, or SFTP options.
+Prepare a server endpoint with custom host-key, authorization, guest-user, or SFTP options. If no authorized keys are configured, the default authorized-keys file is loaded; an empty key set is an error.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| f | `FnOnce(SshServerOptionsBuilder) -> SshServerOptionsBuilder` | Configure server options |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#sshserveroptionsbuilder">FnOnce(SshServerOptionsBuilder)</a></div>
+    <div className="msb-param-desc">Configure host key, authorized keys, guest user, and SFTP.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SshServer`](#sshserver) | Reusable SSH server endpoint |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshserver">SshServer</a></div>
+    <div className="msb-param-desc">Reusable SSH server endpoint.</div>
+  </div>
+</div>
 
-## SshClient
+<p className="msb-label">Example</p>
+
+```rust
+let server = sb.ssh().server_with(|opts| opts
+    .authorized_key("ssh-ed25519 AAAAC3Nza...")
+    .user("app")
+    .sftp(false)).await?;
+```
 
 ---
 
-#### exec()
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">prepare_server_with()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn prepare_server_with(
+    &self,
+    f: impl FnOnce(SshServerOptionsBuilder) -> SshServerOptionsBuilder,
+) -> MicrosandboxResult<SshServer>
+```
+
+Alias for [`server_with`](#ssh-server_with).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#sshserveroptionsbuilder">FnOnce(SshServerOptionsBuilder)</a></div>
+    <div className="msb-param-desc">Configure host key, authorized keys, guest user, and SFTP.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshserver">SshServer</a></div>
+    <div className="msb-param-desc">Reusable SSH server endpoint.</div>
+  </div>
+</div>
+
+## SshClient
+
+A connected, native in-process SSH client session, obtained from [`connect`](#ssh-connect) or [`connect_with`](#ssh-connect_with). Aborts its internal server task on drop.
+
+---
+
+#### <span className="msb-recv">client.</span><span className="msb-hn">exec()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn exec(&self, command: impl Into<String>) -> MicrosandboxResult<SshOutput>
 ```
 
-Run an SSH exec request and collect stdout, stderr, and exit status.
+Run an SSH exec request and collect stdout, stderr, and the exit status. The command is run through the sandbox's configured shell (default `/bin/sh -c`). No PTY is requested.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| command | `impl Into<String>` | Command string sent through SSH |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>command</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Command string sent through SSH.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SshOutput`](#sshoutput) | Captured output and status |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshoutput">SshOutput</a></div>
+    <div className="msb-param-desc">Captured output and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let out = client.exec("echo hello").await?;
+println!("exit {}: {}", out.status, String::from_utf8_lossy(&out.stdout));
+```
 
 ---
 
-#### exec_with()
+#### <span className="msb-recv">client.</span><span className="msb-hn">exec_with()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn exec_with(
@@ -147,40 +416,67 @@ async fn exec_with(
 ) -> MicrosandboxResult<SshOutput>
 ```
 
-Run an SSH exec request with options.
+Run an SSH exec request with options. The closure can request a PTY via [`tty`](#sshexecoptionsbuilder); when a PTY is allocated, stderr is folded into stdout.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| command | `impl Into<String>` | Command string sent through SSH |
-| f | `FnOnce(SshExecOptionsBuilder) -> SshExecOptionsBuilder` | Configure exec options |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>command</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Command string sent through SSH.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#sshexecoptionsbuilder">FnOnce(SshExecOptionsBuilder)</a></div>
+    <div className="msb-param-desc">Configure exec options.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SshOutput`](#sshoutput) | Captured output and status |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshoutput">SshOutput</a></div>
+    <div className="msb-param-desc">Captured output and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let out = client.exec_with("top -bn1", |opts| opts.tty(true)).await?;
+```
 
 ---
 
-#### attach()
+#### <span className="msb-recv">client.</span><span className="msb-hn">attach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn attach(&self) -> MicrosandboxResult<i32>
 ```
 
-Attach the local terminal to an interactive SSH shell.
+Attach the local terminal to an interactive SSH shell. Requests a PTY sized to the current terminal, puts the terminal into raw mode, forwards keystrokes, relays window-resize events, and returns when the shell exits or the default detach key sequence is typed.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `i32` | Exit code |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">i32</span></div>
+    <div className="msb-param-desc">Shell exit code (128 if terminated by signal).</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let code = client.attach().await?;
+println!("shell exited with {code}");
+```
 
 ---
 
-#### attach_with()
+#### <span className="msb-recv">client.</span><span className="msb-hn">attach_with()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn attach_with(
@@ -189,108 +485,324 @@ async fn attach_with(
 ) -> MicrosandboxResult<i32>
 ```
 
-Attach with terminal options.
+Attach an interactive shell with custom terminal and detach-key options.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| f | `FnOnce(SshAttachOptionsBuilder) -> SshAttachOptionsBuilder` | Configure terminal and detach keys |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#sshattachoptionsbuilder">FnOnce(SshAttachOptionsBuilder)</a></div>
+    <div className="msb-param-desc">Configure terminal name and detach keys.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `i32` | Exit code |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">i32</span></div>
+    <div className="msb-param-desc">Shell exit code (128 if terminated by signal).</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let code = client.attach_with(|opts| opts
+    .term("xterm-256color")
+    .detach_keys("ctrl-p,ctrl-q")).await?;
+```
 
 ---
 
-#### sftp()
+#### <span className="msb-recv">client.</span><span className="msb-hn">sftp()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn sftp(&self) -> MicrosandboxResult<SftpClient>
 ```
 
-Open an SFTP session over this SSH connection.
+Open an SFTP client session over this SSH connection. Requests the `sftp` subsystem and returns a high-level SFTP session for reading, writing, and listing files inside the guest.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SftpClient`](#sftpclient) | SFTP client session |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sftpclient">SftpClient</a></div>
+    <div className="msb-param-desc">SFTP client session.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let sftp = client.sftp().await?;
+let mut file = sftp.create("/tmp/hello.txt").await?;
+```
 
 ---
 
-#### close()
+#### <span className="msb-recv">client.</span><span className="msb-hn">close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn close(self) -> MicrosandboxResult<()>
 ```
 
-Close the native SSH client session.
+Close this native SSH client session. Sends a disconnect and aborts the internal server task. Consumes the client.
+
+<p className="msb-label">Example</p>
+
+```rust
+client.close().await?;
+```
 
 ## SshServer
 
+A reusable SSH server endpoint for a sandbox, obtained from [`server`](#ssh-server) or [`server_with`](#ssh-server_with). Cloneable; each call to [`serve`](#server-serve) handles one connection.
+
 ---
 
-#### serve()
+#### <span className="msb-recv">server.</span><span className="msb-hn">serve()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn serve<S>(&self, stream: S) -> MicrosandboxResult<()>
 where
-    S: AsyncRead + AsyncWrite + Unpin + Send + 'static
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 ```
 
-Serve one SSH connection over an ordered duplex stream.
+Serve one SSH connection over an ordered duplex stream. Runs the SSH handshake and session loop to completion. Returns when the connection closes.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| stream | `S` | Ordered duplex SSH transport |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>stream</code><span className="msb-type">S: AsyncRead + AsyncWrite</span></div>
+    <div className="msb-param-desc">Ordered duplex SSH transport.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let server = sb.ssh().server().await?;
+let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+tokio::spawn(async move { server.serve(server_io).await });
+```
+
+---
+
+#### <span className="msb-recv">server.</span><span className="msb-hn">serve_connection()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn serve_connection<S>(&self, stream: S) -> MicrosandboxResult<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+```
+
+Alias for [`serve`](#server-serve).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>stream</code><span className="msb-type">S: AsyncRead + AsyncWrite</span></div>
+    <div className="msb-param-desc">Ordered duplex SSH transport.</div>
+  </div>
+</div>
+
+## SshStdioStream
+
+---
+
+#### <span className="msb-recv">SshStdioStream::</span><span className="msb-hn">new()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
+
+```rust
+fn new() -> Self
+```
+
+Create a stdio SSH transport stream backed by this process's stdin and stdout. Implements [`AsyncRead`](#sshstdiostream) and `AsyncWrite`, so it can be passed straight to [`serve`](#server-serve) to bridge an SSH connection over the parent process's standard streams. Also available via `Default`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshstdiostream">SshStdioStream</a></div>
+    <div className="msb-param-desc">Duplex stream over stdin/stdout.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::SshStdioStream;
+
+let server = sb.ssh().server().await?;
+server.serve(SshStdioStream::new()).await?;
+```
+
+## Constants
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">DEFAULT_SSH_HOST</span>
+<div className="msb-tags"><span className="msb-tag is-static">const</span></div>
+
+```rust
+pub const DEFAULT_SSH_HOST: &str = "127.0.0.1";
+```
+
+Default SSH listener host used by the CLI adapter when binding a sandbox SSH endpoint.
+
+---
+
+#### <span className="msb-recv"></span><span className="msb-hn">DEFAULT_SSH_PORT</span>
+<div className="msb-tags"><span className="msb-tag is-static">const</span></div>
+
+```rust
+pub const DEFAULT_SSH_PORT: u16 = 2222;
+```
+
+Default SSH listener port used by the CLI adapter when binding a sandbox SSH endpoint.
 
 ## Types
 
 ### SshOutput
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#client-exec">client.exec()</a>, <a href="#client-exec_with">client.exec_with()</a></p>
+
+Output from an SSH exec request.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| status | `i32` | Exit status code |
-| stdout | `Bytes` | Captured stdout bytes |
-| stderr | `Bytes` | Captured stderr bytes |
+| `status` | `i32` | Exit status code. |
+| `stdout` | `Bytes` | Captured stdout bytes. |
+| `stderr` | `Bytes` | Captured stderr bytes (folded into stdout when a PTY is allocated). |
+
+### SandboxSsh
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#sb-ssh">sb.ssh()</a></p>
+
+SSH namespace for a sandbox. Cheap to clone; holds a clone of the sandbox.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`connect()`](#ssh-connect) | `SshClient` | Open a client with defaults. |
+| [`open_client()`](#ssh-open_client) | `SshClient` | Alias of `connect()`. |
+| [`connect_with()`](#ssh-connect_with) | `SshClient` | Open a client with options. |
+| [`open_client_with()`](#ssh-open_client_with) | `SshClient` | Alias of `connect_with()`. |
+| [`server()`](#ssh-server) | `SshServer` | Prepare a server endpoint. |
+| [`prepare_server()`](#ssh-prepare_server) | `SshServer` | Alias of `server()`. |
+| [`server_with()`](#ssh-server_with) | `SshServer` | Server endpoint with options. |
+| [`prepare_server_with()`](#ssh-prepare_server_with) | `SshServer` | Alias of `server_with()`. |
+
+### SshClient
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#ssh-connect">ssh.connect()</a>, <a href="#ssh-connect_with">ssh.connect_with()</a></p>
+
+Native in-process SSH client session. Aborts its internal server task on drop.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`exec()`](#client-exec) | `SshOutput` | Run a command. |
+| [`exec_with()`](#client-exec_with) | `SshOutput` | Run with options. |
+| [`attach()`](#client-attach) | `i32` | Interactive shell. |
+| [`attach_with()`](#client-attach_with) | `i32` | Attach with options. |
+| [`sftp()`](#client-sftp) | `SftpClient` | Open an SFTP session. |
+| [`close()`](#client-close) | `()` | Close the session. |
+
+### SshServer
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Returned by <a href="#ssh-server">ssh.server()</a>, <a href="#ssh-server_with">ssh.server_with()</a></p>
+
+Reusable SSH server endpoint for a sandbox. Cloneable.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`serve()`](#server-serve) | `()` | Serve one connection. |
+| [`serve_connection()`](#server-serve_connection) | `()` | Alias of `serve()`. |
 
 ### SftpClient
+<div className="msb-tags"><span className="msb-tag is-type">alias</span></div>
 
-Alias for `russh_sftp::client::SftpSession`.
+<p className="msb-backref">Returned by <a href="#client-sftp">client.sftp()</a></p>
+
+High-level SFTP client session.
+
+```rust
+pub type SftpClient = russh_sftp::client::SftpSession;
+```
+
+### SshStdioStream
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+<p className="msb-backref">Used by <a href="#server-serve">server.serve()</a></p>
+
+Ordered duplex stream backed by this process's stdin and stdout. Implements `AsyncRead` and `AsyncWrite`.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`new()`](#sshstdiostreamnew) | `SshStdioStream` | Create a stdio transport stream. |
 
 ### SshClientOptionsBuilder
+<div className="msb-tags"><span className="msb-tag is-type">builder</span></div>
+
+<p className="msb-backref">Used by <a href="#ssh-connect_with">ssh.connect_with()</a></p>
+
+Builder for SSH client options. Defaults: user `root`, terminal from `$TERM` (falling back to `xterm`), SFTP enabled.
 
 | Method | Parameters | Description |
 |--------|------------|-------------|
-| user() | `impl Into<String>` | SSH login user. Defaults to `root` |
-| term() | `impl Into<String>` | Terminal name for interactive sessions |
-| sftp() | `bool` | Enable or disable SFTP on the internal server |
+| `user()` | `impl Into<String>` | SSH login user. Default `root`. |
+| `term()` | `impl Into<String>` | Terminal name for interactive sessions. |
+| `sftp()` | `bool` | Enable or disable SFTP on the internal server. Default `true`. |
+| `build()` | | Finalize the options. |
 
 ### SshExecOptionsBuilder
+<div className="msb-tags"><span className="msb-tag is-type">builder</span></div>
+
+<p className="msb-backref">Used by <a href="#client-exec_with">client.exec_with()</a></p>
+
+Builder for SSH exec options.
 
 | Method | Parameters | Description |
 |--------|------------|-------------|
-| tty() | `bool` | Request a PTY for the exec channel |
+| `tty()` | `bool` | Request a PTY for the exec channel. Default `false`. |
+| `build()` | | Finalize the options. |
 
 ### SshAttachOptionsBuilder
+<div className="msb-tags"><span className="msb-tag is-type">builder</span></div>
+
+<p className="msb-backref">Used by <a href="#client-attach_with">client.attach_with()</a></p>
+
+Builder for interactive SSH attach options. Default terminal comes from `$TERM` (falling back to `xterm`); detach keys default to the standard sequence.
 
 | Method | Parameters | Description |
 |--------|------------|-------------|
-| term() | `impl Into<String>` | Terminal name for the shell |
-| detach_keys() | `impl Into<String>` | Detach key sequence |
+| `term()` | `impl Into<String>` | Terminal name for the shell. |
+| `detach_keys()` | `impl Into<String>` | Detach key sequence. |
+| `build()` | | Finalize the options. |
 
 ### SshServerOptionsBuilder
+<div className="msb-tags"><span className="msb-tag is-type">builder</span></div>
+
+<p className="msb-backref">Used by <a href="#ssh-server_with">ssh.server_with()</a></p>
+
+Builder for SSH server options. SFTP is enabled by default; when no authorized keys are provided, the default authorized-keys file is loaded.
 
 | Method | Parameters | Description |
 |--------|------------|-------------|
-| host_key_path() | `impl Into<PathBuf>` | Override the host private key path |
-| host_key() | `PrivateKey` | Use an in-memory host private key |
-| authorized_keys_path() | `impl Into<PathBuf>` | Override the authorized-keys path |
-| authorized_key() | `impl Into<String>` | Add one in-memory authorized public key |
-| user() | `impl Into<String>` | Override the guest user used for exec requests |
-| sftp() | `bool` | Enable or disable SFTP |
+| `host_key_path()` | `impl Into<PathBuf>` | Override the host private key path. |
+| `host_key()` | `PrivateKey` | Use an in-memory host private key. |
+| `authorized_keys_path()` | `impl Into<PathBuf>` | Override the authorized-keys path. |
+| `authorized_key()` | `impl Into<String>` | Add one in-memory authorized public key. |
+| `user()` | `impl Into<String>` | Override the guest user used for exec requests. |
+| `sftp()` | `bool` | Enable or disable SFTP. Default `true`. |
+| `build()` | | Finalize the options. |

--- a/docs/sdk/rust/volumes.mdx
+++ b/docs/sdk/rust/volumes.mdx
@@ -3,197 +3,1506 @@ title: Volumes
 description: Rust SDK - Volume API reference
 ---
 
-See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+Create and manage named volumes: persistent storage that lives independently of any sandbox. Read and write a volume's files directly from the host, or mount it into a sandbox. See [Volumes](/sandboxes/volumes) for usage examples and patterns.
 
-## Volume
+<div className="msb-glance">
 
-Named volumes are managed by microsandbox and stored by default under `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+  <p className="msb-gl"><span className="msb-dot static"></span>Static · Volume<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#volumebuilder"><span className="msb-rn">Volume::builder()</span><span className="msb-rg">configure a new volume</span></a>
+  <a className="msb-row" href="#volumecreate"><span className="msb-rn">Volume::create()</span><span className="msb-rg">provision from a config</span></a>
+  <a className="msb-row" href="#volumeget"><span className="msb-rn">Volume::get()</span><span className="msb-rg">handle to an existing one</span></a>
+  <a className="msb-row" href="#volumelist"><span className="msb-rn">Volume::list()</span><span className="msb-rg">all volumes</span></a>
+  <a className="msb-row" href="#volumeremove"><span className="msb-rn">Volume::remove()</span><span className="msb-rg">delete by name</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · Volume<span className="msb-ct">11</span></p>
+  <a className="msb-row" href="#vol-name"><span className="msb-rn">vol.name()</span><span className="msb-rg">volume name</span></a>
+  <a className="msb-row" href="#vol-kind"><span className="msb-rn">vol.kind()</span><span className="msb-rg">directory or disk</span></a>
+  <a className="msb-row" href="#vol-fs"><span className="msb-rn">vol.fs()</span><span className="msb-rg">read / write files</span></a>
+  <a className="msb-row" href="#vol-path"><span className="msb-rn">vol.path()</span><span className="msb-rg">host data directory</span></a>
+  <a className="msb-row" href="#vol-disk_path"><span className="msb-rn">vol.disk_path()</span><span className="msb-rg">host disk image path</span></a>
+  <a className="msb-row" href="#vol-capacity_bytes"><span className="msb-rn">vol.capacity_bytes()</span><span className="msb-rg">disk capacity</span></a>
+  <a className="msb-row" href="#vol-disk_format"><span className="msb-rn">vol.disk_format()</span><span className="msb-rg">disk image format</span></a>
+  <a className="msb-row" href="#vol-disk_fstype"><span className="msb-rn">vol.disk_fstype()</span><span className="msb-rg">inner disk filesystem</span></a>
+  <a className="msb-row" href="#vol-backend_kind"><span className="msb-rn">vol.backend_kind()</span><span className="msb-rg">local or cloud</span></a>
+  <a className="msb-row" href="#vol-local"><span className="msb-rn">vol.local()</span><span className="msb-rg">local-only state</span></a>
+  <a className="msb-row" href="#vol-cloud"><span className="msb-rn">vol.cloud()</span><span className="msb-rg">cloud-only state</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · VolumeHandle<span className="msb-ct">15</span></p>
+  <a className="msb-row" href="#h-name"><span className="msb-rn">h.name()</span><span className="msb-rg">volume name</span></a>
+  <a className="msb-row" href="#h-kind"><span className="msb-rn">h.kind()</span><span className="msb-rg">directory or disk</span></a>
+  <a className="msb-row" href="#h-fs"><span className="msb-rn">h.fs()</span><span className="msb-rg">read / write files</span></a>
+  <a className="msb-row" href="#h-remove"><span className="msb-rn">h.remove()</span><span className="msb-rg">delete this volume</span></a>
+  <a className="msb-row" href="#h-used_bytes"><span className="msb-rn">h.used_bytes()</span><span className="msb-rg">usage snapshot</span></a>
+  <a className="msb-row" href="#h-quota_mib"><span className="msb-rn">h.quota_mib()</span><span className="msb-rg">storage quota</span></a>
+  <a className="msb-row" href="#h-capacity_bytes"><span className="msb-rn">h.capacity_bytes()</span><span className="msb-rg">disk capacity</span></a>
+  <a className="msb-row" href="#h-disk_format"><span className="msb-rn">h.disk_format()</span><span className="msb-rg">disk image format</span></a>
+  <a className="msb-row" href="#h-disk_fstype"><span className="msb-rn">h.disk_fstype()</span><span className="msb-rg">inner disk filesystem</span></a>
+  <a className="msb-row" href="#h-disk_path"><span className="msb-rn">h.disk_path()</span><span className="msb-rg">host disk image path</span></a>
+  <a className="msb-row" href="#h-labels"><span className="msb-rn">h.labels()</span><span className="msb-rg">key-value labels</span></a>
+  <a className="msb-row" href="#h-created_at"><span className="msb-rn">h.created_at()</span><span className="msb-rg">creation time</span></a>
+  <a className="msb-row" href="#h-backend_kind"><span className="msb-rn">h.backend_kind()</span><span className="msb-rg">local or cloud</span></a>
+  <a className="msb-row" href="#h-local"><span className="msb-rn">h.local()</span><span className="msb-rg">local-only state</span></a>
+  <a className="msb-row" href="#h-cloud"><span className="msb-rn">h.cloud()</span><span className="msb-rg">cloud-only state</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · VolumeFs<span className="msb-ct">13</span></p>
+  <a className="msb-row" href="#fs-read"><span className="msb-rn">fs.read()</span><span className="msb-rg">read bytes</span></a>
+  <a className="msb-row" href="#fs-read_to_string"><span className="msb-rn">fs.read_to_string()</span><span className="msb-rg">read UTF-8 text</span></a>
+  <a className="msb-row" href="#fs-read_stream"><span className="msb-rn">fs.read_stream()</span><span className="msb-rg">stream a file in</span></a>
+  <a className="msb-row" href="#fs-write"><span className="msb-rn">fs.write()</span><span className="msb-rg">write bytes</span></a>
+  <a className="msb-row" href="#fs-write_stream"><span className="msb-rn">fs.write_stream()</span><span className="msb-rg">stream a file out</span></a>
+  <a className="msb-row" href="#fs-list"><span className="msb-rn">fs.list()</span><span className="msb-rg">list a directory</span></a>
+  <a className="msb-row" href="#fs-mkdir"><span className="msb-rn">fs.mkdir()</span><span className="msb-rg">create a directory</span></a>
+  <a className="msb-row" href="#fs-remove"><span className="msb-rn">fs.remove()</span><span className="msb-rg">delete a file</span></a>
+  <a className="msb-row" href="#fs-remove_dir"><span className="msb-rn">fs.remove_dir()</span><span className="msb-rg">delete a directory</span></a>
+  <a className="msb-row" href="#fs-copy"><span className="msb-rn">fs.copy()</span><span className="msb-rg">copy a file</span></a>
+  <a className="msb-row" href="#fs-rename"><span className="msb-rn">fs.rename()</span><span className="msb-rg">rename / move</span></a>
+  <a className="msb-row" href="#fs-stat"><span className="msb-rn">fs.stat()</span><span className="msb-rg">metadata</span></a>
+  <a className="msb-row" href="#fs-exists"><span className="msb-rn">fs.exists()</span><span className="msb-rg">existence check</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · VolumeBuilder<span className="msb-ct">7</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#directory">.directory()</a>
+    <a className="msb-chip" href="#disk">.disk()</a>
+    <a className="msb-chip" href="#size">.size()</a>
+    <a className="msb-chip" href="#quota">.quota()</a>
+    <a className="msb-chip" href="#label">.label()</a>
+    <a className="msb-chip" href="#vb-build">.build()</a>
+    <a className="msb-chip" href="#vb-create">.create()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · MountBuilder<span className="msb-ct">15</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#bind">.bind()</a>
+    <a className="msb-chip" href="#named">.named()</a>
+    <a className="msb-chip" href="#named_with">.named_with()</a>
+    <a className="msb-chip" href="#tmpfs">.tmpfs()</a>
+    <a className="msb-chip" href="#mb-disk">.disk()</a>
+    <a className="msb-chip" href="#format">.format()</a>
+    <a className="msb-chip" href="#fstype">.fstype()</a>
+    <a className="msb-chip" href="#readonly">.readonly()</a>
+    <a className="msb-chip" href="#noexec">.noexec()</a>
+    <a className="msb-chip" href="#nosuid">.nosuid()</a>
+    <a className="msb-chip" href="#nodev">.nodev()</a>
+    <a className="msb-chip" href="#stat_virtualization">.stat_virtualization()</a>
+    <a className="msb-chip" href="#host_permissions">.host_permissions()</a>
+    <a className="msb-chip" href="#mb-size">.size()</a>
+    <a className="msb-chip" href="#mb-build">.build()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · NamedVolumeBuilder<span className="msb-ct">9</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#nv-existing">.existing()</a>
+    <a className="msb-chip" href="#nv-create">.create()</a>
+    <a className="msb-chip" href="#nv-ensure_exists">.ensure_exists()</a>
+    <a className="msb-chip" href="#nv-name">.name()</a>
+    <a className="msb-chip" href="#nv-directory">.directory()</a>
+    <a className="msb-chip" href="#nv-disk">.disk()</a>
+    <a className="msb-chip" href="#nv-size">.size()</a>
+    <a className="msb-chip" href="#nv-quota">.quota()</a>
+    <a className="msb-chip" href="#nv-label">.label()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#volume">Volume</a>
+    <a className="msb-typepill" href="#volumehandle">VolumeHandle</a>
+    <a className="msb-typepill" href="#volumebuilder-2">VolumeBuilder</a>
+    <a className="msb-typepill" href="#volumefs">VolumeFs</a>
+    <a className="msb-typepill" href="#volumefsreadstream">VolumeFsReadStream</a>
+    <a className="msb-typepill" href="#volumefswritesink">VolumeFsWriteSink</a>
+    <a className="msb-typepill" href="#mountbuilder-2">MountBuilder</a>
+    <a className="msb-typepill" href="#namedvolumebuilder-2">NamedVolumeBuilder</a>
+    <a className="msb-typepill" href="#volumekind">VolumeKind</a>
+    <a className="msb-typepill" href="#volumespec">VolumeSpec</a>
+    <a className="msb-typepill" href="#mountoptions">MountOptions</a>
+    <a className="msb-typepill" href="#statvirtualization">StatVirtualization</a>
+    <a className="msb-typepill" href="#hostpermissions">HostPermissions</a>
+    <a className="msb-typepill" href="#diskimageformat">DiskImageFormat</a>
+    <a className="msb-typepill" href="#namedvolumemode">NamedVolumeMode</a>
+    <a className="msb-typepill" href="/sdk/rust/filesystem#fsentry">FsEntry</a>
+    <a className="msb-typepill" href="/sdk/rust/filesystem#fsmetadata">FsMetadata</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```rust
+use microsandbox::{Sandbox, Volume};
+
+// 1. create a persistent named volume
+let vol = Volume::builder("pip-cache").create().await?;
+
+// 2. seed it from the host, no sandbox required
+vol.fs().write("/note.txt", "shared cache").await?;
+
+// 3. mount it into a sandbox
+let sb = Sandbox::builder("api")
+    .image("python")
+    .volume("/root/.cache/pip", |v| v.named("pip-cache"))
+    .create()
+    .await?;
+
+sb.exec("pip", ["install", "requests"]).await?;
+sb.stop().await?;
+```
+
+## Static methods
 
 ---
 
-#### Volume::builder()
+#### <span className="msb-recv">Volume::</span><span className="msb-hn">builder()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```rust
 fn builder(name: impl Into<String>) -> VolumeBuilder
 ```
 
-Create a builder for a new named volume. Directory-backed volumes are the default. Call `.disk().size(...)` to create a disk-backed volume.
+Create a builder for configuring a new named volume. Directory-backed volumes are the default; call [`.disk()`](#disk) then [`.size()`](#size) for a raw ext4 disk-image volume. Volume names must start with an alphanumeric character and contain only alphanumeric characters, dots, hyphens, and underscores. See [`VolumeBuilder`](#volumebuilder-2) for all options.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `impl Into<String>` | Volume name (e.g. `"pip-cache"`) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Volume name, e.g. <code>"pip-cache"</code>.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`VolumeBuilder`](#volumebuilder) | Builder with `.directory()`, `.disk()`, `.size()`, `.quota()`, and `.create()` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumebuilder-2">VolumeBuilder</a></div>
+    <div className="msb-param-desc">Builder for configuring the volume.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let vol = Volume::builder("pip-cache").create().await?;
+```
 
 ---
 
-#### Volume::get()
+#### <span className="msb-recv">Volume::</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn create(config: VolumeConfig) -> MicrosandboxResult<Volume>
+```
+
+Provision a volume from a [`VolumeConfig`](#volumespec). Routes through the active backend. Locally this inserts a database record and creates the host directory (formatting a `disk.raw` for disk volumes). Fails with `VolumeAlreadyExists` if a volume of the same name already exists. Most callers use [`Volume::builder()`](#volumebuilder), which calls this internally.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>config</code><a className="msb-type" href="#volumespec">VolumeConfig</a></div>
+    <div className="msb-param-desc">Volume configuration. <code>VolumeConfig</code> is an alias for <a className="msb-type" href="#volumespec">VolumeSpec</a>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volume">Volume</a></div>
+    <div className="msb-param-desc">The created volume.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::volume::{VolumeConfig, VolumeKind};
+
+let vol = Volume::create(VolumeConfig {
+    name: "cache".into(),
+    kind: VolumeKind::Directory,
+    quota_mib: Some(1024),
+    capacity_mib: None,
+    labels: vec![("team".into(), "ml".into())],
+})
+.await?;
+```
+
+---
+
+#### <span className="msb-recv">Volume::</span><span className="msb-hn">get()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn get(name: &str) -> MicrosandboxResult<VolumeHandle>
 ```
 
-Get a handle to an existing named volume. Use the handle to access the volume's filesystem from the host or to delete it.
+Get a handle to an existing named volume. Use the handle to access the volume's filesystem from the host, read its metadata, or delete it. Fails with `VolumeNotFound` if no volume by that name exists.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `&str` | Volume name |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`VolumeHandle`](#volumehandle) | Handle for host-side operations |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumehandle">VolumeHandle</a></div>
+    <div className="msb-param-desc">Handle for host-side operations.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let h = Volume::get("pip-cache").await?;
+println!("{} — {} bytes used", h.name(), h.used_bytes());
+```
 
 ---
 
-#### Volume::list()
+#### <span className="msb-recv">Volume::</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn list() -> MicrosandboxResult<Vec<VolumeHandle>>
 ```
 
-List all named volumes.
+List all named volumes, newest first.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Vec<`[`VolumeHandle`](#volumehandle)`>` | All volume handles |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumehandle">Vec&lt;VolumeHandle&gt;</a></div>
+    <div className="msb-param-desc">All volume handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+for h in Volume::list().await? {
+    println!("{} — {:?}", h.name(), h.kind());
+}
+```
 
 ---
 
-#### Volume::remove()
+#### <span className="msb-recv">Volume::</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
 async fn remove(name: &str) -> MicrosandboxResult<()>
 ```
 
-Delete a named volume and its contents from disk. Fails if the volume is currently mounted by a running sandbox.
+Delete a named volume and its contents from disk. Locally the database record is deleted first, then the directory, so an orphaned directory is easier to detect than an orphaned record. Fails with `VolumeNotFound` if the volume does not exist.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `&str` | Volume name |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+Volume::remove("pip-cache").await?;
+```
+
+---
+
+## Volume instance methods
+
+A live `Volume`, returned by [`Volume::create()`](#volumecreate) or [`VolumeBuilder::create()`](#vb-create). Carries the backend it was created on.
+
+---
+
+#### <span className="msb-recv">vol.</span><span className="msb-hn">name()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn name(&self) -> &str
+```
+
+The unique name identifying this volume.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">vol.</span><span className="msb-hn">kind()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn kind(&self) -> VolumeKind
+```
+
+The storage kind: [`Directory`](#volumekind) or [`Disk`](#volumekind).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumekind">VolumeKind</a></div>
+    <div className="msb-param-desc">Storage kind.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">vol.</span><span className="msb-hn">fs()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn fs(&self) -> VolumeFs<'_>
+```
+
+Get a filesystem handle for reading and writing the volume's files directly, without a running sandbox. Local volumes route to `tokio::fs`. See [`VolumeFs`](#volumefs) for the operations.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumefs">VolumeFs</a></div>
+    <div className="msb-param-desc">Filesystem handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+vol.fs().write("/seed.txt", "hello").await?;
+```
+
+---
+
+#### <span className="msb-recv">vol.</span><span className="msb-hn">path()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn path(&self) -> MicrosandboxResult<&Path>
+```
+
+The host-side directory where this volume's data is stored (local backend only). Errors with `Unsupported` for cloud volumes, whose bytes live in the org's object storage rather than on the caller's host.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">&amp;Path</span></div>
+    <div className="msb-param-desc">Host data directory, e.g. <code>~/.microsandbox/volumes/pip-cache/</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+println!("{}", vol.path()?.display());
+```
+
+---
+
+#### <span className="msb-recv">vol.</span><span className="msb-hn">disk_path()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn disk_path(&self) -> Option<PathBuf>
+```
+
+Host path to the managed raw disk image (`disk.raw`) for disk volumes. Returns `None` for directory volumes.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;PathBuf&gt;</span></div>
+    <div className="msb-param-desc">Path to <code>disk.raw</code>, or <code>None</code> for directory volumes.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">vol.</span><span className="msb-hn">capacity_bytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn capacity_bytes(&self) -> Option<u64>
+```
+
+Disk capacity in bytes for disk volumes. `None` for directory volumes.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;u64&gt;</span></div>
+    <div className="msb-param-desc">Capacity in bytes, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">vol.</span><span className="msb-hn">disk_format()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn disk_format(&self) -> Option<&str>
+```
+
+Disk image format for disk volumes (always `"raw"` for managed disk volumes). `None` for directory volumes.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;&amp;str&gt;</span></div>
+    <div className="msb-param-desc">Format string, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">vol.</span><span className="msb-hn">disk_fstype()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn disk_fstype(&self) -> Option<&str>
+```
+
+Inner disk filesystem type for disk volumes (always `"ext4"` for managed disk volumes). `None` for directory volumes.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;&amp;str&gt;</span></div>
+    <div className="msb-param-desc">Filesystem type, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">vol.</span><span className="msb-hn">backend_kind()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn backend_kind(&self) -> BackendKind
+```
+
+Which backend variant this volume is bound to: `Local` or `Cloud`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">BackendKind</span></div>
+    <div className="msb-param-desc"><code>Local</code> or <code>Cloud</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">vol.</span><span className="msb-hn">local()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn local(&self) -> Option<&VolumeLocalState>
+```
+
+Local-only volume state. Returns `Some` for local-backed volumes, `None` for cloud-backed ones.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;&amp;VolumeLocalState&gt;</span></div>
+    <div className="msb-param-desc">Local state, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">vol.</span><span className="msb-hn">cloud()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn cloud(&self) -> Option<&VolumeCloudState>
+```
+
+Cloud-only volume state. Returns `Some` for cloud-backed volumes, `None` for local-backed ones.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;&amp;VolumeCloudState&gt;</span></div>
+    <div className="msb-param-desc">Cloud state, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+## VolumeHandle methods
+
+A lightweight handle returned by [`Volume::get()`](#volumeget) and [`Volume::list()`](#volumelist). Exposes metadata captured at read time plus filesystem and delete operations, without holding a live [`Volume`](#volume).
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">name()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn name(&self) -> &str
+```
+
+The unique name identifying this volume.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">kind()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn kind(&self) -> VolumeKind
+```
+
+The storage kind: [`Directory`](#volumekind) or [`Disk`](#volumekind).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumekind">VolumeKind</a></div>
+    <div className="msb-param-desc">Storage kind.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">fs()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn fs(&self) -> VolumeFs<'_>
+```
+
+Get a filesystem handle for reading and writing the volume's files directly, without a running sandbox. See [`VolumeFs`](#volumefs).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumefs">VolumeFs</a></div>
+    <div className="msb-param-desc">Filesystem handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let h = Volume::get("pip-cache").await?;
+let names = h.fs().list("/").await?;
+```
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn remove(&self) -> MicrosandboxResult<()>
+```
+
+Delete this volume and its contents. Locally the database record is removed first, then the directory.
+
+<p className="msb-label">Example</p>
+
+```rust
+Volume::get("pip-cache").await?.remove().await?;
+```
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">used_bytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn used_bytes(&self) -> u64
+```
+
+Disk usage snapshot from when this handle was created. Not live, call [`Volume::get()`](#volumeget) again for a fresh reading.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">u64</span></div>
+    <div className="msb-param-desc">Bytes used at handle-creation time.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">quota_mib()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn quota_mib(&self) -> Option<u32>
+```
+
+Maximum storage in MiB, or `None` if unlimited.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;u32&gt;</span></div>
+    <div className="msb-param-desc">Quota in MiB, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">capacity_bytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn capacity_bytes(&self) -> Option<u64>
+```
+
+Disk capacity in bytes for disk volumes. `None` for directory volumes.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;u64&gt;</span></div>
+    <div className="msb-param-desc">Capacity in bytes, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">disk_format()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn disk_format(&self) -> Option<&str>
+```
+
+Disk image format for disk volumes. `None` for directory volumes.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;&amp;str&gt;</span></div>
+    <div className="msb-param-desc">Format string, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">disk_fstype()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn disk_fstype(&self) -> Option<&str>
+```
+
+Inner disk filesystem type for disk volumes. `None` for directory volumes.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;&amp;str&gt;</span></div>
+    <div className="msb-param-desc">Filesystem type, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">disk_path()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn disk_path(&self) -> Option<PathBuf>
+```
+
+Host path to the managed raw disk image (`disk.raw`) for local disk volumes. `None` otherwise.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;PathBuf&gt;</span></div>
+    <div className="msb-param-desc">Path to <code>disk.raw</code>, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">labels()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn labels(&self) -> &[(String, String)]
+```
+
+Key-value labels for organizing and filtering volumes.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">&amp;[(String, String)]</span></div>
+    <div className="msb-param-desc">Label pairs.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">created_at()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn created_at(&self) -> Option<DateTime<Utc>>
+```
+
+When this volume was first created, if recorded.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;DateTime&lt;Utc&gt;&gt;</span></div>
+    <div className="msb-param-desc">Creation timestamp, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">backend_kind()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn backend_kind(&self) -> BackendKind
+```
+
+Which backend variant this handle is bound to: `Local` or `Cloud`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">BackendKind</span></div>
+    <div className="msb-param-desc"><code>Local</code> or <code>Cloud</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">local()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn local(&self) -> Option<&VolumeHandleLocalState>
+```
+
+Local-only handle state. Returns `Some` for local-backed handles, `None` for cloud-backed ones.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;&amp;VolumeHandleLocalState&gt;</span></div>
+    <div className="msb-param-desc">Local state, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">cloud()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn cloud(&self) -> Option<&VolumeHandleCloudState>
+```
+
+Cloud-only handle state. Returns `Some` for cloud-backed handles, `None` for local-backed ones.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Option&lt;&amp;VolumeHandleCloudState&gt;</span></div>
+    <div className="msb-param-desc">Cloud state, or <code>None</code>.</div>
+  </div>
+</div>
+
+---
+
+## VolumeFs methods
+
+Host-side filesystem operations on a named volume, obtained via [`Volume::fs()`](#vol-fs) or [`VolumeHandle::fs()`](#h-fs). Unlike [`SandboxFs`](/sdk/rust/filesystem), which goes through the agent protocol, `VolumeFs` reads and writes the volume's bytes directly. Paths are relative to the volume root; a leading `/` is stripped, and path traversal outside the root is rejected.
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn read(&self, path: &str) -> MicrosandboxResult<Bytes>
+```
+
+Read an entire file into memory as raw bytes.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">File path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Bytes</span></div>
+    <div className="msb-param-desc">File contents.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let data = vol.fs().read("/seed.txt").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read_to_string()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn read_to_string(&self, path: &str) -> MicrosandboxResult<String>
+```
+
+Read an entire file into memory as a UTF-8 string.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">File path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">String</span></div>
+    <div className="msb-param-desc">File contents as UTF-8.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let text = vol.fs().read_to_string("/seed.txt").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn read_stream(&self, path: &str) -> MicrosandboxResult<VolumeFsReadStream>
+```
+
+Open a file for streaming reads. Returns a [`VolumeFsReadStream`](#volumefsreadstream) that yields 64 KiB chunks, so large files don't have to be held in memory at once.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">File path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumefsreadstream">VolumeFsReadStream</a></div>
+    <div className="msb-param-desc">Chunked reader.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let mut stream = vol.fs().read_stream("/model.bin").await?;
+while let Some(chunk) = stream.recv().await? {
+    // process chunk
+}
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">write()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn write(&self, path: &str, data: impl AsRef<[u8]>) -> MicrosandboxResult<()>
+```
+
+Write data to a file, creating parent directories as needed. Overwrites if the file already exists.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">File path relative to the volume root.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>data</code><span className="msb-type">impl AsRef&lt;[u8]&gt;</span></div>
+    <div className="msb-param-desc">Bytes to write.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+vol.fs().write("/config/app.json", r#"{"ready":true}"#).await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">write_stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn write_stream(&self, path: &str) -> MicrosandboxResult<VolumeFsWriteSink>
+```
+
+Open a file for streaming writes. Returns a [`VolumeFsWriteSink`](#volumefswritesink) that accepts chunks of bytes. Creates parent directories as needed.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">File path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumefswritesink">VolumeFsWriteSink</a></div>
+    <div className="msb-param-desc">Chunked writer.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let mut sink = vol.fs().write_stream("/upload.bin").await?;
+sink.write(&chunk).await?;
+sink.close().await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn list(&self, path: &str) -> MicrosandboxResult<Vec<FsEntry>>
+```
+
+List the immediate children of a directory (non-recursive). Each entry includes the path, kind, size, permissions, and modification time.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Directory path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/rust/filesystem#fsentry">Vec&lt;FsEntry&gt;</a></div>
+    <div className="msb-param-desc">Directory entries.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+for entry in vol.fs().list("/").await? {
+    println!("{} ({} bytes)", entry.path, entry.size);
+}
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn mkdir(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Create a directory and any missing parents.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Directory path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+vol.fs().mkdir("/data/incoming").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn remove(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Delete a single file. Use [`remove_dir()`](#fs-remove_dir) for directories.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">File path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+vol.fs().remove("/data/stale.tmp").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">remove_dir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn remove_dir(&self, path: &str) -> MicrosandboxResult<()>
+```
+
+Remove a directory and its contents recursively. Targeting the volume root is rejected.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Directory path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+vol.fs().remove_dir("/data/incoming").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">copy()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn copy(&self, from: &str, to: &str) -> MicrosandboxResult<()>
+```
+
+Copy a file within the volume. Creates the destination's parent directories as needed.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>from</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Source path relative to the volume root.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>to</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Destination path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+vol.fs().copy("/seed.txt", "/backup/seed.txt").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">rename()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn rename(&self, from: &str, to: &str) -> MicrosandboxResult<()>
+```
+
+Rename or move a file or directory. Creates the destination's parent directories as needed.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>from</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Source path relative to the volume root.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>to</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Destination path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+vol.fs().rename("/tmp/out.txt", "/done/out.txt").await?;
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">stat()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn stat(&self, path: &str) -> MicrosandboxResult<FsMetadata>
+```
+
+Get metadata for a file or directory: kind, size, permission bits, read-only flag, and timestamps.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/rust/filesystem#fsmetadata">FsMetadata</a></div>
+    <div className="msb-param-desc">Entry metadata.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let meta = vol.fs().stat("/seed.txt").await?;
+println!("{} bytes", meta.size);
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">exists()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn exists(&self, path: &str) -> MicrosandboxResult<bool>
+```
+
+Check whether a file or directory exists at the given path. Returns `false` rather than an error if the path is absent.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">&amp;str</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> if the path exists.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+if !vol.fs().exists("/seed.txt").await? {
+    vol.fs().write("/seed.txt", "hello").await?;
+}
+```
 
 ---
 
 ## VolumeBuilder
 
-Builder for creating a named volume.
+Builder for configuring a named volume before creation. Obtained via [`Volume::builder(name)`](#volumebuilder). Directory-backed is the default; disk volumes require [`.disk()`](#disk) plus [`.size()`](#size). Every setter returns `Self`, so calls chain.
 
 ---
 
-#### create()
-
-```rust
-async fn create(self) -> MicrosandboxResult<Volume>
-```
-
-Create the volume on disk.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Volume` | The created volume |
-
----
-
-#### quota()
-
-```rust
-fn quota(self, mib: u64) -> Self
-```
-
-Set the recorded quota metadata for a directory-backed volume.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| mib | `u64` | Quota in MiB |
-
----
-
-#### directory()
+#### <span className="msb-recv">.</span><span className="msb-hn">directory()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn directory(self) -> Self
 ```
 
-Create a directory-backed named volume. This is the default.
+Create a directory-backed named volume (mounted through virtiofs). This is the default.
 
 ---
 
-#### disk()
+#### <span className="msb-recv">.</span><span className="msb-hn">disk()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn disk(self) -> Self
 ```
 
-Create a raw ext4 disk-backed named volume.
+Create a raw ext4 disk-image named volume (mounted through virtio-blk). Requires [`.size()`](#size).
 
 ---
 
-#### size()
+#### <span className="msb-recv">.</span><span className="msb-hn">size()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn size(self, size: impl Into<Mebibytes>) -> Self
 ```
 
-Set disk volume capacity. Required after `.disk()`.
+Set the disk volume's capacity. Required for disk volumes; rejected for directory volumes. Accepts a bare `u32` (MiB) or a `SizeExt` helper such as `20.gib()`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>size</code><span className="msb-type">impl Into&lt;Mebibytes&gt;</span></div>
+    <div className="msb-param-desc">Capacity in MiB.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+use microsandbox::size::SizeExt;
+
+let vol = Volume::builder("docker-data")
+    .disk()
+    .size(20.gib())
+    .create()
+    .await?;
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">quota()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn quota(self, size: impl Into<Mebibytes>) -> Self
+```
+
+Limit a directory volume's storage. Accepts a bare `u32` (MiB) or a `SizeExt` helper such as `1.gib()`. Omit for unlimited growth (the default). Rejected for disk volumes, which size up front via [`.size()`](#size).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>size</code><span className="msb-type">impl Into&lt;Mebibytes&gt;</span></div>
+    <div className="msb-param-desc">Quota in MiB.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">label()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn label(self, key: impl Into<String>, value: impl Into<String>) -> Self
+```
+
+Attach a key-value label for organizing and filtering volumes. Can be called multiple times.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Label key.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Label value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="vb-build"></a>
+
+```rust
+fn build(self) -> VolumeConfig
+```
+
+Materialize the [`VolumeConfig`](#volumespec) without creating the volume. Pass the result to [`Volume::create()`](#volumecreate) to provision it later.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumespec">VolumeConfig</a></div>
+    <div className="msb-param-desc">The volume configuration.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
+
+<a id="vb-create"></a>
+
+```rust
+async fn create(self) -> MicrosandboxResult<Volume>
+```
+
+Create the volume on the active backend. Equivalent to `Volume::create(self.build())`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volume">Volume</a></div>
+    <div className="msb-param-desc">The created volume.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```rust
+let vol = Volume::builder("pip-cache")
+    .quota(1024)
+    .label("team", "ml")
+    .create()
+    .await?;
+```
 
 ---
 
 ## MountBuilder
 
-Builder for configuring a volume mount. Used in `SandboxBuilder::volume(path, |v| v...)`.
+Builder for configuring a volume mount on a sandbox. Used in `SandboxBuilder::volume(guest_path, |v| v...)` (see [`.volume()`](/sdk/rust/sandbox#volume)). Pick exactly one mount kind: [`.bind()`](#bind), [`.named()`](#named) / [`.named_with()`](#named_with), [`.tmpfs()`](#tmpfs), or [`.disk()`](#mb-disk). Kind-specific options are validated when the surrounding `SandboxBuilder` is finalized, so an option set on the wrong kind surfaces a clear error rather than being silently dropped.
 
 ---
 
-#### bind()
+#### <span className="msb-recv">.</span><span className="msb-hn">bind()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn bind(self, host_path: impl Into<PathBuf>) -> Self
+fn bind(self, host: impl Into<PathBuf>) -> Self
 ```
 
-Mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
+Bind mount a host directory into the guest. Changes in the guest are reflected on the host and vice versa. The host path must be valid UTF-8 and must not contain `,`, `:`, or `;`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| host_path | `impl Into<PathBuf>` | Directory path on the host |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">impl Into&lt;PathBuf&gt;</span></div>
+    <div className="msb-param-desc">Directory path on the host.</div>
+  </div>
+</div>
 
 ---
 
-#### named()
+#### <span className="msb-recv">.</span><span className="msb-hn">named()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn named(self, name: impl Into<String>) -> Self
 ```
 
-Mount a named volume. The volume must already exist (create it with [`Volume::builder()`](#volumebuilder)).
+Mount a named volume created via [`Volume::create()`](#volumecreate). The volume must already exist. Persists across sandbox restarts and can be shared between sandboxes. For sandbox-time provisioning, use [`.named_with()`](#named_with).
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `impl Into<String>` | Volume name |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
 
 ---
 
-#### named_with()
+#### <span className="msb-recv">.</span><span className="msb-hn">named_with()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn named_with(
@@ -203,9 +1512,26 @@ fn named_with(
 ) -> Self
 ```
 
-Mount a named volume with explicit sandbox-time existence behavior. `NamedVolumeMode::Existing` is the default and behaves like [`named()`](#named). `.create()` creates the volume and fails if it already exists. `.ensure_exists()` creates the volume if it is missing or reuses an existing compatible volume.
+Mount a named volume with explicit sandbox-time existence behavior, configured via a [`NamedVolumeBuilder`](#namedvolumebuilder-2) closure. `existing` (the default) behaves like [`.named()`](#named); `create` provisions the volume and fails if it already exists; `ensure_exists` provisions it if missing or reuses a compatible existing volume. The ensure-exists mode validates existing metadata and errors when the kind, quota, capacity, or explicitly requested labels differ; it does not mutate existing metadata.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><a className="msb-type" href="#namedvolumebuilder-2">FnOnce(NamedVolumeBuilder)</a></div>
+    <div className="msb-param-desc">Configure existence behavior and creation metadata.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```rust
+use microsandbox::size::SizeExt;
+
 let sb = Sandbox::builder("worker")
     .image("python")
     .volume("/cache", |v| v.named_with("pip-cache", |n| n.ensure_exists()))
@@ -216,111 +1542,653 @@ let sb = Sandbox::builder("worker")
     .await?;
 ```
 
-The ensure-exists mode validates existing volume metadata. It errors when the existing volume has a different kind, quota, capacity, or explicitly requested labels than the requested configuration; it does not mutate existing volume metadata.
-
-**Named volume builder methods**
-
-| Method | Description |
-|--------|-------------|
-| `existing()` | Require the volume to already exist. This is the default. |
-| `create()` | Create the volume and fail if it already exists. |
-| `ensure_exists()` | Create the volume if missing or reuse a compatible existing volume. |
-| `directory()` | Use directory-backed storage. This is the default. |
-| `disk()` | Use disk-backed raw ext4 storage. Requires `size(...)` when creating or ensuring a missing volume. |
-| `size(size)` | Disk capacity. |
-| `quota(size)` | Directory volume quota. |
-| `label(key, value)` | Attach a label to newly-created volumes and require matching labels for ensure-existing volumes when labels are requested. |
-
 ---
 
-#### readonly()
-
-```rust
-fn readonly(self) -> Self
-```
-
-Mount as read-only. The guest can read but not write, and virtiofs-backed mounts also reject writes in the host filesystem server.
-
----
-
-#### noexec()
-
-```rust
-fn noexec(self) -> Self
-```
-
-Prevent direct execution from this mount. Interpreters can still read scripts from the mount, such as `sh /mnt/script.sh`.
-
----
-
-#### disk()
-
-```rust
-fn disk(self, host_path: impl Into<PathBuf>) -> Self
-```
-
-Mount a host disk image as a virtio-blk device. The disk image format defaults from the extension (`.qcow2`, `.raw`, `.vmdk`; otherwise raw).
-
----
-
-#### format()
-
-```rust
-fn format(self, format: DiskImageFormat) -> Self
-```
-
-Set the disk image format explicitly. Valid only with [`disk()`](#disk).
-
----
-
-#### fstype()
-
-```rust
-fn fstype(self, fstype: impl Into<String>) -> Self
-```
-
-Set the inner filesystem type for a disk-image volume, for example `"ext4"`. If omitted, agentd probes supported filesystems and uses the first type that mounts cleanly. Empty values and mount-spec separators are rejected.
-
----
-
-#### size()
-
-```rust
-fn size(self, mib: impl Into<Mebibytes>) -> Self
-```
-
-Set the size limit for a tmpfs mount. Valid only for tmpfs mounts.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| mib | `impl Into<Mebibytes>` | Size limit in MiB |
-
----
-
-#### tmpfs()
+#### <span className="msb-recv">.</span><span className="msb-hn">tmpfs()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
 fn tmpfs(self) -> Self
 ```
 
-Use an in-memory filesystem. Contents are discarded when the sandbox stops. Good for scratch space, temp files, and build artifacts.
+Use an in-memory filesystem. Contents are discarded when the sandbox stops. Good for scratch space, temp files, and build artifacts. Cap its size with [`.size()`](#mb-size).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">disk()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="mb-disk"></a>
+
+```rust
+fn disk(self, host: impl Into<PathBuf>) -> Self
+```
+
+Mount a host disk-image file as a virtio-blk device at the guest path. The format defaults from the file extension (`.qcow2`, `.vmdk`; anything else is `Raw`). Override with [`.format()`](#format).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">impl Into&lt;PathBuf&gt;</span></div>
+    <div className="msb-param-desc">Disk image path on the host.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">format()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn format(self, format: DiskImageFormat) -> Self
+```
+
+Override the disk-image format for a [`.disk()`](#mb-disk) mount. Valid only with `.disk()`; calling it on a bind, named, or tmpfs mount errors when the `SandboxBuilder` is finalized.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>format</code><a className="msb-type" href="#diskimageformat">DiskImageFormat</a></div>
+    <div className="msb-param-desc">Disk image format.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">fstype()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn fstype(self, fstype: impl Into<String>) -> Self
+```
+
+Set the inner filesystem type for a [`.disk()`](#mb-disk) mount, for example `"ext4"`. If omitted, agentd probes `/proc/filesystems` and uses the first type that mounts cleanly. Empty values and the separators `,`, `;`, `:`, `=` are rejected. Valid only with `.disk()`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>fstype</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Inner filesystem type.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">readonly()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn readonly(self) -> Self
+```
+
+Prevent writes to this mount. Enforced both at the host (virtiofs server rejects writes) and in the guest (the kernel returns `EROFS`).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">noexec()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn noexec(self) -> Self
+```
+
+Prevent direct execution of files on this mount. Interpreters can still read scripts from the mount, such as `sh /mnt/script.sh`, because the interpreter binary executes from a different filesystem.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">nosuid()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn nosuid(self) -> Self
+```
+
+Ignore setuid and setgid privilege elevation from files on this mount.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">nodev()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn nodev(self) -> Self
+```
+
+Ignore device files on this mount.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">stat_virtualization()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn stat_virtualization(self, policy: StatVirtualization) -> Self
+```
+
+Set the guest stat virtualization policy for a virtiofs-backed mount. Default: [`Strict`](#statvirtualization). Valid only for bind and named-volume mounts; calling it on a tmpfs or disk-image mount errors at finalize time.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>policy</code><a className="msb-type" href="#statvirtualization">StatVirtualization</a></div>
+    <div className="msb-param-desc">Stat virtualization policy.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">host_permissions()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn host_permissions(self, policy: HostPermissions) -> Self
+```
+
+Set the host permission propagation policy for a virtiofs-backed mount. Default: [`Private`](#hostpermissions). Valid only for bind and named-volume mounts. Combining [`StatVirtualization::Off`](#statvirtualization) with [`HostPermissions::Mirror`](#hostpermissions) is rejected, since with no overlay the guest chmod already hits the host inode and `Mirror` would be a no-op.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>policy</code><a className="msb-type" href="#hostpermissions">HostPermissions</a></div>
+    <div className="msb-param-desc">Host permission propagation policy.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">size()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="mb-size"></a>
+
+```rust
+fn size(self, size: impl Into<Mebibytes>) -> Self
+```
+
+Set the size limit for a [`.tmpfs()`](#tmpfs) mount. Accepts a bare `u32` (MiB) or a `SizeExt` helper such as `1.gib()`. Valid only for tmpfs mounts.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>size</code><span className="msb-type">impl Into&lt;Mebibytes&gt;</span></div>
+    <div className="msb-param-desc">Size limit in MiB.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="mb-build"></a>
+
+```rust
+fn build(self) -> MicrosandboxResult<VolumeMount>
+```
+
+Validate and materialize the mount. Usually called internally by `SandboxBuilder::volume`; call it directly only when assembling a [`VolumeMount`](#mountbuilder-2) by hand. Errors when no mount kind is set, the guest path is not absolute or is `/`, or a kind-specific option was set on the wrong mount kind.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">VolumeMount</span></div>
+    <div className="msb-param-desc">Validated mount specification.</div>
+  </div>
+</div>
+
+---
+
+## NamedVolumeBuilder
+
+Sub-builder for [`MountBuilder::named_with()`](#named_with). Selects the sandbox-time existence behavior and, for `create` / `ensure_exists`, the creation metadata. Defaults to `existing` and directory-backed.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">existing()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="nv-existing"></a>
+
+```rust
+fn existing(self) -> Self
+```
+
+Require the named volume to already exist. This is the default.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="nv-create"></a>
+
+```rust
+fn create(self) -> Self
+```
+
+Create the named volume at sandbox launch and fail if it already exists.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">ensure_exists()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="nv-ensure_exists"></a>
+
+```rust
+fn ensure_exists(self) -> Self
+```
+
+Create the named volume if it is missing, or reuse a compatible existing volume. Errors if an existing volume's kind, quota, capacity, or explicitly requested labels differ.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">name()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="nv-name"></a>
+
+```rust
+fn name(self, name: impl Into<String>) -> Self
+```
+
+Override the volume name passed to [`named_with()`](#named_with).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">directory()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="nv-directory"></a>
+
+```rust
+fn directory(self) -> Self
+```
+
+Use directory-backed storage for a created volume. This is the default. Clears any previously set disk capacity.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">disk()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="nv-disk"></a>
+
+```rust
+fn disk(self) -> Self
+```
+
+Use raw ext4 disk-image storage for a created volume. Requires [`.size()`](#nv-size). Clears any previously set quota.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">size()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="nv-size"></a>
+
+```rust
+fn size(self, size: impl Into<Mebibytes>) -> Self
+```
+
+Set disk capacity for a created disk volume. Accepts a bare `u32` (MiB) or a `SizeExt` helper.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>size</code><span className="msb-type">impl Into&lt;Mebibytes&gt;</span></div>
+    <div className="msb-param-desc">Capacity in MiB.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">quota()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="nv-quota"></a>
+
+```rust
+fn quota(self, size: impl Into<Mebibytes>) -> Self
+```
+
+Set a storage quota for a created directory volume. Accepts a bare `u32` (MiB) or a `SizeExt` helper.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>size</code><span className="msb-type">impl Into&lt;Mebibytes&gt;</span></div>
+    <div className="msb-param-desc">Quota in MiB.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">label()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+<a id="nv-label"></a>
+
+```rust
+fn label(self, key: impl Into<String>, value: impl Into<String>) -> Self
+```
+
+Attach a label to a newly-created volume. For `ensure_exists`, requested labels must match the existing volume. Can be called multiple times.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Label key.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Label value.</div>
+  </div>
+</div>
 
 ---
 
 ## Types
 
+---
+
+### Volume
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+A live named volume, carrying the backend it was created on. Returned by [`Volume::create()`](#volumecreate) and [`VolumeBuilder::create()`](#vb-create).
+
+<p className="msb-backref">Returned by <a href="#volumecreate">Volume::create()</a> · <a href="#vb-create">VolumeBuilder::create()</a></p>
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`name()`](#vol-name) | `&str` | Volume name |
+| [`kind()`](#vol-kind) | [`VolumeKind`](#volumekind) | Directory or disk |
+| [`fs()`](#vol-fs) | [`VolumeFs`](#volumefs) | Host-side filesystem handle |
+| [`path()`](#vol-path) | `MicrosandboxResult<&Path>` | Host data directory (local only) |
+| [`disk_path()`](#vol-disk_path) | `Option<PathBuf>` | Host `disk.raw` path for disk volumes |
+| [`capacity_bytes()`](#vol-capacity_bytes) | `Option<u64>` | Disk capacity in bytes |
+| [`disk_format()`](#vol-disk_format) | `Option<&str>` | Disk image format |
+| [`disk_fstype()`](#vol-disk_fstype) | `Option<&str>` | Inner disk filesystem |
+| [`backend_kind()`](#vol-backend_kind) | `BackendKind` | Local or cloud |
+| [`local()`](#vol-local) | `Option<&VolumeLocalState>` | Local-only state |
+| [`cloud()`](#vol-cloud) | `Option<&VolumeCloudState>` | Cloud-only state |
+
+---
+
 ### VolumeHandle
 
-Handle for interacting with a named volume from the host side.
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-| Property / Method | Type | Description |
-|-------------------|------|-------------|
-| fs() | `VolumeFsHandle` | Host-side filesystem access - read and write files without a running sandbox |
-| name() | `&str` | Volume name |
-| kind() | `VolumeKind` | Volume kind: `Directory` or `Disk` |
-| capacity_bytes() | `Option<u64>` | Disk capacity in bytes |
-| disk_format() | `Option<&str>` | Disk image format |
-| disk_fstype() | `Option<&str>` | Disk filesystem type |
-| remove() | `()` | Delete this volume from disk |
+A lightweight handle to a volume, exposing metadata plus filesystem and delete operations without a live [`Volume`](#volume).
+
+<p className="msb-backref">Returned by <a href="#volumeget">Volume::get()</a> · <a href="#volumelist">Volume::list()</a></p>
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`name()`](#h-name) | `&str` | Volume name |
+| [`kind()`](#h-kind) | [`VolumeKind`](#volumekind) | Directory or disk |
+| [`fs()`](#h-fs) | [`VolumeFs`](#volumefs) | Host-side filesystem handle |
+| [`remove()`](#h-remove) | `MicrosandboxResult<()>` | Delete this volume |
+| [`used_bytes()`](#h-used_bytes) | `u64` | Usage snapshot at read time |
+| [`quota_mib()`](#h-quota_mib) | `Option<u32>` | Storage quota in MiB |
+| [`capacity_bytes()`](#h-capacity_bytes) | `Option<u64>` | Disk capacity in bytes |
+| [`disk_format()`](#h-disk_format) | `Option<&str>` | Disk image format |
+| [`disk_fstype()`](#h-disk_fstype) | `Option<&str>` | Inner disk filesystem |
+| [`disk_path()`](#h-disk_path) | `Option<PathBuf>` | Host `disk.raw` path |
+| [`labels()`](#h-labels) | `&[(String, String)]` | Key-value labels |
+| [`created_at()`](#h-created_at) | `Option<DateTime<Utc>>` | Creation time |
+| [`backend_kind()`](#h-backend_kind) | `BackendKind` | Local or cloud |
+| [`local()`](#h-local) | `Option<&VolumeHandleLocalState>` | Local-only state |
+| [`cloud()`](#h-cloud) | `Option<&VolumeHandleCloudState>` | Cloud-only state |
+
+---
+
+### VolumeBuilder
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Builder for configuring a named volume before creation. Implements `From<VolumeConfig>`.
+
+<p className="msb-backref">Returned by <a href="#volumebuilder">Volume::builder()</a></p>
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`directory()`](#directory) | `Self` | Directory-backed (default) |
+| [`disk()`](#disk) | `Self` | Raw ext4 disk-image volume |
+| [`size()`](#size) | `Self` | Disk capacity (required for disk) |
+| [`quota()`](#quota) | `Self` | Directory storage quota |
+| [`label()`](#label) | `Self` | Attach a label |
+| [`build()`](#vb-build) | [`VolumeConfig`](#volumespec) | Materialize config |
+| [`create()`](#vb-create) | [`Volume`](#volume) | Create the volume |
+
+---
+
+### VolumeFs
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Host-side filesystem operations on a volume. Borrows the parent's backend and name and dispatches each op through the backend. A lifetime-bound handle (`VolumeFs<'_>`).
+
+<p className="msb-backref">Returned by <a href="#vol-fs">Volume::fs()</a> · <a href="#h-fs">VolumeHandle::fs()</a></p>
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`read()`](#fs-read) | `Bytes` | Read bytes |
+| [`read_to_string()`](#fs-read_to_string) | `String` | Read UTF-8 text |
+| [`read_stream()`](#fs-read_stream) | [`VolumeFsReadStream`](#volumefsreadstream) | Stream a file in |
+| [`write()`](#fs-write) | `()` | Write bytes |
+| [`write_stream()`](#fs-write_stream) | [`VolumeFsWriteSink`](#volumefswritesink) | Stream a file out |
+| [`list()`](#fs-list) | `Vec<`[`FsEntry`](/sdk/rust/filesystem#fsentry)`>` | List a directory |
+| [`mkdir()`](#fs-mkdir) | `()` | Create a directory |
+| [`remove()`](#fs-remove) | `()` | Delete a file |
+| [`remove_dir()`](#fs-remove_dir) | `()` | Delete a directory recursively |
+| [`copy()`](#fs-copy) | `()` | Copy a file |
+| [`rename()`](#fs-rename) | `()` | Rename / move |
+| [`stat()`](#fs-stat) | [`FsMetadata`](/sdk/rust/filesystem#fsmetadata) | Metadata |
+| [`exists()`](#fs-exists) | `bool` | Existence check |
+
+`VolumeFs::with_backend(backend, name)` is also available as a public constructor for FFI shims that re-assemble a handle per call; most callers use `Volume::fs()` / `VolumeHandle::fs()`.
+
+---
+
+### VolumeFsReadStream
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+A streaming reader for file data from a local volume directory. Returned by [`VolumeFs::read_stream()`](#fs-read_stream).
+
+<p className="msb-backref">Returned by <a href="#fs-read_stream">VolumeFs::read_stream()</a></p>
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `recv()` | `Option<Bytes>` | Next chunk; `None` at EOF |
+| `collect()` | `Bytes` | Read the rest into one buffer |
+
+---
+
+### VolumeFsWriteSink
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+A streaming writer for file data to a local volume directory. Returned by [`VolumeFs::write_stream()`](#fs-write_stream).
+
+<p className="msb-backref">Returned by <a href="#fs-write_stream">VolumeFs::write_stream()</a></p>
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `write(data)` | `()` | Append a chunk |
+| `close()` | `()` | Flush and close |
+
+---
+
+### MountBuilder
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Builder for a sandbox volume mount, used in `SandboxBuilder::volume`. Builds a `VolumeMount`.
+
+<p className="msb-backref">Used by <a href="/sdk/rust/sandbox#volume">SandboxBuilder::volume()</a></p>
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`bind()`](#bind) | `Self` | Bind a host directory |
+| [`named()`](#named) | `Self` | Mount an existing named volume |
+| [`named_with()`](#named_with) | `Self` | Mount with sandbox-time provisioning |
+| [`tmpfs()`](#tmpfs) | `Self` | In-memory filesystem |
+| [`disk()`](#mb-disk) | `Self` | Host disk image as virtio-blk |
+| [`format()`](#format) | `Self` | Disk image format (disk only) |
+| [`fstype()`](#fstype) | `Self` | Inner filesystem type (disk only) |
+| [`readonly()`](#readonly) | `Self` | Block writes |
+| [`noexec()`](#noexec) | `Self` | Block direct execution |
+| [`nosuid()`](#nosuid) | `Self` | Ignore setuid/setgid |
+| [`nodev()`](#nodev) | `Self` | Ignore device files |
+| [`stat_virtualization()`](#stat_virtualization) | `Self` | Stat virtualization policy (virtiofs) |
+| [`host_permissions()`](#host_permissions) | `Self` | Host permission policy (virtiofs) |
+| [`size()`](#mb-size) | `Self` | tmpfs size limit |
+| [`build()`](#mb-build) | `MicrosandboxResult<VolumeMount>` | Validate and materialize |
+
+---
+
+### NamedVolumeBuilder
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Sub-builder for [`MountBuilder::named_with()`](#named_with). Selects sandbox-time existence behavior and creation metadata.
+
+<p className="msb-backref">Used by <a href="#named_with">MountBuilder::named_with()</a></p>
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`existing()`](#nv-existing) | `Self` | Require the volume to exist (default) |
+| [`create()`](#nv-create) | `Self` | Create, fail if it exists |
+| [`ensure_exists()`](#nv-ensure_exists) | `Self` | Create if missing, else reuse |
+| [`name()`](#nv-name) | `Self` | Override the volume name |
+| [`directory()`](#nv-directory) | `Self` | Directory-backed (default) |
+| [`disk()`](#nv-disk) | `Self` | Disk-backed; requires `size` |
+| [`size()`](#nv-size) | `Self` | Disk capacity |
+| [`quota()`](#nv-quota) | `Self` | Directory quota |
+| [`label()`](#nv-label) | `Self` | Attach a label |
+
+---
+
+### VolumeKind
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+Storage kind for a named volume.
+
+<p className="msb-backref">Returned by <a href="#vol-kind">Volume::kind()</a> · <a href="#h-kind">VolumeHandle::kind()</a></p>
+
+| Variant | Description |
+|---------|-------------|
+| `Directory` | Directory-backed volume mounted through virtiofs |
+| `Disk` | Raw ext4 disk-image volume mounted through virtio-blk |
+
+---
+
+### VolumeSpec
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Configuration for creating a named volume. Re-exported as both `VolumeSpec` and the alias `VolumeConfig`.
+
+<p className="msb-backref">Used by <a href="#volumecreate">Volume::create()</a> · returned by <a href="#vb-build">VolumeBuilder::build()</a></p>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String` | Volume name |
+| `kind` | [`VolumeKind`](#volumekind) | Storage kind |
+| `quota_mib` | `Option<u32>` | Size quota in MiB; `None` is unlimited |
+| `capacity_mib` | `Option<u32>` | Disk capacity in MiB; required for disk volumes |
+| `labels` | `Vec<(String, String)>` | Organization labels |
+
+---
+
+### MountOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
+
+Guest mount behavior shared by every mount kind. Set via the [`MountBuilder`](#mountbuilder-2) toggles; all fields default to `false`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `readonly` | `bool` | Guest writes fail; virtiofs mounts also reject host-side writes |
+| `noexec` | `bool` | Direct execution from the mount is disabled |
+| `nosuid` | `bool` | setuid/setgid elevation from files on the mount is ignored |
+| `nodev` | `bool` | Device files on the mount are ignored |
+
+---
+
+### StatVirtualization
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+Stat virtualization policy for a virtiofs-backed mount. Default: `Strict`. Set via [`MountBuilder::stat_virtualization()`](#stat_virtualization).
+
+| Variant | Description |
+|---------|-------------|
+| `Strict` | Fail-closed: probe the host backing path; require xattr support |
+| `Relaxed` | Opportunistic: apply the overlay when present; tolerate missing xattr support |
+| `Off` | Literal host metadata: do not read or apply the override xattr |
+
+---
+
+### HostPermissions
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+Host permission propagation policy for a virtiofs-backed mount. Default: `Private`. Set via [`MountBuilder::host_permissions()`](#host_permissions).
+
+| Variant | Description |
+|---------|-------------|
+| `Private` | Guest chmod stays in the metadata overlay only |
+| `Mirror` | Mirror ordinary rwx bits for files and directories to the host inode |
+
+---
+
+### DiskImageFormat
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+Disk image format for virtio-blk root filesystems and volume mounts. Used by [`MountBuilder::format()`](#format).
+
+| Variant | Description |
+|---------|-------------|
+| `Qcow2` | QEMU Copy-on-Write v2 |
+| `Raw` | Raw disk image |
+| `Vmdk` | VMware Disk (FLAT/ZERO only, no delta links) |
+
+---
+
+### NamedVolumeMode
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+Sandbox-time behavior for a named volume mount, chosen via [`NamedVolumeBuilder`](#namedvolumebuilder-2).
+
+| Variant | Description |
+|---------|-------------|
+| `Existing` | Require the named volume to already exist (default) |
+| `Create` | Create the named volume and fail if it already exists |
+| `EnsureExists` | Ensure the volume exists, or reuse a compatible existing one |

--- a/docs/sdk/typescript/agent-client.mdx
+++ b/docs/sdk/typescript/agent-client.mdx
@@ -3,81 +3,300 @@ title: Agent client
 description: TypeScript SDK - Low-level agentd client reference
 ---
 
-`AgentClient` is the low-level raw transport for talking to `agentd` through a running sandbox's relay socket. Most applications should use [`Sandbox`](/sdk/typescript/sandbox), [`exec`](/sdk/typescript/execution), and [`fs`](/sdk/typescript/filesystem) instead. Use this API when you are building protocol-level tools or higher-level SDK helpers.
+`AgentClient` is the low-level raw transport for talking to `agentd` through a running sandbox's relay socket. Most applications should use [`Sandbox`](/sdk/typescript/sandbox), [`exec`](/sdk/typescript/execution), and [`fs`](/sdk/typescript/filesystem) instead. Reach for this API when you are building protocol-level tools or higher-level SDK helpers.
 
-All request bodies and response bodies are raw CBOR bytes. The SDK handles framing and correlation ids, but it does not encode or decode the CBOR message body for you.
+All request and response bodies are raw CBOR bytes. The SDK handles framing and correlation ids, but it does not encode or decode the CBOR message body for you: decode it with a library such as `cbor-x`. The raw body is the full CBOR-encoded protocol `Message` body (`v`, `t`, `p`), not just the inner payload.
 
-The raw body is the full CBOR-encoded protocol `Message` body: `v`, `t`, and `p`. It is not just the inner payload.
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Constants<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#flag_terminal"><span className="msb-rn">FLAG_TERMINAL</span><span className="msb-rg">last frame for a correlation id</span></a>
+  <a className="msb-row" href="#flag_session_start"><span className="msb-rn">FLAG_SESSION_START</span><span className="msb-rg">first frame of a session</span></a>
+  <a className="msb-row" href="#flag_shutdown"><span className="msb-rn">FLAG_SHUTDOWN</span><span className="msb-rg">request sandbox shutdown</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Static · AgentClient<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#agentclient-connectsandbox"><span className="msb-rn">AgentClient.connectSandbox()</span><span className="msb-rg">connect by sandbox name</span></a>
+  <a className="msb-row" href="#agentclient-connect"><span className="msb-rn">AgentClient.connect()</span><span className="msb-rg">connect by socket path</span></a>
+  <a className="msb-row" href="#agentclient-socketpath"><span className="msb-rn">AgentClient.socketPath()</span><span className="msb-rg">resolve socket path only</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · AgentClient<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#client-request"><span className="msb-rn">client.request()</span><span className="msb-rg">one frame, one response</span></a>
+  <a className="msb-row" href="#client-stream"><span className="msb-rn">client.stream()</span><span className="msb-rg">open a streaming session</span></a>
+  <a className="msb-row" href="#client-send"><span className="msb-rn">client.send()</span><span className="msb-rg">follow-up frame on an id</span></a>
+  <a className="msb-row" href="#client-readybytes"><span className="msb-rn">client.readyBytes()</span><span className="msb-rg">cached handshake frame</span></a>
+  <a className="msb-row" href="#client-close"><span className="msb-rn">client.close()</span><span className="msb-rg">close the connection</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · AgentStream<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#agentstream"><span className="msb-rn">stream.id</span><span className="msb-rg">protocol correlation id</span></a>
+  <a className="msb-row" href="#agentstream"><span className="msb-rn">stream.next()</span><span className="msb-rg">pull the next frame</span></a>
+  <a className="msb-row" href="#agentstream"><span className="msb-rn">stream.close()</span><span className="msb-rg">release the stream handle</span></a>
+  <a className="msb-row" href="#agentstream"><span className="msb-rn">stream.return()</span><span className="msb-rg">iterator early-exit hook</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#agentclient">AgentClient</a>
+    <a className="msb-typepill" href="#agentstream">AgentStream</a>
+    <a className="msb-typepill" href="#rawframe">RawFrame</a>
+    <a className="msb-typepill" href="#agentconnectoptions">AgentConnectOptions</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```typescript
-import { AgentClient } from "microsandbox";
+import { encode, decode } from "cbor-x";
+import { AgentClient, FLAG_SESSION_START } from "microsandbox";
 
-const client = await AgentClient.connectSandbox("dev");
-const ready = client.readyBytes();
-await client.close();
+const client = await AgentClient.connectSandbox("dev");        // 1. connect
+
+const body = encode({                                          // 2. build a CBOR Message
+  v: 1,
+  t: "core.fs.request",
+  p: encode({ op: { Stat: { path: "/etc" } } }),
+});
+
+const frame = await client.request(FLAG_SESSION_START, body);  // 3. request / response
+console.log(decode(frame.body));
+
+await client.close();                                          // 4. close
 ```
-
----
 
 ## Constants
 
-| Name | Value | Description |
-|------|-------|-------------|
-| `FLAG_TERMINAL` | `0b0000_0001` | Last frame for a correlation id |
-| `FLAG_SESSION_START` | `0b0000_0010` | First frame of a streaming session |
-| `FLAG_SHUTDOWN` | `0b0000_0100` | Shutdown frame |
-
 ---
 
-#### AgentClient.connectSandbox()
+#### <span className="msb-hn">FLAG_TERMINAL</span>
+<div className="msb-tags"><span className="msb-tag is-static">const</span></div>
 
 ```typescript
-static connectSandbox(name: string): Promise<AgentClient>
+const FLAG_TERMINAL = 0b0000_0001
 ```
 
-Connect to a running sandbox by name. Sandbox names are limited to 128 UTF-8 bytes.
+Frame flag: this is the last message for the given correlation id. When a frame on an open stream carries this bit, no further frames will arrive for that id.
 
 ---
 
-#### AgentClient.connect()
+#### <span className="msb-hn">FLAG_SESSION_START</span>
+<div className="msb-tags"><span className="msb-tag is-static">const</span></div>
 
 ```typescript
-static connect(path: string): Promise<AgentClient>
+const FLAG_SESSION_START = 0b0000_0010
 ```
 
-Connect to an agent relay socket by path.
+Frame flag: this is the first message of a new session. Set it on the opening frame of a request/response RPC or a streaming session.
 
 ---
 
-#### AgentClient.socketPath()
+#### <span className="msb-hn">FLAG_SHUTDOWN</span>
+<div className="msb-tags"><span className="msb-tag is-static">const</span></div>
+
+```typescript
+const FLAG_SHUTDOWN = 0b0000_0100
+```
+
+Frame flag: this message requests sandbox shutdown.
+
+## Static methods
+
+---
+
+#### <span className="msb-recv">AgentClient.</span><span className="msb-hn">connectSandbox()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+static connectSandbox(name: string, opts?: AgentConnectOptions): Promise<AgentClient>
+```
+
+Connect to a running sandbox by name. Resolves the sandbox's relay socket path and performs the `core.ready` handshake. Sandbox names are limited to 128 UTF-8 bytes.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#agentconnectoptions">AgentConnectOptions</a></div>
+    <div className="msb-param-desc">Optional connect settings, e.g. handshake timeout.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentclient">Promise&lt;AgentClient&gt;</a></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const client = await AgentClient.connectSandbox("dev", { timeoutMs: 5000 });
+```
+
+---
+
+#### <span className="msb-recv">AgentClient.</span><span className="msb-hn">connect()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+static connect(path: string, opts?: AgentConnectOptions): Promise<AgentClient>
+```
+
+Connect to an `agentd` relay socket by path. Use this when you already have the socket path, for example one returned by [`socketPath()`](#agentclient-socketpath).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Filesystem path of the relay socket.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#agentconnectoptions">AgentConnectOptions</a></div>
+    <div className="msb-param-desc">Optional connect settings, e.g. handshake timeout.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentclient">Promise&lt;AgentClient&gt;</a></div>
+    <div className="msb-param-desc">Connected client.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const path = AgentClient.socketPath("dev");
+const client = await AgentClient.connect(path);
+```
+
+---
+
+#### <span className="msb-recv">AgentClient.</span><span className="msb-hn">socketPath()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```typescript
 static socketPath(name: string): string
 ```
 
-Resolve a sandbox's `agentd` relay socket path **without connecting**. Returns the same path `connectSandbox()` would dial, so you can talk to `agentd` over a raw byte transport (e.g. a transparent relay that splices bytes to and from the socket) instead of this frame client. The sandbox need not be running. Sandbox names are limited to 128 UTF-8 bytes.
+Resolve a sandbox's `agentd` relay socket path **without connecting**. Returns the same path [`connectSandbox()`](#agentclient-connectsandbox) would dial, so you can talk to `agentd` over a raw byte transport (for example a transparent relay that splices bytes to and from the socket) instead of this frame client. The sandbox need not be running. Sandbox names are limited to 128 UTF-8 bytes.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Relay socket path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const path = AgentClient.socketPath("dev");
+```
+
+## Instance methods
 
 ---
 
-#### request()
+#### <span className="msb-recv">client.</span><span className="msb-hn">request()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 request(flags: number, body: Buffer): Promise<RawFrame>
 ```
 
-Send one raw frame and wait for one response frame.
+Send one frame and await a single response frame. Use for request/response RPCs that produce exactly one terminal response (for example `FsRequest` to `FsResponse`).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Frame flag byte, e.g. <code>FLAG_SESSION_START</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">Buffer</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#rawframe">Promise&lt;RawFrame&gt;</a></div>
+    <div className="msb-param-desc">The single response frame.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+import { encode, decode } from "cbor-x";
+import { FLAG_SESSION_START } from "microsandbox";
+
+const body = encode({ v: 1, t: "core.fs.request", p: encode({ op: { Stat: { path: "/etc" } } }) });
+const frame = await client.request(FLAG_SESSION_START, body);
+console.log(decode(frame.body));
+```
 
 ---
 
-#### stream()
+#### <span className="msb-recv">client.</span><span className="msb-hn">stream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 stream(flags: number, body: Buffer): Promise<AgentStream>
 ```
 
-Open a raw streaming session. The returned stream carries the protocol correlation id and is also an async iterator of raw frames.
+Open a streaming session. The returned [`AgentStream`](#agentstream) carries the protocol correlation `id` (pass it to [`send()`](#client-send) for follow-up frames) and is also an async iterator of raw frames.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Frame flag byte for the opening frame, e.g. <code>FLAG_SESSION_START</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">Buffer</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#agentstream">Promise&lt;AgentStream&gt;</a></div>
+    <div className="msb-param-desc">Open stream of raw frames.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```typescript
+import { FLAG_SESSION_START, FLAG_TERMINAL } from "microsandbox";
+
 const stream = await client.stream(FLAG_SESSION_START, body);
 for await (const frame of stream) {
   if ((frame.flags & FLAG_TERMINAL) !== 0) break;
@@ -86,58 +305,140 @@ for await (const frame of stream) {
 
 ---
 
-#### send()
+#### <span className="msb-recv">client.</span><span className="msb-hn">send()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 send(id: number, flags: number, body: Buffer): Promise<void>
 ```
 
-Send a follow-up frame on an existing correlation id. Use this with the `id` on the [`AgentStream`](#agentstream) returned by [`stream()`](#stream).
+Send a follow-up frame on an existing correlation id (for example stdin, a signal, a resize, or data chunks on an open session). Use the `id` of the [`AgentStream`](#agentstream) returned by [`stream()`](#client-stream).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>id</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Correlation id of an open session.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>flags</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Frame flag byte.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>body</code><span className="msb-type">Buffer</span></div>
+    <div className="msb-param-desc">CBOR-encoded protocol message body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await client.send(stream.id, 0, encode({ v: 1, t: "core.pty.stdin", p: encode({ data: "ls\n" }) }));
+```
 
 ---
 
-#### readyBytes()
+#### <span className="msb-recv">client.</span><span className="msb-hn">readyBytes()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```typescript
 readyBytes(): Buffer
 ```
 
-Return the cached handshake `core.ready` frame body as CBOR bytes.
+Return the cached handshake `core.ready` frame body as CBOR bytes. Captured during connect, so this is a synchronous accessor with no protocol traffic.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Buffer</span></div>
+    <div className="msb-param-desc">CBOR-encoded <code>core.ready</code> frame body.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+import { decode } from "cbor-x";
+
+const ready = decode(client.readyBytes());
+```
 
 ---
 
-#### close()
+#### <span className="msb-recv">client.</span><span className="msb-hn">close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 close(): Promise<void>
 ```
 
-Close the client. Calling it more than once is safe.
+Close the connection. Idempotent: calling it more than once is safe.
 
----
-
-## RawFrame
+<p className="msb-label">Example</p>
 
 ```typescript
-interface RawFrame {
-  readonly id: number;
-  readonly flags: number;
-  readonly body: Buffer;
-}
+await client.close();
 ```
 
-`id` is the protocol correlation id, `flags` is the frame flag byte, and `body` is the CBOR-encoded protocol message body.
+## Types
 
----
+### AgentClient
 
-## AgentStream
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
 
-```typescript
-class AgentStream implements AsyncIterableIterator<RawFrame> {
-  readonly id: number;
-  next(): Promise<IteratorResult<RawFrame>>;
-  close(): Promise<void>;
-}
-```
+Low-level client for talking to `agentd` through the sandbox relay socket. All bodies are raw CBOR bytes: encode and decode them in your code with a library like `cbor-x`, and build typed convenience methods on top of this class. Construct it with one of the static connect methods.
 
-`id` is the protocol correlation id. Pass it to [`AgentClient.send()`](#send) for follow-up frames in the same session. `close()` releases the stream handle early.
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| AgentClient.connectSandbox(name, opts?) | `Promise<`[`AgentClient`](#agentclient)`>` | Connect by sandbox name |
+| AgentClient.connect(path, opts?) | `Promise<`[`AgentClient`](#agentclient)`>` | Connect by relay socket path |
+| AgentClient.socketPath(name) | `string` | Resolve the relay socket path without connecting |
+| request(flags, body) | `Promise<`[`RawFrame`](#rawframe)`>` | Send one frame, await one response |
+| stream(flags, body) | `Promise<`[`AgentStream`](#agentstream)`>` | Open a streaming session |
+| send(id, flags, body) | `Promise<void>` | Send a follow-up frame on a correlation id |
+| readyBytes() | `Buffer` | Cached `core.ready` handshake frame body |
+| close() | `Promise<void>` | Close the connection (idempotent) |
+
+### AgentStream
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#client-stream">stream()</a></p>
+
+An open raw agent stream. Implements `AsyncIterableIterator<RawFrame>`, so it can be driven with `for await`. The iterator ends after a frame carrying [`FLAG_TERMINAL`](#flag_terminal) or when the underlying stream is exhausted.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| id | `number` | Protocol correlation id; pass to [`send()`](#client-send) for follow-up frames |
+| next() | `Promise<IteratorResult<`[`RawFrame`](#rawframe)`>>` | Pull the next frame; `done` once terminal or exhausted |
+| close() | `Promise<void>` | Release the stream handle early (idempotent) |
+| return() | `Promise<IteratorResult<`[`RawFrame`](#rawframe)`>>` | Async-iterator early-exit hook; closes the stream |
+| [Symbol.asyncIterator]() | [`AgentStream`](#agentstream) | Returns itself so the stream is iterable |
+
+### RawFrame
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Returned by <a href="#client-request">request()</a> · iterated from <a href="#agentstream">AgentStream</a></p>
+
+A raw protocol frame. The `body` is the CBOR-encoded `Message` body (`v`, `t`, `p`) as it appeared on the wire; decode it with a CBOR library such as `cbor-x`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | `number` | Correlation id from the frame header |
+| flags | `number` | Frame flags (`FLAG_TERMINAL`, `FLAG_SESSION_START`, ...) |
+| body | `Buffer` | Raw CBOR-encoded body bytes |
+
+### AgentConnectOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#agentclient-connectsandbox">connectSandbox()</a> · <a href="#agentclient-connect">connect()</a></p>
+
+Options for connecting to an agent relay.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| timeoutMs | `number` | Handshake timeout in milliseconds. Defaults to `10_000`. |

--- a/docs/sdk/typescript/execution.mdx
+++ b/docs/sdk/typescript/execution.mdx
@@ -3,90 +3,125 @@ title: Execution
 description: TypeScript SDK - Command execution API reference
 ---
 
-See [Commands](/sandboxes/commands) for usage examples.
+Run commands inside a running sandbox: collect output in one shot, stream it as it arrives, attach an interactive PTY, or pipe data to stdin. These methods live on a running [`Sandbox`](/sdk/typescript/sandbox). See [Commands](/sandboxes/commands) for usage examples.
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Run &amp; collect<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#sandbox-exec"><span className="msb-rn">sandbox.exec()</span><span className="msb-rg">run, buffer output</span></a>
+  <a className="msb-row" href="#sandbox-execwith"><span className="msb-rn">sandbox.execWith()</span><span className="msb-rg">run with per-call overrides</span></a>
+  <a className="msb-row" href="#sandbox-shell"><span className="msb-rn">sandbox.shell()</span><span className="msb-rg">run through the shell</span></a>
+  <a className="msb-row" href="#sandbox-attachshell"><span className="msb-rn">sandbox.attachShell()</span><span className="msb-rg">attach the default shell</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Stream &amp; attach<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#sandbox-execstream"><span className="msb-rn">sandbox.execStream()</span><span className="msb-rg">stream events live</span></a>
+  <a className="msb-row" href="#sandbox-execstreamwith"><span className="msb-rn">sandbox.execStreamWith()</span><span className="msb-rg">stream with overrides</span></a>
+  <a className="msb-row" href="#sandbox-shellstream"><span className="msb-rn">sandbox.shellStream()</span><span className="msb-rg">stream through the shell</span></a>
+  <a className="msb-row" href="#sandbox-attach"><span className="msb-rn">sandbox.attach()</span><span className="msb-rg">interactive PTY bridge</span></a>
+  <a className="msb-row" href="#sandbox-attachwith"><span className="msb-rn">sandbox.attachWith()</span><span className="msb-rg">attach with overrides</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · ExecOptionsBuilder<span className="msb-ct">13</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#execoptionsbuilder">.arg()</a>
+    <a className="msb-chip" href="#execoptionsbuilder">.args()</a>
+    <a className="msb-chip" href="#execoptionsbuilder">.cwd()</a>
+    <a className="msb-chip" href="#execoptionsbuilder">.user()</a>
+    <a className="msb-chip" href="#execoptionsbuilder">.env()</a>
+    <a className="msb-chip" href="#execoptionsbuilder">.envs()</a>
+    <a className="msb-chip" href="#execoptionsbuilder">.timeout()</a>
+    <a className="msb-chip" href="#execoptionsbuilder">.stdinPipe()</a>
+    <a className="msb-chip" href="#execoptionsbuilder">.stdinBytes()</a>
+    <a className="msb-chip" href="#execoptionsbuilder">.tty()</a>
+    <a className="msb-more" href="#execoptionsbuilder">+ 3 more in the Types section</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · AttachOptionsBuilder<span className="msb-ct">9</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#attachoptionsbuilder">.arg()</a>
+    <a className="msb-chip" href="#attachoptionsbuilder">.args()</a>
+    <a className="msb-chip" href="#attachoptionsbuilder">.cwd()</a>
+    <a className="msb-chip" href="#attachoptionsbuilder">.user()</a>
+    <a className="msb-chip" href="#attachoptionsbuilder">.env()</a>
+    <a className="msb-chip" href="#attachoptionsbuilder">.envs()</a>
+    <a className="msb-chip" href="#attachoptionsbuilder">.detachKeys()</a>
+    <a className="msb-chip" href="#attachoptionsbuilder">.rlimit()</a>
+    <a className="msb-chip" href="#attachoptionsbuilder">.rlimitRange()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#execoutput">ExecOutput</a>
+    <a className="msb-typepill" href="#exechandle">ExecHandle</a>
+    <a className="msb-typepill" href="#execsink">ExecSink</a>
+    <a className="msb-typepill" href="#execevent">ExecEvent</a>
+    <a className="msb-typepill" href="#exitstatus">ExitStatus</a>
+    <a className="msb-typepill" href="#execoptionsbuilder">ExecOptionsBuilder</a>
+    <a className="msb-typepill" href="#attachoptionsbuilder">AttachOptionsBuilder</a>
+    <a className="msb-typepill" href="#stdin">Stdin</a>
+    <a className="msb-typepill" href="#stdinmode">StdinMode</a>
+    <a className="msb-typepill" href="#rlimit">Rlimit</a>
+    <a className="msb-typepill" href="#rlimitresource">RlimitResource</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+const sandbox = await Sandbox.create("api", { image: "python" });
+
+// 1. one-shot
+const out = await sandbox.exec("python3", ["-c", "print(1 + 1)"]);
+console.log(out.stdout()); // "2\n"
+
+// 2. stream
+const handle = await sandbox.execStream("tail", ["-f", "/var/log/app.log"]);
+for await (const event of handle) {
+  if (event.kind === "stdout") process.stdout.write(event.data);
+  if (event.kind === "exited") break;
+}
+
+await sandbox.stop();
+```
+
+## Run and collect
 
 ---
 
-#### attach()
-
-```typescript
-attach(cmd: string, args?: Iterable<string>): Promise<number>
-```
-
-Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Press `Ctrl+]` (or configured detach keys) to disconnect without stopping the process.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `string` | Command to run |
-| args? | `Iterable<string>` | Command arguments |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Promise<number>` | Exit code of the process |
-
----
-
-#### attachShell()
-
-```typescript
-attachShell(): Promise<number>
-```
-
-Attach to the sandbox's default shell.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Promise<number>` | Exit code |
-
----
-
-#### attachWith()
-
-```typescript
-attachWith(
-  cmd: string,
-  configure: (b: AttachOptionsBuilder) => AttachOptionsBuilder,
-): Promise<number>
-```
-
-Interactive PTY attach with options for environment variables, working directory, user, and custom detach keys. Configure via the builder callback.
-
-```typescript
-const code = await sandbox.attachWith("bash", (a) =>
-  a.cwd("/app")
-    .env("EDITOR", "vim")
-    .detachKeys("ctrl-]"),
-);
-```
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `string` | Command to run |
-| configure | `(b: AttachOptionsBuilder) => AttachOptionsBuilder` | Builder callback — see [`AttachOptionsBuilder`](#attachoptionsbuilder) |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Promise<number>` | Exit code |
-
----
-
-#### exec()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">exec()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 exec(cmd: string, args?: Iterable<string>): Promise<ExecOutput>
 ```
 
-Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`execStream()`](#execstream) instead.
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`execStream()`](#sandbox-execstream) instead.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Command to execute (e.g. <code>"python3"</code>, <code>"/usr/bin/node"</code>).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args?</code><span className="msb-type">Iterable&lt;string&gt;</span></div>
+    <div className="msb-param-desc">Command arguments (e.g. <code>["-c", "print('hello')"]</code>).</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">Promise&lt;ExecOutput&gt;</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```typescript
 const result = await sandbox.exec("python3", ["-c", "print(1 + 1)"]);
@@ -94,66 +129,10 @@ console.log(result.stdout()); // "2\n"
 console.log(result.code);     // 0
 ```
 
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `string` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
-| args? | `Iterable<string>` | Command arguments (e.g. `["-c", "print('hello')"]`) |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
-
 ---
 
-#### execStream()
-
-```typescript
-execStream(cmd: string, args?: Iterable<string>): Promise<ExecHandle>
-```
-
-Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
-
-```typescript
-const handle = await sandbox.execStream("tail", ["-f", "/var/log/app.log"]);
-for await (const event of handle) {
-  if (event.kind === "stdout") process.stdout.write(event.data);
-  if (event.kind === "exited") break;
-}
-```
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `string` | Command to execute |
-| args? | `Iterable<string>` | Command arguments |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Promise<`[`ExecHandle`](#exechandle)`>` | Streaming handle for receiving events and controlling the process |
-
----
-
-#### execStreamWith()
-
-```typescript
-execStreamWith(
-  cmd: string,
-  configure: (b: ExecOptionsBuilder) => ExecOptionsBuilder,
-): Promise<ExecHandle>
-```
-
-Streaming variant of [`execWith()`](#execwith) — same configuration via [`ExecOptionsBuilder`](#execoptionsbuilder), but returns an [`ExecHandle`](#exechandle).
-
----
-
-#### execWith()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">execWith()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 execWith(
@@ -164,6 +143,30 @@ execWith(
 
 Run a command with per-execution overrides. Configure working directory, environment variables, timeout, stdin, TTY allocation, and rlimits via the builder callback. These overrides apply only to this execution and don't change the sandbox's defaults.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Command to execute.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#execoptionsbuilder">(b: ExecOptionsBuilder) =&gt; ExecOptionsBuilder</a></div>
+    <div className="msb-param-desc">Builder callback for per-call overrides.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">Promise&lt;ExecOutput&gt;</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
 ```typescript
 const out = await sandbox.execWith("python3", (e) =>
   e.args(["script.py"])
@@ -173,22 +176,10 @@ const out = await sandbox.execWith("python3", (e) =>
 );
 ```
 
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| cmd | `string` | Command to execute |
-| configure | `(b: ExecOptionsBuilder) => ExecOptionsBuilder` | Builder callback — see [`ExecOptionsBuilder`](#execoptionsbuilder) |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
-
 ---
 
-#### shell()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">shell()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 shell(script: string): Promise<ExecOutput>
@@ -196,110 +187,335 @@ shell(script: string): Promise<ExecOutput>
 
 Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| script | `string` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>script</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Shell command string (e.g. <code>"ls -la /app &amp;&amp; echo done"</code>).</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Promise<`[`ExecOutput`](#execoutput)`>` | Collected stdout, stderr, and exit status |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#execoutput">Promise&lt;ExecOutput&gt;</a></div>
+    <div className="msb-param-desc">Collected stdout, stderr, and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const out = await sandbox.shell("ls -la /app && echo done");
+console.log(out.stdout());
+```
 
 ---
 
-#### shellStream()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">attachShell()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+attachShell(): Promise<number>
+```
+
+Bridge your terminal to the sandbox's default shell in a fully interactive PTY session.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;number&gt;</span></div>
+    <div className="msb-param-desc">Exit code of the shell process.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const code = await sandbox.attachShell();
+```
+
+---
+
+## Stream and attach
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">execStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+execStream(cmd: string, args?: Iterable<string>): Promise<ExecHandle>
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Command to execute.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args?</code><span className="msb-type">Iterable&lt;string&gt;</span></div>
+    <div className="msb-param-desc">Command arguments.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#exechandle">Promise&lt;ExecHandle&gt;</a></div>
+    <div className="msb-param-desc">Streaming handle for receiving events and controlling the process.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const handle = await sandbox.execStream("tail", ["-f", "/var/log/app.log"]);
+for await (const event of handle) {
+  if (event.kind === "stdout") process.stdout.write(event.data);
+  if (event.kind === "exited") break;
+}
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">execStreamWith()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+execStreamWith(
+  cmd: string,
+  configure: (b: ExecOptionsBuilder) => ExecOptionsBuilder,
+): Promise<ExecHandle>
+```
+
+Streaming variant of [`execWith()`](#sandbox-execwith): same configuration via [`ExecOptionsBuilder`](#execoptionsbuilder), but returns an [`ExecHandle`](#exechandle) instead of buffering output.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Command to execute.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#execoptionsbuilder">(b: ExecOptionsBuilder) =&gt; ExecOptionsBuilder</a></div>
+    <div className="msb-param-desc">Builder callback for per-call overrides.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#exechandle">Promise&lt;ExecHandle&gt;</a></div>
+    <div className="msb-param-desc">Streaming handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const handle = await sandbox.execStreamWith("python3", (e) =>
+  e.args(["-u", "worker.py"]).env("LEVEL", "debug").stdinPipe(),
+);
+const stdin = await handle.takeStdin();
+await stdin?.write("task-1\n");
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">shellStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 shellStream(script: string): Promise<ExecHandle>
 ```
 
-Shell command with streaming output.
+Run a shell command with streaming output.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| script | `string` | Shell command string |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>script</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Shell command string.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Promise<`[`ExecHandle`](#exechandle)`>` | Streaming handle |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#exechandle">Promise&lt;ExecHandle&gt;</a></div>
+    <div className="msb-param-desc">Streaming handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const handle = await sandbox.shellStream("for i in 1 2 3; do echo $i; sleep 1; done");
+for await (const event of handle) {
+  if (event.kind === "stdout") process.stdout.write(event.data);
+}
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">attach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+attach(cmd: string, args?: Iterable<string>): Promise<number>
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session. Press `Ctrl+]` (or configured detach keys) to disconnect without stopping the process.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Command to run.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args?</code><span className="msb-type">Iterable&lt;string&gt;</span></div>
+    <div className="msb-param-desc">Command arguments.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;number&gt;</span></div>
+    <div className="msb-param-desc">Exit code of the process.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const code = await sandbox.attach("python3");
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">attachWith()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+attachWith(
+  cmd: string,
+  configure: (b: AttachOptionsBuilder) => AttachOptionsBuilder,
+): Promise<number>
+```
+
+Interactive PTY attach with options for arguments, environment variables, working directory, user, custom detach keys, and rlimits. Configure via the builder callback.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Command to run.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#attachoptionsbuilder">(b: AttachOptionsBuilder) =&gt; AttachOptionsBuilder</a></div>
+    <div className="msb-param-desc">Builder callback for the attach session.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;number&gt;</span></div>
+    <div className="msb-param-desc">Exit code of the process.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const code = await sandbox.attachWith("bash", (a) =>
+  a.cwd("/app")
+    .env("EDITOR", "vim")
+    .detachKeys("ctrl-]"),
+);
+```
 
 ---
 
 ## Types
 
-### AttachOptionsBuilder
+### ExecOutput
 
-Fluent builder used inside `Sandbox.attachWith(cmd, b => ...)`. Every setter returns the same builder so calls can be chained.
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
 
-| Method | Description |
-|--------|-------------|
-| `arg(s)` | Append a single argument |
-| `args(iter)` | Append many arguments |
-| `cwd(path)` | Working directory |
-| `user(user)` | Guest user |
-| `env(key, value)` | Add a single env var |
-| `envs(record \| iter)` | Add many env vars |
-| `detachKeys(spec)` | Detach key sequence (e.g. `"ctrl-]"` or `"ctrl-p,ctrl-q"`) |
-| `rlimit(resource, n)` | Set both soft and hard rlimit |
-| `rlimitRange(resource, soft, hard)` | Set distinct soft/hard rlimits |
-| `build()` | Produce an immutable [`AttachOptions`](#attachoptions) |
+<p className="msb-backref">Returned by <a href="#sandbox-exec">exec()</a> · <a href="#sandbox-execwith">execWith()</a> · <a href="#sandbox-shell">shell()</a> · <a href="#exechandle">ExecHandle.collect()</a></p>
 
-### AttachOptions
+The result of a completed command execution: collected output plus exit status.
 
-The immutable object produced by `AttachOptionsBuilder.build()`.
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `code` | `number` (getter) | Process exit code |
+| `success` | `boolean` (getter) | `true` when `code === 0` |
+| `status` | [`ExitStatus`](#exitstatus) (getter) | Exit status object |
+| `stdout()` | `string` | Collected stdout decoded as UTF-8 (lossy on invalid sequences) |
+| `stderr()` | `string` | Collected stderr decoded as UTF-8 (lossy on invalid sequences) |
+| `stdoutBytes()` | `Uint8Array` | Raw stdout bytes |
+| `stderrBytes()` | `Uint8Array` | Raw stderr bytes |
 
-| Field | Type | Description |
-|-------|------|-------------|
-| args | `readonly string[]` | Command arguments |
-| cwd | `string \| null` | Working directory |
-| user | `string \| null` | Guest user |
-| env | `ReadonlyArray<readonly [string, string]>` | Environment variables |
-| detachKeys | `string \| null` | Detach key sequence |
-| rlimits | `readonly Rlimit[]` | rlimits for the process |
+### ExecHandle
 
-### ExecOptionsBuilder
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
 
-Fluent builder used inside `Sandbox.execWith(cmd, b => ...)`.
+<p className="msb-backref">Returned by <a href="#sandbox-execstream">execStream()</a> · <a href="#sandbox-execstreamwith">execStreamWith()</a> · <a href="#sandbox-shellstream">shellStream()</a></p>
 
-| Method | Description |
-|--------|-------------|
-| `arg(s)` / `args(iter)` | Append arguments |
-| `cwd(path)` | Working directory |
-| `user(user)` | Guest user |
-| `env(key, value)` / `envs(record \| iter)` | Environment variables |
-| `timeout(ms)` | Kill the process after this many milliseconds |
-| `stdinNull()` | Stdin connected to `/dev/null` (default) |
-| `stdinPipe()` | Open a writable stdin pipe — read it back with `ExecHandle.takeStdin()` |
-| `stdinBytes(data)` | Pre-supply stdin (`Uint8Array \| string`) |
-| `tty(enabled)` | Allocate a pseudo-terminal |
-| `rlimit(resource, n)` / `rlimitRange(resource, soft, hard)` | rlimits |
-| `build()` | Produce an immutable [`ExecOptions`](#execoptions) |
+A handle to a running streaming execution. Implements `AsyncIterable<ExecEvent>` and `AsyncDisposable`, so it works with `for await...of` and `await using`.
 
-### ExecOptions
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `recv()` | `Promise<`[`ExecEvent`](#execevent)` \| null>` | Receive the next event, or `null` once the stream ends |
+| `takeStdin()` | `Promise<`[`ExecSink`](#execsink)` \| null>` | Take ownership of the stdin sink. Returns `null` after the first call |
+| `wait()` | `Promise<`[`ExitStatus`](#exitstatus)`>` | Wait for the process to exit |
+| `collect()` | `Promise<`[`ExecOutput`](#execoutput)`>` | Drain stdout/stderr and wait for exit |
+| `signal(signal)` | `Promise<void>` | Send a POSIX signal (numeric) to the process |
+| `kill()` | `Promise<void>` | Force-terminate the process |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<`[`ExecEvent`](#execevent)`>` | Iterate events with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Best-effort kill on `await using` scope exit |
 
-The immutable object produced by `ExecOptionsBuilder.build()`.
+### ExecSink
 
-| Field | Type | Description |
-|-------|------|-------------|
-| args | `readonly string[]` | Command arguments |
-| cwd | `string \| null` | Working directory |
-| user | `string \| null` | Guest user |
-| env | `ReadonlyArray<readonly [string, string]>` | Environment variables |
-| timeoutMs | `number \| null` | Timeout in milliseconds |
-| stdin | `StdinMode` | `null`, `pipe`, or pre-supplied `bytes` |
-| tty | `boolean` | TTY allocation |
-| rlimits | `readonly Rlimit[]` | rlimits |
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#exechandle">ExecHandle.takeStdin()</a></p>
+
+Writer for sending data to a running process's stdin. Implements `AsyncDisposable`. Obtained from [`ExecHandle.takeStdin()`](#exechandle) when the execution was configured with [`.stdinPipe()`](#execoptionsbuilder).
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `write(data)` | `(data: Uint8Array \| string) => Promise<void>` | Write bytes to the process's stdin. Strings are UTF-8 encoded |
+| `close()` | `() => Promise<void>` | Send EOF. Idempotent |
+| `[Symbol.asyncDispose]()` | `() => Promise<void>` | Calls `close()` on `await using` scope exit |
 
 ### ExecEvent
 
-Discriminated union emitted by `ExecHandle`. The discriminator is `kind` (not `eventType`).
+<div className="msb-tags"><span className="msb-tag is-type">union</span></div>
+
+<p className="msb-backref">Emitted by <a href="#exechandle">ExecHandle</a></p>
+
+Discriminated union emitted while iterating an [`ExecHandle`](#exechandle). The discriminator is `kind`.
 
 ```typescript
 type ExecEvent =
@@ -311,53 +527,128 @@ type ExecEvent =
 
 | `kind` | Payload | Description |
 |--------|---------|-------------|
-| `'started'` | `pid: number` | The process has started |
-| `'stdout'` | `data: Uint8Array` | A chunk of stdout data |
-| `'stderr'` | `data: Uint8Array` | A chunk of stderr data |
-| `'exited'` | `code: number` | The process has exited |
-
-### ExecHandle
-
-A handle to a running streaming execution. `AsyncIterable<ExecEvent>` and `AsyncDisposable`.
-
-| Property / Method | Type | Description |
-|-------------------|------|-------------|
-| `recv()` | `Promise<`[`ExecEvent`](#execevent)` \| null>` | Receive the next event. Returns `null` when done. |
-| `takeStdin()` | `Promise<`[`ExecSink`](#execsink)` \| null>` | Take the stdin writer. Returns `null` after first call. |
-| `wait()` | `Promise<`[`ExitStatus`](#exitstatus)`>` | Wait for the process to exit |
-| `collect()` | `Promise<`[`ExecOutput`](#execoutput)`>` | Drain remaining output and wait |
-| `signal(n)` | `Promise<void>` | Send a POSIX signal |
-| `kill()` | `Promise<void>` | Send SIGKILL |
-| `[Symbol.asyncIterator]()` | `AsyncIterator<`[`ExecEvent`](#execevent)`>` | Iterate events with `for await...of` |
-| `[Symbol.asyncDispose]()` | `Promise<void>` | Best-effort kill on `await using` exit |
-
-### ExecOutput
-
-The result of a completed command execution.
-
-| Property / Method | Type | Description |
-|-------------------|------|-------------|
-| `code` | `number` (getter) | Exit code |
-| `success` | `boolean` (getter) | `true` if code is `0` |
-| `status` | [`ExitStatus`](#exitstatus) (getter) | Exit status object |
-| `stdout()` | `string` | Collected stdout decoded as UTF-8 |
-| `stderr()` | `string` | Collected stderr decoded as UTF-8 |
-| `stdoutBytes()` | `Uint8Array` | Raw stdout bytes |
-| `stderrBytes()` | `Uint8Array` | Raw stderr bytes |
-
-### ExecSink
-
-Writer for sending data to a running process's stdin.
-
-| Method | Parameters | Description |
-|--------|-----------|-------------|
-| `write(data)` | `Uint8Array \| string` | Write bytes to the process's stdin |
-| `close()` | - | Close stdin. The process sees EOF. |
-| `[Symbol.asyncDispose]()` | - | Calls `close()` |
+| `"started"` | `pid: number` | The process has started |
+| `"stdout"` | `data: Uint8Array` | A chunk of stdout data |
+| `"stderr"` | `data: Uint8Array` | A chunk of stderr data |
+| `"exited"` | `code: number` | The process has exited |
 
 ### ExitStatus
 
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Returned by <a href="#exechandle">ExecHandle.wait()</a> · <a href="#execoutput">ExecOutput.status</a></p>
+
+The exit result of a process.
+
 | Field | Type | Description |
 |-------|------|-------------|
-| code | `number` | Exit code. `0` typically means success. |
-| success | `boolean` | `true` if code is `0` |
+| code | `number` | Process exit code |
+| success | `boolean` | `true` when `code === 0` |
+
+### ExecOptionsBuilder
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Used by <a href="#sandbox-execwith">execWith()</a> · <a href="#sandbox-execstreamwith">execStreamWith()</a></p>
+
+Fluent builder passed to the callback in `execWith(cmd, b => ...)` and `execStreamWith(cmd, b => ...)`. Every setter mutates the builder and returns it, so calls chain.
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `arg(arg)` | `(arg: string) => this` | Append a single argument |
+| `args(args)` | `(args: string[]) => this` | Append many arguments |
+| `cwd(cwd)` | `(cwd: string) => this` | Working directory |
+| `user(user)` | `(user: string) => this` | Guest user |
+| `env(key, value)` | `(key: string, value: string) => this` | Add a single env var |
+| `envs(vars)` | `(vars: Record<string, string>) => this` | Add many env vars |
+| `timeout(ms)` | `(ms: number) => this` | Kill the process after this many milliseconds |
+| `stdinNull()` | `() => this` | Connect stdin to `/dev/null` (default) |
+| `stdinPipe()` | `() => this` | Open a writable stdin pipe; read it back with [`ExecHandle.takeStdin()`](#exechandle) |
+| `stdinBytes(data)` | `(data: Buffer) => this` | Pre-supply stdin bytes and close it |
+| `tty(enabled)` | `(enabled: boolean) => this` | Allocate a pseudo-terminal |
+| `rlimit(resource, limit)` | `(resource: `[`RlimitResource`](#rlimitresource)`, limit: number) => this` | Set both soft and hard rlimit |
+| `rlimitRange(resource, soft, hard)` | `(resource: `[`RlimitResource`](#rlimitresource)`, soft: number, hard: number) => this` | Set distinct soft and hard rlimits |
+
+### AttachOptionsBuilder
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Used by <a href="#sandbox-attachwith">attachWith()</a></p>
+
+Fluent builder passed to the callback in `attachWith(cmd, b => ...)`. Every setter mutates the builder and returns it, so calls chain.
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `arg(arg)` | `(arg: string) => this` | Append a single argument |
+| `args(args)` | `(args: string[]) => this` | Append many arguments |
+| `cwd(cwd)` | `(cwd: string) => this` | Working directory |
+| `user(user)` | `(user: string) => this` | Guest user |
+| `env(key, value)` | `(key: string, value: string) => this` | Add a single env var |
+| `envs(vars)` | `(vars: Record<string, string>) => this` | Add many env vars |
+| `detachKeys(spec)` | `(spec: string) => this` | Detach key sequence (e.g. `"ctrl-]"` or `"ctrl-p,ctrl-q"`) |
+| `rlimit(resource, limit)` | `(resource: `[`RlimitResource`](#rlimitresource)`, limit: number) => this` | Set both soft and hard rlimit |
+| `rlimitRange(resource, soft, hard)` | `(resource: `[`RlimitResource`](#rlimitresource)`, soft: number, hard: number) => this` | Set distinct soft and hard rlimits |
+
+### Stdin
+
+<div className="msb-tags"><span className="msb-tag is-type">const</span></div>
+
+<p className="msb-backref">Produces <a href="#stdinmode">StdinMode</a></p>
+
+Helper factory for constructing a [`StdinMode`](#stdinmode). Equivalent to the `stdinNull` / `stdinPipe` / `stdinBytes` setters on [`ExecOptionsBuilder`](#execoptionsbuilder).
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `Stdin.null()` | `() => `[`StdinMode`](#stdinmode) | Connect stdin to `/dev/null` |
+| `Stdin.pipe()` | `() => `[`StdinMode`](#stdinmode) | Open a writable pipe; caller writes via [`ExecHandle.takeStdin()`](#exechandle) |
+| `Stdin.bytes(data)` | `(data: Uint8Array \| string) => `[`StdinMode`](#stdinmode) | Send the given bytes (or UTF-8-encoded string) and close stdin |
+
+### StdinMode
+
+<div className="msb-tags"><span className="msb-tag is-type">union</span></div>
+
+<p className="msb-backref">Produced by <a href="#stdin">Stdin</a></p>
+
+Discriminated union describing stdin behavior for an execution.
+
+```typescript
+type StdinMode =
+  | { kind: "null" }
+  | { kind: "pipe" }
+  | { kind: "bytes"; data: Uint8Array };
+```
+
+| `kind` | Payload | Description |
+|--------|---------|-------------|
+| `"null"` | - | Stdin connected to `/dev/null` |
+| `"pipe"` | - | Writable pipe opened for the caller |
+| `"bytes"` | `data: Uint8Array` | Pre-supplied stdin bytes, then EOF |
+
+### Rlimit
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Set via <a href="#execoptionsbuilder">ExecOptionsBuilder.rlimit()</a> · <a href="#attachoptionsbuilder">AttachOptionsBuilder.rlimit()</a></p>
+
+A POSIX resource limit applied to the process.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| resource | [`RlimitResource`](#rlimitresource) | Which resource is limited |
+| soft | `number` | Soft limit |
+| hard | `number` | Hard limit |
+
+### RlimitResource
+
+<div className="msb-tags"><span className="msb-tag is-type">union</span></div>
+
+<p className="msb-backref">Used by <a href="#rlimit">Rlimit.resource</a> · <a href="#execoptionsbuilder">rlimit()</a> · <a href="#attachoptionsbuilder">rlimit()</a></p>
+
+String union naming a limitable POSIX resource.
+
+```typescript
+type RlimitResource =
+  | "cpu" | "fsize" | "data" | "stack" | "core" | "rss"
+  | "nproc" | "nofile" | "memlock" | "as" | "locks"
+  | "sigpending" | "msgqueue" | "nice" | "rtprio" | "rttime";
+```

--- a/docs/sdk/typescript/filesystem.mdx
+++ b/docs/sdk/typescript/filesystem.mdx
@@ -3,133 +3,64 @@ title: Filesystem
 description: TypeScript SDK - Filesystem API reference
 ---
 
-See [Filesystem](/sandboxes/filesystem) for usage examples.
+Read and write files inside a running sandbox over the same host-guest channel as command execution: no SSH, no network. Obtain a handle with `sandbox.fs()`. See [Filesystem](/sandboxes/filesystem) for usage examples. For bulk transfers, consider a [bind-mounted volume](/sandboxes/volumes) instead.
 
-## SandboxFsOps
+<div className="msb-glance">
 
-Filesystem handle for a running sandbox. Obtained via `sb.fs()`. All operations go through the same host-guest channel as command execution — no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
+  <p className="msb-gl"><span className="msb-dot instance"></span>SandboxFsOps · read / write<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#fs-read"><span className="msb-rn">fs.read()</span><span className="msb-rg">read a file as bytes</span></a>
+  <a className="msb-row" href="#fs-readtostring"><span className="msb-rn">fs.readToString()</span><span className="msb-rg">read a file as UTF-8</span></a>
+  <a className="msb-row" href="#fs-write"><span className="msb-rn">fs.write()</span><span className="msb-rg">write a whole file</span></a>
+  <a className="msb-row" href="#fs-readstream"><span className="msb-rn">fs.readStream()</span><span className="msb-rg">stream a file in chunks</span></a>
+  <a className="msb-row" href="#fs-writestream"><span className="msb-rn">fs.writeStream()</span><span className="msb-rg">stream writes to a file</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SandboxFsOps · directories &amp; paths<span className="msb-ct">6</span></p>
+  <a className="msb-row" href="#fs-list"><span className="msb-rn">fs.list()</span><span className="msb-rg">list a directory</span></a>
+  <a className="msb-row" href="#fs-mkdir"><span className="msb-rn">fs.mkdir()</span><span className="msb-rg">create a directory</span></a>
+  <a className="msb-row" href="#fs-removedir"><span className="msb-rn">fs.removeDir()</span><span className="msb-rg">remove a directory</span></a>
+  <a className="msb-row" href="#fs-remove"><span className="msb-rn">fs.remove()</span><span className="msb-rg">remove a file</span></a>
+  <a className="msb-row" href="#fs-stat"><span className="msb-rn">fs.stat()</span><span className="msb-rg">file metadata</span></a>
+  <a className="msb-row" href="#fs-exists"><span className="msb-rn">fs.exists()</span><span className="msb-rg">check a path exists</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SandboxFsOps · move &amp; copy<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#fs-copy"><span className="msb-rn">fs.copy()</span><span className="msb-rg">copy within the guest</span></a>
+  <a className="msb-row" href="#fs-rename"><span className="msb-rn">fs.rename()</span><span className="msb-rg">rename / move</span></a>
+  <a className="msb-row" href="#fs-copyfromhost"><span className="msb-rn">fs.copyFromHost()</span><span className="msb-rg">host into guest</span></a>
+  <a className="msb-row" href="#fs-copytohost"><span className="msb-rn">fs.copyToHost()</span><span className="msb-rg">guest out to host</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#fsentry">FsEntry</a>
+    <a className="msb-typepill" href="#fsmetadata">FsMetadata</a>
+    <a className="msb-typepill" href="#fsentrykind">FsEntryKind</a>
+    <a className="msb-typepill" href="#fsreadstream">FsReadStream</a>
+    <a className="msb-typepill" href="#fswritesink">FsWriteSink</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```typescript
 const fs = sandbox.fs();
 
-await fs.write("/tmp/config.json", '{"debug": true}');
-const content = await fs.readToString("/tmp/config.json");
+await fs.write("/tmp/config.json", '{"debug": true}');   // write
+const content = await fs.readToString("/tmp/config.json"); // read back
+console.log(content);
+
+for (const entry of await fs.list("/tmp")) {              // list
+  console.log(entry.path);
+}
 ```
+
+## SandboxFsOps
+
+Filesystem handle for a running sandbox, obtained via [`sandbox.fs()`](/sdk/typescript/sandbox#sandboxfs). Every method is async and returns a `Promise`. Paths are absolute inside the guest.
 
 ---
 
-#### copy()
-
-```typescript
-copy(from: string, to: string): Promise<void>
-```
-
-Copy a file within the sandbox.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| from | `string` | Source path |
-| to | `string` | Destination path |
-
----
-
-#### copyFromHost()
-
-```typescript
-copyFromHost(hostPath: string, guestPath: string): Promise<void>
-```
-
-Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| hostPath | `string` | Path on the host filesystem |
-| guestPath | `string` | Destination path inside the sandbox |
-
----
-
-#### copyToHost()
-
-```typescript
-copyToHost(guestPath: string, hostPath: string): Promise<void>
-```
-
-Copy a file from the sandbox to the host machine.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| guestPath | `string` | Path inside the sandbox |
-| hostPath | `string` | Destination path on the host |
-
----
-
-#### exists()
-
-```typescript
-exists(path: string): Promise<boolean>
-```
-
-Check whether a path exists inside the sandbox.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Promise<boolean>` | `true` if the path exists |
-
----
-
-#### list()
-
-```typescript
-list(path: string): Promise<FsEntry[]>
-```
-
-List the entries in a directory.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute directory path inside the guest |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Promise<`[`FsEntry`](#fsentry)`[]>` | Directory entries |
-
----
-
-#### mkdir()
-
-```typescript
-mkdir(path: string): Promise<void>
-```
-
-Create a directory. Parent directories must already exist.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute directory path |
-
----
-
-#### read()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">read()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 read(path: string): Promise<Uint8Array>
@@ -137,142 +68,71 @@ read(path: string): Promise<Uint8Array>
 
 Read the entire contents of a file as raw bytes.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest (e.g. <code>"/app/config.json"</code>).</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Promise<Uint8Array>` | File contents as raw bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;Uint8Array&gt;</span></div>
+    <div className="msb-param-desc">File contents as raw bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const bytes = await fs.read("/app/logo.png");
+console.log(`${bytes.byteLength} bytes`);
+```
 
 ---
 
-#### readStream()
-
-```typescript
-readStream(path: string): Promise<FsReadStream>
-```
-
-Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory.
-
-```typescript
-for await (const chunk of await fs.readStream("/var/log/syslog")) {
-  process.stdout.write(chunk); // chunk is a Uint8Array
-}
-```
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Promise<`[`FsReadStream`](#fsreadstream)`>` | Async stream that yields chunks of file data |
-
----
-
-#### readToString()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">readToString()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 readToString(path: string): Promise<string>
 ```
 
-Read the entire contents of a file and decode as UTF-8.
+Read the entire contents of a file and decode it as UTF-8.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Promise<string>` | File contents as a string |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;string&gt;</span></div>
+    <div className="msb-param-desc">File contents as a string.</div>
+  </div>
+</div>
 
----
-
-#### remove()
-
-```typescript
-remove(path: string): Promise<void>
-```
-
-Remove a file.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute file path |
-
----
-
-#### removeDir()
+<p className="msb-label">Example</p>
 
 ```typescript
-removeDir(path: string): Promise<void>
+const text = await fs.readToString("/etc/hostname");
+console.log(text.trim());
 ```
-
-Remove a directory.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute directory path |
 
 ---
 
-#### rename()
-
-```typescript
-rename(from: string, to: string): Promise<void>
-```
-
-Rename or move a file or directory within the sandbox.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| from | `string` | Current path |
-| to | `string` | New path |
-
----
-
-#### stat()
-
-```typescript
-stat(path: string): Promise<FsMetadata>
-```
-
-Get detailed metadata for a file or directory.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Promise<`[`FsMetadata`](#fsmetadata)`>` | File metadata |
-
----
-
-#### write()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">write()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 write(path: string, data: Uint8Array | string): Promise<void>
@@ -280,39 +140,405 @@ write(path: string, data: Uint8Array | string): Promise<void>
 
 Write content to a file, creating it if it doesn't exist and overwriting if it does. Parent directories must already exist. `string` payloads are encoded as UTF-8.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest |
-| data | `Uint8Array \| string` | File content |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>data</code><span className="msb-type">Uint8Array | string</span></div>
+    <div className="msb-param-desc">File content. Strings are written as UTF-8.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await fs.write("/tmp/config.json", '{"debug": true}');
+```
 
 ---
 
-#### writeStream()
+#### <span className="msb-recv">fs.</span><span className="msb-hn">readStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+readStream(path: string): Promise<FsReadStream>
+```
+
+Open a streaming reader for a file. Data is transferred in chunks. Use this for files too large to fit in memory. The returned [`FsReadStream`](#fsreadstream) is an `AsyncIterable<Uint8Array>`, so it works with `for await...of`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsreadstream">Promise&lt;FsReadStream&gt;</a></div>
+    <div className="msb-param-desc">Async stream that yields chunks of file data.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+for await (const chunk of await fs.readStream("/var/log/syslog")) {
+  process.stdout.write(chunk); // chunk is a Uint8Array
+}
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">writeStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 writeStream(path: string): Promise<FsWriteSink>
 ```
 
-Open a streaming writer for a file. Use for files too large to hold in memory; pair with `await using` so the sink closes itself.
+Open a streaming writer for a file. Use this for files too large to hold in memory; pair with `await using` so the [`FsWriteSink`](#fswritesink) closes itself when the scope exits.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fswritesink">Promise&lt;FsWriteSink&gt;</a></div>
+    <div className="msb-param-desc">Streaming writer.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```typescript
 await using sink = await fs.writeStream("/tmp/big.bin");
 await sink.write(new Uint8Array(1 << 20));
 ```
 
-**Parameters**
+---
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest |
+#### <span className="msb-recv">fs.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
-**Returns**
+```typescript
+list(path: string): Promise<FsEntry[]>
+```
 
-| Type | Description |
-|------|-------------|
-| `Promise<`[`FsWriteSink`](#fswritesink)`>` | Streaming writer |
+List the entries in a directory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute directory path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsentry">Promise&lt;FsEntry[]&gt;</a></div>
+    <div className="msb-param-desc">Directory entries.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+for (const entry of await fs.list("/app")) {
+  console.log(`${entry.kind}\t${entry.path}`);
+}
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+mkdir(path: string): Promise<void>
+```
+
+Create a directory. Parent directories must already exist.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute directory path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await fs.mkdir("/app/data");
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">removeDir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+removeDir(path: string): Promise<void>
+```
+
+Remove a directory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute directory path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await fs.removeDir("/app/data");
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+remove(path: string): Promise<void>
+```
+
+Remove a file.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute file path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await fs.remove("/tmp/config.json");
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">stat()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+stat(path: string): Promise<FsMetadata>
+```
+
+Get detailed metadata for a file or directory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#fsmetadata">Promise&lt;FsMetadata&gt;</a></div>
+    <div className="msb-param-desc">File metadata.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const meta = await fs.stat("/app/config.json");
+console.log(`${meta.size} bytes, mode ${meta.mode.toString(8)}`);
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">exists()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+exists(path: string): Promise<boolean>
+```
+
+Check whether a path exists inside the sandbox.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;boolean&gt;</span></div>
+    <div className="msb-param-desc"><code>true</code> if the path exists.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+if (await fs.exists("/app/config.json")) {
+  console.log("config present");
+}
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">copy()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+copy(from: string, to: string): Promise<void>
+```
+
+Copy a file within the sandbox.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>from</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Source path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>to</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await fs.copy("/app/config.json", "/app/config.bak.json");
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">rename()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+rename(from: string, to: string): Promise<void>
+```
+
+Rename or move a file or directory within the sandbox.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>from</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Current path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>to</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">New path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await fs.rename("/tmp/draft.txt", "/tmp/final.txt");
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">copyFromHost()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+copyFromHost(hostPath: string, guestPath: string): Promise<void>
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hostPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path on the host filesystem.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guestPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination path inside the sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await fs.copyFromHost("./seed.db", "/app/data/seed.db");
+```
+
+---
+
+#### <span className="msb-recv">fs.</span><span className="msb-hn">copyToHost()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+copyToHost(guestPath: string, hostPath: string): Promise<void>
+```
+
+Copy a file from the sandbox to the host machine.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guestPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path inside the sandbox.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hostPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination path on the host.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await fs.copyToHost("/app/out/report.pdf", "./report.pdf");
+```
 
 ---
 
@@ -320,32 +546,27 @@ await sink.write(new Uint8Array(1 << 20));
 
 ### FsEntry
 
-Metadata for a single directory entry, returned by [`list()`](#list).
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Returned by <a href="#fs-list">list()</a></p>
+
+Metadata for a single directory entry.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| path | `string` | File path |
+| path | `string` | Entry path |
 | kind | [`FsEntryKind`](#fsentrykind) | Type of entry |
 | size | `number` | File size in bytes |
 | mode | `number` | Unix permission bits |
-| modified | `Date \| null` | Last modified timestamp |
-
-### FsEntryKind
-
-```typescript
-type FsEntryKind = "file" | "directory" | "symlink" | "other";
-```
-
-| Value | Description |
-|-------|-------------|
-| `'file'` | Regular file |
-| `'directory'` | Directory |
-| `'symlink'` | Symbolic link |
-| `'other'` | Other entry type |
+| modified | `Date \| null` | Last modified timestamp, or `null` if unavailable |
 
 ### FsMetadata
 
-Detailed file metadata, returned by [`stat()`](#stat).
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Returned by <a href="#fs-stat">stat()</a></p>
+
+Detailed file metadata.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -353,26 +574,51 @@ Detailed file metadata, returned by [`stat()`](#stat).
 | size | `number` | File size in bytes |
 | mode | `number` | Unix permission bits |
 | readonly | `boolean` | Whether the file is read-only |
-| modified | `Date \| null` | Last modified timestamp |
-| created | `Date \| null` | Creation timestamp |
+| modified | `Date \| null` | Last modified timestamp, or `null` if unavailable |
+| created | `Date \| null` | Creation timestamp, or `null` if unavailable |
+
+### FsEntryKind
+
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+<p className="msb-backref">Used by <a href="#fsentry">FsEntry.kind</a> · <a href="#fsmetadata">FsMetadata.kind</a></p>
+
+```typescript
+type FsEntryKind = "file" | "directory" | "symlink" | "other";
+```
+
+| Value | Description |
+|-------|-------------|
+| `"file"` | Regular file |
+| `"directory"` | Directory |
+| `"symlink"` | Symbolic link |
+| `"other"` | Other entry type |
 
 ### FsReadStream
 
-Async stream for reading a file in chunks. Obtained via [`readStream()`](#readstream). `AsyncIterable<Uint8Array>` and `AsyncDisposable`.
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#fs-readstream">readStream()</a></p>
+
+Async stream for reading a file in chunks. Implements `AsyncIterable<Uint8Array>` and `AsyncDisposable`, so it works with `for await...of` and `await using`.
 
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `recv()` | `Promise<Uint8Array \| null>` | Receive the next chunk. Returns `null` when the file has been fully read. |
 | `collect()` | `Promise<Uint8Array>` | Drain the stream into a single buffer |
-| `[Symbol.asyncIterator]()` | `AsyncIterator<Uint8Array>` | Use with `for await...of` |
-| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop reading; safe to use with `await using` |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<Uint8Array>` | Iterate chunks with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop reading; runs on `await using` scope exit |
 
 ### FsWriteSink
 
-Streaming writer returned by [`writeStream()`](#writestream). `AsyncDisposable`.
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
 
-| Method | Parameters | Description |
-|--------|-----------|-------------|
-| `write(data)` | `Uint8Array \| string` | Append a chunk |
-| `close()` | - | Flush and close. Idempotent. |
-| `[Symbol.asyncDispose]()` | - | Calls `close()` |
+<p className="msb-backref">Returned by <a href="#fs-writestream">writeStream()</a></p>
+
+Streaming writer for a file. Implements `AsyncDisposable`, so it can be paired with `await using`.
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `write(data)` | `Uint8Array \| string` | `Promise<void>` | Append a chunk. Strings are encoded as UTF-8. |
+| `close()` | - | `Promise<void>` | Flush and close. Idempotent. |
+| `[Symbol.asyncDispose]()` | - | `Promise<void>` | Calls `close()` on `await using` scope exit |

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -3,17 +3,168 @@ title: Networking
 description: TypeScript SDK - Network API reference
 ---
 
-See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+Configure a sandbox's network stack: a first-match-wins egress/ingress policy, published ports, DNS interception, TLS interception, and secret-violation handling. See [Networking](/networking/overview) for the conceptual overview and [TLS Interception](/networking/tls) for proxy details.
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Factory · NetworkPolicy<span className="msb-ct">5</span></p>
+  <a className="msb-row" href="#networkpolicybuilder"><span className="msb-rn">NetworkPolicy.builder()</span><span className="msb-rg">start the fluent builder</span></a>
+  <a className="msb-row" href="#networkpolicy-none"><span className="msb-rn">NetworkPolicy.none()</span><span className="msb-rg">deny everything</span></a>
+  <a className="msb-row" href="#networkpolicy-allowall"><span className="msb-rn">NetworkPolicy.allowAll()</span><span className="msb-rg">allow everything</span></a>
+  <a className="msb-row" href="#networkpolicy-publiconly"><span className="msb-rn">NetworkPolicy.publicOnly()</span><span className="msb-rg">public internet only (default)</span></a>
+  <a className="msb-row" href="#networkpolicy-nonlocal"><span className="msb-rn">NetworkPolicy.nonLocal()</span><span className="msb-rg">public + private, no local</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Factory · Rule / Destination / PortRange<span className="msb-ct">14</span></p>
+  <a className="msb-row" href="#rule-allowegress"><span className="msb-rn">Rule.allowEgress()</span><span className="msb-rg">allow rule, egress</span></a>
+  <a className="msb-row" href="#rule-denyegress"><span className="msb-rn">Rule.denyEgress()</span><span className="msb-rg">deny rule, egress</span></a>
+  <a className="msb-row" href="#rule-allowingress"><span className="msb-rn">Rule.allowIngress()</span><span className="msb-rg">allow rule, ingress</span></a>
+  <a className="msb-row" href="#rule-denyingress"><span className="msb-rn">Rule.denyIngress()</span><span className="msb-rg">deny rule, ingress</span></a>
+  <a className="msb-row" href="#rule-allowany"><span className="msb-rn">Rule.allowAny()</span><span className="msb-rg">allow rule, both directions</span></a>
+  <a className="msb-row" href="#rule-denyany"><span className="msb-rn">Rule.denyAny()</span><span className="msb-rg">deny rule, both directions</span></a>
+  <a className="msb-row" href="#rule-allowdns"><span className="msb-rn">Rule.allowDns()</span><span className="msb-rg">open plain DNS to gateway</span></a>
+  <a className="msb-row" href="#destination-any"><span className="msb-rn">Destination.any()</span><span className="msb-rg">match any destination</span></a>
+  <a className="msb-row" href="#destination-cidr"><span className="msb-rn">Destination.cidr()</span><span className="msb-rg">match an IP range</span></a>
+  <a className="msb-row" href="#destination-domain"><span className="msb-rn">Destination.domain()</span><span className="msb-rg">match an exact domain</span></a>
+  <a className="msb-row" href="#destination-domainsuffix"><span className="msb-rn">Destination.domainSuffix()</span><span className="msb-rg">match apex + subdomains</span></a>
+  <a className="msb-row" href="#destinationgroup"><span className="msb-rn">Destination.group()</span><span className="msb-rg">match an address group</span></a>
+  <a className="msb-row" href="#portrange-single"><span className="msb-rn">PortRange.single()</span><span className="msb-rg">a single port</span></a>
+  <a className="msb-row" href="#portrange-range"><span className="msb-rn">PortRange.range()</span><span className="msb-rg">an inclusive port range</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · NetworkBuilder<span className="msb-ct">18</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#policy">.policy()</a>
+    <a className="msb-chip" href="#port">.port()</a>
+    <a className="msb-chip" href="#portudp">.portUdp()</a>
+    <a className="msb-chip" href="#portbind">.portBind()</a>
+    <a className="msb-chip" href="#portudpbind">.portUdpBind()</a>
+    <a className="msb-chip" href="#dns">.dns()</a>
+    <a className="msb-chip" href="#tls">.tls()</a>
+    <a className="msb-chip" href="#trusthostcas">.trustHostCAs()</a>
+    <a className="msb-chip" href="#maxconnections">.maxConnections()</a>
+    <a className="msb-chip" href="#ipv4pool">.ipv4Pool()</a>
+    <a className="msb-chip" href="#ipv6pool">.ipv6Pool()</a>
+    <a className="msb-chip" href="#nb-interface">.interface()</a>
+    <a className="msb-chip" href="#enabled">.enabled()</a>
+    <a className="msb-chip" href="#onsecretviolation">.onSecretViolation()</a>
+    <a className="msb-chip" href="#nb-secret">.secret()</a>
+    <a className="msb-chip" href="#secretenv">.secretEnv()</a>
+    <a className="msb-chip" href="#secretenvsimple">.secretEnvSimple()</a>
+    <a className="msb-chip" href="#nb-build">.build()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · NetworkPolicyBuilder<span className="msb-ct">9</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#defaultdeny">.defaultDeny()</a>
+    <a className="msb-chip" href="#defaultallow">.defaultAllow()</a>
+    <a className="msb-chip" href="#defaultegress">.defaultEgress()</a>
+    <a className="msb-chip" href="#defaultingress">.defaultIngress()</a>
+    <a className="msb-chip" href="#egress">.egress()</a>
+    <a className="msb-chip" href="#ingress">.ingress()</a>
+    <a className="msb-chip" href="#any">.any()</a>
+    <a className="msb-chip" href="#rule">.rule()</a>
+    <a className="msb-chip" href="#build">.build()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · RuleBuilder<span className="msb-ct">36</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#rb-egress">.egress()</a>
+    <a className="msb-chip" href="#rb-ingress">.ingress()</a>
+    <a className="msb-chip" href="#rb-any">.any()</a>
+    <a className="msb-chip" href="#tcp">.tcp()</a>
+    <a className="msb-chip" href="#udp">.udp()</a>
+    <a className="msb-chip" href="#port-1">.port()</a>
+    <a className="msb-chip" href="#allowpublic">.allowPublic()</a>
+    <a className="msb-chip" href="#allowprivate">.allowPrivate()</a>
+    <a className="msb-chip" href="#allowhost">.allowHost()</a>
+    <a className="msb-chip" href="#allowlocal">.allowLocal()</a>
+    <a className="msb-chip" href="#allowdomains">.allowDomains()</a>
+    <a className="msb-chip" href="#rb-allow">.allow()</a>
+    <a className="msb-chip" href="#rb-deny">.deny()</a>
+    <a className="msb-more" href="#rulebuilder">+ 23 more in the RuleBuilder section</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · RuleDestinationBuilder<span className="msb-ct">6</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#rd-ip">.ip()</a>
+    <a className="msb-chip" href="#rd-cidr">.cidr()</a>
+    <a className="msb-chip" href="#rd-domain">.domain()</a>
+    <a className="msb-chip" href="#rd-domainsuffix">.domainSuffix()</a>
+    <a className="msb-chip" href="#rd-group">.group()</a>
+    <a className="msb-chip" href="#rd-any">.any()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · DnsBuilder · TlsBuilder · ViolationActionBuilder<span className="msb-ct">16</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#nameservers">.nameservers()</a>
+    <a className="msb-chip" href="#querytimeoutms">.queryTimeoutMs()</a>
+    <a className="msb-chip" href="#rebindprotection">.rebindProtection()</a>
+    <a className="msb-chip" href="#bypass">.bypass()</a>
+    <a className="msb-chip" href="#interceptedports">.interceptedPorts()</a>
+    <a className="msb-chip" href="#verifyupstream">.verifyUpstream()</a>
+    <a className="msb-chip" href="#blockquic">.blockQuic()</a>
+    <a className="msb-chip" href="#interceptcacert">.interceptCaCert()</a>
+    <a className="msb-chip" href="#interceptcakey">.interceptCaKey()</a>
+    <a className="msb-chip" href="#upstreamcacert">.upstreamCaCert()</a>
+    <a className="msb-chip" href="#va-block">.block()</a>
+    <a className="msb-chip" href="#blockandlog">.blockAndLog()</a>
+    <a className="msb-chip" href="#blockandterminate">.blockAndTerminate()</a>
+    <a className="msb-chip" href="#passthroughhost">.passthroughHost()</a>
+    <a className="msb-chip" href="#passthroughhostpattern">.passthroughHostPattern()</a>
+    <a className="msb-chip" href="#passthroughallhosts">.passthroughAllHosts()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#networkconfig">NetworkConfig</a>
+    <a className="msb-typepill" href="#networkpolicy-2">NetworkPolicy</a>
+    <a className="msb-typepill" href="#rule-2">Rule</a>
+    <a className="msb-typepill" href="#action">Action</a>
+    <a className="msb-typepill" href="#direction">Direction</a>
+    <a className="msb-typepill" href="#destination">Destination</a>
+    <a className="msb-typepill" href="#destinationgroup">DestinationGroup</a>
+    <a className="msb-typepill" href="#protocol">Protocol</a>
+    <a className="msb-typepill" href="#portrange-2">PortRange</a>
+    <a className="msb-typepill" href="#publishedport">PublishedPort</a>
+    <a className="msb-typepill" href="#dnsconfig">DnsConfig</a>
+    <a className="msb-typepill" href="#tlsconfig">TlsConfig</a>
+    <a className="msb-typepill" href="/sdk/typescript/secrets#violationaction">ViolationAction</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```typescript
+import { NetworkPolicy, Sandbox } from "microsandbox";
+
+const policy = NetworkPolicy.builder()          // 1. compose a policy
+  .defaultDeny()
+  .egress((e) => e.tcp().port(443).allowPublic())
+  .rule((r) => r.any().deny((d) => d.ip("198.51.100.5")))
+  .build();
+
+const sb = await Sandbox.builder("api")
+  .image("python")
+  .network((n) =>
+    n                                            // 2. wire it into the sandbox
+      .policy(policy)
+      .port(8080, 80)
+      .dns((d) => d.rebindProtection(true)),
+  )
+  .create();
+```
+
+The default policy denies egress except for an implicit allow-public rule (plus DNS), and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry. `NetworkPolicy`, `Rule`, `Destination`, and `PortRange` each merge a value-type interface with a factory namespace under one name, all re-exported from `microsandbox`.
 
 ## NetworkPolicy
 
-A list of rules plus two per-direction defaults, evaluated first-match-wins. Use a static factory for a preset, build a literal, or chain through [`NetworkPolicy.builder()`](#networkpolicybuilder) for the fluent builder:
+A [`NetworkPolicy`](#networkpolicy-2) is an ordered rule list plus two per-direction defaults, evaluated first-match-wins. The presets below construct common shapes directly; for anything custom, start from [`builder()`](#networkpolicybuilder) or write a literal and pass it to [`NetworkBuilder.policy()`](#policy).
 
 ```typescript
 import { NetworkPolicy, Rule, Destination } from "microsandbox";
 
 // Custom policy literal
-const custom = {
+const custom: NetworkPolicy = {
   defaultEgress: "deny",
   defaultIngress: "allow",
   rules: [
@@ -29,14 +180,12 @@ const built = NetworkPolicy.builder()
   .build();
 ```
 
-Pass any of these to `NetworkBuilder.policy(...)`.
-
 ### Rule order matters
 
 The first matching rule wins, so a broad rule placed before a narrow one swallows it:
 
 ```typescript
-const policy = {
+const policy: NetworkPolicy = {
   defaultEgress: "deny",
   defaultIngress: "allow",
   rules: [
@@ -50,7 +199,7 @@ Put specific rules before general ones.
 
 ### Shadow detection
 
-[`NetworkPolicyBuilder.build()`](#networkpolicybuilder) walks the rules and warns when a rule is fully covered by an earlier one in the same direction. Only `ip`, `cidr`, and `group` destinations are checked; domain coverage depends on runtime DNS and is skipped. Builds still succeed; the warning surfaces as a host-side `tracing::warn!` from the rust core:
+[`NetworkPolicyBuilder.build()`](#build) walks the rules and warns when a rule is fully covered by an earlier one in the same direction. Only `cidr` and `group` destinations are checked; domain coverage depends on runtime DNS and is skipped. Builds still succeed; the warning surfaces as a host-side `tracing::warn!` from the rust core:
 
 ```text
 WARN rule #1 (Egress Cidr(10.0.0.5/32) Deny) is shadowed by rule #0 (Egress Cidr(10.0.0.0/8) Allow); to narrow, place the more specific rule first
@@ -58,76 +207,833 @@ WARN rule #1 (Egress Cidr(10.0.0.5/32) Deny) is shadowed by rule #0 (Egress Cidr
 
 Policy literals constructed via `Rule.allowEgress(...)` etc. do not run through the builder and skip this check.
 
-### State accumulation
+---
 
-State setters (`.tcp()`, `.port()`, etc.) inside a [`RuleBuilder`](#rulebuilder) callback carry into every rule-adder that follows. State is **not reset** between adders:
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">builder()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
 
 ```typescript
-NetworkPolicy.builder()
-  .egress((r) => r
-    .tcp().port(443).allowPublic()    // rule 1: egress, TCP, 443, allow Public
-    .udp().allowPrivate()             // rule 2: egress, [TCP, UDP], 443, allow Private
-  )
+builder(): NetworkPolicyBuilder
+```
+
+Start the fluent [`NetworkPolicyBuilder`](#networkpolicybuilder). Equivalent to `new NetworkPolicyBuilder()`. String inputs (`.ip()`, `.cidr()`, `.domain()`, `.domainSuffix()`) are stored raw and parsed at [`build()`](#build), so the chain stays clean and the first parse or validation failure surfaces there.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#networkpolicybuilder">NetworkPolicyBuilder</a></div>
+    <div className="msb-param-desc">Empty builder.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+import { NetworkPolicy } from "microsandbox";
+
+const policy = NetworkPolicy.builder()
+  .defaultDeny()
+  .egress((e) => e.tcp().port(443).allowPublic().allowPrivate())
   .build();
 ```
 
-Use separate `.rule()` / `.egress()` callbacks for rules that need different state.
+---
+
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">none()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+none(): NetworkPolicy
+```
+
+Deny all traffic in both directions, no rules. The guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
 
 ---
 
-#### NetworkPolicy.allowAll()
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">allowAll()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
 
 ```typescript
-static allowAll(): NetworkPolicy
+allowAll(): NetworkPolicy
 ```
 
-Unrestricted network access, including to private addresses and the host machine.
+Unrestricted network access: allow everything in both directions, no rules. Includes private addresses and the host machine.
 
 ---
 
-#### NetworkPolicy.builder()
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">publicOnly()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
 
 ```typescript
-static builder(): NetworkPolicyBuilder
+publicOnly(): NetworkPolicy
 ```
 
-Start a fluent [`NetworkPolicyBuilder`](#networkpolicybuilder). Equivalent to `new NetworkPolicyBuilder()`.
+Egress allowed only to public destinations (plus DNS to the gateway); ingress allowed by default. Blocks private address ranges and cloud metadata endpoints. This is the **default** policy.
 
 ---
 
-#### NetworkPolicy.none()
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">nonLocal()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
 
 ```typescript
-static none(): NetworkPolicy
+nonLocal(): NetworkPolicy
 ```
 
-Deny all traffic. The guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+Egress allowed to public + private (LAN) destinations (plus DNS); ingress allowed by default. Local groups (loopback, link-local, host, metadata) stay denied.
 
 ---
 
-#### NetworkPolicy.nonLocal()
+## Rule, Destination, PortRange
 
-```typescript
-static nonLocal(): NetworkPolicy
-```
-
-Allow egress to public + private (LAN) destinations; ingress allowed by default.
+Factories for the building blocks of a policy literal. [`Rule`](#rule-2) values pair a [`Destination`](#destination) with a direction and action; [`Destination`](#destination) and [`PortRange`](#portrange-2) construct the matchers.
 
 ---
 
-#### NetworkPolicy.publicOnly()
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">allowEgress()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
 
 ```typescript
-static publicOnly(): NetworkPolicy
+allowEgress(destination: Destination): Rule
 ```
 
-Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+Allow rule with direction `egress`. Empty protocols and ports mean "any".
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>destination</code><a className="msb-type" href="#destination">Destination</a></div>
+    <div className="msb-param-desc">Target filter.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+import { Rule, Destination } from "microsandbox";
+
+const r = Rule.allowEgress(Destination.domain("api.example.com"));
+```
+
+---
+
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">denyEgress()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+denyEgress(destination: Destination): Rule
+```
+
+Deny rule with direction `egress`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>destination</code><a className="msb-type" href="#destination">Destination</a></div>
+    <div className="msb-param-desc">Target filter.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">allowIngress()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+allowIngress(destination: Destination): Rule
+```
+
+Allow rule with direction `ingress`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>destination</code><a className="msb-type" href="#destination">Destination</a></div>
+    <div className="msb-param-desc">Target filter.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">denyIngress()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+denyIngress(destination: Destination): Rule
+```
+
+Deny rule with direction `ingress`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>destination</code><a className="msb-type" href="#destination">Destination</a></div>
+    <div className="msb-param-desc">Target filter.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">allowAny()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+allowAny(destination: Destination): Rule
+```
+
+Allow rule with direction `any` (matches in either direction).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>destination</code><a className="msb-type" href="#destination">Destination</a></div>
+    <div className="msb-param-desc">Target filter.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">denyAny()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+denyAny(destination: Destination): Rule
+```
+
+Deny rule with direction `any` (matches in either direction).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>destination</code><a className="msb-type" href="#destination">Destination</a></div>
+    <div className="msb-param-desc">Target filter.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">allowDns()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+allowDns(): Rule
+```
+
+Allow plain DNS (UDP/53 and TCP/53) to the sandbox gateway, i.e. the in-process DNS forwarder. The standard one-liner for opening DNS under a deny-by-default policy. See [DNS as egress](/networking/dns#dns-as-egress) for the underlying semantics.
+
+DoT (TCP/853) is intentionally not included; add an explicit `Destination.group("host")` tcp/853 allow rule if needed (and pair with TLS interception).
+
+<p className="msb-label">Example</p>
+
+```typescript
+import { NetworkPolicy, Rule } from "microsandbox";
+
+const policy: NetworkPolicy = {
+  defaultEgress: "deny",
+  defaultIngress: "deny",
+  rules: [Rule.allowDns()],
+};
+```
+
+---
+
+#### <span className="msb-recv">Destination.</span><span className="msb-hn">any()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+any(): Destination
+```
+
+Match any destination.
+
+---
+
+#### <span className="msb-recv">Destination.</span><span className="msb-hn">cidr()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+cidr(cidr: string): Destination
+```
+
+Match an IP range.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cidr</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">CIDR notation, e.g. <code>"10.0.0.0/8"</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Destination.</span><span className="msb-hn">domain()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+domain(domain: string): Destination
+```
+
+Match an exact domain.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>domain</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Fully qualified domain name.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Destination.</span><span className="msb-hn">domainSuffix()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+domainSuffix(suffix: string): Destination
+```
+
+Match the apex domain and every subdomain.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>suffix</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Domain suffix.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">Destination.</span><span className="msb-hn">group()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+group(group: DestinationGroup): Destination
+```
+
+Match a predefined address group.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>group</code><a className="msb-type" href="#destinationgroup">DestinationGroup</a></div>
+    <div className="msb-param-desc">Group keyword.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">PortRange.</span><span className="msb-hn">single()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+single(port: number): PortRange
+```
+
+Match a single port. `start` and `end` are set to the same value.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>port</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port number.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">PortRange.</span><span className="msb-hn">range()</span>
+<div className="msb-tags"><span className="msb-tag is-static">factory</span></div>
+
+```typescript
+range(start: number, end: number): PortRange
+```
+
+Match an inclusive port range.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>start</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Lower bound (inclusive).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>end</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Upper bound (inclusive).</div>
+  </div>
+</div>
+
+---
+
+## NetworkBuilder
+
+Passed to the callback you give `SandboxBuilder.network(...)`. Every setter returns the same builder. The runtime serializes the accumulated config when the sandbox is created.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">policy()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+policy(policy: NetworkPolicy | NetworkPolicyBuilder): this
+```
+
+Set the policy. Accepts a [`NetworkPolicy`](#networkpolicy-2) literal or factory result, or a [`NetworkPolicyBuilder`](#networkpolicybuilder) (routed through the native bridge so lazy parse/validation errors surface at this call site).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>policy</code><a className="msb-type" href="#networkpolicy-2">NetworkPolicy</a></div>
+    <div className="msb-param-desc">Policy literal, factory result, or builder.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+import { NetworkPolicy, Sandbox } from "microsandbox";
+
+const sb = await Sandbox.builder("api")
+  .image("python")
+  .network((n) => n.policy(NetworkPolicy.publicOnly()))
+  .create();
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">port()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+port(host: number, guest: number): this
+```
+
+Publish a TCP port from the guest to the host. The default host bind address is `127.0.0.1`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">portBind()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+portBind(bind: string, host: number, guest: number): this
+```
+
+Publish a TCP port on a specific host bind address, such as `0.0.0.0`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>bind</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Host bind address.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">portUdp()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+portUdp(host: number, guest: number): this
+```
+
+Publish a UDP port from the guest to the host. The default host bind address is `127.0.0.1`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">portUdpBind()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+portUdpBind(bind: string, host: number, guest: number): this
+```
+
+Publish a UDP port on a specific host bind address.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>bind</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Host bind address.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">dns()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+dns(configure: (b: DnsBuilder) => DnsBuilder): this
+```
+
+Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#dnsbuilder">DnsBuilder</a></div>
+    <div className="msb-param-desc">Configure DNS.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+.network((n) => n.dns((d) => d.rebindProtection(true).queryTimeoutMs(2000)))
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">tls()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+tls(configure: (b: TlsBuilder) => TlsBuilder): this
+```
+
+Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#tlsbuilder">TlsBuilder</a></div>
+    <div className="msb-param-desc">Configure TLS.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">trustHostCAs()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+trustHostCAs(enabled: boolean): this
+```
+
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in for corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Ship host CAs into the guest.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">maxConnections()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+maxConnections(max: number): this
+```
+
+Limit the maximum number of concurrent network connections from the sandbox.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>max</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Maximum concurrent connections.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">ipv4Pool()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+ipv4Pool(pool: string): this
+```
+
+Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pool</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">IPv4 CIDR pool.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">ipv6Pool()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+ipv6Pool(pool: string): this
+```
+
+Set the IPv6 pool used to derive per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pool</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">IPv6 CIDR pool.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv" id="nb-interface">.</span><span className="msb-hn">interface()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+interface(configure: (b: InterfaceOverridesBuilder) => InterfaceOverridesBuilder): this
+```
+
+Override per-sandbox interface attributes (MAC, MTU, fixed IPv4 / IPv6 address). The [`InterfaceOverridesBuilder`](#interfaceoverridesbuilder) exposes `.mac()`, `.mtu()`, `.ipv4()`, and `.ipv6()`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#interfaceoverridesbuilder">InterfaceOverridesBuilder</a></div>
+    <div className="msb-param-desc">Configure interface overrides.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+.network((n) => n.interface((i) => i.mtu(1400).ipv4("172.16.0.2")))
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">enabled()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+enabled(enabled: boolean): this
+```
+
+Enable or disable networking entirely. When `false`, no network interface is created.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Master enable flag.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">onSecretViolation()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+onSecretViolation(configure: (b: ViolationActionBuilder) => ViolationActionBuilder): this
+```
+
+Configure the action taken when a secret reaches a disallowed host. See [`ViolationActionBuilder`](#violationactionbuilder).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#violationactionbuilder">ViolationActionBuilder</a></div>
+    <div className="msb-param-desc">Configure the violation action.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+.network((n) =>
+  n.onSecretViolation((v) =>
+    v.blockAndLog().passthroughHost("api.anthropic.com"),
+  ),
+)
+```
+
+Passthrough hosts receive placeholders unchanged. They do **not** receive real secret values.
+
+---
+
+#### <span className="msb-recv" id="nb-secret">.</span><span className="msb-hn">secret()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+secret(configure: (b: SecretBuilder) => SecretBuilder): this
+```
+
+Add a secret with full configuration. See [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="/sdk/typescript/secrets#secretbuilder">SecretBuilder</a></div>
+    <div className="msb-param-desc">Configure the secret.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">secretEnv()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+secretEnv(envVar: string, value: string, placeholder: string, allowedHost: string): this
+```
+
+Four-arg explicit-placeholder shorthand for adding a secret without opening a builder callback.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>envVar</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Environment variable name (non-empty, no <code>=</code> or NUL).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Real secret value.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>placeholder</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Placeholder string: non-empty, up to 1024 bytes, no NUL/CR/LF.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>allowedHost</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Single hostname allowed to receive the real value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">secretEnvSimple()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+secretEnvSimple(envVar: string, value: string, allowedHost: string): this
+```
+
+Three-arg auto-placeholder shorthand. Auto-generates the placeholder as `$MSB_<envVar>`, so it is the terse counterpart to [`secretEnv()`](#secretenv) when you do not need a custom placeholder. The full secret API also lives on the [secrets page](/sdk/typescript/secrets#networkbuilder-secretenvsimple).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>envVar</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Environment variable name (non-empty, no <code>=</code> or NUL).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Real secret value.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>allowedHost</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Single hostname allowed to receive the real value.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+.network((n) =>
+  n.secretEnvSimple("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com"),
+)
+```
+
+---
+
+#### <span className="msb-recv" id="nb-build">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+build(): NetworkConfig
+```
+
+Materialize the accumulated state into a [`NetworkConfig`](#networkconfig). The native bridge returns snake_case serde output, which the wrapper remaps to camelCase keys before handing back a plain JS object. Inside `SandboxBuilder.network(...)` the runtime calls this for you; call it directly only when you want to inspect or persist the resolved config.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#networkconfig">NetworkConfig</a></div>
+    <div className="msb-param-desc">The materialized network configuration.</div>
+  </div>
+</div>
 
 ---
 
 ## NetworkPolicyBuilder
 
-Fluent builder for [`NetworkPolicy`](#networkpolicy). The closure passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` receives a [`RuleBuilder`](#rulebuilder); state setters and rule-adders chain freely. The first parse / validation failure surfaces from `.build()`.
+Fluent builder for [`NetworkPolicy`](#networkpolicy-2). The closure passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` receives a [`RuleBuilder`](#rulebuilder); state setters and rule-adders chain freely. The first parse / validation failure surfaces from [`build()`](#build).
 
 ```typescript
 import { NetworkPolicy } from "microsandbox";
@@ -141,37 +1047,8 @@ const policy = NetworkPolicy.builder()
 
 ---
 
-#### any()
-
-```typescript
-any(configure: (r: RuleBuilder) => RuleBuilder): this
-```
-
-Sugar for [`rule()`](#rule) with direction pre-set to `Any`. Rules committed inside apply in both directions.
-
----
-
-#### build()
-
-```typescript
-build(): NetworkPolicy
-```
-
-Materialize the accumulated state into a [`NetworkPolicy`](#networkpolicy). Lazily parses every recorded `.ip()` / `.cidr()` / `.domain()` / `.domainSuffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a host-side warning for each shadowed rule pair.
-
----
-
-#### defaultAllow()
-
-```typescript
-defaultAllow(): this
-```
-
-Set both `defaultEgress` and `defaultIngress` to `"allow"`.
-
----
-
-#### defaultDeny()
+#### <span className="msb-recv">.</span><span className="msb-hn">defaultDeny()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 defaultDeny(): this
@@ -181,7 +1058,19 @@ Set both `defaultEgress` and `defaultIngress` to `"deny"`.
 
 ---
 
-#### defaultEgress()
+#### <span className="msb-recv">.</span><span className="msb-hn">defaultAllow()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+defaultAllow(): this
+```
+
+Set both `defaultEgress` and `defaultIngress` to `"allow"`.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">defaultEgress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 defaultEgress(action: "allow" | "deny"): this
@@ -189,15 +1078,19 @@ defaultEgress(action: "allow" | "deny"): this
 
 Per-direction override for the egress default action.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| action | `"allow" \| "deny"` | Default action for egress |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>action</code><span className="msb-type">"allow" | "deny"</span></div>
+    <div className="msb-param-desc">Default action for egress.</div>
+  </div>
+</div>
 
 ---
 
-#### defaultIngress()
+#### <span className="msb-recv">.</span><span className="msb-hn">defaultIngress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 defaultIngress(action: "allow" | "deny"): this
@@ -205,47 +1098,132 @@ defaultIngress(action: "allow" | "deny"): this
 
 Per-direction override for the ingress default action.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| action | `"allow" \| "deny"` | Default action for ingress |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>action</code><span className="msb-type">"allow" | "deny"</span></div>
+    <div className="msb-param-desc">Default action for ingress.</div>
+  </div>
+</div>
 
 ---
 
-#### egress()
+#### <span className="msb-recv">.</span><span className="msb-hn">egress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-egress(configure: (r: RuleBuilder) => RuleBuilder): this
+egress(configure: (rb: RuleBuilder) => RuleBuilder): this
 ```
 
-Sugar for [`rule()`](#rule) with direction pre-set to `Egress`.
+Sugar for [`rule()`](#rule) with direction pre-set to `egress`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#rulebuilder">RuleBuilder</a></div>
+    <div className="msb-param-desc">Add egress rules.</div>
+  </div>
+</div>
 
 ---
 
-#### ingress()
+#### <span className="msb-recv">.</span><span className="msb-hn">ingress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-ingress(configure: (r: RuleBuilder) => RuleBuilder): this
+ingress(configure: (rb: RuleBuilder) => RuleBuilder): this
 ```
 
-Sugar for [`rule()`](#rule) with direction pre-set to `Ingress`.
+Sugar for [`rule()`](#rule) with direction pre-set to `ingress`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#rulebuilder">RuleBuilder</a></div>
+    <div className="msb-param-desc">Add ingress rules.</div>
+  </div>
+</div>
 
 ---
 
-#### rule()
+#### <span className="msb-recv">.</span><span className="msb-hn">any()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-rule(configure: (r: RuleBuilder) => RuleBuilder): this
+any(configure: (rb: RuleBuilder) => RuleBuilder): this
+```
+
+Sugar for [`rule()`](#rule) with direction pre-set to `any`. Rules committed inside apply in both directions.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#rulebuilder">RuleBuilder</a></div>
+    <div className="msb-param-desc">Add bidirectional rules.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">rule()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+rule(configure: (rb: RuleBuilder) => RuleBuilder): this
 ```
 
 Open a multi-rule batch closure. Direction must be set inside via `.egress()`, `.ingress()`, or `.any()` before any rule-adder.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#rulebuilder">RuleBuilder</a></div>
+    <div className="msb-param-desc">Add rules; set direction first.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+build(): NetworkPolicy
+```
+
+Materialize the accumulated state into a [`NetworkPolicy`](#networkpolicy-2). Lazily parses every recorded `.ip()` / `.cidr()` / `.domain()` / `.domainSuffix()` input, validates direction-set and ICMP-egress-only invariants, and emits a host-side warning for each shadowed rule pair.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#networkpolicy-2">NetworkPolicy</a></div>
+    <div className="msb-param-desc">The materialized policy.</div>
+  </div>
+</div>
 
 ---
 
 ## RuleBuilder
 
-Per-rule-batch builder. Lives only inside the callback passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` on a [`NetworkPolicyBuilder`](#networkpolicybuilder). State setters and rule-adders interleave freely; state accumulates eagerly across the callback (see [State accumulation](#state-accumulation)).
+Per-rule-batch builder. Lives only inside the callback passed to `.rule()` / `.egress()` / `.ingress()` / `.any()` on a [`NetworkPolicyBuilder`](#networkpolicybuilder). State setters and rule-adders interleave freely; state accumulates eagerly across the callback and is **not reset** between adders:
+
+```typescript
+NetworkPolicy.builder()
+  .egress((r) =>
+    r
+      .tcp().port(443).allowPublic()    // rule 1: egress, TCP, 443, allow Public
+      .udp().allowPrivate(),            // rule 2: egress, [TCP, UDP], 443, allow Private
+  )
+  .build();
+```
+
+Use separate `.rule()` / `.egress()` callbacks for rules that need different state.
 
 ### Direction setters
 
@@ -253,33 +1231,36 @@ Last-write-wins. ICMP rule-adders are egress-only at build time.
 
 ---
 
-#### any()
-
-```typescript
-any(): this
-```
-
-Set direction to `Any` for subsequent rule-adders. Rules committed after this apply in both directions.
-
----
-
-#### egress()
+#### <span className="msb-recv" id="rb-egress">.</span><span className="msb-hn">egress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 egress(): this
 ```
 
-Set direction to `Egress` for subsequent rule-adders.
+Set direction to `egress` for subsequent rule-adders.
 
 ---
 
-#### ingress()
+#### <span className="msb-recv" id="rb-ingress">.</span><span className="msb-hn">ingress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 ingress(): this
 ```
 
-Set direction to `Ingress` for subsequent rule-adders.
+Set direction to `ingress` for subsequent rule-adders.
+
+---
+
+#### <span className="msb-recv" id="rb-any">.</span><span className="msb-hn">any()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+any(): this
+```
+
+Set direction to `any` for subsequent rule-adders. Rules committed after this apply in both directions.
 
 ---
 
@@ -289,43 +1270,47 @@ Protocols accumulate as a set; duplicates dedupe.
 
 ---
 
-#### icmpv4()
-
-```typescript
-icmpv4(): this
-```
-
-Add `Icmpv4` to the protocols set. Egress-only; an ICMP rule on an `Ingress` or `Any` direction fails build.
-
----
-
-#### icmpv6()
-
-```typescript
-icmpv6(): this
-```
-
-Add `Icmpv6` to the protocols set. Egress-only; same rules as [`icmpv4()`](#icmpv4).
-
----
-
-#### tcp()
+#### <span className="msb-recv">.</span><span className="msb-hn">tcp()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 tcp(): this
 ```
 
-Add `Tcp` to the protocols set.
+Add `tcp` to the protocols set.
 
 ---
 
-#### udp()
+#### <span className="msb-recv">.</span><span className="msb-hn">udp()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 udp(): this
 ```
 
-Add `Udp` to the protocols set.
+Add `udp` to the protocols set.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">icmpv4()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+icmpv4(): this
+```
+
+Add `icmpv4` to the protocols set. Egress-only; an ICMP rule on an `ingress` or `any` direction fails build.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">icmpv6()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+icmpv6(): this
+```
+
+Add `icmpv6` to the protocols set. Egress-only; same rules as [`icmpv4()`](#icmpv4).
 
 ---
 
@@ -335,7 +1320,8 @@ Ports accumulate as a set; duplicates dedupe. Always guest-side (egress destinat
 
 ---
 
-#### port()
+#### <span className="msb-recv" id="port-1">.</span><span className="msb-hn">port()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 port(port: number): this
@@ -343,38 +1329,58 @@ port(port: number): this
 
 Add a single port to the ports set.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| port | `number` | Port number `0..=65535` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>port</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port number <code>0..=65535</code>.</div>
+  </div>
+</div>
 
 ---
 
-#### portRange()
+#### <span className="msb-recv">.</span><span className="msb-hn">portRange()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 portRange(lo: number, hi: number): this
 ```
 
-Add an inclusive port range. `lo > hi` records an error surfaced at `.build()` time.
+Add an inclusive port range. `lo > hi` records an error surfaced at [`build()`](#build) time.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| lo | `number` | Lower bound (inclusive) |
-| hi | `number` | Upper bound (inclusive) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>lo</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Lower bound (inclusive).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hi</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Upper bound (inclusive).</div>
+  </div>
+</div>
 
 ---
 
-#### ports()
+#### <span className="msb-recv">.</span><span className="msb-hn">ports()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 ports(ports: number[]): this
 ```
 
-Add multiple single ports. Equivalent to calling [`port()`](#port-setters) once per element.
+Add multiple single ports. Equivalent to calling [`port()`](#port-1) once per element.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ports</code><span className="msb-type">number[]</span></div>
+    <div className="msb-param-desc">Port numbers.</div>
+  </div>
+</div>
 
 ---
 
@@ -384,143 +1390,183 @@ Each adder commits one rule using the current state and the named destination gr
 
 ---
 
-#### allowHost()
-
-```typescript
-allowHost(): this
-```
-
-Allow the `Host` group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allowLoopback()`](#allowloopback).
-
----
-
-#### allowLinkLocal()
-
-```typescript
-allowLinkLocal(): this
-```
-
-Allow the `LinkLocal` group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
-
----
-
-#### allowLoopback()
-
-```typescript
-allowLoopback(): this
-```
-
-Allow the `Loopback` group (`127.0.0.0/8`, `::1`). The **guest's own** loopback, not the host. To reach a service on the host's localhost, use [`allowHost()`](#allowhost) instead. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
-
----
-
-#### allowMeta()
-
-```typescript
-allowMeta(): this
-```
-
-Allow the `Metadata` group (`169.254.169.254`). **Dangerous on cloud hosts** (exposes IAM credentials).
-
----
-
-#### allowMulticast()
-
-```typescript
-allowMulticast(): this
-```
-
-Allow the `Multicast` group (`224.0.0.0/4`, `ff00::/8`).
-
----
-
-#### allowPrivate()
-
-```typescript
-allowPrivate(): this
-```
-
-Allow the `Private` group (RFC1918 + ULA + CGN).
-
----
-
-#### allowPublic()
+#### <span className="msb-recv">.</span><span className="msb-hn">allowPublic()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 allowPublic(): this
 ```
 
-Allow the `Public` group (complement of named categories: every IP not in any other group).
+Allow the `public` group (complement of named categories: every IP not in any other group).
 
 ---
 
-#### denyHost()
-
-```typescript
-denyHost(): this
-```
-
-Deny the `Host` group.
-
----
-
-#### denyLinkLocal()
-
-```typescript
-denyLinkLocal(): this
-```
-
-Deny the `LinkLocal` group.
-
----
-
-#### denyLoopback()
-
-```typescript
-denyLoopback(): this
-```
-
-Deny the `Loopback` group.
-
----
-
-#### denyMeta()
-
-```typescript
-denyMeta(): this
-```
-
-Deny the `Metadata` group.
-
----
-
-#### denyMulticast()
-
-```typescript
-denyMulticast(): this
-```
-
-Deny the `Multicast` group.
-
----
-
-#### denyPrivate()
-
-```typescript
-denyPrivate(): this
-```
-
-Deny the `Private` group.
-
----
-
-#### denyPublic()
+#### <span className="msb-recv">.</span><span className="msb-hn">denyPublic()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 denyPublic(): this
 ```
 
-Deny the `Public` group.
+Deny the `public` group.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allowPrivate()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+allowPrivate(): this
+```
+
+Allow the `private` group (RFC1918 + ULA + CGN).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">denyPrivate()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+denyPrivate(): this
+```
+
+Deny the `private` group.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allowLoopback()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+allowLoopback(): this
+```
+
+Allow the `loopback` group (`127.0.0.0/8`, `::1`). The **guest's own** loopback, not the host. To reach a service on the host's localhost, use [`allowHost()`](#allowhost) instead. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">denyLoopback()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+denyLoopback(): this
+```
+
+Deny the `loopback` group.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allowLinkLocal()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+allowLinkLocal(): this
+```
+
+Allow the `link-local` group (`169.254.0.0/16`, `fe80::/10`). Excludes the metadata IP `169.254.169.254`.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">denyLinkLocal()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+denyLinkLocal(): this
+```
+
+Deny the `link-local` group.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allowMeta()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+allowMeta(): this
+```
+
+Allow the `metadata` group (`169.254.169.254`). **Dangerous on cloud hosts** (exposes IAM credentials).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">denyMeta()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+denyMeta(): this
+```
+
+Deny the `metadata` group.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allowMulticast()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+allowMulticast(): this
+```
+
+Allow the `multicast` group (`224.0.0.0/4`, `ff00::/8`).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">denyMulticast()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+denyMulticast(): this
+```
+
+Deny the `multicast` group.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allowHost()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+allowHost(): this
+```
+
+Allow the `host` group: per-sandbox gateway IPs that back `host.microsandbox.internal`. This is the right shortcut for "let the sandbox reach my host's localhost", not [`allowLoopback()`](#allowloopback).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">denyHost()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+denyHost(): this
+```
+
+Deny the `host` group.
+
+---
+
+### Composite rule-adders
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allowLocal()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+allowLocal(): this
+```
+
+Add three allow rules atomically: `loopback + link-local + host`. Each uses the callback's current state. `metadata` is intentionally not included; opt in via [`allowMeta()`](#allowmeta) separately.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">denyLocal()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+denyLocal(): this
+```
+
+Add three deny rules atomically: `loopback + link-local + host`. `metadata` is intentionally not included.
 
 ---
 
@@ -530,7 +1576,8 @@ Singular forms add one rule; plural forms add one rule per element.
 
 ---
 
-#### allowDomain()
+#### <span className="msb-recv">.</span><span className="msb-hn">allowDomain()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 allowDomain(name: string): this
@@ -538,51 +1585,19 @@ allowDomain(name: string): this
 
 Add one `Destination::Domain` allow rule.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `string` | Fully qualified domain name |
-
----
-
-#### allowDomainSuffix()
-
-```typescript
-allowDomainSuffix(suffix: string): this
-```
-
-Add one `Destination::DomainSuffix` allow rule. Matches the apex and any subdomain.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| suffix | `string` | Domain suffix |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Fully qualified domain name.</div>
+  </div>
+</div>
 
 ---
 
-#### allowDomainSuffixes()
-
-```typescript
-allowDomainSuffixes(suffixes: string[]): this
-```
-
-Add one `Destination::DomainSuffix` allow rule per suffix.
-
----
-
-#### allowDomains()
-
-```typescript
-allowDomains(names: string[]): this
-```
-
-Add one `Destination::Domain` allow rule per name.
-
----
-
-#### denyDomain()
+#### <span className="msb-recv">.</span><span className="msb-hn">denyDomain()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 denyDomain(name: string): this
@@ -590,41 +1605,39 @@ denyDomain(name: string): this
 
 Add one `Destination::Domain` deny rule.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `string` | Fully qualified domain name |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Fully qualified domain name.</div>
+  </div>
+</div>
 
 ---
 
-#### denyDomainSuffix()
+#### <span className="msb-recv">.</span><span className="msb-hn">allowDomains()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-denyDomainSuffix(suffix: string): this
+allowDomains(names: string[]): this
 ```
 
-Add one `Destination::DomainSuffix` deny rule. Matches the apex and any subdomain.
+Add one `Destination::Domain` allow rule per name.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| suffix | `string` | Domain suffix |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>names</code><span className="msb-type">string[]</span></div>
+    <div className="msb-param-desc">Fully qualified domain names.</div>
+  </div>
+</div>
 
 ---
 
-#### denyDomainSuffixes()
-
-```typescript
-denyDomainSuffixes(suffixes: string[]): this
-```
-
-Add one `Destination::DomainSuffix` deny rule per suffix.
-
----
-
-#### denyDomains()
+#### <span className="msb-recv">.</span><span className="msb-hn">denyDomains()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 denyDomains(names: string[]): this
@@ -632,29 +1645,94 @@ denyDomains(names: string[]): this
 
 Add one `Destination::Domain` deny rule per name.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>names</code><span className="msb-type">string[]</span></div>
+    <div className="msb-param-desc">Fully qualified domain names.</div>
+  </div>
+</div>
+
 ---
 
-### Composite rule-adders
-
----
-
-#### allowLocal()
+#### <span className="msb-recv">.</span><span className="msb-hn">allowDomainSuffix()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-allowLocal(): this
+allowDomainSuffix(suffix: string): this
 ```
 
-Add three allow rules atomically: `Loopback + LinkLocal + Host`. Each uses the callback's current state. `Metadata` is intentionally not included; opt in via [`allowMeta()`](#allowmeta) separately.
+Add one `Destination::DomainSuffix` allow rule. Matches the apex and any subdomain.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>suffix</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Domain suffix.</div>
+  </div>
+</div>
 
 ---
 
-#### denyLocal()
+#### <span className="msb-recv">.</span><span className="msb-hn">denyDomainSuffix()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-denyLocal(): this
+denyDomainSuffix(suffix: string): this
 ```
 
-Add three deny rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is intentionally not included.
+Add one `Destination::DomainSuffix` deny rule. Matches the apex and any subdomain.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>suffix</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Domain suffix.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allowDomainSuffixes()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+allowDomainSuffixes(suffixes: string[]): this
+```
+
+Add one `Destination::DomainSuffix` allow rule per suffix.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>suffixes</code><span className="msb-type">string[]</span></div>
+    <div className="msb-param-desc">Domain suffixes.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">denyDomainSuffixes()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+denyDomainSuffixes(suffixes: string[]): this
+```
+
+Add one `Destination::DomainSuffix` deny rule per suffix.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>suffixes</code><span className="msb-type">string[]</span></div>
+    <div className="msb-param-desc">Domain suffixes.</div>
+  </div>
+</div>
 
 ---
 
@@ -664,508 +1742,170 @@ Add three deny rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is in
 
 ```typescript
 NetworkPolicy.builder()
-  .egress((r) => r
-    .tcp().port(443).allow((d) => d.domain("api.example.com"))
-    .deny((d) => d.cidr("198.51.100.0/24"))
+  .egress((r) =>
+    r
+      .tcp().port(443).allow((d) => d.domain("api.example.com"))
+      .deny((d) => d.cidr("198.51.100.0/24")),
   )
   .build();
 ```
 
 ---
 
-#### allow()
+#### <span className="msb-recv" id="rb-allow">.</span><span className="msb-hn">allow()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 allow(configure: (d: RuleDestinationBuilder) => RuleDestinationBuilder): this
 ```
 
-Begin an explicit-destination rule with action `Allow`.
+Begin an explicit-destination rule with action `allow`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#ruledestinationbuilder">RuleDestinationBuilder</a></div>
+    <div className="msb-param-desc">Commit exactly one destination.</div>
+  </div>
+</div>
 
 ---
 
-#### deny()
+#### <span className="msb-recv" id="rb-deny">.</span><span className="msb-hn">deny()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 deny(configure: (d: RuleDestinationBuilder) => RuleDestinationBuilder): this
 ```
 
-Begin an explicit-destination rule with action `Deny`.
+Begin an explicit-destination rule with action `deny`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#ruledestinationbuilder">RuleDestinationBuilder</a></div>
+    <div className="msb-param-desc">Commit exactly one destination.</div>
+  </div>
+</div>
 
 ---
 
-## Rule
+## RuleDestinationBuilder
 
-Factory for individual policy rules. Each method returns a single [`Rule`](#rule) value.
+Returned by [`RuleBuilder`](#rulebuilder)`.allow(d => ...)` / `.deny(d => ...)`. Exactly one destination call commits the rule; dropping without a destination call silently does nothing.
 
 ---
 
-#### Rule.allowAny()
+#### <span className="msb-recv" id="rd-ip">.</span><span className="msb-hn">ip()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-static allowAny(destination: Destination): Rule
+ip(ip: string): this
 ```
 
-Allow rule with direction `any` (matches in either direction).
+Commit with `Destination::Cidr` of the IP as `/32` or `/128`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| destination | [`Destination`](#destination) | Target filter |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ip</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Single IPv4 or IPv6 address.</div>
+  </div>
+</div>
 
 ---
 
-#### Rule.allowEgress()
+#### <span className="msb-recv" id="rd-cidr">.</span><span className="msb-hn">cidr()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-static allowEgress(destination: Destination): Rule
+cidr(cidr: string): this
 ```
 
-Allow rule with direction `egress`.
+Commit with `Destination::Cidr`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| destination | [`Destination`](#destination) | Target filter |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cidr</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">CIDR notation.</div>
+  </div>
+</div>
 
 ---
 
-#### Rule.allowIngress()
+#### <span className="msb-recv" id="rd-domain">.</span><span className="msb-hn">domain()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-static allowIngress(destination: Destination): Rule
+domain(domain: string): this
 ```
 
-Allow rule with direction `ingress`.
+Commit with `Destination::Domain`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| destination | [`Destination`](#destination) | Target filter |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>domain</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Fully qualified domain name.</div>
+  </div>
+</div>
 
 ---
 
-#### Rule.denyAny()
+#### <span className="msb-recv" id="rd-domainsuffix">.</span><span className="msb-hn">domainSuffix()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-static denyAny(destination: Destination): Rule
+domainSuffix(suffix: string): this
 ```
 
-Deny rule with direction `any` (matches in either direction).
+Commit with `Destination::DomainSuffix`.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| destination | [`Destination`](#destination) | Target filter |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>suffix</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Domain suffix.</div>
+  </div>
+</div>
 
 ---
 
-#### Rule.denyEgress()
+#### <span className="msb-recv" id="rd-group">.</span><span className="msb-hn">group()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-static denyEgress(destination: Destination): Rule
+group(group: string): this
 ```
 
-Deny rule with direction `egress`.
+Commit with `Destination::Group`. `group` is a [`DestinationGroup`](#destinationgroup) string.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| destination | [`Destination`](#destination) | Target filter |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>group</code><a className="msb-type" href="#destinationgroup">DestinationGroup</a></div>
+    <div className="msb-param-desc">Group keyword.</div>
+  </div>
+</div>
 
 ---
 
-#### Rule.denyIngress()
+#### <span className="msb-recv" id="rd-any">.</span><span className="msb-hn">any()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-static denyIngress(destination: Destination): Rule
+any(): this
 ```
 
-Deny rule with direction `ingress`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| destination | [`Destination`](#destination) | Target filter |
-
----
-
-#### Rule.allowDns()
-
-```typescript
-static allowDns(): Rule
-```
-
-Allow plain DNS (UDP/53 and TCP/53) to the sandbox gateway, i.e. the in-process DNS forwarder. The standard one-liner for opening DNS under a deny-by-default policy. See [DNS as egress](/networking/dns#dns-as-egress) for the underlying semantics.
-
-DoT (TCP/853) is intentionally not included; add an explicit `Group::Host tcp/853` allow rule if needed (and pair with TLS interception).
-
----
-
-## Destination
-
-Factory for rule destinations.
-
----
-
-#### Destination.any()
-
-```typescript
-static any(): Destination
-```
-
-Match any destination.
-
----
-
-#### Destination.cidr()
-
-```typescript
-static cidr(cidr: string): Destination
-```
-
-Match an IP range.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| cidr | `string` | CIDR notation (e.g. `"10.0.0.0/8"`) |
-
----
-
-#### Destination.domain()
-
-```typescript
-static domain(domain: string): Destination
-```
-
-Match an exact domain.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| domain | `string` | Fully qualified domain name |
-
----
-
-#### Destination.domainSuffix()
-
-```typescript
-static domainSuffix(suffix: string): Destination
-```
-
-Match the apex domain and every subdomain.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| suffix | `string` | Domain suffix |
-
----
-
-#### Destination.group()
-
-```typescript
-static group(group: DestinationGroup): Destination
-```
-
-Match a predefined address group.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| group | [`DestinationGroup`](#destinationgroup) | Group keyword |
-
----
-
-## PortRange
-
-Factory for port ranges.
-
----
-
-#### PortRange.range()
-
-```typescript
-static range(start: number, end: number): PortRange
-```
-
-Match an inclusive port range.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| start | `number` | Lower bound (inclusive) |
-| end | `number` | Upper bound (inclusive) |
-
----
-
-#### PortRange.single()
-
-```typescript
-static single(port: number): PortRange
-```
-
-Match a single port. `start` and `end` are set to the same value.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| port | `number` | Port number |
-
----
-
-## NetworkBuilder
-
-Returned to the callback you pass to `SandboxBuilder.network(...)`. Every setter returns the same builder.
-
----
-
-#### denyDomainSuffixes()
-
-```typescript
-denyDomainSuffixes(...suffixes: string[]): this
-```
-
-Deny egress to all subdomains of these suffixes. Same enforcement layers as [`denyDomains()`](#denydomains).
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| suffixes | `string[]` | Domain suffixes |
-
----
-
-#### denyDomains()
-
-```typescript
-denyDomains(...names: string[]): this
-```
-
-Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (NXDOMAIN), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| names | `string[]` | Fully qualified domain names |
-
----
-
-#### dns()
-
-```typescript
-dns(f: (d: DnsBuilder) => DnsBuilder): this
-```
-
-Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
-
----
-
-#### enabled()
-
-```typescript
-enabled(b: boolean): this
-```
-
-Enable or disable networking entirely.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| b | `boolean` | When `false`, no network interface is created |
-
----
-
-#### maxConnections()
-
-```typescript
-maxConnections(n: number): this
-```
-
-Limit the maximum number of concurrent network connections from the sandbox.
-
----
-
-#### ipv4Pool()
-
-```typescript
-ipv4Pool(pool: string): this
-```
-
-Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `172.16.0.0/12`.
-
----
-
-#### ipv6Pool()
-
-```typescript
-ipv6Pool(pool: string): this
-```
-
-Set the IPv6 pool used to derive per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48`.
-
----
-
-#### onSecretViolation()
-
-```typescript
-onSecretViolation(configure: (v: ViolationActionBuilder) => ViolationActionBuilder): this
-```
-
-Configure the action taken when a secret reaches a disallowed host:
-
-```typescript
-.network((n) =>
-  n.onSecretViolation((v) =>
-    v.blockAndLog()
-     .passthroughHost("api.anthropic.com")
-  )
-)
-```
-
-Passthrough hosts receive placeholders unchanged. They do **not** receive real secret values.
-
----
-
-## ViolationActionBuilder
-
-| Method | Description |
-|--------|-------------|
-| `block()` | Block the request silently |
-| `blockAndLog()` | Block the request and emit a warning log |
-| `blockAndTerminate()` | Block the request and terminate the sandbox |
-| `passthroughHost(host)` | Allow placeholders to pass through unchanged to an exact host |
-| `passthroughHostPattern(pattern)` | Allow placeholders to pass through unchanged to matching wildcard hosts |
-| `passthroughAllHosts(true)` | Allow placeholders to pass through unchanged to any host |
-
-Passthrough host calls accumulate. When passthrough hosts are configured, non-matching hosts use the default secret violation action.
-
----
-
-#### policy()
-
-```typescript
-policy(policy: NetworkPolicy): this
-```
-
-Set the policy. Use a [`NetworkPolicy`](#networkpolicy) factory or a literal.
-
----
-
-#### port()
-
-```typescript
-port(host: number, guest: number): this
-```
-
-Publish a TCP port from the guest to the host. The default host bind address is `127.0.0.1`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| host | `number` | Port on the host |
-| guest | `number` | Port inside the sandbox |
-
----
-
-#### portBind()
-
-```typescript
-portBind(bind: string, host: number, guest: number): this
-```
-
-Publish a TCP port on a specific host bind address, such as `0.0.0.0`.
-
----
-
-#### portUdp()
-
-```typescript
-portUdp(host: number, guest: number): this
-```
-
-Publish a UDP port from the guest to the host. The default host bind address is `127.0.0.1`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| host | `number` | Port on the host |
-| guest | `number` | Port inside the sandbox |
-
----
-
-#### portUdpBind()
-
-```typescript
-portUdpBind(bind: string, host: number, guest: number): this
-```
-
-Publish a UDP port on a specific host bind address.
-
----
-
-#### secret()
-
-```typescript
-secret(f: (s: SecretBuilder) => SecretBuilder): this
-```
-
-Add a secret. See [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder).
-
----
-
-#### secretEnv()
-
-```typescript
-secretEnv(envVar: string, value: string, placeholder: string, allowedHost: string): this
-```
-
-Four-arg explicit-placeholder shorthand for adding a secret without opening a builder callback.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| envVar | `string` | Environment variable name (non-empty, no `=` or NUL) |
-| value | `string` | Real secret value |
-| placeholder | `string` | Placeholder string: non-empty, up to 1024 bytes, no NUL/CR/LF |
-| allowedHost | `string` | Single hostname allowed to receive the real value |
-
----
-
-#### tls()
-
-```typescript
-tls(f: (t: TlsBuilder) => TlsBuilder): this
-```
-
-Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
-
----
-
-#### trustHostCAs()
-
-```typescript
-trustHostCAs(enabled: boolean): this
-```
-
-Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in for corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle.
+Commit with `Destination::Any`.
 
 ---
 
@@ -1175,7 +1915,28 @@ Builder for DNS interception settings. Used in `NetworkBuilder.dns(d => ...)`. O
 
 ---
 
-#### nameservers()
+#### <span className="msb-recv">.</span><span className="msb-hn">rebindProtection()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+rebindProtection(enabled: boolean): this
+```
+
+Toggle DNS rebinding protection. When enabled, DNS responses resolving to private IPs are blocked.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Enable rebinding protection.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">nameservers()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 nameservers(servers: string[]): this
@@ -1183,15 +1944,19 @@ nameservers(servers: string[]): this
 
 Override upstream nameservers. Replaces any previously-set nameservers.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| servers | `string[]` | Each entry is `IP`, `IP:PORT`, `HOST`, or `HOST:PORT` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>servers</code><span className="msb-type">string[]</span></div>
+    <div className="msb-param-desc">Each entry is <code>IP</code>, <code>IP:PORT</code>, <code>HOST</code>, or <code>HOST:PORT</code>.</div>
+  </div>
+</div>
 
 ---
 
-#### queryTimeoutMs()
+#### <span className="msb-recv">.</span><span className="msb-hn">queryTimeoutMs()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 queryTimeoutMs(ms: number): this
@@ -1199,15 +1964,14 @@ queryTimeoutMs(ms: number): this
 
 Per-DNS-query timeout in milliseconds.
 
----
+<p className="msb-label">Parameters</p>
 
-#### rebindProtection()
-
-```typescript
-rebindProtection(enabled: boolean): this
-```
-
-Toggle DNS rebinding protection. When enabled, DNS responses resolving to private IPs are blocked.
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ms</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Timeout in milliseconds.</div>
+  </div>
+</div>
 
 ---
 
@@ -1217,17 +1981,8 @@ Builder for TLS interception settings. Used in `NetworkBuilder.tls(t => ...)`.
 
 ---
 
-#### blockQuic()
-
-```typescript
-blockQuic(block: boolean): this
-```
-
-Block QUIC on intercepted ports, forcing TCP/TLS fallback.
-
----
-
-#### bypass()
+#### <span className="msb-recv">.</span><span className="msb-hn">bypass()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 bypass(pattern: string): this
@@ -1235,55 +1990,19 @@ bypass(pattern: string): this
 
 Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). Use for domains with certificate pinning.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| pattern | `string` | Glob pattern |
-
----
-
-#### interceptCaCert()
-
-```typescript
-interceptCaCert(path: string): this
-```
-
-Path to a PEM file used as the intercepting CA's certificate.
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pattern</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Glob pattern.</div>
+  </div>
+</div>
 
 ---
 
-#### interceptCaKey()
-
-```typescript
-interceptCaKey(path: string): this
-```
-
-Path to a PEM file used as the intercepting CA's private key.
-
----
-
-#### interceptedPorts()
-
-```typescript
-interceptedPorts(ports: number[]): this
-```
-
-TCP ports where interception is active. Default: `[443]`.
-
----
-
-#### upstreamCaCert()
-
-```typescript
-upstreamCaCert(path: string): this
-```
-
-Path to a PEM file with extra root CAs the proxy should trust.
-
----
-
-#### verifyUpstream()
+#### <span className="msb-recv">.</span><span className="msb-hn">verifyUpstream()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 verifyUpstream(verify: boolean): this
@@ -1291,27 +2010,246 @@ verifyUpstream(verify: boolean): this
 
 Verify upstream server certificates. Default `true`. Set to `false` only for self-signed servers.
 
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>verify</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Verify upstream certs.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">interceptedPorts()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+interceptedPorts(ports: number[]): this
+```
+
+TCP ports where interception is active. Default: `[443]`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ports</code><span className="msb-type">number[]</span></div>
+    <div className="msb-param-desc">Intercepted TCP ports.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">blockQuic()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+blockQuic(block: boolean): this
+```
+
+Block QUIC on intercepted ports, forcing TCP/TLS fallback.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>block</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Block QUIC.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">interceptCaCert()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+interceptCaCert(path: string): this
+```
+
+Path to a PEM file used as the intercepting CA's certificate.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">PEM cert path.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">interceptCaKey()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+interceptCaKey(path: string): this
+```
+
+Path to a PEM file used as the intercepting CA's private key.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">PEM key path.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">upstreamCaCert()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+upstreamCaCert(path: string): this
+```
+
+Path to a PEM file with extra root CAs the proxy should trust.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">PEM cert path.</div>
+  </div>
+</div>
+
+---
+
+## ViolationActionBuilder
+
+Configures the action taken when a secret would be sent to a disallowed host. Used in `NetworkBuilder.onSecretViolation(v => ...)`. Passthrough host calls accumulate; when passthrough hosts are configured, non-matching hosts use the default secret-violation action.
+
+---
+
+#### <span className="msb-recv" id="va-block">.</span><span className="msb-hn">block()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+block(): this
+```
+
+Block the request silently.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">blockAndLog()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+blockAndLog(): this
+```
+
+Block the request and emit a warning log.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">blockAndTerminate()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+blockAndTerminate(): this
+```
+
+Block the request and terminate the sandbox.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">passthroughHost()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+passthroughHost(host: string): this
+```
+
+Allow placeholders to pass through unchanged to an exact host. The host receives the placeholder, not the real secret value.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Exact host.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">passthroughHostPattern()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+passthroughHostPattern(pattern: string): this
+```
+
+Allow placeholders to pass through unchanged to matching wildcard hosts.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pattern</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Wildcard host pattern.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">passthroughAllHosts()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+passthroughAllHosts(iUnderstand: boolean): this
+```
+
+Allow placeholders to pass through unchanged to any host. The explicit `iUnderstand` flag must be `true` to acknowledge the broad scope.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>iUnderstand</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Must be <code>true</code> to opt in.</div>
+  </div>
+</div>
+
 ---
 
 ## Types
 
 ### NetworkConfig
 
-Built network configuration produced by `NetworkBuilder.build()`.
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Returned by <a href="#nb-build">NetworkBuilder.build()</a></p>
+
+Built network configuration produced by `NetworkBuilder.build()`. Keys are camelCased from the Rust serde output.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | enabled | `boolean` | Master enable flag |
-| ports | `readonly PublishedPort[]` | Port publishings |
-| policy | [`NetworkPolicy`](#networkpolicy) ` \| null` | Active policy |
+| ports | `readonly `[`PublishedPort`](#publishedport)`[]` | Port publishings |
+| policy | [`NetworkPolicy`](#networkpolicy-2) ` \| null` | Active policy |
 | dns | [`DnsConfig`](#dnsconfig) ` \| null` | DNS interception |
 | tls | [`TlsConfig`](#tlsconfig) ` \| null` | TLS interception |
 | secrets | `readonly SecretEntry[]` | Secret entries |
 | secretViolation | [`ViolationAction`](/sdk/typescript/secrets#violationaction) ` \| null` | Action on disallowed secret use |
 | maxConnections | `number \| null` | Maximum concurrent connections |
+| interface | `{ ipv4Pool?, ipv6Pool?, ipv4Address?, ipv6Address?, mac?, mtu? }` | Optional interface overrides |
 | trustHostCAs | `boolean` | Ship host CAs into the guest |
 
 ### NetworkPolicy
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#policy">NetworkBuilder.policy()</a> · returned by <a href="#networkpolicy">NetworkPolicy factories</a></p>
+
+Ordered rule list with per-direction defaults. First-match-wins is evaluated independently for egress and ingress.
 
 ```typescript
 interface NetworkPolicy {
@@ -1323,6 +2261,12 @@ interface NetworkPolicy {
 
 ### Rule
 
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#networkpolicy-2">NetworkPolicy.rules</a> · built via <a href="#rule-allowegress">Rule factories</a></p>
+
+A single ordered policy rule.
+
 ```typescript
 interface Rule {
   readonly direction: Direction;
@@ -1333,7 +2277,37 @@ interface Rule {
 }
 ```
 
+### Action
+
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+<p className="msb-backref">Used by <a href="#rule-2">Rule.action</a> · <a href="#networkpolicy-2">NetworkPolicy defaults</a></p>
+
+Action taken on a matching rule (or the per-direction default).
+
+```typescript
+type Action = "allow" | "deny";
+```
+
+### Direction
+
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+<p className="msb-backref">Used by <a href="#rule-2">Rule.direction</a></p>
+
+Direction the rule applies to.
+
+```typescript
+type Direction = "egress" | "ingress" | "any";
+```
+
 ### Destination
+
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+<p className="msb-backref">Used by <a href="#rule-2">Rule.destination</a> · built via <a href="#destination-any">Destination factories</a></p>
+
+Destination filter. An internally-tagged union; use the [`Destination`](#destination) factory for constructors.
 
 ```typescript
 type Destination =
@@ -1344,25 +2318,13 @@ type Destination =
   | { kind: "group"; group: DestinationGroup };
 ```
 
-### Action
-
-```typescript
-type Action = "allow" | "deny";
-```
-
-### Direction
-
-```typescript
-type Direction = "egress" | "ingress" | "any";
-```
-
-### Protocol
-
-```typescript
-type Protocol = "tcp" | "udp" | "icmpv4" | "icmpv6";
-```
-
 ### DestinationGroup
+
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+<p className="msb-backref">Used by <a href="#destinationgroup">Destination.group()</a> · <a href="#rd-group">RuleDestinationBuilder.group()</a></p>
+
+Predefined address group keyword. The runtime constant `DestinationGroups` lists all values.
 
 ```typescript
 type DestinationGroup =
@@ -1379,13 +2341,31 @@ type DestinationGroup =
 |-------|-------------|
 | `'public'` | Public internet (everything not in another group) |
 | `'loopback'` | Guest's own `127.0.0.0/8` / `::1` |
-| `'private'` | RFC1918 LAN ranges |
+| `'private'` | RFC1918 LAN ranges (+ ULA + CGN) |
 | `'link-local'` | `169.254.0.0/16` / `fe80::/10` |
-| `'metadata'` | Cloud metadata endpoints (`169.254.169.254`, `fd00:ec2::254`) |
-| `'multicast'` | Multicast addresses |
+| `'metadata'` | Cloud metadata endpoint (`169.254.169.254`) |
+| `'multicast'` | `224.0.0.0/4` / `ff00::/8` |
 | `'host'` | The host machine, reached via `host.microsandbox.internal` |
 
+### Protocol
+
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+<p className="msb-backref">Used by <a href="#rule-2">Rule.protocols</a></p>
+
+Transport protocol filter. Empty `Rule.protocols` means "any protocol".
+
+```typescript
+type Protocol = "tcp" | "udp" | "icmpv4" | "icmpv6";
+```
+
 ### PortRange
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#rule-2">Rule.ports</a> · built via <a href="#portrange-single">PortRange factories</a></p>
+
+Inclusive port range. Always interpreted as the guest-side port.
 
 ```typescript
 interface PortRange {
@@ -1394,20 +2374,30 @@ interface PortRange {
 }
 ```
 
-### RuleDestinationBuilder
+### PublishedPort
 
-Returned by [`RuleBuilder`](#rulebuilder)`.allow(d => ...)` / `.deny(d => ...)`. Exactly one destination call commits the rule; dropping without a destination call silently does nothing.
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
 
-| Method | Description |
-|--------|-------------|
-| `.ip(ip)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
-| `.cidr(cidr)` | Commit with `Destination::Cidr` |
-| `.domain(domain)` | Commit with `Destination::Domain` |
-| `.domainSuffix(suffix)` | Commit with `Destination::DomainSuffix` |
-| `.group(group)` | Commit with `Destination::Group`. `group` is a [`DestinationGroup`](#destinationgroup) string |
-| `.any()` | Commit with `Destination::Any` |
+<p className="msb-backref">Used by <a href="#networkconfig">NetworkConfig.ports</a></p>
+
+A published port mapping from the guest to the host.
+
+```typescript
+interface PublishedPort {
+  readonly hostPort: number;
+  readonly guestPort: number;
+  readonly protocol: "tcp" | "udp";
+  readonly hostBind: string;
+}
+```
 
 ### DnsConfig
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#networkconfig">NetworkConfig.dns</a></p>
+
+DNS interception configuration.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -1416,6 +2406,12 @@ Returned by [`RuleBuilder`](#rulebuilder)`.allow(d => ...)` / `.deny(d => ...)`.
 | queryTimeoutMs | `number \| null` | Per-query timeout |
 
 ### TlsConfig
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#networkconfig">NetworkConfig.tls</a></p>
+
+TLS interception configuration.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -1427,13 +2423,17 @@ Returned by [`RuleBuilder`](#rulebuilder)`.allow(d => ...)` / `.deny(d => ...)`.
 | interceptCaCertPath | `string \| null` | Custom intercept CA cert (PEM) |
 | interceptCaKeyPath | `string \| null` | Custom intercept CA key (PEM) |
 
-### PublishedPort
+### InterfaceOverridesBuilder
 
-```typescript
-interface PublishedPort {
-  readonly hostPort: number;
-  readonly guestPort: number;
-  readonly protocol: "tcp" | "udp";
-  readonly hostBind: string;
-}
-```
+<div className="msb-tags"><span className="msb-tag is-type">builder</span></div>
+
+<p className="msb-backref">Used by <a href="#nb-interface">NetworkBuilder.interface()</a></p>
+
+Builder for per-sandbox network interface overrides.
+
+| Method | Description |
+|--------|-------------|
+| `.mac(mac)` | Set the interface MAC address |
+| `.mtu(mtu)` | Set the interface MTU |
+| `.ipv4(address)` | Pin a fixed IPv4 address |
+| `.ipv6(address)` | Pin a fixed IPv6 address |

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -3,191 +3,388 @@ title: Sandbox
 description: TypeScript SDK - Sandbox API reference
 ---
 
-See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Static<span className="msb-ct">7</span></p>
+  <a className="msb-row" href="#sandbox-builder"><span className="msb-rn">Sandbox.builder()</span><span className="msb-rg">configure a new sandbox</span></a>
+  <a className="msb-row" href="#sandbox-get"><span className="msb-rn">Sandbox.get()</span><span className="msb-rg">handle to an existing one</span></a>
+  <a className="msb-row" href="#sandbox-list"><span className="msb-rn">Sandbox.list()</span><span className="msb-rg">all sandboxes</span></a>
+  <a className="msb-row" href="#sandbox-listwith"><span className="msb-rn">Sandbox.listWith()</span><span className="msb-rg">filter by labels</span></a>
+  <a className="msb-row" href="#sandbox-start"><span className="msb-rn">Sandbox.start()</span><span className="msb-rg">restart a stopped one</span></a>
+  <a className="msb-row" href="#sandbox-startdetached"><span className="msb-rn">Sandbox.startDetached()</span><span className="msb-rg">restart detached</span></a>
+  <a className="msb-row" href="#sandbox-remove"><span className="msb-rn">Sandbox.remove()</span><span className="msb-rg">delete a stopped one</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance<span className="msb-ct">20</span></p>
+  <a className="msb-row" href="/sdk/typescript/execution"><span className="msb-rn">sandbox.exec()</span><span className="msb-rg">run a command</span></a>
+  <a className="msb-row" href="/sdk/typescript/execution"><span className="msb-rn">sandbox.shell()</span><span className="msb-rg">run a shell script</span></a>
+  <a className="msb-row" href="/sdk/typescript/execution"><span className="msb-rn">sandbox.attach()</span><span className="msb-rg">attach to a foreground process</span></a>
+  <a className="msb-row" href="#sandbox-fs"><span className="msb-rn">sandbox.fs()</span><span className="msb-rg">read / write files</span></a>
+  <a className="msb-row" href="#sandbox-ssh"><span className="msb-rn">sandbox.ssh()</span><span className="msb-rg">ssh into the guest</span></a>
+  <a className="msb-row" href="#sandbox-config"><span className="msb-rn">sandbox.config()</span><span className="msb-rg">full configuration</span></a>
+  <a className="msb-row" href="#sandbox-logs"><span className="msb-rn">sandbox.logs()</span><span className="msb-rg">captured output</span></a>
+  <a className="msb-row" href="#sandbox-logstream"><span className="msb-rn">sandbox.logStream()</span><span className="msb-rg">stream captured output</span></a>
+  <a className="msb-row" href="#sandbox-metrics"><span className="msb-rn">sandbox.metrics()</span><span className="msb-rg">resource snapshot</span></a>
+  <a className="msb-row" href="#sandbox-metricsstream"><span className="msb-rn">sandbox.metricsStream()</span><span className="msb-rg">stream metrics</span></a>
+  <a className="msb-row" href="#sandbox-stop"><span className="msb-rn">sandbox.stop()</span><span className="msb-rg">graceful shutdown</span></a>
+  <a className="msb-row" href="#sandbox-stopwithtimeout"><span className="msb-rn">sandbox.stopWithTimeout()</span><span className="msb-rg">stop with custom timeout</span></a>
+  <a className="msb-row" href="#sandbox-requeststop"><span className="msb-rn">sandbox.requestStop()</span><span className="msb-rg">stop without waiting</span></a>
+  <a className="msb-row" href="#sandbox-kill"><span className="msb-rn">sandbox.kill()</span><span className="msb-rg">force terminate</span></a>
+  <a className="msb-row" href="#sandbox-killwithtimeout"><span className="msb-rn">sandbox.killWithTimeout()</span><span className="msb-rg">force kill with timeout</span></a>
+  <a className="msb-row" href="#sandbox-requestkill"><span className="msb-rn">sandbox.requestKill()</span><span className="msb-rg">kill without waiting</span></a>
+  <a className="msb-row" href="#sandbox-requestdrain"><span className="msb-rn">sandbox.requestDrain()</span><span className="msb-rg">graceful drain</span></a>
+  <a className="msb-row" href="#sandbox-waituntilstopped"><span className="msb-rn">sandbox.waitUntilStopped()</span><span className="msb-rg">block until it exits</span></a>
+  <a className="msb-row" href="#sandbox-detach"><span className="msb-rn">sandbox.detach()</span><span className="msb-rg">release, keep running</span></a>
+  <a className="msb-row" href="#sandbox-symbol-asyncdispose"><span className="msb-rn">[Symbol.asyncDispose]()</span><span className="msb-rg">auto-stop on scope exit</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SandboxBuilder<span className="msb-ct">47</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#image">.image()</a>
+    <a className="msb-chip" href="#memory">.memory()</a>
+    <a className="msb-chip" href="#cpus">.cpus()</a>
+    <a className="msb-chip" href="#port">.port()</a>
+    <a className="msb-chip" href="#volume">.volume()</a>
+    <a className="msb-chip" href="#env">.env()</a>
+    <a className="msb-chip" href="#secret">.secret()</a>
+    <a className="msb-chip" href="#init">.init()</a>
+    <a className="msb-chip" href="#patch">.patch()</a>
+    <a className="msb-chip" href="#detached">.detached()</a>
+    <a className="msb-chip" href="#create">.create()</a>
+    <a className="msb-chip" href="#build">.build()</a>
+    <a className="msb-more" href="#sandboxbuilder">+ 35 more in the SandboxBuilder section</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#sandboxconfig">SandboxConfig</a>
+    <a className="msb-typepill" href="#sandboxhandle">SandboxHandle</a>
+    <a className="msb-typepill" href="#sandboxmetrics">SandboxMetrics</a>
+    <a className="msb-typepill" href="#sandboxstatus">SandboxStatus</a>
+    <a className="msb-typepill" href="#sandboxstopresult">SandboxStopResult</a>
+    <a className="msb-typepill" href="#metricsstream">MetricsStream</a>
+    <a className="msb-typepill" href="#logentry">LogEntry</a>
+    <a className="msb-typepill" href="#logstream">LogStream</a>
+    <a className="msb-typepill" href="#logreadoptions">LogReadOptions</a>
+    <a className="msb-typepill" href="#logstreamoptions">LogStreamOptions</a>
+    <a className="msb-typepill" href="#logsource">LogSource</a>
+    <a className="msb-typepill" href="#loglevel">LogLevel</a>
+    <a className="msb-typepill" href="#pullpolicy">PullPolicy</a>
+    <a className="msb-typepill" href="#pullprogress">PullProgress</a>
+    <a className="msb-typepill" href="#pullprogresscreate">PullProgressCreate</a>
+    <a className="msb-typepill" href="#patchbuilder">PatchBuilder</a>
+  </div>
+
+</div>
 
 The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox from `Sandbox.builder(name)` and chain configuration calls before terminating with `.create()`. Use `.detached(true)` before `.create()` for detached/background mode. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes.
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```typescript
 import { Sandbox } from "microsandbox";
 
-await using sandbox = await Sandbox.builder("demo")
-  .image("alpine")
-  .cpus(1)
-  .memory(512)
-  .create();
+await using sandbox = await Sandbox.builder("api")  // 1. configure
+  .image("python")
+  .memory(1024)
+  .create();                                        // 2. boot the microVM
+
+const out = await sandbox.exec("python", ["-V"]);   // 3. run
+console.log(out.stdout);
+
+await sandbox.stop();                               // 4. shut down
 ```
 
 ## Static methods
 
 ---
 
-#### Sandbox.builder()
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">builder()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```typescript
 static builder(name: string): SandboxBuilder
 ```
 
-Begin building a new sandbox. Configure it with chainable setters, then call `.create()` to boot it.
+Begin building a new sandbox. Configure it with chainable setters, then call `.create()` to boot it. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes. See [`SandboxBuilder`](#sandboxbuilder) for all available options.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `string` | Sandbox name, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxBuilder`](#sandboxbuilder) | Fluent builder |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxbuilder">SandboxBuilder</a></div>
+    <div className="msb-param-desc">Fluent builder for configuring the sandbox.</div>
+  </div>
+</div>
 
-#### Sandbox.get()
+<p className="msb-label">Example</p>
+
+```typescript
+await using sandbox = await Sandbox.builder("api")
+  .image("python")
+  .create();
+```
+
+---
+
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">get()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 static get(name: string): Promise<SandboxHandle>
 ```
 
-Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control.
+Get a live handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control without requiring a full connection to the guest agent.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `string` | Sandbox name, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxhandle">Promise&lt;SandboxHandle&gt;</a></div>
+    <div className="msb-param-desc">Live handle with status and lifecycle control.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const handle = await Sandbox.get("api");
+console.log(handle.status);
+```
 
 ---
 
-#### Sandbox.list()
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 static list(): Promise<SandboxHandle[]>
 ```
 
-List all sandboxes (running, stopped, and crashed). Handles returned from `list()` are read-only — call `Sandbox.get(name)` to get a live handle for lifecycle calls.
+List all sandboxes (running, stopped, and crashed). Handles returned from `list()` are read-only - call [`Sandbox.get(name)`](#sandbox-get) to get a live handle for lifecycle calls.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxHandle[]`](#sandboxhandle) | All sandboxes (read-only handles) |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxhandle">Promise&lt;SandboxHandle[]&gt;</a></div>
+    <div className="msb-param-desc">All sandboxes (read-only handles).</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+for (const h of await Sandbox.list()) {
+  console.log(`${h.name} — ${h.status}`);
+}
+```
 
 ---
 
-#### Sandbox.remove()
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">listWith()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+static listWith(filter: { labels?: Record<string, string> }): Promise<SandboxHandle[]>
+```
+
+List sandboxes filtered to those carrying all of the given labels (AND-matched). Like [`list()`](#sandbox-list), the returned handles are read-only.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>filter</code><span className="msb-type">&#123; labels?: Record&lt;string, string&gt; &#125;</span></div>
+    <div className="msb-param-desc">Labels that a sandbox must all carry to be included.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxhandle">Promise&lt;SandboxHandle[]&gt;</a></div>
+    <div className="msb-param-desc">Matching sandboxes (read-only handles).</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const workers = await Sandbox.listWith({ labels: { role: "worker" } });
+```
+
+---
+
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 static remove(name: string): Promise<void>
 ```
 
-Delete a stopped sandbox and all its state from disk. Fails if the sandbox is still running.
+Delete a stopped sandbox and all its state from disk (configuration, logs, runtime directory). Fails if the sandbox is still running - stop it first.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `string` | Sandbox name, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await Sandbox.remove("api");
+```
 
 ---
 
-#### Sandbox.start()
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">start()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 static start(name: string): Promise<Sandbox>
 ```
 
-Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration. The sandbox enters attached mode - it stops when the binding goes out of scope (via `await using`) or when [`stop()`](#sandbox-stop) is called.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `string` | Name of a stopped sandbox, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Name of a stopped sandbox, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`Sandbox`](#instance-methods) | Running sandbox |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Promise&lt;Sandbox&gt;</a></div>
+    <div className="msb-param-desc">Running sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await using sandbox = await Sandbox.start("api");
+```
 
 ---
 
-#### Sandbox.startDetached()
+#### <span className="msb-recv">Sandbox.</span><span className="msb-hn">startDetached()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 static startDetached(name: string): Promise<Sandbox>
 ```
 
-Restart a stopped sandbox in detached mode.
+Restart a stopped sandbox in detached mode. The sandbox survives after your process exits.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `string` | Name of a stopped sandbox, up to 128 UTF-8 bytes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Name of a stopped sandbox, up to 128 UTF-8 bytes.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`Sandbox`](#instance-methods) | Running sandbox |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Promise&lt;Sandbox&gt;</a></div>
+    <div className="msb-param-desc">Running sandbox.</div>
+  </div>
+</div>
 
----
-
-## Instance properties
-
----
-
-#### name
-
-```typescript
-readonly name: string
-```
-
-Sandbox name. Names are limited to 128 UTF-8 bytes.
-
----
-
-#### ownsLifecycle
+<p className="msb-label">Example</p>
 
 ```typescript
-readonly ownsLifecycle: boolean
+const sandbox = await Sandbox.startDetached("worker");
 ```
-
-Whether this handle owns the sandbox lifecycle. `true` in attached mode (the auto-disposer will stop the sandbox), `false` in detached mode.
 
 ---
 
 ## Instance methods
 
+A running `Sandbox` also exposes two read-only properties: `name` (`string`, the sandbox name) and `ownsLifecycle` (`boolean`, `true` in attached mode where the auto-disposer stops the sandbox, `false` in detached mode).
+
+Command execution (`exec`, `execWith`, `execStream`, `execStreamWith`, `shell`, `shellStream`) and foreground attachment (`attach`, `attachWith`, `attachShell`) live on the [Execution](/sdk/typescript/execution) page.
+
 ---
 
-#### detach()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">config()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+config(): Promise<SandboxConfig>
+```
+
+Get the full configuration the sandbox was created with - image, cpus, memory, env, mounts, and the rest. The shape mirrors [`SandboxBuilder.build()`](#build).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxconfig">Promise&lt;SandboxConfig&gt;</a></div>
+    <div className="msb-param-desc">Sandbox configuration.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const config = await sandbox.config();
+console.log(`${config.memoryMib} MiB`);
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">detach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 detach(): Promise<void>
 ```
 
-Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.get()`](#sandboxget).
+Release the handle without stopping the sandbox. The sandbox continues running as a background process. Reconnect later with [`Sandbox.get()`](#sandbox-get).
 
----
-
-#### requestDrain()
+<p className="msb-label">Example</p>
 
 ```typescript
-requestDrain(): Promise<void>
+await sandbox.detach(); // keeps running in the background
 ```
-
-Request a graceful drain and return once the request is sent. Existing commands run to completion, but new `exec` calls are rejected. Use [`waitUntilStopped()`](#waituntilstopped) when the caller needs stopped-state observation.
 
 ---
 
-#### fs()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">fs()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```typescript
 fs(): SandboxFsOps
@@ -195,81 +392,96 @@ fs(): SandboxFsOps
 
 Get a filesystem handle for reading and writing files inside the running sandbox. See [Filesystem](/sdk/typescript/filesystem) for API details.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxFsOps`](/sdk/typescript/filesystem) | Filesystem handle |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/typescript/filesystem">SandboxFsOps</a></div>
+    <div className="msb-param-desc">Filesystem handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await sandbox.fs().writeFile("/tmp/hello.txt", "hi");
+```
 
 ---
 
-#### kill()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">kill()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 kill(): Promise<void>
 ```
 
-Force-terminate the sandbox and wait until stopped state is observed. No graceful shutdown. Pending writes that the workload hasn't `fsync`'d may be lost — same durability semantics as a sudden power loss on a physical machine. Use [`stop()`](#stop) for graceful shutdown that gives the workload a chance to flush.
+Force-terminate the sandbox and wait until stopped state is observed. No graceful shutdown - use when the sandbox is unresponsive. Pending writes that the workload hasn't `fsync`'d may be lost, same durability semantics as a sudden power loss on a physical machine. Prefer [`stop()`](#sandbox-stop) for graceful shutdown that gives the workload a chance to flush.
 
----
-
-#### metrics()
+<p className="msb-label">Example</p>
 
 ```typescript
-metrics(): Promise<SandboxMetrics>
+await sandbox.kill(); // no graceful shutdown
 ```
-
-Get a point-in-time snapshot of the sandbox's resource usage.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network, and optional upper disk metrics |
 
 ---
 
-#### config()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">killWithTimeout()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
-config(): Promise<SandboxConfig>
+killWithTimeout(timeoutMs: number): Promise<void>
 ```
 
-Get the configuration the sandbox was built with.
+Force-terminate the sandbox and wait up to `timeoutMs` for stopped-state observation.
 
----
+<p className="msb-label">Parameters</p>
 
-#### metricsStream()
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeoutMs</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Milliseconds to wait for the stopped state to be observed.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```typescript
-metricsStream(intervalMs: number): Promise<MetricsStream>
+await sandbox.killWithTimeout(2000);
 ```
-
-Stream resource metrics at a regular interval. The returned stream supports both `recv()` and `for await...of`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| intervalMs | `number` | Milliseconds between metric snapshots |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`MetricsStream`](#metricsstream) | Async stream of metrics |
 
 ---
 
-#### logs()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">logs()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 logs(opts?: LogReadOptions): Promise<LogEntry[]>
 ```
 
-Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike — there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
+Read captured output from the sandbox's `exec.log`. Backed by an on-disk JSON Lines file the runtime writes via the relay tap. Works on running and stopped sandboxes alike - there is no protocol traffic. The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to start the sandbox first.
 
-The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines.
+The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pass `"system"` to also include synthetic lifecycle markers and runtime/kernel diagnostic lines, or `"all"` for every source.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#logreadoptions">LogReadOptions?</a></div>
+    <div className="msb-param-desc">Filters: <code>tail</code>, <code>since</code>, <code>until</code>, <code>sources</code>. Omit for the default user-program sources.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#logentry">Promise&lt;LogEntry[]&gt;</a></div>
+    <div className="msb-param-desc">Matching entries in chronological order.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```typescript
 import { Sandbox } from "microsandbox";
@@ -299,31 +511,185 @@ const recent = await handle.logs({
 });
 ```
 
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| opts | [`LogReadOptions`](#logreadoptions) `?` | Filters: `tail`, `since`, `until`, `sources`. Omit for the default user-program sources. |
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `Promise<`[`LogEntry`](#logentry)`[]>` | Matching entries in chronological order |
-
 ---
 
-#### remove()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">logStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
-remove(): Promise<void>
+logStream(opts?: LogStreamOptions): Promise<LogStream>
 ```
 
-Remove the sandbox and all its persisted state from disk.
+Stream captured output as it appears, with optional follow. Backed by the same on-disk `exec.log` as [`logs()`](#sandbox-logs), but yields entries lazily. Pass `{ follow: true }` to keep the stream open past current EOF and pick up new entries as they are written; otherwise the stream drains the current contents and ends. Each yielded [`LogEntry`](#logentry) carries an opaque `cursor` that can be passed back via [`LogStreamOptions.fromCursor`](#logstreamoptions) to resume.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#logstreamoptions">LogStreamOptions?</a></div>
+    <div className="msb-param-desc">Filters plus <code>follow</code> and resume controls (<code>since</code>, <code>fromCursor</code>).</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#logstream">Promise&lt;LogStream&gt;</a></div>
+    <div className="msb-param-desc">Async iterable of log entries.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await using stream = await sandbox.logStream({ follow: true });
+for await (const e of stream) {
+  console.log(e.text().trimEnd());
+}
+```
 
 ---
 
-#### stop()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">metrics()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+metrics(): Promise<SandboxMetrics>
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk I/O, network I/O, optional upper disk usage, and uptime.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxmetrics">Promise&lt;SandboxMetrics&gt;</a></div>
+    <div className="msb-param-desc">Resource metrics.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const m = await sandbox.metrics();
+console.log(`cpu ${m.cpuPercent.toFixed(1)}% · mem ${Math.round(m.memoryBytes / 1048576)} MiB`);
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">metricsStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+metricsStream(intervalMs: number): Promise<MetricsStream>
+```
+
+Stream resource metrics at a regular interval. The returned [`MetricsStream`](#metricsstream) supports both `recv()` and `for await...of`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>intervalMs</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Milliseconds between metric snapshots.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#metricsstream">Promise&lt;MetricsStream&gt;</a></div>
+    <div className="msb-param-desc">Async stream yielding a snapshot each interval.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await using stream = await sandbox.metricsStream(1000);
+for await (const snapshot of stream) {
+  console.log(`${snapshot.cpuPercent.toFixed(1)}%`);
+}
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">requestDrain()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+requestDrain(): Promise<void>
+```
+
+Request a graceful drain and return once the request is sent. Existing commands run to completion, but new `exec` calls are rejected. The sandbox transitions to `stopped` when all in-flight commands finish. Use [`waitUntilStopped()`](#sandbox-waituntilstopped) when the caller needs stopped-state observation. Useful for zero-downtime rotation of worker sandboxes.
+
+<p className="msb-label">Example</p>
+
+```typescript
+await sandbox.requestDrain();
+await sandbox.waitUntilStopped();
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">requestKill()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+requestKill(): Promise<void>
+```
+
+Request force termination and return once the signal is sent, without waiting for the stopped state to be observed.
+
+<p className="msb-label">Example</p>
+
+```typescript
+await sandbox.requestKill();
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">requestStop()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+requestStop(): Promise<void>
+```
+
+Request graceful shutdown and return once the request is sent, without waiting for the stopped state to be observed.
+
+<p className="msb-label">Example</p>
+
+```typescript
+await sandbox.requestStop();
+```
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">ssh()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```typescript
+ssh(): SandboxSshOps
+```
+
+Get an SSH handle for opening interactive sessions and port forwards into the running guest. See [SSH](/sdk/typescript/ssh) for API details.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/typescript/ssh">SandboxSshOps</a></div>
+    <div className="msb-param-desc">SSH handle.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">stop()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 stop(): Promise<void>
@@ -331,49 +697,42 @@ stop(): Promise<void>
 
 Gracefully shut down the sandbox and wait until stopped state is observed. Lets the sandbox finish writing any pending data to disk before it exits, so files written inside the sandbox aren't lost across a later restart. Waits up to 10_000 ms for a clean exit; if the sandbox is still running after that, it is force-killed.
 
+<p className="msb-label">Example</p>
+
+```typescript
+await sandbox.stop();
+```
+
 ---
 
-#### stopWithTimeout()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">stopWithTimeout()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 stopWithTimeout(timeoutMs: number): Promise<void>
 ```
 
-Gracefully shut down the sandbox with an explicit observation timeout before force-kill escalation.
+Gracefully shut down the sandbox with an explicit observation timeout before force-kill escalation. `0` force-kills immediately. Resolves successfully either way - it does not throw on timeout expiry.
 
----
+<p className="msb-label">Parameters</p>
 
-#### requestStop()
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeoutMs</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Milliseconds to wait for a clean exit before force-killing. <code>0</code> skips the grace period.</div>
+  </div>
+</div>
 
-```typescript
-requestStop(): Promise<void>
-```
-
-Request graceful shutdown and return once the request is sent.
-
----
-
-#### requestKill()
+<p className="msb-label">Example</p>
 
 ```typescript
-requestKill(): Promise<void>
+await sandbox.stopWithTimeout(5000);
 ```
-
-Request force termination and return once the signal is sent.
 
 ---
 
-#### killWithTimeout()
-
-```typescript
-killWithTimeout(timeoutMs: number): Promise<void>
-```
-
-Force-terminate the sandbox and wait up to `timeoutMs` for stopped-state observation.
-
----
-
-#### waitUntilStopped()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">waitUntilStopped()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 waitUntilStopped(): Promise<SandboxStopResult>
@@ -381,307 +740,139 @@ waitUntilStopped(): Promise<SandboxStopResult>
 
 Block until the sandbox is observed in a terminal non-running state, without triggering a stop or kill request.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxStopResult`](#sandboxstopresult) | Terminal status and optional observed exit code |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxstopresult">Promise&lt;SandboxStopResult&gt;</a></div>
+    <div className="msb-param-desc">Terminal status, exit code, and signal that were observed.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const result = await sandbox.waitUntilStopped();
+console.log(result.status, result.exitCode);
+```
 
 ---
 
-#### \[Symbol.asyncDispose\]()
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">[Symbol.asyncDispose]()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 [Symbol.asyncDispose](): Promise<void>
 ```
 
-Implements `AsyncDisposable` so the sandbox can be used with `await using`. When the binding goes out of scope, the sandbox is stopped (best-effort) — but only if `ownsLifecycle` is `true`.
+Implements `AsyncDisposable` so the sandbox can be used with `await using`. When the binding goes out of scope, the sandbox is stopped (best-effort) - but only if `ownsLifecycle` is `true`.
 
----
-
-## PatchBuilder
-
-Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder.patch(p => p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `{ replace: true }` on the operation to allow overwriting. `mkdir` and `remove` are idempotent.
-
-See [Patches](/sandboxes/customize#patches) for conceptual context.
-
----
-
-#### append()
+<p className="msb-label">Example</p>
 
 ```typescript
-append(path: string, content: string): this
+{
+  await using sandbox = await Sandbox.builder("api").image("python").create();
+  await sandbox.exec("python", ["-V"]);
+} // sandbox.stop() runs here, automatically
 ```
-
-Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest |
-| content | `string` | Text to append |
 
 ---
 
-#### copyDir()
+## SandboxBuilder
 
-```typescript
-copyDir(src: string, dst: string, opts?: { replace?: boolean }): this
-```
-
-Recursively copy a host directory at `src` into the guest rootfs at `dst`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| src | `string` | Host source directory |
-| dst | `string` | Absolute destination path inside the guest |
-| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+Fluent builder for configuring a sandbox before creation. Obtained via [`Sandbox.builder(name)`](#sandbox-builder). Every setter returns the same builder so calls chain. Examples are shown on the methods where usage is non-obvious; simple setters are demonstrated by the [Typical flow](#typical-flow) above.
 
 ---
 
-#### copyFile()
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
-copyFile(
-  src: string,
-  dst: string,
-  opts?: { mode?: number; replace?: boolean },
-): this
+build(): Promise<SandboxConfig>
 ```
 
-Copy a single host file at `src` into the guest rootfs at `dst`.
+Materialize the [`SandboxConfig`](#sandboxconfig) without booting the sandbox. Validates the configuration and consumes the builder. For booting, use [`create`](#create) instead - it builds internally.
 
-**Parameters**
+<p className="msb-label">Returns</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| src | `string` | Host source file |
-| dst | `string` | Absolute destination path inside the guest |
-| opts.mode | `number` | File mode, e.g. `0o644`. Omit to keep the source mode |
-| opts.replace | `boolean` | When `true`, overwrite an existing path at `dst` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxconfig">Promise&lt;SandboxConfig&gt;</a></div>
+    <div className="msb-param-desc">Validated, ready-to-boot configuration.</div>
+  </div>
+</div>
 
 ---
 
-#### file()
+#### <span className="msb-recv">.</span><span className="msb-hn">cpus()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-file(
-  path: string,
-  content: Buffer,
-  opts?: { mode?: number; replace?: boolean },
-): this
+cpus(n: number): this
 ```
 
-Write raw bytes at `path`.
+Set the number of virtual CPUs. This is a limit, not a reservation.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest |
-| content | `Buffer` | Raw byte content |
-| opts.mode | `number` | File mode, e.g. `0o644` |
-| opts.replace | `boolean` | When `true`, overwrite an existing path |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>n</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Number of vCPUs.</div>
+  </div>
+</div>
 
 ---
 
-#### mkdir()
+#### <span className="msb-recv">.</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
-mkdir(path: string, opts?: { mode?: number }): this
+create(): Promise<Sandbox>
 ```
 
-Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+Build and boot the sandbox. By default the sandbox is attached - it stops when the `await using` binding goes out of scope. Call [`detached(true)`](#detached) first for background mode.
 
-**Parameters**
+<p className="msb-label">Returns</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest |
-| opts.mode | `number` | Directory mode, e.g. `0o755` |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Promise&lt;Sandbox&gt;</a></div>
+    <div className="msb-param-desc">Running sandbox.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const sandbox = await Sandbox.builder("worker")
+  .image("python")
+  .detached(true)
+  .create();
+await sandbox.detach();
+```
 
 ---
 
-#### remove()
+#### <span className="msb-recv">.</span><span className="msb-hn">createWithPullProgress()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
-remove(path: string): this
+createWithPullProgress(): Promise<PullProgressCreate>
 ```
 
-Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+Build and boot while streaming image pull progress. Returns a [`PullProgressCreate`](#pullprogresscreate) that yields [`PullProgress`](#pullprogress) events as the image is resolved, downloaded, and materialized; call `awaitSandbox()` after iteration to obtain the live sandbox.
 
-**Parameters**
+<p className="msb-label">Returns</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#pullprogresscreate">Promise&lt;PullProgressCreate&gt;</a></div>
+    <div className="msb-param-desc">Async iterable creation handle.</div>
+  </div>
+</div>
 
----
-
-#### symlink()
-
-```typescript
-symlink(target: string, link: string, opts?: { replace?: boolean }): this
-```
-
-Create a symlink at `link` pointing to `target`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| target | `string` | What the symlink points to (literal symlink target text) |
-| link | `string` | Absolute path of the symlink itself |
-| opts.replace | `boolean` | When `true`, overwrite an existing path at `link` |
-
----
-
-#### text()
-
-```typescript
-text(
-  path: string,
-  content: string,
-  opts?: { mode?: number; replace?: boolean },
-): this
-```
-
-Write UTF-8 text content at `path`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `string` | Absolute path inside the guest |
-| content | `string` | Text content |
-| opts.mode | `number` | File mode, e.g. `0o644` |
-| opts.replace | `boolean` | When `true`, overwrite an existing path |
-
----
-
-## Types
-
-### SandboxBuilder
-
-Fluent configuration builder returned by `Sandbox.builder(name)`. Every setter returns the same builder so calls can be chained.
-
-| Method | Description |
-|--------|-------------|
-| `image(src)` | OCI image (`"alpine"`) or local rootfs/disk path. **Required.** |
-| `imageWith(i => i.oci("alpine").upperSize(8192))` | Configure explicit OCI upper size or disk-image details |
-| `cpus(n)` | Virtual CPUs |
-| `memory(mib)` | Guest memory in MiB |
-| `logLevel(level)` | Override log verbosity |
-| `quietLogs()` | Suppress log output |
-| `workdir(path)` | Default working directory for commands |
-| `shell(shell)` | Shell binary used by `sandbox.shell(...)` |
-| `security(profile)` | In-guest security profile (`"default"` or `"restricted"`) |
-| `entrypoint(iter)` | Override the image's stored ENTRYPOINT. Consulted by `msb exec` / `msb run` (CLI command resolution), **not** by `sandbox.exec` / `sandbox.shell` — those pass `cmd` literally |
-| `init(cmd, args?)` | Hand off PID 1 to `cmd` (absolute path or `"auto"`, including known image ENTRYPOINT inits and attached init-entrypoint commands) after agentd setup. See [Custom init system](/sandboxes/customize#custom-init-system) |
-| `initWith(cmd, i => ...)` | Like `init` but with a closure-builder for argv and env (`.arg`, `.args`, `.env`, `.envs`) |
-| `hostname(name)` | Guest hostname |
-| `user(user)` | Default guest user |
-| `pullPolicy(policy)` | Image pull behavior |
-| `libkrunfwPath(path)` | Override the bundled libkrunfw shared library |
-| `env(key, value)` | Add a single env var |
-| `envs(record \| iter)` | Add many env vars |
-| `script(name, content)` | Mount a script at `/.msb/scripts/<name>` |
-| `scripts(record \| iter)` | Mount many scripts |
-| `replace()` | Replace any existing sandbox with the same name (10s SIGTERM grace, then SIGKILL) |
-| `replaceWithTimeout(timeoutMs)` | Same as `replace()` with a custom SIGTERM timeout in milliseconds. `0` skips SIGTERM. Implies `replace()` |
-| `maxDuration(secs)` | Maximum sandbox lifetime |
-| `idleTimeout(secs)` | Stop the sandbox after this many idle seconds |
-| `volume(guestPath, m => ...)` | Mount a volume — see [Volumes](/sdk/typescript/volumes) |
-| `patch(p => ...)` | Modify the rootfs before boot — see [Snapshots](/sdk/typescript/snapshots) |
-| `addPatch(patch)` | Append a pre-built `Patch` |
-| `registry(r => r.auth(...).insecure().caCertsPath(...))` | Configure the OCI registry |
-| `port(host, guest)` | Publish a TCP port |
-| `portUdp(host, guest)` | Publish a UDP port |
-| `disableNetwork()` | Disable networking entirely |
-| `network(n => ...)` | Configure DNS / TLS / policy / secrets — see [Networking](/sdk/typescript/networking) |
-| `secret(s => ...)` | Add a secret via [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder) |
-| `secretEnv(envVar, value, allowedHost)` | Auto-placeholder shorthand. Generates `$MSB_<env_var>`. |
-| `detached(enabled)` | Create in detached/background mode when `true` |
-| `build(): Promise<SandboxConfig>` | Materialize without booting. Consumes the builder |
-| `create(): Promise<Sandbox>` | Build and boot |
-| `createWithPullProgress(): Promise<PullProgressCreate>` | Build and boot while streaming image pull progress |
-
-### LogLevel
-
-Sandbox process log verbosity.
-
-| Value | Description |
-|-------|-------------|
-| `'debug'` | Debug and higher |
-| `'error'` | Errors only |
-| `'info'` | Info and higher |
-| `'trace'` | Most verbose - all diagnostic output |
-| `'warn'` | Warnings and errors only |
-
-### LogEntry
-
-A class wrapping one captured log entry. Returned by [`logs()`](#logs).
-
-| Property / Method | Type | Description |
-|-------------------|------|-------------|
-| timestamp | `Date` | Wall-clock capture time on the host |
-| source | [`LogSource`](#logsource) | Where the chunk came from |
-| sessionId | `number \| null` | Relay-monotonic session id; `null` for `"system"` entries |
-| data | `Uint8Array` | The chunk's bytes (UTF-8 lossy decoded by default) |
-| `text()` | `string` | Convenience: UTF-8 decode of `data` (lossy — invalid bytes are replaced) |
-
-### LogReadOptions
-
-Filters passed to [`logs()`](#logs). All fields optional. Omit the argument entirely for the default sources (`stdout` + `stderr` + `output`).
-
-| Field | Type | Description |
-|-------|------|-------------|
-| tail | `number?` | Show only the last N entries after other filters apply |
-| since | `Date?` | Inclusive lower bound on entry timestamp |
-| until | `Date?` | Exclusive upper bound on entry timestamp |
-| sources | [`LogSource`](#logsource)`[]?` | Sources to include. Omit = `["stdout", "stderr", "output"]`. Add `"system"` to merge runtime/kernel diagnostics. |
-
-### LogSource
-
-Tag indicating where a captured log entry came from. String literal type:
-
-```typescript
-type LogSource = "stdout" | "stderr" | "output" | "system";
-```
-
-| Value | Description |
-|-------|-------------|
-| `"stdout"` | Captured from a session's stdout (pipe mode — streams stayed separated) |
-| `"stderr"` | Captured from a session's stderr (pipe mode) |
-| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream — tagged `"output"` rather than mislabelled as `"stdout"`. |
-| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested. |
-
-### MetricsStream
-
-Async stream for receiving periodic metrics snapshots.
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `[Symbol.asyncIterator]` | `AsyncIterator<`[`SandboxMetrics`](#sandboxmetrics)`>` | Use with `for await...of` |
-| `recv()` | `Promise<`[`SandboxMetrics`](#sandboxmetrics)` \| null>` | Receive next snapshot. Returns `null` when the stream ends. |
-| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop iterating; safe to use with `await using`. |
-
-### PullPolicy
-
-Controls when the SDK fetches an OCI image from the registry.
-
-| Value | Description |
-|-------|-------------|
-| `'always'` | Pull the image every time, even if cached locally |
-| `'if-missing'` | Pull only if the image is not already cached. This is the default. |
-| `'never'` | Never pull; fail if the image is not cached locally |
-
-### PullProgress
-
-Image pull and materialize progress event emitted by [`PullProgressCreate`](#pullprogresscreate). A discriminated union. Narrow on `kind` to access variant-specific fields:
+<p className="msb-label">Example</p>
 
 ```typescript
 const creation = await Sandbox.builder("demo")
@@ -697,38 +888,1346 @@ for await (const ev of creation) {
 const sandbox = await creation.awaitSandbox();
 ```
 
-| `kind` value | Additional fields |
-|--------------|-------------------|
-| `'resolving'` | `reference: string` |
-| `'resolved'` | `reference: string`, `manifestDigest: string`, `layerCount: number`, `totalDownloadBytes?: number` |
-| `'layerDownloadProgress'` | `layerIndex: number`, `digest: string`, `downloadedBytes: number`, `totalBytes?: number` |
-| `'layerDownloadComplete'` | `layerIndex: number`, `digest: string`, `downloadedBytes: number` |
-| `'layerDownloadVerifying'` | `layerIndex: number`, `digest: string` |
-| `'layerMaterializeStarted'` | `layerIndex: number`, `diffId: string` |
-| `'layerMaterializeProgress'` | `layerIndex: number`, `bytesRead: number`, `totalBytes: number` |
-| `'layerMaterializeWriting'` | `layerIndex: number` |
-| `'layerMaterializeComplete'` | `layerIndex: number`, `diffId: string` |
-| `'stitchMergingTrees'` | `layerCount: number` |
-| `'stitchWritingFsmeta'` | (none) |
-| `'stitchWritingVmdk'` | (none) |
-| `'stitchComplete'` | (none) |
-| `'complete'` | `reference: string`, `layerCount: number` |
+---
 
-`totalDownloadBytes` and `totalBytes` on the `'resolved'` / `'layerDownloadProgress'` variants may be absent if the manifest omits sizes.
+#### <span className="msb-recv">.</span><span className="msb-hn">detached()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
-### PullProgressCreate
+```typescript
+detached(enabled: boolean): this
+```
 
-Async iterable creation handle returned by `Sandbox.builder(name).createWithPullProgress()`. Yields [`PullProgress`](#pullprogress) events as the image is resolved, downloaded, and materialized. Call `awaitSandbox()` after iteration to obtain the live sandbox.
+Create in detached/background mode when `true`. A detached sandbox survives after your process exits and does not auto-stop on `await using` scope exit.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Whether to boot in detached mode.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">disableMetricsSample()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+disableMetricsSample(): this
+```
+
+Disable periodic background metrics sampling for this sandbox.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">disableNetwork()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+disableNetwork(): this
+```
+
+Fully disable networking. No network interface is created.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">entrypoint()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+entrypoint(cmd: string[]): this
+```
+
+Override the OCI image's stored ENTRYPOINT. Consulted by `msb exec` / `msb run` (CLI command resolution), **not** by [`sandbox.exec`](/sdk/typescript/execution) / [`sandbox.shell`](/sdk/typescript/execution) - those pass `cmd` literally to the guest agent. Use this when configuring a sandbox via the SDK for later CLI attachment.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string[]</span></div>
+    <div className="msb-param-desc">Entrypoint command and arguments.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">env()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+env(key: string, value: string): this
+```
+
+Set an environment variable visible to all commands. Can be called multiple times. Per-command env vars (via `execWith`) are merged on top.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Variable name.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Variable value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">envs()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+envs(vars: Record<string, string>): this
+```
+
+Add many environment variables at once.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>vars</code><span className="msb-type">Record&lt;string, string&gt;</span></div>
+    <div className="msb-param-desc">Map of variable names to values.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">ephemeral()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+ephemeral(enabled: boolean): this
+```
+
+When `true`, the sandbox and all its persisted state are removed automatically once it stops, rather than left on disk for restart.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Whether the sandbox is ephemeral.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">fromSnapshot()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+fromSnapshot(pathOrName: string): this
+```
+
+Boot from a previously captured snapshot instead of a fresh image. The image reference and upper-layer source are pinned from the snapshot manifest. See [Snapshots](/sdk/typescript/snapshots).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pathOrName</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Snapshot name or filesystem path.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">hostname()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+hostname(name: string): this
+```
+
+Set the guest hostname.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Hostname.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">idleTimeout()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+idleTimeout(secs: number): this
+```
+
+Auto-drain the sandbox after this many seconds of inactivity (no active exec sessions). Enforced on the host side.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>secs</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Idle timeout in seconds.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">image()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+image(src: string): this
+```
+
+Set the root filesystem source. Accepts OCI image names (`"alpine"`), local directory paths, or disk image paths. The format is auto-detected. **Required** unless [`fromSnapshot`](#fromsnapshot) is used.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">OCI image name, local directory path, or disk image path.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">imageWith()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+imageWith(configure: (b: ImageBuilder) => ImageBuilder): this
+```
+
+Configure an explicit rootfs source. Use this for OCI-only settings such as the writable overlay upper size, or for disk images when the filesystem type can't be auto-detected.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><span className="msb-type">(b: ImageBuilder) =&gt; ImageBuilder</span></div>
+    <div className="msb-param-desc">Configure the rootfs source.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const sandbox = await Sandbox.builder("worker")
+  .imageWith((i) => i.oci("python:3.12").upperSize(8192))
+  .create();
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">init()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+init(cmd: string, args?: string[]): this
+```
+
+Hand off PID 1 inside the guest to `cmd` after agentd finishes its boot-time setup. `cmd` is either an absolute path inside the guest rootfs or the literal `"auto"`, which honors a known image ENTRYPOINT init then falls back to probing common init paths. See [Custom init system](/sandboxes/customize#custom-init-system). For init binaries that need extra env, use [`initWith`](#initwith).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest, or <code>"auto"</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>args</code><span className="msb-type">string[]?</span></div>
+    <div className="msb-param-desc">Optional argv for the init binary.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const sandbox = await Sandbox.builder("worker")
+  .image("jrei/systemd-debian:12")
+  .init("auto")
+  .create();
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">initWith()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+initWith(cmd: string, configure: (b: InitOptionsBuilder) => InitOptionsBuilder): this
+```
+
+Like [`init`](#init), but with a closure-builder for argv and env vars. The builder exposes `.arg`, `.args`, `.env`, and `.envs`. Calling `init` or `initWith` more than once overwrites.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cmd</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path to the init binary inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><span className="msb-type">(b: InitOptionsBuilder) =&gt; InitOptionsBuilder</span></div>
+    <div className="msb-param-desc">Closure populating argv and env.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const sandbox = await Sandbox.builder("worker")
+  .image("jrei/systemd-debian:12")
+  .initWith("/lib/systemd/systemd", (i) =>
+    i.args(["--unit=multi-user.target"]).env("container", "microsandbox"))
+  .create();
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">label()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+label(key: string, value: string): this
+```
+
+Attach a single label to the sandbox. Labels can be matched later with [`Sandbox.listWith()`](#sandbox-listwith).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Label key.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Label value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">labels()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+labels(labels: Record<string, string>): this
+```
+
+Attach many labels at once.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>labels</code><span className="msb-type">Record&lt;string, string&gt;</span></div>
+    <div className="msb-param-desc">Map of label keys to values.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">libkrunfwPath()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+libkrunfwPath(path: string): this
+```
+
+Override the path to the `libkrunfw` library used to boot the microVM. Rarely needed; set it only when running against a custom or non-default libkrunfw build.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Filesystem path to the <code>libkrunfw</code> library.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">logLevel()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+logLevel(level: LogLevel): this
+```
+
+Override the sandbox process's log verbosity.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>level</code><a className="msb-type" href="#loglevel">LogLevel</a></div>
+    <div className="msb-param-desc">Log level.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">maxDuration()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+maxDuration(secs: number): this
+```
+
+Set the maximum sandbox lifetime in seconds. When exceeded, the sandbox is drained and stopped. Enforced on the host side - the guest cannot override it.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>secs</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Maximum lifetime in seconds.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">memory()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+memory(mib: number): this
+```
+
+Set the guest memory size in MiB. Physical pages are only allocated as the guest touches them, so this is a limit, not an upfront reservation.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mib</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Memory in MiB.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">metricsSampleIntervalMs()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+metricsSampleIntervalMs(ms: number): this
+```
+
+Set the interval, in milliseconds, at which the host samples background metrics for this sandbox.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>ms</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Sampling interval in milliseconds.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">network()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+network(configure: (b: NetworkBuilder) => NetworkBuilder): this
+```
+
+Configure DNS, TLS, policy, and secrets. See [Networking](/sdk/typescript/networking) for the full builder API.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="/sdk/typescript/networking">(b: NetworkBuilder) =&gt; NetworkBuilder</a></div>
+    <div className="msb-param-desc">Configure the network.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">patch()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+patch(configure: (b: PatchBuilder) => PatchBuilder): this
+```
+
+Modify the rootfs before the VM boots. Patches go into the writable layer - the base image is untouched. See [`PatchBuilder`](#patchbuilder) for the operations.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#patchbuilder">(b: PatchBuilder) =&gt; PatchBuilder</a></div>
+    <div className="msb-param-desc">Configure rootfs patches.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const sandbox = await Sandbox.builder("worker")
+  .image("python")
+  .patch((p) => p.text("/etc/app.conf", "mode=prod\n", { mode: 0o644 }))
+  .create();
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">port()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+port(host: number, guest: number): this
+```
+
+Publish a TCP port from the sandbox to the host. The default host bind address is `127.0.0.1`. For an explicit bind address, use [`portBind`](#portbind).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">portBind()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+portBind(bind: string, host: number, guest: number): this
+```
+
+Publish a TCP port on a specific host bind address, such as `"0.0.0.0"`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>bind</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Host bind address.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">portUdp()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+portUdp(host: number, guest: number): this
+```
+
+Publish a UDP port. The default host bind address is `127.0.0.1`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">portUdpBind()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+portUdpBind(bind: string, host: number, guest: number): this
+```
+
+Publish a UDP port on a specific host bind address.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>bind</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Host bind address.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port on the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Port inside the sandbox.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">pullPolicy()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+pullPolicy(policy: PullPolicy): this
+```
+
+Control when the OCI image is pulled from the registry.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>policy</code><a className="msb-type" href="#pullpolicy">PullPolicy</a></div>
+    <div className="msb-param-desc">Pull behavior.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">quietLogs()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+quietLogs(): this
+```
+
+Suppress sandbox process log output.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">registry()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+registry(configure: (b: RegistryBuilder) => RegistryBuilder): this
+```
+
+Configure the OCI registry connection: authentication, insecure transport, and CA certificates.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><span className="msb-type">(b: RegistryBuilder) =&gt; RegistryBuilder</span></div>
+    <div className="msb-param-desc">Configure the registry.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const sandbox = await Sandbox.builder("worker")
+  .image("registry.internal/app:latest")
+  .registry((r) => r.auth("user", "token"))
+  .create();
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">replace()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+replace(): this
+```
+
+If a sandbox with the same name already exists, stop it (10s SIGTERM grace, then SIGKILL), remove it, and create a fresh one. Without this, creation fails on name conflict.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">replaceWithTimeout()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+replaceWithTimeout(timeoutMs: number): this
+```
+
+Same as [`replace()`](#replace) with a custom SIGTERM timeout in milliseconds. `0` skips SIGTERM and force-kills immediately. Implies `replace()`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>timeoutMs</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Milliseconds to wait after SIGTERM before escalating to SIGKILL.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">rlimit()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+rlimit(resource: string, limit: number): this
+```
+
+Set a guest resource limit (a soft and hard limit at the same value). For separate soft/hard values, use [`rlimitRange`](#rlimitrange).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>resource</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Resource name, e.g. <code>"nofile"</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>limit</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Limit value applied to both soft and hard.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">rlimitRange()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+rlimitRange(resource: string, soft: number, hard: number): this
+```
+
+Set a guest resource limit with explicit soft and hard values.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>resource</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Resource name, e.g. <code>"nofile"</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>soft</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Soft limit.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>hard</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Hard limit.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">script()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+script(name: string, content: string): this
+```
+
+Add a named script at `/.msb/scripts/` inside the guest. Scripts are added to `PATH` and can be called by name via `exec()` or `shell()`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Script name (becomes the filename).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Script content.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">scripts()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+scripts(scripts: Record<string, string>): this
+```
+
+Add many named scripts at once.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>scripts</code><span className="msb-type">Record&lt;string, string&gt;</span></div>
+    <div className="msb-param-desc">Map of script names to contents.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">security()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+security(profile: "default" | "restricted"): this
+```
+
+Set the in-guest security profile.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>profile</code><span className="msb-type">"default" | "restricted"</span></div>
+    <div className="msb-param-desc">Security profile.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">secret()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+secret(configure: (b: SecretBuilder) => SecretBuilder): this
+```
+
+Add a secret with full configuration. See [Secrets](/sdk/typescript/secrets) for the builder API. Automatically enables TLS interception.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="/sdk/typescript/secrets#secretbuilder">(b: SecretBuilder) =&gt; SecretBuilder</a></div>
+    <div className="msb-param-desc">Configure the secret.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">secretEnv()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+secretEnv(envVar: string, value: string, allowedHost: string): this
+```
+
+Auto-placeholder shorthand for adding a header-injected secret. Generates a `$MSB_<env_var>` placeholder usable in headers.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>envVar</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Environment variable name (non-empty, no <code>=</code> or NUL).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Secret value.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>allowedHost</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Allowed destination host.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">shell()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+shell(shell: string): this
+```
+
+Set the shell binary used by [`sandbox.shell()`](/sdk/typescript/execution).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>shell</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Shell path (e.g. <code>"/bin/bash"</code>).</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">user()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+user(user: string): this
+```
+
+Set the default guest user for all commands.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>user</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">User name or UID.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">volume()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+volume(guest: string, configure: (b: MountBuilder) => MountBuilder): this
+```
+
+Add a volume mount. See [Volumes](/sdk/typescript/volumes) for mount types.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>guest</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Mount point inside the sandbox.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="/sdk/typescript/volumes">(b: MountBuilder) =&gt; MountBuilder</a></div>
+    <div className="msb-param-desc">Configure the mount.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">workdir()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+workdir(path: string): this
+```
+
+Set the default working directory for all commands.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+---
+
+## PatchBuilder
+
+Fluent builder for the ordered list of pre-boot rootfs patches. Used in `SandboxBuilder.patch(p => p...)`. Each method appends one operation; calls are chainable. By default a method that targets a path already present in the image errors at boot; pass `{ replace: true }` on the operation to allow overwriting. `mkdir` and `remove` are idempotent. See [Patches](/sandboxes/customize#patches) for conceptual context.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">append()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+append(path: string, content: string): this
+```
+
+Append `content` to an existing file at `path`. If the file lives in a lower image layer, it's copied up first.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Text to append.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">copyDir()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+copyDir(src: string, dst: string, opts?: { replace?: boolean }): this
+```
+
+Recursively copy a host directory at `src` into the guest rootfs at `dst`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Host source directory.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute destination path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts.replace</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">When <code>true</code>, overwrite an existing path at <code>dst</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">copyFile()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+copyFile(src: string, dst: string, opts?: { mode?: number; replace?: boolean }): this
+```
+
+Copy a single host file at `src` into the guest rootfs at `dst`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>src</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Host source file.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dst</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute destination path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts.mode</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">File mode, e.g. <code>0o644</code>. Omit to keep the source mode.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts.replace</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">When <code>true</code>, overwrite an existing path at <code>dst</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">file()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+file(path: string, content: Buffer, opts?: { mode?: number; replace?: boolean }): this
+```
+
+Write raw bytes at `path`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">Buffer</span></div>
+    <div className="msb-param-desc">Raw byte content.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts.mode</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">File mode, e.g. <code>0o644</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts.replace</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">When <code>true</code>, overwrite an existing path.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+mkdir(path: string, opts?: { mode?: number }): this
+```
+
+Create a directory at `path`. Idempotent: a no-op if the directory already exists.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts.mode</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Directory mode, e.g. <code>0o755</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+remove(path: string): this
+```
+
+Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't exist.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">symlink()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+symlink(target: string, link: string, opts?: { replace?: boolean }): this
+```
+
+Create a symlink at `link` pointing to `target`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>target</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">What the symlink points to (literal symlink target text).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>link</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path of the symlink itself.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts.replace</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">When <code>true</code>, overwrite an existing path at <code>link</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">text()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+text(path: string, content: string, opts?: { mode?: number; replace?: boolean }): this
+```
+
+Write UTF-8 text content at `path`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>content</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Text content.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts.mode</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">File mode, e.g. <code>0o644</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts.replace</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">When <code>true</code>, overwrite an existing path.</div>
+  </div>
+</div>
+
+---
+
+## Types
+
+### LogEntry
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sandbox-logs">logs()</a> · <a href="#sandbox-logstream">logStream()</a></p>
+
+A class wrapping one captured log entry from `exec.log`. Bytes are exposed via `data`; use `text()` for a UTF-8-lossy decode.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| timestamp | `Date` | Wall-clock capture time on the host |
+| source | [`LogSource`](#logsource) | Where the chunk came from |
+| sessionId | `number \| null` | Relay-monotonic session id; `null` for `"system"` entries |
+| data | `Uint8Array` | The captured chunk's bytes (UTF-8 lossy decoded by default) |
+| cursor | `string` | Opaque resume token; pass to [`LogStreamOptions.fromCursor`](#logstreamoptions) to resume |
+| `text()` | `string` | Convenience: UTF-8 decode of `data` (lossy - invalid bytes are replaced) |
+
+### LogLevel
+
+<div className="msb-tags"><span className="msb-tag is-type">union</span></div>
+
+<p className="msb-backref">Used by <a href="#loglevel">logLevel()</a></p>
+
+Sandbox process log verbosity. String literal type.
+
+| Value | Description |
+|-------|-------------|
+| `"error"` | Errors only |
+| `"warn"` | Warnings and errors only |
+| `"info"` | Info and higher |
+| `"debug"` | Debug and higher |
+| `"trace"` | Most verbose - all diagnostic output |
+
+### LogReadOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#sandbox-logs">logs()</a></p>
+
+Filters passed to [`logs()`](#sandbox-logs). All fields optional. Omit the argument entirely for the default sources (`stdout` + `stderr` + `output`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tail | `number?` | Show only the last N entries after other filters apply |
+| since | `Date?` | Inclusive lower bound on entry timestamp |
+| until | `Date?` | Exclusive upper bound on entry timestamp |
+| sources | `ReadonlyArray<`[`LogSource`](#logsource)` \| "all">?` | Sources to include. Omit = `["stdout", "stderr", "output"]`. Add `"system"` or pass `"all"` to merge runtime/kernel diagnostics. |
+
+### LogStream
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sandbox-logstream">logStream()</a></p>
+
+An async iterable of [`LogEntry`](#logentry) values. Drain it with `for await...of` or call `recv()` directly. Implements `AsyncDisposable`, so it works with `await using`.
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| [Symbol.asyncIterator] | `AsyncGenerator<`[`PullProgress`](#pullprogress)`>` | Use with `for await...of` |
-| progress.recv() | `Promise<`[`PullProgress`](#pullprogress)` \| null>` | Receive next event. Returns `null` when the stream ends. |
-| awaitSandbox() | `Promise<`[`Sandbox`](#instance-methods)`>` | Resolve the underlying creation task and return the running sandbox. Single-shot: a second call throws an already-consumed error. |
+| `recv()` | `Promise<`[`LogEntry`](#logentry)` \| null>` | Receive the next entry. Returns `null` when the stream ends. |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<`[`LogEntry`](#logentry)`>` | Use with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop iterating; safe to use with `await using` |
+
+### LogStreamOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#sandbox-logstream">logStream()</a></p>
+
+Options passed to [`logStream()`](#sandbox-logstream). All fields optional. `since` and `fromCursor` are mutually exclusive - passing both rejects at the boundary.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sources | `ReadonlyArray<`[`LogSource`](#logsource)` \| "all">?` | Same shape as [`LogReadOptions.sources`](#logreadoptions) |
+| since | `Date?` | Start at the first entry whose timestamp is `>= since`. Mutually exclusive with `fromCursor`. |
+| fromCursor | `string?` | Resume strictly after the entry whose [`LogEntry.cursor`](#logentry) matches. Mutually exclusive with `since`. |
+| until | `Date?` | Stop emitting at the first entry whose timestamp is `>= until` |
+| follow | `boolean?` | When `true`, keep the stream open past current EOF and yield new entries as they are written. Defaults to `false`. |
+
+### LogSource
+
+<div className="msb-tags"><span className="msb-tag is-type">union</span></div>
+
+<p className="msb-backref">Used by <a href="#logentry">LogEntry.source</a> · <a href="#logreadoptions">LogReadOptions.sources</a></p>
+
+Tag indicating where a captured log entry came from. String literal type:
+
+```typescript
+type LogSource = "stdout" | "stderr" | "output" | "system";
+```
+
+| Value | Description |
+|-------|-------------|
+| `"stdout"` | Captured from a session's stdout (pipe mode - streams stayed separated) |
+| `"stderr"` | Captured from a session's stderr (pipe mode) |
+| `"output"` | Captured from a session running in PTY mode. PTY allocation merges stdout and stderr at the kernel level inside the guest, so they arrive as a single stream - tagged `"output"` rather than mislabelled as `"stdout"`. |
+| `"system"` | Synthetic entry: lifecycle markers in `exec.log` plus runtime/kernel diagnostic lines merged in at read time when `"system"` is requested. |
+
+### MetricsStream
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#sandbox-metricsstream">metricsStream()</a></p>
+
+Async stream for receiving periodic metrics snapshots. Implements `AsyncDisposable`, so it works with `await using`.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `recv()` | `Promise<`[`SandboxMetrics`](#sandboxmetrics)` \| null>` | Receive the next snapshot. Returns `null` when the stream ends. |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<`[`SandboxMetrics`](#sandboxmetrics)`>` | Use with `for await...of` |
+| `[Symbol.asyncDispose]()` | `Promise<void>` | Stop iterating; safe to use with `await using` |
+
+### PullPolicy
+
+<div className="msb-tags"><span className="msb-tag is-type">union</span></div>
+
+<p className="msb-backref">Used by <a href="#pullpolicy">pullPolicy()</a></p>
+
+Controls when the SDK fetches an OCI image from the registry. String literal type.
+
+| Value | Description |
+|-------|-------------|
+| `"always"` | Pull the image every time, even if cached locally |
+| `"if-missing"` | Pull only if the image is not already cached. This is the default. |
+| `"never"` | Never pull; fail if the image is not cached locally |
+
+### PullProgress
+
+<div className="msb-tags"><span className="msb-tag is-type">union</span></div>
+
+<p className="msb-backref">Yielded by <a href="#pullprogresscreate">PullProgressCreate</a></p>
+
+Image pull and materialize progress event emitted by [`PullProgressCreate`](#pullprogresscreate). A discriminated union. Narrow on `kind` to access variant-specific fields.
+
+| `kind` value | Additional fields |
+|--------------|-------------------|
+| `"resolving"` | `reference: string` |
+| `"resolved"` | `reference: string`, `manifestDigest: string`, `layerCount: number`, `totalDownloadBytes?: number` |
+| `"layerDownloadProgress"` | `layerIndex: number`, `digest: string`, `downloadedBytes: number`, `totalBytes?: number` |
+| `"layerDownloadComplete"` | `layerIndex: number`, `digest: string`, `downloadedBytes: number` |
+| `"layerDownloadVerifying"` | `layerIndex: number`, `digest: string` |
+| `"layerMaterializeStarted"` | `layerIndex: number`, `diffId: string` |
+| `"layerMaterializeProgress"` | `layerIndex: number`, `bytesRead: number`, `totalBytes: number` |
+| `"layerMaterializeWriting"` | `layerIndex: number` |
+| `"layerMaterializeComplete"` | `layerIndex: number`, `diffId: string` |
+| `"stitchMergingTrees"` | `layerCount: number` |
+| `"stitchWritingFsmeta"` | (none) |
+| `"stitchWritingVmdk"` | (none) |
+| `"stitchComplete"` | (none) |
+| `"complete"` | `reference: string`, `layerCount: number` |
+
+`totalDownloadBytes` and `totalBytes` on the `"resolved"` / `"layerDownloadProgress"` variants may be absent if the manifest omits sizes.
+
+### PullProgressCreate
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#createwithpullprogress">createWithPullProgress()</a></p>
+
+Async iterable creation handle returned by [`createWithPullProgress()`](#createwithpullprogress). Yields [`PullProgress`](#pullprogress) events as the image is resolved, downloaded, and materialized. Call `awaitSandbox()` after iteration to obtain the live sandbox.
+
+| Method / Property | Returns | Description |
+|-------------------|---------|-------------|
+| progress | `NapiPullProgressStream` | The underlying progress event stream |
+| `[Symbol.asyncIterator]()` | `AsyncIterator<`[`PullProgress`](#pullprogress)`>` | Use with `for await...of` |
+| `awaitSandbox()` | `Promise<`[`Sandbox`](#instance-methods)`>` | Resolve the underlying creation task and return the running sandbox |
 
 ### SandboxConfig
 
-Configuration object produced by `SandboxBuilder.build()` and returned by `sandbox.config()`. You generally should not construct this by hand; use the builder.
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
+
+<p className="msb-backref">Returned by <a href="#sandbox-config">config()</a> · <a href="#build">build()</a></p>
+
+Configuration object produced by [`build()`](#build) and returned by [`config()`](#sandbox-config). You generally should not construct this by hand; use the builder.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -736,7 +2235,7 @@ Configuration object produced by `SandboxBuilder.build()` and returned by `sandb
 | image | `RootfsSource` | OCI / bind / disk discriminated union |
 | cpus | `number \| null` | Virtual CPUs |
 | memoryMib | `number \| null` | Guest memory in MiB |
-| logLevel | `LogLevel \| null` | Log verbosity |
+| logLevel | [`LogLevel`](#loglevel)` \| null` | Log verbosity |
 | quietLogs | `boolean` | Suppress log output |
 | workdir | `string \| null` | Default working directory |
 | shell | `string \| null` | Shell binary |
@@ -745,12 +2244,11 @@ Configuration object produced by `SandboxBuilder.build()` and returned by `sandb
 | cmd | `string[] \| null` | Override image cmd |
 | hostname | `string \| null` | Guest hostname |
 | user | `string \| null` | Default guest user |
-| libkrunfwPath | `string \| null` | Custom libkrunfw path |
 | env | `Array<readonly [string, string]>` | Environment variables |
 | scripts | `Array<readonly [string, string]>` | Named scripts |
 | mounts | `VolumeMount[]` | Volume mounts |
 | patches | `Patch[]` | Rootfs modifications applied before boot |
-| pullPolicy | `PullPolicy \| null` | Image pull behavior |
+| pullPolicy | [`PullPolicy`](#pullpolicy)` \| null` | Image pull behavior |
 | replace | `boolean` | Replace existing sandbox with same name |
 | replaceWithTimeoutMs | `number` | Milliseconds to wait after `SIGTERM` before escalating to `SIGKILL` (default `10000`; `0` skips `SIGTERM`) |
 | maxDurationSecs | `number \| null` | Maximum sandbox lifetime |
@@ -764,9 +2262,13 @@ Configuration object produced by `SandboxBuilder.build()` and returned by `sandb
 
 ### SandboxHandle
 
-A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandboxget) or [`Sandbox.list()`](#sandboxlist).
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
 
-Handles from `Sandbox.get(name)` are **live** — they expose lifecycle methods (`start`, `stop`, `kill`, `connect`, etc). Handles in the array returned by `Sandbox.list()` are **read-only**: calling lifecycle methods on them throws. Use `Sandbox.get(name)` to upgrade to a live handle.
+<p className="msb-backref">Returned by <a href="#sandbox-get">Sandbox.get()</a> · <a href="#sandbox-list">Sandbox.list()</a> · <a href="#sandbox-listwith">Sandbox.listWith()</a></p>
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandbox-get), [`Sandbox.list()`](#sandbox-list), or [`Sandbox.listWith()`](#sandbox-listwith). Provides status, configuration, and lifecycle control without an active connection to the guest agent.
+
+Handles from `Sandbox.get(name)` are **live** - they expose lifecycle methods (`start`, `stop`, `kill`, `connect`, etc). Handles in the arrays returned by `Sandbox.list()` / `Sandbox.listWith()` are **read-only**: calling lifecycle methods on them throws. Use `Sandbox.get(name)` to upgrade to a live handle.
 
 | Property / Method | Type | Description |
 |-------------------|------|-------------|
@@ -775,8 +2277,11 @@ Handles from `Sandbox.get(name)` are **live** — they expose lifecycle methods 
 | configJson | `string` | Raw JSON configuration |
 | createdAt | `Date \| null` | Creation timestamp |
 | updatedAt | `Date \| null` | Last update timestamp |
+| config() | [`SandboxConfig`](#sandboxconfig) | Parsed configuration |
+| refresh() | `Promise<`[`SandboxHandle`](#sandboxhandle)`>` | Re-read the handle's state from the database |
 | metrics() | `Promise<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
 | logs() | `Promise<`[`LogEntry`](#logentry)`[]>` | Read captured `exec.log` (works without starting) |
+| logStream() | `Promise<`[`LogStream`](#logstream)`>` | Stream captured `exec.log`, with optional follow |
 | start() | `Promise<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
 | startDetached() | `Promise<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |
 | connect() | `Promise<`[`Sandbox`](#instance-methods)`>` | Connect to a running sandbox without taking ownership. Returns an error if it doesn't respond within 10_000 ms |
@@ -790,40 +2295,63 @@ Handles from `Sandbox.get(name)` are **live** — they expose lifecycle methods 
 | requestDrain() | `Promise<void>` | Request graceful drain without waiting |
 | waitUntilStopped() | `Promise<`[`SandboxStopResult`](#sandboxstopresult)`>` | Block until the sandbox reaches terminal state |
 | remove() | `Promise<void>` | Delete sandbox and state |
-
-### SandboxStopResult
-
-Observed terminal sandbox state returned by [`waitUntilStopped()`](#waituntilstopped).
-
-| Field | Type | Description |
-|-------|------|-------------|
-| status | [`SandboxStatus`](#sandboxstatus) | Terminal status that was observed |
-| exitCode | `number \| null` | Process exit code when it is available |
+| snapshot(name) | `Promise<Snapshot>` | Snapshot this stopped sandbox under a bare name. See [Snapshots](/sdk/typescript/snapshots) |
+| snapshotTo(path) | `Promise<Snapshot>` | Snapshot this stopped sandbox to an explicit filesystem path |
 
 ### SandboxMetrics
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Returned by <a href="#sandbox-metrics">metrics()</a> · yielded by <a href="#metricsstream">MetricsStream</a></p>
 
 Point-in-time resource usage snapshot.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | cpuPercent | `number` | CPU usage as a percentage |
+| vcpuTimeNs | `number` | Cumulative vCPU time in nanoseconds |
+| memoryBytes | `number` | Current memory usage in bytes |
+| memoryAvailableBytes | `number \| null` | Guest-visible available memory in bytes when reported |
+| memoryHostResidentBytes | `number \| null` | Host-resident memory backing the guest in bytes when reported |
+| memoryLimitBytes | `number` | Memory limit in bytes |
 | diskReadBytes | `number` | Total bytes read from disk since boot |
 | diskWriteBytes | `number` | Total bytes written to disk since boot |
-| memoryBytes | `number` | Current memory usage in bytes |
-| memoryLimitBytes | `number` | Memory limit in bytes |
 | netRxBytes | `number` | Total bytes received over the network since boot |
 | netTxBytes | `number` | Total bytes sent over the network since boot |
 | upperUsedBytes | `number \| null` | Guest-visible OCI upper filesystem used bytes when the protected reporter is available and fresh |
 | upperFreeBytes | `number \| null` | Guest-visible OCI upper filesystem free bytes when the protected reporter is available and fresh |
 | upperHostAllocatedBytes | `number \| null` | Host-allocated bytes for the writable OCI upper image when available |
-| timestamp | `Date` | When this measurement was taken |
 | uptimeMs | `number` | Time since the sandbox was created (ms) |
+| timestamp | `Date` | When this measurement was taken |
+
+### SandboxStopResult
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Returned by <a href="#sandbox-waituntilstopped">waitUntilStopped()</a></p>
+
+Observed terminal sandbox state returned by [`waitUntilStopped()`](#sandbox-waituntilstopped).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Sandbox name |
+| status | [`SandboxStatus`](#sandboxstatus) | Terminal status that was observed |
+| exitCode | `number \| null` | Process exit code when it is available |
+| signal | `number \| null` | Terminating signal when the process was killed |
+| observedAt | `Date` | When the terminal state was observed |
+| source | `string \| null` | Origin of the observation when reported |
 
 ### SandboxStatus
 
+<div className="msb-tags"><span className="msb-tag is-type">union</span></div>
+
+<p className="msb-backref">Used by <a href="#sandboxhandle">SandboxHandle.status</a> · <a href="#sandboxstopresult">SandboxStopResult.status</a></p>
+
+Current lifecycle state of a sandbox. String literal type.
+
 | Value | Description |
 |-------|-------------|
-| `'crashed'` | VM exited unexpectedly |
-| `'draining'` | Graceful shutdown in progress |
-| `'running'` | Guest agent is ready |
-| `'stopped'` | VM shut down; can be restarted |
+| `"running"` | Guest agent is ready; `exec`, `shell`, `fs` work |
+| `"stopped"` | VM shut down; configuration persisted; can be restarted |
+| `"crashed"` | VM exited unexpectedly (kernel panic, OOM, etc.) |
+| `"draining"` | Graceful shutdown in progress; existing commands finish, new ones rejected |

--- a/docs/sdk/typescript/secrets.mdx
+++ b/docs/sdk/typescript/secrets.mdx
@@ -3,23 +3,494 @@ title: Secrets
 description: TypeScript SDK - Secret injection API reference
 ---
 
-See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+Inject credentials into outbound HTTP without ever exposing the real value to the guest. The guest only ever sees a placeholder; microsandbox's TLS proxy swaps in the real secret on connections to allowed hosts and blocks everything else. See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
 
-## Adding secrets
+<div className="msb-glance">
 
-Secrets are configured on a sandbox via `SandboxBuilder.secret(s => ...)` (or its shorthand `secretEnv`). The guest only ever sees a placeholder — the real value is substituted by the TLS proxy when traffic reaches an allowed host.
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SecretBuilder<span className="msb-ct">13</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#env">.env()</a>
+    <a className="msb-chip" href="#value">.value()</a>
+    <a className="msb-chip" href="#placeholder">.placeholder()</a>
+    <a className="msb-chip" href="#allowhost">.allowHost()</a>
+    <a className="msb-chip" href="#allowhostpattern">.allowHostPattern()</a>
+    <a className="msb-chip" href="#allowanyhostdangerous">.allowAnyHostDangerous()</a>
+    <a className="msb-chip" href="#requiretlsidentity">.requireTlsIdentity()</a>
+    <a className="msb-chip" href="#injectheaders">.injectHeaders()</a>
+    <a className="msb-chip" href="#injectbasicauth">.injectBasicAuth()</a>
+    <a className="msb-chip" href="#injectquery">.injectQuery()</a>
+    <a className="msb-chip" href="#injectbody">.injectBody()</a>
+    <a className="msb-chip" href="#onviolation">.onViolation()</a>
+    <a className="msb-chip" href="#build">.build()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · ViolationActionBuilder<span className="msb-ct">6</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#block">.block()</a>
+    <a className="msb-chip" href="#blockandlog">.blockAndLog()</a>
+    <a className="msb-chip" href="#blockandterminate">.blockAndTerminate()</a>
+    <a className="msb-chip" href="#passthroughhost">.passthroughHost()</a>
+    <a className="msb-chip" href="#passthroughhostpattern">.passthroughHostPattern()</a>
+    <a className="msb-chip" href="#passthroughallhosts">.passthroughAllHosts()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Shorthand · SandboxBuilder<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#sandboxbuilder-secret"><span className="msb-rn">.secret()</span><span className="msb-rg">configure a secret with a closure</span></a>
+  <a className="msb-row" href="#sandboxbuilder-secretenv"><span className="msb-rn">.secretEnv()</span><span className="msb-rg">one-line header-injected secret</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Shorthand · NetworkBuilder<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#networkbuilder-secret"><span className="msb-rn">.secret()</span><span className="msb-rg">configure a secret with a closure</span></a>
+  <a className="msb-row" href="#networkbuilder-secretenv"><span className="msb-rn">.secretEnv()</span><span className="msb-rg">secret with explicit placeholder</span></a>
+  <a className="msb-row" href="#networkbuilder-secretenvsimple"><span className="msb-rn">.secretEnvSimple()</span><span className="msb-rg">auto-placeholder secret</span></a>
+  <a className="msb-row" href="#networkbuilder-onsecretviolation"><span className="msb-rn">.onSecretViolation()</span><span className="msb-rg">sandbox-wide violation policy</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#secretentry">SecretEntry</a>
+    <a className="msb-typepill" href="#secretinjection">SecretInjection</a>
+    <a className="msb-typepill" href="#violationaction">ViolationAction</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```typescript
 import { Sandbox } from "microsandbox";
 
-// Auto-placeholder shorthand: generates `$MSB_SERVICE_API_KEY`.
-await using sb = await Sandbox.builder("worker")
+await using sb = await Sandbox.builder("agent")
   .image("python")
-  .secretEnv("SERVICE_API_KEY", process.env.SERVICE_API_KEY!, "api.example.com")
+  .secret((s) =>
+    s.env("OPENAI_API_KEY")              // guest sees $MSB_OPENAI_API_KEY
+      .value(process.env.OPENAI_API_KEY!)
+      .allowHost("api.openai.com"),      // real value only reaches this host
+  )
   .create();
 
-// Full control via SecretBuilder.
-await using sb2 = await Sandbox.builder("payments-worker")
+// In the guest, the placeholder is swapped for the real key
+// only on TLS connections to api.openai.com.
+const out = await sb.exec("python", ["agent.py"]);
+```
+
+## SecretBuilder
+
+Fluent builder for one secret's placeholder, allowed hosts, and injection scopes. Obtained through [`SandboxBuilder.secret(s => ...)`](#sandboxbuilder-secret) or [`NetworkBuilder.secret(s => ...)`](#networkbuilder-secret); each secret maps an environment variable to a real value that is only revealed when traffic reaches an allowed host through the TLS proxy. Every setter returns the same builder so calls can be chained. [`env()`](#env), [`value()`](#value), and at least one allowed host are required; [`build()`](#build) throws otherwise. Adding any secret automatically enables TLS interception.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">env()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+env(varName: string): this
+```
+
+Set the environment variable name that holds the placeholder inside the guest. The guest sees `$MSB_<varName>` (or a custom [`placeholder`](#placeholder)), never the real value. Names must be non-empty and cannot contain `=` or NUL; shell-identifier syntax is not required. **Required.**
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>varName</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Environment variable name (non-empty, no <code>=</code> or NUL).</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">value()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+value(value: string): this
+```
+
+Set the real secret value. This is the string that replaces the placeholder when a request reaches an allowed host. It never enters the guest VM. **Required.**
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">The actual credential or token.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">placeholder()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+placeholder(placeholder: string): this
+```
+
+Override the auto-generated placeholder string. By default microsandbox generates `$MSB_<envVar>`. Use this when you need a specific format or when the placeholder must match a particular byte length. Placeholders must be non-empty, at most 1024 bytes, and cannot contain NUL, CR, or LF.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>placeholder</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Custom placeholder string: non-empty, up to 1024 bytes, no NUL/CR/LF.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allowHost()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+allowHost(host: string): this
+```
+
+Add an exact host allowed to receive the real secret value. The proxy checks the host against the connection's verified TLS identity and observed DNS history. Can be called multiple times to allow several hosts. At least one allowed host (exact, pattern, or any) is required.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Exact hostname, e.g. <code>"api.example.com"</code> (ASCII case-insensitive).</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+.secret((s) =>
+  s.env("STRIPE_KEY")
+    .value(process.env.STRIPE_KEY!)
+    .allowHost("api.stripe.com")
+    .allowHost("files.stripe.com"),
+)
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allowHostPattern()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+allowHostPattern(pattern: string): this
+```
+
+Add a wildcard host pattern. A `*.suffix` pattern matches the suffix itself and any single-or-multi label subdomain of it.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pattern</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Wildcard pattern, e.g. <code>"*.googleapis.com"</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">allowAnyHostDangerous()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+allowAnyHostDangerous(iUnderstand: boolean): this
+```
+
+Allow substitution on **any** host. Every server the guest connects to can then receive the real secret, which effectively disables host-based protection. The call is a no-op unless `iUnderstand` is `true`. Only use this when the secret is not sensitive or the sandbox network is fully locked down. This is the one allow-list pattern that skips DNS and TLS-identity pinning.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>iUnderstand</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Must be <code>true</code> to take effect.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">requireTlsIdentity()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+requireTlsIdentity(enabled: boolean): this
+```
+
+When `true`, the secret is only substituted on TLS-intercepted connections where the proxy has verified it is performing MITM and the SNI matches an allowed host. Bypassed TLS is opaque and never receives substitution. Disable only when you know the traffic path is safe and explicitly supports non-TLS substitution. Default: `true`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Require verified TLS identity. Default: <code>true</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">injectHeaders()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+injectHeaders(enabled: boolean): this
+```
+
+Control whether the placeholder is replaced anywhere in HTTP headers. This is the most common injection scope, covering `Authorization: Bearer $MSB_...` and similar patterns. Default: `true`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Substitute in headers. Default: <code>true</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">injectBasicAuth()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+injectBasicAuth(enabled: boolean): this
+```
+
+Control whether `Authorization: Basic <base64>` credentials are decoded, substituted in the decoded `user:password`, then re-encoded. Orthogonal to [`injectHeaders`](#injectheaders): this flag handles the encoded-credentials case for the Basic scheme; `injectHeaders` handles literal substitution in any header line, including non-Basic Authorization schemes (`Bearer`, `Digest`). Default: `true`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Substitute inside Basic Auth credentials. Default: <code>true</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">injectQuery()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+injectQuery(enabled: boolean): this
+```
+
+Control whether the placeholder is replaced in the URL query string (the `?key=value` portion of the request line). Default: `false`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Substitute in query parameters. Default: <code>false</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">injectBody()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+injectBody(enabled: boolean): this
+```
+
+Control whether the placeholder is replaced in request bodies when microsandbox can inspect and rewrite them safely. Encoded bodies are forwarded unchanged, and body placeholders in unsupported body formats are blocked rather than leaked. Default: `false`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Substitute in request bodies. Default: <code>false</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">onViolation()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+onViolation(configure: (b: ViolationActionBuilder) => ViolationActionBuilder): this
+```
+
+Configure violation behavior for this secret. Overrides the sandbox-wide secret violation policy and can let selected hosts receive the placeholder unchanged. See [`ViolationActionBuilder`](#violationactionbuilder) for the full set of `block*` and `passthrough*` methods.
+
+Passthrough hosts do **not** receive the real secret value; substitution still only happens for hosts configured with [`allowHost()`](#allowhost) or [`allowHostPattern()`](#allowhostpattern). When a per-secret passthrough policy does not match the request host, microsandbox falls back to the sandbox-wide secret violation action.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#violationactionbuilder">(b: ViolationActionBuilder) =&gt; ViolationActionBuilder</a></div>
+    <div className="msb-param-desc">Configure the per-secret violation action.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+.secret((s) =>
+  s.env("API_KEY")
+    .value(process.env.API_KEY!)
+    .allowHost("api.github.com")
+    .onViolation((v) =>
+      v.blockAndLog().passthroughHost("api.anthropic.com"),
+    ),
+)
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+build(): SecretEntry
+```
+
+Materialize the [`SecretEntry`](#secretentry). Called for you by [`SandboxBuilder.secret`](#sandboxbuilder-secret), so you rarely call it directly. If [`placeholder`](#placeholder) was not set, it defaults to `$MSB_<envVar>`. Throws a `MicrosandboxError` if `env` or `value` was not set, or if the allow-list is empty.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#secretentry">SecretEntry</a></div>
+    <div className="msb-param-desc">The materialized secret entry.</div>
+  </div>
+</div>
+
+---
+
+## ViolationActionBuilder
+
+Fluent builder for the action taken when a secret placeholder is sent to a disallowed host. Obtained through the closure passed to [`SecretBuilder.onViolation(v => ...)`](#onviolation) (per-secret) or [`NetworkBuilder.onSecretViolation(v => ...)`](#networkbuilder-onsecretviolation) (sandbox-wide). The terminal `block*` methods set the base action; the `passthrough*` methods carve out hosts that get the placeholder forwarded unchanged.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">block()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+block(): this
+```
+
+Silently drop a violating request. The guest sees a connection reset. This is the default.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">blockAndLog()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+blockAndLog(): this
+```
+
+Drop the request and emit a warning log on the host side.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">blockAndTerminate()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+blockAndTerminate(): this
+```
+
+Drop the request, log an error, and shut down the entire sandbox.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">passthroughHost()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+passthroughHost(host: string): this
+```
+
+Forward requests to an exact host with the placeholder unchanged, instead of blocking. The host does **not** receive the real value. Non-matching hosts fall back to the base `block*` action.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Exact hostname to forward unchanged.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">passthroughHostPattern()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+passthroughHostPattern(pattern: string): this
+```
+
+Forward requests to any host matching a wildcard pattern with the placeholder unchanged.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pattern</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Wildcard pattern, e.g. <code>"*.internal.example.com"</code>.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">passthroughAllHosts()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+passthroughAllHosts(iUnderstand: boolean): this
+```
+
+Forward the placeholder unchanged to **every** host instead of blocking. The call is a no-op unless `iUnderstand` is `true`. The real value is still never substituted on these hosts; this only stops the request from being dropped.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>iUnderstand</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Must be <code>true</code> to take effect.</div>
+  </div>
+</div>
+
+---
+
+## SandboxBuilder shorthand
+
+Two methods on [`SandboxBuilder`](/sdk/typescript/sandbox) for adding secrets without reaching into a [`NetworkBuilder`](/sdk/typescript/networking). Both automatically enable TLS interception.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn" id="sandboxbuilder-secret">secret()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+secret(configure: (s: SecretBuilder) => SecretBuilder): this
+```
+
+Add a secret with full configuration via a [`SecretBuilder`](#secretbuilder) closure. The builder's [`build()`](#build) is called for you.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#secretbuilder">(s: SecretBuilder) =&gt; SecretBuilder</a></div>
+    <div className="msb-param-desc">Configure the secret.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await using sb = await Sandbox.builder("payments-worker")
   .image("python")
   .secret((s) =>
     s.env("STRIPE_KEY")
@@ -32,112 +503,226 @@ await using sb2 = await Sandbox.builder("payments-worker")
   .create();
 ```
 
-The same `secret(...)` and `secretEnv(...)` methods are also available inside `SandboxBuilder.network(n => n.secret(...))` and on `NetworkBuilder.secretEnv(envVar, value, placeholder, allowedHost)` (4-arg explicit-placeholder shorthand).
-
 ---
 
-## Host Matching
-
-TypeScript host settings map to the runtime `HostPattern` model. Allow-list methods decide where the real secret value may be substituted; passthrough methods decide where the placeholder may be forwarded unchanged.
-
-| Pattern kind | Builder methods | Matches |
-|--------------|-----------------|---------|
-| Exact host | `allowHost("api.example.com")`, `passthroughHost("api.example.com")` | That exact SNI host |
-| Wildcard host | `allowHostPattern("*.example.com")`, `passthroughHostPattern("*.example.com")` | Hosts matching the wildcard pattern |
-| Any host | `allowAnyHostDangerous(true)`, `passthroughAllHosts(true)` | Every host |
-
-Passthrough host patterns do **not** make a secret eligible for substitution. They only prevent blocking when the guest sends the placeholder to a matching host, so the request is forwarded with the placeholder unchanged.
-
-Exact and wildcard allow-list entries are pinned to observed DNS answers and TLS identity. `allowAnyHostDangerous(true)` is the explicit opt-out from host pinning. Empty allow-lists are rejected by `SecretBuilder.build()`.
-
----
-
-## SecretBuilder
-
-Fluent builder used inside `SandboxBuilder.secret(s => ...)` or `NetworkBuilder.secret(s => ...)`. Every setter returns the same builder so calls can be chained.
-
-| Method | Description |
-|--------|-------------|
-| `env(varName)` | Environment variable to expose the placeholder under. Must be non-empty and cannot contain `=` or NUL; shell-identifier syntax is not required. **Required.** |
-| `value(value)` | The real secret value (stays on the host). **Required.** |
-| `placeholder(placeholder)` | Custom placeholder: non-empty, up to 1024 bytes, no NUL/CR/LF. Auto-generated as `$MSB_<env_var>` when omitted. |
-| `allowHost(host)` | Allow substitution to a specific host (exact match). |
-| `allowHostPattern(pattern)` | Allow substitution to any host matching a wildcard. |
-| `allowAnyHostDangerous(true)` | Permit substitution to any host. Acknowledge the risk explicitly. |
-| `onViolation(configure)` | Configure per-secret violation behavior with a `ViolationActionBuilder`. |
-| `requireTlsIdentity(enabled)` | Require a verified TLS identity before substituting. Default `true`. |
-| `injectHeaders(enabled)` | Allow substitution in HTTP headers. Default `true`. |
-| `injectBasicAuth(enabled)` | Decode `Authorization: Basic <base64>` credentials, substitute the placeholder in the decoded `user:password`, and re-encode. Default `true`. Other schemes are handled by `injectHeaders`. |
-| `injectQuery(enabled)` | Allow substitution in URL query parameters. Default `false`. |
-| `injectBody(enabled)` | Allow substitution in request bodies when microsandbox can inspect and rewrite them safely. Body placeholders in unsupported body formats are blocked instead of being leaked. Default `false`. |
-| `build()` | Produce a [`SecretEntry`](#secretentry). |
-
----
-
-## Convenience helpers
-
-#### SandboxBuilder.secretEnv()
+#### <span className="msb-recv">.</span><span className="msb-hn" id="sandboxbuilder-secretenv">secretEnv()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
 secretEnv(envVar: string, value: string, allowedHost: string): this
 ```
 
-Three-argument shorthand. Auto-generates the placeholder as `$MSB_<env_var>` and allows substitution only on `allowedHost`.
+Three-argument shorthand. Auto-generates the placeholder as `$MSB_<envVar>` and allows substitution only on `allowedHost`. The default injection scopes apply (headers and Basic Auth enabled, query and body disabled).
 
-#### NetworkBuilder.secretEnv()
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>envVar</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Environment variable name (non-empty, no <code>=</code> or NUL).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Secret value.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>allowedHost</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Allowed destination host (exact match).</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```typescript
-secretEnv(
-  envVar: string,
-  value: string,
-  placeholder: string,
-  allowedHost: string,
-): this
+await using sb = await Sandbox.builder("agent")
+  .image("python")
+  .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+  .create();
 ```
 
-Four-argument shorthand. Same as the `SandboxBuilder` form but lets you provide the placeholder explicitly.
+---
+
+## NetworkBuilder shorthand
+
+The same secret configuration is available inside [`SandboxBuilder.network(n => ...)`](/sdk/typescript/networking) for callers who are already configuring networking. These methods set the secrets and the sandbox-wide violation policy directly on the network.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn" id="networkbuilder-secret">secret()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+secret(configure: (s: SecretBuilder) => SecretBuilder): this
+```
+
+Add a secret with full configuration via a [`SecretBuilder`](#secretbuilder) closure. Identical in behavior to [`SandboxBuilder.secret`](#sandboxbuilder-secret).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#secretbuilder">(s: SecretBuilder) =&gt; SecretBuilder</a></div>
+    <div className="msb-param-desc">Configure the secret.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await using sb = await Sandbox.builder("agent")
+  .image("python")
+  .network((n) =>
+    n.secret((s) =>
+      s.env("OPENAI_API_KEY")
+        .value(process.env.OPENAI_API_KEY!)
+        .allowHost("api.openai.com"),
+    ),
+  )
+  .create();
+```
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn" id="networkbuilder-secretenv">secretEnv()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+secretEnv(envVar: string, value: string, placeholder: string, allowedHost: string): this
+```
+
+Four-argument shorthand. Same as the `SandboxBuilder` form but lets you provide the placeholder explicitly instead of auto-generating `$MSB_<envVar>`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>envVar</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Environment variable name (non-empty, no <code>=</code> or NUL).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Secret value.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>placeholder</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Explicit placeholder: non-empty, up to 1024 bytes, no NUL/CR/LF.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>allowedHost</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Allowed destination host (exact match).</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn" id="networkbuilder-secretenvsimple">secretEnvSimple()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+secretEnvSimple(envVar: string, value: string, allowedHost: string): this
+```
+
+Three-argument shorthand on `NetworkBuilder`. Auto-generates the placeholder as `$MSB_<envVar>`, matching [`SandboxBuilder.secretEnv`](#sandboxbuilder-secretenv).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>envVar</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Environment variable name (non-empty, no <code>=</code> or NUL).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Secret value.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>allowedHost</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Allowed destination host (exact match).</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn" id="networkbuilder-onsecretviolation">onSecretViolation()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+onSecretViolation(configure: (b: ViolationActionBuilder) => ViolationActionBuilder): this
+```
+
+Set the sandbox-wide secret violation policy: what happens when any secret's placeholder is sent to a host outside that secret's allow-list. Per-secret [`SecretBuilder.onViolation`](#onviolation) overrides this for the secret it is set on. See [`ViolationActionBuilder`](#violationactionbuilder) for the available actions.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#violationactionbuilder">(b: ViolationActionBuilder) =&gt; ViolationActionBuilder</a></div>
+    <div className="msb-param-desc">Configure the sandbox-wide violation action.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await using sb = await Sandbox.builder("agent")
+  .image("python")
+  .network((n) =>
+    n.secretEnvSimple("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
+      .onSecretViolation((v) => v.blockAndLog()),
+  )
+  .create();
+```
 
 ---
 
 ## Types
 
 ### SecretEntry
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
 
-The object produced by `SecretBuilder.build()`. You normally construct one with the builder, but the shape is available for callers that prefer plain objects.
+<p className="msb-backref">Returned by <a href="#build">SecretBuilder.build()</a></p>
+
+The object produced by [`SecretBuilder.build()`](#build). You normally construct one with the builder, but the shape is available for callers that prefer plain objects.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| envVar | `string` | Environment variable name (non-empty, no `=` or NUL) |
-| value | `string` | Real secret value (stays on the host) |
-| placeholder | `string \| null` | Custom placeholder: non-empty, up to 1024 bytes, no NUL/CR/LF; defaults to `$MSB_<env_var>` when `null` |
-| allowedHosts | `readonly string[]` | Allowed hosts (exact match) |
-| allowedHostPatterns | `readonly string[]` | Wildcard host patterns |
-| allowAnyHost | `boolean` | Permit substitution to any host |
-| requireTlsIdentity | `boolean` | Require verified TLS identity |
-| injection | [`SecretInjection`](#secretinjection) | Where to substitute |
+| `envVar` | `string` | Environment variable name (non-empty, no `=` or NUL) |
+| `value` | `string` | Real secret value (stays on the host) |
+| `placeholder` | `string \| null` | Custom placeholder: non-empty, up to 1024 bytes, no NUL/CR/LF; defaults to `$MSB_<envVar>` when `null` |
+| `allowedHosts` | `readonly string[]` | Allowed hosts (exact match) |
+| `allowedHostPatterns` | `readonly string[]` | Wildcard host patterns |
+| `allowAnyHost` | `boolean` | Permit substitution to any host |
+| `requireTlsIdentity` | `boolean` | Require verified TLS identity before substituting |
+| `injection` | [`SecretInjection`](#secretinjection) | Where in the request the value may be substituted |
 
 ### SecretInjection
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
 
-Controls where the TLS proxy substitutes the placeholder with the real value. Each field is optional; omitted fields use the default.
+<p className="msb-backref">Used by <a href="#secretentry">SecretEntry.injection</a></p>
+
+Controls where the TLS proxy substitutes the placeholder with the real value. Each field is optional; omitted fields use the default. Set through the [`inject*`](#injectheaders) methods on [`SecretBuilder`](#secretbuilder).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| headers? | `boolean` | `true` | Replace the placeholder anywhere in HTTP headers. |
-| basicAuth? | `boolean` | `true` | Decode `Authorization: Basic <base64>` credentials, substitute the placeholder in the decoded `user:password`, and re-encode. Other schemes (`Bearer`, `Digest`) are handled by `headers`. |
-| queryParams? | `boolean` | `false` | Replace the placeholder in URL query parameters. |
-| body? | `boolean` | `false` | Replace the placeholder in request bodies when microsandbox can inspect and rewrite them safely. Encoded bodies are forwarded unchanged, and body placeholders in unsupported body formats are blocked instead of being leaked. |
+| `headers?` | `boolean` | `true` | Replace the placeholder anywhere in HTTP headers. |
+| `basicAuth?` | `boolean` | `true` | Decode `Authorization: Basic <base64>` credentials, substitute in the decoded `user:password`, and re-encode. Other schemes (`Bearer`, `Digest`) are handled by `headers`. |
+| `queryParams?` | `boolean` | `false` | Replace the placeholder in URL query parameters. |
+| `body?` | `boolean` | `false` | Replace the placeholder in request bodies when microsandbox can inspect and rewrite them safely. Encoded bodies are forwarded unchanged, and body placeholders in unsupported body formats are blocked instead of being leaked. |
 
 ### ViolationAction
+<div className="msb-tags"><span className="msb-tag is-type">type</span></div>
 
-Action taken when a secret placeholder is sent to a disallowed host. Set on the network builder via `NetworkBuilder.onSecretViolation(action)`.
+<p className="msb-backref">Built by <a href="#violationactionbuilder">ViolationActionBuilder</a></p>
+
+The string identifier for the base action taken when a secret placeholder is sent to a disallowed host. Configured through [`ViolationActionBuilder`](#violationactionbuilder) (via [`SecretBuilder.onViolation`](#onviolation) or [`NetworkBuilder.onSecretViolation`](#networkbuilder-onsecretviolation)). The `ViolationActions` array enumerates all values.
 
 ```typescript
 type ViolationAction = "block" | "block-and-log" | "block-and-terminate" | "passthrough";
 ```
 
-| Value | Description |
-|-------|-------------|
-| `'block'` | Silently drop the request. The guest sees a connection reset. This is the default. |
-| `'block-and-log'` | Drop the request and emit a warning log on the host side. |
-| `'block-and-terminate'` | Drop the request, log an error, and shut down the entire sandbox. |
-| `'passthrough'` | Forward matching hosts with the placeholder unchanged. Non-matching hosts use the default secret violation action. |
+| Value | Builder method | Description |
+|-------|----------------|-------------|
+| `'block'` | [`block()`](#block) | Silently drop the request. The guest sees a connection reset. This is the default. |
+| `'block-and-log'` | [`blockAndLog()`](#blockandlog) | Drop the request and emit a warning log on the host side. |
+| `'block-and-terminate'` | [`blockAndTerminate()`](#blockandterminate) | Drop the request, log an error, and shut down the entire sandbox. |
+| `'passthrough'` | [`passthroughHost()`](#passthroughhost) / [`passthroughHostPattern()`](#passthroughhostpattern) / [`passthroughAllHosts()`](#passthroughallhosts) | Forward matching hosts with the placeholder unchanged. Non-matching hosts use the base block action. |

--- a/docs/sdk/typescript/snapshots.mdx
+++ b/docs/sdk/typescript/snapshots.mdx
@@ -3,179 +3,675 @@ title: Snapshots
 description: TypeScript SDK - Snapshot API reference
 ---
 
-Disk-only snapshots of a sandbox that is not running. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the TypeScript SDK reference.
+Capture the disk state of a stopped sandbox into a portable artifact, then boot fresh sandboxes from it. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs.
 
-```ts
+```typescript
 import { Sandbox, Snapshot, SnapshotHandle } from "microsandbox";
 import type { ExportOpts, SnapshotVerifyReport } from "microsandbox";
 ```
 
 <Note>
-  Snapshots are **disk-only** and require a sandbox that is not running.
+  Snapshots are **disk-only** and require a sandbox that is not running (stopped or crashed).
 </Note>
 
-## SandboxBuilder
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Capture &amp; boot<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="/sdk/typescript/sandbox#fromsnapshot"><span className="msb-rn">.fromSnapshot()</span><span className="msb-rg">boot a sandbox from a snapshot</span></a>
+  <a className="msb-row" href="#handle-snapshot"><span className="msb-rn">handle.snapshot()</span><span className="msb-rg">snapshot a stopped sandbox by name</span></a>
+  <a className="msb-row" href="#handle-snapshotto"><span className="msb-rn">handle.snapshotTo()</span><span className="msb-rg">snapshot to an explicit path</span></a>
+
+  <p className="msb-gl"><span className="msb-dot static"></span>Snapshot · static<span className="msb-ct">9</span></p>
+  <a className="msb-row" href="#snapshotbuilder"><span className="msb-rn">Snapshot.builder()</span><span className="msb-rg">configure a new snapshot</span></a>
+  <a className="msb-row" href="#snapshot-open"><span className="msb-rn">Snapshot.open()</span><span className="msb-rg">open an existing artifact</span></a>
+  <a className="msb-row" href="#snapshot-get"><span className="msb-rn">Snapshot.get()</span><span className="msb-rg">indexed handle by name or digest</span></a>
+  <a className="msb-row" href="#snapshot-list"><span className="msb-rn">Snapshot.list()</span><span className="msb-rg">indexed snapshots</span></a>
+  <a className="msb-row" href="#snapshot-listdir"><span className="msb-rn">Snapshot.listDir()</span><span className="msb-rg">parse a directory, no index</span></a>
+  <a className="msb-row" href="#snapshot-remove"><span className="msb-rn">Snapshot.remove()</span><span className="msb-rg">delete an artifact</span></a>
+  <a className="msb-row" href="#snapshot-reindex"><span className="msb-rn">Snapshot.reindex()</span><span className="msb-rg">rebuild the local index</span></a>
+  <a className="msb-row" href="#snapshot-export"><span className="msb-rn">Snapshot.export()</span><span className="msb-rg">bundle into an archive</span></a>
+  <a className="msb-row" href="#snapshot-import"><span className="msb-rn">Snapshot.import()</span><span className="msb-rg">unpack an archive</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Snapshot · instance<span className="msb-ct">12</span></p>
+  <a className="msb-row" href="#snap-path"><span className="msb-rn">snap.path</span><span className="msb-rg">artifact directory</span></a>
+  <a className="msb-row" href="#snap-digest"><span className="msb-rn">snap.digest</span><span className="msb-rg">canonical content digest</span></a>
+  <a className="msb-row" href="#snap-sizebytes"><span className="msb-rn">snap.sizeBytes</span><span className="msb-rg">apparent upper-layer size</span></a>
+  <a className="msb-row" href="#snap-imageref"><span className="msb-rn">snap.imageRef</span><span className="msb-rg">source image reference</span></a>
+  <a className="msb-row" href="#snap-imagemanifestdigest"><span className="msb-rn">snap.imageManifestDigest</span><span className="msb-rg">pinned image manifest digest</span></a>
+  <a className="msb-row" href="#snap-format"><span className="msb-rn">snap.format</span><span className="msb-rg">upper-layer on-disk format</span></a>
+  <a className="msb-row" href="#snap-fstype"><span className="msb-rn">snap.fstype</span><span className="msb-rg">upper-layer filesystem type</span></a>
+  <a className="msb-row" href="#snap-parent"><span className="msb-rn">snap.parent</span><span className="msb-rg">parent digest, or null</span></a>
+  <a className="msb-row" href="#snap-createdat"><span className="msb-rn">snap.createdAt</span><span className="msb-rg">creation timestamp</span></a>
+  <a className="msb-row" href="#snap-labels"><span className="msb-rn">snap.labels</span><span className="msb-rg">user labels</span></a>
+  <a className="msb-row" href="#snap-sourcesandbox"><span className="msb-rn">snap.sourceSandbox</span><span className="msb-rg">recorded source sandbox</span></a>
+  <a className="msb-row" href="#snap-verify"><span className="msb-rn">snap.verify()</span><span className="msb-rg">recheck content hash</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SnapshotBuilder<span className="msb-ct">6</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#name">.name()</a>
+    <a className="msb-chip" href="#path">.path()</a>
+    <a className="msb-chip" href="#label">.label()</a>
+    <a className="msb-chip" href="#force">.force()</a>
+    <a className="msb-chip" href="#recordintegrity">.recordIntegrity()</a>
+    <a className="msb-chip" href="#create">.create()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SnapshotHandle<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#snapshothandleopen"><span className="msb-rn">snapshotHandle.open()</span><span className="msb-rg">open the underlying artifact</span></a>
+  <a className="msb-row" href="#snapshothandleremove"><span className="msb-rn">snapshotHandle.remove()</span><span className="msb-rg">delete artifact and index row</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#snapshothandle-class">SnapshotHandle</a>
+    <a className="msb-typepill" href="#exportopts-interface">ExportOpts</a>
+    <a className="msb-typepill" href="#snapshotverifyreport-union">SnapshotVerifyReport</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```typescript
+import { Sandbox, Snapshot } from "microsandbox";
+
+// 1. capture: stop the sandbox, then snapshot its disk
+const sb = await Sandbox.get("baseline");
+await sb.stop();
+const snap = await Snapshot.builder("baseline")
+  .name("after-pip-install")     // bare name in the default dir
+  .recordIntegrity()             // hash the upper layer
+  .create();
+
+// 2. boot a fresh sandbox from the snapshot
+const fresh = await Sandbox.builder("worker")
+  .fromSnapshot(snap.path)
+  .create();
+```
+
+## Capture and boot
+
+These entry points live on `SandboxBuilder` and `SandboxHandle`; they are the bridge between sandboxes and snapshot artifacts.
 
 ---
 
-#### fromSnapshot()
+#### <span className="msb-recv">.</span><span className="msb-hn">fromSnapshot()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
-```ts
+```typescript
 fromSnapshot(pathOrName: string): SandboxBuilder
 ```
 
-Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`image()`](/sdk/typescript/sandbox#image) — the snapshot already pins the image.
+Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`.image()`](/sdk/typescript/sandbox#image) — the snapshot already pins the image. Documented in full on the [Sandbox](/sdk/typescript/sandbox#fromsnapshot) page.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| pathOrName | `string` | Bare name (resolved under `~/.microsandbox/snapshots/`) or filesystem path to an artifact directory |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pathOrName</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Bare name (resolved under the default snapshots directory) or filesystem path to an artifact directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/typescript/sandbox#sandboxbuilder">SandboxBuilder</a></div>
+    <div className="msb-param-desc">The same builder, for chaining.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const sb = await Sandbox.builder("worker")
+  .fromSnapshot("after-pip-install")
+  .create();
+```
 
 ---
 
-## SandboxHandle methods
+#### <span className="msb-recv">handle.</span><span className="msb-hn">snapshot()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
----
-
-#### snapshot()
-
-```ts
+```typescript
 snapshot(name: string): Promise<Snapshot>
 ```
 
-Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). The sandbox must be stopped or crashed. For an explicit filesystem destination, see [`snapshotTo()`](#snapshotto).
+Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). Called on a [`SandboxHandle`](/sdk/typescript/sandbox#sandboxhandle). The sandbox must be stopped or crashed; running sandboxes are rejected with a `SnapshotSandboxRunning` error. For an explicit filesystem destination, see [`snapshotTo()`](#handle-snapshotto).
 
-**Errors**
+<p className="msb-label">Parameters</p>
 
-- `SnapshotSandboxRunning` — the sandbox is not stopped
-- `SnapshotAlreadyExists` — destination exists (use the builder with `.force()` to overwrite)
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Bare name; becomes the artifact directory under the default snapshots dir.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshot-instance">Promise&lt;Snapshot&gt;</a></div>
+    <div className="msb-param-desc">The created snapshot artifact.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const h = await Sandbox.get("baseline");
+await h.stop();
+const snap = await h.snapshot("after-pip-install");
+```
 
 ---
 
-#### snapshotTo()
+#### <span className="msb-recv">handle.</span><span className="msb-hn">snapshotTo()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
-```ts
+```typescript
 snapshotTo(path: string): Promise<Snapshot>
 ```
 
-Snapshot this sandbox to an explicit filesystem path. The sandbox must be stopped or crashed.
+Snapshot this sandbox to an explicit filesystem path. Called on a [`SandboxHandle`](/sdk/typescript/sandbox#sandboxhandle). The sandbox must be stopped or crashed.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination artifact directory path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshot-instance">Promise&lt;Snapshot&gt;</a></div>
+    <div className="msb-param-desc">The created snapshot artifact.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const snap = await h.snapshotTo("/data/snapshots/baseline-v2");
+```
 
 ---
 
-## Snapshot (instance)
+## Snapshot static methods
 
 ---
 
-#### path
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">builder()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
-```ts
-readonly path: string
+```typescript
+static builder(sourceSandbox: string): SnapshotBuilder
+```
+
+Begin building a new snapshot of `sourceSandbox` (which must be stopped). The fluent builder is what powers the CLI internally. The bare-name and explicit-path destinations are mutually exclusive — call exactly one of [`.name()`](#name) or [`.path()`](#path). See [`SnapshotBuilder`](#snapshotbuilder) for all setters.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>sourceSandbox</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Name of the stopped sandbox to capture.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotbuilder">SnapshotBuilder</a></div>
+    <div className="msb-param-desc">Builder for configuring the snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const snap = await Snapshot.builder("baseline")
+  .name("after-pip-install")
+  .label("stage", "post-deps")
+  .recordIntegrity()
+  .create();
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">open()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+static open(pathOrName: string): Promise<Snapshot>
+```
+
+Open an existing snapshot artifact. Bare names resolve under the default snapshots directory; anything else is treated as a path. Cheap metadata validation only — does not read the upper file. Use [`verify()`](#snap-verify) for content checks.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pathOrName</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Bare name (resolved under the default snapshots dir) or filesystem path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshot-instance">Promise&lt;Snapshot&gt;</a></div>
+    <div className="msb-param-desc">The opened snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const snap = await Snapshot.open("after-pip-install");
+console.log(snap.digest);
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">get()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+static get(nameOrDigest: string): Promise<SnapshotHandle>
+```
+
+Look up an indexed snapshot by digest, name, or path. Returns a lightweight [`SnapshotHandle`](#snapshothandle-class) backed by the local index row.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nameOrDigest</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Name, digest (<code>sha256:...</code>), or path of an indexed snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandle-class">Promise&lt;SnapshotHandle&gt;</a></div>
+    <div className="msb-param-desc">Index-backed handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const h = await Snapshot.get("after-pip-install");
+console.log(h.digest, h.createdAt);
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+static list(): Promise<SnapshotHandle[]>
+```
+
+List indexed snapshots from the local DB cache.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandle-class">Promise&lt;SnapshotHandle[]&gt;</a></div>
+    <div className="msb-param-desc">All indexed snapshot handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+for (const h of await Snapshot.list()) {
+  console.log(h.name ?? h.digest, h.sizeBytes);
+}
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">listDir()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+static listDir(dir: string): Promise<Snapshot[]>
+```
+
+Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections that were never imported. Skips entries that don't look like snapshot artifacts.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dir</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Directory to scan for artifact subdirectories.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshot-instance">Promise&lt;Snapshot[]&gt;</a></div>
+    <div className="msb-param-desc">Parsed snapshots found in the directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const found = await Snapshot.listDir("/mnt/external/snapshots");
+console.log(`${found.length} artifacts`);
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+static remove(pathOrName: string, opts?: { force?: boolean }): Promise<void>
+```
+
+Remove a snapshot by path, name, or digest. Refuses if the snapshot has indexed children unless `force` is set.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pathOrName</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path, name, or digest of the snapshot to remove.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts.force</code><span className="msb-type">boolean</span></div>
+    <div className="msb-param-desc">Remove even if the snapshot has indexed children. Defaults to <code>false</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await Snapshot.remove("after-pip-install", { force: true });
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">reindex()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+static reindex(dir?: string): Promise<number>
+```
+
+Walk the snapshots directory (default: the configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dir</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Directory to scan. Defaults to the configured snapshots dir.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;number&gt;</span></div>
+    <div className="msb-param-desc">Count of artifacts indexed.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const count = await Snapshot.reindex();
+console.log(`reindexed ${count} snapshots`);
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">export()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+static export(nameOrPath: string, out: string, opts?: ExportOpts): Promise<void>
+```
+
+Bundle a snapshot into a `.tar.zst` archive. When the snapshot has no integrity hash yet, one is computed and embedded in the bundled manifest so the receiver can verify. See [`ExportOpts`](#exportopts-interface) for bundling options.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>nameOrPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Name or path of the snapshot to bundle.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>out</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Output archive path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#exportopts-interface">ExportOpts</a></div>
+    <div className="msb-param-desc">Bundling options. All fields default to <code>false</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await Snapshot.export("after-pip-install", "./baseline.tar.zst", {
+  withImage: true,
+});
+```
+
+---
+
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">import()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+static import(archive: string, dest?: string): Promise<SnapshotHandle>
+```
+
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>archive</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path to the archive to unpack.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dest</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination directory. Defaults to the snapshots directory.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshothandle-class">Promise&lt;SnapshotHandle&gt;</a></div>
+    <div className="msb-param-desc">Handle to the imported snapshot.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const h = await Snapshot.import("./baseline.tar.zst");
+console.log("imported", h.digest);
+```
+
+---
+
+## Snapshot instance members {#snapshot-instance}
+
+A `Snapshot` is a snapshot artifact on disk. The artifact is a directory containing `manifest.json` and the captured `upper.ext4`. The directory is the source of truth; the local DB index is just a rebuildable cache. Returned by [`Snapshot.builder().create()`](#snapshotbuilder), [`Snapshot.open()`](#snapshot-open), [`handle.snapshot()`](#handle-snapshot), and [`handle.snapshotTo()`](#handle-snapshotto).
+
+---
+
+#### <span className="msb-recv">snap.</span><span className="msb-hn">path</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
+
+```typescript
+get path(): string
 ```
 
 Path to the artifact directory.
 
 ---
 
-#### digest
+#### <span className="msb-recv">snap.</span><span className="msb-hn">digest</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
-```ts
-readonly digest: string
+```typescript
+get digest(): string
 ```
 
-Canonical content digest (`sha256:hex`) over the manifest bytes. The snapshot's identity.
+Canonical content digest (`sha256:hex`). The snapshot's identity.
 
 ---
 
-#### sizeBytes
+#### <span className="msb-recv">snap.</span><span className="msb-hn">sizeBytes</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
-```ts
-readonly sizeBytes: bigint
+```typescript
+get sizeBytes(): bigint
 ```
 
-Apparent size of the captured upper layer in bytes (the ext4 virtual size, sparse on disk).
+Apparent size of the captured upper layer in bytes (sparse on disk).
 
 ---
 
-#### imageRef
+#### <span className="msb-recv">snap.</span><span className="msb-hn">imageRef</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
-```ts
-readonly imageRef: string
+```typescript
+get imageRef(): string
 ```
 
 Image reference the snapshot was taken from.
 
 ---
 
-#### imageManifestDigest
+#### <span className="msb-recv">snap.</span><span className="msb-hn">imageManifestDigest</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
-```ts
-readonly imageManifestDigest: string
+```typescript
+get imageManifestDigest(): string
 ```
 
 OCI manifest digest of the pinned image.
 
 ---
 
-#### format
+#### <span className="msb-recv">snap.</span><span className="msb-hn">format</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
-```ts
-readonly format: "raw" | "qcow2"
+```typescript
+get format(): "raw" | "qcow2"
 ```
 
-On-disk format of the upper layer. Always `"raw"` today.
+On-disk format of the upper layer.
 
 ---
 
-#### fstype
+#### <span className="msb-recv">snap.</span><span className="msb-hn">fstype</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
-```ts
-readonly fstype: string
+```typescript
+get fstype(): string
 ```
 
 Filesystem type inside the upper (e.g. `"ext4"`).
 
 ---
 
-#### parent
+#### <span className="msb-recv">snap.</span><span className="msb-hn">parent</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
-```ts
-readonly parent: string | null
+```typescript
+get parent(): string | null
 ```
 
 Manifest digest of the parent snapshot, or `null` for a root.
 
 ---
 
-#### createdAt
+#### <span className="msb-recv">snap.</span><span className="msb-hn">createdAt</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
-```ts
-readonly createdAt: string
+```typescript
+get createdAt(): string
 ```
 
 RFC 3339 timestamp when the snapshot was created.
 
 ---
 
-#### labels
+#### <span className="msb-recv">snap.</span><span className="msb-hn">labels</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
-```ts
-readonly labels: ReadonlyArray<readonly [string, string]>
+```typescript
+get labels(): ReadonlyArray<readonly [string, string]>
 ```
 
-User-supplied labels (sorted by key in canonical form).
+User-supplied labels (sorted by key in canonical form), as `[key, value]` pairs.
 
 ---
 
-#### verify()
+#### <span className="msb-recv">snap.</span><span className="msb-hn">sourceSandbox</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
-```ts
+```typescript
+get sourceSandbox(): string | null
+```
+
+Best-effort source-sandbox name, if recorded. `null` when the manifest has no source recorded.
+
+---
+
+#### <span className="msb-recv">snap.</span><span className="msb-hn">verify()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
 verify(): Promise<SnapshotVerifyReport>
 ```
 
-Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds.
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds. The report's `upper.kind` is `"notRecorded"` when the manifest has no integrity hash recorded.
 
-```ts
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshotverifyreport-union">Promise&lt;SnapshotVerifyReport&gt;</a></div>
+    <div className="msb-param-desc">Verification result.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
 const report = await snap.verify();
 if (report.upper.kind === "verified") {
   console.log(`hash matches: ${report.upper.digest}`);
@@ -186,162 +682,217 @@ if (report.upper.kind === "verified") {
 
 ---
 
-## Snapshot.builder()
+## SnapshotBuilder
 
-```ts
-static builder(sourceSandbox: string): SnapshotBuilder
+Fluent builder for a snapshot, returned by [`Snapshot.builder(name)`](#snapshotbuilder). Every setter mutates in place and returns `this`, so calls chain. Pick exactly one destination: [`.name()`](#name) or [`.path()`](#path).
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">name()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+name(name: string): this
 ```
 
-Start configuring a new snapshot. The fluent builder is what powers the CLI internally.
+Set a bare name; the artifact lands under the default snapshots directory. Mutually exclusive with [`.path()`](#path).
 
-```ts
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Bare snapshot name.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">path()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+path(path: string): this
+```
+
+Set an explicit filesystem path for the artifact. Mutually exclusive with [`.name()`](#name).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination artifact directory path.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">label()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+label(key: string, value: string): this
+```
+
+Add a `key=value` label to the snapshot manifest. May be called repeatedly.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Label key.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Label value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">force()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+force(): this
+```
+
+Overwrite an existing artifact at the destination instead of failing on conflict.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">recordIntegrity()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+recordIntegrity(): this
+```
+
+Compute and record a content-integrity hash of the upper layer at creation time, so the snapshot can be verified later or across a trust boundary.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+create(): Promise<Snapshot>
+```
+
+Capture the configured snapshot and return the resulting artifact.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#snapshot-instance">Promise&lt;Snapshot&gt;</a></div>
+    <div className="msb-param-desc">The created snapshot artifact.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
 const snap = await Snapshot.builder("baseline")
-  .name("after-pip-install")        // bare name in default dir
-  .label("stage", "post-deps")
-  .force()                           // overwrite if it exists
-  .recordIntegrity()                 // hash the upper layer
+  .path("/data/snapshots/baseline-v2")
+  .force()
+  .recordIntegrity()
   .create();
-```
-
-**Builder methods**
-
-| Method | Description |
-|--------|-------------|
-| `.name(string)` | Bare name under the default snapshots directory |
-| `.path(string)` | Explicit filesystem path |
-| `.label(key, value)` | Add a `key=value` label (may be repeated) |
-| `.force()` | Overwrite an existing artifact at the destination |
-| `.recordIntegrity()` | Compute and record a content-integrity hash at creation |
-| `.build()` | Snapshot the accumulated configuration |
-| `.create()` | Build and execute |
-
----
-
-## Snapshot (static)
-
----
-
-#### Snapshot.open()
-
-```ts
-static open(pathOrName: string): Promise<Snapshot>
-```
-
-Open an existing artifact by bare name (resolved under the default snapshots directory) or path. Cheap metadata validation only; does **not** read the upper file. Use [`verify()`](#verify) for content checks.
-
----
-
-#### Snapshot.get()
-
-```ts
-static get(nameOrDigest: string): Promise<SnapshotHandle>
-```
-
-Look up a handle in the local index by name, digest, or path.
-
----
-
-#### Snapshot.list()
-
-```ts
-static list(): Promise<SnapshotHandle[]>
-```
-
-List indexed snapshots from the local DB cache.
-
----
-
-#### Snapshot.listDir()
-
-```ts
-static listDir(dir: string): Promise<Snapshot[]>
-```
-
-Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
-
----
-
-#### Snapshot.remove()
-
-```ts
-static remove(pathOrName: string, opts?: { force?: boolean }): Promise<void>
-```
-
-Remove a snapshot artifact and its index row. Refuses if the snapshot has indexed children unless `force: true`.
-
----
-
-#### Snapshot.reindex()
-
-```ts
-static reindex(dir?: string): Promise<number>
-```
-
-Walk `dir` (default: configured snapshots dir) and rebuild the local index. Returns the number of artifacts indexed.
-
----
-
-#### Snapshot.export()
-
-```ts
-static export(nameOrPath: string, out: string, opts?: ExportOpts): Promise<void>
-```
-
-Bundle a snapshot into a `.tar.zst` archive. The existing snapshot manifest is archived as-is; create the snapshot with recorded integrity when the archive will cross a trust boundary.
-
-**ExportOpts**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `withParents` | `boolean` | Walk the parent chain and include each ancestor |
-| `withImage` | `boolean` | Bundle the OCI image cache for offline transport |
-| `plainTar` | `boolean` | Skip zstd compression and write a plain `.tar` |
-
----
-
-#### Snapshot.import()
-
-```ts
-static import(archive: string, dest?: string): Promise<SnapshotHandle>
-```
-
-Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity when present. Compression is detected from magic bytes.
-
----
-
-## SnapshotHandle
-
-Lightweight handle backed by an index row. Returned by [`Snapshot.list()`](#snapshotlist) and [`Snapshot.get()`](#snapshotget).
-
-```ts
-const h = await Snapshot.get("after-pip-install");
-
-h.digest;          // string ("sha256:...")
-h.name;            // string | null
-h.parentDigest;    // string | null
-h.imageRef;        // string
-h.format;          // "raw" | "qcow2"
-h.sizeBytes;       // bigint | null
-h.createdAt;       // Date
-h.path;            // string
-
-const snap = await h.open();              // metadata-validated
-await h.remove({ force: false });          // refuse if has children
 ```
 
 ---
 
 ## Types
 
-```ts
-export interface ExportOpts {
-  withParents?: boolean;
-  withImage?: boolean;
-  plainTar?: boolean;
-}
+---
 
-export type SnapshotVerifyReport =
-  | { digest: string; path: string; upper: { kind: "notRecorded" } }
-  | { digest: string; path: string;
-      upper: { kind: "verified"; algorithm: string; digest: string } };
+### SnapshotHandle <span className="msb-tag is-type">class</span>
+
+Lightweight handle backed by an index row. Values are snapshotted from the index at construction time — call [`Snapshot.get()`](#snapshot-get) again for a fresh reading if needed. Handles from [`Snapshot.list()`](#snapshot-list) are read-only and throw on [`open()`](#snapshothandleopen) / [`remove()`](#snapshothandleremove); fetch a live handle via [`Snapshot.get()`](#snapshot-get) for those lifecycle methods.
+
+<p className="msb-backref">Returned by <a href="#snapshot-get">Snapshot.get()</a>, <a href="#snapshot-list">Snapshot.list()</a>, <a href="#snapshot-import">Snapshot.import()</a></p>
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `digest` | `string` | Manifest digest (`sha256:hex`), the canonical identity. |
+| `name` | `string \| null` | Convenience name; `null` for digest-only entries. |
+| `parentDigest` | `string \| null` | Parent snapshot's manifest digest, or `null` for a root. |
+| `imageRef` | `string` | Image reference the snapshot was taken from. |
+| `format` | `"raw" \| "qcow2"` | On-disk format of the upper layer. |
+| `sizeBytes` | `bigint \| null` | Apparent size of the upper file at index time. |
+| `createdAt` | `Date` | Snapshot creation time (from manifest). |
+| `path` | `string` | Local artifact directory path. |
+| `open()` | `Promise<`[`Snapshot`](#snapshot-instance)`>` | Open and metadata-validate the underlying artifact. |
+| `remove(opts?)` | `Promise<void>` | Remove the artifact and its index row; refuses on children unless `force`. |
+
+<p className="msb-label" id="snapshothandleopen">snapshotHandle.open()</p>
+
+```typescript
+open(): Promise<Snapshot>
 ```
+
+Open and metadata-validate the underlying artifact. Throws if this handle is read-only (came from [`Snapshot.list()`](#snapshot-list)) — fetch a live handle via [`Snapshot.get()`](#snapshot-get) first.
+
+<p className="msb-label" id="snapshothandleremove">snapshotHandle.remove()</p>
+
+```typescript
+remove(opts?: { force?: boolean }): Promise<void>
+```
+
+Remove the artifact and its index row. Refuses if the snapshot has indexed children unless `force` is set. Throws if this handle is read-only.
+
+```typescript
+const h = await Snapshot.get("after-pip-install");
+const snap = await h.open();          // metadata-validated
+await h.remove({ force: false });     // refuse if it has children
+```
+
+---
+
+### ExportOpts <span className="msb-tag is-type">interface</span>
+
+Bundle options for [`Snapshot.export()`](#snapshot-export). All fields default to `false`.
+
+<p className="msb-backref">Used by <a href="#snapshot-export">Snapshot.export()</a></p>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `withParents` | `boolean` | Walk the parent chain and include each ancestor (no-op in v1). |
+| `withImage` | `boolean` | Include the OCI image cache so the archive boots offline. |
+| `plainTar` | `boolean` | Skip zstd compression and write a plain `.tar`. |
+
+---
+
+### SnapshotVerifyReport <span className="msb-tag is-type">union</span>
+
+Result of [`snap.verify()`](#snap-verify). The `upper` discriminant is `"notRecorded"` when no integrity hash was stored at create time, or `"verified"` when the recorded hash matched the recomputed one.
+
+<p className="msb-backref">Returned by <a href="#snap-verify">snap.verify()</a></p>
+
+```typescript
+type SnapshotVerifyReport =
+  | {
+      readonly digest: string;
+      readonly path: string;
+      readonly upper: { readonly kind: "notRecorded" };
+    }
+  | {
+      readonly digest: string;
+      readonly path: string;
+      readonly upper: {
+        readonly kind: "verified";
+        readonly algorithm: string;
+        readonly digest: string;
+      };
+    };
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `digest` | `string` | Snapshot's manifest digest. |
+| `path` | `string` | Artifact directory path. |
+| `upper.kind` | `"notRecorded" \| "verified"` | Whether an integrity hash was recorded and checked. |
+| `upper.algorithm` | `string` | Hash algorithm (`"verified"` only). |
+| `upper.digest` | `string` | Recomputed upper-layer digest (`"verified"` only). |

--- a/docs/sdk/typescript/ssh.mdx
+++ b/docs/sdk/typescript/ssh.mdx
@@ -3,138 +3,280 @@ title: SSH
 description: TypeScript SDK - SSH API reference
 ---
 
-See [SSH](/sandboxes/ssh) for usage flows.
+Reach a running sandbox over SSH: open an in-process client, run commands or attach an interactive shell, transfer files over SFTP, or expose the sandbox as a server endpoint. See [SSH](/sandboxes/ssh) for usage flows.
 
-## Sandbox
+<div className="msb-glance">
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Sandbox · SandboxSshOps<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#sb-ssh"><span className="msb-rn">sb.ssh()</span><span className="msb-rg">SSH namespace for the sandbox</span></a>
+  <a className="msb-row" href="#ssh-openclient"><span className="msb-rn">ssh.openClient()</span><span className="msb-rg">open an in-process SSH client</span></a>
+  <a className="msb-row" href="#ssh-prepareserver"><span className="msb-rn">ssh.prepareServer()</span><span className="msb-rg">prepare a server endpoint</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SshClient<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#client-exec"><span className="msb-rn">client.exec()</span><span className="msb-rg">run a command, collect output</span></a>
+  <a className="msb-row" href="#client-attach"><span className="msb-rn">client.attach()</span><span className="msb-rg">attach an interactive shell</span></a>
+  <a className="msb-row" href="#client-sftp"><span className="msb-rn">client.sftp()</span><span className="msb-rg">open an SFTP session</span></a>
+  <a className="msb-row" href="#client-close"><span className="msb-rn">client.close()</span><span className="msb-rg">close the client</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SftpClient<span className="msb-ct">10</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#sftp-read">.read()</a>
+    <a className="msb-chip" href="#sftp-write">.write()</a>
+    <a className="msb-chip" href="#sftp-mkdir">.mkdir()</a>
+    <a className="msb-chip" href="#sftp-removefile">.removeFile()</a>
+    <a className="msb-chip" href="#sftp-removedir">.removeDir()</a>
+    <a className="msb-chip" href="#sftp-rename">.rename()</a>
+    <a className="msb-chip" href="#sftp-realpath">.realPath()</a>
+    <a className="msb-chip" href="#sftp-readlink">.readLink()</a>
+    <a className="msb-chip" href="#sftp-symlink">.symlink()</a>
+    <a className="msb-chip" href="#sftp-close">.close()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>SshServer<span className="msb-ct">2</span></p>
+  <a className="msb-row" href="#server-serveconnection"><span className="msb-rn">server.serveConnection()</span><span className="msb-rg">serve one transport over stdio</span></a>
+  <a className="msb-row" href="#server-close"><span className="msb-rn">server.close()</span><span className="msb-rg">release the endpoint</span></a>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#sshoutput">SshOutput</a>
+    <a className="msb-typepill" href="#sshclientoptions">SshClientOptions</a>
+    <a className="msb-typepill" href="#sshexecoptions">SshExecOptions</a>
+    <a className="msb-typepill" href="#sshattachoptions">SshAttachOptions</a>
+    <a className="msb-typepill" href="#sshserveroptions">SshServerOptions</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+await using sandbox = await Sandbox.builder("api")   // 1. boot the sandbox
+  .image("python")
+  .create();
+
+const client = await sandbox.ssh().openClient();     // 2. open an SSH client
+const out = await client.exec("python -V");          // 3. run a command
+console.log(out.stdout.toString());
+
+await client.close();                                // 4. close the client
+```
+
+## SandboxSshOps
+
+The SSH namespace for a sandbox, returned by [`sb.ssh()`](#sb-ssh). It opens in-process SSH clients and prepares server endpoints against the running sandbox.
 
 ---
 
-#### ssh()
+#### <span className="msb-recv">sb.</span><span className="msb-hn">ssh()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```typescript
 ssh(): SandboxSshOps
 ```
 
-Return the SSH namespace for this sandbox.
+Return the SSH namespace for this sandbox. The returned object exposes [`openClient()`](#ssh-openclient) and [`prepareServer()`](#ssh-prepareserver).
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`SandboxSshOps`](#sandboxssh) | SSH client and server helpers |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxsshops">SandboxSshOps</a></div>
+    <div className="msb-param-desc">SSH client and server helpers.</div>
+  </div>
+</div>
 
-## SandboxSshOps
+<p className="msb-label">Example</p>
+
+```typescript
+const ssh = sandbox.ssh();
+const client = await ssh.openClient();
+```
 
 ---
 
-#### connect()
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">openClient()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
-connect(opts?: SshClientOptions): Promise<SshClient>
+openClient(opts?: SshClientOptions): Promise<SshClient>
 ```
 
-Connect a native in-process SSH client to the sandbox.
+Open a native in-process SSH client connected to the sandbox.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| opts? | [`SshClientOptions`](#sshclientoptions) | Client options |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshclientoptions">SshClientOptions</a></div>
+    <div className="msb-param-desc">Optional client options: login user, terminal name, SFTP toggle.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Promise<`[`SshClient`](#sshclient)`>` | Native SSH client session |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshclient">Promise&lt;SshClient&gt;</a></div>
+    <div className="msb-param-desc">Connected SSH client session.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const client = await sandbox.ssh().openClient({ user: "root" });
+```
 
 ---
 
-#### server()
+#### <span className="msb-recv">ssh.</span><span className="msb-hn">prepareServer()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
-server(opts?: SshServerOptions): Promise<SshServer>
+prepareServer(opts?: SshServerOptions): Promise<SshServer>
 ```
 
-Prepare a reusable SSH server endpoint.
+Prepare a reusable SSH server endpoint backed by the sandbox.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| opts? | [`SshServerOptions`](#sshserveroptions) | Server options |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshserveroptions">SshServerOptions</a></div>
+    <div className="msb-param-desc">Optional server options: host key path, authorized-keys path, guest user, SFTP toggle.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Promise<`[`SshServer`](#sshserver)`>` | Server endpoint |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshserver">Promise&lt;SshServer&gt;</a></div>
+    <div className="msb-param-desc">Prepared server endpoint.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const server = await sandbox.ssh().prepareServer({ user: "root" });
+await server.serveConnection();
+```
 
 ## SshClient
 
+A native in-process SSH client session, returned by [`openClient()`](#ssh-openclient). Run commands, attach an interactive shell, or open an SFTP session over the same connection. Close it with [`close()`](#client-close) when done.
+
 ---
 
-#### exec()
+#### <span className="msb-recv">client.</span><span className="msb-hn">exec()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 exec(command: string, opts?: SshExecOptions): Promise<SshOutput>
 ```
 
-Run an SSH exec request and collect stdout, stderr, and exit status.
+Run an SSH exec request and collect stdout, stderr, and the exit status.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| command | `string` | Command string sent through SSH |
-| opts? | [`SshExecOptions`](#sshexecoptions) | Exec options |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>command</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Command string sent through SSH.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshexecoptions">SshExecOptions</a></div>
+    <div className="msb-param-desc">Optional exec options: request a PTY for the channel.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Promise<`[`SshOutput`](#sshoutput)`>` | Captured output and status |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sshoutput">Promise&lt;SshOutput&gt;</a></div>
+    <div className="msb-param-desc">Captured output and exit status.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const out = await client.exec("uname -a");
+console.log(out.status, out.stdout.toString());
+```
 
 ---
 
-#### attach()
+#### <span className="msb-recv">client.</span><span className="msb-hn">attach()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 attach(opts?: SshAttachOptions): Promise<number>
 ```
 
-Attach the local terminal to an interactive SSH shell.
+Attach the local terminal to an interactive SSH shell. Resolves with the shell's exit code once the session ends.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| opts? | [`SshAttachOptions`](#sshattachoptions) | Attach options |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshattachoptions">SshAttachOptions</a></div>
+    <div className="msb-param-desc">Optional attach options: terminal name and detach key sequence.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Promise<number>` | Exit code |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;number&gt;</span></div>
+    <div className="msb-param-desc">Exit code of the interactive shell.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const code = await client.attach({ detachKeys: "ctrl-p,ctrl-q" });
+console.log(`shell exited with ${code}`);
+```
 
 ---
 
-#### sftp()
+#### <span className="msb-recv">client.</span><span className="msb-hn">sftp()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 sftp(): Promise<SftpClient>
 ```
 
-Open an SFTP session over this SSH connection.
+Open an SFTP session over this SSH connection for file transfer and remote filesystem operations.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Promise<`[`SftpClient`](#sftpclient)`>` | SFTP client session |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sftpclient">Promise&lt;SftpClient&gt;</a></div>
+    <div className="msb-param-desc">SFTP client session.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const sftp = await client.sftp();
+await sftp.write("/tmp/data.bin", Buffer.from([1, 2, 3]));
+await sftp.close();
+```
 
 ---
 
-#### close()
+#### <span className="msb-recv">client.</span><span className="msb-hn">close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 close(): Promise<void>
@@ -142,36 +284,336 @@ close(): Promise<void>
 
 Close the native SSH client session.
 
+<p className="msb-label">Example</p>
+
+```typescript
+await client.close();
+```
+
 ## SftpClient
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| read(path) | `Promise<Buffer>` | Read a file into memory |
-| write(path, data) | `Promise<void>` | Create or truncate a file |
-| mkdir(path) | `Promise<void>` | Create a directory |
-| removeFile(path) | `Promise<void>` | Remove a file |
-| removeDir(path) | `Promise<void>` | Remove an empty directory |
-| rename(oldPath, newPath) | `Promise<void>` | Rename a file or directory |
-| realPath(path) | `Promise<string>` | Resolve a canonical path |
-| readLink(path) | `Promise<string>` | Read a symlink target |
-| symlink(target, linkPath) | `Promise<void>` | Create a symlink |
-| close() | `Promise<void>` | Close the SFTP session |
-
-## SshServer
+An SFTP session over an [`SshClient`](#sshclient) connection, returned by [`sftp()`](#client-sftp). Read and write files, manage directories, and resolve symlinks on the remote sandbox. Close it with [`close()`](#sftp-close) when done.
 
 ---
 
-#### serveConnection()
+#### <span className="msb-recv">sftp.</span><span className="msb-hn">read()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+read(path: string): Promise<Buffer>
+```
+
+Read a remote file into memory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Remote file path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;Buffer&gt;</span></div>
+    <div className="msb-param-desc">File contents.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const data = await sftp.read("/etc/hostname");
+console.log(data.toString().trim());
+```
+
+---
+
+#### <span className="msb-recv">sftp.</span><span className="msb-hn">write()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+write(path: string, data: Buffer): Promise<void>
+```
+
+Create or truncate a remote file and write the given bytes.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Remote file path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>data</code><span className="msb-type">Buffer</span></div>
+    <div className="msb-param-desc">Bytes to write.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await sftp.write("/tmp/config.json", Buffer.from(JSON.stringify({ ok: true })));
+```
+
+---
+
+#### <span className="msb-recv">sftp.</span><span className="msb-hn">mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+mkdir(path: string): Promise<void>
+```
+
+Create a remote directory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Remote directory path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await sftp.mkdir("/tmp/uploads");
+```
+
+---
+
+#### <span className="msb-recv">sftp.</span><span className="msb-hn">removeFile()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+removeFile(path: string): Promise<void>
+```
+
+Remove a remote file.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Remote file path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await sftp.removeFile("/tmp/config.json");
+```
+
+---
+
+#### <span className="msb-recv">sftp.</span><span className="msb-hn">removeDir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+removeDir(path: string): Promise<void>
+```
+
+Remove an empty remote directory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Remote directory path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await sftp.removeDir("/tmp/uploads");
+```
+
+---
+
+#### <span className="msb-recv">sftp.</span><span className="msb-hn">rename()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+rename(oldPath: string, newPath: string): Promise<void>
+```
+
+Rename or move a remote file or directory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>oldPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Existing remote path.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>newPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">New remote path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await sftp.rename("/tmp/data.bin", "/tmp/data.old");
+```
+
+---
+
+#### <span className="msb-recv">sftp.</span><span className="msb-hn">realPath()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+realPath(path: string): Promise<string>
+```
+
+Resolve a remote path to its canonical, absolute form.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Remote path to resolve.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;string&gt;</span></div>
+    <div className="msb-param-desc">Canonical absolute path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const abs = await sftp.realPath("./logs");
+console.log(abs);
+```
+
+---
+
+#### <span className="msb-recv">sftp.</span><span className="msb-hn">readLink()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+readLink(path: string): Promise<string>
+```
+
+Read the target of a remote symlink.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Remote symlink path.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;string&gt;</span></div>
+    <div className="msb-param-desc">The symlink target.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const target = await sftp.readLink("/etc/localtime");
+console.log(target);
+```
+
+---
+
+#### <span className="msb-recv">sftp.</span><span className="msb-hn">symlink()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+symlink(target: string, linkPath: string): Promise<void>
+```
+
+Create a remote symlink at `linkPath` pointing to `target`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>target</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">What the symlink points to.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>linkPath</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path of the symlink itself.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await sftp.symlink("/tmp/data.bin", "/tmp/latest");
+```
+
+---
+
+#### <span className="msb-recv">sftp.</span><span className="msb-hn">close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+close(): Promise<void>
+```
+
+Close the SFTP session.
+
+<p className="msb-label">Example</p>
+
+```typescript
+await sftp.close();
+```
+
+## SshServer
+
+A prepared SSH server endpoint, returned by [`prepareServer()`](#ssh-prepareserver). Serves SSH transports over standard streams and is released with [`close()`](#server-close).
+
+---
+
+#### <span className="msb-recv">server.</span><span className="msb-hn">serveConnection()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 serveConnection(): Promise<void>
 ```
 
-Serve one SSH transport over stdin/stdout.
+Serve one SSH transport over stdin/stdout. Resolves when the connection ends.
+
+<p className="msb-label">Example</p>
+
+```typescript
+const server = await sandbox.ssh().prepareServer();
+await server.serveConnection();
+await server.close();
+```
 
 ---
 
-#### close()
+#### <span className="msb-recv">server.</span><span className="msb-hn">close()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 close(): Promise<void>
@@ -179,9 +621,23 @@ close(): Promise<void>
 
 Release the prepared server endpoint.
 
+<p className="msb-label">Example</p>
+
+```typescript
+await server.close();
+```
+
 ## Types
 
+---
+
 ### SshOutput
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Returned by <a href="#client-exec">exec()</a></p>
+
+Captured result of an SSH exec request.
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -189,28 +645,60 @@ Release the prepared server endpoint.
 | stdout | `Buffer` | Captured stdout bytes |
 | stderr | `Buffer` | Captured stderr bytes |
 
+---
+
 ### SshClientOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#ssh-openclient">openClient()</a></p>
+
+Options for opening an SSH client. All fields are optional.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| user | `string` | SSH login user. Defaults to `root` |
+| user | `string` | SSH login user |
 | term | `string` | Terminal name for interactive sessions |
 | sftp | `boolean` | Enable or disable SFTP on the internal server |
 
+---
+
 ### SshExecOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#client-exec">exec()</a></p>
+
+Options for an SSH exec request. All fields are optional.
 
 | Property | Type | Description |
 |----------|------|-------------|
 | tty | `boolean` | Request a PTY for the exec channel |
 
+---
+
 ### SshAttachOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#client-attach">attach()</a></p>
+
+Options for attaching an interactive SSH shell. All fields are optional.
 
 | Property | Type | Description |
 |----------|------|-------------|
 | term | `string` | Terminal name for the shell |
 | detachKeys | `string` | Detach key sequence |
 
+---
+
 ### SshServerOptions
+
+<div className="msb-tags"><span className="msb-tag is-type">interface</span></div>
+
+<p className="msb-backref">Used by <a href="#ssh-prepareserver">prepareServer()</a></p>
+
+Options for preparing an SSH server endpoint. All fields are optional.
 
 | Property | Type | Description |
 |----------|------|-------------|

--- a/docs/sdk/typescript/volumes.mdx
+++ b/docs/sdk/typescript/volumes.mdx
@@ -3,108 +3,197 @@ title: Volumes
 description: TypeScript SDK - Volume API reference
 ---
 
-See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+Create and manage named volumes: persistent storage that lives independently of any sandbox. Build a volume, look one up, read and write its files from the host, then delete it. See [Volumes](/sandboxes/volumes) for usage examples and patterns.
 
-## Volume
+<div className="msb-glance">
 
-Named volumes are managed by microsandbox and stored by default under `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+  <p className="msb-gl"><span className="msb-dot static"></span>Static · Volume<span className="msb-ct">4</span></p>
+  <a className="msb-row" href="#volume-builder"><span className="msb-rn">Volume.builder()</span><span className="msb-rg">configure a new volume</span></a>
+  <a className="msb-row" href="#volume-get"><span className="msb-rn">Volume.get()</span><span className="msb-rg">handle to an existing one</span></a>
+  <a className="msb-row" href="#volume-list"><span className="msb-rn">Volume.list()</span><span className="msb-rg">all volumes</span></a>
+  <a className="msb-row" href="#volume-remove"><span className="msb-rn">Volume.remove()</span><span className="msb-rg">delete a volume</span></a>
+
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · Volume<span className="msb-ct">3</span></p>
+  <a className="msb-row" href="#volume-name"><span className="msb-rn">volume.name</span><span className="msb-rg">volume name</span></a>
+  <a className="msb-row" href="#volume-path"><span className="msb-rn">volume.path</span><span className="msb-rg">host directory path</span></a>
+  <a className="msb-row" href="#volume-fs"><span className="msb-rn">volume.fs()</span><span className="msb-rg">host-side filesystem</span></a>
+
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · VolumeBuilder<span className="msb-ct">7</span></p>
+  <div className="msb-chiprow">
+    <a className="msb-chip" href="#directory">.directory()</a>
+    <a className="msb-chip" href="#disk">.disk()</a>
+    <a className="msb-chip" href="#size">.size()</a>
+    <a className="msb-chip" href="#quota">.quota()</a>
+    <a className="msb-chip" href="#label">.label()</a>
+    <a className="msb-chip" href="#build">.build()</a>
+    <a className="msb-chip" href="#create">.create()</a>
+  </div>
+
+  <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
+  <div className="msb-chiprow">
+    <a className="msb-typepill" href="#volumehandle">VolumeHandle</a>
+    <a className="msb-typepill" href="#volumefs">VolumeFs</a>
+    <a className="msb-typepill" href="#volumefsreadstream">VolumeFsReadStream</a>
+    <a className="msb-typepill" href="#volumefswritesink">VolumeFsWriteSink</a>
+    <a className="msb-typepill" href="/sdk/typescript/filesystem#fsentry">FsEntry</a>
+    <a className="msb-typepill" href="/sdk/typescript/filesystem#fsmetadata">FsMetadata</a>
+  </div>
+
+</div>
+
+<p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```typescript
 import { Volume } from "microsandbox";
 
-const data = await Volume.builder("my-data")
+const data = await Volume.builder("my-data")   // 1. configure
   .label("env", "prod")
-  .create();
+  .create();                                    // 2. create on disk
 
-const dockerData = await Volume.builder("docker-data")
-  .disk()
-  .size(20 * 1024)
-  .create();
+const vfs = data.fs();                          // 3. host-side I/O
+await vfs.write("seed.txt", "hello");
+console.log(await vfs.list(""));
+
+await Volume.remove("my-data");                 // 4. delete
 ```
 
 ## Static methods
 
 ---
 
-#### Volume.builder()
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">builder()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```typescript
 static builder(name: string): VolumeBuilder
 ```
 
-Begin building a named volume. Directory-backed volumes are the default. Call `.disk().size(...)` to create a disk-backed volume.
+Begin building a named volume. Directory-backed volumes are the default. Call `.disk().size(...)` for a disk-backed volume. See [`VolumeBuilder`](#volumebuilder) for all options.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `string` | Volume name |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| [`VolumeBuilder`](#volumebuilder) | Fluent builder |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volume-builder">VolumeBuilder</a></div>
+    <div className="msb-param-desc">Fluent builder for configuring the volume.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const data = await Volume.builder("my-data")
+  .label("env", "prod")
+  .create();
+```
 
 ---
 
-#### Volume.get()
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">get()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 static get(name: string): Promise<VolumeHandle>
 ```
 
-Get a handle to an existing named volume.
+Get a live handle to an existing named volume. A live handle supports `.fs()` and `.remove()`, unlike the read-only handles returned by [`list()`](#volume-list).
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `string` | Volume name |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Promise<`[`VolumeHandle`](#volumehandle)`>` | Volume handle |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumehandle">Promise&lt;VolumeHandle&gt;</a></div>
+    <div className="msb-param-desc">Live handle with metadata, filesystem access, and removal.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const handle = await Volume.get("my-data");
+console.log(handle.usedBytes);
+```
 
 ---
 
-#### Volume.list()
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 static list(): Promise<VolumeHandle[]>
 ```
 
-List all named volumes. Handles returned from `list()` are read-only — call `Volume.get(name)` to get a live handle for `.remove()` / `.fs()`.
+List all named volumes. Handles returned here are **read-only**: calling `.fs()` or `.remove()` on them throws. Call [`Volume.get(name)`](#volume-get) to upgrade to a live handle.
 
-**Returns**
+<p className="msb-label">Returns</p>
 
-| Type | Description |
-|------|-------------|
-| `Promise<`[`VolumeHandle`](#volumehandle)`[]>` | All volumes |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumehandle">Promise&lt;VolumeHandle[]&gt;</a></div>
+    <div className="msb-param-desc">All volumes, as read-only handles.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+for (const v of await Volume.list()) {
+  console.log(`${v.name} — ${v.kind} — ${v.usedBytes} bytes`);
+}
+```
 
 ---
 
-#### Volume.remove()
+#### <span className="msb-recv">Volume.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
 static remove(name: string): Promise<void>
 ```
 
-Delete a named volume and its contents. Fails if the volume is currently mounted.
+Delete a named volume and its contents. Fails if the volume is currently mounted by a sandbox.
 
-**Parameters**
+<p className="msb-label">Parameters</p>
 
-| Name | Type | Description |
-|------|------|-------------|
-| name | `string` | Volume name |
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await Volume.remove("my-data");
+```
 
 ---
 
-## Instance properties
+## Instance methods
 
-#### name
+---
+
+#### <span className="msb-recv">volume.</span><span className="msb-hn">name</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
 ```typescript
 get name(): string
@@ -112,156 +201,714 @@ get name(): string
 
 The volume's name.
 
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Volume name.</div>
+  </div>
+</div>
+
 ---
 
-#### path
+#### <span className="msb-recv">volume.</span><span className="msb-hn">path</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
 
 ```typescript
 get path(): string
 ```
 
-Absolute host path to the volume's directory.
+Absolute host path to the volume's directory. By default volumes live under `~/.microsandbox/volumes/<name>/`.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Absolute host directory path.</div>
+  </div>
+</div>
 
 ---
 
-#### fs()
+#### <span className="msb-recv">volume.</span><span className="msb-hn">fs()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
 ```typescript
 fs(): VolumeFs
 ```
 
-Get a host-side filesystem handle for this volume — no sandbox required.
+Get a host-side filesystem handle for this volume's directory. Reads and writes happen directly on the host, with no sandbox running. See [`VolumeFs`](#volumefs-methods) for the full API.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumefs">VolumeFs</a></div>
+    <div className="msb-param-desc">Host-side filesystem handle.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
 
 ```typescript
 const vfs = data.fs();
 await vfs.write("seed.txt", "hello");
-console.log(await vfs.list(""));
+console.log(await vfs.readToString("seed.txt"));
 ```
 
 ---
 
-## Mounts
+## VolumeBuilder
 
-Volume mounts attach a host directory, named volume, tmpfs, or disk image to a guest path. Configure them via `SandboxBuilder.volume(guestPath, m => ...)`:
+Fluent builder for a named volume. Obtained via [`Volume.builder(name)`](#volume-builder). Directory-backed volumes are the default; call [`disk()`](#disk) plus [`size()`](#size) for a disk-backed volume. Every setter returns the builder, so calls chain.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">directory()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-await using sb = await Sandbox.builder("worker")
-  .image("alpine")
-  .volume("/host",    (m) => m.bind("/var/data"))
-  .volume("/data",    (m) => m.named("my-data"))
-  .volume("/scratch", (m) => m.tmpfs().size(128))
-  .volume("/img",     (m) => m.disk("./data.qcow2").fstype("ext4").readonly())
+directory(): this
+```
+
+Create a directory-backed volume. This is the default, so calling it is only needed for clarity.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">disk()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+disk(): this
+```
+
+Create a raw ext4 disk-backed volume. Pair with [`size()`](#size) to set the capacity.
+
+<p className="msb-label">Example</p>
+
+```typescript
+const dockerData = await Volume.builder("docker-data")
+  .disk()
+  .size(20 * 1024)
   .create();
 ```
 
-### MountBuilder
+---
 
-Used inside `SandboxBuilder.volume(guestPath, m => ...)`. Pick exactly one mount kind, then chain modifiers.
-
-| Method | Description |
-|--------|-------------|
-| `bind(host)` | Mount a host directory into the guest. |
-| `named(name)` | Mount an existing named volume created via [`Volume.builder`](#volumebuilder). |
-| `namedWith(name, mode?, kind?, sizeMib?, quotaMib?)` | Mount a named volume with explicit behavior. `mode` is `"existing"`, `"create"`, or `"ensure-exists"`; `kind` is `"dir"` or `"disk"`. |
-| `tmpfs()` | Mount an in-memory filesystem. |
-| `disk(host)` | Mount a host disk image as a virtio-blk device. |
-| `format(fmt)` | Disk image format (`'qcow2' \| 'raw' \| 'vmdk'`). Defaults to the file extension. Disk only. |
-| `fstype(fs)` | Inner filesystem type (e.g. `"ext4"`). Disk only; omit to autodetect. |
-| `readonly()` | Mount read-only; virtiofs-backed mounts also reject writes in the host filesystem server. |
-| `noexec()` | Prevent direct execution from the mount. Interpreters can still read scripts from it. |
-| `nosuid()` | Ignore setuid and setgid privilege elevation from files on the mount. |
-| `nodev()` | Ignore device files on the mount. |
-| `size(mib)` | Cap in MiB. Tmpfs only. |
-| `build()` | Internal — produce a `VolumeMount`. |
-
-`named(name)` is existing-only. Use `namedWith` when sandbox creation should create or ensure the volume exists:
+#### <span className="msb-recv">.</span><span className="msb-hn">size()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-await using sb = await Sandbox.builder("worker")
-  .image("python")
-  .volume("/cache", (m) => m.namedWith("pip-cache", "ensure-exists"))
-  .volume("/var/lib/docker", (m) =>
-    m.namedWith("docker-data", "ensure-exists", "disk", 20 * 1024)
-  )
-  .create();
+size(mib: number): this
 ```
 
-`"create"` fails when the named volume already exists. `"ensure-exists"` creates the volume if it is missing and reuses a compatible existing volume. The ensure-exists mode errors when the existing volume has a different kind, quota, or capacity than the requested configuration; it does not mutate existing volume metadata.
+Set the disk capacity in MiB. Required after [`disk()`](#disk).
 
-### VolumeMount
+<p className="msb-label">Parameters</p>
 
-Discriminated union produced by `MountBuilder.build()`.
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mib</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Disk capacity in MiB.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">quota()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-type VolumeMount =
-  | { kind: "bind"; host: string; guest: string; readonly: boolean; noexec: boolean; nosuid: boolean; nodev: boolean }
-  | { kind: "named"; name: string; guest: string; readonly: boolean; noexec: boolean; nosuid: boolean; nodev: boolean }
-  | { kind: "tmpfs"; guest: string; sizeMib: number | null; readonly: boolean; noexec: boolean; nosuid: boolean; nodev: boolean }
-  | {
-      kind: "disk";
-      host: string;
-      guest: string;
-      format: DiskImageFormat;
-      fstype: string | null;
-      readonly: boolean;
-      noexec: boolean;
-      nosuid: boolean;
-      nodev: boolean;
-    };
+quota(mib: number): this
 ```
 
-### DiskImageFormat
+Record a quota in MiB as metadata for directory-backed volumes.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>mib</code><span className="msb-type">number</span></div>
+    <div className="msb-param-desc">Quota in MiB.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">label()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-type DiskImageFormat = "qcow2" | "raw" | "vmdk";
+label(key: string, value: string): this
+```
+
+Add a metadata label. Can be called multiple times.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Label key.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Label value.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+build(): { name: string; kind: string; quotaMib?: number | null; capacityMib?: number | null; labels: Record<string, string> }
+```
+
+Materialize the volume configuration without creating the volume on disk. To create it, use [`create()`](#create) instead. The returned config object is the internal `NapiVolumeConfig` shape (not a public export).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">{`{ name, kind, quotaMib?, capacityMib?, labels }`}</span></div>
+    <div className="msb-param-desc">Frozen volume configuration object.</div>
+  </div>
+</div>
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">create()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+create(): Promise<Volume>
+```
+
+Build and create the volume on disk, returning a [`Volume`](#instance-methods).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Promise&lt;Volume&gt;</a></div>
+    <div className="msb-param-desc">The created volume.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const data = await Volume.builder("my-data").create();
+```
+
+---
+
+## VolumeFs methods
+
+Host-side filesystem operations on a volume's directory. Obtained via [`volume.fs()`](#volume-fs) or [`VolumeHandle.fs()`](#volumehandle). All operations run directly on the host without booting a sandbox. Paths are relative to the volume's root directory. Every method is async.
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">read()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+read(path: string): Promise<Uint8Array>
+```
+
+Read a file's full contents as bytes.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;Uint8Array&gt;</span></div>
+    <div className="msb-param-desc">File contents.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const bytes = await vfs.read("data.bin");
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">readToString()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+readToString(path: string): Promise<string>
+```
+
+Read a file's full contents as a UTF-8 string.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;string&gt;</span></div>
+    <div className="msb-param-desc">Decoded file contents.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const text = await vfs.readToString("config.json");
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">readStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+readStream(path: string): Promise<VolumeFsReadStream>
+```
+
+Open a streaming reader for a file, for chunked reads of large files without loading them fully into memory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumefsreadstream">Promise&lt;VolumeFsReadStream&gt;</a></div>
+    <div className="msb-param-desc">Async-iterable read stream.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const stream = await vfs.readStream("large.bin");
+for await (const chunk of stream) {
+  console.log(chunk.byteLength);
+}
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">write()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+write(path: string, data: Uint8Array | string): Promise<void>
+```
+
+Write a file, replacing any existing contents. Strings are encoded as UTF-8.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>data</code><span className="msb-type">Uint8Array | string</span></div>
+    <div className="msb-param-desc">Bytes, or a UTF-8 string.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await vfs.write("seed.txt", "hello");
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">writeStream()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+writeStream(path: string): Promise<VolumeFsWriteSink>
+```
+
+Open a streaming writer for a file, for chunked writes of large files.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#volumefswritesink">Promise&lt;VolumeFsWriteSink&gt;</a></div>
+    <div className="msb-param-desc">Write sink; call <code>close()</code> when done.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const sink = await vfs.writeStream("out.bin");
+await sink.write(chunk);
+await sink.close();
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">list()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+list(path: string): Promise<FsEntry[]>
+```
+
+List the entries in a directory. Pass `""` for the volume root.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Directory path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/typescript/filesystem#fsentry">Promise&lt;FsEntry[]&gt;</a></div>
+    <div className="msb-param-desc">Directory entries.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+for (const e of await vfs.list("")) {
+  console.log(e.path, e.kind, e.size);
+}
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">mkdir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+mkdir(path: string): Promise<void>
+```
+
+Create a directory, including any missing parents.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Directory path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await vfs.mkdir("cache/images");
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">removeDir()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+removeDir(path: string): Promise<void>
+```
+
+Recursively remove a directory and its contents.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Directory path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await vfs.removeDir("cache");
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">remove()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+remove(path: string): Promise<void>
+```
+
+Remove a single file.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">File path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await vfs.remove("seed.txt");
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">copy()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+copy(from: string, to: string): Promise<void>
+```
+
+Copy a file or directory from one path to another.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>from</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Source path relative to the volume root.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>to</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await vfs.copy("seed.txt", "backup/seed.txt");
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">rename()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+rename(from: string, to: string): Promise<void>
+```
+
+Move or rename a file or directory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>from</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Source path relative to the volume root.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>to</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Destination path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+await vfs.rename("draft.txt", "final.txt");
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">stat()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+stat(path: string): Promise<FsMetadata>
+```
+
+Get metadata for a file or directory.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="/sdk/typescript/filesystem#fsmetadata">Promise&lt;FsMetadata&gt;</a></div>
+    <div className="msb-param-desc">Kind, size, mode, and timestamps.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+const meta = await vfs.stat("seed.txt");
+console.log(meta.size, meta.kind);
+```
+
+---
+
+#### <span className="msb-recv">vfs.</span><span className="msb-hn">exists()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```typescript
+exists(path: string): Promise<boolean>
+```
+
+Check whether a path exists.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path relative to the volume root.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">Promise&lt;boolean&gt;</span></div>
+    <div className="msb-param-desc"><code>true</code> if the path exists.</div>
+  </div>
+</div>
+
+<p className="msb-label">Example</p>
+
+```typescript
+if (await vfs.exists("seed.txt")) {
+  await vfs.remove("seed.txt");
+}
 ```
 
 ---
 
 ## Types
 
-### VolumeBuilder
-
-| Method | Description |
-|--------|-------------|
-| `directory()` | Create a directory-backed volume |
-| `disk()` | Create a raw ext4 disk-backed volume |
-| `size(mib)` | Disk capacity in MiB; required after `disk()` |
-| `quota(mib)` | Recorded quota metadata for directory volumes |
-| `label(key, value)` | Add a metadata label |
-| `build()` | Materialize a [`VolumeConfig`](#volumeconfig) |
-| `create()` | Build and create the volume; returns a [`Volume`](#volume) |
-
-### VolumeConfig
-
-Frozen configuration produced by `VolumeBuilder.build()`.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| name | `string` | Volume name |
-| kind | `"dir" \| "disk"` | Volume kind |
-| quotaMib | `number \| null` | Maximum storage size in MiB |
-| capacityMib | `number \| null` | Disk capacity in MiB |
-| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
-
 ### VolumeHandle
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#volume-get">Volume.get()</a> · <a href="#volume-list">Volume.list()</a></p>
+
+A handle to an existing named volume, carrying its metadata. Handles from [`Volume.get()`](#volume-get) are **live**: `.fs()` and `.remove()` work. Handles in the array from [`Volume.list()`](#volume-list) are **read-only**: those two methods throw, so call `Volume.get(name)` to upgrade.
 
 | Property / Method | Type | Description |
 |-------------------|------|-------------|
 | name | `string` | Volume name |
-| kind | `string` | Volume kind |
-| quotaMib | `number \| null` | Storage quota |
+| kind | `string` | Volume kind (`"dir"` or `"disk"`) |
+| quotaMib | `number \| null` | Recorded storage quota in MiB |
 | usedBytes | `number` | Current disk usage in bytes |
-| capacityBytes | `number \| null` | Disk capacity in bytes |
-| diskFormat | `string \| null` | Disk image format |
-| diskFstype | `string \| null` | Inner disk filesystem |
+| capacityBytes | `number \| null` | Disk capacity in bytes (disk volumes) |
+| diskFormat | `string \| null` | Disk image format (disk volumes) |
+| diskFstype | `string \| null` | Inner disk filesystem (disk volumes) |
 | labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
 | createdAt | `Date \| null` | Creation timestamp |
-| fs() | [`VolumeFs`](#volumefs) | Host-side filesystem on this volume (live handles only) |
-| remove() | `Promise<void>` | Delete this volume (live handles only) |
-
-Handles in the array returned by `Volume.list()` are read-only: calling `.fs()` or `.remove()` throws. Use `Volume.get(name)` to upgrade.
+| fs() | [`VolumeFs`](#volumefs) | Host-side filesystem (live handles only; throws on read-only handles) |
+| remove() | `Promise<void>` | Delete this volume (live handles only; throws on read-only handles) |
 
 ### VolumeFs
 
-Host-side filesystem operations on a volume's directory. Same surface area as [`SandboxFsOps`](/sdk/typescript/filesystem) (read, readToString, readStream, write, writeStream, list, mkdir, removeDir, remove, copy, rename, stat, exists) — but operates directly on the host without booting a sandbox.
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#volume-fs">volume.fs()</a> · <a href="#volumehandle">VolumeHandle.fs()</a></p>
+
+Host-side filesystem operations on a volume's directory. The methods mirror [`SandboxFsOps`](/sdk/typescript/filesystem) but run directly on the host with no sandbox booted. See the [VolumeFs methods](#volumefs-methods) section above for full per-method details.
+
+| Method | Type | Description |
+|--------|------|-------------|
+| read(path) | `Promise<Uint8Array>` | Read a file as bytes |
+| readToString(path) | `Promise<string>` | Read a file as a UTF-8 string |
+| readStream(path) | `Promise<`[`VolumeFsReadStream`](#volumefsreadstream)`>` | Open a streaming reader |
+| write(path, data) | `Promise<void>` | Write a file (bytes or string) |
+| writeStream(path) | `Promise<`[`VolumeFsWriteSink`](#volumefswritesink)`>` | Open a streaming writer |
+| list(path) | `Promise<`[`FsEntry`](/sdk/typescript/filesystem#fsentry)`[]>` | List directory entries |
+| mkdir(path) | `Promise<void>` | Create a directory, with parents |
+| removeDir(path) | `Promise<void>` | Recursively remove a directory |
+| remove(path) | `Promise<void>` | Remove a file |
+| copy(from, to) | `Promise<void>` | Copy a file or directory |
+| rename(from, to) | `Promise<void>` | Move or rename a file or directory |
+| stat(path) | `Promise<`[`FsMetadata`](/sdk/typescript/filesystem#fsmetadata)`>` | Get file metadata |
+| exists(path) | `Promise<boolean>` | Check whether a path exists |
+
+### VolumeFsReadStream
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#volumefs-methods">VolumeFs.readStream()</a></p>
+
+A streaming reader over a volume file. Implements `AsyncIterable<Uint8Array>` and `AsyncDisposable`, so it works with `for await` and `using`.
+
+| Method | Type | Description |
+|--------|------|-------------|
+| recv() | `Promise<Uint8Array \| null>` | Read the next chunk; `null` when the stream is exhausted |
+| collect() | `Promise<Uint8Array>` | Drain the stream into a single byte array |
+| [Symbol.asyncIterator]() | `AsyncIterator<Uint8Array>` | Iterate chunks with `for await` |
+| [Symbol.asyncDispose]() | `Promise<void>` | Mark the stream done (for `using`) |
+
+### VolumeFsWriteSink
+
+<div className="msb-tags"><span className="msb-tag is-type">class</span></div>
+
+<p className="msb-backref">Returned by <a href="#volumefs-methods">VolumeFs.writeStream()</a></p>
+
+A streaming writer for a volume file. Implements `AsyncDisposable`, so `await using` closes it automatically.
+
+| Method | Type | Description |
+|--------|------|-------------|
+| write(data) | `Promise<void>` | Write a chunk (`Uint8Array` or UTF-8 string) |
+| close() | `Promise<void>` | Flush and close the sink; idempotent |
+| [Symbol.asyncDispose]() | `Promise<void>` | Close the sink (for `await using`) |

--- a/docs/style.css
+++ b/docs/style.css
@@ -6,6 +6,7 @@ body {
  * microsandbox SDK reference styles
  * Auto-loaded by Mintlify (any .css in the docs root). Class names are
  * prefixed with `msb-` to avoid clashing with Mintlify / Tailwind utilities.
+ * Light is the default; `.dark` (toggled by Mintlify on <html>) overrides.
  */
 
 /* kind tags: static / instance / builder / type / async */
@@ -26,41 +27,69 @@ body {
 .dark .msb-tag.is-type     { background: #3a1424; color: #F4C0D1; }
 .dark .msb-tag.is-async    { background: rgba(211,209,199,.14); color: #B4B2A9; }
 
-/* at a glance panel */
+/* at a glance — grouped table, border-only (no fill, so no muddy dark blob) */
 .msb-glance {
-  border: 1px solid rgba(127,119,221,.22);
-  border-radius: 14px; padding: 18px 20px; margin: 20px 0 8px;
+  border: 1px solid #e7e4ef; border-radius: 14px;
+  padding: 6px 18px 14px; margin: 20px 0 8px;
 }
-.msb-glance-grid {
-  display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 18px 24px;
-}
-.msb-eyebrow {
-  font-size: 11px; font-weight: 600; letter-spacing: .06em;
-  text-transform: uppercase; opacity: .55; margin: 0 0 12px;
-}
-.msb-eyebrow-mt { margin-top: 16px; }
-.msb-col-title {
-  font-size: 13px; font-weight: 600; margin: 0 0 8px;
+.dark .msb-glance { border-color: #322f2b; }
+
+/* group label row: dot + label + count */
+.msb-gl {
   display: flex; align-items: center; gap: 7px;
+  font-size: 11px; font-weight: 600; letter-spacing: .05em;
+  text-transform: uppercase; opacity: .6; padding: 14px 0 4px;
 }
-.msb-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex: none; }
+.msb-gl:first-child { padding-top: 6px; }
+.msb-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
 .msb-dot.static   { background: #7F77DD; }
 .msb-dot.instance { background: #1D9E75; }
 .msb-dot.builder  { background: #D85A30; }
-.msb-mrow { margin: 0 0 7px; line-height: 1.3; }
-.msb-m { font-family: var(--font-mono, monospace); font-size: 13px; text-decoration: none; }
-.msb-gloss { display: block; font-size: 12px; opacity: .6; }
+.msb-dot.type     { background: #D4537E; }
+.msb-ct { margin-left: auto; font-weight: 500; opacity: .8; }
 
-/* type pills + inline type links */
-.msb-m, .msb-type { color: #6d4bc4; }
-.dark .msb-m, .dark .msb-type { color: #c9a4ff; }
-.msb-typestrip { display: flex; flex-wrap: wrap; gap: 6px; }
-.msb-typepill {
-  font-family: var(--font-mono, monospace); font-size: 12px; text-decoration: none;
-  background: #FBEAF0; color: #4B1528; padding: 3px 9px; border-radius: 6px;
+/* method rows */
+.msb-row {
+  display: grid; grid-template-columns: 200px 1fr; gap: 16px;
+  padding: 5px 6px; margin: 0 -6px; border-radius: 6px;
+  border-top: 1px solid #f2f0f8; font-size: 12.5px; text-decoration: none;
 }
-.dark .msb-typepill { background: #3a1424; color: #F4C0D1; }
+.dark .msb-row { border-top-color: #211f1c; }
+.msb-row:hover { background: rgba(127,119,221,.07); }
+.msb-rn { font-family: var(--font-mono, monospace); color: #6d4bc4; }
+.dark .msb-rn { color: #c9a4ff; }
+.msb-row:hover .msb-rn { text-decoration: underline; }
+.msb-rg { opacity: .7; }
+
+/* builder + types chip rows */
+.msb-chiprow {
+  display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
+  padding: 7px 0 2px; border-top: 1px solid #f2f0f8;
+}
+.dark .msb-chiprow { border-top-color: #211f1c; }
+.msb-chip {
+  font-family: var(--font-mono, monospace); font-size: 11.5px; text-decoration: none;
+  padding: 2px 9px; border-radius: 6px; background: #f4f1fb; color: #4b3f7a;
+}
+.dark .msb-chip { background: #241f33; color: #c8baf2; }
+.msb-typepill {
+  font-family: var(--font-mono, monospace); font-size: 11.5px; text-decoration: none;
+  padding: 2px 9px; border-radius: 6px; background: #fbeef4; color: #7a2348;
+}
+.dark .msb-typepill { background: #321826; color: #f0b9d0; }
+.msb-more { font-size: 11.5px; opacity: .6; text-decoration: none; }
+
+/* our links shouldn't get Mintlify's prose underline-border */
+.msb-row, .msb-chip, .msb-typepill, .msb-more, .msb-backref a, .msb-type { border-bottom: 0 !important; }
+
+/* method headings: monospace name with a muted receiver / path prefix */
+.msb-hn { font-family: var(--font-mono, monospace); font-weight: 500; }
+.msb-recv { font-family: var(--font-mono, monospace); font-weight: 400; color: #a3a29c; }
+.dark .msb-recv { color: #6f6e68; }
+
+/* inline type links (in param/return rows) */
+.msb-type { color: #6d4bc4; }
+.dark .msb-type { color: #c9a4ff; }
 
 /* small section labels (parameters / returns / example) */
 .msb-label {
@@ -83,5 +112,7 @@ body {
 .msb-backref a { font-family: var(--font-mono, monospace); font-size: 12.5px; text-decoration: none; }
 
 @media (max-width: 640px) {
+  .msb-row { grid-template-columns: 1fr; gap: 0; }
+  .msb-rg { font-size: 11.5px; opacity: .6; }
   .msb-param { grid-template-columns: 1fr; gap: 2px; }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,3 +1,87 @@
 body {
   font-size: 12px;
 }
+
+/*
+ * microsandbox SDK reference styles
+ * Auto-loaded by Mintlify (any .css in the docs root). Class names are
+ * prefixed with `msb-` to avoid clashing with Mintlify / Tailwind utilities.
+ */
+
+/* kind tags: static / instance / builder / type / async */
+.msb-tags { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin: 2px 0 12px; }
+.msb-tag {
+  font-size: 11px; line-height: 1; padding: 4px 9px;
+  border-radius: 6px; font-weight: 600; letter-spacing: .01em;
+}
+.msb-tag.is-static   { background: #EEEDFE; color: #26215C; }
+.msb-tag.is-instance { background: #E1F5EE; color: #04342C; }
+.msb-tag.is-builder  { background: #FAECE7; color: #4A1B0C; }
+.msb-tag.is-type     { background: #FBEAF0; color: #4B1528; }
+.msb-tag.is-async    { background: rgba(135,134,128,.18); color: #5F5E5A; }
+
+.dark .msb-tag.is-static   { background: #2b2655; color: #CECBF6; }
+.dark .msb-tag.is-instance { background: #0c3a2e; color: #9FE1CB; }
+.dark .msb-tag.is-builder  { background: #3a1c10; color: #F5C4B3; }
+.dark .msb-tag.is-type     { background: #3a1424; color: #F4C0D1; }
+.dark .msb-tag.is-async    { background: rgba(211,209,199,.14); color: #B4B2A9; }
+
+/* at a glance panel */
+.msb-glance {
+  border: 1px solid rgba(127,119,221,.22);
+  border-radius: 14px; padding: 18px 20px; margin: 20px 0 8px;
+}
+.msb-glance-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px 24px;
+}
+.msb-eyebrow {
+  font-size: 11px; font-weight: 600; letter-spacing: .06em;
+  text-transform: uppercase; opacity: .55; margin: 0 0 12px;
+}
+.msb-eyebrow-mt { margin-top: 16px; }
+.msb-col-title {
+  font-size: 13px; font-weight: 600; margin: 0 0 8px;
+  display: flex; align-items: center; gap: 7px;
+}
+.msb-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex: none; }
+.msb-dot.static   { background: #7F77DD; }
+.msb-dot.instance { background: #1D9E75; }
+.msb-dot.builder  { background: #D85A30; }
+.msb-mrow { margin: 0 0 7px; line-height: 1.3; }
+.msb-m { font-family: var(--font-mono, monospace); font-size: 13px; text-decoration: none; }
+.msb-gloss { display: block; font-size: 12px; opacity: .6; }
+
+/* type pills + inline type links */
+.msb-m, .msb-type { color: #6d4bc4; }
+.dark .msb-m, .dark .msb-type { color: #c9a4ff; }
+.msb-typestrip { display: flex; flex-wrap: wrap; gap: 6px; }
+.msb-typepill {
+  font-family: var(--font-mono, monospace); font-size: 12px; text-decoration: none;
+  background: #FBEAF0; color: #4B1528; padding: 3px 9px; border-radius: 6px;
+}
+.dark .msb-typepill { background: #3a1424; color: #F4C0D1; }
+
+/* small section labels (parameters / returns / example) */
+.msb-label {
+  font-size: 11px; font-weight: 600; letter-spacing: .05em;
+  text-transform: uppercase; opacity: .55; margin: 16px 0 6px;
+}
+
+/* parameter + return rows */
+.msb-params { margin: 4px 0 0; }
+.msb-param {
+  display: grid; grid-template-columns: 180px 1fr; gap: 4px 18px;
+  padding: 9px 0; border-top: 1px solid rgba(135,134,128,.18);
+}
+.msb-param-key code { font-size: 13px; }
+.msb-param-key .msb-type { font-size: 12px; display: inline-block; margin-top: 3px; }
+.msb-param-desc { font-size: 14px; opacity: .85; }
+
+/* back-references on types (returned by / used by) */
+.msb-backref { font-size: 13px; opacity: .7; margin: 4px 0 12px; }
+.msb-backref a { font-family: var(--font-mono, monospace); font-size: 12.5px; text-decoration: none; }
+
+@media (max-width: 640px) {
+  .msb-param { grid-template-columns: 1fr; gap: 2px; }
+}


### PR DESCRIPTION
## TL;DR
Rebuild the Rust Sandbox API reference as a new, easier-to-scan template: an at-a-glance method index, per-method examples, color-coded kind tags, and types that link both ways. This is the proposed template for the rest of the SDK reference pages.

## Description
- Add an "at a glance" panel at the top of the page that groups every member by kind (static, instance, builder) with one-line glosses, plus a related-types strip, so the whole surface of the type is visible before you scroll.
- Add a "typical flow" snippet and a per-method example to the action methods, so usage is shown and not just signatures.
- Make every type reference a link and add bidirectional back-references on each type (a "Returned by" or "Used by" line), so you can navigate method to type and type to method.
- Switch method parameters and returns to a name + type-pill + description row layout, and add color-coded kind tags (static, instance, builder, type) for quick scanning.
- Add docs/style.css with a small msb- prefixed utility layer, auto-loaded by Mintlify and styled for both light and dark mode.
- Rebuild the page against the current method set (it kept evolving while this was written), so no in-progress API edits were reverted.

The new per-method and type blocks follow this pattern, which other pages will copy:

````mdx
#### metrics()

<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>

```rust
async fn metrics(&self) -> MicrosandboxResult<SandboxMetrics>
```

<p className="msb-label">Returns</p>

<div className="msb-params">
  <div className="msb-param">
    <div className="msb-param-key"><a className="msb-type" href="#sandboxmetrics">SandboxMetrics</a></div>
    <div className="msb-param-desc">Resource metrics.</div>
  </div>
</div>
````

## Test Plan
- [x] `mint broken-links` reports no broken links (run with an LTS Node, e.g. node@20; Node 25+ is rejected by mint)
- [x] `mint dev` serves /sdk/rust/sandbox and the at-a-glance panel, kind tags, and param rows render in both light and dark mode
- [x] the custom msb- classes resolve (style.css is auto-loaded) and no HTML shows as escaped text
- [x] the page method and type set matches the current Rust SDK (no reverted API edits)