### PR TITLE
fix(sdk): stop waiting on zombie sandbox runtimes

### DIFF
--- a/crates/runtime/lib/maintenance.rs
+++ b/crates/runtime/lib/maintenance.rs
@@ -97,7 +97,7 @@ pub struct MaintenanceLimits {
 /// Summary of what one maintenance sweep did. Best-effort counters only.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MaintenanceReport {
-    /// Stale active sandboxes reconciled to `Crashed`.
+    /// Stale active sandboxes reconciled to a terminal status.
     pub reconciled: u64,
     /// Terminal ephemeral sandboxes removed.
     pub removed: u64,
@@ -177,7 +177,7 @@ pub async fn run_sandbox_lifecycle_maintenance(
     let start = Instant::now();
 
     // Phase 1: stale active reconciliation. Mark sandboxes whose owning
-    // runtime died (dead PID) as Crashed.
+    // runtime died (dead PID) as terminal.
     let active = sandbox_entity::Entity::find()
         .filter(sandbox_entity::Column::Status.is_in([
             sandbox_entity::SandboxStatus::Running,
@@ -394,7 +394,7 @@ async fn record_completion(db: &DbWriteConnection) -> RuntimeResult<()> {
 //--------------------------------------------------------------------------------------------------
 
 /// Reconcile one active sandbox whose owning runtime may have died. Returns
-/// `true` when the sandbox was marked `Crashed`.
+/// `true` when the sandbox was marked terminal.
 async fn reconcile_stale_active(
     db: &DbWriteConnection,
     sandbox: &sandbox_entity::Model,
@@ -412,41 +412,36 @@ async fn reconcile_stale_active(
         return Ok(false);
     };
 
-    // NOTE: `pid_is_alive` uses `kill(pid, 0)`, which cannot distinguish a
-    // genuinely live runtime from an unrelated process that reused the PID
-    // after a reboot. A post-reboot stale row whose PID was reused therefore
-    // stays Running until that PID exits. Addressing this needs a boot-id or
-    // process-start-time check stored alongside the PID; left as a known,
-    // pre-existing limitation (the prior SDK reaper had the same gap).
+    // NOTE: `pid_is_alive` treats zombies as dead, but still cannot
+    // distinguish a genuinely live runtime from an unrelated process that
+    // reused the PID after a reboot. A post-reboot stale row whose PID was
+    // reused therefore stays Running until that PID exits. Addressing this
+    // needs a boot-id or process-start-time check stored alongside the PID;
+    // left as a known, pre-existing limitation.
     if run.pid.is_some_and(pid_is_alive) {
         return Ok(false);
     }
 
     let now = chrono::Utc::now().naive_utc();
+    let (terminal_status, reason) = stale_runtime_terminal_state(sandbox.status);
 
-    // Mark the dead run Terminated/InternalError only while still Running.
+    // Mark the dead run Terminated only while still Running.
     run_entity::Entity::update_many()
         .col_expr(
             run_entity::Column::Status,
             Expr::value(run_entity::RunStatus::Terminated),
         )
-        .col_expr(
-            run_entity::Column::TerminationReason,
-            Expr::value(run_entity::TerminationReason::InternalError),
-        )
+        .col_expr(run_entity::Column::TerminationReason, Expr::value(reason))
         .col_expr(run_entity::Column::TerminatedAt, Expr::value(now))
         .filter(run_entity::Column::Id.eq(run.id))
         .filter(run_entity::Column::Status.eq(run_entity::RunStatus::Running))
         .exec(db)
         .await?;
 
-    // Mark Crashed only while still Running/Draining so a concurrent start
-    // that flipped the row back to Running is not clobbered.
+    // Reconcile only while still active so a concurrent lifecycle transition
+    // is not clobbered.
     let result = sandbox_entity::Entity::update_many()
-        .col_expr(
-            sandbox_entity::Column::Status,
-            Expr::value(sandbox_entity::SandboxStatus::Crashed),
-        )
+        .col_expr(sandbox_entity::Column::Status, Expr::value(terminal_status))
         .col_expr(sandbox_entity::Column::UpdatedAt, Expr::value(now))
         .filter(sandbox_entity::Column::Id.eq(sandbox.id))
         .filter(sandbox_entity::Column::Status.is_in([
@@ -457,6 +452,24 @@ async fn reconcile_stale_active(
         .await?;
 
     Ok(result.rows_affected > 0)
+}
+
+fn stale_runtime_terminal_state(
+    status: sandbox_entity::SandboxStatus,
+) -> (sandbox_entity::SandboxStatus, run_entity::TerminationReason) {
+    match status {
+        // Draining means a stop/drain request was already accepted. If the
+        // owning runtime is now gone, the lifecycle reached its requested
+        // terminal state even when the original observer could not reap it.
+        sandbox_entity::SandboxStatus::Draining => (
+            sandbox_entity::SandboxStatus::Stopped,
+            run_entity::TerminationReason::ShutdownRequested,
+        ),
+        _ => (
+            sandbox_entity::SandboxStatus::Crashed,
+            run_entity::TerminationReason::InternalError,
+        ),
+    }
 }
 
 /// Whether the sandbox has any run that is still Running with a live PID.
@@ -477,16 +490,10 @@ fn is_terminal(status: sandbox_entity::SandboxStatus) -> bool {
     )
 }
 
-/// Best-effort liveness probe for a PID. Treats `EPERM` as alive (the PID
-/// exists but is owned by another user).
+/// Best-effort liveness probe for a PID. Zombies are treated as dead because
+/// the runtime has exited even if its parent has not reaped the process yet.
 fn pid_is_alive(pid: i32) -> bool {
-    if unsafe { libc::kill(pid, 0) } == 0 {
-        return true;
-    }
-    matches!(
-        std::io::Error::last_os_error().raw_os_error(),
-        Some(code) if code == libc::EPERM
-    )
+    microsandbox_utils::process::pid_is_alive(pid)
 }
 
 /// Remove a directory tree, treating a missing directory as success.
@@ -706,6 +713,22 @@ mod tests {
         let dead = insert_sandbox(&db, "dead", sandbox_entity::SandboxStatus::Running, false).await;
         insert_run(&db, dead, Some(DEAD_PID), run_entity::RunStatus::Running).await;
 
+        // Persistent Draining sandbox with a dead PID completed a requested stop.
+        let draining = insert_sandbox(
+            &db,
+            "draining",
+            sandbox_entity::SandboxStatus::Draining,
+            false,
+        )
+        .await;
+        insert_run(
+            &db,
+            draining,
+            Some(DEAD_PID),
+            run_entity::RunStatus::Running,
+        )
+        .await;
+
         // Ephemeral Stopped sandbox should be removed in phase 2.
         let eph = insert_sandbox(&db, "eph", sandbox_entity::SandboxStatus::Stopped, true).await;
         std::fs::create_dir_all(dir.path().join("eph")).unwrap();
@@ -715,12 +738,16 @@ mod tests {
                 .await
                 .unwrap();
 
-        assert_eq!(report.reconciled, 1);
+        assert_eq!(report.reconciled, 2);
         assert_eq!(report.removed, 1);
         assert_eq!(report.errors, 0);
         assert_eq!(
             status_of(&db, dead).await,
             Some(sandbox_entity::SandboxStatus::Crashed)
+        );
+        assert_eq!(
+            status_of(&db, draining).await,
+            Some(sandbox_entity::SandboxStatus::Stopped)
         );
         assert!(status_of(&db, eph).await.is_none());
         assert!(!dir.path().join("eph").exists());

--- a/crates/utils/lib/lib.rs
+++ b/crates/utils/lib/lib.rs
@@ -3,6 +3,7 @@
 pub mod copy;
 pub mod format;
 pub mod log_text;
+pub mod process;
 pub mod size;
 pub mod ttl_reverse_index;
 pub mod wake_pipe;

--- a/crates/utils/lib/process.rs
+++ b/crates/utils/lib/process.rs
@@ -1,0 +1,144 @@
+//! Process-state helpers shared by host-side lifecycle code.
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Return whether `pid` names a live, runnable process.
+///
+/// This intentionally treats zombies as not alive. `kill(pid, 0)` reports
+/// success for zombies because the PID still exists, but a zombie sandbox
+/// runtime has already exited and can only be reaped by its parent.
+pub fn pid_is_alive(pid: i32) -> bool {
+    if !pid_exists(pid) {
+        return false;
+    }
+
+    !pid_is_zombie(pid).unwrap_or(false)
+}
+
+/// Return whether `pid` exists, regardless of whether it can still run.
+pub fn pid_exists(pid: i32) -> bool {
+    if pid <= 0 {
+        return false;
+    }
+
+    let result = unsafe { libc::kill(pid, 0) };
+    if result == 0 {
+        return true;
+    }
+
+    matches!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(code) if code == libc::EPERM
+    )
+}
+
+/// Return whether `pid` is currently a zombie process.
+///
+/// Returns `None` when the platform cannot report process state or when the
+/// process disappears between the existence check and the state probe.
+pub fn pid_is_zombie(pid: i32) -> Option<bool> {
+    if pid <= 0 {
+        return Some(false);
+    }
+
+    pid_is_zombie_platform(pid)
+}
+
+#[cfg(target_os = "linux")]
+fn pid_is_zombie_platform(pid: i32) -> Option<bool> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let close_paren = stat.rfind(')')?;
+    let state = stat
+        .get(close_paren + 1..)?
+        .bytes()
+        .find(|byte| !byte.is_ascii_whitespace())?;
+    Some(state == b'Z')
+}
+
+#[cfg(target_os = "macos")]
+fn pid_is_zombie_platform(pid: i32) -> Option<bool> {
+    // `proc_pidinfo(PROC_PIDTBSDINFO)` returns no record for zombies on
+    // Darwin, but the kern.proc.pid sysctl still exposes `extern_proc.p_stat`.
+    // On 64-bit Darwin the offset is stable:
+    // p_un(16) + p_vmspace(8) + p_sigacts(8) + p_flag(4) = 36.
+    const KINFO_PROC_P_STAT_OFFSET: usize = 36;
+
+    let mut mib = [libc::CTL_KERN, libc::KERN_PROC, libc::KERN_PROC_PID, pid];
+    let mut len: libc::size_t = 0;
+    let size_result = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as libc::c_uint,
+            std::ptr::null_mut(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if size_result != 0 || len <= KINFO_PROC_P_STAT_OFFSET {
+        return None;
+    }
+
+    let mut buf = vec![0u8; len];
+    let read_result = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as libc::c_uint,
+            buf.as_mut_ptr().cast::<libc::c_void>(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if read_result != 0 || len <= KINFO_PROC_P_STAT_OFFSET {
+        return None;
+    }
+
+    Some(buf[KINFO_PROC_P_STAT_OFFSET] == libc::SZOMB as u8)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn pid_is_zombie_platform(_pid: i32) -> Option<bool> {
+    None
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+    use std::time::{Duration, Instant};
+
+    use super::*;
+
+    #[test]
+    fn pid_liveness_treats_zombies_as_dead() {
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("exit 0")
+            .spawn()
+            .expect("spawn short-lived child");
+        let pid = child.id() as i32;
+        let deadline = Instant::now() + Duration::from_secs(5);
+
+        while Instant::now() < deadline {
+            if pid_is_zombie(pid) == Some(true) {
+                assert!(
+                    !pid_is_alive(pid),
+                    "zombie process should not count as alive"
+                );
+                let _ = child.wait();
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let status = child.try_wait().expect("poll child");
+        let _ = child.wait();
+        panic!("child did not become observable as a zombie; last status: {status:?}");
+    }
+}

--- a/sdk/rust/lib/sandbox/attach.rs
+++ b/sdk/rust/lib/sandbox/attach.rs
@@ -332,7 +332,9 @@ pub(crate) mod local {
                             }
 
                             let payload = ExecStdin { data: data.to_vec() };
-                            let _ = client.send(id, MessageType::ExecStdin, &payload).await;
+                            if client.send(id, MessageType::ExecStdin, &payload).await.is_err() {
+                                break;
+                            }
                         }
                         Ok(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
                         Ok(Err(_)) => break,
@@ -340,7 +342,11 @@ pub(crate) mod local {
                     }
                 }
 
-                Some(msg) = rx.recv() => {
+                msg = rx.recv() => {
+                    let Some(msg) = msg else {
+                        break;
+                    };
+
                     let mut should_break = false;
 
                     match msg.t {

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -877,6 +877,15 @@ pub(crate) async fn stop_local(
         return Ok(());
     }
 
+    if model.status == SandboxStatus::Running {
+        update_sandbox_status(
+            local_backend.db().await?.write(),
+            model.id,
+            SandboxStatus::Draining,
+        )
+        .await?;
+    }
+
     // Try the clean-shutdown path: connect to the agent relay UDS and send
     // `core.shutdown`. agentd runs `sync()` + `reboot(RB_POWER_OFF)` so
     // block-root filesystems unmount cleanly.
@@ -888,7 +897,19 @@ pub(crate) async fn stop_local(
     .await
     {
         Ok(client) => {
-            client.send(0, MessageType::Shutdown, &()).await?;
+            if let Err(e) = client.send(0, MessageType::Shutdown, &()).await {
+                tracing::warn!(
+                    sandbox = %name,
+                    error = %e,
+                    "stop_local: failed to send shutdown; falling back to SIGTERM",
+                );
+                if let Some(pid) = pid.filter(|p| pid_is_alive(*p)) {
+                    nix::sys::signal::kill(
+                        nix::unistd::Pid::from_raw(pid),
+                        nix::sys::signal::Signal::SIGTERM,
+                    )?;
+                }
+            }
             Ok(())
         }
         Err(e) => {
@@ -982,7 +1003,20 @@ pub(crate) async fn drain_local(
                 feature: "drain_local".into(),
                 available_when: "with a LocalBackend".into(),
             })?;
-    let (_, pid) = get_local_handle_state(local_backend, name).await?;
+    let (model, pid) = get_local_handle_state(local_backend, name).await?;
+    if model.status != SandboxStatus::Running && model.status != SandboxStatus::Draining {
+        return Ok(());
+    }
+
+    if model.status == SandboxStatus::Running {
+        update_sandbox_status(
+            local_backend.db().await?.write(),
+            model.id,
+            SandboxStatus::Draining,
+        )
+        .await?;
+    }
+
     if let Some(pid) = pid.filter(|p| pid_is_alive(*p)) {
         nix::sys::signal::kill(
             nix::unistd::Pid::from_raw(pid),
@@ -1942,7 +1976,15 @@ pub(super) async fn reconcile_sandbox_runtime_state(
         return Ok(sandbox);
     }
 
-    mark_sandbox_runtime_stale(pools.write(), sandbox.id, Some(run.id)).await?;
+    let (terminal_status, reason) = stale_runtime_terminal_state(sandbox.status);
+    mark_sandbox_runtime_stale(
+        pools.write(),
+        sandbox.id,
+        Some(run.id),
+        terminal_status,
+        reason,
+    )
+    .await?;
 
     sandbox_entity::Entity::find_by_id(sandbox.id)
         .one(pools.read())
@@ -1996,10 +2038,30 @@ fn pid_from_run(run: Option<&run_entity::Model>) -> Option<i32> {
         .filter(|pid| pid_is_alive(*pid))
 }
 
+fn stale_runtime_terminal_state(
+    status: SandboxStatus,
+) -> (SandboxStatus, run_entity::TerminationReason) {
+    match status {
+        // Draining means a stop/drain request was already accepted. If the
+        // owning runtime is now gone, the lifecycle reached its requested
+        // terminal state even when the original observer could not reap it.
+        SandboxStatus::Draining => (
+            SandboxStatus::Stopped,
+            run_entity::TerminationReason::ShutdownRequested,
+        ),
+        _ => (
+            SandboxStatus::Crashed,
+            run_entity::TerminationReason::InternalError,
+        ),
+    }
+}
+
 async fn mark_sandbox_runtime_stale(
     db: &DbWriteConnection,
     sandbox_id: i32,
     run_id: Option<i32>,
+    terminal_status: SandboxStatus,
+    reason: run_entity::TerminationReason,
 ) -> MicrosandboxResult<()> {
     db.transaction(|txn| async move {
         let now = chrono::Utc::now().naive_utc();
@@ -2010,23 +2072,17 @@ async fn mark_sandbox_runtime_stale(
                     run_entity::Column::Status,
                     Expr::value(run_entity::RunStatus::Terminated),
                 )
-                .col_expr(
-                    run_entity::Column::TerminationReason,
-                    Expr::value(run_entity::TerminationReason::InternalError),
-                )
+                .col_expr(run_entity::Column::TerminationReason, Expr::value(reason))
                 .col_expr(run_entity::Column::TerminatedAt, Expr::value(now))
                 .filter(run_entity::Column::Id.eq(run_id))
                 .exec(&txn)
                 .await?;
         }
 
-        // Only mark Crashed if the sandbox is still Running or Draining. This
-        // prevents a concurrent start() from having its Running status overwritten.
+        // Only reconcile an active row. This prevents a concurrent start()
+        // from having its newly-terminal or newly-running status overwritten.
         sandbox_entity::Entity::update_many()
-            .col_expr(
-                sandbox_entity::Column::Status,
-                Expr::value(SandboxStatus::Crashed),
-            )
+            .col_expr(sandbox_entity::Column::Status, Expr::value(terminal_status))
             .col_expr(sandbox_entity::Column::UpdatedAt, Expr::value(now))
             .filter(sandbox_entity::Column::Id.eq(sandbox_id))
             .filter(
@@ -2042,15 +2098,7 @@ async fn mark_sandbox_runtime_stale(
 }
 
 pub(super) fn pid_is_alive(pid: i32) -> bool {
-    let result = unsafe { libc::kill(pid, 0) };
-    if result == 0 {
-        return true;
-    }
-
-    matches!(
-        std::io::Error::last_os_error().raw_os_error(),
-        Some(code) if code == libc::EPERM
-    )
+    microsandbox_utils::process::pid_is_alive(pid)
 }
 
 fn pid_is_dead_or_reaped(pid: i32) -> bool {
@@ -3203,6 +3251,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_reconcile_sandbox_runtime_state_marks_dead_draining_stopped() {
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let pools = open_test_pools(&db_path).await;
+
+        let config = test_config("draining-stale");
+        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
+        super::update_sandbox_status(pools.write(), sandbox_id, SandboxStatus::Draining)
+            .await
+            .unwrap();
+
+        let run = run_entity::ActiveModel {
+            sandbox_id: Set(sandbox_id),
+            pid: Set(Some(dead_pid())),
+            status: Set(run_entity::RunStatus::Running),
+            ..Default::default()
+        };
+        let run_id = run_entity::Entity::insert(run)
+            .exec(pools.write())
+            .await
+            .unwrap()
+            .last_insert_id;
+
+        let sandbox = super::sandbox_entity::Entity::find_by_id(sandbox_id)
+            .one(pools.write())
+            .await
+            .unwrap()
+            .unwrap();
+        let reconciled = reconcile_sandbox_runtime_state(&pools, sandbox)
+            .await
+            .unwrap();
+        assert_eq!(reconciled.status, SandboxStatus::Stopped);
+
+        let run = run_entity::Entity::find_by_id(run_id)
+            .one(pools.write())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(run.status, run_entity::RunStatus::Terminated);
+        assert_eq!(
+            run.termination_reason,
+            Some(run_entity::TerminationReason::ShutdownRequested)
+        );
+        assert!(run.terminated_at.is_some());
+    }
+
+    #[tokio::test]
     async fn test_prepare_create_target_force_replaces_stale_running_sandbox_state() {
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
@@ -3368,7 +3463,7 @@ mod tests {
         .await
         .unwrap();
 
-        // --- Sandbox C: Draining + dead PID → should become Crashed ---
+        // --- Sandbox C: Draining + dead PID → should become Stopped ---
         let cfg_c = test_config("draining-dead");
         let id_c = insert_sandbox_record(pools.write(), &cfg_c).await.unwrap();
         super::update_sandbox_status(pools.write(), id_c, SandboxStatus::Draining)
@@ -3423,7 +3518,7 @@ mod tests {
 
         assert_eq!(load(id_a).await.status, SandboxStatus::Crashed);
         assert_eq!(load(id_b).await.status, SandboxStatus::Running);
-        assert_eq!(load(id_c).await.status, SandboxStatus::Crashed);
+        assert_eq!(load(id_c).await.status, SandboxStatus::Stopped);
         assert_eq!(load(id_d).await.status, SandboxStatus::Stopped);
         assert_eq!(load(id_e).await.status, SandboxStatus::Running);
 


### PR DESCRIPTION
## TL;DR
Fix local sandbox stop and attach behavior when the runtime process has already exited as a zombie. This prevents `msb stop` from waiting forever on a dead runtime and makes dead attach sessions close instead of swallowing input.

## Description
- Treat zombie PIDs as dead in shared host-side process helpers, while preserving the existing PID existence behavior for permission-protected processes.
- Use the shared zombie-aware liveness check in SDK reconciliation and runtime startup maintenance.
- Mark local stop and drain requests as `Draining` before signaling so later reconciliation can tell an expected shutdown from an unexpected crash.
- Reconcile stale `Draining` runtimes to `Stopped` with `ShutdownRequested`, while stale `Running` runtimes still become `Crashed` with `InternalError`.
- Fall back to SIGTERM if the agent shutdown send fails after connecting.
- Exit attach sessions when stdin forwarding fails or the relay receiver closes, so a dead terminal does not keep consuming input.
- Cover the zombie PID helper, stale `Draining` reconciliation, maintenance sweeps, and attach close behavior with focused tests.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p microsandbox-utils process`
- [x] `cargo test -p microsandbox --lib sandbox::tests`
- [x] `cargo test -p microsandbox-runtime maintenance`
- [x] `cargo test -p microsandbox --lib sandbox::attach::tests`
- [x] `cargo build -p microsandbox-cli`