### PR TITLE
feat(filesystem): add guest-write quotas for virtiofs mounts

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -755,6 +755,7 @@ pub fn apply_volume(builder: SandboxBuilder, spec: &str) -> anyhow::Result<Sandb
         spec,
         CliMountOptionSupport {
             policies: true,
+            quota: true,
             ..CliMountOptionSupport::default()
         },
     )?;
@@ -764,10 +765,23 @@ pub fn apply_volume(builder: SandboxBuilder, spec: &str) -> anyhow::Result<Sandb
     let guest = parsed.guest.to_string();
     let options = parsed.options;
     Ok(builder.volume(guest, move |mut m| {
+        let quota_mib = options.quota_mib;
         m = if is_path {
-            m.bind(&source)
+            let mut b = m.bind(&source);
+            if let Some(q) = quota_mib {
+                b = b.quota(q);
+            }
+            b
         } else {
-            m.named_with(&source, |v| v.ensure_exists())
+            // A named volume routes its quota through the named sub-builder
+            // rather than the bind-only `.quota()`.
+            m.named_with(&source, move |mut v| {
+                v = v.ensure_exists();
+                if let Some(q) = quota_mib {
+                    v = v.quota(q);
+                }
+                v
+            })
         };
         if options.readonly {
             m = m.readonly();
@@ -829,6 +843,7 @@ pub fn apply_explicit_dir_mount(
         spec,
         CliMountOptionSupport {
             policies: true,
+            quota: true,
             ..CliMountOptionSupport::default()
         },
     )?;
@@ -976,6 +991,9 @@ fn apply_common_mount_options(mut mount: MountBuilder, options: CliMountOptions)
     }
     if let Some(hp) = options.host_permissions {
         mount = mount.host_permissions(hp);
+    }
+    if let Some(quota) = options.quota_mib {
+        mount = mount.quota(quota);
     }
     mount
 }

--- a/crates/cli/lib/commands/inspect.rs
+++ b/crates/cli/lib/commands/inspect.rs
@@ -153,10 +153,17 @@ pub async fn run(args: InspectArgs) -> anyhow::Result<()> {
                         options,
                         stat_virtualization,
                         host_permissions,
+                        quota_mib,
                     } => {
                         let flags = mount_flags_suffix(*options);
                         let suffix = mount_policy_suffix(*stat_virtualization, *host_permissions);
-                        println!("  {guest:<16}\u{2192} {}{flags}{suffix}", host.display());
+                        let quota = quota_mib
+                            .map(|mib| format!(" [quota={mib}MiB]"))
+                            .unwrap_or_default();
+                        println!(
+                            "  {guest:<16}\u{2192} {}{flags}{suffix}{quota}",
+                            host.display()
+                        );
                     }
                     VolumeMount::Named {
                         name,

--- a/crates/filesystem/lib/backends/passthroughfs/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/builder.rs
@@ -46,6 +46,7 @@ pub struct PassthroughFsBuilder {
     writeback: bool,
     inject_init: bool,
     bind_identity_map: Option<BindIdentityMapHandle>,
+    quota_bytes: Option<u64>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -66,6 +67,7 @@ impl PassthroughFsBuilder {
             writeback: false,
             inject_init: true,
             bind_identity_map: None,
+            quota_bytes: None,
         }
     }
 
@@ -129,6 +131,12 @@ impl PassthroughFsBuilder {
         self
     }
 
+    /// Set an optional guest-write byte budget for this mount's subtree.
+    pub fn quota_bytes(mut self, bytes: Option<u64>) -> Self {
+        self.quota_bytes = bytes;
+        self
+    }
+
     /// Build the PassthroughFs instance.
     pub fn build(self) -> io::Result<PassthroughFs> {
         let root_dir = self
@@ -163,6 +171,7 @@ impl PassthroughFsBuilder {
             writeback: self.writeback,
             inject_init: self.inject_init,
             bind_identity_map: self.bind_identity_map,
+            quota_bytes: self.quota_bytes,
         };
         if cfg_probe.strict_enabled() && cfg_probe.xattr_enabled() {
             let supported = stat_override::probe_xattr_support(root_fd.as_raw_fd())?;
@@ -194,6 +203,10 @@ impl PassthroughFsBuilder {
 
         let cfg = cfg_probe;
 
+        let quota = cfg
+            .quota_bytes
+            .map(|limit| super::quota::DirQuota::new(cfg.root_dir.clone(), limit));
+
         Ok(PassthroughFs {
             cfg,
             root_fd,
@@ -208,6 +221,7 @@ impl PassthroughFsBuilder {
             has_openat2,
             #[cfg(target_os = "linux")]
             proc_self_fd,
+            quota,
         })
     }
 }

--- a/crates/filesystem/lib/backends/passthroughfs/create_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/create_ops.rs
@@ -64,6 +64,10 @@ pub(crate) fn do_create(
         return Err(platform::eacces());
     }
 
+    // Snapshot the quota baseline before creating the file, so the new file's
+    // bytes are charged as guest growth rather than absorbed into the baseline.
+    fs.quota_ensure_baseline();
+
     let parent_fd = inode::get_inode_fd(fs, parent)?;
 
     // Apply umask.

--- a/crates/filesystem/lib/backends/passthroughfs/file_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/file_ops.rs
@@ -50,6 +50,13 @@ pub(crate) fn do_open(
         return Err(platform::erofs());
     }
 
+    // Snapshot the quota baseline before any write-intent open (which may carry
+    // O_TRUNC). This precedes the file's first write, so the baseline reflects
+    // pre-guest-write state. Read-only opens never trigger the walk.
+    if open_flags_mutate(open_flags) {
+        fs.quota_ensure_baseline();
+    }
+
     // Writeback cache: kernel may issue reads on O_WRONLY fds for cache coherency,
     // so widen to O_RDWR. Strip O_APPEND because it races with the kernel's cached
     // write position.
@@ -138,9 +145,14 @@ pub(crate) fn do_write(
     let handles = fs.handles.read().unwrap();
     let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
     let f = data.file.read().unwrap();
-    let written = r.read_to(&f, size as usize, offset)?;
 
     let fd = f.as_raw_fd();
+    // Charge the quota for any growth past EOF before writing, so an
+    // over-budget write is refused with ENOSPC rather than hitting the disk.
+    fs.quota_charge_to(fd, offset.saturating_add(size as u64))?;
+
+    let written = r.read_to(&f, size as usize, offset)?;
+
     if kill_priv {
         if fs.cfg.xattr_enabled() {
             if let Some(ovr) = stat_override::get_override(fd, true, fs.cfg.strict_enabled())? {

--- a/crates/filesystem/lib/backends/passthroughfs/metadata.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/metadata.rs
@@ -185,6 +185,15 @@ pub(crate) fn do_setattr(
 
     // Handle size changes via ftruncate.
     if valid.contains(SetattrValid::SIZE) {
+        // Snapshot the quota baseline before truncating — a path-based truncate
+        // reaches here without a prior `open`, so this is the write-gating point
+        // that guarantees the baseline predates the mutation.
+        fs.quota_ensure_baseline();
+
+        // Quota: an extending truncate grows the file. Charge the growth past
+        // EOF before ftruncate (a shrinking truncate charges nothing).
+        fs.quota_charge_to(*close_fd, attr.st_size.max(0) as u64)?;
+
         let ret = unsafe { libc::ftruncate(*close_fd, attr.st_size) };
         if ret < 0 {
             return Err(platform::linux_error(io::Error::last_os_error()));

--- a/crates/filesystem/lib/backends/passthroughfs/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/mod.rs
@@ -11,6 +11,7 @@ mod file_ops;
 mod host_mode;
 pub(crate) mod inode;
 mod metadata;
+pub(crate) mod quota;
 mod remove_ops;
 mod special;
 mod xattr_ops;
@@ -149,6 +150,14 @@ pub struct PassthroughConfig {
 
     /// Optional user-volume identity map for host metadata fallback.
     pub bind_identity_map: Option<stat_override::BindIdentityMapHandle>,
+
+    /// Optional guest-write byte budget for this mount's subtree.
+    ///
+    /// `None` means unbounded (the default). When set, guest-attributable
+    /// growth past this many bytes is rejected with `ENOSPC`, and guest
+    /// `statfs` reports the budget instead of the host filesystem. Enforced by
+    /// the `quota` module.
+    pub quota_bytes: Option<u64>,
 }
 
 /// Passthrough filesystem backend.
@@ -193,6 +202,9 @@ pub struct PassthroughFs {
     /// after first rejecting real host symlinks on the pinned inode.
     #[cfg(target_os = "linux")]
     pub(crate) proc_self_fd: File,
+
+    /// Optional guest-write byte budget for this mount's subtree.
+    pub(crate) quota: Option<quota::DirQuota>,
 }
 
 /// Open directory handle with a lazy point-in-time snapshot.
@@ -288,6 +300,10 @@ impl PassthroughFs {
             unsafe { File::from_raw_fd(fd) }
         };
 
+        let quota = cfg
+            .quota_bytes
+            .map(|limit| quota::DirQuota::new(cfg.root_dir.clone(), limit));
+
         Ok(Self {
             cfg,
             root_fd,
@@ -302,6 +318,7 @@ impl PassthroughFs {
             has_openat2,
             #[cfg(target_os = "linux")]
             proc_self_fd,
+            quota,
         })
     }
 }
@@ -401,6 +418,32 @@ impl PassthroughFs {
     pub(crate) fn is_virtual_init_inode(&self, inode: u64) -> bool {
         self.injects_init() && inode == init_binary::INIT_INODE
     }
+
+    /// Charge the quota for growing an open file to `new_end` bytes.
+    ///
+    /// No-op when this mount has no quota. Otherwise charges the delta between
+    /// the file's current logical size and `new_end` (zero when the operation
+    /// stays within the existing size), returning `ENOSPC` if it would exceed
+    /// the budget.
+    pub(crate) fn quota_charge_to(&self, fd: std::os::fd::RawFd, new_end: u64) -> io::Result<()> {
+        if let Some(q) = &self.quota {
+            let old = quota::fd_size(fd);
+            q.charge(new_end.saturating_sub(old))?;
+        }
+        Ok(())
+    }
+
+    /// Capture the quota baseline now if it has not been captured yet.
+    ///
+    /// No-op when this mount has no quota. Called from the write-gating
+    /// handlers so the baseline reflects the pre-guest-write state without
+    /// walking the directory at mount time. May block for one directory walk on
+    /// its first call for a heavy mount; cheap thereafter.
+    pub(crate) fn quota_ensure_baseline(&self) {
+        if let Some(q) = &self.quota {
+            q.ensure_baseline();
+        }
+    }
 }
 
 impl PassthroughConfig {
@@ -444,6 +487,7 @@ impl Default for PassthroughConfig {
             writeback: false,
             inject_init: true,
             bind_identity_map: None,
+            quota_bytes: None,
         }
     }
 }

--- a/crates/filesystem/lib/backends/passthroughfs/quota.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/quota.rs
@@ -1,0 +1,300 @@
+//! Directory byte-budget quota for the passthrough filesystem.
+//!
+//! A passthrough mount shares a host directory directly, so without a budget a
+//! guest can write unbounded data straight onto the host disk. [`DirQuota`]
+//! bounds the *guest-attributable* growth of one mount's subtree.
+//!
+//! ## Accounting model
+//!
+//! `used` is an optimistic running estimate of the subtree's logical size,
+//! charged on growth (write / fallocate / truncate-extend / copy). It is
+//! deliberately **never decremented** on the unlink / rename / truncate-shrink
+//! paths — that would mean fstat-before-remove bookkeeping on every mutation.
+//! Instead, when an optimistic charge would cross `limit`, the budget walks the
+//! root to recompute the ground-truth size and corrects `used`. The walk is
+//! ground truth at the only moment it matters (the limit boundary), so the hot
+//! path stays cheap while a churning workload (e.g. a heartbeat file rewritten
+//! every second) converges on its true size instead of monotonically draining
+//! the budget.
+//!
+//! Accounting is **logical** (`st_size`, not allocated blocks): a sparse file is
+//! charged at its apparent size. That is conservative for a fill-prevention
+//! quota — it bounds what the guest could later fill.
+//!
+//! ## Delta semantics
+//!
+//! The budget bounds *guest additions beyond what already existed when the
+//! guest first writes*, not the absolute subtree size. That baseline — the
+//! host-written control-plane files for `/.msb`, or a pre-existing host
+//! directory for a bind mount — never counts against the guest. So
+//! `quota = 1 GiB` on a directory that already holds 5 GiB means "the guest may
+//! add up to 1 GiB," not "instantly full."
+//!
+//! ## Lazy baseline
+//!
+//! The baseline is **not** walked at mount — that would put a directory walk on
+//! the VM-setup path, costly for a heavy bind mount. It is computed once, on the
+//! first guest write-access ([`DirQuota::ensure_baseline`], called from the
+//! `open`/`create`/`setattr` handlers). Those ops necessarily precede the first
+//! `write`/`fallocate`/truncate-extend, so the baseline always reflects the
+//! pre-guest-write state — the snapshot just happens at first touch instead of
+//! at boot. A read-only workload never triggers it.
+
+use std::{
+    io,
+    os::fd::RawFd,
+    path::{Path, PathBuf},
+    sync::{
+        OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use crate::{backends::shared::platform, statvfs64};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// A delta-charged byte budget for one passthrough mount subtree.
+pub(crate) struct DirQuota {
+    /// Hard ceiling in bytes for guest additions. Growth past this returns `ENOSPC`.
+    limit: u64,
+
+    /// Host directory whose subtree is bounded.
+    root: PathBuf,
+
+    /// Subtree size at first guest write-access. Never counts against the
+    /// guest. Computed lazily so a heavy directory is not walked at boot.
+    baseline: OnceLock<u64>,
+
+    /// Optimistic running estimate of guest-added bytes beyond the baseline.
+    used: AtomicU64,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl DirQuota {
+    /// Create a budget of `limit` guest-addable bytes over the subtree at `root`.
+    ///
+    /// Does not walk the directory — the baseline is captured lazily on the
+    /// first guest write-access (see [`Self::ensure_baseline`]).
+    pub(crate) fn new(root: PathBuf, limit: u64) -> Self {
+        Self {
+            limit,
+            root,
+            baseline: OnceLock::new(),
+            used: AtomicU64::new(0),
+        }
+    }
+
+    /// The configured ceiling in bytes for guest additions.
+    pub(crate) fn limit(&self) -> u64 {
+        self.limit
+    }
+
+    /// Bytes present at the moment the baseline was first captured (never
+    /// charged to the guest). Computes the baseline if it has not been yet.
+    pub(crate) fn baseline(&self) -> u64 {
+        *self.baseline.get_or_init(|| subtree_size(&self.root))
+    }
+
+    /// Capture the baseline now if it has not been captured yet.
+    ///
+    /// Called from the write-gating FUSE handlers (`open` with write intent,
+    /// `create`, `setattr`-truncate) so the baseline is snapshotted *before* the
+    /// guest's first mutation. Idempotent and cheap after the first call.
+    pub(crate) fn ensure_baseline(&self) {
+        let _ = self.baseline();
+    }
+
+    /// Current best estimate of bytes used, clamped to the ceiling for display.
+    pub(crate) fn used(&self) -> u64 {
+        self.used.load(Ordering::Relaxed).min(self.limit)
+    }
+
+    /// Charge `growth` bytes of pending subtree growth.
+    ///
+    /// Returns `ENOSPC` if the growth would exceed the limit even after a
+    /// ground-truth recount. The pending write has not happened yet, so the
+    /// recount measures the subtree *without* this growth and the decision is
+    /// made against `real + growth`.
+    pub(crate) fn charge(&self, growth: u64) -> io::Result<()> {
+        if growth == 0 {
+            return Ok(());
+        }
+
+        let prev = self.used.fetch_add(growth, Ordering::Relaxed);
+        if prev.saturating_add(growth) <= self.limit {
+            return Ok(());
+        }
+
+        // The optimistic estimate crossed the ceiling. It may be stale (deletes
+        // and overwrites are not tracked incrementally), so fall back to ground
+        // truth — guest additions beyond the baseline — before refusing.
+        let real = subtree_size(&self.root).saturating_sub(self.baseline());
+        if real.saturating_add(growth) <= self.limit {
+            self.used
+                .store(real.saturating_add(growth), Ordering::Relaxed);
+            Ok(())
+        } else {
+            self.used.store(real, Ordering::Relaxed);
+            Err(platform::enospc())
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Logical size of an open file by fd, or 0 if it cannot be stat'd.
+pub(crate) fn fd_size(fd: RawFd) -> u64 {
+    platform::fstat(fd)
+        .map(|st| st.st_size.max(0) as u64)
+        .unwrap_or(0)
+}
+
+/// Sum the logical size of every regular file beneath `root`.
+///
+/// Best-effort: unreadable directories and entries are skipped. Symlinks are
+/// not followed, so the walk stays within the mount subtree.
+fn subtree_size(root: &Path) -> u64 {
+    let mut total = 0u64;
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else if file_type.is_file() {
+                let len = entry.metadata().map(|m| m.len()).unwrap_or(0);
+                total = total.saturating_add(len);
+            }
+        }
+    }
+    total
+}
+
+/// Build a `statvfs64` reply that reports the quota as the filesystem size.
+///
+/// Makes guest `df` reflect the mount's real constraint instead of the host
+/// filesystem's much larger figures. Includes the baseline so that `df`'s
+/// derived *used* (total − free) tracks what `du` reports, while *available*
+/// stays the remaining guest budget:
+///
+/// - total     = `baseline + limit`
+/// - available = `limit - used`
+/// - used (df) = total − available = `baseline + used`
+pub(crate) fn quota_statvfs(baseline: u64, limit: u64, used: u64) -> statvfs64 {
+    let bsize = 4096u64;
+    let total = baseline.saturating_add(limit);
+    let free = limit.saturating_sub(used);
+    let mut st: statvfs64 = unsafe { std::mem::zeroed() };
+
+    #[cfg(target_os = "linux")]
+    {
+        st.f_bsize = bsize;
+        st.f_frsize = bsize;
+        st.f_blocks = total / bsize;
+        st.f_bfree = free / bsize;
+        st.f_bavail = free / bsize;
+        st.f_namemax = 255;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        st.f_bsize = bsize;
+        st.f_frsize = bsize;
+        st.f_blocks = (total / bsize) as _;
+        st.f_bfree = (free / bsize) as _;
+        st.f_bavail = (free / bsize) as _;
+        st.f_namemax = 255;
+    }
+
+    st
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn charge_allows_up_to_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let q = DirQuota::new(dir.path().to_path_buf(), 1024);
+        assert!(q.charge(512).is_ok());
+        assert!(q.charge(512).is_ok());
+        assert_eq!(q.used(), 1024);
+    }
+
+    #[test]
+    fn charge_past_limit_is_enospc_when_real_growth_exceeds_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let q = DirQuota::new(dir.path().to_path_buf(), 1024);
+        // The handlers force the baseline before the first guest write; mirror
+        // that here so the about-to-be-written file is charged, not baselined.
+        q.ensure_baseline();
+        // Guest writes a real 1 KiB file (charge succeeds, then the write lands).
+        assert!(q.charge(1024).is_ok());
+        std::fs::write(dir.path().join("a"), vec![0u8; 1024]).unwrap();
+        // A second 1 KiB write crosses the ceiling; the recount finds the real
+        // 1 KiB already on disk and refuses the new growth.
+        let err = q.charge(1024).unwrap_err();
+        assert_eq!(err.raw_os_error(), platform::enospc().raw_os_error());
+    }
+
+    #[test]
+    fn baseline_files_are_not_charged() {
+        let dir = tempfile::tempdir().unwrap();
+        // A pre-existing 4 KiB file forms the baseline.
+        std::fs::write(dir.path().join("preexisting"), vec![0u8; 4096]).unwrap();
+        let q = DirQuota::new(dir.path().to_path_buf(), 1024);
+        q.ensure_baseline();
+        assert_eq!(q.baseline(), 4096);
+        // The guest may still add up to the full quota beyond the baseline.
+        assert!(q.charge(1024).is_ok());
+    }
+
+    #[test]
+    fn baseline_is_captured_lazily_not_at_construction() {
+        let dir = tempfile::tempdir().unwrap();
+        let q = DirQuota::new(dir.path().to_path_buf(), 1024);
+        // A file appearing after construction but before first access (e.g. a
+        // host-written control file) counts as baseline, not guest usage.
+        std::fs::write(dir.path().join("late"), vec![0u8; 800]).unwrap();
+        q.ensure_baseline();
+        assert_eq!(q.baseline(), 800);
+    }
+
+    #[test]
+    fn recount_reclaims_drift_from_untracked_deletes() {
+        let dir = tempfile::tempdir().unwrap();
+        let q = DirQuota::new(dir.path().to_path_buf(), 1024);
+        // Simulate a churning writer: the optimistic counter drifts up to the
+        // ceiling even though nothing is actually on disk.
+        assert!(q.charge(1024).is_ok());
+        // Next charge crosses the ceiling, triggers a recount, finds an empty
+        // subtree, and succeeds — the budget did not get permanently stuck.
+        assert!(q.charge(512).is_ok());
+        assert_eq!(q.used(), 512);
+    }
+
+    #[test]
+    fn zero_growth_is_free() {
+        let dir = tempfile::tempdir().unwrap();
+        let q = DirQuota::new(dir.path().to_path_buf(), 0);
+        assert!(q.charge(0).is_ok());
+    }
+}

--- a/crates/filesystem/lib/backends/passthroughfs/special.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/special.rs
@@ -107,6 +107,14 @@ pub(crate) fn do_fallocate(
     let f = data.file.write().unwrap();
     let fd = f.as_raw_fd();
 
+    // Quota: a non-hole-punching fallocate reserves space and may grow the
+    // file. Charge the growth past EOF before allocating. Hole-punching frees
+    // space, so it is never charged.
+    const FALLOC_FL_PUNCH_HOLE: u32 = 0x02;
+    if mode & FALLOC_FL_PUNCH_HOLE == 0 {
+        fs.quota_charge_to(fd, offset.saturating_add(length))?;
+    }
+
     #[cfg(target_os = "linux")]
     {
         let ret = unsafe { libc::fallocate64(fd, mode as i32, offset as i64, length as i64) };
@@ -223,6 +231,9 @@ pub(crate) fn do_copyfilerange(
         let f_in = data_in.file.read().unwrap();
         let f_out = data_out.file.read().unwrap();
 
+        // Quota: the copy may grow the destination past EOF.
+        fs.quota_charge_to(f_out.as_raw_fd(), offset_out.saturating_add(len))?;
+
         let mut off_in = offset_in as i64;
         let mut off_out = offset_out as i64;
 
@@ -253,6 +264,16 @@ pub(crate) fn do_copyfilerange(
 
 /// Get filesystem statistics.
 pub(crate) fn do_statfs(fs: &PassthroughFs, _ctx: Context, inode: u64) -> io::Result<statvfs64> {
+    // A quota'd mount reports its budget so guest `df` reflects the cap rather
+    // than the host filesystem's (much larger) real figures.
+    if let Some(q) = &fs.quota {
+        return Ok(super::quota::quota_statvfs(
+            q.baseline(),
+            q.limit(),
+            q.used(),
+        ));
+    }
+
     // Keep InodeFd guard alive so the fd isn't closed before fstatvfs uses it.
     let inode_fd;
     let fd = if fs.is_virtual_init_inode(inode) || inode == 1 {

--- a/crates/filesystem/lib/backends/passthroughfs/tests/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/tests/mod.rs
@@ -13,6 +13,7 @@ mod test_lookup_inode;
 mod test_metadata;
 mod test_name_validation;
 mod test_open_after_unlink;
+mod test_quota;
 mod test_readonly;
 mod test_remove_ops;
 mod test_special_ops;

--- a/crates/filesystem/lib/backends/passthroughfs/tests/test_quota.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/tests/test_quota.rs
@@ -1,0 +1,112 @@
+//! End-to-end quota invariants, driven through the real FUSE handlers
+//! (`create` / `write` / `statfs`) against a quota'd `PassthroughFs`.
+
+use super::*;
+
+/// Linux `ENOSPC`, the errno the quota returns when a write is refused.
+const ENOSPC: i32 = 28;
+
+/// Build a test sandbox whose mount has a `limit`-byte guest-write budget.
+fn quota_fs(limit: u64) -> TestSandbox {
+    TestSandbox::with_config(|mut cfg| {
+        cfg.quota_bytes = Some(limit);
+        cfg
+    })
+}
+
+#[test]
+fn writes_within_quota_succeed() {
+    let sb = quota_fs(64 * 1024);
+    let (entry, handle) = sb.fuse_create_root("a").unwrap();
+    let data = vec![0u8; 64 * 1024];
+    let n = sb.fuse_write(entry.inode, handle, &data, 0).unwrap();
+    assert_eq!(n, data.len());
+}
+
+#[test]
+fn writes_past_quota_return_enospc() {
+    let sb = quota_fs(64 * 1024);
+    let (entry, handle) = sb.fuse_create_root("a").unwrap();
+    // Fill the budget exactly.
+    sb.fuse_write(entry.inode, handle, &vec![0u8; 64 * 1024], 0)
+        .unwrap();
+    // One more byte past the cap is refused with ENOSPC.
+    let err = sb
+        .fuse_write(entry.inode, handle, &[0u8; 1], 64 * 1024)
+        .unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(ENOSPC));
+}
+
+#[test]
+fn overwrites_in_place_do_not_drain_quota() {
+    // The heartbeat invariant: rewriting the same region forever stays in
+    // budget because only growth is charged, not write volume.
+    let sb = quota_fs(64 * 1024);
+    let (entry, handle) = sb.fuse_create_root("hb").unwrap();
+    let chunk = vec![0u8; 1024];
+    for _ in 0..1000 {
+        // 1000 * 1 KiB = 1 MiB of writes, but the file never grows past 1 KiB.
+        sb.fuse_write(entry.inode, handle, &chunk, 0).unwrap();
+    }
+}
+
+#[test]
+fn baseline_files_are_not_charged() {
+    let sb = quota_fs(64 * 1024);
+    // A pre-existing host file larger than the quota itself forms the baseline.
+    sb.host_create_file("preexisting.bin", &vec![0u8; 1024 * 1024]);
+    // The guest can still add a full quota's worth beyond it.
+    let (entry, handle) = sb.fuse_create_root("new").unwrap();
+    let n = sb
+        .fuse_write(entry.inode, handle, &vec![0u8; 64 * 1024], 0)
+        .unwrap();
+    assert_eq!(n, 64 * 1024);
+}
+
+#[test]
+fn statfs_reports_baseline_plus_quota() {
+    let limit = 64 * 1024u64;
+    let baseline = 32 * 1024u64;
+    let used = 16 * 1024u64;
+    let sb = quota_fs(limit);
+    sb.host_create_file("base.bin", &vec![0u8; baseline as usize]);
+
+    let (entry, handle) = sb.fuse_create_root("g").unwrap();
+    sb.fuse_write(entry.inode, handle, &vec![0u8; used as usize], 0)
+        .unwrap();
+
+    let st = sb.fs.statfs(sb.ctx(), ROOT_INODE).unwrap();
+    let frsize = st.f_frsize as u64;
+    let total = st.f_blocks as u64 * frsize;
+    let avail = st.f_bavail as u64 * frsize;
+    // df total = baseline + quota; available = quota - used.
+    assert_eq!(total, baseline + limit);
+    assert_eq!(avail, limit - used);
+}
+
+#[test]
+fn no_quota_means_unbounded() {
+    let sb = TestSandbox::new(); // default config: no quota
+    let (entry, handle) = sb.fuse_create_root("big").unwrap();
+    let big = vec![0u8; 4 * 1024 * 1024];
+    let n = sb.fuse_write(entry.inode, handle, &big, 0).unwrap();
+    assert_eq!(n, big.len());
+}
+
+#[test]
+fn deleting_then_rewriting_reclaims_budget() {
+    // After filling the quota and removing the file, the recount reclaims the
+    // freed space so the guest can write again — no permanent exhaustion.
+    let sb = quota_fs(64 * 1024);
+    let (entry, handle) = sb.fuse_create_root("a").unwrap();
+    sb.fuse_write(entry.inode, handle, &vec![0u8; 64 * 1024], 0)
+        .unwrap();
+    // Free it on the host (models the guest deleting its file).
+    std::fs::remove_file(sb.root.join("a")).unwrap();
+
+    let (entry2, handle2) = sb.fuse_create_root("b").unwrap();
+    let n = sb
+        .fuse_write(entry2.inode, handle2, &vec![0u8; 64 * 1024], 0)
+        .unwrap();
+    assert_eq!(n, 64 * 1024);
+}

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -54,6 +54,16 @@ pub const AGENT_PORT_NAME: &str = "agent";
 /// Virtiofs tag for the runtime filesystem (scripts, heartbeat).
 pub const RUNTIME_FS_TAG: &str = "msb_runtime";
 
+/// Guest-write byte budget for the runtime (`/.msb`) virtiofs mount.
+///
+/// `/.msb` is a host↔guest control channel, not bulk storage: the only
+/// guest-written payload is a ~1 KiB heartbeat (host-written scripts and TLS
+/// certs form the mount's baseline and are not charged). This 16 MiB ceiling is
+/// therefore almost entirely abuse headroom — it exists so the channel cannot be
+/// used to fill the host disk. It is intentionally a fixed constant rather than
+/// a user-facing knob.
+pub const RUNTIME_FS_QUOTA_BYTES: u64 = 16 * 1024 * 1024;
+
 /// Guest mount point for the runtime filesystem.
 pub const RUNTIME_MOUNT_POINT: &str = "/.msb";
 

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -1058,12 +1058,18 @@ fn build_vm(
     }
 
     // Runtime directory mount — agentd mounts this at /.msb for scripts
-    // and heartbeat.
+    // and heartbeat. It is a host↔guest control channel (the host writes
+    // scripts/TLS certs and reads heartbeat.json through it), so it stays a
+    // virtiofs share rather than a block device. A fixed budget caps guest
+    // writes so the channel can never be used to fill the host disk; the
+    // legitimate guest footprint is a ~1 KiB heartbeat, so the budget is
+    // almost entirely abuse headroom and is not user-configurable.
     {
         let runtime_tag = microsandbox_protocol::RUNTIME_FS_TAG.to_string();
         let cfg = PassthroughConfig {
             root_dir: config.runtime_dir.clone(),
             inject_init: false,
+            quota_bytes: Some(microsandbox_protocol::RUNTIME_FS_QUOTA_BYTES),
             ..Default::default()
         };
         let backend = PassthroughFs::new(cfg)
@@ -1086,6 +1092,7 @@ fn build_vm(
             host_permissions: parsed.host_permissions,
             readonly: parsed.readonly,
             bind_identity_map: mount_bind_identity_map,
+            quota_bytes: parsed.quota_bytes,
             ..Default::default()
         };
         let backend = PassthroughFs::new(cfg)
@@ -1530,6 +1537,7 @@ struct ParsedMountSpec {
     stat_virtualization: StatVirtualization,
     host_permissions: HostPermissions,
     readonly: bool,
+    quota_bytes: Option<u64>,
 }
 
 /// Parse a `--mount` spec into [`ParsedMountSpec`].
@@ -1562,12 +1570,14 @@ fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
     let mut stat_virtualization = StatVirtualization::Strict;
     let mut host_permissions = HostPermissions::Private;
     let mut readonly = false;
+    let mut quota_bytes = None;
     let mut seen_stat_virt = false;
     let mut seen_host_perms = false;
     let mut seen_access = false;
     let mut seen_noexec = false;
     let mut seen_nosuid = false;
     let mut seen_nodev = false;
+    let mut seen_quota = false;
 
     if let Some(opts) = options {
         for opt in opts.split(',') {
@@ -1643,6 +1653,20 @@ fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
                                 }
                             }
                         }
+                        "quota" => {
+                            if seen_quota {
+                                return Err(
+                                    "mount option `quota` specified more than once".to_string()
+                                );
+                            }
+                            seen_quota = true;
+                            let mib = value.parse::<u64>().map_err(|_| {
+                                format!(
+                                    "invalid quota {value:?} (expected an integer count of MiB)"
+                                )
+                            })?;
+                            quota_bytes = Some(mib.saturating_mul(1024 * 1024));
+                        }
                         other => return Err(format!("unknown mount option {other:?}")),
                     }
                 }
@@ -1656,6 +1680,7 @@ fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
         stat_virtualization,
         host_permissions,
         readonly,
+        quota_bytes,
     })
 }
 
@@ -1746,6 +1771,33 @@ mod tests {
         let p = parse_mount_spec("foo:/host/data:stat-virt=off").unwrap();
         assert!(matches!(p.stat_virtualization, StatVirtualization::Off));
         assert!(!p.readonly);
+    }
+
+    #[test]
+    fn test_parse_mount_spec_quota_in_mib() {
+        let p = parse_mount_spec("foo:/host/data:quota=2048").unwrap();
+        assert_eq!(p.quota_bytes, Some(2048 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_parse_mount_spec_quota_default_none() {
+        let p = parse_mount_spec("foo:/host/data:ro").unwrap();
+        assert_eq!(p.quota_bytes, None);
+    }
+
+    #[test]
+    fn test_parse_mount_spec_rejects_duplicate_quota() {
+        let err = parse_mount_spec("foo:/host/data:quota=1,quota=2").unwrap_err();
+        assert!(
+            err.contains("`quota` specified more than once"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_mount_spec_rejects_non_numeric_quota() {
+        let err = parse_mount_spec("foo:/host/data:quota=big").unwrap_err();
+        assert!(err.contains("invalid quota"), "got: {err}");
     }
 
     #[test]

--- a/packages/microsandbox-types/rust/lib/domain.rs
+++ b/packages/microsandbox-types/rust/lib/domain.rs
@@ -247,6 +247,12 @@ pub enum VolumeMount {
         stat_virtualization: StatVirtualization,
         /// Host permission propagation policy.
         host_permissions: HostPermissions,
+        /// Guest-write byte budget in MiB.
+        ///
+        /// Bounds how much the guest may add beyond the directory's existing
+        /// contents. `None` applies the protective default at spawn time; set a
+        /// value to override it.
+        quota_mib: Option<u32>,
     },
 
     /// Mount a named volume into the guest.
@@ -1086,14 +1092,16 @@ impl Serialize for VolumeMount {
                 options,
                 stat_virtualization,
                 host_permissions,
+                quota_mib,
             } => {
-                let mut map = serializer.serialize_map(Some(6))?;
+                let mut map = serializer.serialize_map(Some(7))?;
                 map.serialize_entry("type", "Bind")?;
                 map.serialize_entry("host", host)?;
                 map.serialize_entry("guest", guest)?;
                 map.serialize_entry("options", options)?;
                 map.serialize_entry("stat_virtualization", stat_virtualization)?;
                 map.serialize_entry("host_permissions", host_permissions)?;
+                map.serialize_entry("quota_mib", quota_mib)?;
                 map.end()
             }
             Self::Named {
@@ -1169,6 +1177,8 @@ impl<'de> Deserialize<'de> for VolumeMount {
                 stat_virtualization: StatVirtualization,
                 #[serde(default = "default_private")]
                 host_permissions: HostPermissions,
+                #[serde(default)]
+                quota_mib: Option<u32>,
             },
             Named {
                 name: String,
@@ -1213,12 +1223,14 @@ impl<'de> Deserialize<'de> for VolumeMount {
                 readonly,
                 stat_virtualization,
                 host_permissions,
+                quota_mib,
             } => Self::Bind {
                 host,
                 guest,
                 options: decode_mount_options(options, readonly),
                 stat_virtualization,
                 host_permissions,
+                quota_mib,
             },
             VolumeMountHelper::Named {
                 name,
@@ -1272,6 +1284,7 @@ impl fmt::Debug for VolumeMount {
                 options,
                 stat_virtualization,
                 host_permissions,
+                quota_mib,
             } => f
                 .debug_struct("Bind")
                 .field("host", host)
@@ -1279,6 +1292,7 @@ impl fmt::Debug for VolumeMount {
                 .field("options", options)
                 .field("stat_virtualization", stat_virtualization)
                 .field("host_permissions", host_permissions)
+                .field("quota_mib", quota_mib)
                 .finish(),
             Self::Named {
                 name,

--- a/packages/microsandbox-types/typescript/src/index.ts
+++ b/packages/microsandbox-types/typescript/src/index.ts
@@ -130,7 +130,15 @@ stat_virtualization: StatVirtualization,
 /**
  * Host permission propagation policy.
  */
-host_permissions: HostPermissions, } | { "type": "Named",
+host_permissions: HostPermissions,
+/**
+ * Guest-write byte budget in MiB.
+ *
+ * Bounds how much the guest may add beyond the directory's existing
+ * contents. `None` applies the protective default at spawn time; set a
+ * value to override it.
+ */
+quota_mib: number | null, } | { "type": "Named",
 /**
  * Volume name.
  */

--- a/sdk/node-ts/native/mount_builder.rs
+++ b/sdk/node-ts/native/mount_builder.rs
@@ -31,6 +31,7 @@ pub struct JsBuiltVolumeMount {
     pub host: Option<String>,
     pub name: Option<String>,
     pub size_mib: Option<u32>,
+    pub quota_mib: Option<u32>,
     pub format: Option<String>,
     pub fstype: Option<String>,
     /// `"strict" | "relaxed" | "off"` for bind/named mounts; `None` for tmpfs/disk.
@@ -210,6 +211,17 @@ impl JsMountBuilder {
         self
     }
 
+    /// Guest-write quota in MiB (only valid with `.bind()`).
+    ///
+    /// Bounds how much the guest may add beyond the bind-mounted directory's
+    /// existing contents. Without it, a protective default is applied.
+    #[napi]
+    pub fn quota(&mut self, mib: u32) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.quota(Mebibytes::from(mib)));
+        self
+    }
+
     /// Set the guest stat virtualization policy.
     ///
     /// Accepts `"strict"`, `"relaxed"`, or `"off"`. Valid only for bind and
@@ -289,6 +301,7 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             options,
             stat_virtualization,
             host_permissions,
+            quota_mib,
         } => JsBuiltVolumeMount {
             kind: "bind".into(),
             guest,
@@ -299,6 +312,7 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             host: Some(host.to_string_lossy().into_owned()),
             name: None,
             size_mib: None,
+            quota_mib,
             format: None,
             fstype: None,
             stat_virtualization: Some(sv_str(stat_virtualization)),
@@ -321,6 +335,7 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             host: None,
             name: Some(name),
             size_mib: None,
+            quota_mib: None,
             format: None,
             fstype: None,
             stat_virtualization: Some(sv_str(stat_virtualization)),
@@ -340,6 +355,7 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             host: None,
             name: None,
             size_mib,
+            quota_mib: None,
             format: None,
             fstype: None,
             stat_virtualization: None,
@@ -361,6 +377,7 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             host: Some(host.to_string_lossy().into_owned()),
             name: None,
             size_mib: None,
+            quota_mib: None,
             format: Some(
                 match format {
                     RustDiskImageFormat::Qcow2 => "qcow2",

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -347,6 +347,8 @@ class MountConfig:
             if self.bind is None:
                 raise ValueError("MountConfig kind=BIND requires bind=...")
             d["bind"] = self.bind
+            if self.quota_mib is not None:
+                d["quota_mib"] = self.quota_mib
         elif self.kind == MountKind.NAMED:
             if self.named is None:
                 raise ValueError("MountConfig kind=NAMED requires named=...")

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -460,6 +460,7 @@ fn apply_mount(
         .transpose()?;
 
     if let Some(bind_path) = extract_opt::<String>(mount, "bind")? {
+        let quota_mib = extract_opt::<u32>(mount, "quota_mib")?;
         Ok(builder.volume(&guest_path, |v| {
             let mut m = v.bind(&bind_path);
             if readonly {
@@ -479,6 +480,9 @@ fn apply_mount(
             }
             if let Some(p) = host_perms {
                 m = m.host_permissions(p);
+            }
+            if let Some(quota_mib) = quota_mib {
+                m = m.quota(quota_mib);
             }
             m
         }))

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -866,6 +866,7 @@ async fn stage_file_mounts(
 }
 
 /// Push a `--mount tag:host_path[:ro]` arg pair.
+#[allow(clippy::too_many_arguments)]
 fn push_dir_mount_arg(
     mounts: &mut Vec<String>,
     guest: &str,
@@ -873,11 +874,15 @@ fn push_dir_mount_arg(
     options: MountOptions,
     stat_virtualization: StatVirtualization,
     host_permissions: HostPermissions,
+    quota_mib: Option<u32>,
 ) {
     let tag = guest_mount_tag(guest);
     let mut arg = format!("{tag}:{host_display}");
     let mut opts = mount_option_tokens(options);
     append_policy_options(&mut opts, stat_virtualization, host_permissions);
+    if let Some(mib) = quota_mib {
+        opts.push(format!("quota={mib}"));
+    }
     append_option_block(&mut arg, opts);
     mounts.push(arg);
 }
@@ -1205,6 +1210,7 @@ fn sandbox_cli_args(
                 options,
                 stat_virtualization,
                 host_permissions,
+                quota_mib,
             } => {
                 if let Some((file_mount_dir, filename, tag)) = staged_file_mounts.get(guest) {
                     push_file_mount_arg(
@@ -1217,6 +1223,9 @@ fn sandbox_cli_args(
                     );
                     push_file_mounts_spec(&mut file_mounts_val, tag, filename, guest, *options);
                 } else {
+                    // A directory bind mount gets a protective guest-write
+                    // quota: the caller's override, or the default.
+                    let quota = quota_mib.unwrap_or(crate::sandbox::config::DEFAULT_BIND_QUOTA_MIB);
                     push_dir_mount_arg(
                         &mut launch.mounts,
                         guest,
@@ -1224,6 +1233,7 @@ fn sandbox_cli_args(
                         *options,
                         *stat_virtualization,
                         *host_permissions,
+                        Some(quota),
                     );
                     push_dir_mounts_spec(&mut dir_mounts_val, guest, *options);
                 }
@@ -1234,9 +1244,14 @@ fn sandbox_cli_args(
                 options,
                 stat_virtualization,
                 host_permissions,
-                create: _,
+                create,
             } => {
                 let vol_path = local.volume_path(name);
+                // Directory named volumes honor their configured quota. The
+                // value is available here when the volume is created or ensured
+                // this spawn (`create`); a quota set on a prior run and reloaded
+                // from a persisted config is not yet re-resolved from the store.
+                let quota_mib = create.as_ref().and_then(|c| c.quota_mib);
                 push_dir_mount_arg(
                     &mut launch.mounts,
                     guest,
@@ -1244,6 +1259,7 @@ fn sandbox_cli_args(
                     *options,
                     *stat_virtualization,
                     *host_permissions,
+                    quota_mib,
                 );
                 push_dir_mounts_spec(&mut dir_mounts_val, guest, *options);
             }
@@ -2217,6 +2233,49 @@ mod tests {
         // File mount in MSB_FILE_MOUNTS.
         assert!(
             rendered.contains(&"MSB_FILE_MOUNTS=fm_11223344:file.txt:/guest/file.txt".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_cli_args_bind_mount_gets_default_quota() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/data", |m| m.bind("/host/data"))
+            .build()
+            .await
+            .unwrap();
+
+        let rendered = render_args(&config);
+        let data_tag = super::guest_mount_tag("/data");
+        let expected = format!(
+            "{data_tag}:/host/data:quota={}",
+            crate::sandbox::config::DEFAULT_BIND_QUOTA_MIB
+        );
+        assert!(
+            rendered
+                .windows(2)
+                .any(|pair| pair[0] == "--mount" && pair[1] == expected),
+            "missing default-quota --mount arg in {rendered:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_cli_args_bind_mount_quota_override() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/data", |m| m.bind("/host/data").quota(2048u32))
+            .build()
+            .await
+            .unwrap();
+
+        let rendered = render_args(&config);
+        let data_tag = super::guest_mount_tag("/data");
+        let expected = format!("{data_tag}:/host/data:quota=2048");
+        assert!(
+            rendered
+                .windows(2)
+                .any(|pair| pair[0] == "--mount" && pair[1] == expected),
+            "missing override-quota --mount arg in {rendered:?}"
         );
     }
 

--- a/sdk/rust/lib/sandbox/config.rs
+++ b/sdk/rust/lib/sandbox/config.rs
@@ -24,6 +24,14 @@ const DEFAULT_OCI_TMPFS_MAX_SIZE_MIB: u32 = 512;
 const DEFAULT_OCI_TMPFS_MEMORY_DIVISOR: u32 = 4;
 pub(crate) const DEFAULT_OCI_UPPER_SIZE_MIB: u32 = 4 * 1024;
 
+/// Default guest-write budget for a bind mount, in MiB.
+///
+/// Bounds how much the guest may add beyond a bind-mounted host directory's
+/// existing contents, so a sandbox cannot fill the host disk through a mount.
+/// Anchored to [`DEFAULT_OCI_UPPER_SIZE_MIB`] for a consistent mental model;
+/// overridable per mount via [`MountBuilder::quota`](crate::sandbox::MountBuilder::quota).
+pub(crate) const DEFAULT_BIND_QUOTA_MIB: u32 = DEFAULT_OCI_UPPER_SIZE_MIB;
+
 /// Default timeout given to the existing sandbox during a `.replace()`
 /// create before it is force-killed.
 ///
@@ -1293,6 +1301,7 @@ mod tests {
                     options: MountOptions::default(),
                     stat_virtualization: crate::sandbox::StatVirtualization::Strict,
                     host_permissions: crate::sandbox::HostPermissions::Private,
+                    quota_mib: None,
                 }],
                 ..Default::default()
             },

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -7,7 +7,7 @@
 
 pub(crate) mod attach;
 mod builder;
-mod config;
+pub(crate) mod config;
 pub mod exec;
 pub mod fs;
 mod handle;

--- a/sdk/rust/lib/sandbox/types.rs
+++ b/sdk/rust/lib/sandbox/types.rs
@@ -62,6 +62,7 @@ pub struct MountBuilder {
     mount: MountKind,
     options: MountOptions,
     size_mib: Option<u32>,
+    quota_mib: Option<u32>,
     disk_format: Option<DiskImageFormat>,
     disk_fstype: Option<String>,
     stat_virtualization: Option<StatVirtualization>,
@@ -178,6 +179,7 @@ impl MountBuilder {
             mount: MountKind::Unset,
             options: MountOptions::default(),
             size_mib: None,
+            quota_mib: None,
             disk_format: None,
             disk_fstype: None,
             stat_virtualization: None,
@@ -329,6 +331,21 @@ impl MountBuilder {
         self
     }
 
+    /// Set a guest-write quota for a bind mount.
+    ///
+    /// Bounds how much the guest may add beyond the directory's existing
+    /// contents. Without this, a protective default is applied. Valid only for
+    /// bind mounts; for named volumes use
+    /// [`named_with`](Self::named_with) with the named builder's `quota`.
+    ///
+    /// ```ignore
+    /// .bind("./data").quota(2.gib())   // guest may add up to 2 GiB
+    /// ```
+    pub fn quota(mut self, size: impl Into<Mebibytes>) -> Self {
+        self.quota_mib = Some(size.into().as_u32());
+        self
+    }
+
     /// Build the volume mount.
     pub fn build(self) -> crate::MicrosandboxResult<VolumeMount> {
         if let Some(err) = self.error {
@@ -361,6 +378,14 @@ impl MountBuilder {
         if self.size_mib.is_some() && !is_tmpfs {
             return Err(crate::MicrosandboxError::InvalidConfig(
                 ".size() is only valid for tmpfs mounts".into(),
+            ));
+        }
+        let is_bind = matches!(self.mount, MountKind::Bind(_));
+        if self.quota_mib.is_some() && !is_bind {
+            return Err(crate::MicrosandboxError::InvalidConfig(
+                ".quota() is only valid for bind mounts; for named volumes use \
+                 .named_with(|v| v.quota(..))"
+                    .into(),
             ));
         }
         if self.disk_format.is_some() && !is_disk {
@@ -440,6 +465,7 @@ impl MountBuilder {
                     options: self.options,
                     stat_virtualization,
                     host_permissions,
+                    quota_mib: self.quota_mib,
                 }
             }
             MountKind::Named { name, create } => {
@@ -1008,6 +1034,29 @@ mod tests {
     }
 
     #[test]
+    fn test_mount_builder_quota_on_bind() {
+        let mount = MountBuilder::new("/data")
+            .bind("/host/data")
+            .quota(2048u32)
+            .build()
+            .unwrap();
+        match mount {
+            VolumeMount::Bind { quota_mib, .. } => assert_eq!(quota_mib, Some(2048)),
+            other => panic!("expected bind mount, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_mount_builder_quota_rejected_on_tmpfs() {
+        let err = MountBuilder::new("/data")
+            .tmpfs()
+            .quota(64u32)
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains(".quota() is only valid for bind"));
+    }
+
+    #[test]
     fn test_mount_builder_format_rejected_on_non_disk() {
         let err = MountBuilder::new("/data")
             .bind("/host/data")
@@ -1124,6 +1173,7 @@ mod tests {
             options: MountOptions::default(),
             stat_virtualization: StatVirtualization::Off,
             host_permissions: HostPermissions::Mirror,
+            quota_mib: None,
         };
 
         let err = validate_volume_mounts(&[mount]).unwrap_err();
@@ -1142,6 +1192,7 @@ mod tests {
             },
             stat_virtualization: StatVirtualization::Strict,
             host_permissions: HostPermissions::Private,
+            quota_mib: None,
         };
 
         let value = serde_json::to_value(&mount).unwrap();


### PR DESCRIPTION
## TL;DR
PassthroughFs now caps how much a guest can write to a virtiofs mount, so a sandbox can no longer fill the host disk through `/.msb` or a bind mount. Fixes #1007.

## Description
- `/.msb` gets a fixed 16 MiB guest-write cap. It stays a virtiofs control channel (the host reads `heartbeat.json` and writes scripts/TLS certs through it) rather than becoming a block device, so the cap is not user-configurable.
- Bind mounts get a default 4 GiB guest-write quota, overridable per mount.
- Named directory volumes now enforce their existing `quota_mib`, which was stored but ignored before.
- Enforcement charges only file growth (new EOF minus current size), not write volume, so a file rewritten in place like the 1 KiB/s heartbeat never drains the budget.
- Pre-existing files are never charged. That baseline is walked lazily on the guest's first write, so a heavy bind mount adds nothing to boot and a read-only workload never walks the tree.
- Guest `df` on a quota'd mount now reports the budget (total = baseline + quota, used tracks `du`) instead of the host's full disk.

Rust SDK:
```rust
let sandbox = Sandbox::builder()
    .image("python:3.12")
    .volume("/data", |m| m.bind("./data").quota(2.gib()))
    .build()
    .await?;
```

CLI (default applies when omitted, `quota=` is in MiB):
```bash
msb run python --mount-dir ./cache:/cache:quota=512
msb run python -v ./data:/data:quota=2048
```

Python (mounts are keyed by guest path):
```python
from microsandbox import MountConfig, MountKind

volumes = {"/data": MountConfig(kind=MountKind.BIND, bind="./data", quota_mib=2048)}
```

Node:
```ts
sandbox.volume("/data", (m) => m.bind("./data").quota(2048));
```

## Test Plan
- [x] `cargo test -p microsandbox-filesystem` passes (quota unit + end-to-end FUSE invariants, 607 tests)
- [x] `cargo test -p microsandbox-runtime -p microsandbox-types -p microsandbox -p microsandbox-cli` passes (605 tests)
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo doc --workspace --no-deps` is clean
- [x] live check: `dd` past 16 MiB into `/.msb` returns ENOSPC and `df /.msb` shows the cap (verified in a booted alpine sandbox)