### PR TITLE
docs(nav): make security its own top-level tab

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -60,18 +60,6 @@
             ]
           },
           {
-            "group": "Security",
-            "icon": "shield-halved",
-            "pages": [
-              "security/overview",
-              "security/isolation",
-              "security/filesystem",
-              "security/network",
-              "security/secrets",
-              "security/hardening"
-            ]
-          },
-          {
             "group": "Observability",
             "icon": "gauge",
             "pages": [
@@ -222,6 +210,17 @@
               "recipes/metrics-backends/datadog"
             ]
           }
+        ]
+      },
+      {
+        "tab": "Security",
+        "pages": [
+          "security/overview",
+          "security/isolation",
+          "security/filesystem",
+          "security/network",
+          "security/secrets",
+          "security/hardening"
         ]
       },
       {


### PR DESCRIPTION
## TL;DR
Move the Security docs out of the Documentation tab and give them their own top-level tab, so the security model is easier to find.

## Description
- Pull the Security group out of the Documentation tab's groups
- Add a top-level "Security" tab using a flat page list, the same shape the Changelog tab already uses
- Place the tab after Recipes, just before Changelog
- Leave all /security/* routes and cross-links unchanged, so nothing else moves

## Test Plan
- [x] `docs.json` parses as valid JSON
- [x] Security is a single top-level tab with 6 pages and is no longer a group under Documentation
- [x] `mintlify dev` serves all six /security/* pages (HTTP 200) under the new tab
