### PR TITLE
fix(sdk): restore live sandbox lifecycle APIs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -824,7 +824,22 @@ jobs:
           export MSB_HOME
           export PATH="$HOME/.microsandbox/bin:$PATH"
           export LD_LIBRARY_PATH="${{ github.workspace }}/build:$HOME/.microsandbox/lib"
-          go test -tags "integration microsandbox_ffi_path" -count=1 -timeout 20m ./integration/...
+          status=0
+          go test -tags "integration microsandbox_ffi_path" -count=1 -timeout 45m ./integration/... || status=$?
+
+          if [ "$status" -ne 0 ]; then
+            echo "::group::Go sandbox runtime logs without core.ready"
+            find "$MSB_HOME/sandboxes" -path '*/logs/runtime.log' -type f -print0 2>/dev/null \
+              | while IFS= read -r -d '' log; do
+                  if ! grep -q 'agent relay: received core.ready' "$log"; then
+                    echo "--- $log"
+                    tail -120 "$log" || true
+                  fi
+                done
+            echo "::endgroup::"
+          fi
+
+          exit "$status"
 
       - name: Disk usage
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,6 +218,27 @@ jobs:
         if: matrix.os == 'darwin'
         run: codesign --entitlements msb-entitlements.plist --force -s - build/msb
 
