### PR TITLE
build(sdk): add Windows SDK packages

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -264,7 +264,10 @@ jobs:
 
       - name: Build Node SDK
         working-directory: sdk/node-ts
-        run: npm ci && npm run build
+        run: |
+          node scripts/prune-platform-optional-deps.mjs
+          npm install --package-lock=false
+          npm run build
 
       # -- Checks (Python SDK) --
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -585,7 +588,9 @@ jobs:
 
       - name: Install Node.js dependencies
         working-directory: sdk/node-ts
-        run: npm ci --ignore-scripts
+        run: |
+          node scripts/prune-platform-optional-deps.mjs
+          npm install --package-lock=false --ignore-scripts
 
       # The published platform-pkg msb may lag the SDK; replace it with the
       # freshly-built binaries so the smoke test runs against current code.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -371,6 +371,7 @@ jobs:
             sdk/node-ts/dist/
             sdk/node-ts/package.json
             sdk/node-ts/package-lock.json
+            sdk/node-ts/scripts/prune-platform-optional-deps.mjs
             sdk/node-ts/tests/
             sdk/node-ts/tsconfig.json
             sdk/node-ts/vitest.config.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,8 @@ jobs:
       - name: Build Node SDK
         working-directory: sdk/node-ts
         run: |
-          npm ci
+          node scripts/prune-platform-optional-deps.mjs
+          npm install --package-lock=false
           npm run build:native -- --target ${{ matrix.napi_target }}
           npm run build:ts
 
@@ -413,6 +414,9 @@ jobs:
             agentd_artifact: agentd-aarch64-linux-musl
             vs_arch: arm64
             vs_host_arch: arm64
+            napi_target: aarch64-pc-windows-msvc
+            node_file: microsandbox.win32-arm64-msvc.node
+            npm_dir: win32-arm64-msvc
             msb_asset: msb-windows-aarch64.exe
             msb_metrics_asset: msb-metrics-windows-aarch64.exe
             libkrunfw_asset: libkrunfw-windows-aarch64.dll
@@ -423,6 +427,9 @@ jobs:
             agentd_artifact: agentd-x86_64-linux-musl
             vs_arch: amd64
             vs_host_arch: amd64
+            napi_target: x86_64-pc-windows-msvc
+            node_file: microsandbox.win32-x64-msvc.node
+            npm_dir: win32-x64-msvc
             msb_asset: msb-windows-x86_64.exe
             msb_metrics_asset: msb-metrics-windows-x86_64.exe
             libkrunfw_asset: libkrunfw-windows-x86_64.dll
@@ -486,6 +493,68 @@ jobs:
           New-Item -ItemType Directory -Force -Path build | Out-Null
           Copy-Item target\${{ matrix.rust_target }}\release\msb-metrics.exe build\msb-metrics.exe -Force
 
