### PR TITLE
chore(release): bump microsandbox to 0.5.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "base64",
  "chrono",
@@ -3213,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "base64",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-go"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "base64",
  "cbindgen",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "chrono",
  "libc",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics-collector"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "base64",
  "bytes",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "chrono",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "chrono",
  "futures",
@@ -3452,7 +3452,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "chrono",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "chrono",
  "serde",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "dirs",
  "libc",
@@ -6481,14 +6481,14 @@ dependencies = [
 
 [[package]]
 name = "test-init"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "test-macros"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6497,7 +6497,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.5.9"
+version = "0.5.10"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -64,18 +64,18 @@ panic = "abort"
 # Exact (`=`) pins: these crates share private, unstable APIs across patch
 # releases, so every published version must resolve its siblings to the same
 # version. Caret would let an older release pull newer siblings and break.
-microsandbox = { version = "=0.5.9", path = "sdk/rust", default-features = false }
-microsandbox-agent-client = { version = "=0.5.9", path = "packages/agent-client/rust" }
-microsandbox-db = { version = "=0.5.9", path = "crates/db" }
-microsandbox-filesystem = { version = "=0.5.9", path = "crates/filesystem", default-features = false }
-microsandbox-image = { version = "=0.5.9", path = "crates/image" }
-microsandbox-metrics = { version = "=0.5.9", path = "crates/metrics" }
-microsandbox-types = { version = "=0.5.9", path = "packages/microsandbox-types/rust" }
-microsandbox-migration = { version = "=0.5.9", path = "crates/migration" }
-microsandbox-network = { version = "=0.5.9", path = "crates/network" }
-microsandbox-protocol = { version = "=0.5.9", path = "crates/protocol" }
-microsandbox-runtime = { version = "=0.5.9", path = "crates/runtime", default-features = false }
-microsandbox-utils = { version = "=0.5.9", path = "crates/utils" }
+microsandbox = { version = "=0.5.10", path = "sdk/rust", default-features = false }
+microsandbox-agent-client = { version = "=0.5.10", path = "packages/agent-client/rust" }
+microsandbox-db = { version = "=0.5.10", path = "crates/db" }
+microsandbox-filesystem = { version = "=0.5.10", path = "crates/filesystem", default-features = false }
+microsandbox-image = { version = "=0.5.10", path = "crates/image" }
+microsandbox-metrics = { version = "=0.5.10", path = "crates/metrics" }
+microsandbox-types = { version = "=0.5.10", path = "packages/microsandbox-types/rust" }
+microsandbox-migration = { version = "=0.5.10", path = "crates/migration" }
+microsandbox-network = { version = "=0.5.10", path = "crates/network" }
+microsandbox-protocol = { version = "=0.5.10", path = "crates/protocol" }
+microsandbox-runtime = { version = "=0.5.10", path = "crates/runtime", default-features = false }
+microsandbox-utils = { version = "=0.5.10", path = "crates/utils" }
 msb_krun = { version = "0.1.17" }
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }

--- a/examples/typescript/cloud-backend/package.json
+++ b/examples/typescript/cloud-backend/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/init-handoff/package.json
+++ b/examples/typescript/init-handoff/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/snapshot-fork/package.json
+++ b/examples/typescript/snapshot-fork/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.5.9"
+    "microsandbox": "0.5.10"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/packages/agent-client/rust/README.md
+++ b/packages/agent-client/rust/README.md
@@ -10,19 +10,19 @@ Use this crate when you already have an agent relay endpoint and want direct pro
 
 ```toml
 [dependencies]
-microsandbox-agent-client = "0.5.9"
-microsandbox-protocol = "0.5.9"
+microsandbox-agent-client = "0.5.10"
+microsandbox-protocol = "0.5.10"
 ```
 
 The crate is transport-agnostic by default. Enable exactly the transport adapter you need:
 
 ```toml
 # Local microsandbox relay sockets.
-microsandbox-agent-client = { version = "0.5.9", features = ["uds"] }
+microsandbox-agent-client = { version = "0.5.10", features = ["uds"] }
 
 # Any caller-owned byte-stream transport (e.g. a pre-authenticated WebSocket
 # adapted to bytes).
-microsandbox-agent-client = { version = "0.5.9", features = ["stream"] }
+microsandbox-agent-client = { version = "0.5.10", features = ["stream"] }
 ```
 
 The high-level `microsandbox` SDK enables `uds` explicitly because local sandboxes are reached through Unix domain sockets.
