### PR TITLE
feat(sdk): support a host-directory bind rootfs

### DIFF
--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -1381,6 +1381,7 @@ type SandboxListFilter struct {
 type CreateOptions struct {
 	Image                string               `json:"image,omitempty"`
 	ImageFstype          string               `json:"image_fstype,omitempty"`
+	ImageBind            string               `json:"image_bind,omitempty"`
 	OCIUpperSizeMiB      *uint32              `json:"oci_upper_size_mib,omitempty"`
 	Snapshot             string               `json:"snapshot,omitempty"`
 	MemoryMiB            uint32               `json:"memory_mib,omitempty"`

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -899,6 +899,9 @@ struct RegistryAuthOpts {
 struct SandboxCreateOpts {
     image: Option<String>,
     image_fstype: Option<String>,
+    /// Host directory used directly as the root filesystem (bind rootfs).
+    /// Mutually exclusive with `image` and `snapshot`.
+    image_bind: Option<String>,
     oci_upper_size_mib: Option<u32>,
     snapshot: Option<String>,
     memory_mib: Option<u32>,
@@ -1741,12 +1744,20 @@ pub unsafe extern "C" fn msb_sandbox_create(
                     "oci_upper_size_mib is not valid when booting from a snapshot",
                 ));
             }
+            if opts.image_bind.is_some() && (opts.image.is_some() || opts.snapshot.is_some()) {
+                return Err(FfiError::invalid_argument(
+                    "image_bind is mutually exclusive with image and snapshot",
+                ));
+            }
             if let Some(img) = opts.image {
                 if let Some(fstype) = opts.image_fstype {
                     builder = builder.image_with(|i| i.disk(img).fstype(fstype));
                 } else {
                     builder = builder.image(img.as_str());
                 }
+            }
+            if let Some(bind_path) = opts.image_bind {
+                builder = builder.image_with(|i| i.bind(bind_path));
             }
             if let Some(size_mib) = opts.oci_upper_size_mib {
                 builder = builder.oci_upper_size(size_mib);

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -15,6 +15,7 @@ type SandboxConfig struct {
 	Name            string
 	Image           string
 	ImageFstype     string
+	ImageBind       string
 	OCIUpperSizeMiB uint32
 	ociUpperSizeSet bool
 	Snapshot        string
@@ -263,6 +264,14 @@ func WithImageDisk(path string, fstype string) SandboxOption {
 		o.Image = path
 		o.ImageFstype = fstype
 	}
+}
+
+// WithBindRootfs uses a host directory directly as the sandbox root filesystem
+// (a bind rootfs): the directory's contents become the guest root filesystem
+// as-is, with no OCI pull and no overlay. Mutually exclusive with WithImage,
+// WithImageDisk, and WithSnapshot.
+func WithBindRootfs(path string) SandboxOption {
+	return func(o *SandboxConfig) { o.ImageBind = path }
 }
 
 // WithSnapshot boots from a snapshot artifact by bare name or filesystem path.

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -49,6 +49,7 @@ func buildFFICreateOptions(o SandboxConfig) ffi.CreateOptions {
 	ffiOpts := ffi.CreateOptions{
 		Image:           o.Image,
 		ImageFstype:     o.ImageFstype,
+		ImageBind:       o.ImageBind,
 		Snapshot:        o.Snapshot,
 		MemoryMiB:       o.MemoryMiB,
 		CPUs:            o.CPUs,

--- a/sdk/go/sandbox_options_test.go
+++ b/sdk/go/sandbox_options_test.go
@@ -81,6 +81,16 @@ func TestFFIWireShape_WithImage(t *testing.T) {
 	}
 }
 
+func TestFFIWireShape_WithBindRootfs(t *testing.T) {
+	got := marshalCreateOptions(t, WithBindRootfs("/srv/rootfs"))
+	if v := mustField(t, got, "image_bind"); v != "/srv/rootfs" {
+		t.Fatalf("image_bind = %v, want %q", v, "/srv/rootfs")
+	}
+	if _, present := got["image"]; present {
+		t.Fatal("image must not appear in payload when only image_bind is set")
+	}
+}
+
 func TestFFIWireShape_WithOCIUpperSize(t *testing.T) {
 	got := marshalCreateOptions(t, WithImage("python:3.12"), WithOCIUpperSize(8192))
 	if v := mustField(t, got, "oci_upper_size_mib"); v != float64(8192) {

--- a/sdk/node-ts/native/image_builder.rs
+++ b/sdk/node-ts/native/image_builder.rs
@@ -58,6 +58,16 @@ impl JsImageBuilder {
         self
     }
 
+    /// Use a host directory directly as the root filesystem (bind rootfs).
+    /// The directory's contents become the guest rootfs as-is — no OCI pull
+    /// and no overlay.
+    #[napi]
+    pub fn bind(&mut self, host: String) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.bind(PathBuf::from(host)));
+        self
+    }
+
     /// Set the inner filesystem type (e.g. `"ext4"`). Omit to let agentd
     /// auto-detect by probing `/proc/filesystems`.
     #[napi]

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -244,6 +244,12 @@ export declare class ImageBuilder {
    */
   disk(path: string): this
   /**
+   * Use a host directory directly as the root filesystem (bind rootfs).
+   * The directory's contents become the guest rootfs as-is — no OCI pull
+   * and no overlay.
+   */
+  bind(host: string): this
+  /**
    * Set the inner filesystem type (e.g. `"ext4"`). Omit to let agentd
    * auto-detect by probing `/proc/filesystems`.
    */

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -1028,5 +1028,6 @@ export interface NapiImageBuilder {
   oci(reference: string): this;
   upperSize(sizeMiB: number): this;
   disk(path: string): this;
+  bind(host: string): this;
   fstype(fstype: string): this;
 }

--- a/sdk/rust/lib/sandbox/types.rs
+++ b/sdk/rust/lib/sandbox/types.rs
@@ -755,6 +755,20 @@ impl ImageBuilder {
         self
     }
 
+    /// Use a host directory directly as the root filesystem (bind rootfs).
+    ///
+    /// The directory's contents become the guest root filesystem as-is — no
+    /// OCI pull and no overlay. Mutually exclusive with [`oci`](Self::oci) and
+    /// [`disk`](Self::disk).
+    ///
+    /// ```ignore
+    /// .image_with(|i| i.bind("/srv/rootfs"))
+    /// ```
+    pub fn bind(mut self, host: impl Into<PathBuf>) -> Self {
+        self.source = Some(RootfsSource::Bind(host.into()));
+        self
+    }
+
     /// Consume the builder and return the resolved [`RootfsSource`].
     pub fn build(self) -> crate::MicrosandboxResult<RootfsSource> {
         if let Some(e) = self.error {
@@ -762,7 +776,7 @@ impl ImageBuilder {
         }
         self.source.ok_or_else(|| {
             crate::MicrosandboxError::InvalidConfig(
-                "ImageBuilder: no image source set (call .oci() or .disk())".into(),
+                "ImageBuilder: no image source set (call .oci(), .disk(), or .bind())".into(),
             )
         })
     }
@@ -1395,6 +1409,17 @@ mod tests {
             .fstype("key=value")
             .build();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_image_builder_bind() {
+        let rootfs = ImageBuilder::new().bind("/srv/rootfs").build().unwrap();
+        match rootfs {
+            RootfsSource::Bind(path) => {
+                assert_eq!(path, std::path::PathBuf::from("/srv/rootfs"))
+            }
+            _ => panic!("expected Bind"),
+        }
     }
 }
 


### PR DESCRIPTION
## What

Expose a **bind rootfs** (`RootfsSource::Bind`) as a first-class SDK option — boot a sandbox with a host directory used directly as the root filesystem (no OCI pull, no overlay), mirroring the existing disk-image rootfs path. Python already exposed it (`ImageSource.bind`); this brings Rust, Go, and Node to parity.

- **Rust SDK** (`sdk/rust`): `ImageBuilder::bind(host)` resolves to `RootfsSource::Bind`, alongside `oci()`/`disk()`.
- **Go FFI** (`sdk/go/native`): new `image_bind` create option, threaded to `builder.image_with(|i| i.bind(path))`. Mutually exclusive with `image` and `snapshot`.
- **Go SDK** (`sdk/go`): `WithBindRootfs(path)`, alongside `WithImage`/`WithImageDisk`.
- **Node SDK** (`sdk/node-ts`): `ImageBuilder.bind(host)` on the napi builder + type declarations.

`RootfsSource::Bind` already existed in the model and resolver; this adds the builder/FFI/SDK plumbing to construct it explicitly rather than relying on path-shape inference.

## Test

- `cargo test -p microsandbox` — `ImageBuilder::bind` resolves to `RootfsSource::Bind`.
- `cargo check -p microsandbox-go` / `-p microsandbox-node` — the FFI/napi crates compile with the new option.
- `go test ./sdk/go` — `image_bind` wire shape (present when set; `image` absent).