+      # -- Node SDK --
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Build Node SDK
+        shell: pwsh
+        working-directory: sdk/node-ts
+        run: |
+          $ErrorActionPreference = "Stop"
+          . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"
+          Set-MsvcEnvironment -Architecture ${{ matrix.vs_arch }} -HostArchitecture ${{ matrix.vs_host_arch }}
+          node scripts/prune-platform-optional-deps.mjs
+          npm install --package-lock=false
+          npm run build:native -- --target ${{ matrix.napi_target }}
+          npm run build:ts
+
+      - name: Prepare Node platform package
+        shell: pwsh
+        working-directory: sdk/node-ts
+        run: node scripts/prepare-platform-package.mjs ${{ matrix.npm_dir }}
+
+      - name: Upload Node SDK artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: node-sdk-${{ matrix.npm_dir }}
+          path: |
+            sdk/node-ts/native/${{ matrix.node_file }}
+            sdk/node-ts/native/index.cjs
+            sdk/node-ts/native/index.d.ts
+            sdk/node-ts/npm/${{ matrix.npm_dir }}/${{ matrix.node_file }}
+            sdk/node-ts/npm/${{ matrix.npm_dir }}/bin/*
+            sdk/node-ts/npm/${{ matrix.npm_dir }}/lib/*
+
+      # -- Python SDK --
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "sdk/python/uv.lock"
+
+      - name: Stage runtime bundle (Python SDK)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          New-Item -ItemType Directory -Force -Path sdk\python\microsandbox\_bundled\bin | Out-Null
+          New-Item -ItemType Directory -Force -Path sdk\python\microsandbox\_bundled\lib | Out-Null
+          Copy-Item build\msb.exe sdk\python\microsandbox\_bundled\bin\msb.exe -Force
+          Copy-Item build\libkrunfw.dll sdk\python\microsandbox\_bundled\lib\libkrunfw.dll -Force
+
+      - name: Build Python wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+        with:
+          working-directory: sdk/python
+          command: build
+          args: --release --out dist --target ${{ matrix.rust_target }}
+
+      - name: Upload Python SDK wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-sdk-${{ matrix.target }}
+          path: sdk/python/dist/*.whl
+
       - name: Stage artifacts
         shell: pwsh
         run: |
@@ -495,6 +564,7 @@ jobs:
           Copy-Item build\msb-metrics.exe artifacts\${{ matrix.msb_metrics_asset }} -Force
           Copy-Item build\libkrunfw.dll artifacts\${{ matrix.libkrunfw_asset }} -Force
           Compress-Archive -Path build\msb.exe, build\libkrunfw.dll -DestinationPath artifacts\microsandbox-${{ matrix.target }}.zip -Force
+          tar.exe -czf artifacts\microsandbox-${{ matrix.target }}.tar.gz -C build msb.exe libkrunfw.dll
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -625,7 +695,7 @@ jobs:
   # ---------------------------------------------------------------------------
   npm-publish:
     name: Publish npm packages
-    needs: build
+    needs: [build, build-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -644,14 +714,16 @@ jobs:
       - name: Place binaries and update generated files
         run: |
           # Copy prepared platform package payloads.
-          for dir in darwin-arm64 linux-x64-gnu linux-arm64-gnu; do
+          for dir in darwin-arm64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc win32-arm64-msvc; do
             mkdir -p "sdk/node-ts/npm/$dir/bin" "sdk/node-ts/npm/$dir/lib"
             cp "node-artifacts/node-sdk-$dir/npm/$dir"/microsandbox.*.node "sdk/node-ts/npm/$dir/"
-            cp "node-artifacts/node-sdk-$dir/npm/$dir/bin/msb" "sdk/node-ts/npm/$dir/bin/"
+            cp "node-artifacts/node-sdk-$dir/npm/$dir/bin/"* "sdk/node-ts/npm/$dir/bin/"
             cp "node-artifacts/node-sdk-$dir/npm/$dir/lib/"* "sdk/node-ts/npm/$dir/lib/"
             # GitHub Actions artifacts strip Unix exec bits; restore before publish
             # so the published tarball carries 0755 on the binary.
-            chmod +x "sdk/node-ts/npm/$dir/bin/msb"
+            if [ -f "sdk/node-ts/npm/$dir/bin/msb" ]; then
+              chmod +x "sdk/node-ts/npm/$dir/bin/msb"
+            fi
           done
 
           # Copy napi-generated bindings into the root package's native/ dir
@@ -664,7 +736,7 @@ jobs:
       - name: Build TypeScript output (root package dist/)
         working-directory: sdk/node-ts
         run: |
-          npm ci
+          npm install --omit=optional --package-lock=false
           npm run build:ts
 
       - name: Build and publish agent client package
@@ -689,7 +761,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          for dir in darwin-arm64 linux-x64-gnu linux-arm64-gnu; do
+          for dir in darwin-arm64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc win32-arm64-msvc; do
             echo "Publishing @superradcompany/microsandbox-$dir..."
             cd sdk/node-ts/npm/$dir
             npm publish --access public
@@ -698,6 +770,30 @@ jobs:
 
       - name: Wait for npm to index platform packages
         run: sleep 30
+
+      - name: Verify root package platform dependencies
+        working-directory: sdk/node-ts
+        run: |
+          node - <<'NODE'
+          const fs = require("node:fs");
+
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const optionalDependencies = pkg.optionalDependencies ?? {};
+          const required = [
+            "@superradcompany/microsandbox-darwin-arm64",
+            "@superradcompany/microsandbox-linux-arm64-gnu",
+            "@superradcompany/microsandbox-linux-x64-gnu",
+            "@superradcompany/microsandbox-win32-arm64-msvc",
+            "@superradcompany/microsandbox-win32-x64-msvc",
+          ];
+
+          const missing = required.filter((name) => optionalDependencies[name] !== pkg.version);
+
+          if (missing.length > 0) {
+            console.error(`Missing or mismatched platform optional dependencies: ${missing.join(", ")}`);
+            process.exit(1);
+          }
+          NODE
 
       - name: Publish root package
         env:
@@ -815,7 +911,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pypi-publish:
     name: Publish Python SDK
-    needs: build
+    needs: [build, build-windows]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@
 ##
 
 - <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **Hardware Isolation**: Hardware-level isolation with microVM technology.
-- <img height="14" src="https://octicons-col.vercel.app/globe/A770EF"> **Cross Platform**: Runs on Linux and macOS.
-<!-- - <img height="14" src="https://octicons-col.vercel.app/globe/A770EF"> **Cross Platform**: Runs on Linux, macOS, and Windows. -->
+- <img height="14" src="https://octicons-col.vercel.app/globe/A770EF"> **Cross Platform**: Runs on Linux, macOS, and Windows.
 - <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **OCI Compatible**: Runs standard container images from Docker Hub, GHCR, or any OCI registry.
 - <img height="14" src="https://octicons-col.vercel.app/container/A770EF"> **Docker-Like Workflows**: Familiar image, command, shell, and volume workflows.
 - <img height="14" src="https://octicons-col.vercel.app/zap/A770EF"> **Instant Startup**: Average boot times[^boot-time] under 100 milliseconds.
@@ -78,12 +77,10 @@
 > curl -fsSL https://install.microsandbox.dev | sh        # 🍎 macOS / 🐧 Linux
 > ```
 >
-<!--
 > ```powershell
 > irm https://install.microsandbox.dev/windows | iex      # 🪟 Windows
 > ```
 >
--->
 > <details>
 > <summary><em>&nbsp;We also support other package managers  →</em></summary>
 >
@@ -93,12 +90,10 @@
 > brew install superradcompany/tap/microsandbox
 > ```
 >
-<!--
 > ```sh
 > winget install SuperRadCompany.Microsandbox
 > ```
 >
--->
 > ```sh
 > npm i -g microsandbox
 > ```
@@ -127,7 +122,7 @@
 >
 > - <img height="14" src="https://api.iconify.design/simple-icons:apple.svg?color=%23A770EF" alt="macOS"> **macOS**: Apple Silicon.
 > - <img height="14" src="https://api.iconify.design/simple-icons:linux.svg?color=%23A770EF" alt="Linux"> **Linux**: KVM enabled.
-<!-- > - <img height="14" src="https://api.iconify.design/simple-icons:windows.svg?color=%23A770EF" alt="Windows"> **Windows**: WHP enabled. -->
+> - <img height="14" src="https://api.iconify.design/simple-icons:windows.svg?color=%23A770EF" alt="Windows"> **Windows**: WHP enabled.
 >
 > **Warning**: Microsandbox is still **beta software**. Expect breaking changes, missing features, and rough edges.
 

--- a/sdk/go/integration/metrics_test.go
+++ b/sdk/go/integration/metrics_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,12 +26,7 @@ func TestMetricsStreamRecv(t *testing.T) {
 
 	var lastUptime time.Duration
 	for i := 0; i < 3; i++ {
-		recvCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		m, err := stream.Recv(recvCtx)
-		cancel()
-		if err != nil {
-			t.Fatalf("Recv #%d: %v", i, err)
-		}
+		m := recvMetricsEventually(t, ctx, stream, i)
 		if m == nil {
 			t.Fatalf("Recv #%d: stream closed early", i)
 		}
@@ -57,9 +53,7 @@ func TestMetricsStreamCloseStopsBackgroundTask(t *testing.T) {
 	}
 
 	// Pull at least one snapshot before closing.
-	if _, err := stream.Recv(ctx); err != nil {
-		t.Fatalf("Recv before close: %v", err)
-	}
+	_ = recvMetricsEventually(t, ctx, stream, 0)
 	if err := stream.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -78,6 +72,33 @@ func TestMetricsStreamCloseStopsBackgroundTask(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Recv after Close did not return within 5s")
 	}
+}
+
+func recvMetricsEventually(
+	t *testing.T,
+	ctx context.Context,
+	stream *microsandbox.MetricsStreamHandle,
+	index int,
+) *microsandbox.Metrics {
+	t.Helper()
+
+	var lastErr error
+	for attempt := 0; attempt < 20; attempt++ {
+		recvCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		m, err := stream.Recv(recvCtx)
+		cancel()
+		if err == nil {
+			return m
+		}
+		if !strings.Contains(err.Error(), "no live metrics slot") {
+			t.Fatalf("Recv #%d: %v", index, err)
+		}
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Fatalf("Recv #%d: %v", index, lastErr)
+	return nil
 }
 
 // TestAllSandboxMetricsCoversMultipleSandboxes spins up two sandboxes and

--- a/sdk/node-ts/bin/microsandbox.cjs
+++ b/sdk/node-ts/bin/microsandbox.cjs
@@ -10,7 +10,13 @@ const TRIPLES = {
   "darwin-arm64": "darwin-arm64",
   "linux-x64": "linux-x64-gnu",
   "linux-arm64": "linux-arm64-gnu",
+  "win32-x64": "win32-x64-msvc",
+  "win32-arm64": "win32-arm64-msvc",
 };
+
+function msbFileName() {
+  return process.platform === "win32" ? "msb.exe" : "msb";
+}
 
 function resolveMsb() {
   if (process.env.MSB_PATH) {
@@ -23,7 +29,7 @@ function resolveMsb() {
       const pkgPath = require.resolve(
         `@superradcompany/microsandbox-${triple}/package.json`,
       );
-      const candidate = path.join(path.dirname(pkgPath), "bin", "msb");
+      const candidate = path.join(path.dirname(pkgPath), "bin", msbFileName());
       if (fs.existsSync(candidate)) {
         return { path: candidate, source: "platform-package" };
       }

--- a/sdk/node-ts/native/error.rs
+++ b/sdk/node-ts/native/error.rs
@@ -27,7 +27,14 @@ fn error_type_str(err: &MicrosandboxError) -> &'static str {
         MicrosandboxError::BootStart { .. } => "BootStart",
         MicrosandboxError::Json(_) => "Json",
         MicrosandboxError::Protocol(_) => "Protocol",
+        MicrosandboxError::AgentClient(microsandbox::AgentClientError::UnsupportedOperation {
+            ..
+        }) => "UnsupportedOperation",
+        MicrosandboxError::AgentClient(_) => "AgentClient",
+        #[cfg(unix)]
         MicrosandboxError::Nix(_) => "Nix",
+        #[cfg(windows)]
+        MicrosandboxError::WindowsHostSetup(_) => "WindowsHostSetup",
         MicrosandboxError::ExecTimeout(_) => "ExecTimeout",
         MicrosandboxError::ExecFailed(_) => "ExecFailed",
         MicrosandboxError::Terminal(_) => "Terminal",
@@ -48,10 +55,6 @@ fn error_type_str(err: &MicrosandboxError) -> &'static str {
         MicrosandboxError::MetricsUnavailable(_) => "MetricsUnavailable",
         MicrosandboxError::MissedRotation { .. } => "MissedRotation",
         MicrosandboxError::InvalidCursor(_) => "InvalidCursor",
-        MicrosandboxError::AgentClient(microsandbox::AgentClientError::UnsupportedOperation {
-            ..
-        }) => "UnsupportedOperation",
-        MicrosandboxError::AgentClient(_) => "AgentClient",
         MicrosandboxError::Unsupported { .. } => "Unsupported",
         MicrosandboxError::Custom(_) => "Custom",
     }

--- a/sdk/node-ts/native/sandbox.rs
+++ b/sdk/node-ts/native/sandbox.rs
@@ -781,11 +781,19 @@ pub fn sandbox_stop_result_to_js(
 }
 
 pub(crate) fn exit_status_to_js(status: std::process::ExitStatus) -> ExitStatus {
-    use std::os::unix::process::ExitStatusExt;
-    let code = status.code().unwrap_or_else(|| {
-        // If no code, the process was killed by a signal.
-        status.signal().map(|s| 128 + s).unwrap_or(-1)
-    });
+    #[cfg(unix)]
+    let code = {
+        use std::os::unix::process::ExitStatusExt;
+
+        status.code().unwrap_or_else(|| {
+            // If no code exists on Unix, the process was killed by a signal.
+            status.signal().map(|s| 128 + s).unwrap_or(-1)
+        })
+    };
+
+    #[cfg(not(unix))]
+    let code = status.code().unwrap_or(-1);
+
     ExitStatus {
         code,
         success: status.success(),

--- a/sdk/node-ts/npm/win32-arm64-msvc/package.json
+++ b/sdk/node-ts/npm/win32-arm64-msvc/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@superradcompany/microsandbox-win32-arm64-msvc",
+  "version": "0.5.10",
+  "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Windows arm64.",
+  "os": ["win32"],
+  "cpu": ["arm64"],
+  "main": "microsandbox.win32-arm64-msvc.node",
+  "files": [
+    "microsandbox.win32-arm64-msvc.node",
+    "bin/msb.exe",
+    "lib/libkrunfw.dll"
+  ],
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">= 22"
+  }
+}

--- a/sdk/node-ts/npm/win32-x64-msvc/package.json
+++ b/sdk/node-ts/npm/win32-x64-msvc/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@superradcompany/microsandbox-win32-x64-msvc",
+  "version": "0.5.10",
+  "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Windows x64.",
+  "os": ["win32"],
+  "cpu": ["x64"],
+  "main": "microsandbox.win32-x64-msvc.node",
+  "files": [
+    "microsandbox.win32-x64-msvc.node",
+    "bin/msb.exe",
+    "lib/libkrunfw.dll"
+  ],
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">= 22"
+  }
+}

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -24,7 +24,9 @@
       "optionalDependencies": {
         "@superradcompany/microsandbox-darwin-arm64": "0.5.10",
         "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.10",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.10"
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.5.10",
+        "@superradcompany/microsandbox-win32-arm64-msvc": "0.5.10",
+        "@superradcompany/microsandbox-win32-x64-msvc": "0.5.10"
       }
     },
     "node_modules/@emnapi/core": {

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -24,7 +24,9 @@
     "targets": [
       "aarch64-apple-darwin",
       "x86_64-unknown-linux-gnu",
-      "aarch64-unknown-linux-gnu"
+      "aarch64-unknown-linux-gnu",
+      "x86_64-pc-windows-msvc",
+      "aarch64-pc-windows-msvc"
     ]
   },
   "license": "Apache-2.0",
@@ -50,7 +52,9 @@
   "optionalDependencies": {
     "@superradcompany/microsandbox-darwin-arm64": "0.5.10",
     "@superradcompany/microsandbox-linux-arm64-gnu": "0.5.10",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.5.10"
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.5.10",
+    "@superradcompany/microsandbox-win32-arm64-msvc": "0.5.10",
+    "@superradcompany/microsandbox-win32-x64-msvc": "0.5.10"
   },
   "files": [
     "dist",

--- a/sdk/node-ts/scripts/prepare-platform-package.mjs
+++ b/sdk/node-ts/scripts/prepare-platform-package.mjs
@@ -5,9 +5,10 @@
 //
 // Layout produced:
 //   npm/<triple>/microsandbox.<triple>.node            (the napi binding)
-//   npm/<triple>/bin/msb                                (the msb CLI)
+//   npm/<triple>/bin/msb[.exe]                          (the msb CLI)
 //   npm/<triple>/lib/libkrunfw.<ABI>.dylib              (macOS only)
 //   npm/<triple>/lib/libkrunfw.so.<VERSION>             (Linux only)
+//   npm/<triple>/lib/libkrunfw.dll                      (Windows only)
 //
 // Refuses to run when the host triple doesn't match the requested target,
 // since we don't cross-compile here — CI orchestrates that matrix.
@@ -35,17 +36,29 @@ function detectHostTriple() {
   if (p === "darwin" && a === "arm64") return "darwin-arm64";
   if (p === "linux" && a === "x64") return "linux-x64-gnu";
   if (p === "linux" && a === "arm64") return "linux-arm64-gnu";
+  if (p === "win32" && a === "x64") return "win32-x64-msvc";
+  if (p === "win32" && a === "arm64") return "win32-arm64-msvc";
   throw new Error(`unsupported host: ${p}-${a}`);
 }
 
 const triple = process.argv[2] ?? detectHostTriple();
-if (!["darwin-arm64", "linux-x64-gnu", "linux-arm64-gnu"].includes(triple)) {
+const supportedTriples = [
+  "darwin-arm64",
+  "linux-x64-gnu",
+  "linux-arm64-gnu",
+  "win32-x64-msvc",
+  "win32-arm64-msvc",
+];
+if (!supportedTriples.includes(triple)) {
   console.error(`unknown triple: ${triple}`);
   process.exit(2);
 }
-if (triple !== detectHostTriple()) {
+const hostTriple = detectHostTriple();
+const isExplicitWindowsTarget =
+  process.argv[2] && process.platform === "win32" && triple.startsWith("win32-");
+if (triple !== hostTriple && !isExplicitWindowsTarget) {
   console.error(
-    `cannot prepare ${triple} on host ${detectHostTriple()} — cross-compile in CI instead.`,
+    `cannot prepare ${triple} on host ${hostTriple} — cross-compile in CI instead.`,
   );
   process.exit(2);
 }
@@ -70,10 +83,18 @@ console.log(`copied ${nodeFile}`);
 
 // 2. msb binary -----------------------------------------------------------
 // Prefer the just-built msb in build/msb (signed). Fall back to target/release.
-const msbCandidates = [
-  join(repoRoot, "build", "msb"),
-  join(repoRoot, "target", "release", "microsandbox"),
-];
+const isWindows = process.platform === "win32";
+const msbFile = isWindows ? "msb.exe" : "msb";
+const msbCandidates = isWindows
+  ? [
+      join(repoRoot, "build", "msb.exe"),
+      join(repoRoot, "target", "release", "msb.exe"),
+      join(repoRoot, "target", "release", "microsandbox.exe"),
+    ]
+  : [
+      join(repoRoot, "build", "msb"),
+      join(repoRoot, "target", "release", "microsandbox"),
+    ];
 const msbSrc = msbCandidates.find((p) => existsSync(p));
 if (!msbSrc) {
   console.error(
@@ -83,9 +104,11 @@ if (!msbSrc) {
   );
   process.exit(1);
 }
-const msbDst = join(binDir, "msb");
+const msbDst = join(binDir, msbFile);
 copyFileSync(msbSrc, msbDst);
-execFileSync("chmod", ["+x", msbDst]);
+if (!isWindows) {
+  execFileSync("chmod", ["+x", msbDst]);
+}
 console.log(`copied msb (${msbSrc})`);
 
 // On macOS, codesign the bundled binary with the hypervisor entitlement
@@ -120,7 +143,9 @@ mkdirSync(libDir, { recursive: true });
 const krunfwPattern =
   process.platform === "darwin"
     ? /^libkrunfw\..+\.dylib$/
-    : /^libkrunfw\.so\..+$/;
+    : process.platform === "win32"
+      ? /^libkrunfw\.dll$/
+      : /^libkrunfw\.so\..+$/;
 const krunfwEntry = existsSync(buildDir)
   ? readdirSync(buildDir).find((entry) => krunfwPattern.test(entry))
   : undefined;
@@ -142,5 +167,5 @@ function du(p) {
 }
 console.log(`\npopulated npm/${triple}:`);
 console.log(`  ${nodeFile}     ${du(join(pkgDir, nodeFile))} KiB`);
-console.log(`  bin/msb         ${du(msbDst)} KiB`);
+console.log(`  bin/${msbFile} ${du(msbDst)} KiB`);
 console.log(`  lib/${krunfwName}  ${du(krunfwDst)} KiB`);

--- a/sdk/node-ts/scripts/prune-platform-optional-deps.mjs
+++ b/sdk/node-ts/scripts/prune-platform-optional-deps.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageJsonPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "package.json",
+);
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+const optionalDependencies = packageJson.optionalDependencies ?? {};
+const removed = [];
+
+for (const dependencyName of Object.keys(optionalDependencies)) {
+  if (dependencyName.startsWith("@superradcompany/microsandbox-")) {
+    delete optionalDependencies[dependencyName];
+    removed.push(dependencyName);
+  }
+}
+
+if (removed.length > 0) {
+  packageJson.optionalDependencies = optionalDependencies;
+  writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+}
+
+console.log(
+  removed.length === 0
+    ? "No microsandbox platform optional dependencies to prune."
+    : `Pruned microsandbox platform optional dependencies: ${removed.join(", ")}`,
+);

--- a/sdk/node-ts/src/internal/resolve-binary.ts
+++ b/sdk/node-ts/src/internal/resolve-binary.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { homedir } from "node:os";
 
 function detectTriple(): string {
   const p = process.platform;
@@ -8,7 +9,13 @@ function detectTriple(): string {
   if (p === "darwin" && a === "arm64") return "darwin-arm64";
   if (p === "linux" && a === "x64") return "linux-x64-gnu";
   if (p === "linux" && a === "arm64") return "linux-arm64-gnu";
+  if (p === "win32" && a === "x64") return "win32-x64-msvc";
+  if (p === "win32" && a === "arm64") return "win32-arm64-msvc";
   throw new Error(`microsandbox: unsupported platform ${p}-${a}`);
+}
+
+function msbFileName(): string {
+  return process.platform === "win32" ? "msb.exe" : "msb";
 }
 
 // Search from multiple roots so the platform package resolves whether
@@ -36,7 +43,7 @@ function resolvePlatformRoot(): string | null {
       // Only accept this base if it actually carries the bundled binaries —
       // the published 0.x platform package may exist in the resolver's
       // path with only the .node file.
-      if (existsSync(join(root, "bin", "msb"))) return root;
+      if (existsSync(join(root, "bin", msbFileName()))) return root;
     } catch {
       // try next base
     }
@@ -54,7 +61,7 @@ function resolveBinDir(): string {
     return cachedBinDir;
   }
   // Fall back to ~/.microsandbox if no platform package carries binaries.
-  const home = process.env.HOME ?? "";
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
   cachedBinDir = join(home, ".microsandbox", "bin");
   return cachedBinDir;
 }
@@ -66,6 +73,6 @@ function resolveBinDir(): string {
  * read at the JS layer just adds an alternate code path for the same
  * outcome. */
 export function msbPath(): string | null {
-  const p = join(resolveBinDir(), "msb");
+  const p = join(resolveBinDir(), msbFileName());
   return existsSync(p) ? p : null;
 }

