### PR TITLE
fix(sdk): restore named volume mount semantics

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -947,6 +947,12 @@ pub fn apply_explicit_named_mount(
     {
         anyhow::bail!("mount-named kind=disk does not support quota=...");
     }
+    if matches!(parsed.options.named_kind, Some(VolumeKind::Disk))
+        && (parsed.options.stat_virtualization.is_some()
+            || parsed.options.host_permissions.is_some())
+    {
+        anyhow::bail!("mount-named kind=disk does not support stat-virt=... or host-perms=...");
+    }
 
     let source = parsed.source.to_string();
     let guest = parsed.guest.to_string();
@@ -968,7 +974,9 @@ pub fn apply_explicit_named_mount(
             }
             v
         });
-        apply_common_mount_options(mount, options)
+        let mut common_options = options;
+        common_options.quota_mib = None;
+        apply_common_mount_options(mount, common_options)
     }))
 }
 
@@ -2444,6 +2452,44 @@ mod tests {
             }
             other => panic!("expected Named, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_apply_explicit_named_mount_directory_quota() {
+        let mount = build_explicit("cache:/data:quota=1G", apply_explicit_named_mount).await;
+        match mount {
+            VolumeMount::Named { create, .. } => {
+                let create = create.expect("mount-named should ensure the named volume");
+                assert_eq!(
+                    create.mode(),
+                    microsandbox::sandbox::NamedVolumeMode::EnsureExists
+                );
+                assert_eq!(create.kind(), VolumeKind::Directory);
+                assert_eq!(create.quota_mib(), Some(1024));
+            }
+            other => panic!("expected Named, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_apply_explicit_named_mount_disk_rejects_policy_options() {
+        let err = match apply_explicit_named_mount(
+            SandboxBuilder::new("test").image("alpine"),
+            "cache-disk:/data:kind=disk,size=2G,stat-virt=relaxed",
+        ) {
+            Ok(_) => panic!("expected mount-named disk to reject stat-virt"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("does not support stat-virt"));
+
+        let err = match apply_explicit_named_mount(
+            SandboxBuilder::new("test").image("alpine"),
+            "cache-disk:/data:kind=disk,size=2G,host-perms=mirror",
+        ) {
+            Ok(_) => panic!("expected mount-named disk to reject host-perms"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("does not support stat-virt"));
     }
 
     #[test]

--- a/docs/sdk/rust/volumes.mdx
+++ b/docs/sdk/rust/volumes.mdx
@@ -1718,7 +1718,7 @@ Ignore device files on this mount.
 fn stat_virtualization(self, policy: StatVirtualization) -> Self
 ```
 
-Set the guest stat virtualization policy for a virtiofs-backed mount. Default: [`Strict`](#statvirtualization). Valid only for bind and named-volume mounts; calling it on a tmpfs or disk-image mount errors at finalize time.
+Set the guest stat virtualization policy for a virtiofs-backed mount. Default: [`Strict`](#statvirtualization). Valid only for bind and directory-backed named-volume mounts. Tmpfs and disk-image mounts are rejected when the mount is built; disk-backed named volumes are rejected once the backing volume kind is known during sandbox create or start.
 
 <p className="msb-label">Parameters</p>
 
@@ -1738,7 +1738,7 @@ Set the guest stat virtualization policy for a virtiofs-backed mount. Default: [
 fn host_permissions(self, policy: HostPermissions) -> Self
 ```
 
-Set the host permission propagation policy for a virtiofs-backed mount. Default: [`Private`](#hostpermissions). Valid only for bind and named-volume mounts. Combining [`StatVirtualization::Off`](#statvirtualization) with [`HostPermissions::Mirror`](#hostpermissions) is rejected, since with no overlay the guest chmod already hits the host inode and `Mirror` would be a no-op.
+Set the host permission propagation policy for a virtiofs-backed mount. Default: [`Private`](#hostpermissions). Valid only for bind and directory-backed named-volume mounts. Combining [`StatVirtualization::Off`](#statvirtualization) with [`HostPermissions::Mirror`](#hostpermissions) is rejected, since with no overlay the guest chmod already hits the host inode and `Mirror` would be a no-op.
 
 <p className="msb-label">Parameters</p>
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -79,6 +79,8 @@ Create and control a microVM sandbox: boot it from an image, run commands, strea
 
 The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox from `Sandbox.builder(name)` and chain configuration calls before terminating with `.create()`. Use `.detached(true)` before `.create()` for detached/background mode. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes.
 
+`libkrunfw` selection is process-level, not per sandbox. To use a custom library, call `setRuntimeLibkrunfwPath(path)` before creating local sandboxes, set `MSB_LIBKRUNFW_PATH`, or configure `paths.libkrunfw`.
+
 <p className="msb-label" id="typical-flow">Typical flow</p>
 
 ```typescript
@@ -1106,6 +1108,26 @@ Set the guest hostname.
 
 ---
 
+#### <span className="msb-recv">.</span><span className="msb-hn">libkrunfwPath()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span><span className="msb-tag">deprecated</span></div>
+
+```typescript
+libkrunfwPath(path: string): this
+```
+
+Deprecated compatibility alias for older builder chains. This sets the same process-level override as `setRuntimeLibkrunfwPath(path)` and returns the builder; it is not a per-sandbox setting.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path to the libkrunfw shared library.</div>
+  </div>
+</div>
+
+---
+
 #### <span className="msb-recv">.</span><span className="msb-hn">idleTimeout()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
@@ -1288,28 +1310,6 @@ Attach many labels at once.
     <div className="msb-param-desc">Map of label keys to values.</div>
   </div>
 </div>
-
----
-
-#### <span className="msb-recv">.</span><span className="msb-hn">libkrunfwPath()</span>
-<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
-
-```typescript
-libkrunfwPath(path: string): this
-```
-
-Override the path to the `libkrunfw` library used to boot the microVM. Rarely needed; set it only when running against a custom or non-default libkrunfw build.
-
-<p className="msb-label">Parameters</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
-    <div className="msb-param-desc">Filesystem path to the <code>libkrunfw</code> library.</div>
-  </div>
-</div>
-
----
 
 #### <span className="msb-recv">.</span><span className="msb-hn">logLevel()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -51,15 +51,15 @@ use std::{
 use base64::Engine;
 use microsandbox::{
     AgentBridge, LogLevel, MicrosandboxError, RegistryAuth, Sandbox, Snapshot, UpperVerifyStatus,
-    logs::{self, LogOptions, LogSource},
+    logs::{LogOptions, LogSource},
     sandbox::{
-        FsEntryKind, PullPolicy, all_sandbox_metrics,
+        FsEntryKind, PullPolicy, SecurityProfile, all_sandbox_metrics,
         exec::{ExecEvent, ExecHandle, ExecSink},
         fs::{FsReadStream, FsWriteSink},
         ssh::{SftpClient, SshClient, SshServer, SshStdioStream},
     },
     snapshot::{ExportOpts, SnapshotDestination, SnapshotFormat},
-    volume::{Volume, VolumeBuilder, VolumeHandle},
+    volume::{Volume, VolumeBuilder, VolumeHandle, VolumeKind},
 };
 use microsandbox_network::{builder::ViolationActionBuilder, secrets::config::ViolationAction};
 use tokio::io::AsyncWriteExt;
@@ -449,6 +449,9 @@ mod error_kind {
     pub const SNAPSHOT_IMAGE_MISSING: &str = "snapshot_image_missing";
     pub const SNAPSHOT_INTEGRITY: &str = "snapshot_integrity";
     pub const PATCH_FAILED: &str = "patch_failed";
+    pub const METRICS_DISABLED: &str = "metrics_disabled";
+    pub const METRICS_UNAVAILABLE: &str = "metrics_unavailable";
+    pub const UNSUPPORTED_OPERATION: &str = "unsupported_operation";
     pub const IO: &str = "io";
 }
 
@@ -506,6 +509,9 @@ impl From<MicrosandboxError> for FfiError {
             MicrosandboxError::SnapshotImageMissing(_) => error_kind::SNAPSHOT_IMAGE_MISSING,
             MicrosandboxError::SnapshotIntegrity(_) => error_kind::SNAPSHOT_INTEGRITY,
             MicrosandboxError::PatchFailed(_) => error_kind::PATCH_FAILED,
+            MicrosandboxError::MetricsDisabled(_) => error_kind::METRICS_DISABLED,
+            MicrosandboxError::MetricsUnavailable(_) => error_kind::METRICS_UNAVAILABLE,
+            MicrosandboxError::Unsupported { .. } => error_kind::UNSUPPORTED_OPERATION,
             MicrosandboxError::Io(_) => error_kind::IO,
             _ => error_kind::INTERNAL,
         };
@@ -912,6 +918,7 @@ struct SandboxCreateOpts {
     ephemeral: bool,
     hostname: Option<String>,
     user: Option<String>,
+    security_profile: Option<String>,
     #[serde(default)]
     replace: bool,
     /// Timeout in milliseconds between SIGTERM and SIGKILL when
@@ -1022,6 +1029,8 @@ struct SnapshotExportOpts {
 struct MountSpec {
     bind: Option<String>,
     named: Option<String>,
+    named_mode: Option<String>,
+    named_kind: Option<String>,
     #[serde(default)]
     tmpfs: bool,
     /// Mount a host disk image (.img/.qcow2/etc.).
@@ -1034,13 +1043,25 @@ struct MountSpec {
     readonly: bool,
     #[serde(default)]
     noexec: bool,
+    #[serde(default)]
+    nosuid: bool,
+    #[serde(default)]
+    nodev: bool,
     size_mib: Option<u32>,
+    quota_mib: Option<u32>,
     /// Per-mount stat-virtualization policy ("strict" | "relaxed" | "off").
     /// Only valid for bind / named mounts.
     stat_virtualization: Option<String>,
     /// Per-mount host-permission policy ("private" | "mirror").
     /// Only valid for bind / named mounts.
     host_permissions: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+enum FfiNamedMode {
+    Existing,
+    Create,
+    EnsureExists,
 }
 
 // ---------------------------------------------------------------------------
@@ -1447,6 +1468,16 @@ fn parse_pull_policy(s: &str) -> Result<PullPolicy, FfiError> {
     }
 }
 
+fn parse_security_profile(s: &str) -> Result<SecurityProfile, FfiError> {
+    match s {
+        "" | "default" => Ok(SecurityProfile::Default),
+        "restricted" => Ok(SecurityProfile::Restricted),
+        other => Err(FfiError::invalid_argument(format!(
+            "unknown security profile: {other}"
+        ))),
+    }
+}
+
 fn apply_secret(
     mut builder: microsandbox::sandbox::SandboxBuilder,
     s: &SecretOpts,
@@ -1604,7 +1635,12 @@ fn apply_volume(
     let fstype = m.fstype.clone();
     let readonly = m.readonly;
     let noexec = m.noexec;
+    let nosuid = m.nosuid;
+    let nodev = m.nodev;
     let size_mib = m.size_mib;
+    let quota_mib = m.quota_mib;
+    let raw_named_mode = m.named_mode.clone();
+    let raw_named_kind = m.named_kind.clone();
 
     let kinds_set: u8 =
         bind.is_some() as u8 + named.is_some() as u8 + tmpfs as u8 + disk.is_some() as u8;
@@ -1614,11 +1650,58 @@ fn apply_volume(
         ));
     }
 
+    let named_mode = if named.is_some() {
+        raw_named_mode
+            .as_deref()
+            .map(parse_named_mode)
+            .transpose()?
+    } else {
+        None
+    };
+    let named_kind = if named.is_some() {
+        raw_named_kind
+            .as_deref()
+            .map(parse_volume_kind)
+            .transpose()?
+    } else {
+        None
+    };
+    let needs_named_create_options = raw_named_mode.is_some()
+        || raw_named_kind.is_some()
+        || size_mib.is_some()
+        || quota_mib.is_some();
+    if size_mib.is_some() && !tmpfs && named.is_none() {
+        return Err(FfiError::invalid_argument(
+            "size_mib is only valid for tmpfs mounts or named volume provisioning",
+        ));
+    }
+
     Ok(builder.volume(guest_path, move |mb| {
         let mut mb = if let Some(ref host) = bind {
             mb.bind(host)
         } else if let Some(ref name) = named {
-            mb.named(name)
+            if needs_named_create_options {
+                mb.named_with(name, |mut nb| {
+                    nb = match named_mode.unwrap_or(FfiNamedMode::Existing) {
+                        FfiNamedMode::Existing => nb.existing(),
+                        FfiNamedMode::Create => nb.create(),
+                        FfiNamedMode::EnsureExists => nb.ensure_exists(),
+                    };
+                    nb = match named_kind.unwrap_or(VolumeKind::Directory) {
+                        VolumeKind::Directory => nb.directory(),
+                        VolumeKind::Disk => nb.disk(),
+                    };
+                    if let Some(siz) = size_mib {
+                        nb = nb.size(siz);
+                    }
+                    if let Some(quota) = quota_mib {
+                        nb = nb.quota(quota);
+                    }
+                    nb
+                })
+            } else {
+                mb.named(name)
+            }
         } else if tmpfs {
             mb.tmpfs()
         } else if let Some(ref host) = disk {
@@ -1638,7 +1721,13 @@ fn apply_volume(
         if noexec {
             mb = mb.noexec();
         }
-        if let Some(siz) = size_mib {
+        if nosuid {
+            mb = mb.nosuid();
+        }
+        if nodev {
+            mb = mb.nodev();
+        }
+        if tmpfs && let Some(siz) = size_mib {
             mb = mb.size(siz);
         }
         if let Some(p) = stat_virt {
@@ -1649,6 +1738,27 @@ fn apply_volume(
         }
         mb
     }))
+}
+
+fn parse_named_mode(s: &str) -> Result<FfiNamedMode, FfiError> {
+    match s {
+        "" | "existing" => Ok(FfiNamedMode::Existing),
+        "create" => Ok(FfiNamedMode::Create),
+        "ensure-exists" | "ensure_exists" => Ok(FfiNamedMode::EnsureExists),
+        other => Err(FfiError::invalid_argument(format!(
+            "invalid named volume mode {other:?} (expected existing|create|ensure-exists)"
+        ))),
+    }
+}
+
+fn parse_volume_kind(s: &str) -> Result<VolumeKind, FfiError> {
+    match s {
+        "" | "dir" | "directory" => Ok(VolumeKind::Directory),
+        "disk" => Ok(VolumeKind::Disk),
+        other => Err(FfiError::invalid_argument(format!(
+            "invalid volume kind {other:?} (expected dir|disk)"
+        ))),
+    }
 }
 
 fn parse_stat_virt(s: &str) -> Result<microsandbox::sandbox::StatVirtualization, FfiError> {
@@ -1728,6 +1838,10 @@ pub unsafe extern "C" fn msb_sandbox_create(
             Some(s) => Some(parse_log_level(s)?),
             None => None,
         };
+        let security_profile = match opts.security_profile.as_deref() {
+            Some(s) => Some(parse_security_profile(s)?),
+            None => None,
+        };
 
         Ok(Box::pin(async move {
             let mut builder = Sandbox::builder(&name);
@@ -1771,6 +1885,9 @@ pub unsafe extern "C" fn msb_sandbox_create(
             }
             if let Some(u) = opts.user {
                 builder = builder.user(u);
+            }
+            if let Some(profile) = security_profile {
+                builder = builder.security(profile);
             }
             if let Some(timeout_ms) = opts.replace_with_timeout_ms {
                 builder =
@@ -2568,9 +2685,8 @@ pub unsafe extern "C" fn msb_sandbox_handle_logs(
         let name = unsafe { cstr(name) }?.to_owned();
         let opts = parse_log_options(opts_json)?;
         Ok(Box::pin(async move {
-            let entries = logs::read_logs(&name, &opts)
-                .await
-                .map_err(FfiError::from)?;
+            let handle = Sandbox::get(&name).await.map_err(FfiError::from)?;
+            let entries = handle.logs(&opts).await.map_err(FfiError::from)?;
             log_entries_json(entries)
         }))
     })
@@ -3526,6 +3642,10 @@ pub unsafe extern "C" fn msb_fs_exists(
 struct VolumeCreateOpts {
     #[serde(default)]
     quota_mib: u32,
+    #[serde(default)]
+    kind: String,
+    #[serde(default)]
+    size_mib: u32,
     /// Optional key-value labels.
     #[serde(default)]
     labels: HashMap<String, String>,
@@ -3554,6 +3674,17 @@ pub unsafe extern "C" fn msb_volume_create(
         };
         Ok(Box::pin(async move {
             let mut b: VolumeBuilder = Volume::builder(&name);
+            match parse_volume_kind(&opts.kind)? {
+                VolumeKind::Directory => {
+                    b = b.directory();
+                }
+                VolumeKind::Disk => {
+                    b = b.disk();
+                }
+            }
+            if opts.size_mib > 0 {
+                b = b.size(opts.size_mib);
+            }
             if opts.quota_mib > 0 {
                 b = b.quota(opts.quota_mib);
             }
@@ -3570,37 +3701,31 @@ pub unsafe extern "C" fn msb_volume_create(
 
 /// Serialise a `VolumeHandle` into the public JSON shape.
 fn volume_handle_json(vh: &VolumeHandle) -> String {
-    let quota = match vh.quota_mib() {
-        Some(q) => format!("{q}"),
-        None => "null".to_string(),
-    };
-    let created = match vh.created_at() {
-        Some(dt) => format!("{}", dt.timestamp()),
-        None => "null".to_string(),
-    };
     // Use serde_json for the labels object so escaping is correct.
     let labels_map: HashMap<&str, &str> = vh
         .labels()
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
-    let labels_json = serde_json::to_string(&labels_map).unwrap_or_else(|_| "{}".into());
-    // Best-effort: when the default backend is local we surface the host
-    // path; otherwise fall back to an empty path since cloud volumes don't
-    // expose a host-side directory.
-    let path = microsandbox::backend::default_backend()
-        .as_local()
-        .map(|local| local.volume_path(vh.name()).to_string_lossy().into_owned())
+    // Best-effort: local handles carry their exact backend path; cloud
+    // volumes don't expose a host-side directory.
+    let path = vh
+        .local()
+        .map(|local| local.path.to_string_lossy().into_owned())
         .unwrap_or_default();
-    let name_json = serde_json::to_string(vh.name()).unwrap_or_else(|_| "\"\"".into());
-    let path_json = serde_json::to_string(&path).unwrap_or_else(|_| "\"\"".into());
-    format!(
-        r#"{{"name":{name},"path":{path},"quota_mib":{quota},"used_bytes":{used},"labels":{labels},"created_at_unix":{created}}}"#,
-        name = name_json,
-        path = path_json,
-        used = vh.used_bytes(),
-        labels = labels_json,
-    )
+    serde_json::json!({
+        "name": vh.name(),
+        "path": path,
+        "kind": vh.kind().as_str(),
+        "quota_mib": vh.quota_mib(),
+        "used_bytes": vh.used_bytes(),
+        "capacity_bytes": vh.capacity_bytes(),
+        "disk_format": vh.disk_format(),
+        "disk_fstype": vh.disk_fstype(),
+        "labels": labels_map,
+        "created_at_unix": vh.created_at().map(|dt| dt.timestamp()),
+    })
+    .to_string()
 }
 
 #[unsafe(no_mangle)]
@@ -3812,14 +3937,16 @@ fn remove_log_stream(handle: Handle) {
 
 /// Spawn a forwarder that drives the engine stream into an unbounded mpsc
 /// channel, register the receiver, and return the handle.
-async fn start_log_stream_for(
-    log_dir_name: &str,
-    opts: microsandbox::logs::LogStreamOptions,
+async fn start_log_stream_from_stream(
+    mut stream: std::pin::Pin<
+        Box<
+            dyn tokio_stream::Stream<
+                    Item = microsandbox::MicrosandboxResult<microsandbox::logs::LogEntry>,
+                > + Send
+                + 'static,
+        >,
+    >,
 ) -> Result<Handle, FfiError> {
-    let stream = microsandbox::logs::log_stream(log_dir_name, &opts)
-        .await
-        .map_err(FfiError::from)?;
-    let mut stream = Box::pin(stream);
     let (tx, rx) = tokio::sync::mpsc::channel::<LogStreamItem>(16);
     // The forwarder task is moved off the foreground future so the caller
     // can return the stream handle immediately. The task stops naturally
@@ -3848,8 +3975,8 @@ pub unsafe extern "C" fn msb_sandbox_log_stream(
         let opts = parse_log_stream_options(opts_json)?;
         Ok(Box::pin(async move {
             let sb = get(handle)?;
-            let name = sb.name().to_string();
-            let sh = start_log_stream_for(&name, opts).await?;
+            let stream = sb.log_stream(&opts).await.map_err(FfiError::from)?;
+            let sh = start_log_stream_from_stream(stream).await?;
             Ok(format!(r#"{{"stream_handle":{sh}}}"#))
         }))
     })
@@ -3869,7 +3996,9 @@ pub unsafe extern "C" fn msb_sandbox_handle_log_stream(
         let name = unsafe { cstr(name) }?.to_owned();
         let opts = parse_log_stream_options(opts_json)?;
         Ok(Box::pin(async move {
-            let sh = start_log_stream_for(&name, opts).await?;
+            let handle = Sandbox::get(&name).await.map_err(FfiError::from)?;
+            let stream = handle.log_stream(&opts).await.map_err(FfiError::from)?;
+            let sh = start_log_stream_from_stream(stream).await?;
             Ok(format!(r#"{{"stream_handle":{sh}}}"#))
         }))
     })
@@ -5651,6 +5780,27 @@ mod tests {
         let opts: SandboxCreateOpts = serde_json::from_str(r#"{"image":"python:3.12"}"#).unwrap();
 
         assert_eq!(opts.oci_upper_size_mib, None);
+    }
+
+    #[test]
+    fn apply_volume_rejects_size_on_non_tmpfs_or_named_provisioning() {
+        let builder = microsandbox::sandbox::SandboxBuilder::new("test").image("alpine");
+        let spec = MountSpec {
+            bind: Some("/host/data".to_string()),
+            size_mib: Some(64),
+            ..Default::default()
+        };
+
+        let err = match apply_volume(builder, "/data", &spec) {
+            Ok(_) => panic!("size_mib on bind mounts should be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.message.contains("size_mib is only valid"),
+            "got: {}",
+            err.message
+        );
     }
 
     #[test]

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -404,14 +404,14 @@ export declare class MountBuilder {
    * Set the guest stat virtualization policy.
    *
    * Accepts `"strict"`, `"relaxed"`, or `"off"`. Valid only for bind and
-   * named volume mounts.
+   * directory-backed named volume mounts.
    */
   statVirtualization(policy: string): this
   /**
    * Set the host permission propagation policy.
    *
-   * Accepts `"private"` or `"mirror"`. Valid only for bind and named volume
-   * mounts.
+   * Accepts `"private"` or `"mirror"`. Valid only for bind and
+   * directory-backed named volume mounts.
    */
   hostPermissions(policy: string): this
   /**
@@ -975,6 +975,15 @@ export declare class SandboxBuilder {
   initWith(cmd: string, configure: (arg: InitOptionsBuilder) => InitOptionsBuilder): this
   /** Override the guest hostname. */
   hostname(name: string): this
+  /**
+   * Deprecated compatibility setter for older Node SDK callers.
+   *
+   * The libkrunfw path is a process-level concern (one dylib per process
+   * address space), not a per-sandbox builder setting. Keep this chainable
+   * alias so pre-backend-split code still compiles, but route it through the
+   * same process-wide override as `microsandbox.setRuntimeLibkrunfwPath(...)`.
+   */
+  libkrunfwPath(path: string): this
   /** Default running user. */
   user(user: string): this
   /** Image pull policy: `"always" | "if-missing" | "never"`. */
@@ -2125,6 +2134,8 @@ export interface VolumeMount {
   nodev: boolean
   host?: string
   name?: string
+  namedMode?: string
+  namedKind?: string
   sizeMib?: number
   quotaMib?: number
   format?: string

--- a/sdk/node-ts/native/mount_builder.rs
+++ b/sdk/node-ts/native/mount_builder.rs
@@ -3,10 +3,11 @@ use std::path::PathBuf;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
+use microsandbox::VolumeKind as RustVolumeKind;
 use microsandbox::sandbox::{
     DiskImageFormat as RustDiskImageFormat, HostPermissions as RustHostPermissions,
-    MountBuilder as RustMountBuilder, StatVirtualization as RustStatVirtualization,
-    VolumeMount as RustVolumeMount,
+    MountBuilder as RustMountBuilder, NamedVolumeMode as RustNamedVolumeMode,
+    StatVirtualization as RustStatVirtualization, VolumeMount as RustVolumeMount,
 };
 use microsandbox::size::Mebibytes;
 
@@ -30,6 +31,8 @@ pub struct JsBuiltVolumeMount {
     pub nodev: bool,
     pub host: Option<String>,
     pub name: Option<String>,
+    pub named_mode: Option<String>,
+    pub named_kind: Option<String>,
     pub size_mib: Option<u32>,
     pub quota_mib: Option<u32>,
     pub format: Option<String>,
@@ -225,7 +228,7 @@ impl JsMountBuilder {
     /// Set the guest stat virtualization policy.
     ///
     /// Accepts `"strict"`, `"relaxed"`, or `"off"`. Valid only for bind and
-    /// named volume mounts.
+    /// directory-backed named volume mounts.
     #[napi]
     pub fn stat_virtualization(&mut self, policy: String) -> Result<&Self> {
         let p = match policy.as_str() {
@@ -245,8 +248,8 @@ impl JsMountBuilder {
 
     /// Set the host permission propagation policy.
     ///
-    /// Accepts `"private"` or `"mirror"`. Valid only for bind and named volume
-    /// mounts.
+    /// Accepts `"private"` or `"mirror"`. Valid only for bind and
+    /// directory-backed named volume mounts.
     #[napi]
     pub fn host_permissions(&mut self, policy: String) -> Result<&Self> {
         let p = match policy.as_str() {
@@ -311,6 +314,8 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             nodev: options.nodev,
             host: Some(host.to_string_lossy().into_owned()),
             name: None,
+            named_mode: None,
+            named_kind: None,
             size_mib: None,
             quota_mib,
             format: None,
@@ -321,26 +326,42 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
         RustVolumeMount::Named {
             name,
             guest,
-            create: _,
+            create,
             options,
             stat_virtualization,
             host_permissions,
-        } => JsBuiltVolumeMount {
-            kind: "named".into(),
-            guest,
-            readonly: options.readonly,
-            noexec: options.noexec,
-            nosuid: options.nosuid,
-            nodev: options.nodev,
-            host: None,
-            name: Some(name),
-            size_mib: None,
-            quota_mib: None,
-            format: None,
-            fstype: None,
-            stat_virtualization: Some(sv_str(stat_virtualization)),
-            host_permissions: Some(hp_str(host_permissions)),
-        },
+        } => {
+            let named_mode = create.as_ref().map(|create| match create.mode() {
+                RustNamedVolumeMode::Existing => "existing".to_string(),
+                RustNamedVolumeMode::Create => "create".to_string(),
+                RustNamedVolumeMode::EnsureExists => "ensure-exists".to_string(),
+            });
+            let named_kind = create.as_ref().map(|create| match create.kind() {
+                RustVolumeKind::Directory => "dir".to_string(),
+                RustVolumeKind::Disk => "disk".to_string(),
+            });
+            let size_mib = create.as_ref().and_then(|create| create.capacity_mib());
+            let quota_mib = create.as_ref().and_then(|create| create.quota_mib());
+
+            JsBuiltVolumeMount {
+                kind: "named".into(),
+                guest,
+                readonly: options.readonly,
+                noexec: options.noexec,
+                nosuid: options.nosuid,
+                nodev: options.nodev,
+                host: None,
+                name: Some(name),
+                named_mode,
+                named_kind,
+                size_mib,
+                quota_mib,
+                format: None,
+                fstype: None,
+                stat_virtualization: Some(sv_str(stat_virtualization)),
+                host_permissions: Some(hp_str(host_permissions)),
+            }
+        }
         RustVolumeMount::Tmpfs {
             guest,
             size_mib,
@@ -354,6 +375,8 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             nodev: options.nodev,
             host: None,
             name: None,
+            named_mode: None,
+            named_kind: None,
             size_mib,
             quota_mib: None,
             format: None,
@@ -376,6 +399,8 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             nodev: options.nodev,
             host: Some(host.to_string_lossy().into_owned()),
             name: None,
+            named_mode: None,
+            named_kind: None,
             size_mib: None,
             quota_mib: None,
             format: Some(

--- a/sdk/node-ts/native/sandbox.rs
+++ b/sdk/node-ts/native/sandbox.rs
@@ -1,3 +1,4 @@
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -517,11 +518,8 @@ impl Sandbox {
     pub async fn logs(&self, opts: Option<LogOptions>) -> Result<Vec<LogEntry>> {
         let guard = self.inner.lock().await;
         let sb = guard.as_ref().ok_or_else(consumed_error)?;
-        let name = sb.name().to_string();
         let rust_opts = log_options_from_js(opts).map_err(napi::Error::from_reason)?;
-        let entries = microsandbox::logs::read_logs(&name, &rust_opts)
-            .await
-            .map_err(to_napi_error)?;
+        let entries = sb.logs(&rust_opts).await.map_err(to_napi_error)?;
         Ok(entries.into_iter().map(log_entry_to_js).collect())
     }
 
@@ -535,9 +533,9 @@ impl Sandbox {
     pub async fn log_stream(&self, opts: Option<LogStreamOptions>) -> Result<JsLogStream> {
         let guard = self.inner.lock().await;
         let sb = guard.as_ref().ok_or_else(consumed_error)?;
-        let name = sb.name().to_string();
         let rust_opts = log_stream_options_from_js(opts).map_err(napi::Error::from_reason)?;
-        spawn_log_stream(&name, rust_opts).await
+        let stream = sb.log_stream(&rust_opts).await.map_err(to_napi_error)?;
+        spawn_log_stream_from_stream(stream).await
     }
 }
 
@@ -618,15 +616,16 @@ impl AsyncGenerator for JsLogStream {
 /// Open a log stream against the given sandbox name and bridge it
 /// onto a JS-side mpsc channel. Shared between `Sandbox::log_stream`
 /// and `SandboxHandle::log_stream`.
-pub async fn spawn_log_stream(
-    name: &str,
-    opts: microsandbox::logs::LogStreamOptions,
+pub async fn spawn_log_stream_from_stream(
+    mut stream: Pin<
+        Box<
+            dyn futures::Stream<
+                    Item = microsandbox::MicrosandboxResult<microsandbox::logs::LogEntry>,
+                > + Send
+                + 'static,
+        >,
+    >,
 ) -> Result<JsLogStream> {
-    let mut stream = Box::pin(
-        microsandbox::logs::log_stream(name, &opts)
-            .await
-            .map_err(to_napi_error)?,
-    );
     let (tx, rx) = tokio::sync::mpsc::channel(16);
     tokio::spawn(async move {
         while let Some(result) = stream.next().await {

--- a/sdk/node-ts/native/sandbox_builder.rs
+++ b/sdk/node-ts/native/sandbox_builder.rs
@@ -318,9 +318,20 @@ impl JsSandboxBuilder {
         self
     }
 
-    // `libkrunfwPath` is a process-level concern (one dylib per process
-    // address space), not a per-sandbox builder method. Users set it once via
-    // `microsandbox.setLibkrunfwPath(...)` or the `MSB_LIBKRUNFW_PATH` env var.
+    /// Deprecated compatibility setter for older Node SDK callers.
+    ///
+    /// The libkrunfw path is a process-level concern (one dylib per process
+    /// address space), not a per-sandbox builder setting. Keep this chainable
+    /// alias so pre-backend-split code still compiles, but route it through the
+    /// same process-wide override as `microsandbox.setRuntimeLibkrunfwPath(...)`.
+    #[napi(js_name = "libkrunfwPath")]
+    pub fn libkrunfw_path(&mut self, path: String) -> Result<&Self> {
+        self.inner
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("SandboxBuilder already consumed"))?;
+        microsandbox::config::set_sdk_libkrunfw_path(path);
+        Ok(self)
+    }
 
     /// Default running user.
     #[napi]

--- a/sdk/node-ts/native/sandbox_handle.rs
+++ b/sdk/node-ts/native/sandbox_handle.rs
@@ -210,7 +210,12 @@ impl JsSandboxHandle {
     ) -> Result<crate::sandbox::JsLogStream> {
         let rust_opts =
             crate::sandbox::log_stream_options_from_js(opts).map_err(napi::Error::from_reason)?;
-        crate::sandbox::spawn_log_stream(self.inner.name(), rust_opts).await
+        let stream = self
+            .inner
+            .log_stream(&rust_opts)
+            .await
+            .map_err(to_napi_error)?;
+        crate::sandbox::spawn_log_stream_from_stream(stream).await
     }
 
     /// Snapshot this (stopped) sandbox under a bare name.

--- a/sdk/node-ts/native/volume.rs
+++ b/sdk/node-ts/native/volume.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use microsandbox::Backend;
-
 use microsandbox::sandbox::FsEntry as RustFsEntry;
 use microsandbox::sandbox::FsEntryKind as RustFsEntryKind;
 use microsandbox::sandbox::FsMetadata as RustFsMetadata;
@@ -31,8 +29,12 @@ pub struct JsVolumeHandle {
 
 #[napi(js_name = "VolumeFs")]
 pub struct JsVolumeFs {
-    backend: Arc<dyn Backend>,
-    name: String,
+    inner: JsVolumeFsInner,
+}
+
+enum JsVolumeFsInner {
+    Volume(Arc<Volume>),
+    Handle(VolumeHandle),
 }
 
 #[napi(async_iterator, js_name = "VolumeFsReadStream")]
@@ -87,8 +89,7 @@ impl JsVolume {
     #[napi]
     pub fn fs(&self) -> JsVolumeFs {
         JsVolumeFs {
-            backend: microsandbox::default_backend(),
-            name: self.inner.name().to_string(),
+            inner: JsVolumeFsInner::Volume(self.inner.clone()),
         }
     }
 }
@@ -160,8 +161,7 @@ impl JsVolumeHandle {
     #[napi]
     pub fn fs(&self) -> JsVolumeFs {
         JsVolumeFs {
-            backend: microsandbox::default_backend(),
-            name: self.inner.name().to_string(),
+            inner: JsVolumeFsInner::Handle(self.inner.clone()),
         }
     }
 }
@@ -169,11 +169,12 @@ impl JsVolumeHandle {
 #[napi]
 impl JsVolumeFs {
     fn make(&self) -> microsandbox::volume::VolumeFs<'_> {
-        // VolumeFs borrows the parent's backend + name; we keep an owned copy
-        // of each on `JsVolumeFs` and re-construct per call.
-        // Safety / lifetime note: the temporary VolumeFs only lives for the
-        // duration of each FFI call.
-        microsandbox::volume::VolumeFs::with_backend(self.backend.clone(), &self.name)
+        // VolumeFs only borrows the wrapped Volume/VolumeHandle for the
+        // duration of the FFI call, while the wrapper owns that parent object.
+        match &self.inner {
+            JsVolumeFsInner::Volume(volume) => volume.fs(),
+            JsVolumeFsInner::Handle(handle) => handle.fs(),
+        }
     }
 
     #[napi]

--- a/sdk/node-ts/src/index.ts
+++ b/sdk/node-ts/src/index.ts
@@ -357,6 +357,15 @@ export type PullProgressStream = NapiPullProgressStream;
 export { Setup, install, isInstalled, setup } from "./setup.js";
 export { allSandboxMetrics } from "./all-metrics.js";
 
+/** Override the `libkrunfw` shared library path used by subsequently created local sandboxes. */
+export function setRuntimeLibkrunfwPath(path: string): void {
+  const setter = napi.setRuntimeLibkrunfwPath;
+  if (!setter) {
+    throw new Error("native binding does not expose setRuntimeLibkrunfwPath");
+  }
+  setter(path);
+}
+
 // Errors
 export {
   CustomError,

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -24,6 +24,7 @@ export const napi = native;
 
 export interface NativeBindings {
   readonly setRuntimeMsbPath?: (path: string) => void;
+  readonly setRuntimeLibkrunfwPath?: (path: string) => void;
   readonly setDefaultBackend?: (
     kind: string,
     url?: string,
@@ -150,6 +151,8 @@ export interface NapiSandboxBuilderSetters {
   workdir(path: string): this;
   shell(shell: string): this;
   security(profile: "default" | "restricted"): this;
+  /** @deprecated Use setRuntimeLibkrunfwPath(path) before creating local sandboxes. */
+  libkrunfwPath(path: string): this;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registry(configure: (b: any) => any): this;
   replace(): this;
@@ -159,7 +162,6 @@ export interface NapiSandboxBuilderSetters {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   initWith(cmd: string, configure: (b: any) => any): this;
   hostname(name: string): this;
-  libkrunfwPath(path: string): this;
   user(user: string): this;
   pullPolicy(policy: string): this;
   disableNetwork(): this;
@@ -978,7 +980,10 @@ export interface NapiVolumeMount {
   readonly nodev: boolean;
   readonly host?: string;
   readonly name?: string;
+  readonly namedMode?: "existing" | "create" | "ensure-exists";
+  readonly namedKind?: "dir" | "disk";
   readonly sizeMib?: number;
+  readonly quotaMib?: number;
   readonly format?: string;
   readonly fstype?: string;
   readonly statVirtualization?: string;

--- a/sdk/node-ts/tests/unit/builders.test.ts
+++ b/sdk/node-ts/tests/unit/builders.test.ts
@@ -203,6 +203,32 @@ describe("MountBuilder", () => {
     });
   });
 
+  it("preserves namedWith disk creation metadata in the flat mount shape", () => {
+    const m = new MountBuilder("/var/lib/docker")
+      .namedWith("docker-data", "ensure-exists", "disk", 10240)
+      .build();
+    expect(m).toMatchObject({
+      kind: "named",
+      name: "docker-data",
+      namedMode: "ensure-exists",
+      namedKind: "disk",
+      sizeMib: 10240,
+    });
+  });
+
+  it("preserves namedWith directory quota metadata in the flat mount shape", () => {
+    const m = new MountBuilder("/cache")
+      .namedWith("build-cache", "create", "dir", undefined, 512)
+      .build();
+    expect(m).toMatchObject({
+      kind: "named",
+      name: "build-cache",
+      namedMode: "create",
+      namedKind: "dir",
+      quotaMib: 512,
+    });
+  });
+
   it("rejects unknown stat-virt strings at the FFI boundary", () => {
     expect(() =>
       new MountBuilder("/data").bind("/host").statVirtualization("bogus"),
@@ -306,6 +332,11 @@ describe("SandboxBuilder.build", () => {
       .ephemeral(true)
       .build();
     expect((cfg.lifecycle as { ephemeral: boolean }).ephemeral).toBe(true);
+  });
+
+  it("keeps libkrunfwPath as a chainable compatibility alias", async () => {
+    const builder = Sandbox.builder("x");
+    expect(builder.libkrunfwPath("/tmp/libkrunfw.dylib")).toBe(builder);
   });
 
   it("invalid volume invocations defer to .build() / .create()", async () => {

--- a/sdk/python/src/logs.rs
+++ b/sdk/python/src/logs.rs
@@ -129,6 +129,49 @@ pub fn convert_entry(entry: microsandbox::logs::LogEntry) -> PyLogEntry {
     }
 }
 
+/// Build a [`microsandbox::logs::LogOptions`] from the keyword args the
+/// Python snapshot-log methods accept.
+pub fn parse_log_options(
+    tail: Option<usize>,
+    since_ms: Option<f64>,
+    until_ms: Option<f64>,
+    sources: Option<Vec<String>>,
+) -> PyResult<microsandbox::logs::LogOptions> {
+    use microsandbox::logs::{LogOptions, LogSource};
+
+    let mut opts = LogOptions {
+        tail,
+        since: since_ms.and_then(ms_to_datetime),
+        until: until_ms.and_then(ms_to_datetime),
+        sources: Vec::new(),
+    };
+    if let Some(src) = sources {
+        for s in src {
+            match s.as_str() {
+                "stdout" => opts.sources.push(LogSource::Stdout),
+                "stderr" => opts.sources.push(LogSource::Stderr),
+                "output" => opts.sources.push(LogSource::Output),
+                "system" => opts.sources.push(LogSource::System),
+                "all" => {
+                    opts.sources = vec![
+                        LogSource::Stdout,
+                        LogSource::Stderr,
+                        LogSource::Output,
+                        LogSource::System,
+                    ];
+                }
+                other => {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "unknown log source {other:?}"
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(opts)
+}
+
 /// Build a [`microsandbox::logs::LogStreamOptions`] from the keyword
 /// args the Python method accepts. `since_ms` and `from_cursor` are
 /// mutually exclusive.
@@ -189,66 +232,6 @@ pub fn parse_log_stream_options(
         until: until_ms.and_then(ms_to_datetime),
         follow,
     })
-}
-
-/// Open a log stream against the named sandbox and wrap it as a
-/// `PyLogStream`. Shared between `Sandbox.log_stream` and
-/// `SandboxHandle.log_stream`.
-pub async fn open_log_stream(
-    name: &str,
-    opts: microsandbox::logs::LogStreamOptions,
-) -> PyResult<PyLogStream> {
-    let stream = microsandbox::logs::log_stream(name, &opts)
-        .await
-        .map_err(to_py_err)?;
-    Ok(PyLogStream::new(stream))
-}
-
-/// Read captured logs for a sandbox by name. Filters are encoded as a
-/// `LogOptions` Rust struct on the caller's side.
-pub fn read_logs_blocking(
-    name: &str,
-    tail: Option<usize>,
-    since_ms: Option<f64>,
-    until_ms: Option<f64>,
-    sources: Option<Vec<String>>,
-) -> PyResult<Vec<PyLogEntry>> {
-    use microsandbox::logs::{LogOptions, LogSource};
-
-    let mut opts = LogOptions {
-        tail,
-        since: since_ms.and_then(ms_to_datetime),
-        until: until_ms.and_then(ms_to_datetime),
-        sources: Vec::new(),
-    };
-    if let Some(src) = sources {
-        for s in src {
-            match s.as_str() {
-                "stdout" => opts.sources.push(LogSource::Stdout),
-                "stderr" => opts.sources.push(LogSource::Stderr),
-                "output" => opts.sources.push(LogSource::Output),
-                "system" => opts.sources.push(LogSource::System),
-                "all" => {
-                    opts.sources = vec![
-                        LogSource::Stdout,
-                        LogSource::Stderr,
-                        LogSource::Output,
-                        LogSource::System,
-                    ];
-                }
-                other => {
-                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                        "unknown log source {other:?}"
-                    )));
-                }
-            }
-        }
-    }
-
-    let entries = tokio::runtime::Handle::current()
-        .block_on(microsandbox::logs::read_logs(name, &opts))
-        .map_err(to_py_err)?;
-    Ok(entries.into_iter().map(convert_entry).collect())
 }
 
 fn ms_to_datetime(ms: f64) -> Option<chrono::DateTime<chrono::Utc>> {

--- a/sdk/python/src/sandbox.rs
+++ b/sdk/python/src/sandbox.rs
@@ -10,7 +10,6 @@ use crate::error::to_py_err;
 use crate::exec::{PyExecHandle, PyExecOutput};
 use crate::fs::PySandboxFs;
 use crate::helpers::sandbox_builder_from_args;
-use crate::logs::read_logs_blocking;
 use crate::metrics::PyMetricsStream;
 use crate::metrics::convert_metrics;
 use crate::sandbox_handle::PySandboxHandle;
@@ -569,15 +568,14 @@ impl PySandbox {
         sources: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
+        let opts = crate::logs::parse_log_options(tail, since_ms, until_ms, sources)?;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
-            let name = sandbox.name().to_string();
-            let entries = tokio::task::spawn_blocking(move || {
-                read_logs_blocking(&name, tail, since_ms, until_ms, sources)
-            })
-            .await
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))??;
-            Ok(entries)
+            let entries = sandbox.logs(&opts).await.map_err(to_py_err)?;
+            Ok(entries
+                .into_iter()
+                .map(crate::logs::convert_entry)
+                .collect::<Vec<_>>())
         })
     }
 
@@ -625,8 +623,8 @@ impl PySandbox {
         )?;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
-            let name = sandbox.name().to_string();
-            crate::logs::open_log_stream(&name, opts).await
+            let stream = sandbox.log_stream(&opts).await.map_err(to_py_err)?;
+            Ok(crate::logs::PyLogStream::new(stream))
         })
     }
 

--- a/sdk/python/src/sandbox_handle.rs
+++ b/sdk/python/src/sandbox_handle.rs
@@ -127,16 +127,14 @@ impl PySandboxHandle {
         sources: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
+        let opts = crate::logs::parse_log_options(tail, since_ms, until_ms, sources)?;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let guard = inner.lock().await;
-            let name = guard.name().to_string();
-            drop(guard);
-            let entries = tokio::task::spawn_blocking(move || {
-                crate::logs::read_logs_blocking(&name, tail, since_ms, until_ms, sources)
-            })
-            .await
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))??;
-            Ok(entries)
+            let entries = guard.logs(&opts).await.map_err(to_py_err)?;
+            Ok(entries
+                .into_iter()
+                .map(crate::logs::convert_entry)
+                .collect::<Vec<_>>())
         })
     }
 
@@ -172,9 +170,8 @@ impl PySandboxHandle {
         )?;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let guard = inner.lock().await;
-            let name = guard.name().to_string();
-            drop(guard);
-            crate::logs::open_log_stream(&name, opts).await
+            let stream = guard.log_stream(&opts).await.map_err(to_py_err)?;
+            Ok(crate::logs::PyLogStream::new(stream))
         })
     }
 

--- a/sdk/python/src/volume.rs
+++ b/sdk/python/src/volume.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyModule};
@@ -314,11 +313,9 @@ impl PyVolumeHandle {
 
     /// Remove this volume.
     fn remove<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let name = self.inner.name().to_string();
+        let handle = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            microsandbox::Volume::remove(&name)
-                .await
-                .map_err(to_py_err)?;
+            handle.remove().await.map_err(to_py_err)?;
             Ok(())
         })
     }
@@ -327,8 +324,7 @@ impl PyVolumeHandle {
     #[getter]
     fn fs(&self) -> PyVolumeFs {
         PyVolumeFs {
-            name: self.inner.name().to_string().into(),
-            backend: microsandbox::default_backend(),
+            inner: self.inner.clone(),
         }
     }
 }
@@ -338,30 +334,27 @@ impl PyVolumeHandle {
 //--------------------------------------------------------------------------------------------------
 
 /// Host-side filesystem operations on a volume (no running sandbox needed).
-/// Holds the volume name + a backend Arc; constructs a [`VolumeFs`] per op.
+/// Holds a volume handle; constructs a [`VolumeFs`] per op.
 #[pyclass(name = "VolumeFs")]
 pub struct PyVolumeFs {
-    name: Arc<str>,
-    backend: Arc<dyn microsandbox::Backend>,
+    inner: microsandbox::volume::VolumeHandle,
 }
 
 #[pymethods]
 impl PyVolumeFs {
     fn read<'py>(&self, py: Python<'py>, path: String) -> PyResult<Bound<'py, PyAny>> {
-        let name = Arc::clone(&self.name);
-        let backend = Arc::clone(&self.backend);
+        let handle = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let fs = microsandbox::volume::VolumeFs::with_backend(backend, &name);
+            let fs = handle.fs();
             let data = fs.read(&path).await.map_err(to_py_err)?;
             Ok(data.to_vec())
         })
     }
 
     fn read_text<'py>(&self, py: Python<'py>, path: String) -> PyResult<Bound<'py, PyAny>> {
-        let name = Arc::clone(&self.name);
-        let backend = Arc::clone(&self.backend);
+        let handle = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let fs = microsandbox::volume::VolumeFs::with_backend(backend, &name);
+            let fs = handle.fs();
             let text = fs.read_to_string(&path).await.map_err(to_py_err)?;
             Ok(text)
         })
@@ -373,20 +366,18 @@ impl PyVolumeFs {
         path: String,
         data: Vec<u8>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let name = Arc::clone(&self.name);
-        let backend = Arc::clone(&self.backend);
+        let handle = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let fs = microsandbox::volume::VolumeFs::with_backend(backend, &name);
+            let fs = handle.fs();
             fs.write(&path, &data).await.map_err(to_py_err)?;
             Ok(())
         })
     }
 
     fn list<'py>(&self, py: Python<'py>, path: String) -> PyResult<Bound<'py, PyAny>> {
-        let name = Arc::clone(&self.name);
-        let backend = Arc::clone(&self.backend);
+        let handle = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let fs = microsandbox::volume::VolumeFs::with_backend(backend, &name);
+            let fs = handle.fs();
             let entries = fs.list(&path).await.map_err(to_py_err)?;
             let py_entries: Vec<crate::fs::PyFsEntry> = entries
                 .into_iter()
@@ -397,30 +388,27 @@ impl PyVolumeFs {
     }
 
     fn mkdir<'py>(&self, py: Python<'py>, path: String) -> PyResult<Bound<'py, PyAny>> {
-        let name = Arc::clone(&self.name);
-        let backend = Arc::clone(&self.backend);
+        let handle = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let fs = microsandbox::volume::VolumeFs::with_backend(backend, &name);
+            let fs = handle.fs();
             fs.mkdir(&path).await.map_err(to_py_err)?;
             Ok(())
         })
     }
 
     fn remove_file<'py>(&self, py: Python<'py>, path: String) -> PyResult<Bound<'py, PyAny>> {
-        let name = Arc::clone(&self.name);
-        let backend = Arc::clone(&self.backend);
+        let handle = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let fs = microsandbox::volume::VolumeFs::with_backend(backend, &name);
+            let fs = handle.fs();
             fs.remove(&path).await.map_err(to_py_err)?;
             Ok(())
         })
     }
 
     fn exists<'py>(&self, py: Python<'py>, path: String) -> PyResult<Bound<'py, PyAny>> {
-        let name = Arc::clone(&self.name);
-        let backend = Arc::clone(&self.backend);
+        let handle = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let fs = microsandbox::volume::VolumeFs::with_backend(backend, &name);
+            let fs = handle.fs();
             let exists = fs.exists(&path).await.map_err(to_py_err)?;
             Ok(exists)
         })

--- a/sdk/rust/lib/backend/local.rs
+++ b/sdk/rust/lib/backend/local.rs
@@ -15,11 +15,18 @@
 //! the bulk of the old global config singleton plus the SQLite pool, so multiple
 //! backends can hold different configurations for tests / migrations.
 
-use std::collections::HashMap;
-use std::num::NonZero;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    num::NonZero,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+#[cfg(unix)]
+use std::{
+    fs::{File, OpenOptions},
+    os::fd::AsRawFd,
+};
 
 use microsandbox_db::pool::DbPools;
 use microsandbox_migration::{Migrator, MigratorTrait};
@@ -75,6 +82,11 @@ pub struct LocalBackendBuilder {
     ca_certs: Option<Option<PathBuf>>,
     registry_hosts: Option<HashMap<String, RegistryEntry>>,
     log_level: Option<microsandbox_runtime::logging::LogLevel>,
+}
+
+struct MigrationLock {
+    #[cfg(unix)]
+    file: File,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -399,6 +411,36 @@ impl LocalBackendBuilder {
     }
 }
 
+impl MigrationLock {
+    #[cfg(unix)]
+    fn acquire(path: PathBuf) -> MicrosandboxResult<Self> {
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|err| {
+                MicrosandboxError::Runtime(format!("open migration lock {}: {err}", path.display()))
+            })?;
+
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            return Err(MicrosandboxError::Runtime(format!(
+                "lock migration file {}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            )));
+        }
+
+        Ok(Self { file })
+    }
+
+    #[cfg(not(unix))]
+    fn acquire(_path: PathBuf) -> MicrosandboxResult<Self> {
+        Ok(Self {})
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
@@ -433,6 +475,13 @@ impl From<LocalBackend> for Arc<dyn Backend> {
     }
 }
 
+#[cfg(unix)]
+impl Drop for MigrationLock {
+    fn drop(&mut self) {
+        let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
@@ -446,6 +495,7 @@ async fn connect_and_migrate(
     database: &DatabaseConfig,
 ) -> MicrosandboxResult<DbPools> {
     tokio::fs::create_dir_all(db_dir).await?;
+    let _migration_lock = acquire_migration_lock(db_dir).await?;
 
     let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
     let pools = DbPools::open(
@@ -460,6 +510,16 @@ async fn connect_and_migrate(
     Migrator::up(pools.write().inner(), None).await?;
 
     Ok(pools)
+}
+
+async fn acquire_migration_lock(db_dir: &Path) -> MicrosandboxResult<MigrationLock> {
+    let path = db_dir.join(format!(
+        "{}.migration.lock",
+        microsandbox_utils::DB_FILENAME
+    ));
+    tokio::task::spawn_blocking(move || MigrationLock::acquire(path))
+        .await
+        .map_err(|err| MicrosandboxError::Runtime(format!("migration lock task failed: {err}")))?
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/sdk/rust/lib/backend/sandbox.rs
+++ b/sdk/rust/lib/backend/sandbox.rs
@@ -565,7 +565,7 @@ impl SandboxBackend for LocalBackend {
         name: &'a str,
         opts: &'a LogOptions,
     ) -> BoxFuture<'a, MicrosandboxResult<Vec<LogEntry>>> {
-        Box::pin(async move { crate::logs::read_logs(name, opts).await })
+        Box::pin(async move { crate::logs::read_logs_local(self, name, opts).await })
     }
 
     fn log_stream<'a>(
@@ -575,7 +575,7 @@ impl SandboxBackend for LocalBackend {
         opts: &'a LogStreamOptions,
     ) -> BoxFuture<'a, MicrosandboxResult<LogStream>> {
         Box::pin(async move {
-            let stream = crate::logs::log_stream(name, opts).await?;
+            let stream = crate::logs::log_stream_local(self, name, opts).await?;
             Ok(Box::pin(stream) as LogStream)
         })
     }

--- a/sdk/rust/lib/backend/volume.rs
+++ b/sdk/rust/lib/backend/volume.rs
@@ -73,6 +73,7 @@ pub struct VolumeCloudState {
 }
 
 /// Backend-private state behind [`VolumeHandle`] — the lightweight DB-row view.
+#[derive(Clone)]
 pub enum VolumeHandleInner {
     /// Local persisted volume handle.
     Local(VolumeHandleLocalState),
@@ -81,6 +82,7 @@ pub enum VolumeHandleInner {
 }
 
 /// Local handle state. Snapshot of the database row.
+#[derive(Clone)]
 pub struct VolumeHandleLocalState {
     /// SQLite row id for this volume.
     pub db_id: i32,
@@ -107,6 +109,7 @@ pub struct VolumeHandleLocalState {
 /// Cloud handle state. Captures the snapshot msb-cloud returned at fetch time.
 ///
 /// Placeholder shape — populated when cloud volumes ship in Phase 6.
+#[derive(Clone)]
 pub struct VolumeHandleCloudState {
     /// Server-side UUID.
     pub id: String,

--- a/sdk/rust/lib/logs/mod.rs
+++ b/sdk/rust/lib/logs/mod.rs
@@ -69,6 +69,7 @@ use futures::Stream;
 
 use stream::{LogEngine, LogFileConfig, LogFileFormat};
 
+use crate::backend::LocalBackend;
 use crate::{MicrosandboxError, MicrosandboxResult};
 
 //--------------------------------------------------------------------------------------------------
@@ -126,13 +127,18 @@ pub struct LogSnapshot {
 pub fn log_dir_for(name: &str) -> PathBuf {
     crate::backend::default_backend()
         .as_local()
-        .map(|local| local.config().sandboxes_dir().join(name).join("logs"))
+        .map(|local| log_dir_for_local(local, name))
         .unwrap_or_else(|| {
             microsandbox_utils::resolve_home()
                 .join(microsandbox_utils::SANDBOXES_SUBDIR)
                 .join(name)
                 .join("logs")
         })
+}
+
+/// Compute the on-disk log directory for an explicit local backend.
+pub(crate) fn log_dir_for_local(local: &LocalBackend, name: &str) -> PathBuf {
+    local.config().sandboxes_dir().join(name).join("logs")
 }
 
 /// Read all matching log entries for the named sandbox.
@@ -152,12 +158,33 @@ pub async fn read_logs(name: &str, opts: &LogOptions) -> MicrosandboxResult<Vec<
     Ok(read_logs_snapshot(name, opts).await?.entries)
 }
 
+/// Read all matching log entries through an explicit local backend.
+pub(crate) async fn read_logs_local(
+    local: &LocalBackend,
+    name: &str,
+    opts: &LogOptions,
+) -> MicrosandboxResult<Vec<LogEntry>> {
+    Ok(
+        read_logs_snapshot_from_dir(name, log_dir_for_local(local, name), opts)
+            .await?
+            .entries,
+    )
+}
+
 /// Read all matching log entries and return the snapshot end cursor.
 ///
 /// This is useful when handing a bounded historical read to
 /// [`log_stream`] with [`LogStreamStart::From`] without losing log
 /// lines written between the snapshot drain and follow startup.
 pub async fn read_logs_snapshot(name: &str, opts: &LogOptions) -> MicrosandboxResult<LogSnapshot> {
+    read_logs_snapshot_from_dir(name, log_dir_for(name), opts).await
+}
+
+async fn read_logs_snapshot_from_dir(
+    name: &str,
+    log_dir: PathBuf,
+    opts: &LogOptions,
+) -> MicrosandboxResult<LogSnapshot> {
     crate::sandbox::validate_sandbox_name(name)?;
     let stream_opts = LogStreamOptions {
         sources: opts.sources.clone(),
@@ -167,7 +194,6 @@ pub async fn read_logs_snapshot(name: &str, opts: &LogOptions) -> MicrosandboxRe
         until: None,
         follow: false,
     };
-    let log_dir = log_dir_for(name);
     if !tokio::fs::try_exists(&log_dir).await.unwrap_or(false) {
         return Err(MicrosandboxError::SandboxNotFound(name.to_string()));
     }
@@ -197,8 +223,24 @@ pub async fn log_stream(
     name: &str,
     opts: &LogStreamOptions,
 ) -> MicrosandboxResult<impl Stream<Item = MicrosandboxResult<LogEntry>> + Send + 'static + use<>> {
+    log_stream_from_dir(name, log_dir_for(name), opts).await
+}
+
+/// Stream log entries through an explicit local backend.
+pub(crate) async fn log_stream_local(
+    local: &LocalBackend,
+    name: &str,
+    opts: &LogStreamOptions,
+) -> MicrosandboxResult<impl Stream<Item = MicrosandboxResult<LogEntry>> + Send + 'static + use<>> {
+    log_stream_from_dir(name, log_dir_for_local(local, name), opts).await
+}
+
+async fn log_stream_from_dir(
+    name: &str,
+    log_dir: PathBuf,
+    opts: &LogStreamOptions,
+) -> MicrosandboxResult<impl Stream<Item = MicrosandboxResult<LogEntry>> + Send + 'static + use<>> {
     crate::sandbox::validate_sandbox_name(name)?;
-    let log_dir = log_dir_for(name);
     if !tokio::fs::try_exists(&log_dir).await.unwrap_or(false) {
         return Err(MicrosandboxError::SandboxNotFound(name.to_string()));
     }

--- a/sdk/rust/lib/runtime/mod.rs
+++ b/sdk/rust/lib/runtime/mod.rs
@@ -14,7 +14,8 @@ pub(crate) mod spawn;
 pub use handle::ProcessHandle;
 pub use spawn::{SpawnMode, spawn_sandbox};
 pub(crate) use spawn::{
-    resolve_sandbox_agent_socket_path, sandbox_agent_socket_path_candidates,
+    ensure_named_volumes, resolve_sandbox_agent_socket_path, resolve_sandbox_agent_socket_path_for,
+    rollback_created_named_volumes, sandbox_agent_socket_path_candidates,
     sandbox_agent_socket_path_candidates_for,
 };
 

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -12,9 +12,10 @@ use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, BTreeSet, HashMap},
     ffi::OsString,
     fmt::Write,
+    fs::File,
     io::{Seek, SeekFrom, Write as IoWrite},
     os::fd::{FromRawFd, OwnedFd},
     path::{Path, PathBuf},
@@ -52,11 +53,11 @@ use crate::{
     runtime::handle::{MetricsReservationCleanup, ProcessHandle},
     sandbox::{
         DiskImageFormat, HostPermissions, MountOptions, NamedVolumeMode, Rlimit, RootfsSource,
-        SandboxConfig, StatVirtualization, VolumeMount,
+        SandboxConfig, StatVirtualization, VolumeMount, validate_named_disk_mount_options,
     },
     volume::{
-        VolumeConfig, VolumeKind, provision_volume_path, validate_volume_config,
-        validate_volume_name,
+        VolumeConfig, VolumeKind, lock_volume_name, materialize_volume_path,
+        validate_volume_config, validate_volume_name,
     },
 };
 
@@ -91,6 +92,38 @@ struct Pipe {
     write_fd: OwnedFd,
 }
 
+/// Local storage metadata for a named volume mounted by a sandbox.
+#[derive(Clone, Debug)]
+struct ResolvedNamedVolume {
+    kind: VolumeKind,
+    path: PathBuf,
+    format: Option<DiskImageFormat>,
+    fstype: Option<String>,
+    quota_mib: Option<u32>,
+}
+
+#[derive(Clone, Debug)]
+struct DiskLockRequest {
+    path: PathBuf,
+    readonly: bool,
+    label: String,
+    volume_name: Option<String>,
+}
+
+/// Named volume row and path created for one sandbox create attempt.
+#[derive(Debug)]
+pub(crate) struct CreatedNamedVolume {
+    pub(crate) id: i32,
+    pub(crate) path: PathBuf,
+}
+
+/// Sandbox-create named volume preflight state.
+#[derive(Debug)]
+pub(crate) struct EnsuredNamedVolumes {
+    created: Vec<CreatedNamedVolume>,
+    _locks: Vec<File>,
+}
+
 /// How the sandbox process should behave relative to the creating process.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SpawnMode {
@@ -99,6 +132,16 @@ pub enum SpawnMode {
 
     /// The sandbox must survive after the creating process exits.
     Detached,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl EnsuredNamedVolumes {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.created.is_empty()
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -163,14 +206,16 @@ pub async fn spawn_sandbox(
         tokio::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).await?;
     }
 
-    // Compute the agent relay socket path.
-    let agent_sock_path = resolve_sandbox_agent_socket_path(&config.spec.name)?;
+    // Compute the agent relay socket path from the backend being used for
+    // this spawn, not from the ambient default backend.
+    let agent_sock_path = resolve_sandbox_agent_socket_path_for(local, &config.spec.name)?;
 
     // Stage file bind mounts: each file gets its own isolated directory so
     // that virtio-fs (which requires directories) can share it without
     // exposing adjacent files on the host.
     let (staged_file_mounts, file_mounts_staging) = stage_file_mounts(config).await?;
-    ensure_named_volumes(local, config).await?;
+    let named_volumes = resolve_named_volumes(local, config).await?;
+    let disk_locks = lock_disk_mounts(config, &named_volumes)?;
     let metrics_reservation = if config.effective_metrics_interval().is_some() {
         reserve_metrics_slot(local, config, sandbox_id)
     } else {
@@ -211,6 +256,7 @@ pub async fn spawn_sandbox(
         &agent_sock_path,
         &libkrunfw_path,
         &staged_file_mounts,
+        &named_volumes,
         metrics_reservation.as_ref(),
         parent_watchdog
             .as_ref()
@@ -388,7 +434,7 @@ pub async fn spawn_sandbox(
         config.spec.name.clone(),
         child,
         file_mounts_staging,
-        Vec::new(),
+        disk_locks,
         parent_watchdog.map(|pipe| pipe.write_fd),
         metrics_reservation.as_ref().map(|reservation| {
             MetricsReservationCleanup::new(
@@ -641,9 +687,28 @@ fn patch_sigchld_handler_uses_alt_stack() {
     }
 }
 
-async fn ensure_named_volumes(
+pub(crate) async fn ensure_named_volumes(
     local: &LocalBackend,
     config: &SandboxConfig,
+) -> MicrosandboxResult<EnsuredNamedVolumes> {
+    let locks = lock_named_volume_mounts(local, config)?;
+    let mut created = Vec::new();
+
+    if let Err(err) = ensure_named_volumes_inner(local, config, &mut created).await {
+        rollback_created_named_volume_records(local, &created).await;
+        return Err(err);
+    }
+
+    Ok(EnsuredNamedVolumes {
+        created,
+        _locks: locks,
+    })
+}
+
+async fn ensure_named_volumes_inner(
+    local: &LocalBackend,
+    config: &SandboxConfig,
+    created: &mut Vec<CreatedNamedVolume>,
 ) -> MicrosandboxResult<()> {
     for mount in &config.spec.mounts {
         let Some(create) = mount.named_create() else {
@@ -657,14 +722,18 @@ async fn ensure_named_volumes(
             .one(pools.read())
             .await?;
 
-        if existing.is_some() {
+        if let Some(existing) = existing {
             match create.mode() {
                 NamedVolumeMode::Create => {
                     return Err(MicrosandboxError::VolumeAlreadyExists(
                         create.name().to_string(),
                     ));
                 }
-                NamedVolumeMode::EnsureExists | NamedVolumeMode::Existing => continue,
+                NamedVolumeMode::EnsureExists => {
+                    validate_existing_named_volume(create, &existing)?;
+                    continue;
+                }
+                NamedVolumeMode::Existing => continue,
             }
         }
 
@@ -703,12 +772,348 @@ async fn ensure_named_volumes(
             updated_at: Set(Some(now)),
             ..Default::default()
         };
-        volume_entity::Entity::insert(model)
+        let inserted = volume_entity::Entity::insert(model)
             .exec(pools.write())
             .await?;
-        provision_volume_path(&volume_config, &local.volume_path(&volume_config.name)).await?;
+        let volume_id = inserted.last_insert_id;
+
+        let path = local.volume_path(&volume_config.name);
+        if let Err(err) = materialize_volume_path(&volume_config, &path).await {
+            let _ = volume_entity::Entity::delete_by_id(volume_id)
+                .exec(pools.write())
+                .await;
+            let _ = tokio::fs::remove_dir_all(&path).await;
+            return Err(err);
+        }
+        created.push(CreatedNamedVolume {
+            id: volume_id,
+            path,
+        });
     }
 
+    Ok(())
+}
+
+pub(crate) async fn rollback_created_named_volumes(
+    local: &LocalBackend,
+    volumes: &EnsuredNamedVolumes,
+) {
+    rollback_created_named_volume_records(local, &volumes.created).await;
+}
+
+async fn rollback_created_named_volume_records(
+    local: &LocalBackend,
+    volumes: &[CreatedNamedVolume],
+) {
+    if volumes.is_empty() {
+        return;
+    }
+
+    for volume in volumes {
+        let _ = tokio::fs::remove_dir_all(&volume.path).await;
+    }
+
+    let ids = volumes.iter().map(|volume| volume.id).collect::<Vec<_>>();
+    if let Ok(pools) = local.db().await {
+        let _ = volume_entity::Entity::delete_many()
+            .filter(volume_entity::Column::Id.is_in(ids))
+            .exec(pools.write())
+            .await;
+    }
+}
+
+fn lock_named_volume_mounts(
+    local: &LocalBackend,
+    config: &SandboxConfig,
+) -> MicrosandboxResult<Vec<File>> {
+    let mut names = BTreeSet::new();
+    for mount in &config.spec.mounts {
+        if let VolumeMount::Named { name, .. } = mount {
+            validate_volume_name(name)?;
+            names.insert(name.clone());
+        }
+    }
+
+    let mut locks = Vec::with_capacity(names.len());
+    for name in names {
+        locks.push(lock_volume_name(local, &name)?);
+    }
+    Ok(locks)
+}
+
+async fn resolve_named_volumes(
+    local: &LocalBackend,
+    config: &SandboxConfig,
+) -> MicrosandboxResult<HashMap<String, ResolvedNamedVolume>> {
+    let mut resolved: HashMap<String, ResolvedNamedVolume> = HashMap::new();
+
+    for mount in &config.spec.mounts {
+        let VolumeMount::Named {
+            name,
+            stat_virtualization,
+            host_permissions,
+            ..
+        } = mount
+        else {
+            continue;
+        };
+
+        if let Some(volume) = resolved.get(name) {
+            if volume.kind == VolumeKind::Disk {
+                validate_named_disk_mount_options(name, *stat_virtualization, *host_permissions)?;
+            }
+            continue;
+        }
+
+        let pools = local.db().await?;
+        let model = volume_entity::Entity::find()
+            .filter(volume_entity::Column::Name.eq(name))
+            .one(pools.read())
+            .await?
+            .ok_or_else(|| MicrosandboxError::VolumeNotFound(name.clone()))?;
+
+        let kind = VolumeKind::from_db_value(&model.kind);
+        let path = local.volume_path(name);
+        let volume = match kind {
+            VolumeKind::Directory => ResolvedNamedVolume {
+                kind,
+                path,
+                format: None,
+                fstype: None,
+                quota_mib: model.quota_mib.map(|value| value.max(0) as u32),
+            },
+            VolumeKind::Disk => {
+                validate_named_disk_mount_options(name, *stat_virtualization, *host_permissions)?;
+                let format = model
+                    .disk_format
+                    .as_deref()
+                    .unwrap_or("raw")
+                    .parse::<DiskImageFormat>()
+                    .map_err(|err| {
+                        MicrosandboxError::InvalidConfig(format!(
+                            "disk named volume {name:?} has invalid disk format: {err}"
+                        ))
+                    })?;
+
+                ResolvedNamedVolume {
+                    kind,
+                    path: path.join("disk.raw"),
+                    format: Some(format),
+                    fstype: model.disk_fstype,
+                    quota_mib: None,
+                }
+            }
+        };
+
+        resolved.insert(name.clone(), volume);
+    }
+
+    Ok(resolved)
+}
+
+fn validate_existing_named_volume(
+    requested: &microsandbox_types::NamedVolumeCreate,
+    existing: &volume_entity::Model,
+) -> MicrosandboxResult<()> {
+    let actual_kind = VolumeKind::from_db_value(&existing.kind);
+    if requested.kind() != actual_kind {
+        return Err(MicrosandboxError::InvalidConfig(format!(
+            "named volume {:?} already exists as {}, but this sandbox requested {}",
+            requested.name(),
+            actual_kind.as_str(),
+            requested.kind().as_str()
+        )));
+    }
+
+    if let Some(requested_quota_mib) = requested.quota_mib()
+        && existing.quota_mib != Some(requested_quota_mib as i32)
+    {
+        return Err(MicrosandboxError::InvalidConfig(format!(
+            "named volume {:?} already exists with quota {:?} MiB, but this sandbox requested {} MiB",
+            requested.name(),
+            existing.quota_mib,
+            requested_quota_mib
+        )));
+    }
+
+    if let Some(requested_capacity_mib) = requested.capacity_mib() {
+        let requested_capacity_bytes = i64::from(requested_capacity_mib) * 1024 * 1024;
+        if existing.capacity_bytes != Some(requested_capacity_bytes) {
+            return Err(MicrosandboxError::InvalidConfig(format!(
+                "named volume {:?} already exists with capacity {:?} bytes, but this sandbox requested {} bytes",
+                requested.name(),
+                existing.capacity_bytes,
+                requested_capacity_bytes
+            )));
+        }
+    }
+
+    validate_requested_named_volume_labels(requested, existing)?;
+
+    Ok(())
+}
+
+fn validate_requested_named_volume_labels(
+    requested: &microsandbox_types::NamedVolumeCreate,
+    existing: &volume_entity::Model,
+) -> MicrosandboxResult<()> {
+    if requested.labels().is_empty() {
+        return Ok(());
+    }
+
+    let existing_labels = existing
+        .labels
+        .as_deref()
+        .map(serde_json::from_str::<Vec<(String, String)>>)
+        .transpose()?
+        .unwrap_or_default()
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+
+    for (key, requested_value) in requested.labels() {
+        match existing_labels.get(key) {
+            Some(existing_value) if existing_value == requested_value => {}
+            Some(existing_value) => {
+                return Err(MicrosandboxError::InvalidConfig(format!(
+                    "named volume {:?} already exists with label {key:?}={existing_value:?}, but this sandbox requested {requested_value:?}",
+                    requested.name()
+                )));
+            }
+            None => {
+                return Err(MicrosandboxError::InvalidConfig(format!(
+                    "named volume {:?} already exists without requested label {key:?}",
+                    requested.name()
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn lock_disk_mounts(
+    config: &SandboxConfig,
+    named_volumes: &HashMap<String, ResolvedNamedVolume>,
+) -> MicrosandboxResult<Vec<File>> {
+    let mut locks = Vec::new();
+    let mut requests = Vec::new();
+
+    if let RootfsSource::DiskImage { path, .. } = &config.spec.image {
+        requests.push(DiskLockRequest {
+            path: path.clone(),
+            readonly: false,
+            label: format!("disk image rootfs {}", path.display()),
+            volume_name: None,
+        });
+    }
+
+    for mount in &config.spec.mounts {
+        match mount {
+            VolumeMount::DiskImage { host, options, .. } => {
+                requests.push(DiskLockRequest {
+                    path: host.clone(),
+                    readonly: options.readonly,
+                    label: format!("disk image {}", host.display()),
+                    volume_name: None,
+                });
+            }
+            VolumeMount::Named { name, options, .. } => {
+                if let Some(ResolvedNamedVolume {
+                    kind: VolumeKind::Disk,
+                    path,
+                    ..
+                }) = named_volumes.get(name)
+                {
+                    requests.push(DiskLockRequest {
+                        path: path.clone(),
+                        readonly: options.readonly,
+                        label: format!("named disk volume {name:?}"),
+                        volume_name: Some(name.clone()),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut seen = HashMap::new();
+    for request in requests {
+        let canonical = std::fs::canonicalize(&request.path).map_err(|err| {
+            MicrosandboxError::InvalidConfig(format!(
+                "disk image host path does not exist: {} ({err})",
+                request.path.display()
+            ))
+        })?;
+        if let Some(previous) = seen.insert(canonical.clone(), request.label.clone()) {
+            return Err(MicrosandboxError::InvalidConfig(format!(
+                "disk images cannot be attached more than once per sandbox: {} ({previous}; {})",
+                canonical.display(),
+                request.label
+            )));
+        }
+        locks.push(lock_disk_image(
+            &canonical,
+            request.readonly,
+            request.volume_name.as_deref(),
+        )?);
+    }
+
+    Ok(locks)
+}
+
+fn lock_disk_image(
+    path: &Path,
+    readonly: bool,
+    volume_name: Option<&str>,
+) -> MicrosandboxResult<File> {
+    let file = if readonly {
+        std::fs::OpenOptions::new().read(true).open(path)
+    } else {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+    }
+    .map_err(|err| {
+        MicrosandboxError::InvalidConfig(format!("open disk image lock {}: {err}", path.display()))
+    })?;
+
+    let operation = if readonly {
+        libc::LOCK_SH | libc::LOCK_NB
+    } else {
+        libc::LOCK_EX | libc::LOCK_NB
+    };
+
+    if unsafe { libc::flock(file.as_raw_fd(), operation) } != 0 {
+        let err = std::io::Error::last_os_error();
+        let message = if matches!(err.kind(), std::io::ErrorKind::WouldBlock) {
+            match volume_name {
+                Some(name) => {
+                    format!("volume {name:?} is already attached with an incompatible disk mode")
+                }
+                None => format!(
+                    "disk image {:?} is already attached with an incompatible disk mode",
+                    path.display().to_string()
+                ),
+            }
+        } else {
+            format!("lock disk image {}: {err}", path.display())
+        };
+        return Err(MicrosandboxError::InvalidConfig(message));
+    }
+
+    clear_cloexec(file.as_raw_fd())?;
+    Ok(file)
+}
+
+fn clear_cloexec(fd: i32) -> MicrosandboxResult<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
     Ok(())
 }
 
@@ -749,9 +1154,24 @@ fn sandbox_agent_socket_path_candidates_with_roots(
     ]
 }
 
+/// Pick the first explicit-backend socket path usable on this platform.
+pub(crate) fn resolve_sandbox_agent_socket_path_for(
+    local: &LocalBackend,
+    name: &str,
+) -> MicrosandboxResult<PathBuf> {
+    let candidates = sandbox_agent_socket_path_candidates_for(local, name);
+    resolve_sandbox_agent_socket_path_from_candidates(candidates)
+}
+
 /// Pick the first socket path usable on this platform.
 pub(crate) fn resolve_sandbox_agent_socket_path(name: &str) -> MicrosandboxResult<PathBuf> {
     let candidates = sandbox_agent_socket_path_candidates(name);
+    resolve_sandbox_agent_socket_path_from_candidates(candidates)
+}
+
+fn resolve_sandbox_agent_socket_path_from_candidates(
+    candidates: [PathBuf; 2],
+) -> MicrosandboxResult<PathBuf> {
     for path in &candidates {
         if sandbox_agent_socket_path_fits(path) {
             return Ok(path.clone());
@@ -1154,6 +1574,7 @@ fn sandbox_cli_args(
     agent_sock_path: &Path,
     libkrunfw_path: &Path,
     staged_file_mounts: &HashMap<String, (PathBuf, String, String)>,
+    named_volumes: &HashMap<String, ResolvedNamedVolume>,
     metrics_reservation: Option<&MetricsReservation>,
     parent_watch_fd: Option<i32>,
     startup_fd: Option<i32>,
@@ -1307,24 +1728,53 @@ fn sandbox_cli_args(
                 options,
                 stat_virtualization,
                 host_permissions,
-                create,
+                create: _,
             } => {
-                let vol_path = local.volume_path(name);
-                // Directory named volumes honor their configured quota. The
-                // value is available here when the volume is created or ensured
-                // this spawn (`create`); a quota set on a prior run and reloaded
-                // from a persisted config is not yet re-resolved from the store.
-                let quota_mib = create.as_ref().and_then(|c| c.quota_mib);
-                push_dir_mount_arg(
-                    &mut launch.mounts,
-                    guest,
-                    &vol_path.display(),
-                    *options,
-                    *stat_virtualization,
-                    *host_permissions,
-                    quota_mib,
-                );
-                push_dir_mounts_spec(&mut dir_mounts_val, guest, *options);
+                let named_volume = named_volumes
+                    .get(name)
+                    .expect("resolve_named_volumes must resolve every named volume before render");
+                match named_volume {
+                    ResolvedNamedVolume {
+                        kind: VolumeKind::Disk,
+                        path,
+                        format,
+                        fstype,
+                        ..
+                    } => {
+                        let format = format
+                            .as_ref()
+                            .expect("resolved disk named volumes must carry a disk format");
+                        let id = guest_mount_tag(guest);
+                        push_disk_mount_arg(
+                            &mut launch.disks,
+                            &id,
+                            &path.display(),
+                            format,
+                            *options,
+                        );
+                        push_disk_mounts_spec(
+                            &mut disk_mounts_val,
+                            &id,
+                            guest,
+                            fstype.as_deref(),
+                            *options,
+                        );
+                    }
+                    ResolvedNamedVolume {
+                        path, quota_mib, ..
+                    } => {
+                        push_dir_mount_arg(
+                            &mut launch.mounts,
+                            guest,
+                            &path.display(),
+                            *options,
+                            *stat_virtualization,
+                            *host_permissions,
+                            *quota_mib,
+                        );
+                        push_dir_mounts_spec(&mut dir_mounts_val, guest, *options);
+                    }
+                }
             }
             VolumeMount::Tmpfs {
                 guest,
@@ -1520,6 +1970,7 @@ mod tests {
 
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
     use microsandbox_types::HandoffInit;
+    use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
     use serde::de::DeserializeOwned;
     use tempfile::tempdir;
 
@@ -1530,9 +1981,11 @@ mod tests {
         LogLevel,
         backend::LocalBackend,
         sandbox::{
-            DiskImageFormat, OciRootfsSource, Rlimit, RlimitResource, RootfsSource, SandboxBuilder,
-            SandboxConfig,
+            DiskImageFormat, HostPermissions, MountOptions, OciRootfsSource, Rlimit,
+            RlimitResource, RootfsSource, SandboxBuilder, SandboxConfig, StatVirtualization,
+            VolumeMount,
         },
+        volume::VolumeKind,
     };
 
     #[test]
@@ -1680,6 +2133,13 @@ mod tests {
     /// Render the full arg set (visible argv + the flattened config payload)
     /// as strings. Tests assert on the union since both feed `msb sandbox`.
     fn render_args(config: &SandboxConfig) -> Vec<String> {
+        render_args_with_named_volumes(config, &HashMap::new())
+    }
+
+    fn render_args_with_named_volumes(
+        config: &SandboxConfig,
+        named_volumes: &HashMap<String, super::ResolvedNamedVolume>,
+    ) -> Vec<String> {
         let local = test_local_backend();
         let (visible, launch) = sandbox_cli_args(
             &local,
@@ -1692,6 +2152,7 @@ mod tests {
             Path::new("/tmp/agent.sock"),
             Path::new("/tmp/libkrunfw.dylib"),
             &HashMap::new(),
+            named_volumes,
             None,
             None,
             None,
@@ -1701,6 +2162,68 @@ mod tests {
             .map(|arg| arg.to_string_lossy().into_owned())
             .chain(flatten_launch(&launch))
             .collect()
+    }
+
+    fn named_disk(path: impl Into<PathBuf>) -> super::ResolvedNamedVolume {
+        super::ResolvedNamedVolume {
+            kind: VolumeKind::Disk,
+            path: path.into(),
+            format: Some(DiskImageFormat::Raw),
+            fstype: Some("ext4".to_string()),
+            quota_mib: None,
+        }
+    }
+
+    fn named_directory(
+        path: impl Into<PathBuf>,
+        quota_mib: Option<u32>,
+    ) -> super::ResolvedNamedVolume {
+        super::ResolvedNamedVolume {
+            kind: VolumeKind::Directory,
+            path: path.into(),
+            format: None,
+            fstype: None,
+            quota_mib,
+        }
+    }
+
+    fn named_volume_create(
+        name: &str,
+        kind: VolumeKind,
+        quota_mib: Option<u32>,
+        capacity_mib: Option<u32>,
+        labels: Vec<(String, String)>,
+    ) -> microsandbox_types::NamedVolumeCreate {
+        microsandbox_types::NamedVolumeCreate {
+            mode: crate::sandbox::NamedVolumeMode::EnsureExists,
+            name: name.to_string(),
+            kind,
+            quota_mib,
+            capacity_mib,
+            labels,
+        }
+    }
+
+    fn existing_volume_model(
+        name: &str,
+        kind: VolumeKind,
+        quota_mib: Option<i32>,
+        capacity_bytes: Option<i64>,
+        labels: Option<Vec<(String, String)>>,
+    ) -> super::volume_entity::Model {
+        super::volume_entity::Model {
+            id: 1,
+            name: name.to_string(),
+            kind: kind.as_str().to_string(),
+            quota_mib,
+            size_bytes: None,
+            capacity_bytes,
+            disk_format: (kind == VolumeKind::Disk).then(|| "raw".to_string()),
+            disk_fstype: (kind == VolumeKind::Disk).then(|| "ext4".to_string()),
+            labels: labels.map(|labels| serde_json::to_string(&labels).unwrap()),
+            created_at: Some(chrono::Utc::now().naive_utc()),
+            updated_at: Some(chrono::Utc::now().naive_utc()),
+        }
     }
 
     /// Render only the `visible` argv (what shows up in `ps`).
@@ -1716,6 +2239,7 @@ mod tests {
             Path::new("/tmp/runtime"),
             Path::new("/tmp/agent.sock"),
             Path::new("/tmp/libkrunfw.dylib"),
+            &HashMap::new(),
             &HashMap::new(),
             None,
             None,
@@ -1748,6 +2272,7 @@ mod tests {
             Path::new("/tmp/agent.sock"),
             Path::new("/tmp/libkrunfw.dylib"),
             staged_file_mounts,
+            &HashMap::new(),
             None,
             None,
             None,
@@ -1827,6 +2352,7 @@ mod tests {
             Path::new("/tmp/runtime"),
             Path::new("/tmp/agent.sock"),
             Path::new("/tmp/libkrunfw.dylib"),
+            &HashMap::new(),
             &HashMap::new(),
             None,
             None,
@@ -1928,6 +2454,21 @@ mod tests {
                 .join("runtime")
                 .join("agent.sock")
         );
+    }
+
+    #[tokio::test]
+    async fn test_agent_socket_resolution_uses_explicit_local_backend_paths() {
+        let temp = tempfile::Builder::new()
+            .prefix("msb")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let home = temp.path().join("msb-home");
+        let backend = LocalBackend::builder().home(&home).build().await.unwrap();
+
+        let resolved =
+            super::resolve_sandbox_agent_socket_path_for(&backend, "sdk-socket-test").unwrap();
+
+        assert!(resolved.starts_with(backend.config().run_dir().join("agent")));
     }
 
     #[tokio::test]
@@ -2375,6 +2916,318 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_sandbox_cli_args_named_disk_volume() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/var/lib/docker", |m| {
+                m.named_with("docker-data", |v| v.disk().size(2048u32).ensure_exists())
+            })
+            .build()
+            .await
+            .unwrap();
+
+        let mut named_volumes = HashMap::new();
+        let raw_path = PathBuf::from("/tmp/docker-data/disk.raw");
+        named_volumes.insert("docker-data".to_string(), named_disk(&raw_path));
+
+        let rendered = render_args_with_named_volumes(&config, &named_volumes);
+        let tag = super::guest_mount_tag("/var/lib/docker");
+
+        assert!(
+            rendered.windows(2).any(|pair| pair[0] == "--disk"
+                && pair[1] == format!("{tag}:{}:raw", raw_path.display()))
+        );
+        assert!(rendered.contains(&format!(
+            "MSB_DISK_MOUNTS={tag}:/var/lib/docker:fstype=ext4"
+        )));
+        assert!(
+            !rendered
+                .iter()
+                .any(|arg| arg.starts_with("MSB_DIR_MOUNTS=") && arg.contains("/var/lib/docker")),
+            "named disk volume must not be routed through virtiofs: {rendered:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_cli_args_named_directory_volume() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/data", |m| {
+                m.named_with("mydir", |v| v.quota(512u32).ensure_exists())
+            })
+            .build()
+            .await
+            .unwrap();
+
+        let mut named_volumes = HashMap::new();
+        named_volumes.insert(
+            "mydir".to_string(),
+            named_directory("/tmp/mydir", Some(512)),
+        );
+
+        let rendered = render_args_with_named_volumes(&config, &named_volumes);
+        let tag = super::guest_mount_tag("/data");
+
+        assert!(
+            rendered.windows(2).any(
+                |pair| pair[0] == "--mount" && pair[1] == format!("{tag}:/tmp/mydir:quota=512")
+            )
+        );
+        assert!(rendered.contains(&format!("MSB_DIR_MOUNTS={tag}:/data")));
+        assert!(
+            !rendered.windows(2).any(|pair| pair[0] == "--disk"),
+            "named directory volume must not emit --disk: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_existing_named_volume_rejects_quota_mismatch() {
+        let requested =
+            named_volume_create("mydir", VolumeKind::Directory, Some(1024), None, Vec::new());
+        let existing = existing_volume_model("mydir", VolumeKind::Directory, Some(512), None, None);
+
+        let err = super::validate_existing_named_volume(&requested, &existing).unwrap_err();
+
+        assert!(err.to_string().contains("quota"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_existing_named_volume_rejects_capacity_mismatch() {
+        let requested =
+            named_volume_create("mydisk", VolumeKind::Disk, None, Some(2048), Vec::new());
+        let existing_capacity_bytes = 1024_i64 * 1024 * 1024;
+        let existing = existing_volume_model(
+            "mydisk",
+            VolumeKind::Disk,
+            None,
+            Some(existing_capacity_bytes),
+            None,
+        );
+
+        let err = super::validate_existing_named_volume(&requested, &existing).unwrap_err();
+
+        assert!(err.to_string().contains("capacity"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_existing_named_volume_rejects_requested_label_mismatch() {
+        let requested = named_volume_create(
+            "mydir",
+            VolumeKind::Directory,
+            None,
+            None,
+            vec![("env".to_string(), "prod".to_string())],
+        );
+        let existing = existing_volume_model(
+            "mydir",
+            VolumeKind::Directory,
+            None,
+            None,
+            Some(vec![("env".to_string(), "dev".to_string())]),
+        );
+
+        let err = super::validate_existing_named_volume(&requested, &existing).unwrap_err();
+
+        assert!(err.to_string().contains("label"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_existing_named_volume_allows_extra_existing_labels() {
+        let requested = named_volume_create(
+            "mydir",
+            VolumeKind::Directory,
+            None,
+            None,
+            vec![("env".to_string(), "prod".to_string())],
+        );
+        let existing = existing_volume_model(
+            "mydir",
+            VolumeKind::Directory,
+            None,
+            None,
+            Some(vec![
+                ("env".to_string(), "prod".to_string()),
+                ("team".to_string(), "runtime".to_string()),
+            ]),
+        );
+
+        super::validate_existing_named_volume(&requested, &existing).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_ensure_named_volumes_rolls_back_db_row_on_provision_failure() {
+        let temp = tempdir().unwrap();
+        let home = temp.path().join("home");
+        let volumes_dir = temp.path().join("volumes");
+        std::fs::create_dir_all(&volumes_dir).unwrap();
+        std::fs::write(volumes_dir.join("broken"), b"not a directory").unwrap();
+        let local = LocalBackend::builder()
+            .home(&home)
+            .volumes_dir(&volumes_dir)
+            .build()
+            .await
+            .unwrap();
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/data", |m| m.named_with("broken", |v| v.ensure_exists()))
+            .build()
+            .await
+            .unwrap();
+
+        let err = super::ensure_named_volumes(&local, &config)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("already exists"), "got: {err}");
+        let pools = local.db().await.unwrap();
+        let existing = super::volume_entity::Entity::find()
+            .filter(super::volume_entity::Column::Name.eq("broken"))
+            .one(pools.read())
+            .await
+            .unwrap();
+        assert!(
+            existing.is_none(),
+            "failed sandbox-time provisioning must not leave a phantom volume row"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ensure_named_volumes_rolls_back_earlier_created_volumes_on_later_failure() {
+        let temp = tempdir().unwrap();
+        let home = temp.path().join("home");
+        let volumes_dir = temp.path().join("volumes");
+        let local = LocalBackend::builder()
+            .home(&home)
+            .volumes_dir(&volumes_dir)
+            .build()
+            .await
+            .unwrap();
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/ok", |m| {
+                m.named_with("first-created", |v| v.ensure_exists())
+            })
+            .volume("/bad", |m| {
+                m.named_with("bad-disk", |v| v.ensure_exists().disk())
+            })
+            .build()
+            .await
+            .unwrap();
+
+        let err = super::ensure_named_volumes(&local, &config)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("disk named volumes require"),
+            "got: {err}"
+        );
+        assert!(!local.volume_path("first-created").exists());
+        let pools = local.db().await.unwrap();
+        let existing = super::volume_entity::Entity::find()
+            .filter(super::volume_entity::Column::Name.eq("first-created"))
+            .one(pools.read())
+            .await
+            .unwrap();
+        assert!(
+            existing.is_none(),
+            "later sandbox-time provisioning failure must roll back earlier created volumes"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_named_volumes_recovers_disk_metadata_from_store() {
+        let temp = tempdir().unwrap();
+        let local = LocalBackend::builder()
+            .home(temp.path())
+            .build()
+            .await
+            .unwrap();
+        let pools = local.db().await.unwrap();
+        super::volume_entity::ActiveModel {
+            name: Set("mydata".to_string()),
+            kind: Set(VolumeKind::Disk.as_str().to_string()),
+            disk_format: Set(Some("raw".to_string())),
+            disk_fstype: Set(Some("ext4".to_string())),
+            created_at: Set(Some(chrono::Utc::now().naive_utc())),
+            updated_at: Set(Some(chrono::Utc::now().naive_utc())),
+            ..Default::default()
+        }
+        .insert(pools.write())
+        .await
+        .unwrap();
+
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/data", |m| m.named("mydata"))
+            .build()
+            .await
+            .unwrap();
+
+        let resolved = super::resolve_named_volumes(&local, &config).await.unwrap();
+        let volume = resolved.get("mydata").expect("volume should resolve");
+        assert_eq!(volume.kind, VolumeKind::Disk);
+        assert_eq!(volume.format, Some(DiskImageFormat::Raw));
+        assert_eq!(volume.fstype.as_deref(), Some("ext4"));
+        assert_eq!(volume.path, local.volume_path("mydata").join("disk.raw"));
+
+        let rendered = render_args_with_named_volumes(&config, &resolved);
+        let tag = super::guest_mount_tag("/data");
+        assert!(
+            rendered.windows(2).any(|pair| pair[0] == "--disk"
+                && pair[1] == format!("{tag}:{}:raw", volume.path.display()))
+        );
+        assert!(rendered.contains(&format!("MSB_DISK_MOUNTS={tag}:/data:fstype=ext4")));
+    }
+
+    #[tokio::test]
+    async fn test_existing_named_volume_mode_does_not_validate_default_metadata() {
+        let temp = tempdir().unwrap();
+        let local = LocalBackend::builder()
+            .home(temp.path())
+            .build()
+            .await
+            .unwrap();
+        let pools = local.db().await.unwrap();
+        super::volume_entity::ActiveModel {
+            name: Set("docker-data".to_string()),
+            kind: Set(VolumeKind::Disk.as_str().to_string()),
+            capacity_bytes: Set(Some(2048_i64 * 1024 * 1024)),
+            disk_format: Set(Some("raw".to_string())),
+            disk_fstype: Set(Some("ext4".to_string())),
+            created_at: Set(Some(chrono::Utc::now().naive_utc())),
+            updated_at: Set(Some(chrono::Utc::now().naive_utc())),
+            ..Default::default()
+        }
+        .insert(pools.write())
+        .await
+        .unwrap();
+
+        let mut config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/var/lib/docker", |m| m.named("docker-data"))
+            .build()
+            .await
+            .unwrap();
+        if let VolumeMount::Named { create, .. } = &mut config.spec.mounts[0] {
+            // Directly deserialized configs can still carry an explicit
+            // Existing create object even though the builder normalizes this
+            // path to a plain named mount.
+            *create = Some(microsandbox_types::NamedVolumeCreate {
+                mode: crate::sandbox::NamedVolumeMode::Existing,
+                name: "docker-data".to_string(),
+                kind: VolumeKind::Directory,
+                quota_mib: None,
+                capacity_mib: None,
+                labels: Vec::new(),
+            });
+        }
+
+        let ensured = super::ensure_named_volumes(&local, &config).await.unwrap();
+        assert!(ensured.is_empty());
+    }
+
+    #[tokio::test]
     async fn test_sandbox_cli_args_disk_image_volume() {
         // SandboxBuilder::validate canonicalizes disk hosts, so the file
         // must exist. Stage one in a tempdir.
@@ -2432,6 +3285,72 @@ mod tests {
             |pair| pair[0] == "--disk" && pair[1] == format!("{tag}:{}:raw:ro", host.display())
         ));
         assert!(rendered.contains(&format!("MSB_DISK_MOUNTS={tag}:/seed:ro,noexec")));
+    }
+
+    #[test]
+    fn test_lock_disk_mounts_rejects_rootfs_and_mount_same_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let disk = dir.path().join("root.raw");
+        std::fs::write(&disk, b"disk").unwrap();
+
+        let config = SandboxConfig {
+            spec: microsandbox_types::SandboxSpec {
+                image: RootfsSource::DiskImage {
+                    path: disk.clone(),
+                    format: DiskImageFormat::Raw,
+                    fstype: None,
+                },
+                mounts: vec![VolumeMount::DiskImage {
+                    host: disk,
+                    guest: "/data".to_string(),
+                    format: DiskImageFormat::Raw,
+                    fstype: None,
+                    options: MountOptions::default(),
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let err = super::lock_disk_mounts(&config, &HashMap::new()).unwrap_err();
+        assert!(err.to_string().contains("more than once per sandbox"));
+    }
+
+    #[test]
+    fn test_lock_disk_mounts_rejects_duplicate_named_disk_volume() {
+        let dir = tempfile::tempdir().unwrap();
+        let disk = dir.path().join("disk.raw");
+        std::fs::write(&disk, b"disk").unwrap();
+
+        let config = SandboxConfig {
+            spec: microsandbox_types::SandboxSpec {
+                mounts: vec![
+                    VolumeMount::Named {
+                        name: "data".to_string(),
+                        guest: "/data-a".to_string(),
+                        create: None,
+                        options: MountOptions::default(),
+                        stat_virtualization: StatVirtualization::Strict,
+                        host_permissions: HostPermissions::Private,
+                    },
+                    VolumeMount::Named {
+                        name: "data".to_string(),
+                        guest: "/data-b".to_string(),
+                        create: None,
+                        options: MountOptions::default(),
+                        stat_virtualization: StatVirtualization::Strict,
+                        host_permissions: HostPermissions::Private,
+                    },
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut named_volumes = HashMap::new();
+        named_volumes.insert("data".to_string(), named_disk(disk));
+
+        let err = super::lock_disk_mounts(&config, &named_volumes).unwrap_err();
+        assert!(err.to_string().contains("more than once per sandbox"));
     }
 
     #[tokio::test]

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -977,8 +977,18 @@ impl SandboxBuilder {
                 "sandbox name is required".into(),
             ));
         }
-        super::validate_sandbox_name_for_runtime(&self.config.spec.name)?;
+        super::validate_sandbox_name(&self.config.spec.name)?;
         super::validate_hostname(self.config.spec.runtime.hostname.as_deref())?;
+        if self.config.spec.resources.cpus == 0 {
+            return Err(crate::MicrosandboxError::InvalidConfig(
+                "cpus must be greater than 0".into(),
+            ));
+        }
+        if self.config.spec.resources.memory_mib == 0 {
+            return Err(crate::MicrosandboxError::InvalidConfig(
+                "memory must be greater than 0".into(),
+            ));
+        }
 
         // Check that image is set (non-empty OCI string or Bind path).
         match &self.config.spec.image {
@@ -1082,7 +1092,6 @@ impl From<SandboxConfig> for SandboxBuilder {
 mod tests {
     use super::SandboxBuilder;
     use crate::LogLevel;
-    use crate::backend::{LocalBackend, with_backend};
     use crate::sandbox::{MAX_HOSTNAME_BYTES, MAX_SANDBOX_NAME_BYTES, RlimitResource};
     #[cfg(feature = "net")]
     use microsandbox_network::secrets::config::{HostPattern, SecretEntry, SecretInjection};
@@ -1091,7 +1100,6 @@ mod tests {
     use microsandbox_types::SandboxLogLevel;
     #[cfg(feature = "net")]
     use std::net::{IpAddr, Ipv4Addr};
-    use tempfile::Builder as TempDirBuilder;
 
     #[tokio::test]
     async fn test_builder_sets_runtime_log_level() {
@@ -1131,27 +1139,14 @@ mod tests {
         assert_eq!(config.spec.lifecycle.max_duration_secs, Some(60));
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn test_builder_accepts_128_byte_sandbox_name() {
-        let temp = TempDirBuilder::new()
-            .prefix("msb")
-            .tempdir_in("/tmp")
-            .unwrap();
-        let backend = LocalBackend::builder()
-            .home(temp.path())
+        let name = "x".repeat(MAX_SANDBOX_NAME_BYTES);
+        let config = SandboxBuilder::new(name.clone())
+            .image("alpine")
             .build()
             .await
             .unwrap();
-        let name = "x".repeat(MAX_SANDBOX_NAME_BYTES);
-        let config = with_backend(backend, async {
-            SandboxBuilder::new(name.clone())
-                .image("alpine")
-                .build()
-                .await
-                .unwrap()
-        })
-        .await;
 
         assert_eq!(config.spec.name, name);
     }
@@ -1169,6 +1164,30 @@ mod tests {
             err.to_string(),
             "invalid config: sandbox name must be at most 128 characters: got 129"
         );
+    }
+
+    #[tokio::test]
+    async fn test_builder_rejects_zero_cpus() {
+        let err = SandboxBuilder::new("test")
+            .image("alpine")
+            .cpus(0)
+            .build()
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("cpus must be greater than 0"));
+    }
+
+    #[tokio::test]
+    async fn test_builder_rejects_zero_memory() {
+        let err = SandboxBuilder::new("test")
+            .image("alpine")
+            .memory(0)
+            .build()
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("memory must be greater than 0"));
     }
 
     #[tokio::test]

--- a/sdk/rust/lib/sandbox/config.rs
+++ b/sdk/rust/lib/sandbox/config.rs
@@ -174,6 +174,11 @@ impl SandboxConfig {
         let mut config = self.clone();
         config.startup_command_requested = false;
         config.initial_command = None;
+        for mount in &mut config.spec.mounts {
+            if let VolumeMount::Named { create, .. } = mount {
+                *create = None;
+            }
+        }
         config
     }
 
@@ -524,11 +529,13 @@ mod tests {
     use std::path::PathBuf;
 
     use super::{SandboxConfig, merge_env};
-    use crate::sandbox::{HandoffInit, MountOptions, RootfsSource, VolumeMount};
+    use crate::sandbox::{
+        HandoffInit, MountOptions, NamedVolumeMode, RootfsSource, StatVirtualization, VolumeMount,
+    };
     use microsandbox_image::ImageConfig;
     use microsandbox_types::{
-        EnvVar, SandboxLogLevel, SandboxPolicy, SandboxResources, SandboxRuntimeOptions,
-        SandboxSpec, SecurityProfile,
+        EnvVar, NamedVolumeCreate, SandboxLogLevel, SandboxPolicy, SandboxResources,
+        SandboxRuntimeOptions, SandboxSpec, SecurityProfile, VolumeKind,
     };
 
     #[test]
@@ -875,6 +882,41 @@ mod tests {
             persisted_init.args,
             vec!["--unit=multi-user.target".to_string()]
         );
+    }
+
+    #[test]
+    fn test_clone_for_persistence_strips_named_volume_create_intent() {
+        let config = SandboxConfig {
+            spec: SandboxSpec {
+                mounts: vec![VolumeMount::Named {
+                    name: "cache".to_string(),
+                    guest: "/cache".to_string(),
+                    create: Some(NamedVolumeCreate {
+                        mode: NamedVolumeMode::Create,
+                        name: "cache".to_string(),
+                        kind: VolumeKind::Directory,
+                        quota_mib: Some(512),
+                        capacity_mib: None,
+                        labels: Vec::new(),
+                    }),
+                    options: MountOptions::default(),
+                    stat_virtualization: StatVirtualization::Strict,
+                    host_permissions: crate::sandbox::HostPermissions::Private,
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let persisted = config.clone_for_persistence();
+
+        match &persisted.spec.mounts[0] {
+            VolumeMount::Named { name, create, .. } => {
+                assert_eq!(name, "cache");
+                assert!(create.is_none());
+            }
+            other => panic!("expected named mount, got {other:?}"),
+        }
     }
 
     #[test]

--- a/sdk/rust/lib/sandbox/handle.rs
+++ b/sdk/rust/lib/sandbox/handle.rs
@@ -232,13 +232,24 @@ impl SandboxHandle {
         &self,
         opts: &crate::logs::LogOptions,
     ) -> MicrosandboxResult<Vec<crate::logs::LogEntry>> {
-        if self.backend.as_local().is_none() {
-            return Err(crate::MicrosandboxError::Unsupported {
-                feature: "SandboxHandle::logs on cloud".into(),
-                available_when: "when cloud logs land".into(),
-            });
-        }
-        crate::logs::read_logs(&self.name, opts).await
+        self.backend
+            .sandboxes()
+            .logs(self.backend.clone(), &self.name, opts)
+            .await
+    }
+
+    /// Stream captured output for this sandbox.
+    ///
+    /// Same backing data as [`Sandbox::log_stream`](super::Sandbox::log_stream).
+    /// Works without starting the sandbox.
+    pub async fn log_stream(
+        &self,
+        opts: &crate::logs::LogStreamOptions,
+    ) -> MicrosandboxResult<crate::backend::sandbox::LogStream> {
+        self.backend
+            .sandboxes()
+            .log_stream(self.backend.clone(), &self.name, opts)
+            .await
     }
 
     /// Get the latest metrics snapshot for this sandbox. **Local handles only**.
@@ -523,9 +534,19 @@ impl SandboxHandle {
     /// backend trait so cloud handles hit `DELETE /v1/sandboxes/by-name/:name`.
     pub async fn remove(&self) -> MicrosandboxResult<()> {
         match &self.inner {
-            SandboxHandleInner::Local(local) => {
-                if local.status == SandboxStatus::Running || local.status == SandboxStatus::Draining
-                {
+            SandboxHandleInner::Local(_) => {
+                let refreshed = self.refresh().await?;
+                let local =
+                    refreshed
+                        .local()
+                        .ok_or_else(|| crate::MicrosandboxError::Unsupported {
+                            feature: "SandboxHandle::remove on cloud".into(),
+                            available_when: "wired via Cloud variant".into(),
+                        })?;
+                if matches!(
+                    local.status,
+                    SandboxStatus::Running | SandboxStatus::Draining | SandboxStatus::Paused
+                ) {
                     return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
                         "cannot remove sandbox '{}': still running",
                         self.name

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -46,10 +46,14 @@ use microsandbox_image::{
 use crate::{
     MicrosandboxResult,
     agent::AgentClient,
+    backend::LocalBackend,
     db::entity::{
         run as run_entity, sandbox as sandbox_entity, sandbox_rootfs as sandbox_rootfs_entity,
     },
-    runtime::{ProcessHandle, SpawnMode, spawn_sandbox},
+    runtime::{
+        ProcessHandle, SpawnMode, ensure_named_volumes, rollback_created_named_volumes,
+        spawn_sandbox,
+    },
 };
 
 use self::exec::{ExecHandle, ExecOptions};
@@ -73,10 +77,13 @@ pub fn validate_sandbox_name(name: &str) -> MicrosandboxResult<()> {
     microsandbox_types::validate_sandbox_name(name).map_err(Into::into)
 }
 
-/// Validate sandbox-name-derived runtime paths before the sandbox process starts.
-pub(super) fn validate_sandbox_name_for_runtime(name: &str) -> MicrosandboxResult<()> {
+/// Validate sandbox-name-derived runtime paths using an explicit local backend.
+pub(super) fn validate_sandbox_name_for_runtime_with_backend(
+    local: &LocalBackend,
+    name: &str,
+) -> MicrosandboxResult<()> {
     validate_sandbox_name(name)?;
-    crate::runtime::resolve_sandbox_agent_socket_path(name).map(|_| ())
+    crate::runtime::resolve_sandbox_agent_socket_path_for(local, name).map(|_| ())
 }
 
 /// Validate an explicit guest hostname before it is forwarded to agentd.
@@ -95,6 +102,8 @@ pub(crate) fn reserved_label_prefix(key: &str) -> Option<&'static str> {
         .copied()
         .find(|prefix| key.starts_with(prefix))
 }
+
+pub(crate) use types::validate_named_disk_mount_options;
 
 //--------------------------------------------------------------------------------------------------
 // Re-Exports
@@ -460,11 +469,12 @@ pub(crate) async fn create_local(
     let mut pinned_reference: Option<String> = None;
 
     config.apply_runtime_defaults();
-    validate_sandbox_name_for_runtime(&config.spec.name)?;
+    validate_sandbox_name_for_runtime_with_backend(local_backend, &config.spec.name)?;
     validate_hostname(config.spec.runtime.hostname.as_deref())?;
     validate_rootfs_source(&config.spec.image)?;
     validate_env(&config.spec.env)?;
     validate_labels(&config.spec.labels)?;
+    types::validate_volume_mounts(&config.spec.mounts)?;
     if let Some(init) = &config.spec.init {
         init::validate(init)?;
     }
@@ -594,10 +604,21 @@ pub(crate) async fn create_local(
         patch::apply_patches(&config.spec.image, &config.spec.patches).await?;
     }
 
+    // Sandbox-time named-volume creation is one-shot create intent. Provision
+    // before inserting the sandbox row so volume conflicts or incompatibilities
+    // cannot leave a stopped sandbox that never booted.
+    let created_named_volumes = ensure_named_volumes(local_backend, &config).await?;
+
     // Insert the sandbox record and keep its stable database ID.
     let write_db = db.write();
     let persisted_config = config.clone_for_persistence();
-    let sandbox_id = insert_sandbox_record(write_db, &persisted_config).await?;
+    let sandbox_id = match insert_sandbox_record(write_db, &persisted_config).await {
+        Ok(sandbox_id) => sandbox_id,
+        Err(err) => {
+            rollback_created_named_volumes(local_backend, &created_named_volumes).await;
+            return Err(err);
+        }
+    };
     tracing::debug!(sandbox_id, sandbox = %config.spec.name, "create_local: db record inserted");
 
     // Spawn the sandbox process and create the bridge. On failure, mark the sandbox
@@ -606,7 +627,13 @@ pub(crate) async fn create_local(
         match create_inner_local(local_backend, config, sandbox_id, mode).await {
             Ok(pair) => pair,
             Err(e) => {
-                let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
+                if created_named_volumes.is_empty() {
+                    let _ =
+                        update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
+                } else {
+                    rollback_created_named_volumes(local_backend, &created_named_volumes).await;
+                    let _ = delete_sandbox_record(write_db, sandbox_id).await;
+                }
                 return Err(e);
             }
         };
@@ -618,19 +645,48 @@ pub(crate) async fn create_local(
     ) && let Err(err) = persist_oci_manifest_pin(write_db, sandbox_id, manifest_digest).await
     {
         let _ = sandbox.stop().await;
-        let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
+        if created_named_volumes.is_empty() {
+            let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
+        } else {
+            rollback_created_named_volumes(local_backend, &created_named_volumes).await;
+            let _ = delete_sandbox_record(write_db, sandbox_id).await;
+        }
         return Err(err);
     }
 
-    // Validate that the configured workdir exists inside the guest.
-    if let Some(ref workdir) = sandbox.config.spec.runtime.workdir
-        && !sandbox.fs().exists(workdir).await.unwrap_or(false)
-    {
-        let _ = sandbox.stop().await;
-        let _ = update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
-        return Err(crate::MicrosandboxError::InvalidConfig(format!(
-            "workdir does not exist in guest: {workdir}"
-        )));
+    // Validate that the configured workdir exists inside the guest and is a
+    // directory before returning a ready sandbox. Shell/exec calls inherit this
+    // cwd, so accepting a regular file here leads to later, murkier failures.
+    if let Some(ref workdir) = sandbox.config.spec.runtime.workdir {
+        match sandbox.fs().stat(workdir).await {
+            Ok(metadata) if metadata.kind == FsEntryKind::Directory => {}
+            Ok(_) => {
+                let _ = sandbox.stop().await;
+                if created_named_volumes.is_empty() {
+                    let _ =
+                        update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
+                } else {
+                    rollback_created_named_volumes(local_backend, &created_named_volumes).await;
+                    let _ = delete_sandbox_record(write_db, sandbox_id).await;
+                }
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "workdir is not a directory in guest: {workdir}"
+                )));
+            }
+            Err(_) => {
+                let _ = sandbox.stop().await;
+                if created_named_volumes.is_empty() {
+                    let _ =
+                        update_sandbox_status(write_db, sandbox_id, SandboxStatus::Stopped).await;
+                } else {
+                    rollback_created_named_volumes(local_backend, &created_named_volumes).await;
+                    let _ = delete_sandbox_record(write_db, sandbox_id).await;
+                }
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "workdir does not exist in guest: {workdir}"
+                )));
+            }
+        }
     }
 
     Ok(sandbox)
@@ -671,11 +727,12 @@ pub(crate) async fn start_local(
 
     let mut config: SandboxConfig = serde_json::from_str(&model.config)?;
     config.apply_runtime_defaults();
-    validate_sandbox_name_for_runtime(&config.spec.name)?;
+    validate_sandbox_name_for_runtime_with_backend(local_backend, &config.spec.name)?;
     validate_hostname(config.spec.runtime.hostname.as_deref())?;
     validate_rootfs_source(&config.spec.image)?;
     validate_env(&config.spec.env)?;
     validate_labels(&config.spec.labels)?;
+    types::validate_volume_mounts(&config.spec.mounts)?;
     validate_start_state(
         local_backend,
         &config,
@@ -2437,6 +2494,13 @@ async fn insert_sandbox_record(
     .await
 }
 
+async fn delete_sandbox_record(db: &DbWriteConnection, sandbox_id: i32) -> MicrosandboxResult<()> {
+    sandbox_entity::Entity::delete_by_id(sandbox_id)
+        .exec(db)
+        .await?;
+    Ok(())
+}
+
 async fn persist_oci_manifest_pin(
     db: &DbWriteConnection,
     sandbox_id: i32,
@@ -2551,16 +2615,19 @@ mod tests {
     use microsandbox_db::entity::{run as run_entity, sandbox_rootfs as sandbox_rootfs_entity};
     use microsandbox_db::pool::DbPools;
 
-    use crate::sandbox::OciRootfsSource;
+    use crate::{
+        backend::{Backend, LocalBackend},
+        sandbox::OciRootfsSource,
+    };
     use microsandbox_migration::{Migrator, MigratorTrait};
     use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
     use tempfile::tempdir;
 
     use super::{
-        MAX_HOSTNAME_BYTES, MAX_SANDBOX_NAME_BYTES, RootfsSource, SandboxConfig, SandboxStatus,
-        hostname_from_sandbox_name, insert_sandbox_record, persist_oci_manifest_pin,
-        prepare_create_target, reconcile_sandbox_runtime_state, remove_dir_if_exists,
-        validate_hostname, validate_rootfs_source,
+        MAX_HOSTNAME_BYTES, MAX_SANDBOX_NAME_BYTES, MountOptions, RootfsSource, SandboxConfig,
+        SandboxStatus, VolumeMount, hostname_from_sandbox_name, insert_sandbox_record,
+        persist_oci_manifest_pin, prepare_create_target, reconcile_sandbox_runtime_state,
+        remove_dir_if_exists, validate_hostname, validate_rootfs_source,
     };
 
     /// Open both pools at `db_path` for tests, with migrations applied.
@@ -2615,6 +2682,66 @@ mod tests {
             pid += 1;
         }
         pid
+    }
+
+    #[tokio::test]
+    async fn test_runtime_name_validation_uses_explicit_backend_paths() {
+        let temp = tempfile::Builder::new()
+            .prefix("msb")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let home = temp.path().join("msb-home");
+        let backend = LocalBackend::builder().home(&home).build().await.unwrap();
+
+        super::validate_sandbox_name_for_runtime_with_backend(&backend, "sdk-socket-test").unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_create_local_validates_direct_config_mounts() {
+        let temp = tempfile::Builder::new()
+            .prefix("msb")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let rootfs = temp.path().join("rootfs");
+        std::fs::create_dir_all(&rootfs).unwrap();
+        let backend = Arc::new(
+            LocalBackend::builder()
+                .home(temp.path().join("home"))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let backend_trait: Arc<dyn Backend> = backend;
+        let mut config = test_config_with_rootfs("bad-mounts", RootfsSource::Bind(rootfs));
+        config.spec.mounts = vec![
+            VolumeMount::Tmpfs {
+                guest: "/dup".to_string(),
+                size_mib: None,
+                options: MountOptions::default(),
+            },
+            VolumeMount::Tmpfs {
+                guest: "/dup".to_string(),
+                size_mib: None,
+                options: MountOptions::default(),
+            },
+        ];
+
+        let err = match super::create_local(
+            backend_trait,
+            config,
+            crate::runtime::SpawnMode::Attached,
+            None,
+        )
+        .await
+        {
+            Ok(_) => panic!("expected invalid direct-config mounts to be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string().contains("multiple volumes cannot mount"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/sdk/rust/lib/sandbox/types.rs
+++ b/sdk/rust/lib/sandbox/types.rs
@@ -400,13 +400,35 @@ impl MountBuilder {
         }
         if self.stat_virtualization.is_some() && !is_virtiofs {
             return Err(crate::MicrosandboxError::InvalidConfig(
-                ".stat_virtualization() is only valid for bind and named volume mounts".into(),
+                ".stat_virtualization() is only valid for bind and directory-backed named volume mounts"
+                    .into(),
             ));
         }
         if self.host_permissions.is_some() && !is_virtiofs {
             return Err(crate::MicrosandboxError::InvalidConfig(
-                ".host_permissions() is only valid for bind and named volume mounts".into(),
+                ".host_permissions() is only valid for bind and directory-backed named volume mounts"
+                    .into(),
             ));
+        }
+        if let MountKind::Named {
+            name,
+            create: Some(create),
+        } = &self.mount
+            && create.kind() == VolumeKind::Disk
+        {
+            // Disk-backed named volumes are passed to the VMM as block
+            // devices, so virtiofs-only policies are invalid even when the
+            // caller explicitly sets the same values as the defaults.
+            if self.stat_virtualization.is_some() {
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "stat_virtualization is only valid for directory named volumes: {name}"
+                )));
+            }
+            if self.host_permissions.is_some() {
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "host_permissions is only valid for directory named volumes: {name}"
+                )));
+            }
         }
 
         // `Off + Mirror` is a contradiction. With xattr disabled there is no
@@ -831,11 +853,19 @@ fn validate_volume_mount(mount: &VolumeMount) -> crate::MicrosandboxResult<()> {
             guest,
             stat_virtualization,
             host_permissions,
+            create,
             ..
         } => {
             validate_guest_mount_path(guest)?;
             crate::volume::validate_volume_name(name)?;
-            validate_virtiofs_policies(*stat_virtualization, *host_permissions)?;
+            if create
+                .as_ref()
+                .is_some_and(|create| create.kind() == VolumeKind::Disk)
+            {
+                validate_named_disk_mount_options(name, *stat_virtualization, *host_permissions)?;
+            } else {
+                validate_virtiofs_policies(*stat_virtualization, *host_permissions)?;
+            }
         }
         VolumeMount::Tmpfs { guest, .. } => {
             validate_guest_mount_path(guest)?;
@@ -917,6 +947,24 @@ fn validate_virtiofs_policies(
              Drop one or the other."
                 .into(),
         ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_named_disk_mount_options(
+    name: &str,
+    stat_virtualization: StatVirtualization,
+    host_permissions: HostPermissions,
+) -> crate::MicrosandboxResult<()> {
+    if stat_virtualization != StatVirtualization::Strict {
+        return Err(crate::MicrosandboxError::InvalidConfig(format!(
+            "stat_virtualization is only valid for directory named volumes: {name}"
+        )));
+    }
+    if host_permissions != HostPermissions::Private {
+        return Err(crate::MicrosandboxError::InvalidConfig(format!(
+            "host_permissions is only valid for directory named volumes: {name}"
+        )));
     }
     Ok(())
 }
@@ -1092,6 +1140,51 @@ mod tests {
             }
             other => panic!("expected Named, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_mount_builder_rejects_named_disk_virtiofs_policy() {
+        let err = MountBuilder::new("/data")
+            .named_with("cache-disk", |v| v.disk().size(1024u32).ensure_exists())
+            .stat_virtualization(StatVirtualization::Relaxed)
+            .build()
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("only valid for directory named volumes"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_mount_builder_rejects_named_disk_explicit_default_stat_policy() {
+        let err = MountBuilder::new("/data")
+            .named_with("cache-disk", |v| v.disk().size(1024u32).ensure_exists())
+            .stat_virtualization(StatVirtualization::Strict)
+            .build()
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("only valid for directory named volumes"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_mount_builder_rejects_named_disk_explicit_default_host_policy() {
+        let err = MountBuilder::new("/data")
+            .named_with("cache-disk", |v| v.disk().size(1024u32).ensure_exists())
+            .host_permissions(HostPermissions::Private)
+            .build()
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("only valid for directory named volumes"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/sdk/rust/lib/volume/mod.rs
+++ b/sdk/rust/lib/volume/mod.rs
@@ -15,17 +15,25 @@ pub mod fs;
 pub use fs::{VolumeFs, VolumeFsReadStream, VolumeFsWriteSink};
 pub use microsandbox_types::{VolumeKind, VolumeSpec, VolumeSpec as VolumeConfig};
 
+use std::fs::File;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use microsandbox_image::ext4::{self, Ext4FormatOptions};
+use sea_orm::ConnectionTrait;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
 
 use crate::backend::{
-    Backend, BackendKind, VolumeHandleInner, VolumeHandleLocalState, VolumeInner, VolumeLocalState,
+    Backend, BackendKind, LocalBackend, VolumeHandleInner, VolumeHandleLocalState, VolumeInner,
+    VolumeLocalState,
 };
 use crate::{
-    MicrosandboxError, MicrosandboxResult, db::entity::volume as volume_entity, size::Mebibytes,
+    MicrosandboxError, MicrosandboxResult,
+    db::entity::{sandbox as sandbox_entity, volume as volume_entity},
+    sandbox::{SandboxConfig, SandboxStatus, VolumeMount},
+    size::Mebibytes,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -52,6 +60,7 @@ pub struct Volume {
 ///
 /// Like [`Volume`], holds an [`Arc<dyn Backend>`] plus a backend-private
 /// [`VolumeHandleInner`] enum; users see a single uniform type.
+#[derive(Clone)]
 pub struct VolumeHandle {
     backend: Arc<dyn Backend>,
     inner: VolumeHandleInner,
@@ -502,6 +511,7 @@ pub(crate) async fn create_local(
             available_when: "with a LocalBackend".into(),
         })?;
     let pools = local_backend.db().await?;
+    let _name_lock = lock_volume_name(local_backend, &config.name)?;
 
     // Check for existing volume.
     let existing = volume_entity::Entity::find()
@@ -511,6 +521,8 @@ pub(crate) async fn create_local(
     if existing.is_some() {
         return Err(MicrosandboxError::VolumeAlreadyExists(config.name));
     }
+    let path = local_backend.volume_path(&config.name);
+    materialize_volume_path(&config, &path).await?;
 
     // Serialize labels.
     let labels_json = if config.labels.is_empty() {
@@ -519,8 +531,8 @@ pub(crate) async fn create_local(
         Some(serde_json::to_string(&config.labels)?)
     };
 
-    // Insert DB record first — orphaned directories are easier to clean
-    // up than orphaned DB records.
+    // The filesystem artifact is already materialized. If the DB insert
+    // loses a race, remove it so no orphaned final path remains.
     let now = chrono::Utc::now().naive_utc();
     let model = volume_entity::ActiveModel {
         name: Set(config.name.clone()),
@@ -536,19 +548,12 @@ pub(crate) async fn create_local(
         ..Default::default()
     };
 
-    volume_entity::Entity::insert(model)
+    if let Err(e) = volume_entity::Entity::insert(model)
         .exec(pools.write())
-        .await?;
-
-    // Create the volume directory. If this fails, clean up the DB record.
-    let path = local_backend.volume_path(&config.name);
-
-    if let Err(e) = provision_volume_path(&config, &path).await {
-        let _ = volume_entity::Entity::delete_many()
-            .filter(volume_entity::Column::Name.eq(&config.name))
-            .exec(pools.write())
-            .await;
-        return Err(e);
+        .await
+    {
+        let _ = tokio::fs::remove_dir_all(&path).await;
+        return Err(e.into());
     }
 
     Ok(Volume::from_local(
@@ -584,7 +589,7 @@ pub(crate) async fn get_local(
         .await?
         .ok_or_else(|| MicrosandboxError::VolumeNotFound(name.into()))?;
 
-    let handle = VolumeHandle::from_local_model(backend, model);
+    let handle = VolumeHandle::from_local_model(backend.clone(), model);
     Ok(handle)
 }
 
@@ -624,8 +629,12 @@ pub(crate) async fn remove_local(backend: Arc<dyn Backend>, name: &str) -> Micro
         .one(pools.read())
         .await?
         .ok_or_else(|| MicrosandboxError::VolumeNotFound(name.into()))?;
+    let handle = VolumeHandle::from_local_model(backend.clone(), model);
+    let _name_lock = lock_volume_name(local_backend, name)?;
+    let _disk_lock = lock_disk_volume_for_remove(&handle)?;
+    ensure_volume_not_referenced_by_active_sandbox(pools.read(), name).await?;
 
-    volume_entity::Entity::delete_by_id(model.id)
+    volume_entity::Entity::delete_by_id(handle.local().expect("local handle").db_id)
         .exec(pools.write())
         .await?;
 
@@ -640,6 +649,34 @@ pub(crate) async fn remove_local(backend: Arc<dyn Backend>, name: &str) -> Micro
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
+
+/// Materialize a volume under a temporary sibling directory, then atomically
+/// rename it into place. This keeps failed disk formatting from exposing a
+/// half-populated final volume path.
+pub(crate) async fn materialize_volume_path(
+    config: &VolumeConfig,
+    path: &Path,
+) -> MicrosandboxResult<()> {
+    let parent = path.parent().ok_or_else(|| {
+        MicrosandboxError::InvalidConfig(format!(
+            "volume path has no parent directory: {}",
+            path.display()
+        ))
+    })?;
+
+    tokio::fs::create_dir_all(parent).await?;
+    if path.exists() {
+        return Err(MicrosandboxError::VolumeAlreadyExists(config.name.clone()));
+    }
+
+    let temp = tempfile::Builder::new()
+        .prefix(&format!(".{}.", config.name))
+        .tempdir_in(parent)?;
+    provision_volume_path(config, temp.path()).await?;
+    tokio::fs::rename(temp.path(), path).await?;
+    let _ = temp.keep();
+    Ok(())
+}
 
 pub(crate) async fn provision_volume_path(
     config: &VolumeConfig,
@@ -669,6 +706,105 @@ pub(crate) async fn provision_volume_path(
             Ok(())
         }
     }
+}
+
+pub(crate) fn lock_volume_name(local: &LocalBackend, name: &str) -> MicrosandboxResult<File> {
+    let volumes_dir = local.volumes_dir();
+    std::fs::create_dir_all(&volumes_dir)?;
+    let locks_dir = volumes_dir.join(".locks");
+    std::fs::create_dir_all(&locks_dir)?;
+    let path = locks_dir.join(format!("{name}.lock"));
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .truncate(false)
+        .write(true)
+        .open(&path)?;
+
+    #[cfg(unix)]
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    Ok(file)
+}
+
+fn lock_disk_volume_for_remove(handle: &VolumeHandle) -> MicrosandboxResult<Option<File>> {
+    if handle.kind() != VolumeKind::Disk {
+        return Ok(None);
+    }
+
+    let Some(path) = handle.disk_path() else {
+        return Ok(None);
+    };
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(|err| {
+            MicrosandboxError::InvalidConfig(format!(
+                "open disk named volume {} for removal: {err}",
+                handle.name()
+            ))
+        })?;
+
+    #[cfg(unix)]
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        let err = std::io::Error::last_os_error();
+        if matches!(err.kind(), std::io::ErrorKind::WouldBlock) {
+            return Err(MicrosandboxError::InvalidConfig(format!(
+                "volume {:?} is currently attached by a running sandbox",
+                handle.name()
+            )));
+        }
+        return Err(MicrosandboxError::InvalidConfig(format!(
+            "lock disk named volume {} for removal: {err}",
+            handle.name()
+        )));
+    }
+
+    Ok(Some(file))
+}
+
+async fn ensure_volume_not_referenced_by_active_sandbox<C>(
+    db: &C,
+    name: &str,
+) -> MicrosandboxResult<()>
+where
+    C: ConnectionTrait,
+{
+    let sandboxes = sandbox_entity::Entity::find()
+        .filter(sandbox_entity::Column::Status.is_in([
+            SandboxStatus::Running,
+            SandboxStatus::Draining,
+            SandboxStatus::Paused,
+        ]))
+        .all(db)
+        .await?;
+
+    for sandbox in sandboxes {
+        let config: SandboxConfig = serde_json::from_str(&sandbox.config)?;
+        if config.spec.mounts.iter().any(|mount| {
+            matches!(
+                mount,
+                VolumeMount::Named {
+                    name: mounted_name,
+                    ..
+                } if mounted_name == name
+            )
+        }) {
+            return Err(MicrosandboxError::InvalidConfig(format!(
+                "volume {name:?} is attached to active sandbox {:?}",
+                sandbox.name
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 pub(crate) fn validate_volume_config(config: &VolumeConfig) -> MicrosandboxResult<()> {
@@ -724,4 +860,78 @@ pub(crate) fn validate_volume_name(name: &str) -> MicrosandboxResult<()> {
     }
 
     Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use sea_orm::{ActiveModelTrait, Set};
+
+    use crate::backend::{Backend, LocalBackend};
+    use crate::sandbox::{HostPermissions, MountOptions, SandboxStatus, StatVirtualization};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_remove_local_rejects_active_named_volume_reference() {
+        let temp = tempfile::tempdir().unwrap();
+        let local = Arc::new(
+            LocalBackend::builder()
+                .home(temp.path().join("home"))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let backend: Arc<dyn Backend> = local.clone();
+        create_local(
+            backend.clone(),
+            VolumeConfig {
+                name: "active-cache".to_string(),
+                kind: VolumeKind::Directory,
+                quota_mib: None,
+                capacity_mib: None,
+                labels: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let config = SandboxConfig {
+            spec: microsandbox_types::SandboxSpec {
+                name: "active-sandbox".to_string(),
+                mounts: vec![VolumeMount::Named {
+                    name: "active-cache".to_string(),
+                    guest: "/cache".to_string(),
+                    create: None,
+                    options: MountOptions::default(),
+                    stat_virtualization: StatVirtualization::Strict,
+                    host_permissions: HostPermissions::Private,
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        sandbox_entity::ActiveModel {
+            name: Set("active-sandbox".to_string()),
+            config: Set(serde_json::to_string(&config).unwrap()),
+            status: Set(SandboxStatus::Running),
+            ephemeral: Set(false),
+            created_at: Set(Some(chrono::Utc::now().naive_utc())),
+            updated_at: Set(Some(chrono::Utc::now().naive_utc())),
+            ..Default::default()
+        }
+        .insert(local.db().await.unwrap().write())
+        .await
+        .unwrap();
+
+        let err = remove_local(backend, "active-cache").await.unwrap_err();
+
+        assert!(err.to_string().contains("attached to active sandbox"));
+        assert!(local.volume_path("active-cache").exists());
+    }
 }


### PR DESCRIPTION
## TL;DR
Restore the named-volume behavior that regressed in the backend split, including disk-backed named volumes for Docker-in-Docker. This also restores the lifecycle cleanup, locking, backend routing, and SDK bindings that depended on that old behavior.

## Description
- Restore named-volume resolution so disk-backed named volumes attach as block devices and directory-backed named volumes stay on virtiofs.
- Hold named-volume locks through sandbox create, roll back created rows and paths by id, reject active volume removal, and restore migration locking.
- Restore direct config mount validation, explicit local backend path validation, persisted config cleanup, and backend-routed logs and volume filesystem helpers.
- Bring Go, Node, and Python bindings back in line for named-volume options, logs, volume handles, Go security profile propagation, typed Go errors, and Node's deprecated `libkrunfwPath` builder chain.
- Tighten CLI and FFI validation for disk named mount options, and update docs for the restored directory-backed versus disk-backed policy contract.

```bash
msb run --name docker-demo --replace \
  --memory 2G \
  --mount-named docker-data:/var/lib/docker:kind=disk,size=10G \
  docker:dind
```

```typescript
const builder = Sandbox.builder("vm")
  .libkrunfwPath("/opt/microsandbox/libkrunfw.dylib")
  .image("alpine");
```

## Test Plan
- [x] `cargo fmt --all -- --check` and `git diff --check`
- [x] `cargo test -p microsandbox --lib runtime::spawn::tests`
- [x] `cargo test -p microsandbox-cli --lib commands::common::tests`
- [x] `cargo test -p microsandbox-go --lib` and `cd sdk/go && go test -count=1 ./...`
- [x] `cd sdk/node-ts && npm run build:native:debug && npm run build:ts && npm run typecheck && npm run test:unit`
- [x] `just build-msb` plus a `docker:dind` smoke using `--mount-named ...:kind=disk,size=10G` runs `docker run --rm hello-world`