### PR TITLE
ci: cap cargo jobs and bound timeouts on self-hosted runners

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -394,6 +394,15 @@ jobs:
     needs: [check, changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: self-hosted-ubuntu-2404-x64
+    # Bound a wedged run so it can't squat a shared runner for the 6h default.
+    timeout-minutes: 45
+    # The self-hosted box has 32 cores shared by several runners. Uncapped cargo
+    # (-j defaults to ncpu) lets concurrent jobs oversubscribe the CPU ~4x and
+    # starve microVM boots past the 180s agent-relay deadline (flaky
+    # "timed out waiting for agent relay"). Cap per-job build parallelism so
+    # several jobs can build at once without crushing VM boot latency.
+    env:
+      CARGO_BUILD_JOBS: "12"
     steps:
       - name: Clean workspace
         run: |
@@ -429,6 +438,15 @@ jobs:
     needs: [check, changes, cli-smoke-test]
     if: needs.changes.outputs.code == 'true'
     runs-on: self-hosted-ubuntu-2404-x64
+    # Bound a wedged run so it can't squat a shared runner for the 6h default.
+    timeout-minutes: 45
+    # The self-hosted box has 32 cores shared by several runners. Uncapped cargo
+    # (-j defaults to ncpu) lets concurrent jobs oversubscribe the CPU ~4x and
+    # starve microVM boots past the 180s agent-relay deadline (flaky
+    # "timed out waiting for agent relay"). Cap per-job build parallelism so
+    # several jobs can build at once without crushing VM boot latency.
+    env:
+      CARGO_BUILD_JOBS: "12"
     steps:
       - name: Clean workspace
         run: |
@@ -515,6 +533,15 @@ jobs:
     needs: [check, changes, integration-test]
     if: needs.changes.outputs.code == 'true'
     runs-on: self-hosted-ubuntu-2404-x64
+    # Bound a wedged run so it can't squat a shared runner for the 6h default.
+    timeout-minutes: 45
+    # The self-hosted box has 32 cores shared by several runners. Uncapped cargo
+    # (-j defaults to ncpu) lets concurrent jobs oversubscribe the CPU ~4x and
+    # starve microVM boots past the 180s agent-relay deadline (flaky
+    # "timed out waiting for agent relay"). Cap per-job build parallelism so
+    # several jobs can build at once without crushing VM boot latency.
+    env:
+      CARGO_BUILD_JOBS: "12"
     steps:
       - name: Clean workspace
         run: |
@@ -651,6 +678,15 @@ jobs:
     needs: [check, changes, node-sdk-test]
     if: needs.changes.outputs.code == 'true'
     runs-on: self-hosted-ubuntu-2404-x64
+    # Bound a wedged run so it can't squat a shared runner for the 6h default.
+    timeout-minutes: 45
+    # The self-hosted box has 32 cores shared by several runners. Uncapped cargo
+    # (-j defaults to ncpu) lets concurrent jobs oversubscribe the CPU ~4x and
+    # starve microVM boots past the 180s agent-relay deadline (flaky
+    # "timed out waiting for agent relay"). Cap per-job build parallelism so
+    # several jobs can build at once without crushing VM boot latency.
+    env:
+      CARGO_BUILD_JOBS: "12"
     steps:
       - name: Clean workspace
         run: |
@@ -725,6 +761,15 @@ jobs:
     needs: [check, changes, python-sdk-test]
     if: needs.changes.outputs.code == 'true'
     runs-on: self-hosted-ubuntu-2404-x64
+    # Bound a wedged run so it can't squat a shared runner for the 6h default.
+    timeout-minutes: 45
+    # The self-hosted box has 32 cores shared by several runners. Uncapped cargo
+    # (-j defaults to ncpu) lets concurrent jobs oversubscribe the CPU ~4x and
+    # starve microVM boots past the 180s agent-relay deadline (flaky
+    # "timed out waiting for agent relay"). Cap per-job build parallelism so
+    # several jobs can build at once without crushing VM boot latency.
+    env:
+      CARGO_BUILD_JOBS: "12"
     steps:
       - name: Clean workspace
         run: |


### PR DESCRIPTION
## TL;DR
CI flakes with "timed out waiting for agent relay" across PRs because the shared self-hosted runner box gets CPU-oversubscribed and microVM boots blow past the 180s relay deadline. This caps per-job cargo parallelism and adds job timeouts on the self-hosted jobs. Two box-side changes (swap, /tmp cleanup) were also applied directly to the runner.

## Description
- The self-hosted box (32 cores, shared by 4 active runners) runs all the VM-booting jobs (cli-smoke, integration, node/python/go SDK). They are serialized within a PR via `needs:`, but multiple PRs run their chains concurrently.
- With cargo's default `-j` (= 32) per job, a few concurrent builds oversubscribe the CPU ~4x and starve microVM vCPU threads, so a boot that normally takes <2s exceeded 180s and failed (`create sandbox: Runtime("timed out waiting for agent relay: deadline has elapsed")`, observed at 207s).
- Add `CARGO_BUILD_JOBS: "12"` to each self-hosted job so several can build at once without crushing VM boot latency. Scoped to self-hosted only; GitHub-hosted jobs have <= 12 cores so they are unaffected.
- Add `timeout-minutes: 45` to each self-hosted job. There were zero `timeout-minutes` in the workflow, so a wedged run could hold a shared runner for GitHub's 6h default and back up everyone's queue.
- Applied directly on the runner (not in this PR, noted for the record): added an 8G swapfile with `vm.swappiness=10` (the box had 0 swap on 28G RAM), and cleared ~66k stale `/tmp/.tmp*` dirs left by old test runs (1.9G -> 329M).

## Test Plan
- [x] `ruby -ryaml -e "YAML.load_file('.github/workflows/check.yml')"` parses (YAML valid)
- [x] Each self-hosted job defines `timeout-minutes: 45` and `CARGO_BUILD_JOBS: "12"` (verified by parsing the workflow)
- [x] Re-run the integration suite a few times under normal PR load and confirm no `timed out waiting for agent relay` flakes (runs in CI on the self-hosted runner)
- [ ] Confirm overall "Check" wall-clock drops from the 90-176m range back toward ~15-20m (observed in CI, post-merge)
