### PR TITLE
fix(runtime): drop always-on heartbeat staleness kill

### DIFF
--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -3,6 +3,8 @@
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::os::fd::AsRawFd;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 use std::{env, ptr};
 
@@ -160,7 +162,14 @@ pub async fn run(
     // Heartbeat/activity state.
     let mut activity = ActivityTracker::new();
     let (heartbeat_tx, heartbeat_rx) = watch::channel(heartbeat_snapshot(&state, &activity));
-    let heartbeat_task = tokio::spawn(heartbeat_writer_task(heartbeat_rx));
+    // The liveness pulse runs on a dedicated OS thread, NOT a Tokio task. On the
+    // single-threaded agent runtime a flood of exec output can monopolize the
+    // executor and starve a heartbeat *task*, freezing the pulse even though the
+    // agent is alive — which makes the host wrongly declare it unresponsive and
+    // kill the sandbox. A plain OS thread is scheduled by the guest kernel
+    // independently of the async runtime, so the pulse keeps ticking under load.
+    let heartbeat_shutdown = Arc::new(AtomicBool::new(false));
+    let heartbeat_thread = spawn_heartbeat_thread(heartbeat_rx, Arc::clone(&heartbeat_shutdown));
 
     // Send core.ready with boot timing data.
     let ready_time_ns = clock::boottime_ns();
@@ -341,7 +350,8 @@ pub async fn run(
         }
     }
 
-    heartbeat_task.abort();
+    heartbeat_shutdown.store(true, Ordering::Relaxed);
+    let _ = heartbeat_thread.join();
 
     Ok(())
 }
@@ -657,37 +667,64 @@ fn message_refreshes_idle_timer(t: &MessageType) -> bool {
     !matches!(t, MessageType::ClockSync)
 }
 