--- a/sdk/node-ts/tests/smoke.test.ts
+++ b/sdk/node-ts/tests/smoke.test.ts
@@ -5,6 +5,29 @@ import type { PullProgress } from "../dist/index.js";
 
 const SANDBOX_NAME = "sdk-smoke-test";
 
+async function waitForSandboxMetrics(sb: Sandbox) {
+  let lastError: unknown;
+
+  // The runtime publishes the live metrics slot asynchronously after boot
+  // readiness, so `create()` can return just before the first slot appears.
+  for (let attempt = 0; attempt < 20; attempt++) {
+    try {
+      return await sb.metrics();
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.includes("no live metrics slot")
+      ) {
+        throw error;
+      }
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  throw lastError;
+}
+
 describe.skipIf(!msbPath())("end-to-end smoke", () => {
   let sb: Sandbox;
 
@@ -59,7 +82,7 @@ describe.skipIf(!msbPath())("end-to-end smoke", () => {
   });
 
   it("snapshots metrics", async () => {
-    const m = await sb.metrics();
+    const m = await waitForSandboxMetrics(sb);
     expect(m.timestamp).toBeInstanceOf(Date);
     expect(typeof m.cpuPercent).toBe("number");
   });

--- a/sdk/python/integration/test_metrics_logs.py
+++ b/sdk/python/integration/test_metrics_logs.py
@@ -23,7 +23,10 @@ async def wait_for_metrics(sandbox):
             last_error = error
             await asyncio.sleep(0.1)
 
-    raise last_error
+    if last_error is not None:
+        raise last_error
+
+    raise MicrosandboxError("timed out waiting for sandbox metrics")
 
 
 @pytest.mark.asyncio

--- a/sdk/python/integration/test_metrics_logs.py
+++ b/sdk/python/integration/test_metrics_logs.py
@@ -2,9 +2,28 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
-from microsandbox import Sandbox, all_sandbox_metrics
+from microsandbox import MicrosandboxError, Sandbox, all_sandbox_metrics
+
+
+async def wait_for_metrics(sandbox):
+    last_error = None
+
+    # The runtime publishes the live metrics slot asynchronously after boot
+    # readiness, so the first metrics snapshot may race slot creation.
+    for _ in range(20):
+        try:
+            return await sandbox.metrics()
+        except MicrosandboxError as error:
+            if "no live metrics slot" not in str(error):
+                raise
+            last_error = error
+            await asyncio.sleep(0.1)
+
+    raise last_error
 
 
 @pytest.mark.asyncio
@@ -14,7 +33,7 @@ async def test_metrics_snapshot_stream_and_all_sandbox_metrics(sandbox_factory):
 
     await sandbox.shell("true")
 
-    metrics = await sandbox.metrics()
+    metrics = await wait_for_metrics(sandbox)
     assert isinstance(metrics.cpu_percent, float)
     assert metrics.memory_limit_bytes > 0
     assert metrics.uptime_ms >= 0

--- a/sdk/python/microsandbox/_cli.py
+++ b/sdk/python/microsandbox/_cli.py
@@ -2,7 +2,7 @@
 
 Resolution order:
   1. ``MSB_PATH`` environment variable
-  2. Wheel-bundled ``microsandbox/_bundled/bin/msb``
+  2. Wheel-bundled ``microsandbox/_bundled/bin/msb[.exe]``
 """
 
 from __future__ import annotations
@@ -12,9 +12,14 @@ import sys
 from pathlib import Path
 
 
+def _msb_filename() -> str:
+    """Return the platform-specific bundled CLI filename."""
+    return "msb.exe" if os.name == "nt" else "msb"
+
+
 def main() -> None:
     override = os.environ.get("MSB_PATH")
-    msb = override or str(Path(__file__).parent / "_bundled" / "bin" / "msb")
+    msb = override or str(Path(__file__).parent / "_bundled" / "bin" / _msb_filename())
 
     if not os.path.isfile(msb):
         sys.stderr.write(

--- a/sdk/python/microsandbox/_runtime.py
+++ b/sdk/python/microsandbox/_runtime.py
@@ -19,12 +19,18 @@ overrides aren't supported.
 
 from __future__ import annotations
 
+import os
 from importlib.resources import files
 from pathlib import Path
 
 _BUNDLED = files("microsandbox._bundled")
 
 
+def _msb_filename() -> str:
+    """Return the platform-specific bundled CLI filename."""
+    return "msb.exe" if os.name == "nt" else "msb"
+
+
 def msb_path() -> Path:
     """Return the absolute path to the bundled ``msb`` binary."""
-    return Path(str(_BUNDLED.joinpath("bin", "msb")))
+    return Path(str(_BUNDLED.joinpath("bin", _msb_filename())))


### PR DESCRIPTION
## TL;DR
Add Windows package support for the Node and Python SDKs so release builds can publish usable Windows artifacts with `msb.exe` and `libkrunfw.dll`.

## Description
- Add `win32-arm64-msvc` and `win32-x64-msvc` Node platform package manifests.
- Teach the Node SDK package metadata, CLI shim, binary resolver, and platform package prep script about Windows triples and `msb.exe`.
- Fix Windows compilation in the Node native binding by gating Unix-only Nix and signal handling and mapping Windows host setup errors.
- Teach the Python SDK runtime and CLI entrypoint to resolve bundled `msb.exe` on Windows.
- Extend release CI so Windows jobs build Node platform artifacts and Python wheels, then include those artifacts in npm and PyPI publish jobs.
- Adjust Node SDK CI install steps to skip optional platform package resolution before the first Windows packages exist on npm.

## Test Plan
- [x] `git diff --check -- .github/workflows/release.yml .github/workflows/check.yml sdk/node-ts/package.json sdk/node-ts/package-lock.json sdk/node-ts/scripts/prepare-platform-package.mjs sdk/node-ts/src/internal/resolve-binary.ts sdk/node-ts/bin/microsandbox.cjs sdk/node-ts/native/error.rs sdk/node-ts/native/sandbox.rs sdk/python/microsandbox/_runtime.py sdk/python/microsandbox/_cli.py sdk/node-ts/npm/win32-arm64-msvc/package.json sdk/node-ts/npm/win32-x64-msvc/package.json` exits 0
- [x] `pnpm run build:native -- --target aarch64-pc-windows-msvc` exits 0 from `sdk/node-ts` in an ARM64 MSVC dev shell
- [x] `pnpm run build:ts` exits 0 from `sdk/node-ts`
- [x] `node scripts/prepare-platform-package.mjs win32-arm64-msvc` creates a package with `bin/msb.exe`, `lib/libkrunfw.dll`, and `microsandbox.win32-arm64-msvc.node`
- [ ] ARM64 Node can `require('@superradcompany/microsandbox-win32-arm64-msvc')` from a local consumer install and the SDK resolver returns `bin/msb.exe`
- [ ] ARM64 Python builds and installs `microsandbox-0.5.10-cp310-abi3-win_arm64.whl`, and `_runtime.msb_path()` plus the `msb.exe` console script resolve the bundled binary