+      - name: Free build-only artifacts before tests (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          echo "::group::runner disk before test cleanup"
+          df -hT / /tmp "${GITHUB_WORKSPACE}" "${RUNNER_WORKSPACE}" || true
+          echo "::endgroup::"
+
+          # The test job builds release msb, a musl agentd, and libkrunfw
+          # before compiling the debug test graph. Keep the staged runtime
+          # bundle in build/, but drop large one-off build directories so
+          # rustc has enough room for workspace test artifacts.
+          rm -rf target/release
+          rm -rf target/${{ matrix.agentd_target }}/release
+          rm -rf vendor/libkrunfw/linux-*
+          rm -rf vendor/libkrunfw/tarballs
+
+          echo "::group::runner disk after test cleanup"
+          df -hT / /tmp "${GITHUB_WORKSPACE}" "${RUNNER_WORKSPACE}" || true
+          du -xhd1 "${GITHUB_WORKSPACE}" 2>/dev/null | sort -h | tail -30 || true
+          echo "::endgroup::"
+
       # -- Tests --
       - name: Test workspace
         run: cargo test --workspace --exclude microsandbox-agentd

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -361,6 +361,17 @@ sb.drain().await?;
 
 ---
 
+#### <span className="msb-recv">sb.</span><span className="msb-hn">request_drain()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn request_drain(&self) -> MicrosandboxResult<()>
+```
+
+Request graceful drain and return once the request is sent. Pair with [`wait_until_stopped()`](#sb-wait-until-stopped) when the caller needs stopped-state observation.
+
+---
+
 #### <span className="msb-recv">sb.</span><span className="msb-hn">fs()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
 
@@ -396,7 +407,7 @@ sb.fs().write("/tmp/hello.txt", "hi").await?;
 async fn kill(&self) -> MicrosandboxResult<()>
 ```
 
-Force-terminate the sandbox immediately with SIGKILL. No graceful shutdown — use when the sandbox is unresponsive. Pending writes that the workload hasn't `fsync`'d may be lost, same durability semantics as a sudden power loss on a physical machine. Prefer [`stop()`](#sb-stop) for graceful shutdown that gives the workload a chance to flush.
+Force-terminate the sandbox immediately with SIGKILL. No graceful shutdown - use when the sandbox is unresponsive. Waits up to five seconds for stopped-state observation after the kill request. Pending writes that the workload hasn't `fsync`'d may be lost, same durability semantics as a sudden power loss on a physical machine. Prefer [`stop()`](#sb-stop) for graceful shutdown that gives the workload a chance to flush.
 
 <Accordion title="Example">
 
@@ -405,6 +416,28 @@ sb.kill().await?; // SIGKILL, no graceful shutdown
 ```
 
 </Accordion>
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">kill_with_timeout()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn kill_with_timeout(&self, timeout: Duration) -> MicrosandboxResult<()>
+```
+
+Force-terminate the sandbox and wait up to `timeout` for stopped-state observation.
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">request_kill()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn request_kill(&self) -> MicrosandboxResult<()>
+```
+
+Request force termination and return once the request is sent, without waiting for stopped-state observation.
 
 ---
 
@@ -611,6 +644,17 @@ sb.remove_persisted().await?;
 
 ---
 
+#### <span className="msb-recv">sb.</span><span className="msb-hn">request_stop()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn request_stop(&self) -> MicrosandboxResult<()>
+```
+
+Request graceful shutdown and return once the request is sent, without waiting for stopped-state observation. Pair with [`wait_until_stopped()`](#sb-wait-until-stopped) when the caller needs the terminal state.
+
+---
+
 #### <span className="msb-recv">sb.</span><span className="msb-hn">stop()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
@@ -630,6 +674,17 @@ sb.stop().await?;
 
 ---
 
+#### <span className="msb-recv">sb.</span><span className="msb-hn">stop_with_timeout()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn stop_with_timeout(&self, timeout: Duration) -> MicrosandboxResult<()>
+```
+
+Gracefully shut down the sandbox with an explicit timeout before escalation. `Duration::ZERO` skips graceful shutdown and force-kills immediately.
+
+---
+
 #### <span className="msb-recv">sb.</span><span className="msb-hn">stop_and_wait()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
 
@@ -637,7 +692,7 @@ sb.stop().await?;
 async fn stop_and_wait(&self) -> MicrosandboxResult<ExitStatus>
 ```
 
-Stop the sandbox and wait for the exit status.
+Stop the sandbox and wait for the exit status. This is a local-backend compatibility helper; prefer [`stop()`](#stop) or [`stop_with_timeout()`](#stop_with_timeout) when the caller only needs stopped-state observation.
 
 <p className="msb-label">Returns</p>
 
@@ -684,6 +739,23 @@ let status = sb.wait().await?;
 ```
 
 </Accordion>
+
+---
+
+#### <span className="msb-recv">sb.</span><span className="msb-hn">wait_until_stopped()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
+
+```rust
+async fn wait_until_stopped(&self) -> MicrosandboxResult<SandboxStopResult>
+```
+
+Block until the sandbox is observed in a terminal non-running state. Owned local sandboxes can include process exit details; detached, name-addressed, and cloud-backed sandboxes report the observed backend state.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxStopResult`](#sandboxstopresult) | Observed terminal sandbox state |
 
 ---
 
@@ -1791,17 +1863,35 @@ A lightweight handle to an existing sandbox (running or stopped). Obtained via [
 | connect() | `Result<`[`Sandbox`](#instance-methods)`>` | Connect to a running sandbox; returns an error if it doesn't respond within ten seconds |
 | connect_with_timeout(timeout) | `Result<`[`Sandbox`](#instance-methods)`>` | Same as `connect()` with an explicit timeout |
 | created_at() | `Option<DateTime<Utc>>` | Creation timestamp |
-| kill() | `Result<()>` | Force terminate immediately. Pending writes may be lost |
+| kill() | `Result<()>` | Force terminate and wait until stopped state is observed |
+| kill_with_timeout(timeout) | `Result<()>` | Same as `kill()` with an explicit observation timeout |
 | logs() | `Result<Vec<`[`LogEntry`](#logentry)`>>` | Read captured `exec.log` (works without starting) |
 | metrics() | `Result<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
 | name() | `&str` | Sandbox name, up to 128 UTF-8 bytes |
 | remove() | `Result<()>` | Delete sandbox and state |
+| request_drain() | `Result<()>` | Request graceful drain without waiting |
+| request_kill() | `Result<()>` | Request force termination without waiting |
+| request_stop() | `Result<()>` | Request graceful shutdown without waiting |
 | start() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in attached mode |
 | start_detached() | `Result<`[`Sandbox`](#instance-methods)`>` | Start in detached mode |
 | status() | [`SandboxStatus`](#sandboxstatus) | Current status |
 | stop() | `Result<()>` | Gracefully shut down. Waits up to ten seconds for pending writes to flush, then force-kills |
 | stop_with_timeout(timeout) | `Result<()>` | Same as `stop()` with an explicit timeout; `Duration::ZERO` force-kills immediately |
 | updated_at() | `Option<DateTime<Utc>>` | Last update timestamp |
+| wait_until_stopped() | `Result<`[`SandboxStopResult`](#sandboxstopresult)`>` | Block until terminal state is observed |
+
+### SandboxStopResult
+
+Observed terminal sandbox state returned by [`wait_until_stopped()`](#wait_until_stopped).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `String` | Sandbox name |
+| status | [`SandboxStatus`](#sandboxstatus) | Terminal status that was observed |
+| exit_code | `Option<i32>` | Process exit code when available from an owned child process |
+| signal | `Option<i32>` | Terminating signal when available from an owned child process |
+| observed_at | `DateTime<Utc>` | When the terminal state was observed |
+| source | `Option<String>` | Description of the observation source |
 
 ### SandboxMetrics
 

--- a/sdk/go/integration/config_test.go
+++ b/sdk/go/integration/config_test.go
@@ -44,7 +44,7 @@ func TestWithShellRoundTripsThroughConfig(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-shell-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithShell("/bin/sh"),
 	)
@@ -75,7 +75,7 @@ func TestWithEntrypointVisibleInConfig(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-entrypoint-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithEntrypoint("/bin/sh", "-c", "echo hi"),
 	)
@@ -106,7 +106,7 @@ func TestWithInitAuto(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-init-auto-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithInit(microsandbox.Init.Auto()),
 	)
@@ -146,7 +146,7 @@ func TestWithLogLevelRoundTrip(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-log-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithLogLevel(microsandbox.LogLevelInfo),
 	)
@@ -177,7 +177,7 @@ func TestWithQuietLogsClearsLogLevel(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-quiet-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithQuietLogs(),
 	)
@@ -208,7 +208,7 @@ func TestWithMaxDurationAndIdleTimeoutCreates(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-timeouts-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithMaxDuration(2*time.Hour),
 		microsandbox.WithIdleTimeout(30*time.Minute),
@@ -243,7 +243,7 @@ func TestWithScriptsRoundTrip(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-scripts-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithScripts(map[string]string{
 			"hello": "echo hello-from-script",
@@ -281,7 +281,7 @@ func TestWithPullPolicyRoundTrip(t *testing.T) {
 		t.Run(string(p), func(t *testing.T) {
 			ctx := integrationCtx(t)
 			name := "go-sdk-pull-" + strings.ToLower(strings.ReplaceAll(t.Name(), "/", "-"))
-			sb, err := microsandbox.CreateSandbox(ctx, name,
+			sb, err := createSandbox(t, ctx, name,
 				microsandbox.WithImage(goIntegrationImage),
 				microsandbox.WithPullPolicy(p),
 			)

--- a/sdk/go/integration/exec_test.go
+++ b/sdk/go/integration/exec_test.go
@@ -243,7 +243,7 @@ func TestExecWithExecUserOverride(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-execuser-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name, microsandbox.WithImage(goIntegrationImage))
+	sb, err := createSandbox(t, ctx, name, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestExecWithExecEnvOverlay(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-execenv-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithEnv(map[string]string{"BASE_VAR": "from-sandbox"}),
 	)

--- a/sdk/go/integration/lifecycle_test.go
+++ b/sdk/go/integration/lifecycle_test.go
@@ -61,7 +61,7 @@ func TestSandboxRemove(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-rmpersist-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name, microsandbox.WithImage(goIntegrationImage))
+	sb, err := createSandbox(t, ctx, name, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestOwnsLifecycleAfterDetachOrConnect(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-ownsconn-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithDetached(),
 	)
@@ -153,7 +153,7 @@ func TestWithReplace(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-replace-" + t.Name()
 
-	first, err := microsandbox.CreateSandbox(ctx, name, microsandbox.WithImage(goIntegrationImage))
+	first, err := createSandbox(t, ctx, name, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("first CreateSandbox: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestWithReplace(t *testing.T) {
 	}
 
 	// With replace, it should succeed.
-	second, err := microsandbox.CreateSandbox(ctx, name,
+	second, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithReplace(),
 	)
@@ -195,7 +195,7 @@ func TestWithUser(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-user-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithUser("nobody"),
 	)
@@ -224,7 +224,7 @@ func TestWithHostname(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-hostname-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithHostname("go-sdk-test-host"),
 	)
@@ -253,7 +253,7 @@ func TestWithWorkdir(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-workdir-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithWorkdir("/var/log"),
 	)
@@ -282,7 +282,7 @@ func TestWithEnvVisibleInsideSandbox(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-env-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithEnv(map[string]string{
 			"FOO_INTEGRATION": "bar-marker-123",
@@ -314,7 +314,7 @@ func TestSandboxHandleListsRichMetadata(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-handle-rich-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name, microsandbox.WithImage(goIntegrationImage))
+	sb, err := createSandbox(t, ctx, name, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)
 	}
@@ -356,7 +356,7 @@ func TestSandboxHandleStopKill(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-handle-stop-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name, microsandbox.WithImage(goIntegrationImage))
+	sb, err := createSandbox(t, ctx, name, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)
 	}

--- a/sdk/go/integration/metrics_test.go
+++ b/sdk/go/integration/metrics_test.go
@@ -87,7 +87,7 @@ func TestAllSandboxMetricsCoversMultipleSandboxes(t *testing.T) {
 	a := "go-sdk-allmetrics-a-" + t.Name()
 	b := "go-sdk-allmetrics-b-" + t.Name()
 
-	sbA, err := microsandbox.CreateSandbox(ctx, a, microsandbox.WithImage(goIntegrationImage))
+	sbA, err := createSandbox(t, ctx, a, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("CreateSandbox a: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestAllSandboxMetricsCoversMultipleSandboxes(t *testing.T) {
 		_ = sbA.Close()
 	})
 
-	sbB, err := microsandbox.CreateSandbox(ctx, b, microsandbox.WithImage(goIntegrationImage))
+	sbB, err := createSandbox(t, ctx, b, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("CreateSandbox b: %v", err)
 	}

--- a/sdk/go/integration/network_test.go
+++ b/sdk/go/integration/network_test.go
@@ -18,7 +18,7 @@ func TestNetworkPolicyNonLocal(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-nonlocal-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(microsandbox.NetworkPolicy.NonLocal()),
 	)
@@ -52,7 +52,7 @@ func TestCustomPolicyDefaultEgressDeny(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-defegress-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
 			DefaultEgress:  microsandbox.PolicyActionDeny,
@@ -95,7 +95,7 @@ func TestCustomPolicyAllowSpecificEgress(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := uniqueIntegrationName(t, "go-net-ip")
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
 			DefaultEgress: microsandbox.PolicyActionDeny,
@@ -160,7 +160,7 @@ func TestCustomPolicyPortRange(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-portrange-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
 			DefaultEgress: microsandbox.PolicyActionDeny,
@@ -210,7 +210,7 @@ func TestCustomPolicyMultiProtocolCreates(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-multiproto-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
 			DefaultEgress: microsandbox.PolicyActionAllow,
@@ -244,7 +244,7 @@ func TestCustomPolicyDirectionAnyCreates(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-dirany-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
 			DefaultEgress:  microsandbox.PolicyActionDeny,
@@ -279,7 +279,7 @@ func TestDNSConfigCreates(t *testing.T) {
 
 	rebind := true
 	timeoutMs := uint64(5000)
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
 			Policy: microsandbox.NetworkPolicyPresetAllowAll,
@@ -316,7 +316,7 @@ func TestNetworkOnSecretViolationCreates(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-onviolation-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
 			Policy:            microsandbox.NetworkPolicyPresetPublicOnly,
@@ -341,7 +341,7 @@ func TestSecretWithOnViolation(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-secretviol-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithSecrets(microsandbox.Secret.Env(
 			"VIOLATION_KEY",
@@ -378,7 +378,7 @@ func TestTLSConfigUpstreamCACertsCreates(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-upstreamcas-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
 			Policy: microsandbox.NetworkPolicyPresetAllowAll,
@@ -405,7 +405,7 @@ func TestNetworkMaxConnectionsCreates(t *testing.T) {
 	name := "go-sdk-maxconn-" + t.Name()
 
 	max := uint(64)
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
 			Policy:         microsandbox.NetworkPolicyPresetAllowAll,

--- a/sdk/go/integration/sandbox_test.go
+++ b/sdk/go/integration/sandbox_test.go
@@ -16,6 +16,15 @@ import (
 
 var goIntegrationImage = getenv("MICROSANDBOX_GO_INTEGRATION_IMAGE", "mirror.gcr.io/library/alpine")
 
+const (
+	// The self-hosted Linux runner can occasionally boot a guest that never
+	// reaches agentd's core.ready event. Keep the per-test budget large enough
+	// for bounded retries while the package-level go test timeout remains the
+	// final guardrail.
+	integrationTestTimeout = 12 * time.Minute
+	createSandboxAttempts  = 3
+)
+
 // TestMain ensures the microsandbox runtime is loaded once before any
 // integration test runs. Without this every test would fail with
 // ErrLibraryNotLoaded.
@@ -32,9 +41,76 @@ func TestMain(m *testing.M) {
 // integrationCtx returns a context with a generous timeout for VM boot.
 func integrationCtx(t *testing.T) context.Context {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)
 	t.Cleanup(cancel)
 	return ctx
+}
+
+func createSandbox(
+	t *testing.T,
+	ctx context.Context,
+	name string,
+	opts ...microsandbox.SandboxOption,
+) (*microsandbox.Sandbox, error) {
+	t.Helper()
+
+	var lastErr error
+	for attempt := 1; attempt <= createSandboxAttempts; attempt++ {
+		sb, err := microsandbox.CreateSandbox(ctx, name, opts...)
+		if err == nil {
+			return sb, nil
+		}
+		lastErr = err
+		if !isAgentRelayTimeout(err) || attempt == createSandboxAttempts {
+			return nil, err
+		}
+
+		t.Logf(
+			"CreateSandbox(%q) hit agent-relay boot timeout on attempt %d/%d; retrying",
+			name,
+			attempt,
+			createSandboxAttempts,
+		)
+		cleanupFailedCreate(t, name)
+		if err := sleepBeforeRetry(ctx, attempt); err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, lastErr
+}
+
+func isAgentRelayTimeout(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "timed out waiting for agent relay") ||
+		strings.Contains(msg, "timed out waiting for core.ready")
+}
+
+func cleanupFailedCreate(t *testing.T, name string) {
+	t.Helper()
+
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	if h, err := microsandbox.GetSandbox(cleanupCtx, name); err == nil {
+		_ = h.Kill(cleanupCtx, microsandbox.WithKillTimeout(10*time.Second))
+		_ = h.Remove(cleanupCtx)
+		return
+	}
+
+	_ = microsandbox.RemoveSandbox(cleanupCtx, name)
+}
+
+func sleepBeforeRetry(ctx context.Context, attempt int) error {
+	timer := time.NewTimer(time.Duration(attempt) * time.Second)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func getenv(key, fallback string) string {
@@ -49,7 +125,7 @@ func newTestSandbox(t *testing.T) *microsandbox.Sandbox {
 	t.Helper()
 	ctx := integrationCtx(t)
 	name := "go-sdk-test-" + strings.ToLower(strings.ReplaceAll(t.Name(), "/", "-"))
-	sb, err := microsandbox.CreateSandbox(ctx, name, microsandbox.WithImage(goIntegrationImage))
+	sb, err := createSandbox(t, ctx, name, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)
 	}
@@ -68,7 +144,7 @@ func newTestSandbox(t *testing.T) *microsandbox.Sandbox {
 func TestCreateSandboxAndClose(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-lifecycle-" + t.Name()
-	sb, err := microsandbox.CreateSandbox(ctx, name, microsandbox.WithImage(goIntegrationImage))
+	sb, err := createSandbox(t, ctx, name, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)
 	}
@@ -382,7 +458,7 @@ func TestDetachedSandboxOutlivesHandle(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-detached-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithDetached(),
 	)
@@ -431,7 +507,7 @@ func TestPortPublishing(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-ports-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithPorts(map[uint16]uint16{17777: 7777}),
 	)
@@ -499,7 +575,7 @@ func TestNetworkPolicyNone(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-netpolicy-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{Policy: "none"}),
 	)
@@ -533,7 +609,7 @@ func TestNetworkPolicyAllowAll(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-netallow-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{Policy: "allow-all"}),
 	)
@@ -567,7 +643,7 @@ func TestDNSBlockDomain(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-dns-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
 			Policy:      microsandbox.NetworkPolicyPresetAllowAll,
@@ -604,7 +680,7 @@ func TestDNSBlockDomainSuffix(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-dnssuffix-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
 			Policy:             microsandbox.NetworkPolicyPresetAllowAll,
@@ -646,7 +722,7 @@ func TestPatchText(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-patch-text-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithPatches(
 			microsandbox.Patch.Text("/etc/go-sdk-test.conf", "hello-from-patch\n", microsandbox.PatchOptions{}),
@@ -677,7 +753,7 @@ func TestPatchMkdir(t *testing.T) {
 	name := "go-sdk-patch-mkdir-" + t.Name()
 
 	mode := uint32(0o755)
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithPatches(
 			microsandbox.Patch.Mkdir("/opt/go-sdk-dir", microsandbox.PatchOptions{Mode: &mode}),
@@ -710,7 +786,7 @@ func TestPatchAppend(t *testing.T) {
 	name := "go-sdk-patch-append-" + t.Name()
 
 	const marker = "go-sdk-append-marker"
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithPatches(
 			microsandbox.Patch.Append("/etc/profile", "\n# "+marker+"\n"),
@@ -742,7 +818,7 @@ func TestPatchSymlink(t *testing.T) {
 
 	// /etc, not /tmp: alpine's default sandbox config mounts a fresh
 	// tmpfs over /tmp at boot, which wipes anything patches put there.
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithPatches(
 			microsandbox.Patch.Text("/etc/original.txt", "original\n", microsandbox.PatchOptions{}),
@@ -955,7 +1031,7 @@ func TestSecretPlaceholderSubstitution(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-secret-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithSecrets(microsandbox.Secret.Env(
 			"MY_API_KEY",
@@ -1000,7 +1076,7 @@ func TestRemoveSandbox(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-remove-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name, microsandbox.WithImage(goIntegrationImage))
+	sb, err := createSandbox(t, ctx, name, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)
 	}
@@ -1039,7 +1115,7 @@ func TestListSandboxesWithLabels(t *testing.T) {
 	other := owner + "-other"
 
 	create := func(name string, labels map[string]string) {
-		sb, err := microsandbox.CreateSandbox(ctx, name,
+		sb, err := createSandbox(t, ctx, name,
 			microsandbox.WithImage(goIntegrationImage),
 			microsandbox.WithLabels(labels),
 		)

--- a/sdk/go/integration/snapshot_test.go
+++ b/sdk/go/integration/snapshot_test.go
@@ -25,7 +25,7 @@ func TestSandboxHandleSnapshotAndWithSnapshotFork(t *testing.T) {
 		removeSnapshotBestEffort(snapshotName)
 	})
 
-	base, err := microsandbox.CreateSandbox(ctx, baseName, microsandbox.WithImage(goIntegrationImage))
+	base, err := createSandbox(t, ctx, baseName, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("CreateSandbox base: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestSandboxHandleSnapshotAndWithSnapshotFork(t *testing.T) {
 		t.Fatalf("Snapshot.List did not include digest %q", artifact.Digest())
 	}
 
-	fork, err := microsandbox.CreateSandbox(ctx, forkName, microsandbox.WithSnapshot(snapshotName))
+	fork, err := createSandbox(t, ctx, forkName, microsandbox.WithSnapshot(snapshotName))
 	if err != nil {
 		t.Fatalf("CreateSandbox with WithSnapshot: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestSandboxHandleSnapshotToAndSnapshotDirectoryOps(t *testing.T) {
 		removeSnapshotBestEffort(snapshotDir)
 	})
 
-	base, err := microsandbox.CreateSandbox(ctx, baseName, microsandbox.WithImage(goIntegrationImage))
+	base, err := createSandbox(t, ctx, baseName, microsandbox.WithImage(goIntegrationImage))
 	if err != nil {
 		t.Fatalf("CreateSandbox base: %v", err)
 	}

--- a/sdk/go/integration/volume_test.go
+++ b/sdk/go/integration/volume_test.go
@@ -189,7 +189,7 @@ func TestNamedVolumeMountIntoSandbox(t *testing.T) {
 		t.Fatalf("Volume Write: %v", err)
 	}
 
-	sb, err := microsandbox.CreateSandbox(ctx, "sb-"+name,
+	sb, err := createSandbox(t, ctx, "sb-"+name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithMounts(map[string]microsandbox.MountConfig{
 			"/data": microsandbox.Mount.Named(name, microsandbox.MountOptions{}),
@@ -225,7 +225,7 @@ func TestNamedVolumeReadonlyMount(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = microsandbox.RemoveVolume(context.Background(), name) })
 
-	sb, err := microsandbox.CreateSandbox(ctx, "sb-"+name,
+	sb, err := createSandbox(t, ctx, "sb-"+name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithMounts(map[string]microsandbox.MountConfig{
 			"/ro": microsandbox.Mount.Named(name, microsandbox.MountOptions{Readonly: true}),
@@ -263,7 +263,7 @@ func TestNamedVolumeNoexecMount(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = microsandbox.RemoveVolume(context.Background(), name) })
 
-	writer, err := microsandbox.CreateSandbox(ctx, "sb-writer-"+name,
+	writer, err := createSandbox(t, ctx, "sb-writer-"+name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithMounts(map[string]microsandbox.MountConfig{
 			"/data": microsandbox.Mount.Named(name, microsandbox.MountOptions{}),
@@ -291,7 +291,7 @@ chmod +x /data/run.sh`)
 		t.Fatalf("writer script failed: stdout=%q stderr=%q", out.Stdout(), out.Stderr())
 	}
 
-	sb, err := microsandbox.CreateSandbox(ctx, "sb-"+name,
+	sb, err := createSandbox(t, ctx, "sb-"+name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithMounts(map[string]microsandbox.MountConfig{
 			"/data": microsandbox.Mount.Named(name, microsandbox.MountOptions{Noexec: true}),
@@ -325,7 +325,7 @@ func TestTmpfsMountWithSizeLimit(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-tmpfs-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithMounts(map[string]microsandbox.MountConfig{
 			"/scratch": microsandbox.Mount.Tmpfs(microsandbox.TmpfsOptions{SizeMiB: 4}),
@@ -376,7 +376,7 @@ func TestBindMountReadonly(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-bindro-" + t.Name()
 
-	sb, err := microsandbox.CreateSandbox(ctx, name,
+	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
 		microsandbox.WithMounts(map[string]microsandbox.MountConfig{
 			"/host-tmp": microsandbox.Mount.Bind("/tmp", microsandbox.MountOptions{Readonly: true}),

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -2172,8 +2172,7 @@ pub unsafe extern "C" fn msb_sandbox_stop(
     run_c(cancel_id, buf, buf_len, || {
         let sb = get(handle)?;
         Ok(Box::pin(async move {
-            let h = Sandbox::get(sb.name()).await.map_err(FfiError::from)?;
-            h.stop_with_timeout(Duration::from_millis(timeout_ms))
+            sb.stop_with_timeout(Duration::from_millis(timeout_ms))
                 .await
                 .map_err(FfiError::from)?;
             Ok(r#"{"ok":true}"#.into())
@@ -2191,8 +2190,7 @@ pub unsafe extern "C" fn msb_sandbox_request_stop(
     run_c(cancel_id, buf, buf_len, || {
         let sb = get(handle)?;
         Ok(Box::pin(async move {
-            let h = Sandbox::get(sb.name()).await.map_err(FfiError::from)?;
-            h.request_stop().await.map_err(FfiError::from)?;
+            sb.request_stop().await.map_err(FfiError::from)?;
             Ok(r#"{"ok":true}"#.into())
         }))
     })
@@ -2231,8 +2229,7 @@ pub unsafe extern "C" fn msb_sandbox_kill(
     run_c(cancel_id, buf, buf_len, || {
         let sb = get(handle)?;
         Ok(Box::pin(async move {
-            let h = Sandbox::get(sb.name()).await.map_err(FfiError::from)?;
-            h.kill_with_timeout(Duration::from_millis(timeout_ms))
+            sb.kill_with_timeout(Duration::from_millis(timeout_ms))
                 .await
                 .map_err(FfiError::from)?;
             Ok(r#"{"ok":true}"#.into())
@@ -2250,8 +2247,7 @@ pub unsafe extern "C" fn msb_sandbox_request_kill(
     run_c(cancel_id, buf, buf_len, || {
         let sb = get(handle)?;
         Ok(Box::pin(async move {
-            let h = Sandbox::get(sb.name()).await.map_err(FfiError::from)?;
-            h.request_kill().await.map_err(FfiError::from)?;
+            sb.request_kill().await.map_err(FfiError::from)?;
             Ok(r#"{"ok":true}"#.into())
         }))
     })
@@ -2288,8 +2284,7 @@ pub unsafe extern "C" fn msb_sandbox_request_drain(
     run_c(cancel_id, buf, buf_len, || {
         let sb = get(handle)?;
         Ok(Box::pin(async move {
-            let h = Sandbox::get(sb.name()).await.map_err(FfiError::from)?;
-            h.request_drain().await.map_err(FfiError::from)?;
+            sb.request_drain().await.map_err(FfiError::from)?;
             Ok(r#"{"ok":true}"#.into())
         }))
     })
@@ -2326,8 +2321,7 @@ pub unsafe extern "C" fn msb_sandbox_wait_until_stopped(
     run_c(cancel_id, buf, buf_len, || {
         let sb = get(handle)?;
         Ok(Box::pin(async move {
-            let h = Sandbox::get(sb.name()).await.map_err(FfiError::from)?;
-            let result = h.wait_until_stopped().await.map_err(FfiError::from)?;
+            let result = sb.wait_until_stopped().await.map_err(FfiError::from)?;
             Ok(sandbox_stop_result_json(result))
         }))
     })

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -394,6 +394,13 @@ export declare class MountBuilder {
   /** Tmpfs size cap in MiB (only valid with `.tmpfs()`). */
   size(mib: number): this
   /**
+   * Guest-write quota in MiB (only valid with `.bind()`).
+   *
+   * Bounds how much the guest may add beyond the bind-mounted directory's
+   * existing contents. Without it, a protective default is applied.
+   */
+  quota(mib: number): this
+  /**
    * Set the guest stat virtualization policy.
    *
    * Accepts `"strict"`, `"relaxed"`, or `"off"`. Valid only for bind and
@@ -766,9 +773,9 @@ export declare class Sandbox {
    */
   static get(name: string): Promise<JsSandboxHandle>
   /** List all sandboxes. */
-  static list(): Promise<Array<SandboxInfo>>
+  static list(): Promise<Array<JsSandboxHandle>>
   /** List sandboxes matching a filter. */
-  static listWith(filter: SandboxListFilter): Promise<Array<SandboxInfo>>
+  static listWith(filter: SandboxListFilter): Promise<Array<JsSandboxHandle>>
   /**
    * Remove a stopped sandbox from the database.
    *
@@ -828,14 +835,26 @@ export declare class Sandbox {
   attachWithBuilder(cmd: string, builder: AttachOptionsBuilder): Promise<number>
   /** Attach to the sandbox's default shell. */
   attachShell(): Promise<number>
-  /** Stop the sandbox gracefully (SIGTERM). */
+  /** Stop the sandbox gracefully and wait for it to exit. */
   stop(): Promise<void>
   /** Stop and wait for exit, returning the exit status. */
   stopAndWait(): Promise<ExitStatus>
-  /** Kill the sandbox immediately (SIGKILL). */
+  /** Request graceful shutdown without waiting for observed exit. */
+  requestStop(): Promise<void>
+  /** Stop gracefully with an explicit timeout before escalating to SIGKILL. */
+  stopWithTimeout(timeoutMs: number): Promise<void>
+  /** Kill the sandbox immediately and wait for observed exit. */
   kill(): Promise<void>
+  /** Request force termination without waiting for observed exit. */
+  requestKill(): Promise<void>
+  /** Force-kill the sandbox with an explicit observation timeout. */
+  killWithTimeout(timeoutMs: number): Promise<void>
   /** Graceful drain (SIGUSR1 — for load balancing). */
   drain(): Promise<void>
+  /** Request graceful drain without waiting for observed exit. */
+  requestDrain(): Promise<void>
+  /** Wait until the sandbox is observed in a terminal non-running state. */
+  waitUntilStopped(): Promise<SandboxStopResult>
   /** Wait for the sandbox process to exit. */
   wait(): Promise<ExitStatus>
   /** Detach from the sandbox — it will continue running after this handle is dropped. */
@@ -1866,15 +1885,6 @@ export interface Rlimit {
   hard: number
 }
 
-/** Lightweight sandbox info returned by `Sandbox.list`. */
-export interface SandboxInfo {
-  name: string
-  status: string
-  configJson: string
-  createdAt?: number
-  updatedAt?: number
-}
-
 /**
  * Filter for `Sandbox.list`. Matched sandboxes must carry all of `labels`
  * (AND-matched). Omit or leave empty to match every sandbox.
@@ -2116,6 +2126,7 @@ export interface VolumeMount {
   host?: string
   name?: string
   sizeMib?: number
+  quotaMib?: number
   format?: string
   fstype?: string
   /** `"strict" | "relaxed" | "off"` for bind/named mounts; `None` for tmpfs/disk. */

--- a/sdk/node-ts/native/sandbox.rs
+++ b/sdk/node-ts/native/sandbox.rs
@@ -117,16 +117,19 @@ impl Sandbox {
 
     /// List all sandboxes.
     #[napi]
-    pub async fn list() -> Result<Vec<SandboxInfo>> {
+    pub async fn list() -> Result<Vec<JsSandboxHandle>> {
         let handles = microsandbox::sandbox::Sandbox::list()
             .await
             .map_err(to_napi_error)?;
-        Ok(handles.iter().map(sandbox_handle_to_info).collect())
+        Ok(handles
+            .into_iter()
+            .map(JsSandboxHandle::from_rust)
+            .collect())
     }
 
     /// List sandboxes matching a filter.
     #[napi(js_name = "listWith")]
-    pub async fn list_with(filter: SandboxListFilter) -> Result<Vec<SandboxInfo>> {
+    pub async fn list_with(filter: SandboxListFilter) -> Result<Vec<JsSandboxHandle>> {
         let handles = match filter.labels {
             Some(labels) if !labels.is_empty() => {
                 let filter = labels.into_iter().fold(
@@ -141,7 +144,10 @@ impl Sandbox {
                 .await
                 .map_err(to_napi_error)?,
         };
-        Ok(handles.iter().map(sandbox_handle_to_info).collect())
+        Ok(handles
+            .into_iter()
+            .map(JsSandboxHandle::from_rust)
+            .collect())
     }
 
     /// Remove a stopped sandbox from the database.
@@ -391,7 +397,7 @@ impl Sandbox {
     // Lifecycle
     //----------------------------------------------------------------------------------------------
 
-    /// Stop the sandbox gracefully (SIGTERM).
+    /// Stop the sandbox gracefully and wait for it to exit.
     #[napi]
     pub async fn stop(&self) -> Result<()> {
         let guard = self.inner.lock().await;
@@ -408,12 +414,46 @@ impl Sandbox {
         Ok(exit_status_to_js(status))
     }
 
-    /// Kill the sandbox immediately (SIGKILL).
+    /// Request graceful shutdown without waiting for observed exit.
+    #[napi]
+    pub async fn request_stop(&self) -> Result<()> {
+        let guard = self.inner.lock().await;
+        let sb = guard.as_ref().ok_or_else(consumed_error)?;
+        sb.request_stop().await.map_err(to_napi_error)
+    }
+
+    /// Stop gracefully with an explicit timeout before escalating to SIGKILL.
+    #[napi]
+    pub async fn stop_with_timeout(&self, timeout_ms: u32) -> Result<()> {
+        let guard = self.inner.lock().await;
+        let sb = guard.as_ref().ok_or_else(consumed_error)?;
+        let timeout = Duration::from_millis(timeout_ms.into());
+        sb.stop_with_timeout(timeout).await.map_err(to_napi_error)
+    }
+
+    /// Kill the sandbox immediately and wait for observed exit.
     #[napi]
     pub async fn kill(&self) -> Result<()> {
         let guard = self.inner.lock().await;
         let sb = guard.as_ref().ok_or_else(consumed_error)?;
         sb.kill().await.map_err(to_napi_error)
+    }
+
+    /// Request force termination without waiting for observed exit.
+    #[napi]
+    pub async fn request_kill(&self) -> Result<()> {
+        let guard = self.inner.lock().await;
+        let sb = guard.as_ref().ok_or_else(consumed_error)?;
+        sb.request_kill().await.map_err(to_napi_error)
+    }
+
+    /// Force-kill the sandbox with an explicit observation timeout.
+    #[napi]
+    pub async fn kill_with_timeout(&self, timeout_ms: u32) -> Result<()> {
+        let guard = self.inner.lock().await;
+        let sb = guard.as_ref().ok_or_else(consumed_error)?;
+        let timeout = Duration::from_millis(timeout_ms.into());
+        sb.kill_with_timeout(timeout).await.map_err(to_napi_error)
     }
 
     /// Graceful drain (SIGUSR1 — for load balancing).
@@ -422,6 +462,23 @@ impl Sandbox {
         let guard = self.inner.lock().await;
         let sb = guard.as_ref().ok_or_else(consumed_error)?;
         sb.drain().await.map_err(to_napi_error)
+    }
+
+    /// Request graceful drain without waiting for observed exit.
+    #[napi]
+    pub async fn request_drain(&self) -> Result<()> {
+        let guard = self.inner.lock().await;
+        let sb = guard.as_ref().ok_or_else(consumed_error)?;
+        sb.request_drain().await.map_err(to_napi_error)
+    }
+
+    /// Wait until the sandbox is observed in a terminal non-running state.
+    #[napi]
+    pub async fn wait_until_stopped(&self) -> Result<SandboxStopResult> {
+        let guard = self.inner.lock().await;
+        let sb = guard.as_ref().ok_or_else(consumed_error)?;
+        let result = sb.wait_until_stopped().await.map_err(to_napi_error)?;
+        Ok(sandbox_stop_result_to_js(result))
     }
 
     /// Wait for the sandbox process to exit.
@@ -721,16 +778,6 @@ pub fn sandbox_stop_result_to_js(
         signal: result.signal,
         observed_at: datetime_to_ms(&result.observed_at),
         source: result.source,
-    }
-}
-
-fn sandbox_handle_to_info(handle: &microsandbox::sandbox::SandboxHandle) -> SandboxInfo {
-    SandboxInfo {
-        name: handle.name().to_string(),
-        status: format!("{:?}", handle.status_snapshot()).to_lowercase(),
-        config_json: handle.config_json().to_string(),
-        created_at: opt_datetime_to_ms(&handle.created_at()),
-        updated_at: opt_datetime_to_ms(&handle.updated_at()),
     }
 }
 

--- a/sdk/node-ts/native/types.rs
+++ b/sdk/node-ts/native/types.rs
@@ -32,16 +32,6 @@ pub struct SandboxListFilter {
     pub labels: Option<HashMap<String, String>>,
 }
 
-/// Lightweight sandbox info returned by `Sandbox.list`.
-#[napi(object)]
-pub struct SandboxInfo {
-    pub name: String,
-    pub status: String,
-    pub config_json: String,
-    pub created_at: Option<f64>,
-    pub updated_at: Option<f64>,
-}
-
 /// One captured log entry from `exec.log`.
 #[napi(object)]
 pub struct LogEntry {

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -343,14 +343,6 @@ export interface NapiSshServer {
   close(): Promise<void>;
 }
 
-export interface NapiSandboxInfo {
-  readonly name: string;
-  readonly status: string;
-  readonly configJson: string;
-  readonly createdAt: number | null | undefined;
-  readonly updatedAt: number | null | undefined;
-}
-
 export interface NapiVolumeStatic {
   get(name: string): Promise<NapiVolumeHandle>;
   list(): Promise<NapiVolumeInfo[]>;

--- a/sdk/node-ts/tests/smoke.test.ts
+++ b/sdk/node-ts/tests/smoke.test.ts
@@ -239,10 +239,15 @@ describe.skipIf(!msbPath())("listWith by labels", () => {
   });
 
   it("filters by a single label (AND across sandboxes)", async () => {
-    const names = (await Sandbox.listWith({ labels: { owner } })).map((h) => h.name);
+    const handles = await Sandbox.listWith({ labels: { owner } });
+    const names = handles.map((h) => h.name);
     expect(names).toContain(webName);
     expect(names).toContain(jobName);
     expect(names).not.toContain(otherName);
+
+    const web = handles.find((h) => h.name === webName);
+    expect(web).toBeDefined();
+    await expect(web!.refresh()).resolves.toMatchObject({ name: webName });
   });
 
   it("AND-matches multiple labels", async () => {

--- a/sdk/node-ts/tests/unit/native-contract.test.ts
+++ b/sdk/node-ts/tests/unit/native-contract.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { napi } from "../../dist/internal/napi.js";
+
+describe("native Sandbox lifecycle contract", () => {
+  it("exports the live lifecycle methods used by the TS wrapper", () => {
+    const proto = napi.Sandbox.prototype as Record<string, unknown>;
+
+    for (const method of [
+      "stop",
+      "requestStop",
+      "stopWithTimeout",
+      "kill",
+      "requestKill",
+      "killWithTimeout",
+      "requestDrain",
+      "waitUntilStopped",
+    ]) {
+      expect(typeof proto[method], method).toBe("function");
+    }
+  });
+});

--- a/sdk/python/integration/test_lifecycle.py
+++ b/sdk/python/integration/test_lifecycle.py
@@ -20,6 +20,15 @@ async def test_create_get_list_connect_stop_start_and_remove(sandbox_name):
     try:
         assert await sandbox.name == name
         assert await sandbox.owns_lifecycle is True
+        for method_name in (
+            "stop",
+            "request_stop",
+            "kill",
+            "request_kill",
+            "request_drain",
+            "wait_until_stopped",
+        ):
+            assert hasattr(sandbox, method_name)
 
         handles = await Sandbox.list()
         assert any(handle.name == name for handle in handles)

--- a/sdk/python/src/sandbox.rs
+++ b/sdk/python/src/sandbox.rs
@@ -634,15 +634,30 @@ impl PySandbox {
     // Lifecycle
     //----------------------------------------------------------------------------------------------
 
-    /// Stop the sandbox gracefully (SIGTERM).
-    fn stop<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    /// Stop the sandbox gracefully and wait until stopped.
+    #[pyo3(signature = (timeout = None))]
+    fn stop<'py>(&self, py: Python<'py>, timeout: Option<f64>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        let timeout = optional_duration(timeout)?;
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let sandbox = Self::clone_sandbox(&inner).await?;
+            match timeout {
+                Some(timeout) => sandbox
+                    .stop_with_timeout(timeout)
+                    .await
+                    .map_err(to_py_err)?,
+                None => sandbox.stop().await.map_err(to_py_err)?,
+            }
+            Ok(())
+        })
+    }
+
+    /// Request graceful shutdown without waiting.
+    fn request_stop<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
-            let handle = microsandbox::sandbox::Sandbox::get(sandbox.name())
-                .await
-                .map_err(to_py_err)?;
-            handle.stop().await.map_err(to_py_err)?;
+            sandbox.request_stop().await.map_err(to_py_err)?;
             Ok(())
         })
     }
@@ -657,12 +672,30 @@ impl PySandbox {
         })
     }
 
-    /// Kill the sandbox (SIGKILL).
-    fn kill<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    /// Kill the sandbox and wait until stopped.
+    #[pyo3(signature = (timeout = None))]
+    fn kill<'py>(&self, py: Python<'py>, timeout: Option<f64>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        let timeout = optional_duration(timeout)?;
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let sandbox = Self::clone_sandbox(&inner).await?;
+            match timeout {
+                Some(timeout) => sandbox
+                    .kill_with_timeout(timeout)
+                    .await
+                    .map_err(to_py_err)?,
+                None => sandbox.kill().await.map_err(to_py_err)?,
+            }
+            Ok(())
+        })
+    }
+
+    /// Request force termination without waiting.
+    fn request_kill<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
-            sandbox.kill().await.map_err(to_py_err)?;
+            sandbox.request_kill().await.map_err(to_py_err)?;
             Ok(())
         })
     }
@@ -674,6 +707,26 @@ impl PySandbox {
             let sandbox = Self::clone_sandbox(&inner).await?;
             sandbox.drain().await.map_err(to_py_err)?;
             Ok(())
+        })
+    }
+
+    /// Request drain without waiting.
+    fn request_drain<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let sandbox = Self::clone_sandbox(&inner).await?;
+            sandbox.request_drain().await.map_err(to_py_err)?;
+            Ok(())
+        })
+    }
+
+    /// Wait until the sandbox is observed in a terminal non-running state.
+    fn wait_until_stopped<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let sandbox = Self::clone_sandbox(&inner).await?;
+            let result = sandbox.wait_until_stopped().await.map_err(to_py_err)?;
+            Ok(PySandboxStopResult::from_rust(result))
         })
     }
 

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -107,7 +107,7 @@ pub use builder::{RegistryConfigBuilder, SandboxBuilder};
 pub use config::SandboxConfig;
 pub use exec::{ExecOptionsBuilder, ExecOutput, Rlimit, RlimitResource};
 pub use fs::{FsEntry, FsEntryKind, FsMetadata, FsReadStream, FsSetAttrs, FsWriteSink, SandboxFs};
-pub use handle::SandboxHandle;
+pub use handle::{DEFAULT_KILL_TIMEOUT, DEFAULT_STOP_TIMEOUT, SandboxHandle};
 pub use init::{HandoffInit, InitOptionsBuilder};
 pub use metrics::{SandboxMetrics, all_sandbox_metrics};
 pub use microsandbox_image::{PullProgress, PullProgressHandle};
@@ -1131,19 +1131,57 @@ impl Sandbox {
         fs::SandboxFs::new(self.backend.clone(), &self.name)
     }
 
-    /// Stop the sandbox gracefully.
+    /// Stop the sandbox gracefully and wait until stopped state is observed.
     ///
-    /// Routes through the backend trait. On local this connects to the
-    /// agent UDS and sends `core.shutdown` (agentd runs `sync()` +
+    /// Uses [`DEFAULT_STOP_TIMEOUT`] before escalating to force termination.
+    pub async fn stop(&self) -> MicrosandboxResult<()> {
+        self.stop_with_timeout(DEFAULT_STOP_TIMEOUT).await
+    }
+
+    /// Request graceful shutdown and return once the request is sent.
+    ///
+    /// Routes through the backend trait. On local this connects to the agent
+    /// UDS and sends `core.shutdown` (agentd runs `sync()` +
     /// `reboot(RB_POWER_OFF)` for a clean ext4 unmount), falling back to
     /// SIGTERM via PID if the socket is unreachable. On cloud this issues
     /// `POST /v1/sandboxes/by-name/:name/stop`.
-    pub async fn stop(&self) -> MicrosandboxResult<()> {
+    pub async fn request_stop(&self) -> MicrosandboxResult<()> {
         tracing::debug!(sandbox = %self.name, "stop: dispatching");
         self.backend
             .sandboxes()
             .stop(self.backend.clone(), &self.name)
             .await
+    }
+
+    /// Stop the sandbox gracefully with an explicit timeout before escalation.
+    pub async fn stop_with_timeout(&self, timeout: std::time::Duration) -> MicrosandboxResult<()> {
+        if timeout.is_zero() {
+            self.kill_with_timeout(DEFAULT_KILL_TIMEOUT).await?;
+            return Ok(());
+        }
+
+        self.request_stop().await?;
+        if let Ok(result) = tokio::time::timeout(timeout, self.wait_until_stopped()).await {
+            result?;
+            return Ok(());
+        }
+
+        tracing::warn!(
+            sandbox = %self.name,
+            timeout_secs = timeout.as_secs(),
+            "graceful stop exceeded timeout, escalating to kill"
+        );
+        self.request_kill().await?;
+        match tokio::time::timeout(DEFAULT_KILL_TIMEOUT, self.wait_until_stopped()).await {
+            Ok(result) => {
+                result?;
+                Ok(())
+            }
+            Err(_) => Err(crate::MicrosandboxError::Runtime(format!(
+                "timed out observing stopped state for sandbox '{}'",
+                self.name
+            ))),
+        }
     }
 
     /// Stop the sandbox gracefully and wait for the process to exit.
@@ -1152,7 +1190,7 @@ impl Sandbox {
     /// on; use [`stop`](Self::stop) and poll [`status`](Self::status) instead.
     pub async fn stop_and_wait(&self) -> MicrosandboxResult<ExitStatus> {
         let local = self.require_local("stop_and_wait")?;
-        let stop_result = self.stop().await;
+        let stop_result = self.request_stop().await;
         if local.handle.is_none() {
             stop_result?;
             // No handle to wait on — return a synthetic success status.
@@ -1163,22 +1201,46 @@ impl Sandbox {
         wait_result
     }
 
-    /// Kill the sandbox immediately (SIGKILL).
-    ///
-    /// Routes through the backend trait. On local the trait impl looks the
-    /// PID up from the DB and signals SIGKILL, then marks the row Stopped
-    /// once the process is confirmed dead. Cloud currently returns
-    /// `Unsupported`.
+    /// Kill the sandbox immediately and wait until stopped state is observed.
     pub async fn kill(&self) -> MicrosandboxResult<()> {
+        self.kill_with_timeout(DEFAULT_KILL_TIMEOUT).await
+    }
+
+    /// Request force termination and return once the request is sent.
+    ///
+    /// Routes through the backend trait. On local the trait impl looks the PID
+    /// up from the DB and signals SIGKILL, then marks the row Stopped once the
+    /// process is confirmed dead. Cloud currently returns `Unsupported`.
+    pub async fn request_kill(&self) -> MicrosandboxResult<()> {
         self.backend
             .sandboxes()
             .kill(self.backend.clone(), &self.name)
             .await
     }
 
+    /// Force-kill the sandbox and wait up to `timeout` for stopped-state observation.
+    pub async fn kill_with_timeout(&self, timeout: std::time::Duration) -> MicrosandboxResult<()> {
+        self.request_kill().await?;
+        match tokio::time::timeout(timeout, self.wait_until_stopped()).await {
+            Ok(result) => {
+                result?;
+                Ok(())
+            }
+            Err(_) => Err(crate::MicrosandboxError::Runtime(format!(
+                "timed out observing stopped state for sandbox '{}'",
+                self.name
+            ))),
+        }
+    }
+
     /// Trigger a graceful drain (SIGUSR1 to the libkrun PID on local).
     /// Cloud sandboxes currently return `Unsupported`.
     pub async fn drain(&self) -> MicrosandboxResult<()> {
+        self.request_drain().await
+    }
+
+    /// Request graceful drain without waiting for observed exit.
+    pub async fn request_drain(&self) -> MicrosandboxResult<()> {
         self.backend
             .sandboxes()
             .drain(self.backend.clone(), &self.name)
@@ -1194,6 +1256,21 @@ impl Sandbox {
                 "cannot wait: not the lifecycle owner".into(),
             )),
         }
+    }
+
+    /// Wait until this sandbox is observed in a terminal non-running state.
+    pub async fn wait_until_stopped(&self) -> MicrosandboxResult<SandboxStopResult> {
+        if self.owns_lifecycle() {
+            let status = self.wait().await?;
+            return Ok(stop_result_from_exit_status(&self.name, status));
+        }
+
+        self.backend
+            .sandboxes()
+            .get(self.backend.clone(), &self.name)
+            .await?
+            .wait_until_stopped()
+            .await
     }
 
     /// Detach this handle without stopping the sandbox.
@@ -1728,6 +1805,19 @@ pub(crate) fn read_from_fd(fd: std::os::fd::RawFd, buf: &mut [u8]) -> std::io::R
         Err(std::io::Error::last_os_error())
     } else {
         Ok(n as usize)
+    }
+}
+
+fn stop_result_from_exit_status(name: &str, status: ExitStatus) -> SandboxStopResult {
+    use std::os::unix::process::ExitStatusExt;
+
+    SandboxStopResult {
+        name: name.to_string(),
+        status: SandboxStatus::Stopped,
+        exit_code: status.code(),
+        signal: status.signal(),
+        observed_at: chrono::Utc::now(),
+        source: Some("owned process wait".to_string()),
     }
 }
 
@@ -2525,6 +2615,21 @@ mod tests {
             pid += 1;
         }
         pid
+    }
+
+    #[test]
+    fn test_live_sandbox_lifecycle_api_methods_stay_available() {
+        // These method items are intentionally referenced without invoking
+        // them. The test is a compile-time tripwire for the unified lifecycle
+        // surface that backs the language SDK bindings.
+        let _ = super::Sandbox::stop;
+        let _ = super::Sandbox::request_stop;
+        let _ = super::Sandbox::stop_with_timeout;
+        let _ = super::Sandbox::kill;
+        let _ = super::Sandbox::request_kill;
+        let _ = super::Sandbox::kill_with_timeout;
+        let _ = super::Sandbox::request_drain;
+        let _ = super::Sandbox::wait_until_stopped;
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR
Restore the live sandbox lifecycle methods across SDK bindings so callers can stop, kill, drain, and wait on the object they already have. This also fixes Node list APIs to return usable sandbox handles again and frees disk in the Linux test job before workspace tests.

## Description
- Restore request, timeout, and wait lifecycle methods on Rust live `Sandbox`, with `stop()` and `kill()` waiting until stopped state is observed.
- Expose the live lifecycle methods through Node and Python native bindings.
- Keep Go native lifecycle FFI calls on the owned live sandbox instead of reloading a name-backed handle.
- Return Node native `JsSandboxHandle` values from `Sandbox.list()` and `Sandbox.listWith()` so listed sandboxes can be refreshed and controlled.
- Refresh generated Node native typings, including the current bind-mount quota fields from main.
- Add docs and contract tests that keep the lifecycle methods from disappearing again.
- Free release-only Cargo outputs and generated libkrunfw build products before Linux workspace tests, so the hosted runner has room for debug test artifacts.

```rust
let sandbox = Sandbox::builder("worker").image("python").create().await?;
sandbox.request_stop().await?;
let result = sandbox.wait_until_stopped().await?;
```

```ts
const sandbox = await Sandbox.builder("worker").image("python").create();
await sandbox.requestStop();
const result = await sandbox.waitUntilStopped();

const [handle] = await Sandbox.listWith({ labels: { owner: "ci" } });
await handle.refresh();
```

```python
sandbox = await Sandbox.create("worker", image="python")
await sandbox.request_stop()
result = await sandbox.wait_until_stopped()
```

## Test Plan
- [x] `cargo fmt --all` exits 0
- [x] `cargo clippy --workspace --exclude microsandbox-agentd -- -D warnings` exits 0
- [x] `cargo test -p microsandbox test_live_sandbox_lifecycle_api_methods_stay_available --lib` passes
- [x] `cargo check -p microsandbox-node` passes
- [x] `cd sdk/node-ts && npm run build:ts && npm run test:unit -- tests/unit/native-contract.test.ts && npm run typecheck` passes
- [x] `cargo check -p microsandbox-py` passes
- [x] `cd sdk/go && go test -count=1 .` passes
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "yaml ok"'` passes
