### PR TITLE
fix(deps): exact-pin internal crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,18 +61,21 @@ panic = "abort"
 # manifest; members reference them via `{ workspace = true }`.
 # `default-features = false` on crates whose consumers opt into features
 # explicitly (see each member manifest); other consumers re-enable defaults.
-microsandbox = { version = "0.5.8", path = "sdk/rust", default-features = false }
-microsandbox-agent-client = { version = "0.5.8", path = "packages/agent-client/rust" }
-microsandbox-db = { version = "0.5.8", path = "crates/db" }
-microsandbox-filesystem = { version = "0.5.8", path = "crates/filesystem", default-features = false }
-microsandbox-image = { version = "0.5.8", path = "crates/image" }
-microsandbox-metrics = { version = "0.5.8", path = "crates/metrics" }
-microsandbox-types = { version = "0.5.8", path = "packages/microsandbox-types/rust" }
-microsandbox-migration = { version = "0.5.8", path = "crates/migration" }
-microsandbox-network = { version = "0.5.8", path = "crates/network" }
-microsandbox-protocol = { version = "0.5.8", path = "crates/protocol" }
-microsandbox-runtime = { version = "0.5.8", path = "crates/runtime", default-features = false }
-microsandbox-utils = { version = "0.5.8", path = "crates/utils" }
+# Exact (`=`) pins: these crates share private, unstable APIs across patch
+# releases, so every published version must resolve its siblings to the same
+# version. Caret would let an older release pull newer siblings and break.
+microsandbox = { version = "=0.5.8", path = "sdk/rust", default-features = false }
+microsandbox-agent-client = { version = "=0.5.8", path = "packages/agent-client/rust" }
+microsandbox-db = { version = "=0.5.8", path = "crates/db" }
+microsandbox-filesystem = { version = "=0.5.8", path = "crates/filesystem", default-features = false }
+microsandbox-image = { version = "=0.5.8", path = "crates/image" }
+microsandbox-metrics = { version = "=0.5.8", path = "crates/metrics" }
+microsandbox-types = { version = "=0.5.8", path = "packages/microsandbox-types/rust" }
+microsandbox-migration = { version = "=0.5.8", path = "crates/migration" }
+microsandbox-network = { version = "=0.5.8", path = "crates/network" }
+microsandbox-protocol = { version = "=0.5.8", path = "crates/protocol" }
+microsandbox-runtime = { version = "=0.5.8", path = "crates/runtime", default-features = false }
+microsandbox-utils = { version = "=0.5.8", path = "crates/utils" }
 msb_krun = { version = "0.1.17" }
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }


### PR DESCRIPTION
## TL;DR
Pin the internal microsandbox-* crates to exact versions so an older published release stops resolving its sibling crates to a newer patch and breaking the build.

## Description
- Internal microsandbox-* deps were declared with caret requirements (version = "0.5.8" means >=0.5.8, <0.6.0), so building an older published release let Cargo pick newer-patch siblings.
- These crates share private APIs that change between patch releases, so the mismatch breaks. Depending on microsandbox 0.5.7 pulls microsandbox-protocol and microsandbox-utils 0.5.8.
- That produced unresolved imports for symbols removed in 0.5.8 (HANDOFF_INIT_SEP, HANDOFF_INIT_SEP_STR) and a runtime bundle download for v0.5.8 while building 0.5.7, since PREBUILT_VERSION is baked into the resolved utils crate.
- Pin every internal dependency in the workspace manifest to an exact "=X.Y.Z" so each published release resolves its siblings to the same version. External deps (msb_krun) and path-only test crates are unchanged.

```toml
microsandbox-protocol = { version = "=0.5.8", path = "crates/protocol" }
microsandbox-utils = { version = "=0.5.8", path = "crates/utils" }
```

## Test Plan
- [x] `cargo metadata --offline --format-version 1` resolves the graph with the exact pins
- [x] `cargo build --all` exits 0
- [x] `grep -c '= "=0.5.8"' Cargo.toml` shows every internal microsandbox-* dep pinned