### PR TITLE
feat(sandbox): move bulky config onto an inherited config fd

### DIFF
--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -4,14 +4,17 @@
 //! [`microsandbox_runtime::vm::enter()`]. This command **never returns**
 //! — the VMM calls `_exit()` on guest shutdown.
 
+use std::fs::File;
+use std::io::Read;
 use std::mem::MaybeUninit;
 use std::path::PathBuf;
 use std::{os::fd::FromRawFd, os::fd::OwnedFd};
 
 use clap::Args;
 use microsandbox_runtime::{
+    launch::LaunchConfig,
     logging::LogLevel,
-    vm::{Config, DiskMountSpec, MetricsSlotHandoff, StartupCommand, VmConfig},
+    vm::{Config, DiskMountSpec, VmConfig},
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -19,6 +22,11 @@ use microsandbox_runtime::{
 //--------------------------------------------------------------------------------------------------
 
 /// Arguments for the `msb sandbox` subcommand.
+///
+/// Only the operator-readable labels and the real inherited fds live on argv.
+/// The bulk of the configuration — paths, env (incl. secrets), mounts, network
+/// config — arrives as a JSON [`LaunchConfig`] over `--config-fd` (or
+/// `--config-file` for manual invocation). See issue #997.
 #[derive(Debug, Args)]
 pub struct SandboxArgs {
     /// Name of the sandbox.
@@ -29,37 +37,9 @@ pub struct SandboxArgs {
     #[arg(long = "sandbox-id")]
     pub sandbox_id: i32,
 
-    /// Path to the sandbox database file.
-    #[arg(long = "db-path")]
-    pub sandbox_db_path: PathBuf,
-
-    /// Timeout when acquiring a sandbox database connection from the pool.
-    #[arg(long = "db-connect-timeout-secs", default_value_t = 30)]
-    pub sandbox_db_connect_timeout_secs: u64,
-
-    /// Directory for log files.
-    #[arg(long)]
-    pub log_dir: PathBuf,
-
     /// Log verbosity for the sandbox runtime (error, warn, info, debug, trace).
     #[arg(long = "log-level", value_name = "LOG_LEVEL", value_parser = parse_log_level)]
     pub log_level: Option<LogLevel>,
-
-    /// Runtime directory (scripts, heartbeat).
-    #[arg(long)]
-    pub runtime_dir: PathBuf,
-
-    /// Root directory holding every sandbox's persisted state.
-    ///
-    /// Passed explicitly so runtime-owned lifecycle maintenance can remove
-    /// ephemeral sandbox directories without inferring the path from
-    /// `--log-dir`.
-    #[arg(long = "sandboxes-dir")]
-    pub sandboxes_dir: PathBuf,
-
-    /// Path to the Unix domain socket for the agent relay.
-    #[arg(long)]
-    pub agent_sock: PathBuf,
 
     /// Read end of the attached-parent watchdog pipe.
     #[arg(long = "parent-watch-fd", hide = true)]
@@ -69,42 +49,9 @@ pub struct SandboxArgs {
     #[arg(long = "startup-fd", hide = true)]
     pub startup_fd: Option<i32>,
 
-    /// Startup workload command to execute after agentd is ready.
-    #[arg(long = "startup-cmd", hide = true)]
-    pub startup_cmd: Option<String>,
-
-    /// Startup workload arguments.
-    #[arg(long = "startup-arg", hide = true)]
-    pub startup_args: Vec<String>,
-
-    /// Startup workload environment variables as `KEY=VALUE`.
-    #[arg(long = "startup-env", hide = true)]
-    pub startup_env: Vec<String>,
-
-    /// Startup workload working directory.
-    #[arg(long = "startup-cwd", hide = true)]
-    pub startup_cwd: Option<String>,
-
-    /// Startup workload guest user.
-    #[arg(long = "startup-user", hide = true)]
-    pub startup_user: Option<String>,
-
     /// Forward VM console output to stdout.
     #[arg(long = "forward")]
     pub forward_output: bool,
-
-    /// Hard cap on total sandbox lifetime in seconds.
-    #[arg(long)]
-    pub max_duration: Option<u64>,
-
-    /// Idle timeout in seconds.
-    #[arg(long)]
-    pub idle_timeout: Option<u64>,
-
-    // ── VM configuration ─────────────────────────────────────────────────
-    /// Path to the libkrunfw shared library.
-    #[arg(long)]
-    pub libkrunfw_path: PathBuf,
 
     /// Number of virtual CPUs.
     #[arg(long, default_value_t = 1)]
@@ -114,83 +61,13 @@ pub struct SandboxArgs {
     #[arg(long, default_value_t = 512)]
     pub memory_mib: u32,
 
-    /// Metrics sampling interval in milliseconds; `0` disables sampling.
-    #[arg(long = "metrics-sample-interval-ms", default_value_t = 1000)]
-    pub metrics_sample_interval_ms: u64,
+    /// Inherited fd carrying the JSON [`LaunchConfig`] (set by the SDK).
+    #[arg(long = "config-fd", hide = true)]
+    pub config_fd: Option<i32>,
 
-    /// Disable metrics sampling; overrides `--metrics-sample-interval-ms`.
-    #[arg(long = "disable-metrics-sample")]
-    pub disable_metrics_sample: bool,
-
-    /// Name of the POSIX shared-memory metrics registry, passed in by the host.
-    #[arg(long = "metrics-shm-name", hide = true)]
-    pub metrics_shm_name: Option<String>,
-
-    /// Reserved slot index inside the metrics registry.
-    #[arg(long = "metrics-slot", hide = true)]
-    pub metrics_slot: Option<u32>,
-
-    /// Generation stamp paired with the reserved slot.
-    #[arg(long = "metrics-generation", hide = true)]
-    pub metrics_generation: Option<u64>,
-
-    /// Root filesystem path for direct passthrough mounts.
-    #[arg(long)]
-    pub rootfs_path: Option<PathBuf>,
-
-    /// Disk image file path for virtio-blk rootfs.
-    #[arg(long)]
-    pub rootfs_disk: Option<PathBuf>,
-
-    /// Disk image format (qcow2, raw, vmdk).
-    #[arg(long)]
-    pub rootfs_disk_format: Option<String>,
-
-    /// Mount disk image as read-only.
-    #[arg(long)]
-    pub rootfs_disk_readonly: bool,
-
-    /// Writable upper ext4 block device for OCI rootfs overlay.
-    #[arg(long = "rootfs-blk")]
-    pub rootfs_upper: Option<PathBuf>,
-
-    /// Additional mounts as `tag:host_path` (repeatable).
-    #[arg(long)]
-    pub mount: Vec<String>,
-
-    /// Disk-image volume mounts as `id:host_path:format[:ro]` (repeatable).
-    #[arg(long)]
-    pub disk: Vec<String>,
-
-    /// Path to the init binary in the guest.
-    #[arg(long)]
-    pub init_path: Option<PathBuf>,
-
-    /// Environment variables as `KEY=VALUE` (repeatable).
-    #[arg(long)]
-    pub env: Vec<String>,
-
-    /// Working directory inside the guest.
-    #[arg(long)]
-    pub workdir: Option<PathBuf>,
-
-    /// Path to the executable to run in the guest.
-    #[arg(long)]
-    pub exec_path: Option<PathBuf>,
-
-    /// Network configuration as JSON.
-    #[cfg(feature = "net")]
-    #[arg(long)]
-    pub network_config: Option<String>,
-
-    /// Sandbox slot for deterministic network address derivation.
-    #[cfg(feature = "net")]
-    #[arg(long, default_value_t = 0)]
-    pub sandbox_slot: u64,
-
-    /// Arguments to pass to the executable.
-    #[arg(last = true)]
-    pub exec_args: Vec<String>,
+    /// Path to a JSON [`LaunchConfig`] file (manual invocation / debugging).
+    #[arg(long = "config-file", hide = true)]
+    pub config_file: Option<PathBuf>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -213,6 +90,13 @@ fn parse_log_level(s: &str) -> Result<LogLevel, String> {
 
 /// Run the sandbox process. This function **never returns**.
 pub fn run(args: SandboxArgs) -> ! {
+    let launch = match load_launch_config(&args) {
+        Ok(launch) => launch,
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(2);
+        }
+    };
     let parent_watchdog = match args
         .parent_watch_fd
         .map(parent_watchdog_from_fd)
@@ -231,8 +115,8 @@ pub fn run(args: SandboxArgs) -> ! {
             std::process::exit(2);
         }
     };
-    let is_vmdk = args.rootfs_disk_format.as_deref() == Some("vmdk");
-    let disks = match parse_disk_args(&args.disk) {
+    let is_vmdk = launch.rootfs.disk_format.as_deref() == Some("vmdk");
+    let disks = match parse_disk_args(&launch.disks) {
         Ok(disks) => disks,
         Err(err) => {
             eprintln!("{err}");
@@ -240,88 +124,98 @@ pub fn run(args: SandboxArgs) -> ! {
         }
     };
     let vm_config = VmConfig {
-        libkrunfw_path: args.libkrunfw_path,
+        libkrunfw_path: launch.libkrunfw_path,
         vcpus: args.vcpus,
         memory_mib: args.memory_mib,
-        rootfs_path: args.rootfs_path,
+        rootfs_path: launch.rootfs.path,
         rootfs_vmdk: if is_vmdk {
-            args.rootfs_disk.clone()
+            launch.rootfs.disk.clone()
         } else {
             None
         },
-        rootfs_upper: args.rootfs_upper,
+        rootfs_upper: launch.rootfs.upper,
         rootfs_upper_spec: None,
-        rootfs_disk: if is_vmdk { None } else { args.rootfs_disk },
+        rootfs_disk: if is_vmdk { None } else { launch.rootfs.disk },
         rootfs_disk_format: if is_vmdk {
             None
         } else {
-            args.rootfs_disk_format
+            launch.rootfs.disk_format
         },
-        rootfs_disk_readonly: args.rootfs_disk_readonly,
-        mounts: args.mount,
+        rootfs_disk_readonly: launch.rootfs.disk_readonly,
+        mounts: launch.mounts,
         disks,
         backends: vec![],
-        init_path: args.init_path,
-        env: args.env,
-        workdir: args.workdir,
-        exec_path: args.exec_path,
-        exec_args: args.exec_args,
+        init_path: launch.init_path,
+        env: launch.env,
+        workdir: launch.workdir,
+        exec_path: launch.exec_path,
+        exec_args: launch.exec_args,
         #[cfg(feature = "net")]
-        network: args
-            .network_config
-            .as_deref()
-            .map(|json| {
-                serde_json::from_str::<microsandbox_network::config::NetworkConfig>(json)
-                    .expect("invalid network config JSON")
-            })
-            .unwrap_or_default(),
+        network: launch.network.unwrap_or_default(),
         #[cfg(feature = "net")]
-        sandbox_slot: args.sandbox_slot,
+        sandbox_slot: launch.sandbox_slot,
     };
 
     let config = Config {
         sandbox_name: args.sandbox_name,
         sandbox_id: args.sandbox_id,
         log_level: args.log_level,
-        sandbox_db_path: args.sandbox_db_path,
-        sandbox_db_connect_timeout_secs: args.sandbox_db_connect_timeout_secs,
-        log_dir: args.log_dir,
-        runtime_dir: args.runtime_dir,
-        sandboxes_dir: args.sandboxes_dir,
-        agent_sock_path: args.agent_sock,
-        startup_command: args.startup_cmd.map(|cmd| StartupCommand {
-            cmd,
-            args: args.startup_args,
-            env: args.startup_env,
-            cwd: args.startup_cwd,
-            user: args.startup_user,
-        }),
+        sandbox_db_path: launch.db_path,
+        sandbox_db_connect_timeout_secs: launch.db_connect_timeout_secs,
+        log_dir: launch.log_dir,
+        runtime_dir: launch.runtime_dir,
+        sandboxes_dir: launch.sandboxes_dir,
+        agent_sock_path: launch.agent_sock,
+        startup_command: launch.startup,
         startup_fd,
         parent_watchdog,
         forward_output: args.forward_output,
-        idle_timeout_secs: args.idle_timeout,
-        max_duration_secs: args.max_duration,
-        metrics_sample_interval_ms: if args.disable_metrics_sample {
+        idle_timeout_secs: launch.lifecycle.idle_timeout_secs,
+        max_duration_secs: launch.lifecycle.max_duration_secs,
+        metrics_sample_interval_ms: if launch.metrics.disabled {
             None
         } else {
-            std::num::NonZero::new(args.metrics_sample_interval_ms)
+            std::num::NonZero::new(launch.metrics.sample_interval_ms)
         },
-        metrics_slot: match (
-            args.metrics_shm_name,
-            args.metrics_slot,
-            args.metrics_generation,
-        ) {
-            (Some(shm_name), Some(slot), Some(generation)) => Some(MetricsSlotHandoff {
-                shm_name,
-                slot,
-                generation,
-            }),
-            _ => None,
-        },
+        metrics_slot: launch.metrics.slot,
         vm: vm_config,
     };
 
     microsandbox_runtime::vm::enter(config)
+}
+
+/// Load the JSON [`LaunchConfig`] for this sandbox from the inherited config
+/// fd, or from `--config-file <path>` for manual invocation.
+///
+/// The launcher keeps only operator-readable labels on the real argv and
+/// serializes the rest — network config, env (including secrets), mounts, and
+/// paths — to an inherited fd, so they no longer appear in `ps` or
+/// `/proc/<pid>/cmdline`. See issue #997.
+fn load_launch_config(args: &SandboxArgs) -> Result<LaunchConfig, String> {
+    let bytes = match (args.config_fd, &args.config_file) {
+        (Some(fd), _) => read_config_fd(fd)?,
+        (None, Some(path)) => std::fs::read(path)
+            .map_err(|e| format!("failed to read --config-file {}: {e}", path.display()))?,
+        (None, None) => {
+            return Err("missing --config-fd or --config-file for `msb sandbox`".to_string());
+        }
+    };
+    serde_json::from_slice(&bytes).map_err(|e| format!("invalid launch config: {e}"))
+}
+
+/// Read the full contents of the inherited config fd, taking ownership so it
+/// is closed once consumed.
+fn read_config_fd(fd: i32) -> Result<Vec<u8>, String> {
+    if fd < 0 {
+        return Err(format!(
+            "invalid --config-fd: must be non-negative, got {fd}"
+        ));
+    }
+    let mut file = unsafe { File::from_raw_fd(fd) };
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|e| format!("failed to read --config-fd {fd}: {e}"))?;
+    Ok(bytes)
 }
 
 fn parent_watchdog_from_fd(fd: i32) -> Result<OwnedFd, String> {
@@ -441,15 +335,7 @@ fn parse_one_disk_arg(entry: &str) -> Result<DiskMountSpec, String> {
 mod tests {
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 
-    use clap::Parser;
-
     use super::*;
-
-    #[derive(Parser)]
-    struct TestCli {
-        #[command(flatten)]
-        args: SandboxArgs,
-    }
 
     fn fmt(s: &str) -> String {
         format!(
@@ -520,35 +406,6 @@ mod tests {
     }
 
     #[test]
-    fn test_hidden_startup_args_accept_hyphen_values() {
-        let parsed = TestCli::parse_from([
-            "test",
-            "--name",
-            "sandbox",
-            "--sandbox-id",
-            "7",
-            "--db-path",
-            "/tmp/msb.db",
-            "--log-dir",
-            "/tmp/logs",
-            "--runtime-dir",
-            "/tmp/runtime",
-            "--sandboxes-dir",
-            "/tmp/sandboxes",
-            "--agent-sock",
-            "/tmp/agent.sock",
-            "--libkrunfw-path",
-            "/tmp/libkrunfw.dylib",
-            "--startup-cmd=/bin/sh",
-            "--startup-arg=-lc",
-            "--startup-arg=echo ok",
-        ]);
-
-        assert_eq!(parsed.args.startup_cmd.as_deref(), Some("/bin/sh"));
-        assert_eq!(parsed.args.startup_args, vec!["-lc", "echo ok"]);
-    }
-
-    #[test]
     fn test_parse_disk_args_keeps_good_entries() {
         let entries = vec![
             "good:/host/g.raw:raw".to_string(),
@@ -603,5 +460,85 @@ mod tests {
         let _write_fd = unsafe { OwnedFd::from_raw_fd(fds[1]) };
 
         validate_pipe_fd(read_fd.as_raw_fd(), read_fd.as_raw_fd(), "parent-watch-fd").unwrap();
+    }
+
+    /// Build a `SandboxArgs` carrying only a config source; the rest is unused
+    /// by `load_launch_config`.
+    fn args_with(config_fd: Option<i32>, config_file: Option<PathBuf>) -> SandboxArgs {
+        SandboxArgs {
+            sandbox_name: "test".to_string(),
+            sandbox_id: 1,
+            log_level: None,
+            parent_watch_fd: None,
+            startup_fd: None,
+            forward_output: false,
+            vcpus: 1,
+            memory_mib: 512,
+            config_fd,
+            config_file,
+        }
+    }
+
+    #[test]
+    fn test_load_launch_config_from_file() {
+        use std::io::Write;
+
+        let launch = LaunchConfig {
+            db_path: PathBuf::from("/tmp/x.db"),
+            env: vec!["TOKEN=secret".to_string()],
+            ..Default::default()
+        };
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&serde_json::to_vec(&launch).unwrap())
+            .unwrap();
+
+        let args = args_with(None, Some(file.path().to_path_buf()));
+        let loaded = load_launch_config(&args).unwrap();
+
+        assert_eq!(loaded.db_path, PathBuf::from("/tmp/x.db"));
+        assert_eq!(loaded.env, vec!["TOKEN=secret".to_string()]);
+    }
+
+    #[test]
+    fn test_load_launch_config_from_fd() {
+        use std::io::{Seek, SeekFrom, Write};
+        use std::os::fd::IntoRawFd;
+
+        let launch = LaunchConfig {
+            workdir: Some(PathBuf::from("/srv")),
+            ..Default::default()
+        };
+        let mut file = tempfile::tempfile().unwrap();
+        file.write_all(&serde_json::to_vec(&launch).unwrap())
+            .unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let fd = file.into_raw_fd();
+
+        let args = args_with(Some(fd), None);
+        let loaded = load_launch_config(&args).unwrap();
+
+        assert_eq!(loaded.workdir, Some(PathBuf::from("/srv")));
+    }
+
+    #[test]
+    fn test_load_launch_config_missing_source() {
+        let err = load_launch_config(&args_with(None, None)).unwrap_err();
+        assert!(err.contains("missing"));
+    }
+
+    #[test]
+    fn test_load_launch_config_rejects_negative_fd() {
+        let err = load_launch_config(&args_with(Some(-1), None)).unwrap_err();
+        assert!(err.contains("config-fd"));
+    }
+
+    #[test]
+    fn test_load_launch_config_rejects_garbage() {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"not json").unwrap();
+        let err =
+            load_launch_config(&args_with(None, Some(file.path().to_path_buf()))).unwrap_err();
+        assert!(err.contains("invalid launch config"));
     }
 }

--- a/crates/runtime/lib/launch.rs
+++ b/crates/runtime/lib/launch.rs
@@ -1,0 +1,130 @@
+//! The typed launch contract between the SDK and the `msb sandbox` process.
+//!
+//! [`LaunchConfig`] is the bulk of a sandbox's configuration. The SDK builds
+//! it, serializes it as JSON, and hands it to `msb sandbox` over an inherited
+//! file descriptor (see [`crate::vm::CONFIG_FD`]); the process deserializes it
+//! and builds its [`crate::vm::Config`] from it. Only a few operator-readable
+//! labels and the real inherited fds stay on the process argv. This keeps the
+//! network config and secret-bearing env out of `ps` and `/proc/<pid>/cmdline`
+//! — see issue #997.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "net")]
+use microsandbox_network::config::NetworkConfig;
+
+use crate::vm::{MetricsSlotHandoff, StartupCommand};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The bulk `msb sandbox` configuration delivered over the config fd.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct LaunchConfig {
+    /// Path to the sandbox database file.
+    pub db_path: PathBuf,
+
+    /// Timeout when acquiring a sandbox database connection from the pool.
+    pub db_connect_timeout_secs: u64,
+
+    /// Directory for log files.
+    pub log_dir: PathBuf,
+
+    /// Runtime directory (scripts, heartbeat).
+    pub runtime_dir: PathBuf,
+
+    /// Root directory holding every sandbox's persisted state.
+    pub sandboxes_dir: PathBuf,
+
+    /// Path to the Unix domain socket for the agent relay.
+    pub agent_sock: PathBuf,
+
+    /// Path to the libkrunfw shared library.
+    pub libkrunfw_path: PathBuf,
+
+    /// User workload to start after boot, if any.
+    pub startup: Option<StartupCommand>,
+
+    /// Lifetime bounds for the sandbox.
+    pub lifecycle: Lifecycle,
+
+    /// Metrics sampling configuration and the host-reserved slot.
+    pub metrics: MetricsConfig,
+
+    /// Root filesystem source.
+    pub rootfs: RootfsConfig,
+
+    /// Additional virtio-fs mounts as `tag:host_path[:opts]`.
+    pub mounts: Vec<String>,
+
+    /// Disk-image volume mounts as `id:host_path:format[:ro]`.
+    pub disks: Vec<String>,
+
+    /// Path to the init binary in the guest.
+    pub init_path: Option<PathBuf>,
+
+    /// Environment variables as `KEY=VALUE` (guest env plus `MSB_*` specs).
+    pub env: Vec<String>,
+
+    /// Working directory inside the guest.
+    pub workdir: Option<PathBuf>,
+
+    /// Path to the executable to run in the guest.
+    pub exec_path: Option<PathBuf>,
+
+    /// Arguments to pass to the executable.
+    pub exec_args: Vec<String>,
+
+    /// Network configuration. Present only when the `net` feature is on.
+    #[cfg(feature = "net")]
+    pub network: Option<NetworkConfig>,
+
+    /// Sandbox slot for deterministic network address derivation.
+    #[cfg(feature = "net")]
+    pub sandbox_slot: u64,
+}
+
+/// Lifetime bounds for the sandbox.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Lifecycle {
+    /// Hard cap on total sandbox lifetime in seconds.
+    pub max_duration_secs: Option<u64>,
+
+    /// Idle timeout in seconds.
+    pub idle_timeout_secs: Option<u64>,
+}
+
+/// Metrics sampling configuration.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct MetricsConfig {
+    /// Sampling interval in milliseconds.
+    pub sample_interval_ms: u64,
+
+    /// Disable sampling; overrides `sample_interval_ms`.
+    pub disabled: bool,
+
+    /// Host-reserved shared-memory slot, if metrics are enabled.
+    pub slot: Option<MetricsSlotHandoff>,
+}
+
+/// Root filesystem source for the sandbox.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct RootfsConfig {
+    /// Root filesystem path for direct passthrough mounts.
+    pub path: Option<PathBuf>,
+
+    /// Disk image file path for virtio-blk rootfs.
+    pub disk: Option<PathBuf>,
+
+    /// Disk image format (qcow2, raw, vmdk).
+    pub disk_format: Option<String>,
+
+    /// Mount the disk image as read-only.
+    pub disk_readonly: bool,
+
+    /// Writable upper ext4 block device for OCI rootfs overlay.
+    pub upper: Option<PathBuf>,
+}

--- a/crates/runtime/lib/lib.rs
+++ b/crates/runtime/lib/lib.rs
@@ -15,6 +15,7 @@ pub mod boot_error;
 pub mod console;
 pub mod exec_log;
 pub mod heartbeat;
+pub mod launch;
 pub mod logging;
 pub mod maintenance;
 pub mod metrics;

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -25,7 +25,7 @@ use microsandbox_protocol::{
 };
 use msb_krun::VmBuilder;
 use sea_orm::{ColumnTrait, EntityTrait, Set};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::console::{AgentConsoleBackend, ConsoleSharedState};
 use crate::heartbeat::{self, HeartbeatDecision, HeartbeatReader};
@@ -56,6 +56,11 @@ const HEARTBEAT_BOOT_GRACE: Duration = Duration::from_secs(180);
 
 /// Short best-effort send budget once agentd is already considered unresponsive.
 const AGENT_UNRESPONSIVE_SHUTDOWN_PUSH_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Fixed fd carrying the bulk `msb sandbox` config (argv overflow) as
+/// NUL-terminated argument records. Keeps the network-config blob and the
+/// repeated `--env` flags off the process argv — see issue #997.
+pub const CONFIG_FD: i32 = 96;
 
 /// Fixed fd used to pass the attached-parent watchdog pipe into `msb sandbox`.
 pub const PARENT_WATCH_FD: i32 = 97;
@@ -142,7 +147,7 @@ pub struct Config {
 
 /// Hidden CLI handoff describing the metrics slot the host reserved for this
 /// sandbox.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MetricsSlotHandoff {
     /// Name of the POSIX shared-memory object holding the registry.
     pub shm_name: String,
@@ -153,7 +158,7 @@ pub struct MetricsSlotHandoff {
 }
 
 /// User workload that the sandbox process should start after boot.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StartupCommand {
     /// Path or command name to execute inside the guest.
     pub cmd: String,

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -15,6 +15,7 @@ use std::{
     collections::HashMap,
     ffi::OsString,
     fmt::Write,
+    io::{Seek, SeekFrom, Write as IoWrite},
     os::fd::{FromRawFd, OwnedFd},
     path::{Path, PathBuf},
     process::Stdio,
@@ -38,6 +39,8 @@ use microsandbox_protocol::{
     ENV_HANDOFF_INIT_ARGS, ENV_HANDOFF_INIT_CWD, ENV_HANDOFF_INIT_ENV, ENV_HOSTNAME,
     ENV_SECURITY_PROFILE, ENV_TMPFS, ENV_USER,
 };
+use microsandbox_runtime::launch::{LaunchConfig, Lifecycle};
+use microsandbox_runtime::vm::{MetricsSlotHandoff, StartupCommand};
 use microsandbox_types::SandboxLogLevel;
 use microsandbox_utils::{DB_FILENAME, DB_SUBDIR};
 
@@ -194,9 +197,10 @@ pub async fn spawn_sandbox(
         },
     };
 
-    // Build the command.
-    let mut cmd = Command::new(&msb_path);
-    cmd.args(sandbox_cli_args(
+    // Split the config: `visible` stays on argv, the typed `LaunchConfig` is
+    // delivered over the config fd (keeps the network-config blob and
+    // secret-bearing env off `ps` / `/proc/<pid>/cmdline` — see issue #997).
+    let (mut visible, launch) = sandbox_cli_args(
         local,
         config,
         sandbox_id,
@@ -214,14 +218,32 @@ pub async fn spawn_sandbox(
         startup_pipe
             .as_ref()
             .map(|_| microsandbox_runtime::vm::STARTUP_FD),
+    );
+    // Serialize the LaunchConfig to an anonymous (unlinked) temp file. Kept
+    // alive until after spawn; `dup2`'d onto CONFIG_FD in pre_exec.
+    let config_file = match write_launch_config_fd(&launch) {
+        Ok(file) => file,
+        Err(err) => {
+            release_metrics_reservation(config, metrics_reservation.as_ref());
+            return Err(err);
+        }
+    };
+    let config_raw_fd = config_file.as_raw_fd();
+    visible.push(OsString::from("--config-fd"));
+    visible.push(OsString::from(
+        microsandbox_runtime::vm::CONFIG_FD.to_string(),
     ));
+
+    // Build the command.
+    let mut cmd = Command::new(&msb_path);
+    cmd.args(visible);
 
     // Prevent the sandbox process from inheriting the parent's terminal on
     // stdin — the VMM's implicit console auto-detects terminals and sets raw
     // mode, which corrupts the parent's terminal output (\n without \r).
     cmd.stdin(Stdio::null());
 
-    if parent_watchdog.is_some() || startup_pipe.is_some() {
+    {
         let parent_watch_fd = parent_watchdog
             .as_ref()
             .map(|pipe| pipe.read_fd.as_raw_fd());
@@ -231,6 +253,7 @@ pub async fn spawn_sandbox(
                 if startup_write_fd.is_some() {
                     detach_from_launcher_session()?;
                 }
+                dup_inherited_fd(config_raw_fd, microsandbox_runtime::vm::CONFIG_FD)?;
                 if let Some(fd) = parent_watch_fd {
                     dup_inherited_fd(fd, microsandbox_runtime::vm::PARENT_WATCH_FD)?;
                 }
@@ -417,6 +440,20 @@ fn create_pipe() -> MicrosandboxResult<Pipe> {
     }
 
     Ok(Pipe { read_fd, write_fd })
+}
+
+/// Serialize the [`LaunchConfig`] as JSON into an anonymous temp file, rewound
+/// to offset 0. The file is unlinked on creation, so there is no path to clean
+/// up or race on; it is `dup2`'d onto
+/// [`CONFIG_FD`](microsandbox_runtime::vm::CONFIG_FD) for the child to read.
+fn write_launch_config_fd(launch: &LaunchConfig) -> MicrosandboxResult<std::fs::File> {
+    let mut file = tempfile::tempfile()?;
+    let json = serde_json::to_vec(launch)
+        .map_err(|e| crate::MicrosandboxError::Runtime(format!("serialize launch config: {e}")))?;
+    file.write_all(&json)?;
+    file.flush()?;
+    file.seek(SeekFrom::Start(0))?;
+    Ok(file)
 }
 
 fn dup_inherited_fd(src: i32, dst: i32) -> std::io::Result<()> {
@@ -830,7 +867,7 @@ async fn stage_file_mounts(
 
 /// Push a `--mount tag:host_path[:ro]` arg pair.
 fn push_dir_mount_arg(
-    args: &mut Vec<OsString>,
+    mounts: &mut Vec<String>,
     guest: &str,
     host_display: &impl std::fmt::Display,
     options: MountOptions,
@@ -842,8 +879,7 @@ fn push_dir_mount_arg(
     let mut opts = mount_option_tokens(options);
     append_policy_options(&mut opts, stat_virtualization, host_permissions);
     append_option_block(&mut arg, opts);
-    args.push(OsString::from("--mount"));
-    args.push(OsString::from(arg));
+    mounts.push(arg);
 }
 
 /// Append a `tag:guest_path[:ro]` entry to the `MSB_DIR_MOUNTS` env var value.
@@ -858,9 +894,9 @@ fn push_dir_mounts_spec(dir_mounts_val: &mut String, guest: &str, options: Mount
     append_option_block(dir_mounts_val, mount_option_tokens(options));
 }
 
-/// Push a `--mount fm_tag:file_mount_dir[:ro]` arg pair.
+/// Collect a `fm_tag:file_mount_dir[:ro]` mount entry.
 fn push_file_mount_arg(
-    args: &mut Vec<OsString>,
+    mounts: &mut Vec<String>,
     tag: &str,
     file_mount_dir: &Path,
     options: MountOptions,
@@ -871,13 +907,12 @@ fn push_file_mount_arg(
     let mut opts = mount_option_tokens(options);
     append_policy_options(&mut opts, stat_virtualization, host_permissions);
     append_option_block(&mut arg, opts);
-    args.push(OsString::from("--mount"));
-    args.push(OsString::from(arg));
+    mounts.push(arg);
 }
 
-/// Push a `--disk id:host_path:format[:ro]` arg pair.
+/// Collect a `id:host_path:format[:ro]` disk entry.
 fn push_disk_mount_arg(
-    args: &mut Vec<OsString>,
+    disks: &mut Vec<String>,
     id: &str,
     host_display: &impl std::fmt::Display,
     format: &DiskImageFormat,
@@ -887,8 +922,7 @@ fn push_disk_mount_arg(
     if options.readonly {
         arg.push_str(":ro");
     }
-    args.push(OsString::from("--disk"));
-    args.push(OsString::from(arg));
+    disks.push(arg);
 }
 
 /// Append a `id:guest_path[:opts]` entry to the `MSB_DISK_MOUNTS` env var value.
@@ -1055,75 +1089,66 @@ fn sandbox_cli_args(
     metrics_reservation: Option<&MetricsReservation>,
     parent_watch_fd: Option<i32>,
     startup_fd: Option<i32>,
-) -> Vec<OsString> {
-    let mut args = vec![OsString::from("sandbox")];
+) -> (Vec<OsString>, LaunchConfig) {
+    // `visible` stays on the process argv: a small set of operator-readable
+    // labels (name, id, sizing, fds) so the sandbox is identifiable in `ps`
+    // and logs. Everything bulky, structured, or secret-bearing goes into the
+    // typed `LaunchConfig`, delivered over the config fd. See issue #997.
+    let mut visible = vec![OsString::from("sandbox")];
 
     if let Some(log_level) = config.spec.runtime.log_level {
-        args.push(OsString::from(sandbox_log_level_cli_flag(log_level)));
+        visible.push(OsString::from(sandbox_log_level_cli_flag(log_level)));
     }
 
-    args.push(OsString::from("--name"));
-    args.push(OsString::from(&config.spec.name));
-    args.push(OsString::from("--sandbox-id"));
-    args.push(OsString::from(sandbox_id.to_string()));
-    args.push(OsString::from("--db-path"));
-    args.push(db_path.as_os_str().to_os_string());
-    args.push(OsString::from("--db-connect-timeout-secs"));
-    args.push(OsString::from(db_connect_timeout_secs.to_string()));
-    args.push(OsString::from("--log-dir"));
-    args.push(log_dir.as_os_str().to_os_string());
-    args.push(OsString::from("--runtime-dir"));
-    args.push(runtime_dir.as_os_str().to_os_string());
-    args.push(OsString::from("--sandboxes-dir"));
-    args.push(local.sandboxes_dir().as_os_str().to_os_string());
-    args.push(OsString::from("--agent-sock"));
-    args.push(agent_sock_path.as_os_str().to_os_string());
+    visible.push(OsString::from("--name"));
+    visible.push(OsString::from(&config.spec.name));
+    visible.push(OsString::from("--sandbox-id"));
+    visible.push(OsString::from(sandbox_id.to_string()));
     if let Some(fd) = parent_watch_fd {
-        args.push(OsString::from("--parent-watch-fd"));
-        args.push(OsString::from(fd.to_string()));
+        visible.push(OsString::from("--parent-watch-fd"));
+        visible.push(OsString::from(fd.to_string()));
     }
     if let Some(fd) = startup_fd {
-        args.push(OsString::from("--startup-fd"));
-        args.push(OsString::from(fd.to_string()));
+        visible.push(OsString::from("--startup-fd"));
+        visible.push(OsString::from(fd.to_string()));
     }
-    push_startup_command_args(&mut args, config);
+    visible.push(OsString::from("--vcpus"));
+    visible.push(OsString::from(config.spec.resources.cpus.to_string()));
+    visible.push(OsString::from("--memory-mib"));
+    visible.push(OsString::from(config.spec.resources.memory_mib.to_string()));
 
-    let sp = &config.spec.lifecycle;
-    if let Some(max_dur) = sp.max_duration_secs {
-        args.push(OsString::from("--max-duration"));
-        args.push(OsString::from(max_dur.to_string()));
-    }
-    if let Some(idle) = sp.idle_timeout_secs {
-        args.push(OsString::from("--idle-timeout"));
-        args.push(OsString::from(idle.to_string()));
-    }
+    let mut launch = LaunchConfig {
+        db_path: db_path.to_path_buf(),
+        db_connect_timeout_secs,
+        log_dir: log_dir.to_path_buf(),
+        runtime_dir: runtime_dir.to_path_buf(),
+        sandboxes_dir: local.sandboxes_dir(),
+        agent_sock: agent_sock_path.to_path_buf(),
+        libkrunfw_path: libkrunfw_path.to_path_buf(),
+        startup: startup_command(config),
+        lifecycle: Lifecycle {
+            max_duration_secs: config.spec.lifecycle.max_duration_secs,
+            idle_timeout_secs: config.spec.lifecycle.idle_timeout_secs,
+        },
+        workdir: config.spec.runtime.workdir.as_ref().map(PathBuf::from),
+        ..Default::default()
+    };
 
-    args.push(OsString::from("--libkrunfw-path"));
-    args.push(libkrunfw_path.as_os_str().to_os_string());
-    args.push(OsString::from("--vcpus"));
-    args.push(OsString::from(config.spec.resources.cpus.to_string()));
-    args.push(OsString::from("--memory-mib"));
-    args.push(OsString::from(config.spec.resources.memory_mib.to_string()));
     match config.effective_metrics_interval() {
-        Some(ms) => {
-            args.push(OsString::from("--metrics-sample-interval-ms"));
-            args.push(OsString::from(ms.get().to_string()));
-        }
-        None => args.push(OsString::from("--disable-metrics-sample")),
+        Some(ms) => launch.metrics.sample_interval_ms = ms.get(),
+        None => launch.metrics.disabled = true,
     }
     if let Some(reservation) = metrics_reservation {
-        args.push(OsString::from("--metrics-shm-name"));
-        args.push(OsString::from(&reservation.shm_name));
-        args.push(OsString::from("--metrics-slot"));
-        args.push(OsString::from(reservation.slot.to_string()));
-        args.push(OsString::from("--metrics-generation"));
-        args.push(OsString::from(reservation.generation.to_string()));
+        launch.metrics.slot = Some(MetricsSlotHandoff {
+            shm_name: reservation.shm_name.clone(),
+            slot: reservation.slot,
+            generation: reservation.generation,
+        });
     }
 
     match &config.spec.image {
         RootfsSource::Bind(path) => {
-            args.push(OsString::from("--rootfs-path"));
-            args.push(path.as_os_str().to_os_string());
+            launch.rootfs.path = Some(path.clone());
         }
         RootfsSource::Oci(_) => {
             // Derive VMDK + upper paths from the stored manifest digest.
@@ -1136,20 +1161,14 @@ fn sandbox_cli_args(
                 let sandbox_dir = local.sandboxes_dir().join(&config.spec.name);
                 let upper_path = sandbox_dir.join("upper.ext4");
 
-                // VMDK (fsmeta + layers) as read-only block device.
-                args.push(OsString::from("--rootfs-disk"));
-                args.push(vmdk_path.as_os_str().to_os_string());
-                args.push(OsString::from("--rootfs-disk-format"));
-                args.push(OsString::from("vmdk"));
-
-                // upper.ext4 as writable block device.
-                args.push(OsString::from("--rootfs-blk"));
-                args.push(upper_path.as_os_str().to_os_string());
+                // VMDK (fsmeta + layers) read-only + upper.ext4 writable.
+                launch.rootfs.disk = Some(vmdk_path);
+                launch.rootfs.disk_format = Some("vmdk".to_string());
+                launch.rootfs.upper = Some(upper_path);
 
                 // MSB_BLOCK_ROOT: always 2 devices.
                 let block_root = "kind=oci-erofs,lower=/dev/vda,upper=/dev/vdb,upper_fstype=ext4";
-                args.push(OsString::from("--env"));
-                args.push(OsString::from(format!("{}={block_root}", ENV_BLOCK_ROOT)));
+                launch.env.push(format!("{}={block_root}", ENV_BLOCK_ROOT));
             }
         }
         RootfsSource::DiskImage {
@@ -1157,21 +1176,17 @@ fn sandbox_cli_args(
             format,
             fstype,
         } => {
-            args.push(OsString::from("--rootfs-disk"));
-            args.push(path.as_os_str().to_os_string());
-            args.push(OsString::from("--rootfs-disk-format"));
-            args.push(OsString::from(format.as_str()));
+            launch.rootfs.disk = Some(path.clone());
+            launch.rootfs.disk_format = Some(format.as_str().to_string());
 
             // Build MSB_BLOCK_ROOT env var value.
             let mut block_root_val = String::from("kind=disk-image,device=/dev/vda");
             if let Some(ft) = fstype {
                 block_root_val.push_str(&format!(",fstype={ft}"));
             }
-            args.push(OsString::from("--env"));
-            args.push(OsString::from(format!(
-                "{}={block_root_val}",
-                ENV_BLOCK_ROOT
-            )));
+            launch
+                .env
+                .push(format!("{}={block_root_val}", ENV_BLOCK_ROOT));
         }
     }
 
@@ -1193,7 +1208,7 @@ fn sandbox_cli_args(
             } => {
                 if let Some((file_mount_dir, filename, tag)) = staged_file_mounts.get(guest) {
                     push_file_mount_arg(
-                        &mut args,
+                        &mut launch.mounts,
                         tag,
                         file_mount_dir,
                         *options,
@@ -1203,7 +1218,7 @@ fn sandbox_cli_args(
                     push_file_mounts_spec(&mut file_mounts_val, tag, filename, guest, *options);
                 } else {
                     push_dir_mount_arg(
-                        &mut args,
+                        &mut launch.mounts,
                         guest,
                         &host.display(),
                         *options,
@@ -1223,7 +1238,7 @@ fn sandbox_cli_args(
             } => {
                 let vol_path = local.volume_path(name);
                 push_dir_mount_arg(
-                    &mut args,
+                    &mut launch.mounts,
                     guest,
                     &vol_path.display(),
                     *options,
@@ -1256,7 +1271,7 @@ fn sandbox_cli_args(
                 options,
             } => {
                 let id = guest_mount_tag(guest);
-                push_disk_mount_arg(&mut args, &id, &host.display(), format, *options);
+                push_disk_mount_arg(&mut launch.disks, &id, &host.display(), format, *options);
                 push_disk_mounts_spec(
                     &mut disk_mounts_val,
                     &id,
@@ -1269,75 +1284,59 @@ fn sandbox_cli_args(
     }
 
     if !tmpfs_val.is_empty() {
-        args.push(OsString::from("--env"));
-        args.push(OsString::from(format!("{}={tmpfs_val}", ENV_TMPFS)));
+        launch.env.push(format!("{}={tmpfs_val}", ENV_TMPFS));
     }
-
     if !dir_mounts_val.is_empty() {
-        args.push(OsString::from("--env"));
-        args.push(OsString::from(format!(
-            "{}={dir_mounts_val}",
-            ENV_DIR_MOUNTS
-        )));
+        launch
+            .env
+            .push(format!("{}={dir_mounts_val}", ENV_DIR_MOUNTS));
     }
-
     if !file_mounts_val.is_empty() {
-        args.push(OsString::from("--env"));
-        args.push(OsString::from(format!(
-            "{}={file_mounts_val}",
-            ENV_FILE_MOUNTS
-        )));
+        launch
+            .env
+            .push(format!("{}={file_mounts_val}", ENV_FILE_MOUNTS));
     }
-
     if !disk_mounts_val.is_empty() {
-        args.push(OsString::from("--env"));
-        args.push(OsString::from(format!(
-            "{}={disk_mounts_val}",
-            ENV_DISK_MOUNTS
-        )));
+        launch
+            .env
+            .push(format!("{}={disk_mounts_val}", ENV_DISK_MOUNTS));
     }
 
     if !config.spec.rlimits.is_empty() {
-        args.push(OsString::from("--env"));
-        args.push(OsString::from(format!(
+        launch.env.push(format!(
             "{}={}",
             microsandbox_protocol::ENV_RLIMITS,
             encode_rlimits(&config.spec.rlimits)
-        )));
+        ));
     }
 
-    // Network configuration.
+    // Network configuration travels as a typed value inside the JSON payload.
     #[cfg(feature = "net")]
     {
-        let network = config
-            .local_network_config()
-            .expect("sandbox network spec should decode to local network config");
-        let net_json = serde_json::to_string(&network).expect("failed to serialize network config");
-        args.push(OsString::from("--network-config"));
-        args.push(OsString::from(net_json));
-        args.push(OsString::from("--sandbox-slot"));
-        args.push(OsString::from(sandbox_id.to_string()));
+        launch.network = Some(
+            config
+                .local_network_config()
+                .expect("sandbox network spec should decode to local network config"),
+        );
+        launch.sandbox_slot = sandbox_id as u64;
     }
 
     for var in &config.spec.env {
-        args.push(OsString::from("--env"));
-        args.push(OsString::from(format!("{}={}", var.key, var.value)));
+        launch.env.push(format!("{}={}", var.key, var.value));
     }
 
     if let Some(ref user) = config.spec.runtime.user {
-        args.push(OsString::from("--env"));
-        args.push(OsString::from(format!("{}={user}", ENV_USER)));
+        launch.env.push(format!("{}={user}", ENV_USER));
     }
 
-    args.push(OsString::from("--env"));
-    args.push(OsString::from(format!(
+    launch.env.push(format!(
         "{}={}",
         ENV_SECURITY_PROFILE,
         match config.spec.security_profile {
             crate::sandbox::SecurityProfile::Default => "default",
             crate::sandbox::SecurityProfile::Restricted => "restricted",
         }
-    )));
+    ));
 
     // Hostname: explicit value or fall back to a sandbox-name-derived form
     // that fits within the Linux UTS limit.
@@ -1346,8 +1345,7 @@ fn sandbox_cli_args(
             Some(h) => h.to_string(),
             None => crate::sandbox::hostname_from_sandbox_name(&config.spec.name),
         };
-        args.push(OsString::from("--env"));
-        args.push(OsString::from(format!("{}={hostname}", ENV_HOSTNAME)));
+        launch.env.push(format!("{}={hostname}", ENV_HOSTNAME));
     }
 
     // Handoff-init: PID 1 hand-off to a user-supplied init binary.
@@ -1359,58 +1357,42 @@ fn sandbox_cli_args(
             .cmd
             .to_str()
             .expect("validate() rejects non-UTF-8 cmd paths");
-        args.push(OsString::from("--env"));
-        args.push(OsString::from(format!("{ENV_HANDOFF_INIT}={cmd}")));
+        launch.env.push(format!("{ENV_HANDOFF_INIT}={cmd}"));
 
         if !init.args.is_empty() {
             let argv_val = encode_handoff_json(&init.args);
-            args.push(OsString::from("--env"));
-            args.push(OsString::from(format!(
-                "{ENV_HANDOFF_INIT_ARGS}={argv_val}"
-            )));
+            launch
+                .env
+                .push(format!("{ENV_HANDOFF_INIT_ARGS}={argv_val}"));
         }
 
         if let Some(ref workdir) = config.spec.runtime.workdir {
-            args.push(OsString::from("--env"));
-            args.push(OsString::from(format!("{ENV_HANDOFF_INIT_CWD}={workdir}")));
+            launch.env.push(format!("{ENV_HANDOFF_INIT_CWD}={workdir}"));
         }
 
         if !init.env.is_empty() {
             let env_val = encode_handoff_json(&init.env);
-            args.push(OsString::from("--env"));
-            args.push(OsString::from(format!("{ENV_HANDOFF_INIT_ENV}={env_val}")));
+            launch.env.push(format!("{ENV_HANDOFF_INIT_ENV}={env_val}"));
         }
     }
 
-    if let Some(ref workdir) = config.spec.runtime.workdir {
-        args.push(OsString::from("--workdir"));
-        args.push(OsString::from(workdir));
-    }
-
-    args
+    (visible, launch)
 }
 
-fn push_startup_command_args(args: &mut Vec<OsString>, config: &SandboxConfig) {
-    let Some((cmd, cmd_args)) = resolve_startup_command(config) else {
-        return;
-    };
-
-    args.push(OsString::from(format!("--startup-cmd={cmd}")));
-    for arg in cmd_args {
-        args.push(OsString::from(format!("--startup-arg={arg}")));
-    }
-    for var in &config.spec.env {
-        args.push(OsString::from(format!(
-            "--startup-env={}={}",
-            var.key, var.value
-        )));
-    }
-    if let Some(workdir) = &config.spec.runtime.workdir {
-        args.push(OsString::from(format!("--startup-cwd={workdir}")));
-    }
-    if let Some(user) = &config.spec.runtime.user {
-        args.push(OsString::from(format!("--startup-user={user}")));
-    }
+fn startup_command(config: &SandboxConfig) -> Option<StartupCommand> {
+    let (cmd, cmd_args) = resolve_startup_command(config)?;
+    Some(StartupCommand {
+        cmd,
+        args: cmd_args,
+        env: config
+            .spec
+            .env
+            .iter()
+            .map(|var| format!("{}={}", var.key, var.value))
+            .collect(),
+        cwd: config.spec.runtime.workdir.clone(),
+        user: config.spec.runtime.user.clone(),
+    })
 }
 
 fn resolve_startup_command(config: &SandboxConfig) -> Option<(String, Vec<String>)> {
@@ -1462,6 +1444,8 @@ mod tests {
     use serde::de::DeserializeOwned;
     use tempfile::tempdir;
 
+    use microsandbox_runtime::launch::LaunchConfig;
+
     use super::sandbox_cli_args;
     use crate::{
         LogLevel,
@@ -1483,9 +1467,110 @@ mod tests {
         LocalBackend::lazy()
     }
 
+    /// Re-expand a [`LaunchConfig`] into the historical `--flag value` token
+    /// stream so the token-based assertions below keep working. Mirrors the
+    /// former producer output field-for-field.
+    fn flatten_launch(launch: &LaunchConfig) -> Vec<String> {
+        fn pair(out: &mut Vec<String>, flag: &str, val: String) {
+            out.push(flag.to_string());
+            out.push(val);
+        }
+        fn path(p: &Path) -> String {
+            p.to_string_lossy().into_owned()
+        }
+
+        let mut out: Vec<String> = Vec::new();
+        pair(&mut out, "--db-path", path(&launch.db_path));
+        pair(
+            &mut out,
+            "--db-connect-timeout-secs",
+            launch.db_connect_timeout_secs.to_string(),
+        );
+        pair(&mut out, "--log-dir", path(&launch.log_dir));
+        pair(&mut out, "--runtime-dir", path(&launch.runtime_dir));
+        pair(&mut out, "--sandboxes-dir", path(&launch.sandboxes_dir));
+        pair(&mut out, "--agent-sock", path(&launch.agent_sock));
+        if let Some(s) = &launch.startup {
+            out.push(format!("--startup-cmd={}", s.cmd));
+            for a in &s.args {
+                out.push(format!("--startup-arg={a}"));
+            }
+            for e in &s.env {
+                out.push(format!("--startup-env={e}"));
+            }
+            if let Some(c) = &s.cwd {
+                out.push(format!("--startup-cwd={c}"));
+            }
+            if let Some(u) = &s.user {
+                out.push(format!("--startup-user={u}"));
+            }
+        }
+        if let Some(d) = launch.lifecycle.max_duration_secs {
+            pair(&mut out, "--max-duration", d.to_string());
+        }
+        if let Some(i) = launch.lifecycle.idle_timeout_secs {
+            pair(&mut out, "--idle-timeout", i.to_string());
+        }
+        pair(&mut out, "--libkrunfw-path", path(&launch.libkrunfw_path));
+        if launch.metrics.disabled {
+            out.push("--disable-metrics-sample".to_string());
+        } else {
+            pair(
+                &mut out,
+                "--metrics-sample-interval-ms",
+                launch.metrics.sample_interval_ms.to_string(),
+            );
+        }
+        if let Some(slot) = &launch.metrics.slot {
+            pair(&mut out, "--metrics-shm-name", slot.shm_name.clone());
+            pair(&mut out, "--metrics-slot", slot.slot.to_string());
+            pair(
+                &mut out,
+                "--metrics-generation",
+                slot.generation.to_string(),
+            );
+        }
+        if let Some(p) = &launch.rootfs.path {
+            pair(&mut out, "--rootfs-path", path(p));
+        }
+        if let Some(d) = &launch.rootfs.disk {
+            pair(&mut out, "--rootfs-disk", path(d));
+        }
+        if let Some(f) = &launch.rootfs.disk_format {
+            pair(&mut out, "--rootfs-disk-format", f.clone());
+        }
+        if let Some(u) = &launch.rootfs.upper {
+            pair(&mut out, "--rootfs-blk", path(u));
+        }
+        for m in &launch.mounts {
+            pair(&mut out, "--mount", m.clone());
+        }
+        for d in &launch.disks {
+            pair(&mut out, "--disk", d.clone());
+        }
+        for e in &launch.env {
+            pair(&mut out, "--env", e.clone());
+        }
+        #[cfg(feature = "net")]
+        if let Some(net) = &launch.network {
+            pair(
+                &mut out,
+                "--network-config",
+                serde_json::to_string(net).unwrap(),
+            );
+            pair(&mut out, "--sandbox-slot", launch.sandbox_slot.to_string());
+        }
+        if let Some(w) = &launch.workdir {
+            pair(&mut out, "--workdir", path(w));
+        }
+        out
+    }
+
+    /// Render the full arg set (visible argv + the flattened config payload)
+    /// as strings. Tests assert on the union since both feed `msb sandbox`.
     fn render_args(config: &SandboxConfig) -> Vec<String> {
         let local = test_local_backend();
-        sandbox_cli_args(
+        let (visible, launch) = sandbox_cli_args(
             &local,
             config,
             42,
@@ -1499,10 +1584,36 @@ mod tests {
             None,
             None,
             None,
-        )
-        .iter()
-        .map(|arg| arg.to_string_lossy().into_owned())
-        .collect()
+        );
+        visible
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .chain(flatten_launch(&launch))
+            .collect()
+    }
+
+    /// Render only the `visible` argv (what shows up in `ps`).
+    fn render_visible_args(config: &SandboxConfig) -> Vec<String> {
+        let local = test_local_backend();
+        let (visible, _piped) = sandbox_cli_args(
+            &local,
+            config,
+            42,
+            Path::new("/tmp/msb.db"),
+            30,
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/agent.sock"),
+            Path::new("/tmp/libkrunfw.dylib"),
+            &HashMap::new(),
+            None,
+            None,
+            None,
+        );
+        visible
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
     }
 
     fn decode_handoff_json<T: DeserializeOwned>(value: &str) -> T {
@@ -1515,7 +1626,7 @@ mod tests {
         staged_file_mounts: &HashMap<String, (PathBuf, String, String)>,
     ) -> Vec<String> {
         let local = test_local_backend();
-        sandbox_cli_args(
+        let (visible, launch) = sandbox_cli_args(
             &local,
             config,
             42,
@@ -1529,10 +1640,12 @@ mod tests {
             None,
             None,
             None,
-        )
-        .iter()
-        .map(|arg| arg.to_string_lossy().into_owned())
-        .collect()
+        );
+        visible
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .chain(flatten_launch(&launch))
+            .collect()
     }
 
     #[tokio::test]
@@ -1593,7 +1706,7 @@ mod tests {
             .unwrap();
 
         let local = test_local_backend();
-        let args = sandbox_cli_args(
+        let (visible, _piped) = sandbox_cli_args(
             &local,
             &config,
             42,
@@ -1609,7 +1722,8 @@ mod tests {
             Some(microsandbox_runtime::vm::STARTUP_FD),
         );
 
-        assert!(args.windows(2).any(|pair| pair
+        // The startup fd is an operator-visible label, so it stays on argv.
+        assert!(visible.windows(2).any(|pair| pair
             == [
                 OsString::from("--startup-fd"),
                 OsString::from(microsandbox_runtime::vm::STARTUP_FD.to_string()),
@@ -1714,32 +1828,44 @@ mod tests {
             .await
             .unwrap();
 
-        let local = test_local_backend();
-        let args = sandbox_cli_args(
-            &local,
-            &config,
-            42,
-            Path::new("/tmp/msb.db"),
-            30,
-            Path::new("/tmp/logs"),
-            Path::new("/tmp/runtime"),
-            Path::new("/tmp/agent.sock"),
-            Path::new("/tmp/libkrunfw.dylib"),
-            &HashMap::new(),
-            None,
-            None,
-            None,
-        );
-
-        let rendered = args
-            .iter()
-            .map(|arg| arg.to_string_lossy().into_owned())
-            .collect::<Vec<_>>();
+        let rendered = render_args(&config);
 
         assert!(rendered.windows(2).any(|pair| {
             pair[0] == "--env"
                 && pair[1] == format!("{}=nofile=65535:65535", microsandbox_protocol::ENV_RLIMITS)
         }));
+    }
+
+    #[tokio::test]
+    async fn test_visible_args_keep_labels_and_omit_bulk() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .env("TOKEN", "secret")
+            .build()
+            .await
+            .unwrap();
+
+        let visible = render_visible_args(&config);
+        let all = render_args(&config);
+
+        // Operator-readable labels stay on argv.
+        assert_eq!(visible.first().map(String::as_str), Some("sandbox"));
+        assert!(visible.windows(2).any(|p| p == ["--name", "test"]));
+        assert!(visible.iter().any(|a| a == "--vcpus"));
+        assert!(visible.iter().any(|a| a == "--memory-mib"));
+
+        // Bulk / secret-bearing flags never appear on argv...
+        for flag in ["--env", "--db-path", "--log-dir", "--agent-sock"] {
+            assert!(
+                !visible.iter().any(|a| a == flag),
+                "visible argv unexpectedly contains {flag}"
+            );
+        }
+        assert!(!visible.iter().any(|a| a.contains("TOKEN=secret")));
+
+        // ...but are present in the full (piped) arg set.
+        assert!(all.iter().any(|a| a == "--db-path"));
+        assert!(all.iter().any(|a| a.contains("TOKEN=secret")));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #997

## TL;DR
The SDK spawned `msb sandbox` with its whole config on argv, so `ps` and logs were a wall of JSON and guest secrets sat in plain text in `/proc/<pid>/cmdline`. This keeps a few readable labels on argv and ships the rest as a typed `LaunchConfig` over an inherited fd.

## Description
- The big offenders were the inline `--network-config` JSON blob and one `--env` flag per variable, which also pushed against the ARG_MAX budget.
- Adds `LaunchConfig` in `microsandbox-runtime` as the shared, serializable contract between the SDK and `msb sandbox`. It lives in runtime because both the SDK and CLI crates already depend on it (the SDK can't see the CLI's `SandboxArgs`).
- `sandbox_cli_args` now returns `(visible argv, LaunchConfig)`. The visible argv keeps operator-readable labels (name, sandbox-id, vcpus, memory, log level, the fds); everything bulky, structured, or secret-bearing fills the `LaunchConfig`.
- `spawn_sandbox` serializes the `LaunchConfig` as JSON into an anonymous `tempfile()`, rewinds it, and `dup2`s it onto the new `CONFIG_FD` (96) in the existing `pre_exec` block, next to the parent-watch (97) and startup (98) fds. A temp file is used over a pipe (one-shot bulk read, not a stream) and over a named file (`tempfile()` unlinks on creation, so nothing to clean up or race on).
- `SandboxArgs` slims down to the labels plus `--config-fd` / `--config-file`. `run()` deserializes the `LaunchConfig` via `load_launch_config` and builds `vm::Config` from the labels plus the bulk. No clap re-parse of the bulk, so the args are no longer argv-shaped.
- `--config-file <path>` reads the same JSON for manual invocation, since the config is no longer on argv.
- This is the only path, no runtime toggle and no second serializer.

A spawned sandbox now shows up as just labels in `ps`:

```bash
msb sandbox --name web --sandbox-id 42 --vcpus 2 --memory-mib 1024 \
            --parent-watch-fd 97 --startup-fd 98 --config-fd 96
```

Manual invocation for debugging, where the file holds a JSON `LaunchConfig`:

```bash
echo '{"sandbox_db_path":"/var/lib/msb/msb.db","env":["TOKEN=secret"]}' > /tmp/web.json
msb sandbox --name web --sandbox-id 42 --config-file /tmp/web.json
```

## Test Plan
- [x] `cargo build -p microsandbox-cli -p microsandbox` exits 0
- [x] `cargo fmt --all -- --check` is clean
- [x] `cargo clippy --workspace --exclude microsandbox-agentd -- -D warnings` is clean
- [x] `cargo test -p microsandbox-runtime -p microsandbox-cli` passes (LaunchConfig round-trip via file and fd, bad-source negatives)
- [x] `cargo test -p microsandbox --lib spawn::` passes, including the visible-vs-bulk split test
- [x] Spawn a sandbox and confirm `ps` shows only the labels with `--config-fd 96`, no env or network JSON

