### PR TITLE
docs(sdk): collapse method examples and refine reference tables

### DIFF
--- a/docs/sdk/go/agent-client.mdx
+++ b/docs/sdk/go/agent-client.mdx
@@ -53,13 +53,13 @@ import (
 
 ctx := context.Background()
 
-client, err := m.ConnectAgentSandbox(ctx, "dev")   // 1. connect
+client, err := m.ConnectAgentSandbox(ctx, "dev")             // 1. connect
 if err != nil {
     return err
 }
 defer client.Close()
 
-body, err := cbor.Marshal(map[string]any{          // 2. build a CBOR Message
+body, err := cbor.Marshal(map[string]any{                    // 2. build a CBOR Message
     "v": 1,
     "t": "core.fs.request",
     "p": fsRequestBytes,
@@ -149,7 +149,7 @@ Connect to a running sandbox by name. Resolves the sandbox's relay socket path a
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 client, err := m.ConnectAgentSandbox(ctx, "dev")
@@ -158,6 +158,8 @@ if err != nil {
 }
 defer client.Close()
 ```
+
+</Accordion>
 
 ---
 
@@ -196,7 +198,7 @@ Connect to an `agentd` relay socket by path. Use this when you already have the 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 path, err := m.AgentSocketPath("dev")
@@ -210,6 +212,8 @@ if err != nil {
 }
 defer client.Close()
 ```
+
+</Accordion>
 
 ---
 
@@ -244,7 +248,7 @@ Resolve a sandbox's `agentd` relay socket path **without connecting**. Returns t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 path, err := m.AgentSocketPath("dev")
@@ -253,6 +257,8 @@ if err != nil {
 }
 fmt.Println(path)
 ```
+
+</Accordion>
 
 ## AgentClient methods
 
@@ -297,7 +303,7 @@ Send one frame and await a single response frame. Use for request/response RPCs 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 frame, err := client.Request(ctx, m.FlagSessionStart, body)
@@ -310,6 +316,8 @@ if err := cbor.Unmarshal(frame.Body, &msg); err != nil {
     return err
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -352,7 +360,7 @@ Open a streaming session. The returned [`AgentStream`](#agentstream) carries the
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 stream, err := client.Stream(ctx, m.FlagSessionStart, body)
@@ -371,6 +379,8 @@ for {
     }
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -413,13 +423,15 @@ Send a follow-up frame on an existing correlation id (for example stdin, a signa
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 if err := client.Send(ctx, stream.ID(), 0, stdinBytes); err != nil {
     return err
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -445,7 +457,7 @@ Return the cached handshake `core.ready` frame body as CBOR bytes. Captured duri
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 ready, err := client.ReadyBytes()
@@ -458,6 +470,8 @@ if err := cbor.Unmarshal(ready, &msg); err != nil {
     return err
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -479,11 +493,13 @@ Release the client handle. Idempotent: calling it more than once is safe.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 defer client.Close()
 ```
+
+</Accordion>
 
 ---
 
@@ -514,13 +530,15 @@ Release the client handle with a caller-controlled context. Like [`Close()`](#c-
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 if err := client.CloseCtx(ctx); err != nil {
     return err
 }
 ```
+
+</Accordion>
 
 ## AgentStream methods
 
@@ -557,7 +575,7 @@ Pull the next frame from the stream. Returns `nil, nil` at EOF, so loop until th
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 for {
@@ -570,6 +588,8 @@ for {
     }
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -591,7 +611,7 @@ Return the protocol correlation id for this stream. Pass it to [`AgentClient.Sen
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 id := stream.ID()
@@ -599,6 +619,8 @@ if err := client.Send(ctx, id, 0, stdinBytes); err != nil {
     return err
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -629,11 +651,13 @@ Release the stream handle.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 defer stream.Close(ctx)
 ```
+
+</Accordion>
 
 ## Types
 

--- a/docs/sdk/go/execution.mdx
+++ b/docs/sdk/go/execution.mdx
@@ -121,7 +121,7 @@ Run a command in the sandbox and return its collected output. Blocks until the c
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 out, err := sb.Exec(ctx, "make", []string{"build"},
@@ -129,6 +129,8 @@ out, err := sb.Exec(ctx, "make", []string{"build"},
     m.WithExecEnv(map[string]string{"DEBUG": "1"}),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -167,7 +169,7 @@ Run `/bin/sh -c command` in the sandbox and collect its output. Blocks until the
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 out, err := sb.Shell(ctx, "echo $HOME && ls /tmp")
@@ -176,6 +178,8 @@ if err != nil {
 }
 fmt.Print(out.Stdout())
 ```
+
+</Accordion>
 
 ---
 
@@ -220,7 +224,7 @@ Start a streaming exec session and return an [`*ExecHandle`](#exechandle). The h
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 h, err := sb.ExecStream(ctx, "cat", nil, m.WithExecStdinPipe())
@@ -229,6 +233,8 @@ if err != nil {
 }
 defer h.Close()
 ```
+
+</Accordion>
 
 ---
 
@@ -267,7 +273,7 @@ Run `/bin/sh -c command` with streaming output. A convenience wrapper over [`Exe
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 h, err := sb.ShellStream(ctx, "tail -f /var/log/app.log")
@@ -289,6 +295,8 @@ for {
     }
 }
 ```
+
+</Accordion>
 
 ## ExecHandle methods
 
@@ -334,13 +342,15 @@ Return the stdin sink for this exec session. Single-take: returns `nil` if the s
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sink := h.TakeStdin()
 sink.Write([]byte("hello\n"))
 sink.Close()
 ```
+
+</Accordion>
 
 ---
 
@@ -371,7 +381,7 @@ Block until the next event arrives or the stream ends. Returns an event with `Ki
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 for {
@@ -393,6 +403,8 @@ for {
     }
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -423,7 +435,7 @@ Drain the stream, accumulate all output, and return it as an [`*ExecOutput`](#ex
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 out, err := h.Collect(ctx)
@@ -432,6 +444,8 @@ if err != nil {
 }
 fmt.Print(out.Stdout())
 ```
+
+</Accordion>
 
 ---
 
@@ -506,7 +520,7 @@ Send a Unix signal to the running process. Pass values from `syscall` (e.g. `int
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 import "syscall"
@@ -515,6 +529,8 @@ if err := h.Signal(ctx, int(syscall.SIGTERM)); err != nil {
     return err
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -527,11 +543,13 @@ func (h *ExecHandle) Close() error
 
 Release the Rust-side exec handle. Does not kill the running process; call [`Signal`](#h-signal) or [`Kill`](#h-kill) first if you need to terminate it. Safe to call after `ExecEventDone` has been received.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 defer h.Close()
 ```
+
+</Accordion>
 
 ## ExecOutput methods
 
@@ -690,7 +708,7 @@ Send data to the process stdin. Implements `io.Writer`. Uses `context.Background
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 h, err := sb.ExecStream(ctx, "cat", nil, m.WithExecStdinPipe())
@@ -706,6 +724,8 @@ sink.Close()
 out, _ := h.Collect(ctx)
 fmt.Print(out.Stdout()) // "hello\n"
 ```
+
+</Accordion>
 
 ---
 
@@ -751,11 +771,13 @@ func (sk *ExecSink) Close() error
 
 Close the stdin pipe, sending EOF to the process. Implements `io.Closer`.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sink.Close()
 ```
+
+</Accordion>
 
 ## Types
 
@@ -955,7 +977,7 @@ Set a per-command timeout. When exceeded, the guest terminates the process and t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 out, err := sb.Shell(ctx, "long-running-task",
@@ -964,6 +986,8 @@ if m.IsKind(err, m.ErrExecTimeout) {
     log.Println("timed out")
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -1016,7 +1040,7 @@ Add per-command environment variables. Called repeatedly, maps merge; later keys
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 out, err := sb.Exec(ctx, "make", []string{"build"},
@@ -1024,3 +1048,5 @@ out, err := sb.Exec(ctx, "make", []string{"build"},
     m.WithExecEnv(map[string]string{"DEBUG": "1"}),
 )
 ```
+
+</Accordion>

--- a/docs/sdk/go/filesystem.mdx
+++ b/docs/sdk/go/filesystem.mdx
@@ -41,14 +41,14 @@ Read and write files inside a running sandbox over the same host-guest channel a
 ```go
 import m "github.com/superradcompany/microsandbox/sdk/go"
 
-fs := sb.FS()                                              // 1. get the accessor
+fs := sb.FS()                                                     // 1. get the accessor
 
 err := fs.WriteString(ctx, "/tmp/config.json", `{"debug":true}`)  // 2. write
 if err != nil {
     return err
 }
 
-content, err := fs.ReadString(ctx, "/tmp/config.json")    // 3. read back
+content, err := fs.ReadString(ctx, "/tmp/config.json")            // 3. read back
 if err != nil {
     return err
 }
@@ -92,7 +92,7 @@ Read the entire contents of a file as raw bytes. The default FFI buffer is 1 MiB
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 data, err := fs.Read(ctx, "/etc/hostname")
@@ -101,6 +101,8 @@ if err != nil {
 }
 fmt.Printf("%d bytes\n", len(data))
 ```
+
+</Accordion>
 
 ---
 
@@ -135,11 +137,13 @@ Read a file and return its contents as a string. The bytes are reinterpreted as 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 content, err := fs.ReadString(ctx, "/tmp/config.json")
 ```
+
+</Accordion>
 
 ---
 
@@ -169,11 +173,13 @@ Write bytes to a file, creating it if it does not exist and truncating it if it 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := fs.Write(ctx, "/tmp/data.bin", []byte{0x00, 0x01, 0x02})
 ```
+
+</Accordion>
 
 ---
 
@@ -203,11 +209,13 @@ Write a UTF-8 string to a file. Convenience wrapper over [`Write`](#fs-write).
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := fs.WriteString(ctx, "/tmp/hello.txt", "hi")
 ```
+
+</Accordion>
 
 ---
 
@@ -242,7 +250,7 @@ List the entries in a directory inside the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 entries, err := fs.List(ctx, "/etc")
@@ -253,6 +261,8 @@ for _, e := range entries {
     fmt.Printf("%s (%s, %d bytes)\n", e.Path, e.Kind, e.Size)
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -287,7 +297,7 @@ Get detailed metadata for a file or directory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 st, err := fs.Stat(ctx, "/etc/hosts")
@@ -296,6 +306,8 @@ if err != nil {
 }
 fmt.Printf("%d bytes, dir=%v\n", st.Size, st.IsDir)
 ```
+
+</Accordion>
 
 ---
 
@@ -321,11 +333,13 @@ Create a directory and any missing parents inside the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := fs.Mkdir(ctx, "/app/cache/sessions")
 ```
+
+</Accordion>
 
 ---
 
@@ -351,11 +365,13 @@ Delete a single file. Use [`RemoveDir`](#fs-removedir) for directories.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := fs.Remove(ctx, "/tmp/scratch.txt")
 ```
+
+</Accordion>
 
 ---
 
@@ -381,11 +397,13 @@ Remove a directory recursively.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := fs.RemoveDir(ctx, "/app/cache")
 ```
+
+</Accordion>
 
 ---
 
@@ -415,11 +433,13 @@ Copy a file within the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := fs.Copy(ctx, "/etc/hosts", "/tmp/hosts.bak")
 ```
+
+</Accordion>
 
 ---
 
@@ -449,11 +469,13 @@ Rename or move a file or directory within the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := fs.Rename(ctx, "/tmp/old.log", "/tmp/archive/old.log")
 ```
+
+</Accordion>
 
 ---
 
@@ -488,7 +510,7 @@ Report whether a file or directory exists at the given path.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 ok, err := fs.Exists(ctx, "/app/.initialized")
@@ -499,6 +521,8 @@ if !ok {
     // first boot
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -528,11 +552,13 @@ Copy a file from the host machine into the sandbox. For transferring many files,
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := fs.CopyFromHost(ctx, "./seed.db", "/app/data/seed.db")
 ```
+
+</Accordion>
 
 ---
 
@@ -562,11 +588,13 @@ Copy a file from the sandbox to the host machine.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := fs.CopyToHost(ctx, "/app/output/report.csv", "./report.csv")
 ```
+
+</Accordion>
 
 ---
 
@@ -601,7 +629,7 @@ Open a streaming reader for a file. Use this for files too large to fit in memor
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 rs, err := fs.ReadStream(ctx, "/var/log/syslog")
@@ -624,6 +652,8 @@ for {
 // Or drain it as an io.WriterTo.
 _, err = rs.WriteTo(os.Stdout)
 ```
+
+</Accordion>
 
 ---
 
@@ -658,7 +688,7 @@ Open a streaming writer for a file. Use this for files too large to fit in memor
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 ws, err := fs.WriteStream(ctx, "/tmp/big.bin")
@@ -673,6 +703,8 @@ if err := ws.Close(ctx); err != nil {
     return err
 }
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/go/images.mdx
+++ b/docs/sdk/go/images.mdx
@@ -100,7 +100,7 @@ Fetch one cached image by reference. Returns `ErrImageNotFound` when no image wi
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 img, err := m.Image.Get(ctx, "python:3.12")
@@ -109,6 +109,8 @@ if err != nil {
 }
 fmt.Println(img.ManifestDigest())
 ```
+
+</Accordion>
 
 ---
 
@@ -143,7 +145,7 @@ Return every cached image, ordered by creation time (newest first).
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 images, err := m.Image.List(ctx)
@@ -154,6 +156,8 @@ for _, img := range images {
     fmt.Println(img.Reference(), img.LayerCount())
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -192,7 +196,7 @@ Return the full detail for a cached image: the [`ImageHandle`](#imagehandle) plu
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 detail, err := m.Image.Inspect(ctx, "python:3.12")
@@ -201,6 +205,8 @@ if err != nil {
 }
 fmt.Println(detail.Config.Entrypoint, len(detail.Layers), "layers")
 ```
+
+</Accordion>
 
 ---
 
@@ -239,13 +245,15 @@ Delete a cached image. When `force` is false, sandboxes that still reference the
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 if err := m.Image.Remove(ctx, "old:tag", false); err != nil {
     return err
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -280,7 +288,7 @@ Remove cached image data that is not used by any sandbox. Returns a report tally
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 report, err := m.Image.Prune(ctx)
@@ -289,6 +297,8 @@ if err != nil {
 }
 fmt.Println(report.LayersRemoved, "layers removed")
 ```
+
+</Accordion>
 
 ---
 
@@ -489,7 +499,7 @@ Delete this image. Equivalent to [`Image.Remove(ctx, h.Reference(), force)`](#im
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 img, err := m.Image.Get(ctx, "old:tag")
@@ -500,6 +510,8 @@ if err := img.Remove(ctx, false); err != nil {
     return err
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -534,7 +546,7 @@ Return the full detail for this image. Equivalent to [`Image.Inspect(ctx, h.Refe
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 img, err := m.Image.Get(ctx, "python:3.12")
@@ -547,6 +559,8 @@ if err != nil {
 }
 fmt.Println(detail.Config.WorkingDir)
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -99,7 +99,7 @@ Set the network configuration for the sandbox. Pass a preset from the [`NetworkP
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.CreateSandbox(ctx, "worker",
@@ -107,6 +107,8 @@ sb, err := m.CreateSandbox(ctx, "worker",
     m.WithNetwork(m.NetworkPolicy.PublicOnly()),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -137,7 +139,7 @@ Make TCP services running in the sandbox reachable on localhost ports on the hos
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.CreateSandbox(ctx, "api",
@@ -145,6 +147,8 @@ sb, err := m.CreateSandbox(ctx, "api",
     m.WithPorts(map[uint16]uint16{8080: 8080}),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -175,7 +179,7 @@ Make UDP services running in the sandbox reachable on localhost ports on the hos
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.CreateSandbox(ctx, "dns",
@@ -183,6 +187,8 @@ sb, err := m.CreateSandbox(ctx, "dns",
     m.WithPortsUDP(map[uint16]uint16{5353: 53}),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -213,7 +219,7 @@ Make services running in the sandbox reachable on explicit host addresses and po
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.CreateSandbox(ctx, "api",
@@ -224,6 +230,8 @@ sb, err := m.CreateSandbox(ctx, "api",
     ),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -251,11 +259,13 @@ Allow only public internet traffic; RFC-1918 private ranges are blocked. This is
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 m.WithNetwork(m.NetworkPolicy.PublicOnly())
 ```
+
+</Accordion>
 
 ---
 
@@ -277,11 +287,13 @@ Block all network access. No network interface is created; the guest is fully of
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 m.WithNetwork(m.NetworkPolicy.None())
 ```
+
+</Accordion>
 
 ---
 
@@ -303,11 +315,13 @@ Permit all network traffic, including private addresses and the host machine.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 m.WithNetwork(m.NetworkPolicy.AllowAll())
 ```
+
+</Accordion>
 
 ---
 
@@ -329,11 +343,13 @@ Allow public internet plus private/LAN egress; block loopback, link-local, and m
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 m.WithNetwork(m.NetworkPolicy.NonLocal())
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -98,20 +98,20 @@ Create and control a microVM sandbox: boot it from an image, run commands, strea
 ```go
 import m "github.com/superradcompany/microsandbox/sdk/go"
 
-sb, err := m.CreateSandbox(ctx, "api",   // 1. configure + boot
+sb, err := m.CreateSandbox(ctx, "api",              // 1. configure + boot
     m.WithImage("python"),
     m.WithMemory(1024),
 )
 if err != nil {
     return err
 }
-defer sb.Close()                         // 4. shut down
+defer sb.Close()                                    // 4. shut down
 
 out, err := sb.Exec(ctx, "python", []string{"-V"})  // 2. run
 if err != nil {
     return err
 }
-fmt.Println(out.Stdout())                // 3. read output
+fmt.Println(out.Stdout())                           // 3. read output
 ```
 
 ## Functions
@@ -157,7 +157,7 @@ Create and boot a new sandbox. Pulls the image if needed, boots the VM, starts t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.CreateSandbox(ctx, "api",
@@ -174,6 +174,8 @@ defer func() {
     _ = sb.Close()
 }()
 ```
+
+</Accordion>
 
 ---
 
@@ -204,7 +206,7 @@ Look up a sandbox by name and return a metadata handle without connecting to it.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 h, err := m.GetSandbox(ctx, "api")
@@ -213,6 +215,8 @@ if err != nil {
 }
 fmt.Println(h.Status())
 ```
+
+</Accordion>
 
 ---
 
@@ -234,7 +238,7 @@ Return metadata for every known sandbox (running, stopped, draining, crashed), o
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 handles, err := m.ListSandboxes(ctx)
@@ -245,6 +249,8 @@ for _, h := range handles {
     fmt.Printf("%s — %s\n", h.Name(), h.Status())
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -275,12 +281,14 @@ Return sandbox metadata narrowed by a [`SandboxFilter`](#sandboxfilter). Label s
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 filter := m.NewSandboxFilter().WithLabels(map[string]string{"user.id": "alice"})
 handles, err := m.ListSandboxesWith(ctx, filter)
 ```
+
+</Accordion>
 
 ---
 
@@ -331,11 +339,13 @@ Restart a previously stopped sandbox. The VM reboots using the persisted configu
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.StartSandbox(ctx, "api")
 ```
+
+</Accordion>
 
 ---
 
@@ -386,11 +396,13 @@ Delete a stopped sandbox and all its persisted state from disk. Fails if the san
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := m.RemoveSandbox(ctx, "api")
 ```
+
+</Accordion>
 
 ---
 
@@ -412,7 +424,7 @@ Return a point-in-time [`Metrics`](#metrics) snapshot for every running sandbox,
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 all, err := m.AllSandboxMetrics(ctx)
@@ -420,6 +432,8 @@ for name, metrics := range all {
     fmt.Printf("%s: %.1f%% CPU\n", name, metrics.CPUPercent)
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -445,13 +459,15 @@ Optional. Ensure msb + libkrunfw are present under `~/.microsandbox/`, downloadi
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 if err := m.EnsureInstalled(ctx); err != nil {
     log.Fatal(err)
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -559,11 +575,13 @@ Return a filesystem accessor for reading and writing files inside the running sa
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := sb.FS().Write(ctx, "/tmp/hello.txt", []byte("hi"))
 ```
+
+</Accordion>
 
 ---
 
@@ -585,11 +603,13 @@ Return an SSH accessor for opening a native in-process SSH client or preparing a
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 client, err := sb.SSH().OpenClient(ctx)
 ```
+
+</Accordion>
 
 ---
 
@@ -620,7 +640,7 @@ Read persisted output from the sandbox's `exec.log`. Backed by an on-disk file, 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 entries, err := sb.Logs(ctx, m.LogOptions{
@@ -630,6 +650,8 @@ for _, e := range entries {
     fmt.Printf("[%s] %s", e.Source, e.Text())
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -660,7 +682,7 @@ Start a streaming log subscription against a live sandbox. Pass `LogStreamOption
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 stream, err := sb.LogStream(ctx, m.LogStreamOptions{Follow: true})
@@ -676,6 +698,8 @@ for {
     fmt.Print(entry.Text())
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -697,13 +721,15 @@ Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 metrics, err := sb.Metrics(ctx)
 fmt.Printf("cpu %.1f%% · mem %d MiB\n",
     metrics.CPUPercent, metrics.MemoryBytes/(1<<20))
 ```
+
+</Accordion>
 
 ---
 
@@ -734,7 +760,7 @@ Start a streaming metrics subscription that delivers a [`Metrics`](#metrics) sna
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 stream, err := sb.MetricsStream(ctx, 500*time.Millisecond)
@@ -750,6 +776,8 @@ for {
     fmt.Printf("CPU: %.1f%%\n", metrics.CPUPercent)
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -824,11 +852,13 @@ Gracefully shut down the sandbox and wait until stopped state is observed. Lets 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := sb.Stop(ctx, m.WithStopTimeout(30*time.Second))
 ```
+
+</Accordion>
 
 ---
 
@@ -861,11 +891,13 @@ Force-terminate the sandbox with SIGKILL and wait until stopped state is observe
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := sb.Kill(ctx)
 ```
+
+</Accordion>
 
 ---
 
@@ -909,12 +941,14 @@ Block until the sandbox is observed in a terminal state, then return how it ende
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 result, err := sb.WaitUntilStopped(ctx)
 fmt.Printf("ended as %s\n", result.Status)
 ```
+
+</Accordion>
 
 ---
 
@@ -927,11 +961,13 @@ func (s *Sandbox) Detach(ctx context.Context) error
 
 Release the Rust-side handle **without** stopping the VM. Use on sandboxes created with [`WithDetached`](#withdetached) once the caller is done with the handle but the sandbox should keep running in the background. After `Detach`, the handle is invalid; a subsequent `Close` returns an error with `Kind == ErrInvalidHandle`. Reconnect later with [`GetSandbox`](#m-getsandbox).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := sb.Detach(ctx) // keeps running in the background
 ```
+
+</Accordion>
 
 ---
 
@@ -944,11 +980,13 @@ func (s *Sandbox) Close() error
 
 Release the Rust-side handle. Safe to call multiple times; the second call returns an error with `Kind == ErrInvalidHandle`. For a sandbox created with [`WithDetached`](#withdetached), `Close` stops the VM, use [`Detach`](#sb-detach) instead to leave it running.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 defer sb.Close()
 ```
+
+</Accordion>
 
 ---
 
@@ -1386,7 +1424,7 @@ Hand off PID 1 inside the guest to a custom init binary after agentd finishes bo
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.CreateSandbox(ctx, "worker",
@@ -1394,6 +1432,8 @@ sb, err := m.CreateSandbox(ctx, "worker",
     m.WithInit(m.Init.Auto()),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -1606,7 +1646,7 @@ Configure the network stack: preset, custom rules, DNS, and TLS interception. Bu
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.CreateSandbox(ctx, "api",
@@ -1614,6 +1654,8 @@ sb, err := m.CreateSandbox(ctx, "api",
     m.WithNetwork(m.NetworkPolicy.PublicOnly()),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -1655,7 +1697,7 @@ Append rootfs patches applied before the VM boots. Patches go into the writable 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.CreateSandbox(ctx, "api",
@@ -1666,6 +1708,8 @@ sb, err := m.CreateSandbox(ctx, "api",
     ),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -1687,7 +1731,7 @@ Add volume mount configurations keyed by guest path. Build values via the [`Moun
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.CreateSandbox(ctx, "api",
@@ -1698,6 +1742,8 @@ sb, err := m.CreateSandbox(ctx, "api",
     }),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -1962,11 +2008,13 @@ Use a known init at the start of the image ENTRYPOINT when present, preserving a
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 m.WithInit(m.Init.Auto())
 ```
+
+</Accordion>
 
 ---
 
@@ -1992,7 +2040,7 @@ Specify the init binary explicitly with optional argv and env. `cmd` must be an 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 m.WithInit(m.Init.Cmd(
@@ -2003,6 +2051,8 @@ m.WithInit(m.Init.Cmd(
     },
 ))
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/go/secrets.mdx
+++ b/docs/sdk/go/secrets.mdx
@@ -83,7 +83,7 @@ Append credential secrets to the sandbox. Each call appends, so multiple calls a
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.CreateSandbox(ctx, "worker",
@@ -96,6 +96,8 @@ sb, err := m.CreateSandbox(ctx, "worker",
     ),
 )
 ```
+
+</Accordion>
 
 ## Methods
 
@@ -138,7 +140,7 @@ Build a [`SecretEntry`](#secretentrystruct) that maps an environment variable to
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 m.Secret.Env("STRIPE_KEY", os.Getenv("STRIPE_KEY"),
@@ -149,6 +151,8 @@ m.Secret.Env("STRIPE_KEY", os.Getenv("STRIPE_KEY"),
     },
 )
 ```
+
+</Accordion>
 
 ## Types
 

--- a/docs/sdk/go/snapshots.mdx
+++ b/docs/sdk/go/snapshots.mdx
@@ -134,7 +134,7 @@ Create a snapshot from a stopped or crashed sandbox. Set exactly one of [`Snapsh
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 snap, err := m.Snapshot.Create(ctx, "baseline", m.SnapshotCreateOptions{
@@ -143,6 +143,8 @@ snap, err := m.Snapshot.Create(ctx, "baseline", m.SnapshotCreateOptions{
     RecordIntegrity: true,
 })
 ```
+
+</Accordion>
 
 ---
 
@@ -177,11 +179,13 @@ Open an existing artifact by bare name or filesystem path. This validates metada
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 snap, err := m.Snapshot.Open(ctx, "after-pip-install")
 ```
+
+</Accordion>
 
 ---
 
@@ -216,11 +220,13 @@ Look up a lightweight handle in the local index by name, digest, or path.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 h, err := m.Snapshot.Get(ctx, "after-pip-install")
 ```
+
+</Accordion>
 
 ---
 
@@ -242,7 +248,7 @@ List indexed snapshots from the local DB cache.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 handles, err := m.Snapshot.List(ctx)
@@ -250,6 +256,8 @@ for _, h := range handles {
     fmt.Println(h.Digest(), h.ImageRef())
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -312,11 +320,13 @@ Remove a snapshot artifact and its index row. Refuses to delete a snapshot with 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := m.Snapshot.Remove(ctx, "after-pip-install", false)
 ```
+
+</Accordion>
 
 ---
 
@@ -351,12 +361,14 @@ Walk `dir` and rebuild the local index from the artifacts it finds.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 n, err := m.Snapshot.Reindex(ctx, "/srv/snapshots")
 fmt.Printf("indexed %d snapshots\n", n)
 ```
+
+</Accordion>
 
 ---
 
@@ -390,13 +402,15 @@ Bundle a snapshot into a `.tar.zst` archive at `outPath`. Set [`SnapshotExportOp
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := m.Snapshot.Export(ctx, "after-pip-install", "/tmp/snap.tar.zst",
     m.SnapshotExportOptions{WithParents: true},
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -435,11 +449,13 @@ Unpack a snapshot archive into the snapshots directory or an explicit `dest` dir
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 h, err := m.Snapshot.Import(ctx, "/tmp/snap.tar.zst", "")
 ```
+
+</Accordion>
 
 ## SandboxHandle methods
 
@@ -489,11 +505,13 @@ Snapshot this sandbox under a bare name in the default snapshots directory. The 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 snap, err := h.Snapshot(ctx, "after-pip-install")
 ```
+
+</Accordion>
 
 ---
 
@@ -528,11 +546,13 @@ Snapshot this sandbox to an explicit artifact directory. The sandbox must be sto
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 snap, err := h.SnapshotTo(ctx, "/srv/snapshots/baseline")
 ```
+
+</Accordion>
 
 ## SnapshotArtifact methods
 
@@ -558,7 +578,7 @@ Recompute recorded content integrity for this snapshot. Requires that the artifa
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 report, err := snap.Verify(ctx)
@@ -567,6 +587,8 @@ if err != nil {
 }
 fmt.Println(report.Upper.Digest)
 ```
+
+</Accordion>
 
 ---
 
@@ -713,11 +735,13 @@ Open the underlying artifact metadata. Equivalent to [`Snapshot.Open`](#snapshot
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 snap, err := h.Open(ctx)
 ```
+
+</Accordion>
 
 ---
 
@@ -743,11 +767,13 @@ Remove this snapshot. Equivalent to [`Snapshot.Remove`](#snapshot-remove) on thi
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := h.Remove(ctx, false)
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/go/ssh.mdx
+++ b/docs/sdk/go/ssh.mdx
@@ -101,12 +101,14 @@ Return the SSH operations namespace for this sandbox. The namespace groups the c
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 ssh := sb.SSH()
 client, err := ssh.OpenClient(ctx)
 ```
+
+</Accordion>
 
 ---
 
@@ -145,7 +147,7 @@ Open a native in-process SSH client to this sandbox. Generates an ephemeral Ed25
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 client, err := sb.SSH().OpenClient(ctx,
@@ -157,6 +159,8 @@ if err != nil {
 }
 defer client.Close(ctx)
 ```
+
+</Accordion>
 
 ---
 
@@ -195,7 +199,7 @@ Prepare a reusable SSH server endpoint for this sandbox. Loads or creates the ho
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 srv, err := sb.SSH().PrepareServer(ctx,
@@ -206,6 +210,8 @@ if err != nil {
 }
 defer srv.Close(ctx)
 ```
+
+</Accordion>
 
 ---
 
@@ -248,7 +254,7 @@ Run an SSH exec request and collect stdout, stderr, and the exit status. The com
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 out, err := client.Exec(ctx, "python -V")
@@ -260,6 +266,8 @@ if !out.Success() {
 }
 fmt.Printf("%s", out.Stdout)
 ```
+
+</Accordion>
 
 ---
 
@@ -298,7 +306,7 @@ Bridge the local terminal to an interactive SSH shell. Requests a PTY sized to t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 code, err := client.Attach(ctx,
@@ -310,6 +318,8 @@ if err != nil {
 }
 fmt.Printf("shell exited with %d\n", code)
 ```
+
+</Accordion>
 
 ---
 
@@ -344,7 +354,7 @@ Open an SFTP session over this SSH connection. Returns a high-level SFTP client 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sftp, err := client.SFTP(ctx)
@@ -357,6 +367,8 @@ if err := sftp.Write(ctx, "/tmp/hello.txt", []byte("hi")); err != nil {
     return err
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -387,11 +399,13 @@ Close this SSH client session. The handle is consumed; do not use it after closi
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 defer client.Close(ctx)
 ```
+
+</Accordion>
 
 ---
 
@@ -422,7 +436,7 @@ Serve one SSH transport over this process's stdin and stdout. Returns when the c
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 srv, err := sb.SSH().PrepareServer(ctx)
@@ -435,6 +449,8 @@ if err := srv.ServeConnection(ctx); err != nil {
     return err
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -465,11 +481,13 @@ Release this prepared server endpoint. The handle is consumed; do not use it aft
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 defer srv.Close(ctx)
 ```
+
+</Accordion>
 
 ---
 
@@ -491,7 +509,7 @@ Report whether the command exited with status `0`.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 out, err := client.Exec(ctx, "test -f /etc/passwd")
@@ -500,6 +518,8 @@ if err != nil {
 }
 fmt.Println("present:", out.Success())
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/go/volumes.mdx
+++ b/docs/sdk/go/volumes.mdx
@@ -81,7 +81,7 @@ Create and manage named persistent volumes, read and write their data directly o
 ```go
 import m "github.com/superradcompany/microsandbox/sdk/go"
 
-vol, err := m.CreateVolume(ctx, "my-data",        // 1. create a named volume
+vol, err := m.CreateVolume(ctx, "my-data",         // 1. create a named volume
     m.WithVolumeQuota(64),
     m.WithVolumeLabels(map[string]string{"env": "prod"}),
 )
@@ -138,7 +138,7 @@ Create a named volume and return a populated [`*Volume`](#volume) with its name 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 vol, err := m.CreateVolume(ctx, "docker-data",
@@ -146,6 +146,8 @@ vol, err := m.CreateVolume(ctx, "docker-data",
     m.WithVolumeSize(20*1024),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -180,12 +182,14 @@ Look up a volume by name and return its metadata. Returns `ErrVolumeNotFound` if
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 h, err := m.GetVolume(ctx, "my-data")
 fmt.Println(h.Path(), h.UsedBytes())
 ```
+
+</Accordion>
 
 ---
 
@@ -216,7 +220,7 @@ Return metadata for every named volume on the host.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 vols, err := m.ListVolumes(ctx)
@@ -224,6 +228,8 @@ for _, h := range vols {
     fmt.Printf("%s — %s\n", h.Name(), h.Kind())
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -249,11 +255,13 @@ Delete a volume by name. All sandboxes referencing the volume must be stopped fi
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := m.RemoveVolume(ctx, "my-data")
 ```
+
+</Accordion>
 
 ## Volume methods
 
@@ -301,12 +309,14 @@ Return a [`*VolumeFs`](#volumefs) for direct host-side file operations on this v
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 vfs := vol.FS()
 err := vfs.WriteString("seed.txt", "hello")
 ```
+
+</Accordion>
 
 ---
 
@@ -319,11 +329,13 @@ func (v *Volume) Remove(ctx context.Context) error
 
 Delete this volume. All sandboxes using it must be stopped. Equivalent to [`RemoveVolume(ctx, v.Name())`](#removevolume).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 err := vol.Remove(ctx)
 ```
+
+</Accordion>
 
 ## VolumeHandle methods
 
@@ -741,11 +753,13 @@ Bind-mount a host directory into the sandbox. Changes in the guest are reflected
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 "/host": m.Mount.Bind("/var/data", m.MountOptions{Readonly: true})
 ```
+
+</Accordion>
 
 ---
 
@@ -771,11 +785,13 @@ Mount an existing named persistent volume. The volume must already exist (create
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 "/data": m.Mount.Named("my-data", m.MountOptions{})
 ```
+
+</Accordion>
 
 ---
 
@@ -805,7 +821,7 @@ Mount a named persistent volume with explicit sandbox-time existence behavior. [
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 sb, err := m.CreateSandbox(ctx, "worker",
@@ -822,6 +838,8 @@ sb, err := m.CreateSandbox(ctx, "worker",
     }),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -843,11 +861,13 @@ Mount an ephemeral in-memory filesystem. Contents are discarded when the sandbox
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 "/scratch": m.Mount.Tmpfs(m.TmpfsOptions{SizeMiB: 128})
 ```
+
+</Accordion>
 
 ---
 
@@ -873,7 +893,7 @@ Mount a host disk image as a virtio-blk device. Supports raw, qcow2, and vmdk fo
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```go
 "/img": m.Mount.Disk("./data.qcow2", m.DiskOptions{
@@ -882,6 +902,8 @@ Mount a host disk image as a virtio-blk device. Supports raw, qcow2, and vmdk fo
     Readonly: true,
 })
 ```
+
+</Accordion>
 
 ## Types
 

--- a/docs/sdk/python/agent-client.mdx
+++ b/docs/sdk/python/agent-client.mdx
@@ -41,7 +41,7 @@ All request and response bodies are raw CBOR bytes. The SDK handles framing and 
 ```python
 from microsandbox import AgentClient
 
-client = await AgentClient.connect_sandbox("dev")  # 1. connect
+client = await AgentClient.connect_sandbox("dev")   # 1. connect
 ready = client.ready_bytes()                        # 2. inspect handshake
 frame = await client.request(0, body)               # 3. raw request/response
 await client.close()                                # 4. close
@@ -91,11 +91,13 @@ Connect to a running sandbox by name. Sandbox names are limited to 128 UTF-8 byt
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 client = await AgentClient.connect_sandbox("dev", timeout=5.0)
 ```
+
+</Accordion>
 
 ---
 
@@ -131,12 +133,14 @@ Connect to an agent relay socket by path. Use this when you already know the soc
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 path = AgentClient.socket_path("dev")
 client = await AgentClient.connect(path)
 ```
+
+</Accordion>
 
 ---
 
@@ -168,11 +172,13 @@ Resolve a sandbox's `agentd` relay socket path **without connecting**. Returns t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 path = AgentClient.socket_path("dev")
 ```
+
+</Accordion>
 
 ---
 
@@ -211,12 +217,14 @@ Send one raw frame and wait for one response frame.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 frame = await client.request(0, body)
 print(frame["id"], frame["flags"])
 ```
+
+</Accordion>
 
 ---
 
@@ -251,7 +259,7 @@ Open a raw streaming session. The returned [`AgentStream`](#agentstream) carries
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 from microsandbox import FLAG_SESSION_START, FLAG_TERMINAL
@@ -261,6 +269,8 @@ async for frame in stream:
     if frame["flags"] & FLAG_TERMINAL:
         break
 ```
+
+</Accordion>
 
 ---
 
@@ -290,12 +300,14 @@ Send a follow-up frame on an existing correlation id. Use the `id` from the [`Ag
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 stream = await client.stream(FLAG_SESSION_START, body)
 await client.send(stream.id, 0, follow_up_body)
 ```
+
+</Accordion>
 
 ---
 
@@ -317,11 +329,13 @@ Return the cached handshake `core.ready` frame body as CBOR bytes.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 ready = client.ready_bytes()
 ```
+
+</Accordion>
 
 ---
 
@@ -334,11 +348,13 @@ async def close(self) -> None
 
 Close the client. Calling it more than once is safe.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await client.close()
 ```
+
+</Accordion>
 
 ---
 
@@ -381,7 +397,7 @@ An open raw agent stream. Carries the protocol correlation id and is both an asy
 | `async with` | [`AgentStream`](#agentstream) | Async context manager; closes the stream on exit |
 | `async for` | [`RawFrame`](#rawframe) | Async iterator over frames until terminal or EOF |
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 from microsandbox import FLAG_SESSION_START, FLAG_TERMINAL
@@ -391,3 +407,5 @@ async with await client.stream(FLAG_SESSION_START, body) as stream:
         if frame["flags"] & FLAG_TERMINAL:
             break
 ```
+
+</Accordion>

--- a/docs/sdk/python/execution.mdx
+++ b/docs/sdk/python/execution.mdx
@@ -131,7 +131,7 @@ Run a command inside the sandbox and wait for it to complete, buffering all stdo
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 out = await sandbox.exec(
@@ -144,6 +144,8 @@ out = await sandbox.exec(
 print(out.stdout_text)
 print(out.exit_code)  # 0
 ```
+
+</Accordion>
 
 ---
 
@@ -188,12 +190,14 @@ Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Sh
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 out = await sandbox.shell("ls -la /app && echo done")
 print(out.stdout_text)
 ```
+
+</Accordion>
 
 ---
 
@@ -247,7 +251,7 @@ Run a command with streaming output. Returns an [`ExecHandle`](#exechandle) that
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 import sys
@@ -259,6 +263,8 @@ async for event in handle:
     elif event.event_type == "exited":
         break
 ```
+
+</Accordion>
 
 ---
 
@@ -303,7 +309,7 @@ Streaming variant of [`shell()`](#sandbox-shell): runs `script` through the conf
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 import sys
@@ -313,6 +319,8 @@ async for event in handle:
     if event.event_type == "stdout":
         sys.stdout.buffer.write(event.data)
 ```
+
+</Accordion>
 
 ---
 
@@ -375,11 +383,13 @@ Bridge your terminal directly to a process inside the sandbox for a fully intera
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 code = await sandbox.attach("bash", cwd="/app", env={"EDITOR": "vim"})
 ```
+
+</Accordion>
 
 ---
 
@@ -401,11 +411,13 @@ Bridge your terminal to the sandbox's default shell in a fully interactive PTY s
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 code = await sandbox.attach_shell()
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/python/filesystem.mdx
+++ b/docs/sdk/python/filesystem.mdx
@@ -47,9 +47,9 @@ Read, write, and manage files inside a running sandbox. Operations go through th
 from microsandbox import Sandbox
 
 async with await Sandbox.create("api", image="python") as sb:
-    fs = sb.fs                                   # 1. grab the handle
+    fs = sb.fs                                     # 1. grab the handle
 
-    await fs.mkdir("/app")                        # 2. set up
+    await fs.mkdir("/app")                         # 2. set up
     await fs.write("/app/config.json", b'{"ok": true}')
 
     data = await fs.read_text("/app/config.json")  # 3. read it back
@@ -89,12 +89,14 @@ Read the entire contents of a file as raw bytes.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 raw = await sb.fs.read("/app/data.bin")
 print(len(raw))
 ```
+
+</Accordion>
 
 ---
 
@@ -125,11 +127,13 @@ Read the entire contents of a file and decode it as UTF-8.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 config = await sb.fs.read_text("/app/config.json")
 ```
+
+</Accordion>
 
 ---
 
@@ -160,13 +164,15 @@ Open a streaming reader for a file. Use this for files too large to hold in memo
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 stream = await sb.fs.read_stream("/app/large.log")
 async for chunk in stream:
     process(chunk)
 ```
+
+</Accordion>
 
 ---
 
@@ -192,11 +198,13 @@ Write content to a file, creating it if it doesn't exist and overwriting it if i
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.fs.write("/app/hello.txt", b"hi\n")
 ```
+
+</Accordion>
 
 ---
 
@@ -227,13 +235,15 @@ Open a streaming writer for a file. Use this for files too large to hold in memo
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 async with await sb.fs.write_stream("/app/out.bin") as sink:
     await sink.write(b"chunk one")
     await sink.write(b"chunk two")
 ```
+
+</Accordion>
 
 ---
 
@@ -264,12 +274,14 @@ List the entries in a directory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 for entry in await sb.fs.list("/app"):
     print(entry.kind, entry.path)
 ```
+
+</Accordion>
 
 ---
 
@@ -291,11 +303,13 @@ Create a directory, including any missing parent directories.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.fs.mkdir("/app/data/cache")
 ```
+
+</Accordion>
 
 ---
 
@@ -326,12 +340,14 @@ Get detailed metadata for a file or directory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 meta = await sb.fs.stat("/app/config.json")
 print(meta.kind, meta.size, meta.readonly)
 ```
+
+</Accordion>
 
 ---
 
@@ -362,12 +378,14 @@ Check whether a path exists inside the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 if not await sb.fs.exists("/app/config.json"):
     await sb.fs.write("/app/config.json", b"{}")
 ```
+
+</Accordion>
 
 ---
 
@@ -389,11 +407,13 @@ Remove a directory and its contents recursively.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.fs.remove_dir("/app/data/cache")
 ```
+
+</Accordion>
 
 ---
 
@@ -419,11 +439,13 @@ Copy a file within the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.fs.copy("/app/config.json", "/app/config.bak.json")
 ```
+
+</Accordion>
 
 ---
 
@@ -449,11 +471,13 @@ Rename or move a file or directory within the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.fs.rename("/app/tmp.txt", "/app/final.txt")
 ```
+
+</Accordion>
 
 ---
 
@@ -475,11 +499,13 @@ Remove a file. Use [`remove_dir()`](#fs-remove_dir) for directories.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.fs.remove("/app/config.bak.json")
 ```
+
+</Accordion>
 
 ---
 
@@ -505,11 +531,13 @@ Copy a file from the host machine into the sandbox. For transferring many files,
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.fs.copy_from_host("./local/seed.csv", "/app/seed.csv")
 ```
+
+</Accordion>
 
 ---
 
@@ -535,11 +563,13 @@ Copy a file from the sandbox out to the host machine.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.fs.copy_to_host("/app/report.pdf", "./report.pdf")
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/python/images.mdx
+++ b/docs/sdk/python/images.mdx
@@ -91,7 +91,7 @@ Create an OCI image rootfs source. Use `upper_size_mib` to size the writable ove
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 sb = await Sandbox.create(
@@ -99,6 +99,8 @@ sb = await Sandbox.create(
     image=Image.oci("python:3.12", upper_size_mib=8192),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -130,11 +132,13 @@ Create a rootfs source that binds a host directory as the guest root filesystem.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 sb = await Sandbox.create("api", image=Image.bind("/srv/rootfs"))
 ```
+
+</Accordion>
 
 ---
 
@@ -170,7 +174,7 @@ Create a rootfs source backed by a disk image. The format is inferred from the f
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 sb = await Sandbox.create(
@@ -178,6 +182,8 @@ sb = await Sandbox.create(
     image=Image.disk("/data/root.qcow2", fstype="ext4"),
 )
 ```
+
+</Accordion>
 
 ## Cache management
 
@@ -213,12 +219,14 @@ Fetch one cached image by reference. Raises [`ImageNotFoundError`](#errors) when
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 handle = await Image.get("python:3.12")
 print(handle.reference, handle.layer_count)
 ```
+
+</Accordion>
 
 ---
 
@@ -241,12 +249,14 @@ Return every cached image.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 for image in await Image.list():
     print(image.reference, image.size_bytes)
 ```
+
+</Accordion>
 
 ---
 
@@ -278,7 +288,7 @@ Return handle metadata plus the parsed OCI config and per-layer detail.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 detail = await Image.inspect("python:3.12")
@@ -286,6 +296,8 @@ print(detail.handle.reference)
 for layer in detail.layers:
     print(layer.position, layer.diff_id)
 ```
+
+</Accordion>
 
 ---
 
@@ -312,11 +324,13 @@ Delete a cached image. When `force` is `False`, an image still referenced by one
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await Image.remove("python:3.12", force=True)
 ```
+
+</Accordion>
 
 ---
 
@@ -339,12 +353,14 @@ Remove cached image data that is not used by any sandbox or indexed snapshot. Th
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 report = await Image.prune()
 print(f"{report.layers_removed} layers, {report.bytes_reclaimed} bytes")
 ```
+
+</Accordion>
 
 ## Types
 

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -65,7 +65,7 @@ from microsandbox import (
     Sandbox,
 )
 
-policy = NetworkPolicy(                            # 1. compose a policy
+policy = NetworkPolicy(                             # 1. compose a policy
     default_egress=Action.DENY,
     rules=(
         *Rule.allow_dns(),
@@ -114,11 +114,13 @@ Deny all traffic. No network interface is created; the guest is fully offline. `
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 sb = await Sandbox.create("offline", image="python", network=Network.none())
 ```
+
+</Accordion>
 
 ---
 
@@ -244,13 +246,15 @@ Create a rule that permits matching traffic. All filters are keyword-only.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 from microsandbox import Destination, Protocol, Rule
 
 r = Rule.allow(protocol=Protocol.TCP, port=443, destination=Destination.domain("api.example.com"))
 ```
+
+</Accordion>
 
 ---
 
@@ -323,7 +327,7 @@ Returns the pair `(udp_rule, tcp_rule)` since this SDK's [`Rule`](#rule) shape c
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 from microsandbox import Action, DestGroup, Destination, NetworkPolicy, Protocol, Rule
@@ -340,6 +344,8 @@ policy = NetworkPolicy(
     ),
 )
 ```
+
+</Accordion>
 
 ## Destination factory
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -126,7 +126,7 @@ The returned `Sandbox` is an async context manager. Use `async with` to guarante
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 async with await Sandbox.create("my-sandbox", image="alpine") as sb:
@@ -134,6 +134,8 @@ async with await Sandbox.create("my-sandbox", image="alpine") as sb:
     print(output.stdout_text)
 # sandbox is automatically killed and removed on exit
 ```
+
+</Accordion>
 
 ---
 
@@ -169,7 +171,7 @@ Same parameters as [`create()`](#sandbox-create) but returns a [`PullSession`](#
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 session = Sandbox.create_with_progress("my-sandbox", image="ubuntu:latest")
@@ -178,6 +180,8 @@ async with session:
         print(event.event_type)
     sb = await session.result()
 ```
+
+</Accordion>
 
 ---
 
@@ -213,11 +217,13 @@ Restart a previously stopped sandbox. The VM reboots using the persisted configu
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 sb = await Sandbox.start("api")
 ```
+
+</Accordion>
 
 ---
 
@@ -249,12 +255,14 @@ Get a handle to an existing sandbox (running or stopped). The handle provides st
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 handle = await Sandbox.get("api")
 print(handle.status)
 ```
+
+</Accordion>
 
 ---
 
@@ -277,12 +285,14 @@ List all sandboxes (running, stopped, and crashed).
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 for h in await Sandbox.list():
     print(h.name, h.status)
 ```
+
+</Accordion>
 
 ---
 
@@ -314,11 +324,13 @@ List sandboxes filtered by label. Only sandboxes whose labels match every suppli
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 workers = await Sandbox.list_with(labels={"role": "worker"})
 ```
+
+</Accordion>
 
 ---
 
@@ -341,11 +353,13 @@ Delete a stopped sandbox and all its state from disk (configuration, logs, runti
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await Sandbox.remove("api")
 ```
+
+</Accordion>
 
 ---
 
@@ -371,11 +385,13 @@ The sandbox name. This is an async method; call `await sb.name()`.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 print(await sb.name())
 ```
+
+</Accordion>
 
 ---
 
@@ -419,11 +435,13 @@ Get a filesystem handle for reading and writing files inside the running sandbox
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.fs.write("/tmp/hello.txt", b"hi")
 ```
+
+</Accordion>
 
 ---
 
@@ -489,11 +507,13 @@ Bridge your terminal directly to a process inside the sandbox for a fully intera
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 code = await sb.attach("python", ["-i"])
 ```
+
+</Accordion>
 
 ---
 
@@ -515,11 +535,13 @@ Attach your terminal to the sandbox's default shell for an interactive session.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.attach_shell()
 ```
+
+</Accordion>
 
 ---
 
@@ -541,12 +563,14 @@ Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 m = await sb.metrics()
 print(f"cpu {m.cpu_percent:.1f}% · mem {m.memory_bytes // 1_048_576} MiB")
 ```
+
+</Accordion>
 
 ---
 
@@ -577,13 +601,15 @@ Stream resource metrics at a regular interval. The returned [`MetricsStream`](#m
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 stream = await sb.metrics_stream(1.0)
 async for snapshot in stream:
     print(f"{snapshot.cpu_percent:.1f}%")
 ```
+
+</Accordion>
 
 ---
 
@@ -634,7 +660,7 @@ The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pas
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 import time
@@ -655,6 +681,8 @@ recent = await handle.logs(
     sources=["stdout", "stderr", "output", "system"],
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -708,13 +736,15 @@ Stream captured log entries as a [`LogStream`](#logstream). With `follow=True` t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 stream = await sb.log_stream(follow=True)
 async for entry in stream:
     print(entry.text().rstrip())
 ```
+
+</Accordion>
 
 ---
 
@@ -736,11 +766,13 @@ Gracefully shut down the sandbox and wait until stopped state is observed. Lets 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.stop()
 ```
+
+</Accordion>
 
 ---
 
@@ -753,11 +785,13 @@ async def request_stop(self) -> None
 
 Request graceful shutdown and return once the request is sent, without waiting for stopped state. Pair with [`wait_until_stopped()`](#sb-wait_until_stopped) when the caller needs to observe the terminal state.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.request_stop()
 ```
+
+</Accordion>
 
 ---
 
@@ -779,11 +813,13 @@ Force-terminate the sandbox and wait until stopped state is observed. No gracefu
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.kill()  # SIGKILL, no graceful shutdown
 ```
+
+</Accordion>
 
 ---
 
@@ -796,11 +832,13 @@ async def request_kill(self) -> None
 
 Request force termination and return once the signal is sent, without waiting for stopped state.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.request_kill()
 ```
+
+</Accordion>
 
 ---
 
@@ -813,11 +851,13 @@ async def request_drain(self) -> None
 
 Request a graceful drain and return once the request is sent. Existing commands run to completion, but new `exec` calls are rejected; the sandbox transitions to stopped when all in-flight commands finish. Useful for zero-downtime rotation of worker sandboxes. Use [`wait_until_stopped()`](#sb-wait_until_stopped) when the caller needs stopped-state observation.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await sb.request_drain()
 ```
+
+</Accordion>
 
 ---
 
@@ -839,12 +879,14 @@ Block until the sandbox is observed in a terminal non-running state, without tri
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 result = await sb.wait_until_stopped()
 print(result.status, result.exit_code)
 ```
+
+</Accordion>
 
 ---
 
@@ -857,12 +899,14 @@ async def detach(self) -> None
 
 Release the handle without stopping the sandbox. The sandbox continues running as a background process. Reconnect later with [`Sandbox.get()`](#sandbox-get).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 sb = await Sandbox.create("worker", image="python", detached=True)
 await sb.detach()  # keeps running in the background
 ```
+
+</Accordion>
 
 ---
 
@@ -903,7 +947,7 @@ Write UTF-8 text content at `path`.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 from microsandbox import Patch, Sandbox
@@ -914,6 +958,8 @@ sb = await Sandbox.create(
     patches=[Patch.text("/etc/app.conf", "debug=1\n", mode=0o644)],
 )
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/python/secrets.mdx
+++ b/docs/sdk/python/secrets.mdx
@@ -117,7 +117,7 @@ Create a secret entry that maps an environment variable to a real value. The gue
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 from microsandbox import Secret, SecretInjection
@@ -129,6 +129,8 @@ secret = Secret.env(
     injection=SecretInjection(query_params=True),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -243,7 +245,7 @@ Forward the placeholder unchanged to matching hosts instead of blocking. Passthr
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 from microsandbox import Secret, ViolationPolicy
@@ -258,6 +260,8 @@ secret = Secret.env(
     ),
 )
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/python/snapshots.mdx
+++ b/docs/sdk/python/snapshots.mdx
@@ -89,13 +89,15 @@ Snapshot this sandbox under a bare name in the default snapshots directory (`~/.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 handle = await Sandbox.get("baseline")
 snap = await handle.snapshot("after-pip-install")
 print(snap.digest)
 ```
+
+</Accordion>
 
 ---
 
@@ -126,12 +128,14 @@ Snapshot this sandbox to an explicit filesystem path. The sandbox must be stoppe
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 handle = await Sandbox.get("baseline")
 snap = await handle.snapshot_to("/data/snapshots/baseline")
 ```
+
+</Accordion>
 
 ---
 
@@ -191,7 +195,7 @@ Create a snapshot from a stopped or crashed sandbox. Exactly one of `name=` (res
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 snap = await Snapshot.create(
@@ -201,6 +205,8 @@ snap = await Snapshot.create(
     record_integrity=True,
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -240,7 +246,7 @@ Boot a fresh sandbox from a snapshot artifact by passing `snapshot=` as a peer o
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 # Boot from a snapshot
@@ -249,6 +255,8 @@ sb = await Sandbox.create("worker", snapshot="after-pip-install")
 # Or from an image (existing flow, unchanged)
 sb = await Sandbox.create("worker", image="python:3.12")
 ```
+
+</Accordion>
 
 ---
 
@@ -284,12 +292,14 @@ Open an existing artifact by bare name (resolved under the default snapshots dir
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 snap = await Snapshot.open("after-pip-install")
 print(snap.image_ref)
 ```
+
+</Accordion>
 
 ---
 
@@ -321,12 +331,14 @@ Look up a handle in the local index by name, digest, or path.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 h = await Snapshot.get("after-pip-install")
 print(h.digest)
 ```
+
+</Accordion>
 
 ---
 
@@ -349,12 +361,14 @@ List indexed snapshots from the local DB cache.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 for h in await Snapshot.list():
     print(h.name, h.digest)
 ```
+
+</Accordion>
 
 ---
 
@@ -386,12 +400,14 @@ Walk a directory and parse each subdirectory's manifest. Does not touch the inde
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 for snap in await Snapshot.list_dir("/mnt/artifacts"):
     print(snap.path, snap.digest)
 ```
+
+</Accordion>
 
 ---
 
@@ -418,11 +434,13 @@ Remove a snapshot artifact and its index row. Refuses if the snapshot has indexe
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await Snapshot.remove("after-pip-install", force=True)
 ```
+
+</Accordion>
 
 ---
 
@@ -454,12 +472,14 @@ Walk `dir` (default: configured snapshots dir) and rebuild the local index. Retu
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 count = await Snapshot.reindex()
 print(f"indexed {count} snapshots")
 ```
+
+</Accordion>
 
 ---
 
@@ -505,7 +525,7 @@ Bundle a snapshot into a `.tar.zst` archive. The existing snapshot manifest is a
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await Snapshot.export(
@@ -514,6 +534,8 @@ await Snapshot.export(
     with_parents=True,
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -557,12 +579,14 @@ Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, v
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 h = await Snapshot.import_("/tmp/after-pip-install.tar.zst")
 print(h.path)
 ```
+
+</Accordion>
 
 ---
 
@@ -588,7 +612,7 @@ Recompute the upper layer's content hash and compare against the manifest. Walks
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 report = await snap.verify()
@@ -597,6 +621,8 @@ if report["upper"]["kind"] == "verified":
 else:
     print("no integrity hash recorded")
 ```
+
+</Accordion>
 
 The report shape:
 
@@ -629,13 +655,15 @@ Load the full [`Snapshot`](#snapshot) metadata for this handle. Metadata-validat
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 h = await Snapshot.get("after-pip-install")
 snap = await h.open()
 print(snap.fstype)
 ```
+
+</Accordion>
 
 ---
 
@@ -657,12 +685,14 @@ Remove this snapshot artifact and its index row. Refuses if the snapshot has ind
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 h = await Snapshot.get("after-pip-install")
 await h.remove(force=False)
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/python/ssh.mdx
+++ b/docs/sdk/python/ssh.mdx
@@ -55,7 +55,7 @@ Reach a running sandbox over SSH: open a native in-process SSH client, run exec 
 from microsandbox import Sandbox
 
 async with await Sandbox.create("api", image="python") as sb:
-    client = await sb.ssh().open_client()      # 1. open an SSH client
+    client = await sb.ssh().open_client()       # 1. open an SSH client
     out = await client.exec("python -V")        # 2. run a command
     print(out.stdout_text)
 
@@ -84,11 +84,13 @@ Return the SSH namespace for this sandbox. The namespace holds the SSH client an
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 client = await sb.ssh().open_client()
 ```
+
+</Accordion>
 
 ## SandboxSshOps
 
@@ -136,12 +138,14 @@ Connect a native in-process SSH client to this sandbox. Generates an ephemeral c
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 client = await sb.ssh().open_client(user="app", term="xterm-256color")
 out = await client.exec("uname -a")
 ```
+
+</Accordion>
 
 ---
 
@@ -190,7 +194,7 @@ Prepare a reusable SSH server endpoint for this sandbox. Loads or creates the ho
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 server = await sb.ssh().prepare_server(
@@ -200,6 +204,8 @@ server = await sb.ssh().prepare_server(
 )
 await server.serve_connection()
 ```
+
+</Accordion>
 
 ## SshClient
 
@@ -238,12 +244,14 @@ Run an SSH exec request and collect stdout, stderr, and the exit status. The com
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 out = await client.exec("echo hello")
 print(f"exit {out.status}: {out.stdout_text}")
 ```
+
+</Accordion>
 
 ---
 
@@ -282,12 +290,14 @@ Attach the local terminal to an interactive SSH shell. Requests a PTY sized to t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 code = await client.attach(term="xterm-256color", detach_keys="ctrl-p,ctrl-q")
 print(f"shell exited with {code}")
 ```
+
+</Accordion>
 
 ---
 
@@ -309,13 +319,15 @@ Open an SFTP client session over this SSH connection. Requests the `sftp` subsys
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 sftp = await client.sftp()
 await sftp.write("/tmp/hello.txt", b"hi")
 data = await sftp.read("/tmp/hello.txt")
 ```
+
+</Accordion>
 
 ---
 
@@ -328,11 +340,13 @@ async def close() -> None
 
 Close this native SSH client session. Sends a disconnect and aborts the internal server task.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await client.close()
 ```
+
+</Accordion>
 
 ## SshServer
 
@@ -349,12 +363,14 @@ async def serve_connection() -> None
 
 Serve one SSH transport over this process's stdin/stdout. Runs the SSH handshake and session loop to completion, returning when the connection closes. Use this to bridge an SSH connection over the parent process's standard streams.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 server = await sb.ssh().prepare_server()
 await server.serve_connection()
 ```
+
+</Accordion>
 
 ---
 
@@ -367,11 +383,13 @@ def close() -> None
 
 Release this prepared server endpoint. This method is synchronous.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 server.close()
 ```
+
+</Accordion>
 
 ## Types
 

--- a/docs/sdk/python/volumes.mdx
+++ b/docs/sdk/python/volumes.mdx
@@ -119,12 +119,14 @@ Create a new named volume. A `"dir"` volume is a host directory; a `"disk"` volu
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await Volume.create("pip-cache", quota_mib=2048)
 await Volume.create("docker-data", kind="disk", size_mib=20 * 1024)
 ```
+
+</Accordion>
 
 ---
 
@@ -155,12 +157,14 @@ Get a lightweight handle to an existing named volume, with its metadata and a ho
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 handle = await Volume.get("pip-cache")
 print(handle.kind, handle.used_bytes)
 ```
+
+</Accordion>
 
 ---
 
@@ -182,12 +186,14 @@ List all named volumes.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 for v in await Volume.list():
     print(v.name, v.used_bytes)
 ```
+
+</Accordion>
 
 ---
 
@@ -209,11 +215,13 @@ Delete a named volume and its contents. Fails if the volume is currently mounted
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 await Volume.remove("pip-cache")
 ```
+
+</Accordion>
 
 ---
 
@@ -273,7 +281,7 @@ Mount a host directory into the sandbox. Changes in the guest are reflected on t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 sb = await Sandbox.create(
@@ -282,6 +290,8 @@ sb = await Sandbox.create(
     volumes={"/src": Volume.bind("/home/me/project", readonly=True)},
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -335,7 +345,7 @@ Mount an existing named volume. The volume must already exist; create it first w
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 sb = await Sandbox.create(
@@ -347,6 +357,8 @@ sb = await Sandbox.create(
     },
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -400,7 +412,7 @@ Use an in-memory filesystem. Contents are discarded when the sandbox stops.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 sb = await Sandbox.create(
@@ -409,6 +421,8 @@ sb = await Sandbox.create(
     volumes={"/tmp/work": Volume.tmpfs(size_mib=256)},
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -472,7 +486,7 @@ Mount a host disk image as a virtio-blk device. `format` is the disk image forma
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 sb = await Sandbox.create(
@@ -481,6 +495,8 @@ sb = await Sandbox.create(
     volumes={"/var/lib/postgresql": Volume.disk("/data/pg.qcow2", fstype="ext4")},
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -545,12 +561,14 @@ Read the entire contents of a file as raw bytes.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 handle = await Volume.get("pip-cache")
 data = await handle.fs.read("index.json")
 ```
+
+</Accordion>
 
 ---
 
@@ -605,12 +623,14 @@ Write content to a file, creating it if it doesn't exist and overwriting if it d
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```python
 handle = await Volume.get("pip-cache")
 await handle.fs.write("seed.txt", b"hello")
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/rust/agent-client.mdx
+++ b/docs/sdk/rust/agent-client.mdx
@@ -133,13 +133,15 @@ Resolve a sandbox name to its agent relay socket path and connect, using the def
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::agent;
 
 let client = agent::connect_sandbox("dev").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -174,7 +176,7 @@ Like [`connect_sandbox`](#agentconnect_sandbox), but with an explicit handshake 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use std::time::Duration;
@@ -182,6 +184,8 @@ use microsandbox::agent;
 
 let client = agent::connect_sandbox_with_timeout("dev", Duration::from_secs(2)).await?;
 ```
+
+</Accordion>
 
 ## AgentClient: static methods
 
@@ -214,7 +218,7 @@ Connect to an arbitrary agent relay socket by path, using the default ten-second
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::agent::AgentClient;
@@ -222,6 +226,8 @@ use microsandbox::agent::AgentClient;
 let path = AgentClient::socket_path("dev")?;
 let client = AgentClient::connect(&path).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -380,7 +386,7 @@ Resolve a sandbox's relay socket path **without connecting**. Returns the same p
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::agent::AgentClient;
@@ -388,6 +394,8 @@ use microsandbox::agent::AgentClient;
 let path = AgentClient::socket_path("dev")?;
 println!("{}", path.display());
 ```
+
+</Accordion>
 
 ---
 
@@ -413,13 +421,15 @@ Check a message type against an explicit negotiated generation. The single place
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::{agent::AgentClient, protocol::message::MessageType};
 
 AgentClient::ensure_version_compat_for(MessageType::FsRequest, 2)?;
 ```
+
+</Accordion>
 
 ## AgentClient: instance methods
 
@@ -456,7 +466,7 @@ Send one typed protocol message and wait for one response frame with the same co
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::protocol::{
@@ -477,6 +487,8 @@ let response = client
     .await?;
 let fs_response: FsResponse = response.payload()?;
 ```
+
+</Accordion>
 
 ---
 
@@ -511,7 +523,7 @@ Open a typed streaming session. The returned id is the protocol correlation id. 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::protocol::{exec::ExecRequest, message::MessageType};
@@ -534,6 +546,8 @@ while let Some(msg) = rx.recv().await {
     println!("{:?}", msg.t);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -563,13 +577,15 @@ Send a typed follow-up message on an existing correlation id (the id returned by
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::protocol::{exec::ExecStdin, message::MessageType};
 
 client.send(id, MessageType::ExecStdin, &ExecStdin { data: b"input\n".to_vec() }).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -604,12 +620,14 @@ Allocate a correlation id, send one raw frame with `(flags, body)`, and wait for
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let frame = client.request_raw(flags, body).await?;
 println!("id={} flags={}", frame.id, frame.flags);
 ```
+
+</Accordion>
 
 ---
 
@@ -692,12 +710,14 @@ Return the decoded `core.ready` payload captured during the handshake (boot timi
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let ready = client.ready()?;
 println!("boot {} ns", ready.boot_time_ns);
 ```
+
+</Accordion>
 
 ---
 
@@ -828,7 +848,7 @@ Whether the connected sandbox is new enough to handle the given message type. Th
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::protocol::message::MessageType;
@@ -837,6 +857,8 @@ if client.supports(MessageType::FsRequest) {
     // safe to issue filesystem RPCs
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -858,13 +880,15 @@ Reject a message type the connected sandbox is too old to handle, against this c
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::protocol::message::MessageType;
 
 client.ensure_version_compat(MessageType::TcpConnect)?;
 ```
+
+</Accordion>
 
 ---
 
@@ -877,11 +901,13 @@ async fn close(self)
 
 Close the client by consuming it. Drops the writer and aborts the reader task; any in-flight requests resolve with [`AgentClientError::Closed`](#agentclienterror). Dropping the client has the same effect.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 client.close().await;
 ```
+
+</Accordion>
 
 ## AgentBridge
 
@@ -1134,7 +1160,7 @@ Pull the next frame from a stream. Returns `None` when the stream has ended (the
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let (id, handle) = bridge.stream_open(flags, body).await?;
@@ -1142,6 +1168,8 @@ while let Some(frame) = bridge.stream_next(handle).await? {
     // decode frame.body with your own CBOR tooling
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -1194,11 +1222,13 @@ async fn close(&self)
 
 Close the connection. Idempotent. After close, every operation except another close returns [`AgentClientError::Closed`](#agentclienterror).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 bridge.close().await;
 ```
+
+</Accordion>
 
 ## Types
 

--- a/docs/sdk/rust/execution.mdx
+++ b/docs/sdk/rust/execution.mdx
@@ -131,12 +131,14 @@ Run a command inside the sandbox and wait for it to complete. Collects all stdou
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let out = sb.exec("python", ["-V"]).await?;
 println!("{}", out.stdout()?);
 ```
+
+</Accordion>
 
 ---
 
@@ -175,7 +177,7 @@ Run a command with per-execution overrides and wait for completion. The closure 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use std::time::Duration;
@@ -187,6 +189,8 @@ let out = sb.exec_with("python", |e| e
     .timeout(Duration::from_secs(30)))
     .await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -217,12 +221,14 @@ Run a command through the sandbox's configured shell (default: `/bin/sh`, set vi
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let out = sb.shell("cat /etc/os-release | grep PRETTY_NAME").await?;
 println!("{}", out.stdout()?);
 ```
+
+</Accordion>
 
 ---
 
@@ -261,11 +267,13 @@ Run a shell command with per-execution overrides and wait for completion. The `-
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let out = sb.shell_with("env | sort", |e| e.env("STAGE", "build")).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -304,7 +312,7 @@ Run a command with streaming output. Returns an [`ExecHandle`](#exechandle) that
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::ExecEvent;
@@ -318,6 +326,8 @@ while let Some(event) = handle.recv().await {
     }
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -356,7 +366,7 @@ Streaming execution with per-execution overrides. Enable [`stdin_pipe()`](#stdin
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let mut handle = sb.exec_stream_with("python", |e| e.stdin_pipe().tty(true)).await?;
@@ -365,6 +375,8 @@ if let Some(stdin) = handle.take_stdin() {
     stdin.close().await?;
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -395,12 +407,14 @@ Like [`shell()`](#sb-shell), but returns a streaming [`ExecHandle`](#exechandle)
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let mut handle = sb.shell_stream("for i in 1 2 3; do echo $i; sleep 1; done").await?;
 let out = handle.collect().await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -439,11 +453,13 @@ Run a shell command with per-execution overrides and streaming I/O. As with [`sh
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let mut handle = sb.shell_stream_with("npm run build", |e| e.cwd("/app")).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -486,11 +502,13 @@ Bridge your terminal directly to a process inside the sandbox for a fully intera
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let exit_code = sb.attach("bash", ["-l"]).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -529,7 +547,7 @@ Interactive PTY attach with options. The closure receives an [`AttachOptionsBuil
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let exit_code = sb.attach_with("zsh", |a| a
@@ -537,6 +555,8 @@ let exit_code = sb.attach_with("zsh", |a| a
     .detach_keys("ctrl-p,ctrl-q"))
     .await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -558,11 +578,13 @@ Attach to the sandbox's default shell (configured via [`SandboxBuilder::shell()`
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let exit_code = sb.attach_shell().await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -803,13 +825,15 @@ Set a POSIX resource limit with soft equal to hard. Applied via `setrlimit()` be
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::sandbox::RlimitResource;
 
 let out = sb.exec_with("./worker", |e| e.rlimit(RlimitResource::Nofile, 1024)).await?;
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/rust/filesystem.mdx
+++ b/docs/sdk/rust/filesystem.mdx
@@ -102,12 +102,14 @@ Read an entire file from the guest filesystem into memory as raw bytes.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let bytes = sb.fs().read("/app/logo.png").await?;
 println!("{} bytes", bytes.len());
 ```
+
+</Accordion>
 
 ---
 
@@ -138,12 +140,14 @@ Read an entire file and decode it as UTF-8. Errors if the contents are not valid
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let text = sb.fs().read_to_string("/etc/hostname").await?;
 println!("{}", text.trim());
 ```
+
+</Accordion>
 
 ---
 
@@ -174,7 +178,7 @@ Open a streaming reader that yields chunks of file data as they arrive. Use this
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let mut stream = sb.fs().read_stream("/var/log/big.log").await?;
@@ -184,6 +188,8 @@ while let Some(chunk) = stream.recv().await? {
 }
 println!("read {total} bytes");
 ```
+
+</Accordion>
 
 ---
 
@@ -213,11 +219,13 @@ Write data to a file in the guest, creating it if it doesn't exist and truncatin
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.fs().write("/tmp/hello.txt", "hi there").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -248,7 +256,7 @@ Open a streaming writer for large files. Write chunks incrementally, then call [
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let sink = sb.fs().write_stream("/tmp/out.bin").await?;
@@ -256,6 +264,8 @@ sink.write(&[0u8; 4096]).await?;
 sink.write(&[1u8; 4096]).await?;
 sink.close().await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -290,13 +300,15 @@ List the immediate children of a directory (non-recursive). Each entry carries i
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 for entry in sb.fs().list("/app").await? {
     println!("{:?} {}", entry.kind, entry.path);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -318,11 +330,13 @@ Create a directory, including any missing parent directories.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.fs().mkdir("/app/data/cache").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -344,11 +358,13 @@ Remove a directory and everything under it, recursively. For a single file use [
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.fs().remove_dir("/app/data/cache").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -374,11 +390,13 @@ Delete a single file. Use [`remove_dir()`](#fs-remove_dir) for directories.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.fs().remove("/tmp/hello.txt").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -404,11 +422,13 @@ Copy a file from one path to another within the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.fs().copy("/app/config.json", "/app/config.bak.json").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -434,11 +454,13 @@ Rename or move a file or directory within the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.fs().rename("/tmp/draft.txt", "/tmp/final.txt").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -473,12 +495,14 @@ Get metadata for a file or directory: kind, size, mode, read-only flag, and time
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let meta = sb.fs().stat("/app/config.json").await?;
 println!("{} bytes, mode {:o}", meta.size, meta.mode);
 ```
+
+</Accordion>
 
 ---
 
@@ -513,12 +537,14 @@ Get metadata, choosing whether to follow a final symlink. With `follow_symlink =
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let link_meta = sb.fs().stat_with_follow("/app/current", false).await?;
 println!("{:?}", link_meta.kind);
 ```
+
+</Accordion>
 
 ---
 
@@ -548,7 +574,7 @@ Update metadata on a file or directory: mode, owner uid/gid, size, and access/mo
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::sandbox::FsSetAttrs;
@@ -558,6 +584,8 @@ sb.fs().set_stat("/app/run.sh", true, FsSetAttrs {
     ..Default::default()
 }).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -588,12 +616,14 @@ Read the target of a symbolic link, returning the literal target text. Local bac
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let target = sb.fs().read_link("/app/current").await?;
 println!("-> {target}");
 ```
+
+</Accordion>
 
 ---
 
@@ -619,11 +649,13 @@ Create a symbolic link at `link_path` that points to `target`. Local backend onl
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.fs().symlink("/app/releases/v2", "/app/current").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -654,13 +686,15 @@ Check whether a file or directory exists at the given path in the guest. Impleme
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 if sb.fs().exists("/app/config.json").await? {
     println!("config present");
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -690,11 +724,13 @@ Copy a file from the host machine into the sandbox, streaming it in chunks. For 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.fs().copy_from_host("./local/model.bin", "/app/model.bin").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -720,11 +756,13 @@ Copy a file from the sandbox to the host machine.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.fs().copy_to_host("/app/out/report.pdf", "./report.pdf").await?;
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -170,7 +170,7 @@ Start the fluent [`NetworkPolicyBuilder`](#networkpolicybuilder). The primary co
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::NetworkPolicy;
@@ -180,6 +180,8 @@ let policy = NetworkPolicy::builder()
     .egress(|e| e.tcp().port(443).allow_public().allow_private())
     .build()?;
 ```
+
+</Accordion>
 
 ---
 
@@ -242,11 +244,13 @@ fn allow_domain<S: AsRef<str>>(self, name: S) -> Result<NetworkPolicy, DomainNam
 
 Prepend a single allow-[`Domain`](#destination) egress rule. Single-name sugar over [`allow_domains()`](#policy-allow_domains).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let policy = NetworkPolicy::public_only().allow_domain("api.openai.com")?;
 ```
+
+</Accordion>
 
 ---
 
@@ -282,12 +286,14 @@ Prepend one allow-[`Domain`](#destination) egress rule per name.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let policy = NetworkPolicy::default()
     .allow_domains(["pypi.org", "files.pythonhosted.org"])?;
 ```
+
+</Accordion>
 
 ---
 
@@ -303,12 +309,14 @@ where
 
 Prepend one deny-[`Domain`](#destination) egress rule per name. Prepending lets the denies outrank catch-all allows.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let policy = NetworkPolicy::allow_all()
     .deny_domains(["evil.com", "tracker.example"])?;
 ```
+
+</Accordion>
 
 ---
 
@@ -360,12 +368,14 @@ where
 
 Prepend one deny-[`DomainSuffix`](#destination) egress rule per suffix.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let policy = NetworkPolicy::allow_all()
     .deny_domain_suffixes([".ads.example", ".doubleclick.net"])?;
 ```
+
+</Accordion>
 
 ---
 
@@ -450,7 +460,7 @@ where
 
 Sugar for [`rule()`](#rule) with direction pre-set to [`Egress`](#direction).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 NetworkPolicy::builder()
@@ -458,6 +468,8 @@ NetworkPolicy::builder()
     .egress(|e| e.tcp().port(443).allow_public())
     .build()?;
 ```
+
+</Accordion>
 
 ---
 
@@ -498,13 +510,15 @@ where
 
 Open a multi-rule batch closure. Direction must be set inside via [`.egress()`](#rb-egress), [`.ingress()`](#rb-ingress), or [`.any()`](#rb-any) before any rule-adder, otherwise [`build()`](#build) returns [`BuildError::DirectionNotSet`](#builderror).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 NetworkPolicy::builder()
     .rule(|r| r.egress().tcp().port(443).allow().domain("api.example.com"))
     .build()?;
 ```
+
+</Accordion>
 
 ---
 
@@ -798,7 +812,7 @@ where
 
 Add one allow-[`Domain`](#destination) rule per name, inheriting the closure's current direction / protocol / port state. Lazy-parse: invalid names surface as [`BuildError::InvalidDomain`](#builderror) from [`build()`](#build).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 NetworkPolicy::builder()
@@ -808,6 +822,8 @@ NetworkPolicy::builder()
         .deny_domain_suffixes([".ads.example", ".doubleclick.net"]))
     .build()?;
 ```
+
+</Accordion>
 
 ---
 
@@ -864,7 +880,7 @@ fn allow(&mut self) -> RuleDestinationBuilder<'_>
 
 Begin an explicit-destination rule with action [`Allow`](#action). The returned [`RuleDestinationBuilder`](#ruledestinationbuilder) requires exactly one destination call to commit; dropping it without one adds no rule.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 NetworkPolicy::builder()
@@ -872,6 +888,8 @@ NetworkPolicy::builder()
     .any(|a| a.deny().cidr("198.51.100.0/24"))
     .build()?;
 ```
+
+</Accordion>
 
 ---
 
@@ -996,11 +1014,13 @@ Set the network access policy. Pass a preset or a builder-constructed [`NetworkP
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 .network(|n| n.policy(NetworkPolicy::builder().default_deny().build()?))
 ```
+
+</Accordion>
 
 ---
 
@@ -1089,7 +1109,7 @@ fn dns(self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self
 
 Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox_network::dns::Nameserver;
@@ -1099,6 +1119,8 @@ use microsandbox_network::dns::Nameserver;
         .nameservers(["1.1.1.1".parse::<Nameserver>()?])
         .query_timeout_ms(3000)))
 ```
+
+</Accordion>
 
 ---
 
@@ -1218,7 +1240,7 @@ fn on_secret_violation(
 
 Set the sandbox-wide action taken when a secret placeholder is detected in traffic to a host not in the secret's allow list. See [`ViolationActionBuilder`](#violationactionbuilder).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 .network(|n| n.on_secret_violation(|v| v
@@ -1226,6 +1248,8 @@ Set the sandbox-wide action taken when a secret placeholder is detected in traff
     .passthrough_host("api.anthropic.com")
     .passthrough_host_pattern("*.example.com")))
 ```
+
+</Accordion>
 
 Passthrough hosts receive the placeholder unchanged. They do **not** receive real secret values.
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -73,16 +73,16 @@ Create and control a microVM sandbox: boot it from an image, run commands, strea
 ```rust
 use microsandbox::Sandbox;
 
-let sb = Sandbox::builder("api")   // 1. configure
+let sb = Sandbox::builder("api")             // 1. configure
     .image("python")
     .memory(1024)
-    .create()                      // 2. boot the microVM
+    .create()                                // 2. boot the microVM
     .await?;
 
 let out = sb.exec("python", ["-V"]).await?;  // 3. run
 println!("{}", out.stdout()?);
 
-sb.stop().await?;                  // 4. shut down
+sb.stop().await?;                            // 4. shut down
 ```
 
 ## Static methods
@@ -116,7 +116,7 @@ Create a builder for configuring a new sandbox. The builder lets you set the ima
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let sb = Sandbox::builder("api")
@@ -124,6 +124,8 @@ let sb = Sandbox::builder("api")
     .create()
     .await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -154,12 +156,14 @@ Get a handle to an existing sandbox (running or stopped). The handle provides st
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let handle = Sandbox::get("api").await?;
 println!("{:?}", handle.status());
 ```
+
+</Accordion>
 
 ---
 
@@ -181,13 +185,15 @@ List all sandboxes (running, stopped, and crashed).
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 for h in Sandbox::list().await? {
     println!("{} — {:?}", h.name(), h.status());
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -209,11 +215,13 @@ Delete a stopped sandbox and all its state from disk (configuration, logs, runti
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 Sandbox::remove("api").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -244,11 +252,13 @@ Restart a previously stopped sandbox. The VM reboots using the persisted configu
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let sb = Sandbox::start("api").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -303,11 +313,13 @@ Access the sandbox's full configuration.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 println!("{} MiB", sb.config().memory_mib);
 ```
+
+</Accordion>
 
 ---
 
@@ -320,11 +332,13 @@ async fn detach(self)
 
 Release the handle without stopping the sandbox. The sandbox continues running as a background process. Reconnect later with [`Sandbox::get()`](#sandboxget).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.detach().await; // keeps running in the background
 ```
+
+</Accordion>
 
 ---
 
@@ -337,11 +351,13 @@ async fn drain(&self) -> MicrosandboxResult<()>
 
 Start a graceful drain. Existing commands run to completion, but new `exec` calls are rejected. The sandbox transitions to `Stopped` when all in-flight commands finish. Useful for zero-downtime rotation of worker sandboxes.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.drain().await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -363,11 +379,13 @@ Get a filesystem handle for reading and writing files inside the running sandbox
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.fs().write("/tmp/hello.txt", "hi").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -380,11 +398,13 @@ async fn kill(&self) -> MicrosandboxResult<()>
 
 Force-terminate the sandbox immediately with SIGKILL. No graceful shutdown — use when the sandbox is unresponsive. Pending writes that the workload hasn't `fsync`'d may be lost, same durability semantics as a sudden power loss on a physical machine. Prefer [`stop()`](#sb-stop) for graceful shutdown that gives the workload a chance to flush.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.kill().await?; // SIGKILL, no graceful shutdown
 ```
+
+</Accordion>
 
 ---
 
@@ -406,12 +426,14 @@ Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let m = sb.metrics().await?;
 println!("cpu {:.1}% · mem {} MiB", m.cpu_percent, m.memory_bytes / 1_048_576);
 ```
+
+</Accordion>
 
 ---
 
@@ -442,7 +464,7 @@ Stream resource metrics at a regular interval. Returns an async stream that yiel
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use futures::StreamExt;
@@ -452,6 +474,8 @@ while let Some(snapshot) = stream.next().await {
     println!("{:.1}%", snapshot?.cpu_percent);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -484,7 +508,7 @@ The default sources are `Stdout`, `Stderr`, and `Output` (PTY-merged). Pass `Log
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::sandbox::{LogOptions, LogSource, Sandbox};
@@ -523,6 +547,8 @@ let recent = handle.logs(&LogOptions {
     ..Default::default()
 })?;
 ```
+
+</Accordion>
 
 ---
 
@@ -575,11 +601,13 @@ async fn remove_persisted(&self) -> MicrosandboxResult<()>
 
 Remove the sandbox and all its persisted state from disk.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.remove_persisted().await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -592,11 +620,13 @@ async fn stop(&self) -> MicrosandboxResult<()>
 
 Gracefully shut down the sandbox. Lets the sandbox finish writing any pending data to disk before it exits, so files written inside the sandbox aren't lost across a later restart. Waits up to ten seconds for a clean exit; if the sandbox is still running after that, it is force-killed.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 sb.stop().await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -618,12 +648,14 @@ Stop the sandbox and wait for the exit status.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let status = sb.stop_and_wait().await?;
 println!("exited: {}", status.success());
 ```
+
+</Accordion>
 
 ---
 
@@ -645,11 +677,13 @@ Block until the sandbox exits on its own (without triggering a stop). Returns th
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let status = sb.wait().await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -737,7 +771,7 @@ Boot the sandbox in detached mode. The sandbox survives after your process exits
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let sb = Sandbox::builder("worker")
@@ -746,6 +780,8 @@ let sb = Sandbox::builder("worker")
     .await?;
 sb.detach().await;
 ```
+
+</Accordion>
 
 ---
 
@@ -864,7 +900,7 @@ Hand off PID 1 inside the guest to `cmd` after agentd finishes its boot-time set
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let sb = Sandbox::builder("worker")
@@ -873,6 +909,8 @@ let sb = Sandbox::builder("worker")
     .create()
     .await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -902,7 +940,7 @@ Like [`init`](#init), but with a closure-builder for argv and env vars. Mirrors 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let sb = Sandbox::builder("worker")
@@ -913,6 +951,8 @@ let sb = Sandbox::builder("worker")
     .create()
     .await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -954,7 +994,7 @@ Configure an explicit rootfs source. Use this for OCI-only settings such as the 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::size::SizeExt;
@@ -964,6 +1004,8 @@ let sb = Sandbox::builder("worker")
     .create()
     .await?;
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/rust/secrets.mdx
+++ b/docs/sdk/rust/secrets.mdx
@@ -84,7 +84,7 @@ Start building a secret with defaults: no env var, no value, no allowed hosts, t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::sandbox::SecretBuilder;
@@ -95,6 +95,8 @@ let entry = SecretBuilder::new()
     .allow_host("api.stripe.com")
     .build();
 ```
+
+</Accordion>
 
 ---
 
@@ -184,7 +186,7 @@ Add an exact host allowed to receive the real secret value. The proxy checks the
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 .secret(|s| s
@@ -193,6 +195,8 @@ Add an exact host allowed to receive the real secret value. The proxy checks the
     .allow_host("api.stripe.com")
     .allow_host("files.stripe.com"))
 ```
+
+</Accordion>
 
 ---
 
@@ -259,7 +263,7 @@ Passthrough hosts do **not** receive the real secret value; substitution still o
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 .secret(|s| s
@@ -270,6 +274,8 @@ Passthrough hosts do **not** receive the real secret value; substitution still o
         .block_and_log()
         .passthrough_host("api.anthropic.com")))
 ```
+
+</Accordion>
 
 ---
 
@@ -438,7 +444,7 @@ Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let sb = Sandbox::builder("agent")
@@ -447,6 +453,8 @@ let sb = Sandbox::builder("agent")
     .create()
     .await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -468,7 +476,7 @@ Add a pre-built [`SecretEntry`](#secretentry) directly. This is the escape hatch
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::sandbox::SecretBuilder;
@@ -485,6 +493,8 @@ let sb = Sandbox::builder("billing")
     .create()
     .await?;
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/rust/snapshots.mdx
+++ b/docs/sdk/rust/snapshots.mdx
@@ -131,7 +131,7 @@ Start configuring a new snapshot of `source_sandbox`. The builder lets you set t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let snap = Snapshot::builder("api")
@@ -139,6 +139,8 @@ let snap = Snapshot::builder("api")
     .create()
     .await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -169,13 +171,15 @@ Create a snapshot artifact from a stopped sandbox. Writes `manifest.json` and th
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let snap = Snapshot::create(
     Snapshot::builder("api").name("baseline").build()?
 ).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -206,12 +210,14 @@ Open an existing artifact by path or bare name. Bare names (no path separator, n
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let snap = Snapshot::open("baseline").await?;
 println!("{}", snap.manifest().image.reference);
 ```
+
+</Accordion>
 
 ---
 
@@ -242,12 +248,14 @@ Look up a lightweight [`SnapshotHandle`](#snapshothandle) in the local index by 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let h = Snapshot::get("after-pip-install").await?;
 println!("{} from {}", h.digest(), h.image_ref());
 ```
+
+</Accordion>
 
 ---
 
@@ -269,13 +277,15 @@ List indexed snapshots from the local DB cache, newest first. External-path arti
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 for h in Snapshot::list().await? {
     println!("{:?} — {}", h.name(), h.digest());
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -306,12 +316,14 @@ Walk a directory and parse each subdirectory's manifest. Does not touch the inde
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let snaps = Snapshot::list_dir("/data/snapshots").await?;
 println!("{} artifacts", snaps.len());
 ```
+
+</Accordion>
 
 ---
 
@@ -337,11 +349,13 @@ Remove a snapshot artifact (by digest, name, or path) and its index row. Refuses
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 Snapshot::remove("after-pip-install", false).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -372,12 +386,14 @@ Rebuild the local index from the artifacts in `dir`. Upserts an index row for ev
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let n = Snapshot::reindex("/data/snapshots").await?;
 println!("indexed {n} snapshots");
 ```
+
+</Accordion>
 
 ---
 
@@ -407,7 +423,7 @@ Bundle a snapshot into a `.tar.zst` archive (or plain `.tar`) at `out`. The head
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::snapshot::ExportOpts;
@@ -419,6 +435,8 @@ Snapshot::export(
     ExportOpts { with_parents: true, with_image: true, ..Default::default() },
 ).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -453,7 +471,7 @@ Unpack a snapshot archive (`.tar.zst` or `.tar`, detected from magic bytes) into
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use std::path::Path;
@@ -461,6 +479,8 @@ use std::path::Path;
 let h = Snapshot::import(Path::new("/tmp/baseline.tar.zst"), None).await?;
 println!("imported {}", h.digest());
 ```
+
+</Accordion>
 
 ---
 
@@ -528,13 +548,15 @@ The parsed [`Manifest`](#manifest): schema, format, fstype, image reference, par
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let snap = Snapshot::open("baseline").await?;
 let m = snap.manifest();
 println!("{} @ {}", m.image.reference, m.image.manifest_digest);
 ```
+
+</Accordion>
 
 ---
 
@@ -576,7 +598,7 @@ Recompute the upper layer's content hash and compare it against the manifest. Wa
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::snapshot::UpperVerifyStatus;
@@ -587,6 +609,8 @@ match snap.verify().await?.upper {
     UpperVerifyStatus::NotRecorded => println!("no integrity hash recorded"),
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -711,13 +735,15 @@ Open the underlying artifact metadata, upgrading this lightweight handle to a fu
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let h = Snapshot::get("baseline").await?;
 let snap = h.open().await?;
 snap.verify().await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -739,12 +765,14 @@ Remove this snapshot. Delegates to [`Snapshot::remove(self.digest(), force)`](#s
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let h = Snapshot::get("baseline").await?;
 h.remove(false).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -772,7 +800,7 @@ fn from_snapshot(self, path_or_name: impl Into<String>) -> Self
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let sb = Sandbox::builder("api-restored")
@@ -780,6 +808,8 @@ let sb = Sandbox::builder("api-restored")
     .create()
     .await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -810,13 +840,15 @@ async fn snapshot(&self, name: &str) -> MicrosandboxResult<Snapshot>
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let h = Sandbox::get("api").await?;
 h.stop().await?;
 let snap = h.snapshot("baseline").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -847,13 +879,15 @@ async fn snapshot_to(&self, path: impl AsRef<Path>) -> MicrosandboxResult<Snapsh
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let h = Sandbox::get("api").await?;
 h.stop().await?;
 let snap = h.snapshot_to("/data/snapshots/baseline").await?;
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/rust/ssh.mdx
+++ b/docs/sdk/rust/ssh.mdx
@@ -84,7 +84,7 @@ let sb = Sandbox::builder("api")
     .create()
     .await?;
 
-let client = sb.ssh().connect().await?;     // 1. open an SSH client
+let client = sb.ssh().connect().await?;      // 1. open an SSH client
 let out = client.exec("python -V").await?;   // 2. run a command
 println!("{}", String::from_utf8_lossy(&out.stdout));
 
@@ -113,11 +113,13 @@ Return the SSH namespace for this sandbox. The namespace holds the SSH client an
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let client = sb.ssh().connect().await?;
 ```
+
+</Accordion>
 
 ## SandboxSsh
 
@@ -143,12 +145,14 @@ Connect a native in-process SSH client to this sandbox. Generates an ephemeral E
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let client = sb.ssh().connect().await?;
 let out = client.exec("uname -a").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -202,13 +206,15 @@ Connect a native in-process SSH client with custom options. The closure configur
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let client = sb.ssh().connect_with(|opts| opts
     .user("app")
     .term("xterm-256color")).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -262,13 +268,15 @@ Prepare a reusable SSH server endpoint for this sandbox. Loads or creates the ho
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let server = sb.ssh().server().await?;
 let (client_io, server_io) = tokio::io::duplex(64 * 1024);
 server.serve(server_io).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -322,7 +330,7 @@ Prepare a server endpoint with custom host-key, authorization, guest-user, or SF
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let server = sb.ssh().server_with(|opts| opts
@@ -330,6 +338,8 @@ let server = sb.ssh().server_with(|opts| opts
     .user("app")
     .sftp(false)).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -396,12 +406,14 @@ Run an SSH exec request and collect stdout, stderr, and the exit status. The com
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let out = client.exec("echo hello").await?;
 println!("exit {}: {}", out.status, String::from_utf8_lossy(&out.stdout));
 ```
+
+</Accordion>
 
 ---
 
@@ -440,11 +452,13 @@ Run an SSH exec request with options. The closure can request a PTY via [`tty`](
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let out = client.exec_with("top -bn1", |opts| opts.tty(true)).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -466,12 +480,14 @@ Attach the local terminal to an interactive SSH shell. Requests a PTY sized to t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let code = client.attach().await?;
 println!("shell exited with {code}");
 ```
+
+</Accordion>
 
 ---
 
@@ -505,13 +521,15 @@ Attach an interactive shell with custom terminal and detach-key options.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let code = client.attach_with(|opts| opts
     .term("xterm-256color")
     .detach_keys("ctrl-p,ctrl-q")).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -533,12 +551,14 @@ Open an SFTP client session over this SSH connection. Requests the `sftp` subsys
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let sftp = client.sftp().await?;
 let mut file = sftp.create("/tmp/hello.txt").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -551,11 +571,13 @@ async fn close(self) -> MicrosandboxResult<()>
 
 Close this native SSH client session. Sends a disconnect and aborts the internal server task. Consumes the client.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 client.close().await?;
 ```
+
+</Accordion>
 
 ## SshServer
 
@@ -583,13 +605,15 @@ Serve one SSH connection over an ordered duplex stream. Runs the SSH handshake a
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let server = sb.ssh().server().await?;
 let (client_io, server_io) = tokio::io::duplex(64 * 1024);
 tokio::spawn(async move { server.serve(server_io).await });
 ```
+
+</Accordion>
 
 ---
 
@@ -635,7 +659,7 @@ Create a stdio SSH transport stream backed by this process's stdin and stdout. I
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::SshStdioStream;
@@ -643,6 +667,8 @@ use microsandbox::SshStdioStream;
 let server = sb.ssh().server().await?;
 server.serve(SshStdioStream::new()).await?;
 ```
+
+</Accordion>
 
 ## Constants
 

--- a/docs/sdk/rust/volumes.mdx
+++ b/docs/sdk/rust/volumes.mdx
@@ -178,11 +178,13 @@ Create a builder for configuring a new named volume. Directory-backed volumes ar
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let vol = Volume::builder("pip-cache").create().await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -213,7 +215,7 @@ Provision a volume from a [`VolumeConfig`](#volumespec). Routes through the acti
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::volume::{VolumeConfig, VolumeKind};
@@ -227,6 +229,8 @@ let vol = Volume::create(VolumeConfig {
 })
 .await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -257,12 +261,14 @@ Get a handle to an existing named volume. Use the handle to access the volume's 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let h = Volume::get("pip-cache").await?;
 println!("{} — {} bytes used", h.name(), h.used_bytes());
 ```
+
+</Accordion>
 
 ---
 
@@ -284,13 +290,15 @@ List all named volumes, newest first.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 for h in Volume::list().await? {
     println!("{} — {:?}", h.name(), h.kind());
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -312,11 +320,13 @@ Delete a named volume and its contents from disk. Locally the database record is
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 Volume::remove("pip-cache").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -384,11 +394,13 @@ Get a filesystem handle for reading and writing the volume's files directly, wit
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 vol.fs().write("/seed.txt", "hello").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -410,11 +422,13 @@ The host-side directory where this volume's data is stored (local backend only).
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 println!("{}", vol.path()?.display());
 ```
+
+</Accordion>
 
 ---
 
@@ -622,12 +636,14 @@ Get a filesystem handle for reading and writing the volume's files directly, wit
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let h = Volume::get("pip-cache").await?;
 let names = h.fs().list("/").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -640,11 +656,13 @@ async fn remove(&self) -> MicrosandboxResult<()>
 
 Delete this volume and its contents. Locally the database record is removed first, then the directory.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 Volume::get("pip-cache").await?.remove().await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -901,11 +919,13 @@ Read an entire file into memory as raw bytes.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let data = vol.fs().read("/seed.txt").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -936,11 +956,13 @@ Read an entire file into memory as a UTF-8 string.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let text = vol.fs().read_to_string("/seed.txt").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -971,7 +993,7 @@ Open a file for streaming reads. Returns a [`VolumeFsReadStream`](#volumefsreads
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let mut stream = vol.fs().read_stream("/model.bin").await?;
@@ -979,6 +1001,8 @@ while let Some(chunk) = stream.recv().await? {
     // process chunk
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -1004,11 +1028,13 @@ Write data to a file, creating parent directories as needed. Overwrites if the f
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 vol.fs().write("/config/app.json", r#"{"ready":true}"#).await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -1039,13 +1065,15 @@ Open a file for streaming writes. Returns a [`VolumeFsWriteSink`](#volumefswrite
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let mut sink = vol.fs().write_stream("/upload.bin").await?;
 sink.write(&chunk).await?;
 sink.close().await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -1076,13 +1104,15 @@ List the immediate children of a directory (non-recursive). Each entry includes 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 for entry in vol.fs().list("/").await? {
     println!("{} ({} bytes)", entry.path, entry.size);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -1104,11 +1134,13 @@ Create a directory and any missing parents.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 vol.fs().mkdir("/data/incoming").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -1130,11 +1162,13 @@ Delete a single file. Use [`remove_dir()`](#fs-remove_dir) for directories.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 vol.fs().remove("/data/stale.tmp").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -1156,11 +1190,13 @@ Remove a directory and its contents recursively. Targeting the volume root is re
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 vol.fs().remove_dir("/data/incoming").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -1186,11 +1222,13 @@ Copy a file within the volume. Creates the destination's parent directories as n
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 vol.fs().copy("/seed.txt", "/backup/seed.txt").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -1216,11 +1254,13 @@ Rename or move a file or directory. Creates the destination's parent directories
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 vol.fs().rename("/tmp/out.txt", "/done/out.txt").await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -1251,12 +1291,14 @@ Get metadata for a file or directory: kind, size, permission bits, read-only fla
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let meta = vol.fs().stat("/seed.txt").await?;
 println!("{} bytes", meta.size);
 ```
+
+</Accordion>
 
 ---
 
@@ -1287,13 +1329,15 @@ Check whether a file or directory exists at the given path. Returns `false` rath
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 if !vol.fs().exists("/seed.txt").await? {
     vol.fs().write("/seed.txt", "hello").await?;
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -1343,7 +1387,7 @@ Set the disk volume's capacity. Required for disk volumes; rejected for director
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::size::SizeExt;
@@ -1354,6 +1398,8 @@ let vol = Volume::builder("docker-data")
     .create()
     .await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -1443,7 +1489,7 @@ Create the volume on the active backend. Equivalent to `Volume::create(self.buil
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 let vol = Volume::builder("pip-cache")
@@ -1452,6 +1498,8 @@ let vol = Volume::builder("pip-cache")
     .create()
     .await?;
 ```
+
+</Accordion>
 
 ---
 
@@ -1527,7 +1575,7 @@ Mount a named volume with explicit sandbox-time existence behavior, configured v
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```rust
 use microsandbox::size::SizeExt;
@@ -1541,6 +1589,8 @@ let sb = Sandbox::builder("worker")
     .create()
     .await?;
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/typescript/agent-client.mdx
+++ b/docs/sdk/typescript/agent-client.mdx
@@ -132,11 +132,13 @@ Connect to a running sandbox by name. Resolves the sandbox's relay socket path a
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const client = await AgentClient.connectSandbox("dev", { timeoutMs: 5000 });
 ```
+
+</Accordion>
 
 ---
 
@@ -171,12 +173,14 @@ Connect to an `agentd` relay socket by path. Use this when you already have the 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const path = AgentClient.socketPath("dev");
 const client = await AgentClient.connect(path);
 ```
+
+</Accordion>
 
 ---
 
@@ -207,11 +211,13 @@ Resolve a sandbox's `agentd` relay socket path **without connecting**. Returns t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const path = AgentClient.socketPath("dev");
 ```
+
+</Accordion>
 
 ## Instance methods
 
@@ -248,7 +254,7 @@ Send one frame and await a single response frame. Use for request/response RPCs 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 import { encode, decode } from "cbor-x";
@@ -258,6 +264,8 @@ const body = encode({ v: 1, t: "core.fs.request", p: encode({ op: { Stat: { path
 const frame = await client.request(FLAG_SESSION_START, body);
 console.log(decode(frame.body));
 ```
+
+</Accordion>
 
 ---
 
@@ -292,7 +300,7 @@ Open a streaming session. The returned [`AgentStream`](#agentstream) carries the
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 import { FLAG_SESSION_START, FLAG_TERMINAL } from "microsandbox";
@@ -302,6 +310,8 @@ for await (const frame of stream) {
   if ((frame.flags & FLAG_TERMINAL) !== 0) break;
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -331,11 +341,13 @@ Send a follow-up frame on an existing correlation id (for example stdin, a signa
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await client.send(stream.id, 0, encode({ v: 1, t: "core.pty.stdin", p: encode({ data: "ls\n" }) }));
 ```
+
+</Accordion>
 
 ---
 
@@ -357,13 +369,15 @@ Return the cached handshake `core.ready` frame body as CBOR bytes. Captured duri
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 import { decode } from "cbor-x";
 
 const ready = decode(client.readyBytes());
 ```
+
+</Accordion>
 
 ---
 
@@ -376,11 +390,13 @@ close(): Promise<void>
 
 Close the connection. Idempotent: calling it more than once is safe.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await client.close();
 ```
+
+</Accordion>
 
 ## Types
 

--- a/docs/sdk/typescript/execution.mdx
+++ b/docs/sdk/typescript/execution.mdx
@@ -121,13 +121,15 @@ Run a command inside the sandbox and wait for it to complete. Collects all stdou
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const result = await sandbox.exec("python3", ["-c", "print(1 + 1)"]);
 console.log(result.stdout()); // "2\n"
 console.log(result.code);     // 0
 ```
+
+</Accordion>
 
 ---
 
@@ -165,7 +167,7 @@ Run a command with per-execution overrides. Configure working directory, environ
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const out = await sandbox.execWith("python3", (e) =>
@@ -175,6 +177,8 @@ const out = await sandbox.execWith("python3", (e) =>
     .timeout(30_000),
 );
 ```
+
+</Accordion>
 
 ---
 
@@ -205,12 +209,14 @@ Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Sh
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const out = await sandbox.shell("ls -la /app && echo done");
 console.log(out.stdout());
 ```
+
+</Accordion>
 
 ---
 
@@ -232,11 +238,13 @@ Bridge your terminal to the sandbox's default shell in a fully interactive PTY s
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const code = await sandbox.attachShell();
 ```
+
+</Accordion>
 
 ---
 
@@ -275,7 +283,7 @@ Run a command with streaming output. Returns a handle that emits stdout, stderr,
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const handle = await sandbox.execStream("tail", ["-f", "/var/log/app.log"]);
@@ -284,6 +292,8 @@ for await (const event of handle) {
   if (event.kind === "exited") break;
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -321,7 +331,7 @@ Streaming variant of [`execWith()`](#sandbox-execwith): same configuration via [
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const handle = await sandbox.execStreamWith("python3", (e) =>
@@ -330,6 +340,8 @@ const handle = await sandbox.execStreamWith("python3", (e) =>
 const stdin = await handle.takeStdin();
 await stdin?.write("task-1\n");
 ```
+
+</Accordion>
 
 ---
 
@@ -360,7 +372,7 @@ Run a shell command with streaming output.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const handle = await sandbox.shellStream("for i in 1 2 3; do echo $i; sleep 1; done");
@@ -368,6 +380,8 @@ for await (const event of handle) {
   if (event.kind === "stdout") process.stdout.write(event.data);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -402,11 +416,13 @@ Bridge your terminal directly to a process inside the sandbox for a fully intera
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const code = await sandbox.attach("python3");
 ```
+
+</Accordion>
 
 ---
 
@@ -444,7 +460,7 @@ Interactive PTY attach with options for arguments, environment variables, workin
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const code = await sandbox.attachWith("bash", (a) =>
@@ -453,6 +469,8 @@ const code = await sandbox.attachWith("bash", (a) =>
     .detachKeys("ctrl-]"),
 );
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/typescript/filesystem.mdx
+++ b/docs/sdk/typescript/filesystem.mdx
@@ -44,11 +44,11 @@ Read and write files inside a running sandbox over the same host-guest channel a
 ```typescript
 const fs = sandbox.fs();
 
-await fs.write("/tmp/config.json", '{"debug": true}');   // write
+await fs.write("/tmp/config.json", '{"debug": true}');     // write
 const content = await fs.readToString("/tmp/config.json"); // read back
 console.log(content);
 
-for (const entry of await fs.list("/tmp")) {              // list
+for (const entry of await fs.list("/tmp")) {               // list
   console.log(entry.path);
 }
 ```
@@ -86,12 +86,14 @@ Read the entire contents of a file as raw bytes.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const bytes = await fs.read("/app/logo.png");
 console.log(`${bytes.byteLength} bytes`);
 ```
+
+</Accordion>
 
 ---
 
@@ -122,12 +124,14 @@ Read the entire contents of a file and decode it as UTF-8.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const text = await fs.readToString("/etc/hostname");
 console.log(text.trim());
 ```
+
+</Accordion>
 
 ---
 
@@ -153,11 +157,13 @@ Write content to a file, creating it if it doesn't exist and overwriting if it d
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await fs.write("/tmp/config.json", '{"debug": true}');
 ```
+
+</Accordion>
 
 ---
 
@@ -188,13 +194,15 @@ Open a streaming reader for a file. Data is transferred in chunks. Use this for 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 for await (const chunk of await fs.readStream("/var/log/syslog")) {
   process.stdout.write(chunk); // chunk is a Uint8Array
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -225,12 +233,14 @@ Open a streaming writer for a file. Use this for files too large to hold in memo
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await using sink = await fs.writeStream("/tmp/big.bin");
 await sink.write(new Uint8Array(1 << 20));
 ```
+
+</Accordion>
 
 ---
 
@@ -261,13 +271,15 @@ List the entries in a directory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 for (const entry of await fs.list("/app")) {
   console.log(`${entry.kind}\t${entry.path}`);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -289,11 +301,13 @@ Create a directory. Parent directories must already exist.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await fs.mkdir("/app/data");
 ```
+
+</Accordion>
 
 ---
 
@@ -315,11 +329,13 @@ Remove a directory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await fs.removeDir("/app/data");
 ```
+
+</Accordion>
 
 ---
 
@@ -341,11 +357,13 @@ Remove a file.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await fs.remove("/tmp/config.json");
 ```
+
+</Accordion>
 
 ---
 
@@ -376,12 +394,14 @@ Get detailed metadata for a file or directory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const meta = await fs.stat("/app/config.json");
 console.log(`${meta.size} bytes, mode ${meta.mode.toString(8)}`);
 ```
+
+</Accordion>
 
 ---
 
@@ -412,13 +432,15 @@ Check whether a path exists inside the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 if (await fs.exists("/app/config.json")) {
   console.log("config present");
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -444,11 +466,13 @@ Copy a file within the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await fs.copy("/app/config.json", "/app/config.bak.json");
 ```
+
+</Accordion>
 
 ---
 
@@ -474,11 +498,13 @@ Rename or move a file or directory within the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await fs.rename("/tmp/draft.txt", "/tmp/final.txt");
 ```
+
+</Accordion>
 
 ---
 
@@ -504,11 +530,13 @@ Copy a file from the host machine into the sandbox. For transferring many files,
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await fs.copyFromHost("./seed.db", "/app/data/seed.db");
 ```
+
+</Accordion>
 
 ---
 
@@ -534,11 +562,13 @@ Copy a file from the sandbox to the host machine.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await fs.copyToHost("/app/out/report.pdf", "./report.pdf");
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -137,7 +137,7 @@ Configure a sandbox's network stack: a first-match-wins egress/ingress policy, p
 ```typescript
 import { NetworkPolicy, Sandbox } from "microsandbox";
 
-const policy = NetworkPolicy.builder()          // 1. compose a policy
+const policy = NetworkPolicy.builder()           // 1. compose a policy
   .defaultDeny()
   .egress((e) => e.tcp().port(443).allowPublic())
   .rule((r) => r.any().deny((d) => d.ip("198.51.100.5")))
@@ -227,7 +227,7 @@ Start the fluent [`NetworkPolicyBuilder`](#networkpolicybuilder). Equivalent to 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 import { NetworkPolicy } from "microsandbox";
@@ -237,6 +237,8 @@ const policy = NetworkPolicy.builder()
   .egress((e) => e.tcp().port(443).allowPublic().allowPrivate())
   .build();
 ```
+
+</Accordion>
 
 ---
 
@@ -308,13 +310,15 @@ Allow rule with direction `egress`. Empty protocols and ports mean "any".
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 import { Rule, Destination } from "microsandbox";
 
 const r = Rule.allowEgress(Destination.domain("api.example.com"));
 ```
+
+</Accordion>
 
 ---
 
@@ -429,7 +433,7 @@ Allow plain DNS (UDP/53 and TCP/53) to the sandbox gateway, i.e. the in-process 
 
 DoT (TCP/853) is intentionally not included; add an explicit `Destination.group("host")` tcp/853 allow rule if needed (and pair with TLS interception).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 import { NetworkPolicy, Rule } from "microsandbox";
@@ -440,6 +444,8 @@ const policy: NetworkPolicy = {
   rules: [Rule.allowDns()],
 };
 ```
+
+</Accordion>
 
 ---
 
@@ -602,7 +608,7 @@ Set the policy. Accepts a [`NetworkPolicy`](#networkpolicy-2) literal or factory
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 import { NetworkPolicy, Sandbox } from "microsandbox";
@@ -612,6 +618,8 @@ const sb = await Sandbox.builder("api")
   .network((n) => n.policy(NetworkPolicy.publicOnly()))
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -737,11 +745,13 @@ Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 .network((n) => n.dns((d) => d.rebindProtection(true).queryTimeoutMs(2000)))
 ```
+
+</Accordion>
 
 ---
 
@@ -863,11 +873,13 @@ Override per-sandbox interface attributes (MAC, MTU, fixed IPv4 / IPv6 address).
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 .network((n) => n.interface((i) => i.mtu(1400).ipv4("172.16.0.2")))
 ```
+
+</Accordion>
 
 ---
 
@@ -909,7 +921,7 @@ Configure the action taken when a secret reaches a disallowed host. See [`Violat
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 .network((n) =>
@@ -918,6 +930,8 @@ Configure the action taken when a secret reaches a disallowed host. See [`Violat
   ),
 )
 ```
+
+</Accordion>
 
 Passthrough hosts receive placeholders unchanged. They do **not** receive real secret values.
 
@@ -1001,13 +1015,15 @@ Three-arg auto-placeholder shorthand. Auto-generates the placeholder as `$MSB_<e
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 .network((n) =>
   n.secretEnvSimple("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com"),
 )
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -126,13 +126,15 @@ Begin building a new sandbox. Configure it with chainable setters, then call `.c
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await using sandbox = await Sandbox.builder("api")
   .image("python")
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -163,12 +165,14 @@ Get a live handle to an existing sandbox (running or stopped). The handle provid
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const handle = await Sandbox.get("api");
 console.log(handle.status);
 ```
+
+</Accordion>
 
 ---
 
@@ -190,13 +194,15 @@ List all sandboxes (running, stopped, and crashed). Handles returned from `list(
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 for (const h of await Sandbox.list()) {
   console.log(`${h.name} — ${h.status}`);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -227,11 +233,13 @@ List sandboxes filtered to those carrying all of the given labels (AND-matched).
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const workers = await Sandbox.listWith({ labels: { role: "worker" } });
 ```
+
+</Accordion>
 
 ---
 
@@ -253,11 +261,13 @@ Delete a stopped sandbox and all its state from disk (configuration, logs, runti
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await Sandbox.remove("api");
 ```
+
+</Accordion>
 
 ---
 
@@ -288,11 +298,13 @@ Restart a previously stopped sandbox. The VM reboots using the persisted configu
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await using sandbox = await Sandbox.start("api");
 ```
+
+</Accordion>
 
 ---
 
@@ -323,11 +335,13 @@ Restart a stopped sandbox in detached mode. The sandbox survives after your proc
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const sandbox = await Sandbox.startDetached("worker");
 ```
+
+</Accordion>
 
 ---
 
@@ -357,12 +371,14 @@ Get the full configuration the sandbox was created with - image, cpus, memory, e
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const config = await sandbox.config();
 console.log(`${config.memoryMib} MiB`);
 ```
+
+</Accordion>
 
 ---
 
@@ -375,11 +391,13 @@ detach(): Promise<void>
 
 Release the handle without stopping the sandbox. The sandbox continues running as a background process. Reconnect later with [`Sandbox.get()`](#sandbox-get).
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sandbox.detach(); // keeps running in the background
 ```
+
+</Accordion>
 
 ---
 
@@ -401,11 +419,13 @@ Get a filesystem handle for reading and writing files inside the running sandbox
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sandbox.fs().writeFile("/tmp/hello.txt", "hi");
 ```
+
+</Accordion>
 
 ---
 
@@ -418,11 +438,13 @@ kill(): Promise<void>
 
 Force-terminate the sandbox and wait until stopped state is observed. No graceful shutdown - use when the sandbox is unresponsive. Pending writes that the workload hasn't `fsync`'d may be lost, same durability semantics as a sudden power loss on a physical machine. Prefer [`stop()`](#sandbox-stop) for graceful shutdown that gives the workload a chance to flush.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sandbox.kill(); // no graceful shutdown
 ```
+
+</Accordion>
 
 ---
 
@@ -444,11 +466,13 @@ Force-terminate the sandbox and wait up to `timeoutMs` for stopped-state observa
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sandbox.killWithTimeout(2000);
 ```
+
+</Accordion>
 
 ---
 
@@ -481,7 +505,7 @@ The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pas
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 import { Sandbox } from "microsandbox";
@@ -510,6 +534,8 @@ const recent = await handle.logs({
   sources: ["stdout", "stderr", "output", "system"],
 });
 ```
+
+</Accordion>
 
 ---
 
@@ -540,7 +566,7 @@ Stream captured output as it appears, with optional follow. Backed by the same o
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await using stream = await sandbox.logStream({ follow: true });
@@ -548,6 +574,8 @@ for await (const e of stream) {
   console.log(e.text().trimEnd());
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -569,12 +597,14 @@ Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const m = await sandbox.metrics();
 console.log(`cpu ${m.cpuPercent.toFixed(1)}% · mem ${Math.round(m.memoryBytes / 1048576)} MiB`);
 ```
+
+</Accordion>
 
 ---
 
@@ -605,7 +635,7 @@ Stream resource metrics at a regular interval. The returned [`MetricsStream`](#m
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await using stream = await sandbox.metricsStream(1000);
@@ -613,6 +643,8 @@ for await (const snapshot of stream) {
   console.log(`${snapshot.cpuPercent.toFixed(1)}%`);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -625,12 +657,14 @@ requestDrain(): Promise<void>
 
 Request a graceful drain and return once the request is sent. Existing commands run to completion, but new `exec` calls are rejected. The sandbox transitions to `stopped` when all in-flight commands finish. Use [`waitUntilStopped()`](#sandbox-waituntilstopped) when the caller needs stopped-state observation. Useful for zero-downtime rotation of worker sandboxes.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sandbox.requestDrain();
 await sandbox.waitUntilStopped();
 ```
+
+</Accordion>
 
 ---
 
@@ -643,11 +677,13 @@ requestKill(): Promise<void>
 
 Request force termination and return once the signal is sent, without waiting for the stopped state to be observed.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sandbox.requestKill();
 ```
+
+</Accordion>
 
 ---
 
@@ -660,11 +696,13 @@ requestStop(): Promise<void>
 
 Request graceful shutdown and return once the request is sent, without waiting for the stopped state to be observed.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sandbox.requestStop();
 ```
+
+</Accordion>
 
 ---
 
@@ -697,11 +735,13 @@ stop(): Promise<void>
 
 Gracefully shut down the sandbox and wait until stopped state is observed. Lets the sandbox finish writing any pending data to disk before it exits, so files written inside the sandbox aren't lost across a later restart. Waits up to 10_000 ms for a clean exit; if the sandbox is still running after that, it is force-killed.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sandbox.stop();
 ```
+
+</Accordion>
 
 ---
 
@@ -723,11 +763,13 @@ Gracefully shut down the sandbox with an explicit observation timeout before for
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sandbox.stopWithTimeout(5000);
 ```
+
+</Accordion>
 
 ---
 
@@ -749,12 +791,14 @@ Block until the sandbox is observed in a terminal non-running state, without tri
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const result = await sandbox.waitUntilStopped();
 console.log(result.status, result.exitCode);
 ```
+
+</Accordion>
 
 ---
 
@@ -767,7 +811,7 @@ console.log(result.status, result.exitCode);
 
 Implements `AsyncDisposable` so the sandbox can be used with `await using`. When the binding goes out of scope, the sandbox is stopped (best-effort) - but only if `ownsLifecycle` is `true`.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 {
@@ -775,6 +819,8 @@ Implements `AsyncDisposable` so the sandbox can be used with `await using`. When
   await sandbox.exec("python", ["-V"]);
 } // sandbox.stop() runs here, automatically
 ```
+
+</Accordion>
 
 ---
 
@@ -842,7 +888,7 @@ Build and boot the sandbox. By default the sandbox is attached - it stops when t
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const sandbox = await Sandbox.builder("worker")
@@ -851,6 +897,8 @@ const sandbox = await Sandbox.builder("worker")
   .create();
 await sandbox.detach();
 ```
+
+</Accordion>
 
 ---
 
@@ -872,7 +920,7 @@ Build and boot while streaming image pull progress. Returns a [`PullProgressCrea
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const creation = await Sandbox.builder("demo")
@@ -887,6 +935,8 @@ for await (const ev of creation) {
 
 const sandbox = await creation.awaitSandbox();
 ```
+
+</Accordion>
 
 ---
 
@@ -1114,13 +1164,15 @@ Configure an explicit rootfs source. Use this for OCI-only settings such as the 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const sandbox = await Sandbox.builder("worker")
   .imageWith((i) => i.oci("python:3.12").upperSize(8192))
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -1146,7 +1198,7 @@ Hand off PID 1 inside the guest to `cmd` after agentd finishes its boot-time set
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const sandbox = await Sandbox.builder("worker")
@@ -1154,6 +1206,8 @@ const sandbox = await Sandbox.builder("worker")
   .init("auto")
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -1179,7 +1233,7 @@ Like [`init`](#init), but with a closure-builder for argv and env vars. The buil
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const sandbox = await Sandbox.builder("worker")
@@ -1188,6 +1242,8 @@ const sandbox = await Sandbox.builder("worker")
     i.args(["--unit=multi-user.target"]).env("container", "microsandbox"))
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -1373,7 +1429,7 @@ Modify the rootfs before the VM boots. Patches go into the writable layer - the 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const sandbox = await Sandbox.builder("worker")
@@ -1381,6 +1437,8 @@ const sandbox = await Sandbox.builder("worker")
   .patch((p) => p.text("/etc/app.conf", "mode=prod\n", { mode: 0o644 }))
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -1537,7 +1595,7 @@ Configure the OCI registry connection: authentication, insecure transport, and C
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const sandbox = await Sandbox.builder("worker")
@@ -1545,6 +1603,8 @@ const sandbox = await Sandbox.builder("worker")
   .registry((r) => r.auth("user", "token"))
   .create();
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/typescript/secrets.mdx
+++ b/docs/sdk/typescript/secrets.mdx
@@ -156,7 +156,7 @@ Add an exact host allowed to receive the real secret value. The proxy checks the
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 .secret((s) =>
@@ -166,6 +166,8 @@ Add an exact host allowed to receive the real secret value. The proxy checks the
     .allowHost("files.stripe.com"),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -329,7 +331,7 @@ Passthrough hosts do **not** receive the real secret value; substitution still o
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 .secret((s) =>
@@ -341,6 +343,8 @@ Passthrough hosts do **not** receive the real secret value; substitution still o
     ),
 )
 ```
+
+</Accordion>
 
 ---
 
@@ -487,7 +491,7 @@ Add a secret with full configuration via a [`SecretBuilder`](#secretbuilder) clo
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await using sb = await Sandbox.builder("payments-worker")
@@ -502,6 +506,8 @@ await using sb = await Sandbox.builder("payments-worker")
   )
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -531,7 +537,7 @@ Three-argument shorthand. Auto-generates the placeholder as `$MSB_<envVar>` and 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await using sb = await Sandbox.builder("agent")
@@ -539,6 +545,8 @@ await using sb = await Sandbox.builder("agent")
   .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -566,7 +574,7 @@ Add a secret with full configuration via a [`SecretBuilder`](#secretbuilder) clo
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await using sb = await Sandbox.builder("agent")
@@ -580,6 +588,8 @@ await using sb = await Sandbox.builder("agent")
   )
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -661,7 +671,7 @@ Set the sandbox-wide secret violation policy: what happens when any secret's pla
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await using sb = await Sandbox.builder("agent")
@@ -672,6 +682,8 @@ await using sb = await Sandbox.builder("agent")
   )
   .create();
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/typescript/snapshots.mdx
+++ b/docs/sdk/typescript/snapshots.mdx
@@ -121,13 +121,15 @@ Boot a fresh sandbox from a snapshot artifact. Mutually exclusive with [`.image(
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const sb = await Sandbox.builder("worker")
   .fromSnapshot("after-pip-install")
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -158,13 +160,15 @@ Snapshot this sandbox under a bare name in the default snapshots directory (`~/.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const h = await Sandbox.get("baseline");
 await h.stop();
 const snap = await h.snapshot("after-pip-install");
 ```
+
+</Accordion>
 
 ---
 
@@ -195,11 +199,13 @@ Snapshot this sandbox to an explicit filesystem path. Called on a [`SandboxHandl
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const snap = await h.snapshotTo("/data/snapshots/baseline-v2");
 ```
+
+</Accordion>
 
 ---
 
@@ -234,7 +240,7 @@ Begin building a new snapshot of `sourceSandbox` (which must be stopped). The fl
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const snap = await Snapshot.builder("baseline")
@@ -243,6 +249,8 @@ const snap = await Snapshot.builder("baseline")
   .recordIntegrity()
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -273,12 +281,14 @@ Open an existing snapshot artifact. Bare names resolve under the default snapsho
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const snap = await Snapshot.open("after-pip-install");
 console.log(snap.digest);
 ```
+
+</Accordion>
 
 ---
 
@@ -309,12 +319,14 @@ Look up an indexed snapshot by digest, name, or path. Returns a lightweight [`Sn
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const h = await Snapshot.get("after-pip-install");
 console.log(h.digest, h.createdAt);
 ```
+
+</Accordion>
 
 ---
 
@@ -336,13 +348,15 @@ List indexed snapshots from the local DB cache.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 for (const h of await Snapshot.list()) {
   console.log(h.name ?? h.digest, h.sizeBytes);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -373,12 +387,14 @@ Walk a directory and parse each subdirectory's manifest. Does not touch the inde
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const found = await Snapshot.listDir("/mnt/external/snapshots");
 console.log(`${found.length} artifacts`);
 ```
+
+</Accordion>
 
 ---
 
@@ -404,11 +420,13 @@ Remove a snapshot by path, name, or digest. Refuses if the snapshot has indexed 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await Snapshot.remove("after-pip-install", { force: true });
 ```
+
+</Accordion>
 
 ---
 
@@ -439,12 +457,14 @@ Walk the snapshots directory (default: the configured snapshots dir) and rebuild
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const count = await Snapshot.reindex();
 console.log(`reindexed ${count} snapshots`);
 ```
+
+</Accordion>
 
 ---
 
@@ -474,13 +494,15 @@ Bundle a snapshot into a `.tar.zst` archive. When the snapshot has no integrity 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await Snapshot.export("after-pip-install", "./baseline.tar.zst", {
   withImage: true,
 });
 ```
+
+</Accordion>
 
 ---
 
@@ -515,12 +537,14 @@ Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, v
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const h = await Snapshot.import("./baseline.tar.zst");
 console.log("imported", h.digest);
 ```
+
+</Accordion>
 
 ---
 
@@ -669,7 +693,7 @@ Recompute the upper layer's content hash and compare against the manifest. Walks
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const report = await snap.verify();
@@ -679,6 +703,8 @@ if (report.upper.kind === "verified") {
   console.log("no integrity hash recorded");
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -792,7 +818,7 @@ Capture the configured snapshot and return the resulting artifact.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const snap = await Snapshot.builder("baseline")
@@ -801,6 +827,8 @@ const snap = await Snapshot.builder("baseline")
   .recordIntegrity()
   .create();
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/sdk/typescript/ssh.mdx
+++ b/docs/sdk/typescript/ssh.mdx
@@ -87,12 +87,14 @@ Return the SSH namespace for this sandbox. The returned object exposes [`openCli
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const ssh = sandbox.ssh();
 const client = await ssh.openClient();
 ```
+
+</Accordion>
 
 ---
 
@@ -123,11 +125,13 @@ Open a native in-process SSH client connected to the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const client = await sandbox.ssh().openClient({ user: "root" });
 ```
+
+</Accordion>
 
 ---
 
@@ -158,12 +162,14 @@ Prepare a reusable SSH server endpoint backed by the sandbox.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const server = await sandbox.ssh().prepareServer({ user: "root" });
 await server.serveConnection();
 ```
+
+</Accordion>
 
 ## SshClient
 
@@ -202,12 +208,14 @@ Run an SSH exec request and collect stdout, stderr, and the exit status.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const out = await client.exec("uname -a");
 console.log(out.status, out.stdout.toString());
 ```
+
+</Accordion>
 
 ---
 
@@ -238,12 +246,14 @@ Attach the local terminal to an interactive SSH shell. Resolves with the shell's
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const code = await client.attach({ detachKeys: "ctrl-p,ctrl-q" });
 console.log(`shell exited with ${code}`);
 ```
+
+</Accordion>
 
 ---
 
@@ -265,13 +275,15 @@ Open an SFTP session over this SSH connection for file transfer and remote files
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const sftp = await client.sftp();
 await sftp.write("/tmp/data.bin", Buffer.from([1, 2, 3]));
 await sftp.close();
 ```
+
+</Accordion>
 
 ---
 
@@ -284,11 +296,13 @@ close(): Promise<void>
 
 Close the native SSH client session.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await client.close();
 ```
+
+</Accordion>
 
 ## SftpClient
 
@@ -323,12 +337,14 @@ Read a remote file into memory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const data = await sftp.read("/etc/hostname");
 console.log(data.toString().trim());
 ```
+
+</Accordion>
 
 ---
 
@@ -354,11 +370,13 @@ Create or truncate a remote file and write the given bytes.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sftp.write("/tmp/config.json", Buffer.from(JSON.stringify({ ok: true })));
 ```
+
+</Accordion>
 
 ---
 
@@ -380,11 +398,13 @@ Create a remote directory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sftp.mkdir("/tmp/uploads");
 ```
+
+</Accordion>
 
 ---
 
@@ -406,11 +426,13 @@ Remove a remote file.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sftp.removeFile("/tmp/config.json");
 ```
+
+</Accordion>
 
 ---
 
@@ -432,11 +454,13 @@ Remove an empty remote directory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sftp.removeDir("/tmp/uploads");
 ```
+
+</Accordion>
 
 ---
 
@@ -462,11 +486,13 @@ Rename or move a remote file or directory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sftp.rename("/tmp/data.bin", "/tmp/data.old");
 ```
+
+</Accordion>
 
 ---
 
@@ -497,12 +523,14 @@ Resolve a remote path to its canonical, absolute form.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const abs = await sftp.realPath("./logs");
 console.log(abs);
 ```
+
+</Accordion>
 
 ---
 
@@ -533,12 +561,14 @@ Read the target of a remote symlink.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const target = await sftp.readLink("/etc/localtime");
 console.log(target);
 ```
+
+</Accordion>
 
 ---
 
@@ -564,11 +594,13 @@ Create a remote symlink at `linkPath` pointing to `target`.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sftp.symlink("/tmp/data.bin", "/tmp/latest");
 ```
+
+</Accordion>
 
 ---
 
@@ -581,11 +613,13 @@ close(): Promise<void>
 
 Close the SFTP session.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await sftp.close();
 ```
+
+</Accordion>
 
 ## SshServer
 
@@ -602,13 +636,15 @@ serveConnection(): Promise<void>
 
 Serve one SSH transport over stdin/stdout. Resolves when the connection ends.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const server = await sandbox.ssh().prepareServer();
 await server.serveConnection();
 await server.close();
 ```
+
+</Accordion>
 
 ---
 
@@ -621,11 +657,13 @@ close(): Promise<void>
 
 Release the prepared server endpoint.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await server.close();
 ```
+
+</Accordion>
 
 ## Types
 

--- a/docs/sdk/typescript/volumes.mdx
+++ b/docs/sdk/typescript/volumes.mdx
@@ -46,7 +46,7 @@ Create and manage named volumes: persistent storage that lives independently of 
 ```typescript
 import { Volume } from "microsandbox";
 
-const data = await Volume.builder("my-data")   // 1. configure
+const data = await Volume.builder("my-data")    // 1. configure
   .label("env", "prod")
   .create();                                    // 2. create on disk
 
@@ -88,13 +88,15 @@ Begin building a named volume. Directory-backed volumes are the default. Call `.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const data = await Volume.builder("my-data")
   .label("env", "prod")
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -125,12 +127,14 @@ Get a live handle to an existing named volume. A live handle supports `.fs()` an
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const handle = await Volume.get("my-data");
 console.log(handle.usedBytes);
 ```
+
+</Accordion>
 
 ---
 
@@ -152,13 +156,15 @@ List all named volumes. Handles returned here are **read-only**: calling `.fs()`
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 for (const v of await Volume.list()) {
   console.log(`${v.name} — ${v.kind} — ${v.usedBytes} bytes`);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -180,11 +186,13 @@ Delete a named volume and its contents. Fails if the volume is currently mounted
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await Volume.remove("my-data");
 ```
+
+</Accordion>
 
 ---
 
@@ -250,13 +258,15 @@ Get a host-side filesystem handle for this volume's directory. Reads and writes 
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const vfs = data.fs();
 await vfs.write("seed.txt", "hello");
 console.log(await vfs.readToString("seed.txt"));
 ```
+
+</Accordion>
 
 ---
 
@@ -286,7 +296,7 @@ disk(): this
 
 Create a raw ext4 disk-backed volume. Pair with [`size()`](#size) to set the capacity.
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const dockerData = await Volume.builder("docker-data")
@@ -294,6 +304,8 @@ const dockerData = await Volume.builder("docker-data")
   .size(20 * 1024)
   .create();
 ```
+
+</Accordion>
 
 ---
 
@@ -399,11 +411,13 @@ Build and create the volume on disk, returning a [`Volume`](#instance-methods).
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const data = await Volume.builder("my-data").create();
 ```
+
+</Accordion>
 
 ---
 
@@ -440,11 +454,13 @@ Read a file's full contents as bytes.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const bytes = await vfs.read("data.bin");
 ```
+
+</Accordion>
 
 ---
 
@@ -475,11 +491,13 @@ Read a file's full contents as a UTF-8 string.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const text = await vfs.readToString("config.json");
 ```
+
+</Accordion>
 
 ---
 
@@ -510,7 +528,7 @@ Open a streaming reader for a file, for chunked reads of large files without loa
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const stream = await vfs.readStream("large.bin");
@@ -518,6 +536,8 @@ for await (const chunk of stream) {
   console.log(chunk.byteLength);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -543,11 +563,13 @@ Write a file, replacing any existing contents. Strings are encoded as UTF-8.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await vfs.write("seed.txt", "hello");
 ```
+
+</Accordion>
 
 ---
 
@@ -578,13 +600,15 @@ Open a streaming writer for a file, for chunked writes of large files.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const sink = await vfs.writeStream("out.bin");
 await sink.write(chunk);
 await sink.close();
 ```
+
+</Accordion>
 
 ---
 
@@ -615,13 +639,15 @@ List the entries in a directory. Pass `""` for the volume root.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 for (const e of await vfs.list("")) {
   console.log(e.path, e.kind, e.size);
 }
 ```
+
+</Accordion>
 
 ---
 
@@ -643,11 +669,13 @@ Create a directory, including any missing parents.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await vfs.mkdir("cache/images");
 ```
+
+</Accordion>
 
 ---
 
@@ -669,11 +697,13 @@ Recursively remove a directory and its contents.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await vfs.removeDir("cache");
 ```
+
+</Accordion>
 
 ---
 
@@ -695,11 +725,13 @@ Remove a single file.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await vfs.remove("seed.txt");
 ```
+
+</Accordion>
 
 ---
 
@@ -725,11 +757,13 @@ Copy a file or directory from one path to another.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await vfs.copy("seed.txt", "backup/seed.txt");
 ```
+
+</Accordion>
 
 ---
 
@@ -755,11 +789,13 @@ Move or rename a file or directory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 await vfs.rename("draft.txt", "final.txt");
 ```
+
+</Accordion>
 
 ---
 
@@ -790,12 +826,14 @@ Get metadata for a file or directory.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 const meta = await vfs.stat("seed.txt");
 console.log(meta.size, meta.kind);
 ```
+
+</Accordion>
 
 ---
 
@@ -826,13 +864,15 @@ Check whether a path exists.
   </div>
 </div>
 
-<p className="msb-label">Example</p>
+<Accordion title="Example">
 
 ```typescript
 if (await vfs.exists("seed.txt")) {
   await vfs.remove("seed.txt");
 }
 ```
+
+</Accordion>
 
 ---
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -97,10 +97,18 @@ body {
   text-transform: uppercase; opacity: .55; margin: 16px 0 6px;
 }
 
-/* parameter + return rows */
-.msb-params { margin: 4px 0 0; }
+/* parameter + return rows
+ * The key column auto-sizes to its content (param name + type) and stays
+ * aligned across rows via subgrid, capped so a long type can't crowd out the
+ * description. */
+.msb-params {
+  margin: 4px 0 0;
+  display: grid;
+  grid-template-columns: minmax(170px, min(34%, 320px)) minmax(0, 1fr);
+  column-gap: 18px;
+}
 .msb-param {
-  display: grid; grid-template-columns: 180px 1fr; gap: 4px 18px;
+  display: grid; grid-template-columns: subgrid; grid-column: 1 / -1; row-gap: 4px;
   padding: 9px 0; border-top: 1px solid rgba(135,134,128,.18);
 }
 .msb-param-key code { font-size: 13px; }
@@ -111,8 +119,28 @@ body {
 .msb-backref { font-size: 13px; opacity: .7; margin: 4px 0 12px; }
 .msb-backref a { font-family: var(--font-mono, monospace); font-size: 12.5px; text-decoration: none; }
 
+/* ----------------------------------------------------------------------------
+ * Table columns — hand the slack to the column that needs it (content-driven
+ * layout) instead of splitting width evenly, and keep name-ish first columns
+ * on one line. Width is unchanged: tables stay within the prose column.
+ * -------------------------------------------------------------------------- */
+table { table-layout: auto; }
+table th, table td { vertical-align: top; overflow-wrap: anywhere; }
+table td:first-child { white-space: nowrap; }
+
+/* ----------------------------------------------------------------------------
+ * Example collapsibles — Mintlify wraps the code block in prose margins
+ * (content wrapper mt-2/mb-4/mx-6 plus the code-block's own mt-5/mb-8), which
+ * leaves a lot of dead space inside the accordion. Trim it to an even, tight
+ * inset. Scoped to accordions that hold a code block so prose accordions are
+ * left alone.
+ * -------------------------------------------------------------------------- */
+details.accordion:has(.code-block) > *:not(summary) { margin: 0 0.75rem 0.75rem !important; }
+details.accordion:has(.code-block) .code-block { margin: 0 !important; }
+
 @media (max-width: 640px) {
   .msb-row { grid-template-columns: 1fr; gap: 0; }
   .msb-rg { font-size: 11.5px; opacity: .6; }
-  .msb-param { grid-template-columns: 1fr; gap: 2px; }
+  .msb-params { grid-template-columns: 1fr; }
+  .msb-param { row-gap: 2px; }
 }


### PR DESCRIPTION
## TL;DR
Make the SDK reference pages easier to read: every per-method example is collapsed by default so the pages stay scannable, and the parameter/table columns size to their content instead of a fixed width.

## Description
- All 485 per-method `Example` code blocks across 38 files are wrapped in a collapsed `<Accordion title="Example">`; method signatures and the top-of-page Typical flow examples stay visible.
- Trim Mintlify's prose margins inside the accordion (content wrapper plus the code block's own margins) so the example sits with a tight, even inset instead of large gaps.
- Parameter key columns switched from a fixed 180px to subgrid with a capped `minmax` track, so they size to their content (name + type) and stay aligned across rows.
- Markdown tables use `table-layout: auto` so the column that needs the space (usually Description) gets it, with name-ish first columns kept on one line. Table width is unchanged: tables stay within the prose column.
- Aligned the trailing step comments in the Typical flow examples so they line up in one column per block.
- The table/accordion styling in `docs/style.css` is global (Mintlify has no reliable per-page CSS hook); the accordion rule is scoped with `:has(.code-block)` so prose-only accordions are untouched.

The example blocks now look like this in the `.mdx` files:

```mdx
<Accordion title="Example">

```rust
let sb = Sandbox::builder("api")
    .image("python")
    .create()
    .await?;
```

</Accordion>
```

## Test Plan
- [x] `mint validate` (strict mode) passes, so the SDK reference pages build without MDX errors
- [x] Method `Example` blocks render as collapsed accordions and expand on click
- [x] Expanded example code sits with a tight, even inset (no large gaps inside the accordion)
- [x] Parameter tables size the key column to content and stay aligned across rows