@@ -99,7 +99,7 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
 Enable the `stream` feature:
 
 ```toml
-microsandbox-agent-client = { version = "0.5.9", features = ["stream"] }
+microsandbox-agent-client = { version = "0.5.10", features = ["stream"] }
 ```
 
 Drive the client over any `AsyncRead + AsyncWrite` — the caller owns the dial and any authentication, then hands over the connected stream:

--- a/packages/agent-client/typescript/package-lock.json
+++ b/packages/agent-client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/agent-client",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "Apache-2.0",
       "dependencies": {
         "cbor-x": "^1.6.0"

--- a/packages/agent-client/typescript/package.json
+++ b/packages/agent-client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "type": "module",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/microsandbox-types/rust/README.md
+++ b/packages/microsandbox-types/rust/README.md
@@ -25,7 +25,7 @@ Backend-private materialized state stays out: registry credentials, local CA pat
 
 ```toml
 [dependencies]
-microsandbox-types = "0.5.9"
+microsandbox-types = "0.5.10"
 ```
 
 ```rust

--- a/packages/microsandbox-types/typescript/package-lock.json
+++ b/packages/microsandbox-types/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/types",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6"

--- a/packages/microsandbox-types/typescript/package.json
+++ b/packages/microsandbox-types/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sdk/go/setup.go
+++ b/sdk/go/setup.go
@@ -24,7 +24,7 @@ import (
 // embedded FFI library and the downloaded msb+libkrunfw artefacts are
 // both pinned to this version. Bump when cutting a new SDK release so
 // it matches published binaries.
-const sdkVersion = "0.5.9"
+const sdkVersion = "0.5.10"
 
 // libkrunfwABI is the major SONAME version of libkrunfw that msb links
 // against.

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.5.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -22,9 +22,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.5.9",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.9",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.9"
+        "@superradcompany/microsandbox-darwin-arm64": "0.5.10",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.10",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.10"
       }
     },
     "node_modules/@emnapi/core": {

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -48,9 +48,9 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.5.9",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.9",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.5.9"
+    "@superradcompany/microsandbox-darwin-arm64": "0.5.10",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.10",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.5.10"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## TL;DR
Bump microsandbox from 0.5.9 to 0.5.10 across the workspace, SDK/package metadata, examples, and release reference docs.

## Description
- Bump the Rust workspace version and exact internal crate pins to 0.5.10.
- Refresh Cargo.lock plus npm lock metadata for the Node SDK and shared TypeScript packages.
- Bump TypeScript example dependencies, Node platform package versions, Node native loader checks, and the Go SDK pinned version.
- Update Rust package README release snippets for `microsandbox-agent-client` and `microsandbox-types`.
- Advance `mcp` to `772f509d` and `skills` to `fa994b6c` for their 0.5.10 release references.
- Related submodule PRs: https://github.com/superradcompany/microsandbox-mcp/pull/12 and https://github.com/superradcompany/skills/pull/11.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `CI=1 cargo check --workspace`
- [x] `CI=1 cargo test --workspace`
- [x] `CI=1 cargo clippy --workspace -- -D warnings`
- [x] `just build-msb`
- [x] `npm ci`, `npm run build`, `npm run typecheck`, and `npm test` in `packages/agent-client/typescript`
- [x] `npm ci`, `npm run build`, and `npm run typecheck` in `packages/microsandbox-types/typescript`
- [x] `cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate -- --check`
- [x] `npm ci`, `CI=1 npm run build`, `npm run typecheck`, and `MSB_PATH=$PWD/../../build/msb MSB_LIBKRUNFW_PATH=$PWD/../../build/libkrunfw.5.dylib npm test` in `sdk/node-ts`
- [x] `go test -count=1 .` in `sdk/go`
- [x] `MICROSANDBOX_FFI_PATH=$PWD/../../target/debug/libmicrosandbox_go_ffi.dylib MSB_PATH=$PWD/../../build/msb MSB_LIBKRUNFW_PATH=$PWD/../../build/libkrunfw.5.dylib go test -tags "smoke microsandbox_ffi_path" -count=1 -timeout 2m .` in `sdk/go`
- [x] `uv sync --group dev`, `CI=1 uv run maturin develop --release`, `uv run pytest`, and `uv run ruff check .` in `sdk/python`
- [x] `npm publish --dry-run --ignore-scripts` for `packages/agent-client/typescript`, `packages/microsandbox-types/typescript`, `sdk/node-ts`, and the three `sdk/node-ts/npm/*` platform packages
- [x] `CI=1 cargo publish --dry-run --workspace --exclude test-init --exclude test-macros --exclude test-utils --allow-dirty --no-verify`
- [ ] Full Cargo publish verification: deferred because package verification downloads the not-yet-published `v0.5.10/agentd-aarch64` release artifact and currently 404s before this release exists.