-async fn heartbeat_writer_task(snapshot_rx: watch::Receiver<HeartbeatSnapshot>) {
-    let mut heartbeat_seq = 0u64;
-    let mut last_activity_seq = snapshot_rx.borrow().activity_seq;
-    let mut last_activity = Utc::now();
-    let mut heartbeat_timer = time::interval(Duration::from_secs(HEARTBEAT_INTERVAL_SECS));
+/// Spawns the heartbeat pulse on a dedicated OS thread.
+///
+/// This thread is intentionally outside the Tokio runtime: it reads the latest
+/// [`HeartbeatSnapshot`] (a lock-free `watch` borrow) and writes the heartbeat
+/// file with blocking `std::fs` once per [`HEARTBEAT_INTERVAL_SECS`]. Because it
+/// is an ordinary kernel-scheduled thread, a CPU-bound or I/O-saturated async
+/// runtime cannot delay the pulse — which is exactly the starvation that made
+/// the host kill busy-but-healthy sandboxes. The sleep is chunked so the thread
+/// observes the shutdown flag promptly when the agent loop exits.
+fn spawn_heartbeat_thread(
+    snapshot_rx: watch::Receiver<HeartbeatSnapshot>,
+    shutdown: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::Builder::new()
+        .name("agentd-heartbeat".to_string())
+        .spawn(move || {
+            let mut heartbeat_seq = 0u64;
+            let mut last_activity_seq = snapshot_rx.borrow().activity_seq;
+            let mut last_activity = Utc::now();
 
-    loop {
-        heartbeat_timer.tick().await;
-        if !heartbeat::heartbeat_dir_exists() {
-            continue;
-        }
+            let interval = Duration::from_secs(HEARTBEAT_INTERVAL_SECS);
+            let step = Duration::from_millis(100);
 
-        heartbeat_seq = heartbeat_seq.saturating_add(1);
-        let snapshot = snapshot_rx.borrow().clone();
-        let timestamp = Utc::now();
-        if snapshot.activity_seq != last_activity_seq {
-            last_activity_seq = snapshot.activity_seq;
-            last_activity = timestamp;
-        }
-        let heartbeat = Heartbeat {
-            heartbeat_seq,
-            activity_seq: snapshot.activity_seq,
-            timestamp,
-            last_activity,
-            active_exec_sessions: snapshot.active_exec_sessions,
-            active_fs_streams: snapshot.active_fs_streams,
-            active_tcp_streams: snapshot.active_tcp_streams,
-            activity_counters: snapshot.counters,
-        };
-        let _ = heartbeat::write_heartbeat(&heartbeat).await;
-    }
+            while !shutdown.load(Ordering::Relaxed) {
+                let mut slept = Duration::ZERO;
+                while slept < interval {
+                    if shutdown.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    std::thread::sleep(step);
+                    slept += step;
+                }
+
+                if !heartbeat::heartbeat_dir_exists() {
+                    continue;
+                }
+
+                heartbeat_seq = heartbeat_seq.saturating_add(1);
+                let snapshot = snapshot_rx.borrow().clone();
+                let timestamp = Utc::now();
+                if snapshot.activity_seq != last_activity_seq {
+                    last_activity_seq = snapshot.activity_seq;
+                    last_activity = timestamp;
+                }
+                let heartbeat = Heartbeat {
+                    heartbeat_seq,
+                    activity_seq: snapshot.activity_seq,
+                    timestamp,
+                    last_activity,
+                    active_exec_sessions: snapshot.active_exec_sessions,
+                    active_fs_streams: snapshot.active_fs_streams,
+                    active_tcp_streams: snapshot.active_tcp_streams,
+                    activity_counters: snapshot.counters,
+                };
+                let _ = heartbeat::write_heartbeat(&heartbeat);
+            }
+        })
+        .expect("failed to spawn agentd heartbeat thread")
 }
 
 fn heartbeat_snapshot(state: &AgentState, activity: &ActivityTracker) -> HeartbeatSnapshot {

--- a/crates/agentd/lib/heartbeat.rs
+++ b/crates/agentd/lib/heartbeat.rs
@@ -21,11 +21,15 @@ const HEARTBEAT_TMP_PATH: &str = "/.msb/heartbeat.tmp";
 //--------------------------------------------------------------------------------------------------
 
 /// Atomically writes the heartbeat JSON to `/.msb/heartbeat.json`.
-pub async fn write_heartbeat(heartbeat: &Heartbeat) -> AgentdResult<()> {
-    let json = serde_json::to_vec(&heartbeat)?;
+///
+/// Deliberately synchronous: the liveness pulse runs on a dedicated OS thread
+/// (see [`crate::agent`]) so a saturated async runtime can never starve it.
+/// Blocking `std::fs` keeps that thread fully independent of Tokio.
+pub fn write_heartbeat(heartbeat: &Heartbeat) -> AgentdResult<()> {
+    let json = serde_json::to_vec(heartbeat)?;
 
-    tokio::fs::write(HEARTBEAT_TMP_PATH, json).await?;
-    tokio::fs::rename(HEARTBEAT_TMP_PATH, HEARTBEAT_PATH).await?;
+    std::fs::write(HEARTBEAT_TMP_PATH, json)?;
+    std::fs::rename(HEARTBEAT_TMP_PATH, HEARTBEAT_PATH)?;
 
     Ok(())
 }

--- a/crates/runtime/lib/heartbeat.rs
+++ b/crates/runtime/lib/heartbeat.rs
@@ -25,9 +25,6 @@ pub struct HeartbeatReader {
     /// Path to the heartbeat.json file on the host.
     path: PathBuf,
 
-    /// Host time when this reader was created.
-    created_at: Instant,
-
     /// Last heartbeat content read successfully.
     last_heartbeat: Option<HeartbeatSnapshot>,
 
@@ -42,15 +39,12 @@ pub struct HeartbeatReader {
 
     /// Host time when the activity sequence last advanced.
     last_activity_seen_at: Option<Instant>,
-
-    /// Host time when heartbeat staleness first crossed the stale budget.
-    stale_confirmed_at: Option<Instant>,
 }
 
 /// Idle decision derived from the heartbeat stream.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HeartbeatDecision {
-    /// No heartbeat is available yet, but startup grace has not elapsed.
+    /// No heartbeat has been observed yet — the guest is still booting.
     PendingBoot(HeartbeatStatus),
 
     /// The sandbox is not idle.
@@ -58,9 +52,6 @@ pub enum HeartbeatDecision {
 
     /// The sandbox is idle.
     Idle(HeartbeatStatus),
-
-    /// agentd stopped producing fresh heartbeat data.
-    AgentUnresponsive(HeartbeatStatus),
 }
 
 /// Snapshot of host-observed heartbeat state used to make a decision.
@@ -104,19 +95,17 @@ struct HeartbeatSnapshot {
 impl HeartbeatReader {
     /// Create a new heartbeat reader for the given runtime directory.
     pub fn new(runtime_dir: &Path) -> Self {
-        Self::new_at(runtime_dir, Instant::now())
+        Self::new_at(runtime_dir)
     }
 
-    fn new_at(runtime_dir: &Path, created_at: Instant) -> Self {
+    fn new_at(runtime_dir: &Path) -> Self {
         Self {
             path: runtime_dir.join(HEARTBEAT_FILE),
-            created_at,
             last_heartbeat: None,
             last_heartbeat_seq: None,
             last_heartbeat_seen_at: None,
             last_activity_seq: None,
             last_activity_seen_at: None,
-            stale_confirmed_at: None,
         }
     }
 
@@ -129,52 +118,31 @@ impl HeartbeatReader {
         serde_json::from_slice(&content).ok()
     }
 
-    /// Check whether the sandbox is idle based on host-observed heartbeat and
-    /// activity sequence changes.
-    pub fn check(
-        &mut self,
-        idle_timeout: Option<Duration>,
-        stale_heartbeat_timeout: Duration,
-        boot_grace: Duration,
-    ) -> HeartbeatDecision {
-        self.check_at(
-            Instant::now(),
-            idle_timeout,
-            stale_heartbeat_timeout,
-            boot_grace,
-        )
+    /// Decide whether the sandbox should be reclaimed for **idleness**.
+    ///
+    /// The heartbeat stream is used purely for idle detection (and activity
+    /// reporting). A stale or missing heartbeat is never, on its own, grounds to
+    /// kill the sandbox: a busy-but-quiet agent is still a healthy agent, and a
+    /// guest that never boots is reclaimed by the relay's `wait_ready` timeout —
+    /// not here. This monitor only ever asks "is the sandbox idle?".
+    pub fn check(&mut self, idle_timeout: Option<Duration>) -> HeartbeatDecision {
+        self.check_at(Instant::now(), idle_timeout)
     }
 
-    fn check_at(
-        &mut self,
-        now: Instant,
-        idle_timeout: Option<Duration>,
-        stale_heartbeat_timeout: Duration,
-        boot_grace: Duration,
-    ) -> HeartbeatDecision {
+    fn check_at(&mut self, now: Instant, idle_timeout: Option<Duration>) -> HeartbeatDecision {
         if let Some(heartbeat) = self.read() {
             self.observe(heartbeat, now);
         }
 
         let status = self.status(now);
 
-        let Some(heartbeat_stale_for) = status.heartbeat_stale_for else {
-            if now.duration_since(self.created_at) >= boot_grace {
-                return HeartbeatDecision::AgentUnresponsive(status);
-            }
+        // No heartbeat seen yet: the guest is still booting. A guest that never
+        // boots is reclaimed by the relay readiness timeout, not this monitor.
+        if status.heartbeat_seq.is_none() {
             return HeartbeatDecision::PendingBoot(status);
-        };
-
-        if heartbeat_stale_for >= stale_heartbeat_timeout {
-            let stale_confirmed_at = *self.stale_confirmed_at.get_or_insert(now);
-            if now.duration_since(stale_confirmed_at) >= stale_heartbeat_timeout {
-                return HeartbeatDecision::AgentUnresponsive(status);
-            }
-            return HeartbeatDecision::Active(status);
         }
 
-        self.stale_confirmed_at = None;
-
+        // Active exec sessions are never idle.
         if status.active_exec_sessions > 0 {
             return HeartbeatDecision::Active(status);
         }
@@ -191,7 +159,6 @@ impl HeartbeatReader {
         if self.last_heartbeat_seq != Some(heartbeat.heartbeat_seq) {
             self.last_heartbeat_seq = Some(heartbeat.heartbeat_seq);
             self.last_heartbeat_seen_at = Some(now);
-            self.stale_confirmed_at = None;
         }
 
         if self.last_activity_seq != Some(heartbeat.activity_seq) {
@@ -268,13 +235,11 @@ mod tests {
         assert!(!tmp_path.exists());
 
         let start = Instant::now();
-        let mut reader = HeartbeatReader::new_at(dir.path(), start);
+        let mut reader = HeartbeatReader::new_at(dir.path());
         assert!(matches!(
             reader.check_at(
                 start + Duration::from_secs(1),
-                Some(Duration::from_secs(60)),
-                Duration::from_secs(5),
-                Duration::from_secs(2),
+                Some(Duration::from_secs(60))
             ),
             HeartbeatDecision::PendingBoot(_)
         ));
@@ -285,16 +250,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(HEARTBEAT_FILE);
         let start = Instant::now();
-        let mut reader = HeartbeatReader::new_at(dir.path(), start);
+        let mut reader = HeartbeatReader::new_at(dir.path());
 
         write_heartbeat_file(&path, heartbeat(1, 1, 1));
         assert!(matches!(
-            reader.check_at(
-                start,
-                Some(Duration::from_secs(60)),
-                Duration::from_secs(5),
-                Duration::ZERO,
-            ),
+            reader.check_at(start, Some(Duration::from_secs(60))),
             HeartbeatDecision::Active(_)
         ));
 
@@ -302,9 +262,7 @@ mod tests {
         assert!(matches!(
             reader.check_at(
                 start + Duration::from_secs(120),
-                Some(Duration::from_secs(60)),
-                Duration::from_secs(5),
-                Duration::ZERO,
+                Some(Duration::from_secs(60))
             ),
             HeartbeatDecision::Active(_)
         ));
@@ -315,16 +273,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(HEARTBEAT_FILE);
         let start = Instant::now();
-        let mut reader = HeartbeatReader::new_at(dir.path(), start);
+        let mut reader = HeartbeatReader::new_at(dir.path());
 
         write_heartbeat_file(&path, heartbeat(1, 1, 0));
         assert!(matches!(
-            reader.check_at(
-                start,
-                Some(Duration::from_secs(60)),
-                Duration::from_secs(5),
-                Duration::ZERO,
-            ),
+            reader.check_at(start, Some(Duration::from_secs(60))),
             HeartbeatDecision::Active(_)
         ));
 
@@ -332,9 +285,7 @@ mod tests {
         assert!(matches!(
             reader.check_at(
                 start + Duration::from_secs(120),
-                Some(Duration::from_secs(60)),
-                Duration::from_secs(5),
-                Duration::ZERO,
+                Some(Duration::from_secs(60))
             ),
             HeartbeatDecision::Idle(_)
         ));
@@ -345,89 +296,92 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(HEARTBEAT_FILE);
         let start = Instant::now();
-        let mut reader = HeartbeatReader::new_at(dir.path(), start);
+        let mut reader = HeartbeatReader::new_at(dir.path());
 
         write_heartbeat_file(&path, heartbeat(1, 1, 0));
         assert!(matches!(
-            reader.check_at(start, None, Duration::from_secs(5), Duration::ZERO,),
+            reader.check_at(start, None),
             HeartbeatDecision::Active(_)
         ));
 
         write_heartbeat_file(&path, heartbeat(2, 1, 0));
         assert!(matches!(
-            reader.check_at(
-                start + Duration::from_secs(120),
-                None,
-                Duration::from_secs(5),
-                Duration::ZERO,
-            ),
+            reader.check_at(start + Duration::from_secs(120), None),
             HeartbeatDecision::Active(_)
         ));
     }
 
     #[test]
-    fn stale_heartbeat_with_running_exec_is_unresponsive_not_active() {
+    fn stale_heartbeat_with_running_exec_is_not_killed() {
+        // The original bug: a busy sandbox whose heartbeat goes stale (the file
+        // stops advancing) while exec sessions are active was killed. It must NOT
+        // be — a busy agent is a healthy agent.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(HEARTBEAT_FILE);
         let start = Instant::now();
-        let mut reader = HeartbeatReader::new_at(dir.path(), start);
+        let mut reader = HeartbeatReader::new_at(dir.path());
 
         write_heartbeat_file(&path, heartbeat(1, 1, 1));
         assert!(matches!(
-            reader.check_at(
-                start,
-                Some(Duration::from_secs(60)),
-                Duration::from_secs(5),
-                Duration::ZERO,
-            ),
+            reader.check_at(start, Some(Duration::from_secs(60))),
             HeartbeatDecision::Active(_)
         ));
 
+        // No new heartbeat for a long time, but an exec session is still open.
         assert!(matches!(
             reader.check_at(
-                start + Duration::from_secs(6),
-                Some(Duration::from_secs(60)),
-                Duration::from_secs(5),
-                Duration::ZERO,
+                start + Duration::from_secs(3600),
+                Some(Duration::from_secs(60))
             ),
             HeartbeatDecision::Active(_)
-        ));
-
-        assert!(matches!(
-            reader.check_at(
-                start + Duration::from_secs(12),
-                Some(Duration::from_secs(60)),
-                Duration::from_secs(5),
-                Duration::ZERO,
-            ),
-            HeartbeatDecision::AgentUnresponsive(_)
         ));
     }
 
     #[test]
-    fn missing_heartbeat_becomes_unresponsive_after_boot_grace() {
+    fn stale_heartbeat_without_idle_timeout_is_never_killed() {
+        // No idle timeout configured: the sandbox runs indefinitely even if the
+        // heartbeat stops advancing entirely. This is what users expect when they
+        // set no timeouts at all.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(HEARTBEAT_FILE);
+        let start = Instant::now();
+        let mut reader = HeartbeatReader::new_at(dir.path());
+
+        write_heartbeat_file(&path, heartbeat(1, 1, 0));
+        assert!(matches!(
+            reader.check_at(start, None),
+            HeartbeatDecision::Active(_)
+        ));
+
+        assert!(matches!(
+            reader.check_at(start + Duration::from_secs(3600), None),
+            HeartbeatDecision::Active(_)
+        ));
+    }
+
+    #[test]
+    fn missing_heartbeat_stays_pending_boot() {
+        // A guest that never writes a heartbeat is NOT killed by this monitor; it
+        // stays PendingBoot. Genuine boot failures are reclaimed by the relay's
+        // wait_ready timeout instead.
         let dir = tempfile::tempdir().unwrap();
         let start = Instant::now();
-        let mut reader = HeartbeatReader::new_at(dir.path(), start);
+        let mut reader = HeartbeatReader::new_at(dir.path());
 
         assert!(matches!(
             reader.check_at(
                 start + Duration::from_secs(1),
-                Some(Duration::from_secs(60)),
-                Duration::from_secs(5),
-                Duration::from_secs(2),
+                Some(Duration::from_secs(60))
             ),
             HeartbeatDecision::PendingBoot(_)
         ));
 
         assert!(matches!(
             reader.check_at(
-                start + Duration::from_secs(3),
-                Some(Duration::from_secs(60)),
-                Duration::from_secs(5),
-                Duration::from_secs(2),
+                start + Duration::from_secs(3600),
+                Some(Duration::from_secs(60))
             ),
-            HeartbeatDecision::AgentUnresponsive(_)
+            HeartbeatDecision::PendingBoot(_)
         ));
     }
 

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -44,18 +44,12 @@ const EXIT_REASON_IDLE_TIMEOUT: u8 = 1;
 const EXIT_REASON_MAX_DURATION: u8 = 2;
 const EXIT_REASON_SIGNAL: u8 = 3;
 const EXIT_REASON_PARENT_EXIT: u8 = 4;
+/// Termination reason when agentd never signals readiness within the relay's
+/// boot window (the guest failed to come up). Reused for the boot-failure exit
+/// triggered from the relay's `wait_ready` path.
 const EXIT_REASON_AGENT_UNRESPONSIVE: u8 = 5;
 const EXIT_REASON_SHUTDOWN_REQUESTED: u8 = 6;
 const EXIT_REASON_STARTUP_COMMAND_FAILED: u8 = 7;
-
-/// Host-observed stale heartbeat budget before agentd is considered unresponsive.
-const STALE_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(5);
-
-/// Startup grace before a missing heartbeat is considered an agentd failure.
-const HEARTBEAT_BOOT_GRACE: Duration = Duration::from_secs(180);
-
-/// Short best-effort send budget once agentd is already considered unresponsive.
-const AGENT_UNRESPONSIVE_SHUTDOWN_PUSH_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Fixed fd carrying the bulk `msb sandbox` config (argv overflow) as
 /// NUL-terminated argument records. Keeps the network-config blob and the
@@ -701,6 +695,8 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     // Relay: spawn a blocking task for wait_ready, then run the accept loop.
     // wait_ready() must run AFTER enter() starts the VM (agentd sends core.ready),
     // so it runs on a background thread, not blocking the main thread.
+    let relay_exit_handle = exit_handle.clone();
+    let relay_exit_reason = Arc::clone(&exit_reason);
     tokio_rt.spawn(async move {
         let ready_result =
             tokio::task::spawn_blocking(move || relay.wait_ready().map(|()| relay)).await;
@@ -734,8 +730,27 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                     tracing::error!("agent relay error: {e}");
                 }
             }
-            Ok(Err(e)) => tracing::error!("agent relay wait_ready failed: {e}"),
-            Err(e) => tracing::error!("agent relay wait_ready task panicked: {e}"),
+            Ok(Err(e)) => {
+                tracing::error!("agent relay wait_ready failed: {e}");
+                // agentd never signalled readiness within the relay's boot window
+                // — the guest failed to come up. Reclaim the VM. This is the boot-
+                // failure backstop that used to live in the heartbeat monitor's
+                // boot-grace path (same 180s deadline), now owned by the relay so
+                // the heartbeat monitor can be purely about idle detection.
+                relay_exit_reason.store(
+                    EXIT_REASON_AGENT_UNRESPONSIVE,
+                    std::sync::atomic::Ordering::SeqCst,
+                );
+                relay_exit_handle.trigger();
+            }
+            Err(e) => {
+                tracing::error!("agent relay wait_ready task panicked: {e}");
+                relay_exit_reason.store(
+                    EXIT_REASON_AGENT_UNRESPONSIVE,
+                    std::sync::atomic::Ordering::SeqCst,
+                );
+                relay_exit_handle.trigger();
+            }
         }
     });
 
@@ -825,8 +840,10 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         });
     }
 
-    // Heartbeat health monitor. Idle reclamation is optional, but missing or stale
-    // heartbeat data means the in-guest agent is not healthy.
+    // Idle monitor. Reclaims the sandbox only when an optional idle timeout is
+    // configured and the guest has been inactive that long. A stale or missing
+    // heartbeat is NOT treated as a failure here — a busy agent is still healthy,
+    // and a guest that never boots is reclaimed by the relay's wait_ready path.
     {
         let mut heartbeat_reader = HeartbeatReader::new(&config.runtime_dir);
         let idle_timeout = config.idle_timeout_secs.map(Duration::from_secs);
@@ -837,8 +854,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
             let mut interval = tokio::time::interval(Duration::from_secs(1));
             loop {
                 interval.tick().await;
-                let decision =
-                    heartbeat_reader.check(idle_timeout, STALE_HEARTBEAT_TIMEOUT, HEARTBEAT_BOOT_GRACE);
+                let decision = heartbeat_reader.check(idle_timeout);
 
                 match decision {
                     HeartbeatDecision::Idle(status) => {
@@ -859,7 +875,8 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                         );
                         match request_guest_shutdown(&heartbeat_shared) {
                             Ok(()) => {
-                                tokio::time::sleep(microsandbox_protocol::SHUTDOWN_FLUSH_TIMEOUT).await;
+                                tokio::time::sleep(microsandbox_protocol::SHUTDOWN_FLUSH_TIMEOUT)
+                                    .await;
                                 tracing::info!(
                                     "idle shutdown flush window elapsed, triggering host exit"
                                 );
@@ -868,39 +885,6 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                                 tracing::warn!(
                                     error = %err,
                                     "idle shutdown request failed, triggering host exit"
-                                );
-                            }
-                        }
-                        heartbeat_exit_handle.trigger();
-                        break;
-                    }
-                    HeartbeatDecision::AgentUnresponsive(status) => {
-                        tracing::warn!(
-                            heartbeat_seq = ?status.heartbeat_seq,
-                            activity_seq = ?status.activity_seq,
-                            heartbeat_stale_for = ?status.heartbeat_stale_for,
-                            active_exec_sessions = status.active_exec_sessions,
-                            active_fs_streams = status.active_fs_streams,
-                            active_tcp_streams = status.active_tcp_streams,
-                            "agent heartbeat stale, triggering host exit"
-                        );
-                        heartbeat_reason.store(
-                            EXIT_REASON_AGENT_UNRESPONSIVE,
-                            std::sync::atomic::Ordering::SeqCst,
-                        );
-                        match request_guest_shutdown_with_timeout(
-                            &heartbeat_shared,
-                            AGENT_UNRESPONSIVE_SHUTDOWN_PUSH_TIMEOUT,
-                        ) {
-                            Ok(()) => {
-                                tracing::info!(
-                                    "agent-unresponsive shutdown request sent, triggering host exit"
-                                );
-                            }
-                            Err(err) => {
-                                tracing::warn!(
-                                    error = %err,
-                                    "agent-unresponsive shutdown request failed, triggering host exit"
                                 );
                             }
                         }


### PR DESCRIPTION
## TL;DR
The agent heartbeat watchdog added in #937 was killing healthy sandboxes after a few minutes whenever the heartbeat went stale, even with active exec sessions and no idle timeout configured. This makes the heartbeat monitor idle-detection only, so a busy or briefly-starved sandbox is never reclaimed for being "unresponsive".

## Description
- Remove the `AgentUnresponsive` decision and the staleness and boot-grace kill paths from the host heartbeat monitor, so a stale or missing heartbeat never reclaims a sandbox.
- The monitor is now idle-detection only: `HeartbeatReader::check(idle_timeout)` returns only `PendingBoot`, `Active`, or `Idle`.
- Reclaim guests that never boot from the relay `wait_ready` timeout instead (same 180s deadline), so genuine boot failures are still cleaned up and no VM is leaked.
- Write the guest heartbeat from a dedicated OS thread (`spawn_heartbeat_thread`) instead of a Tokio task, so a saturated single-threaded agent runtime cannot starve idle detection or the metrics it feeds.
- Keep the `AgentUnresponsive` termination reason for the relay boot-failure exit and for reading historical run records.
- Rewrite the host-side tests to assert a stale heartbeat is not killed and a missing heartbeat stays `PendingBoot`.

## Test Plan
- [x] `cargo test -p microsandbox-runtime --lib heartbeat` passes
- [x] `cargo clippy -p microsandbox-runtime --lib` is clean
- [x] `cargo check -p microsandbox-agentd --target aarch64-unknown-linux-musl` succeeds
- [x] Run a sandbox with a long-running exec workload and no `--idle-timeout`, confirm it does not self-stop after a few minutes (verified: the exact flood that self-stopped at 33s pre-fix ran the full 7 min with no watchdog kill)
- [x] Confirm a sandbox whose agentd never boots is still reclaimed via the relay readiness timeout (verified: a broken agentd that never sends core.ready was reclaimed at 181s via `agent relay wait_ready failed`, sandbox stopped, no leak, no heartbeat-stale kill)

