### PR TITLE
feat(doctor): cross-platform host checks with safe auto-fixes

### DIFF
--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -162,24 +162,30 @@ pub fn run_doctor(args: DoctorArgs) -> anyhow::Result<()> {
     }
 
     let mut applied_any = false;
+    let mut offered_any_fix = false;
     let mut relogin_pending = false;
     for problem in &diagnosis.problems {
         render_problem(problem, !args.fix);
 
         if args.fix
             && let Some(fix) = &problem.fix
-            && apply_fix(fix, args.yes)?
         {
-            applied_any = true;
-            relogin_pending |= fix.requires_relogin;
+            offered_any_fix = true;
+            if apply_fix(fix, args.yes)? {
+                applied_any = true;
+                relogin_pending |= fix.requires_relogin;
+            }
         }
     }
 
     // Windows applies its fix through an elevated, UAC-gated PowerShell flow
     // rather than a `sudo` command, so it's handled out of band.
     #[cfg(windows)]
-    if args.fix {
-        return attempt_windows_fix();
+    if args.fix && has_windows_hypervisor_problem(&diagnosis) {
+        offered_any_fix = true;
+        if apply_windows_fix(args.yes)? {
+            applied_any = true;
+        }
     }
 
     if applied_any {
@@ -202,6 +208,8 @@ pub fn run_doctor(args: DoctorArgs) -> anyhow::Result<()> {
                 )],
             );
         }
+    } else if args.fix && offered_any_fix {
+        ui::warn("no fixes were applied.");
     } else if args.fix {
         ui::warn("no automatic fixes are available for the problems above.");
     }
@@ -299,7 +307,13 @@ fn apply_fix(fix: &microsandbox::setup::Fix, assume_yes: bool) -> anyhow::Result
     // with the per-command spinner below. After this, the cached credential
     // lets the fix commands run without prompting.
     if fix.commands.iter().any(|command| command.program == "sudo") {
-        let _ = Command::new("sudo").arg("-v").status();
+        let status = Command::new("sudo")
+            .arg("-v")
+            .status()
+            .map_err(|e| anyhow::anyhow!("could not pre-authenticate sudo: {e}"))?;
+        if !status.success() {
+            anyhow::bail!("sudo authentication failed ({status}); no fix commands were run");
+        }
     }
 
     for command in &fix.commands {
@@ -336,22 +350,26 @@ fn confirm(prompt: &str) -> anyhow::Result<bool> {
     Ok(input.trim().eq_ignore_ascii_case("y"))
 }
 
-/// Attempt the elevated Windows Hypervisor Platform enable, then re-verify.
+/// Whether this diagnosis includes the WHP host prerequisite problem.
 #[cfg(windows)]
-fn attempt_windows_fix() -> anyhow::Result<()> {
+fn has_windows_hypervisor_problem(diagnosis: &microsandbox::setup::Diagnosis) -> bool {
+    diagnosis
+        .problems
+        .iter()
+        .any(|problem| problem.headline == "Windows Hypervisor Platform is not available")
+}
+
+/// Apply the elevated Windows Hypervisor Platform enable flow.
+#[cfg(windows)]
+fn apply_windows_fix(assume_yes: bool) -> anyhow::Result<bool> {
+    if !assume_yes && !confirm("Apply fix — enable Windows Hypervisor Platform? [y/N] ")? {
+        info("Skipped.");
+        return Ok(false);
+    }
+
     eprintln!();
     enable_windows_hypervisor_platform()?;
-
-    match microsandbox::setup::verify_windows_host_prerequisites() {
-        Ok(()) => {
-            done("Windows Hypervisor Platform is now available.");
-            Ok(())
-        }
-        Err(err) => {
-            ui::warn("Windows may require a reboot before WHP is available.");
-            Err(microsandbox::MicrosandboxError::WindowsHostSetup(err).into())
-        }
-    }
+    Ok(true)
 }
 
 #[cfg(windows)]

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -1,10 +1,11 @@
 //! `msb self` subcommands for managing the msb installation itself.
 
 use std::fs;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 #[cfg(windows)]
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 use clap::{Args, Subcommand};
 use console::{Key, Term, style};
@@ -65,6 +66,10 @@ pub struct DoctorArgs {
     /// Attempt supported host virtualization setup fixes.
     #[arg(long)]
     pub fix: bool,
+
+    /// Apply fixes without prompting for confirmation.
+    #[arg(long, short = 'y')]
+    pub yes: bool,
 }
 
 /// Arguments for `msb self uninstall`.
@@ -141,55 +146,211 @@ pub async fn run(args: SelfArgs) -> anyhow::Result<()> {
 }
 
 /// Check local runtime files and host virtualization prerequisites.
+///
+/// Renders each check in the spinner-completion style shared with `msb start`
+/// and `msb pull` (`✓ <label> <detail>`), followed by a styled error block per
+/// problem. With `--fix`, applies the safe auto-runnable remediation for each
+/// problem (after a `[y/N]` prompt) and re-checks. Exits non-zero when the host
+/// still cannot run local sandboxes.
 pub fn run_doctor(args: DoctorArgs) -> anyhow::Result<()> {
-    if microsandbox::setup::is_installed() {
-        done("Runtime dependencies are installed.");
-    } else {
-        anyhow::bail!("microsandbox runtime is not installed; run `msb self update`");
+    let diagnosis = diagnose_host();
+    render_diagnosis(&diagnosis);
+
+    if diagnosis.is_healthy() {
+        done("Host setup is ready.");
+        return Ok(());
     }
 
-    #[cfg(windows)]
-    {
-        check_windows_host_prerequisites(args.fix)?;
-    }
+    let mut applied_any = false;
+    let mut relogin_pending = false;
+    for problem in &diagnosis.problems {
+        render_problem(problem, !args.fix);
 
-    #[cfg(not(windows))]
-    {
-        if args.fix {
-            ui::warn("No automatic host setup fixes are available for this platform yet.");
+        if args.fix
+            && let Some(fix) = &problem.fix
+            && apply_fix(fix, args.yes)?
+        {
+            applied_any = true;
+            relogin_pending |= fix.requires_relogin;
         }
     }
 
-    done("Host setup is ready.");
-    Ok(())
+    // Windows applies its fix through an elevated, UAC-gated PowerShell flow
+    // rather than a `sudo` command, so it's handled out of band.
+    #[cfg(windows)]
+    if args.fix {
+        return attempt_windows_fix();
+    }
+
+    if applied_any {
+        let recheck = diagnose_host();
+        render_diagnosis(&recheck);
+
+        if recheck.is_healthy() {
+            done("Host setup is ready.");
+            return Ok(());
+        }
+
+        for problem in &recheck.problems {
+            render_problem(problem, false);
+        }
+        if relogin_pending {
+            ui::warn_with_lines(
+                "some fixes apply fully only after you log out and back in",
+                &[ui::ErrorLine::Hint(
+                    "start a new shell (or re-login) to pick up group changes",
+                )],
+            );
+        }
+    } else if args.fix {
+        ui::warn("no automatic fixes are available for the problems above.");
+    }
+
+    std::process::exit(1);
 }
 
-#[cfg(windows)]
-fn check_windows_host_prerequisites(fix: bool) -> anyhow::Result<()> {
-    match microsandbox::setup::verify_windows_host_prerequisites() {
-        Ok(()) => {
-            done("Windows Hypervisor Platform is available.");
-            Ok(())
-        }
-        Err(err) if fix => {
-            ui::warn(&format!(
-                "Windows Hypervisor Platform is unavailable: {}",
-                err.cause()
-            ));
-            enable_windows_hypervisor_platform()?;
+/// Run the diagnosis behind a `Checking host` spinner.
+///
+/// The individual checks are near-instant, so they render as already-resolved
+/// completion lines; this single spinner covers the whole pass (and is visible
+/// on slower hosts, e.g. the Windows hypervisor probe).
+fn diagnose_host() -> microsandbox::setup::Diagnosis {
+    let spinner = ui::Spinner::start("Checking", "host");
+    let diagnosis = microsandbox::setup::diagnose();
+    spinner.finish_clear();
+    diagnosis
+}
 
-            match microsandbox::setup::verify_windows_host_prerequisites() {
-                Ok(()) => {
-                    done("Windows Hypervisor Platform is available.");
-                    Ok(())
-                }
-                Err(err) => {
-                    ui::warn("Windows may require a reboot before WHP is available.");
-                    Err(microsandbox::MicrosandboxError::WindowsHostSetup(err).into())
-                }
+/// Render the checks as a flat log: all `info <label>: <value>` facts first,
+/// then the `✓`/`✗ <label> <detail>` rows — matching the CLI's convention of
+/// leading with `info` metadata before the result rows.
+fn render_diagnosis(diagnosis: &microsandbox::setup::Diagnosis) {
+    use microsandbox::setup::CheckState;
+
+    let checks: Vec<&microsandbox::setup::Check> =
+        diagnosis.sections.iter().flat_map(|s| &s.checks).collect();
+    let (mut facts, rows): (Vec<_>, Vec<_>) = checks
+        .into_iter()
+        .partition(|check| matches!(check.state, CheckState::Info));
+
+    // Lead the metadata block with host identity (Platform) ahead of the
+    // install location; falls back to model order if that label changes.
+    facts.sort_by_key(|check| check.label != "Platform");
+
+    for check in facts.into_iter().chain(rows) {
+        render_check(check);
+    }
+}
+
+/// Render one check. Pass/fail use the `✓`/`✗ <label> <detail>` completion
+/// format; informational facts render as an `info <label>: <value>` line.
+fn render_check(check: &microsandbox::setup::Check) {
+    use microsandbox::setup::CheckState;
+    match check.state {
+        CheckState::Pass => ui::success(&check.label, &check.value),
+        CheckState::Fail => ui::failure(&check.label, &check.value),
+        CheckState::Warn => {
+            eprintln!(
+                "   {} {:<12} {}",
+                style("!").yellow(),
+                check.label,
+                check.value
+            );
+        }
+        CheckState::Info => info(&format!("{}: {}", check.label, check.value)),
+    }
+}
+
+/// Render a single problem as a styled `error:` block with `→` lines.
+///
+/// When the problem carries a [`Fix`](microsandbox::setup::Fix), its commands
+/// are listed; `offer_fix_flag` adds a pointer to `msb doctor --fix` (shown
+/// when we're not already in fix mode).
+fn render_problem(problem: &microsandbox::setup::Problem, offer_fix_flag: bool) {
+    let mut lines: Vec<String> = problem.hints.clone();
+
+    if let Some(fix) = &problem.fix {
+        lines.push(format!("fix: {}", fix.description));
+        for command in &fix.commands {
+            lines.push(format!("  {}", command.display()));
+        }
+        if offer_fix_flag {
+            lines.push("apply automatically: msb doctor --fix".to_string());
+        }
+    }
+
+    let error_lines: Vec<ui::ErrorLine<'_>> =
+        lines.iter().map(|line| ui::ErrorLine::Hint(line)).collect();
+    ui::error_with_lines(&problem.headline, &error_lines);
+}
+
+/// Apply a fix's commands after an optional confirmation prompt.
+///
+/// Returns whether the fix was attempted (i.e. the user agreed). Individual
+/// command failures are reported but don't abort the remaining commands — the
+/// re-check determines the real outcome.
+fn apply_fix(fix: &microsandbox::setup::Fix, assume_yes: bool) -> anyhow::Result<bool> {
+    if !assume_yes && !confirm(&format!("Apply fix — {}? [y/N] ", fix.description))? {
+        info("Skipped.");
+        return Ok(false);
+    }
+
+    // Pre-authenticate sudo up front so its password prompt doesn't collide
+    // with the per-command spinner below. After this, the cached credential
+    // lets the fix commands run without prompting.
+    if fix.commands.iter().any(|command| command.program == "sudo") {
+        let _ = Command::new("sudo").arg("-v").status();
+    }
+
+    for command in &fix.commands {
+        let spinner = ui::Spinner::start("Applying", &command.display());
+        match Command::new(&command.program).args(&command.args).status() {
+            Ok(status) if status.success() => spinner.finish_success("Applied"),
+            Ok(status) => {
+                spinner.finish_fail("Failed");
+                ui::warn(&format!("`{}` exited with {status}", command.display()));
+            }
+            Err(e) => {
+                spinner.finish_fail("Failed");
+                ui::warn(&format!("could not run `{}`: {e}", command.display()));
             }
         }
-        Err(err) => Err(microsandbox::MicrosandboxError::WindowsHostSetup(err).into()),
+    }
+
+    // The fix was attempted; the re-check determines the real outcome.
+    Ok(true)
+}
+
+/// Prompt for a yes/no confirmation on stderr. Errors on a non-interactive
+/// terminal so `--fix` never silently mutates the host without `--yes`.
+fn confirm(prompt: &str) -> anyhow::Result<bool> {
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!("non-interactive terminal; pass --yes to apply fixes");
+    }
+
+    eprint!("{prompt}");
+    std::io::stderr().flush().ok();
+
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    Ok(input.trim().eq_ignore_ascii_case("y"))
+}
+
+/// Attempt the elevated Windows Hypervisor Platform enable, then re-verify.
+#[cfg(windows)]
+fn attempt_windows_fix() -> anyhow::Result<()> {
+    eprintln!();
+    enable_windows_hypervisor_platform()?;
+
+    match microsandbox::setup::verify_windows_host_prerequisites() {
+        Ok(()) => {
+            done("Windows Hypervisor Platform is now available.");
+            Ok(())
+        }
+        Err(err) => {
+            ui::warn("Windows may require a reboot before WHP is available.");
+            Err(microsandbox::MicrosandboxError::WindowsHostSetup(err).into())
+        }
     }
 }
 

--- a/crates/cli/lib/ui.rs
+++ b/crates/cli/lib/ui.rs
@@ -124,6 +124,18 @@ impl Spinner {
         }
     }
 
+    /// Finish with failure. Shows `✗ <label> <target>` in the same completion
+    /// format as [`finish_success`](Self::finish_success), in red.
+    pub fn finish_fail(self, label: &str) {
+        if let Some(pb) = self.pb {
+            pb.finish_and_clear();
+        }
+
+        if !self.quiet {
+            eprintln!("   {} {:<12} {}", style("✗").red(), label, self.target);
+        }
+    }
+
     /// Finish and clear entirely — no output remains on screen.
     ///
     /// Used on both success and failure paths: errors are presented by
@@ -329,12 +341,33 @@ pub fn warn(msg: &str) {
     eprintln!("{} {msg}", style("warn:").yellow().bold());
 }
 
+/// Print a warning message with `→`-prefixed context lines.
+///
+/// Mirrors [`error_with_lines`] but with a yellow `warn:` label. As there, the
+/// message and body text render uncolored; only the `→` bullet is dim.
+pub fn warn_with_lines(msg: &str, lines: &[ErrorLine<'_>]) {
+    eprintln!("{} {msg}", style("warn:").yellow().bold());
+    for line in lines {
+        let text = match line {
+            ErrorLine::Cause(t) | ErrorLine::Hint(t) => t,
+        };
+        eprintln!("  {} {}", style("→").dim(), text);
+    }
+}
+
 /// Print a one-shot success action to stderr.
 ///
 /// Follows the same format as spinner completions:
 /// `   ✓ {verb:<12} {target}`
 pub fn success(verb: &str, target: &str) {
     eprintln!("   {} {:<12} {}", style("✓").green(), verb, target);
+}
+
+/// Print a one-shot failure action to stderr, mirroring [`success`].
+///
+/// Same `   ✗ {label:<12} {detail}` shape as a spinner failure completion.
+pub fn failure(label: &str, detail: &str) {
+    eprintln!("   {} {:<12} {}", style("✗").red(), label, detail);
 }
 
 /// Format a sandbox status with appropriate color.

--- a/sdk/rust/lib/setup/host.rs
+++ b/sdk/rust/lib/setup/host.rs
@@ -1,0 +1,294 @@
+//! Cross-platform host readiness diagnosis backing `msb doctor`.
+//!
+//! The SDK owns the *facts*: which runtime files exist and whether the host
+//! can run local sandboxes. Rendering (colors, glyphs, hint formatting) lives
+//! in the CLI so this layer stays presentation-agnostic.
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Outcome of a single host or runtime check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckState {
+    /// The check passed.
+    Pass,
+
+    /// The check failed in a way that blocks local sandboxes.
+    Fail,
+
+    /// The check passed but with a caveat worth surfacing.
+    Warn,
+
+    /// Informational only — no pass/fail judgement (e.g. the platform name).
+    Info,
+}
+
+/// A single labelled check with a human-readable value.
+#[derive(Debug, Clone)]
+pub struct Check {
+    /// Short label, e.g. `"KVM access"`.
+    pub label: String,
+
+    /// Outcome of the check.
+    pub state: CheckState,
+
+    /// Human-readable value, e.g. `"read/write"` or `"permission denied"`.
+    pub value: String,
+}
+
+/// A titled group of related checks (e.g. `"Runtime"`, `"Host"`).
+#[derive(Debug, Clone)]
+pub struct Section {
+    /// Section title.
+    pub title: String,
+
+    /// Checks within the section, in display order.
+    pub checks: Vec<Check>,
+}
+
+/// A blocking problem, optionally with an auto-runnable [`Fix`].
+#[derive(Debug, Clone)]
+pub struct Problem {
+    /// One-line headline describing what is wrong.
+    pub headline: String,
+
+    /// Ordered hints explaining the cause. Commands live on [`Problem::fix`].
+    pub hints: Vec<String>,
+
+    /// A safe, auto-runnable remediation, when one exists. `None` means the
+    /// problem can only be fixed by a human (firmware setting, hardware, etc.).
+    pub fix: Option<Fix>,
+}
+
+/// A safe, auto-runnable remediation for a [`Problem`].
+///
+/// Every command here is expected to be idempotent and reversible; `msb doctor
+/// --fix` runs them after an explicit confirmation.
+#[derive(Debug, Clone)]
+pub struct Fix {
+    /// Human description of what applying this will do.
+    pub description: String,
+
+    /// Commands to run, in order.
+    pub commands: Vec<FixCommand>,
+
+    /// Whether the persistent part of the fix only takes full effect after the
+    /// user starts a fresh login session (e.g. group membership changes).
+    pub requires_relogin: bool,
+}
+
+/// A single command in a [`Fix`], stored as program + args to avoid any shell
+/// quoting or injection concerns when executed.
+#[derive(Debug, Clone)]
+pub struct FixCommand {
+    /// The program to run, e.g. `"sudo"`.
+    pub program: String,
+
+    /// Arguments passed to the program.
+    pub args: Vec<String>,
+}
+
+/// The full result of a host diagnosis.
+#[derive(Debug, Clone)]
+pub struct Diagnosis {
+    /// Rendered sections, in display order.
+    pub sections: Vec<Section>,
+
+    /// Problems found, in display order. Empty when the host is ready.
+    pub problems: Vec<Problem>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl Check {
+    pub(crate) fn pass(label: &str, value: &str) -> Self {
+        Self {
+            label: label.to_string(),
+            state: CheckState::Pass,
+            value: value.to_string(),
+        }
+    }
+
+    pub(crate) fn fail(label: &str, value: &str) -> Self {
+        Self {
+            label: label.to_string(),
+            state: CheckState::Fail,
+            value: value.to_string(),
+        }
+    }
+
+    pub(crate) fn info(label: &str, value: &str) -> Self {
+        Self {
+            label: label.to_string(),
+            state: CheckState::Info,
+            value: value.to_string(),
+        }
+    }
+}
+
+impl Problem {
+    pub(crate) fn new(headline: impl Into<String>, hints: Vec<String>) -> Self {
+        Self {
+            headline: headline.into(),
+            hints,
+            fix: None,
+        }
+    }
+
+    /// Attach an auto-runnable fix.
+    pub fn with_fix(mut self, fix: Fix) -> Self {
+        self.fix = Some(fix);
+        self
+    }
+}
+
+impl Fix {
+    /// Build a fix from a description and an ordered list of commands.
+    pub fn new(description: impl Into<String>, commands: Vec<FixCommand>) -> Self {
+        Self {
+            description: description.into(),
+            commands,
+            requires_relogin: false,
+        }
+    }
+
+    /// Mark that the persistent effect needs a fresh login session.
+    pub fn requires_relogin(mut self) -> Self {
+        self.requires_relogin = true;
+        self
+    }
+}
+
+impl FixCommand {
+    /// Build a `sudo`-prefixed command from a borrowed argument list.
+    pub fn sudo(args: &[&str]) -> Self {
+        Self {
+            program: "sudo".to_string(),
+            args: args.iter().map(|a| a.to_string()).collect(),
+        }
+    }
+
+    /// Render the command as a single copy-pasteable line.
+    pub fn display(&self) -> String {
+        let mut parts = Vec::with_capacity(self.args.len() + 1);
+        parts.push(self.program.as_str());
+        parts.extend(self.args.iter().map(String::as_str));
+        parts.join(" ")
+    }
+}
+
+impl Diagnosis {
+    /// Whether the host is ready to run local sandboxes.
+    pub fn is_healthy(&self) -> bool {
+        self.problems.is_empty()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Diagnose runtime installation and host virtualization prerequisites.
+///
+/// Always returns a populated [`Diagnosis`]; problems are reported as data
+/// rather than errors so callers can render the full picture before deciding
+/// how to exit.
+pub fn diagnose() -> Diagnosis {
+    let mut sections = Vec::new();
+    let mut problems = Vec::new();
+
+    let (runtime, mut runtime_problems) = runtime_section();
+    sections.push(runtime);
+    problems.append(&mut runtime_problems);
+
+    let (host, mut host_problems) = host_section();
+    sections.push(host);
+    problems.append(&mut host_problems);
+
+    Diagnosis { sections, problems }
+}
+
+/// Build the "Runtime" section: install root and required runtime files.
+fn runtime_section() -> (Section, Vec<Problem>) {
+    let base = microsandbox_utils::resolve_home();
+    let bin_dir = base.join(microsandbox_utils::BIN_SUBDIR);
+    let lib_dir = base.join(microsandbox_utils::LIB_SUBDIR);
+
+    let os = std::env::consts::OS;
+    let msb_name = microsandbox_utils::msb_binary_filename(os);
+    let libkrunfw_name = microsandbox_utils::libkrunfw_filename(os);
+
+    let msb_ok = bin_dir.join(&msb_name).exists();
+    let libkrunfw_ok = lib_dir.join(&libkrunfw_name).exists();
+
+    let checks = vec![
+        Check::info("Install root", &base.display().to_string()),
+        if msb_ok {
+            Check::pass("msb", "present")
+        } else {
+            Check::fail("msb", "missing")
+        },
+        if libkrunfw_ok {
+            Check::pass("libkrunfw", "present")
+        } else {
+            Check::fail("libkrunfw", "missing")
+        },
+    ];
+
+    let mut problems = Vec::new();
+    if !msb_ok || !libkrunfw_ok {
+        problems.push(Problem::new(
+            "microsandbox runtime is not fully installed",
+            vec![
+                format!("expected runtime files under {}", base.display()),
+                "install or repair them: msb self update".to_string(),
+            ],
+        ));
+    }
+
+    (
+        Section {
+            title: "Runtime".to_string(),
+            checks,
+        },
+        problems,
+    )
+}
+
+/// Build the platform-specific "Host" section.
+fn host_section() -> (Section, Vec<Problem>) {
+    #[cfg(target_os = "linux")]
+    {
+        super::linux::host_section()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        super::macos::host_section()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        super::windows::host_section()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        unsupported_host_section()
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn unsupported_host_section() -> (Section, Vec<Problem>) {
+    let label = format!("{} {}", std::env::consts::OS, std::env::consts::ARCH);
+    (
+        Section {
+            title: "Host".to_string(),
+            checks: vec![Check::fail("Platform", &label)],
+        },
+        vec![Problem::new(
+            "this platform is not supported for local sandboxes",
+            vec!["local execution is supported on Linux, macOS (arm64), and Windows".to_string()],
+        )],
+    )
+}

--- a/sdk/rust/lib/setup/host.rs
+++ b/sdk/rust/lib/setup/host.rs
@@ -221,8 +221,8 @@ fn runtime_section() -> (Section, Vec<Problem>) {
     let msb_name = microsandbox_utils::msb_binary_filename(os);
     let libkrunfw_name = microsandbox_utils::libkrunfw_filename(os);
 
-    let msb_ok = bin_dir.join(&msb_name).exists();
-    let libkrunfw_ok = lib_dir.join(&libkrunfw_name).exists();
+    let msb_ok = bin_dir.join(&msb_name).is_file();
+    let libkrunfw_ok = lib_dir.join(&libkrunfw_name).is_file();
 
     let checks = vec![
         Check::info("Install root", &base.display().to_string()),

--- a/sdk/rust/lib/setup/linux.rs
+++ b/sdk/rust/lib/setup/linux.rs
@@ -1,0 +1,254 @@
+//! Linux host prerequisite checks for local sandbox execution.
+//!
+//! Local sandboxes need KVM through `/dev/kvm`. These checks diagnose the
+//! common failure modes — missing CPU virtualization, an absent device node,
+//! and a device the current user cannot open — and surface copy-pasteable
+//! remediation commands. Nothing here mutates the host.
+
+use std::ffi::CStr;
+use std::fs::OpenOptions;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+use super::host::{Check, Fix, FixCommand, Problem, Section};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const KVM_DEVICE: &str = "/dev/kvm";
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Diagnose Linux host virtualization prerequisites.
+pub(super) fn host_section() -> (Section, Vec<Problem>) {
+    let mut checks = Vec::new();
+    let mut problems = Vec::new();
+
+    let arch = std::env::consts::ARCH;
+    checks.push(Check::info("Platform", &format!("Linux {arch}")));
+
+    // x86 requires a VT-x / AMD-V flag in /proc/cpuinfo. On aarch64 the flag
+    // isn't reported there — KVM availability is reflected by /dev/kvm itself —
+    // so the cpuinfo probe would misfire; skip it and rely on the device check.
+    if arch == "x86_64" {
+        match cpu_virt_flag() {
+            Some(flag) => checks.push(Check::pass("CPU virt", flag)),
+            None => {
+                checks.push(Check::fail("CPU virt", "not found"));
+                problems.push(Problem::new(
+                    "CPU virtualization is not available",
+                    vec![
+                        "no vmx (Intel) or svm (AMD) flag in /proc/cpuinfo".to_string(),
+                        "enable virtualization (VT-x / AMD-V) in your BIOS or UEFI firmware"
+                            .to_string(),
+                        "inside a VM, enable nested virtualization on the host".to_string(),
+                    ],
+                ));
+            }
+        }
+    }
+
+    let kvm = Path::new(KVM_DEVICE);
+    if !kvm.exists() {
+        checks.push(Check::fail("KVM device", "missing"));
+        let mut problem = Problem::new(
+            format!("{KVM_DEVICE} is not present"),
+            vec![
+                "the KVM kernel module is not loaded".to_string(),
+                "in containers or CI, the host must expose /dev/kvm to this environment"
+                    .to_string(),
+            ],
+        );
+        // Only the x86 vendor modules are safe to load by name. On aarch64 KVM
+        // is typically built in, so there's nothing to modprobe — leave it
+        // advisory rather than guess.
+        if let Some(module) = kvm_module() {
+            problem = problem.with_fix(Fix::new(
+                format!("load the {module} kernel module"),
+                vec![FixCommand::sudo(&["modprobe", module])],
+            ));
+        }
+        problems.push(problem);
+        return (section(checks), problems);
+    }
+    checks.push(Check::pass("KVM device", KVM_DEVICE));
+
+    // Opening O_RDWR is the same access libkrun needs and is a side-effect-free
+    // permission probe — we drop the handle immediately.
+    match OpenOptions::new().read(true).write(true).open(kvm) {
+        Ok(_) => checks.push(Check::pass("KVM access", "read/write")),
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+            checks.push(Check::fail("KVM access", "permission denied"));
+            problems.push(kvm_permission_problem());
+        }
+        Err(err) => {
+            checks.push(Check::fail("KVM access", "unavailable"));
+            problems.push(Problem::new(
+                format!("{KVM_DEVICE} could not be opened"),
+                vec![format!("opening {KVM_DEVICE} failed: {err}")],
+            ));
+        }
+    }
+
+    (section(checks), problems)
+}
+
+fn section(checks: Vec<Check>) -> Section {
+    Section {
+        title: "Host".to_string(),
+        checks,
+    }
+}
+
+/// Return the first virtualization flag found in `/proc/cpuinfo`, if any.
+fn cpu_virt_flag() -> Option<&'static str> {
+    let info = std::fs::read_to_string("/proc/cpuinfo").ok()?;
+    for line in info.lines() {
+        if line.starts_with("flags") {
+            let flags = line.split(':').nth(1).unwrap_or("");
+            if flags.split_whitespace().any(|f| f == "vmx") {
+                return Some("vmx");
+            }
+            if flags.split_whitespace().any(|f| f == "svm") {
+                return Some("svm");
+            }
+        }
+    }
+    None
+}
+
+/// Build the `/dev/kvm` permission failure, with a fix tailored to whether the
+/// user already belongs to the device's owning group.
+///
+/// The fix pairs two safe, reversible commands: `setfacl` grants the running
+/// user access immediately (this boot), while `usermod -aG` makes it persist
+/// across reboots. We can only build them once we know the real username, so a
+/// missing username degrades to advisory hints.
+fn kvm_permission_problem() -> Problem {
+    let group = device_group(KVM_DEVICE);
+    let group_label = group.clone().unwrap_or_else(|| "kvm".to_string());
+    let already_member = group.as_deref().map(user_in_group).unwrap_or(false);
+    let user = current_username();
+
+    let cause = if already_member {
+        format!("you are in the '{group_label}' group, but this login session predates the change")
+    } else {
+        match &group {
+            Some(g) => format!("{KVM_DEVICE} is owned by group '{g}', which your user is not in"),
+            None => format!("your user lacks read/write access to {KVM_DEVICE}"),
+        }
+    };
+
+    let mut problem = Problem::new(
+        format!("{KVM_DEVICE} is not accessible by your user"),
+        vec![cause],
+    );
+
+    let Some(user) = user else {
+        return problem;
+    };
+    let acl = format!("u:{user}:rw");
+
+    if already_member {
+        // Membership is set; just grant this session direct access.
+        problem = problem.with_fix(Fix::new(
+            format!("grant {user} access to {KVM_DEVICE} for the current session"),
+            vec![FixCommand::sudo(&[
+                "setfacl",
+                "-m",
+                acl.as_str(),
+                KVM_DEVICE,
+            ])],
+        ));
+    } else {
+        problem = problem.with_fix(
+            Fix::new(
+                format!("add {user} to the '{group_label}' group and grant access now"),
+                vec![
+                    FixCommand::sudo(&["usermod", "-aG", group_label.as_str(), user.as_str()]),
+                    FixCommand::sudo(&["setfacl", "-m", acl.as_str(), KVM_DEVICE]),
+                ],
+            )
+            .requires_relogin(),
+        );
+    }
+
+    problem
+}
+
+/// The x86 vendor KVM module to load, derived from the CPU virtualization flag.
+fn kvm_module() -> Option<&'static str> {
+    match cpu_virt_flag() {
+        Some("vmx") => Some("kvm_intel"),
+        Some("svm") => Some("kvm_amd"),
+        _ => None,
+    }
+}
+
+/// Resolve the current effective user's login name.
+fn current_username() -> Option<String> {
+    if let Ok(user) = std::env::var("USER")
+        && !user.is_empty()
+    {
+        return Some(user);
+    }
+
+    // SAFETY: getpwuid returns a pointer into a shared static buffer; the doctor
+    // command is single-threaded, and we copy the name out immediately.
+    unsafe {
+        let entry = libc::getpwuid(libc::geteuid());
+        if entry.is_null() {
+            return None;
+        }
+        Some(
+            CStr::from_ptr((*entry).pw_name)
+                .to_string_lossy()
+                .into_owned(),
+        )
+    }
+}
+
+/// Resolve the owning group name of a device path.
+fn device_group(path: &str) -> Option<String> {
+    let gid = std::fs::metadata(path).ok()?.gid();
+    group_name(gid)
+}
+
+/// Resolve a gid to its group name.
+fn group_name(gid: libc::gid_t) -> Option<String> {
+    // SAFETY: getgrgid returns a pointer into a shared static buffer. The doctor
+    // command is single-threaded, and we copy the name out immediately before
+    // any further libc call can overwrite the buffer.
+    unsafe {
+        let entry = libc::getgrgid(gid);
+        if entry.is_null() {
+            return None;
+        }
+        Some(
+            CStr::from_ptr((*entry).gr_name)
+                .to_string_lossy()
+                .into_owned(),
+        )
+    }
+}
+
+/// Whether the current process belongs to the named group.
+fn user_in_group(name: &str) -> bool {
+    // SAFETY: the first call queries the count; the second fills the buffer.
+    let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+    if count <= 0 {
+        return false;
+    }
+
+    let mut gids = vec![0 as libc::gid_t; count as usize];
+    let filled = unsafe { libc::getgroups(count, gids.as_mut_ptr()) };
+    if filled < 0 {
+        return false;
+    }
+    gids.truncate(filled as usize);
+
+    gids.into_iter().filter_map(group_name).any(|g| g == name)
+}

--- a/sdk/rust/lib/setup/linux.rs
+++ b/sdk/rust/lib/setup/linux.rs
@@ -19,6 +19,23 @@ use super::host::{Check, Fix, FixCommand, Problem, Section};
 const KVM_DEVICE: &str = "/dev/kvm";
 
 //--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct DeviceGroup {
+    name: Option<String>,
+    gid: libc::gid_t,
+    grants_read_write: bool,
+}
+
+#[derive(Debug, Clone)]
+struct UserInfo {
+    name: String,
+    primary_gid: libc::gid_t,
+}
+
+//--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
 
@@ -123,23 +140,45 @@ fn cpu_virt_flag() -> Option<&'static str> {
 /// Build the `/dev/kvm` permission failure, with a fix tailored to whether the
 /// user already belongs to the device's owning group.
 ///
-/// The fix pairs two safe, reversible commands: `setfacl` grants the running
-/// user access immediately (this boot), while `usermod -aG` makes it persist
-/// across reboots. We can only build them once we know the real username, so a
-/// missing username degrades to advisory hints.
+/// The fix always prefers the narrowest safe mutation: `setfacl` grants the
+/// running user access for this boot, and `usermod -aG` is offered only when the
+/// device is owned by the standard `kvm` group with group read/write bits.
+/// We can only build commands once we know the effective username, so a missing
+/// username degrades to advisory hints.
 fn kvm_permission_problem() -> Problem {
-    let group = device_group(KVM_DEVICE);
-    let group_label = group.clone().unwrap_or_else(|| "kvm".to_string());
-    let already_member = group.as_deref().map(user_in_group).unwrap_or(false);
-    let user = current_username();
+    let device_group = device_group(KVM_DEVICE);
+    let user = current_user();
+    let process_member = device_group
+        .as_ref()
+        .map(|group| process_has_group(group.gid))
+        .unwrap_or(false);
+    let persistent_member = match (&user, &device_group) {
+        (Some(user), Some(group)) => persistent_user_in_group(user, group.gid),
+        _ => false,
+    };
 
-    let cause = if already_member {
-        format!("you are in the '{group_label}' group, but this login session predates the change")
-    } else {
-        match &group {
-            Some(g) => format!("{KVM_DEVICE} is owned by group '{g}', which your user is not in"),
-            None => format!("your user lacks read/write access to {KVM_DEVICE}"),
+    let cause = match &device_group {
+        Some(group) if persistent_member && !process_member => {
+            let label = group_label(group);
+            format!("you are in the '{label}' group, but this login session predates the change")
         }
+        Some(group) if process_member => {
+            let label = group_label(group);
+            format!(
+                "your process belongs to the '{label}' group, but {KVM_DEVICE} still rejects read/write access"
+            )
+        }
+        Some(group) if group.grants_read_write => {
+            let label = group_label(group);
+            format!("{KVM_DEVICE} is owned by group '{label}', which your user is not in")
+        }
+        Some(group) => {
+            let label = group_label(group);
+            format!(
+                "{KVM_DEVICE} is owned by group '{label}', but group permissions do not grant read/write access"
+            )
+        }
+        None => format!("your user lacks read/write access to {KVM_DEVICE}"),
     };
 
     let mut problem = Problem::new(
@@ -150,12 +189,18 @@ fn kvm_permission_problem() -> Problem {
     let Some(user) = user else {
         return problem;
     };
-    let acl = format!("u:{user}:rw");
+    let acl = format!("u:{}:rw", user.name);
 
-    if already_member {
-        // Membership is set; just grant this session direct access.
+    if persistent_member || process_member || !can_offer_group_fix(device_group.as_ref()) {
+        // When persistent membership is already present, the direct ACL grants
+        // this login session access immediately. For non-standard device groups
+        // it is also the only safe automatic mutation; adding users to arbitrary
+        // groups can accidentally grant unrelated host privileges.
         problem = problem.with_fix(Fix::new(
-            format!("grant {user} access to {KVM_DEVICE} for the current session"),
+            format!(
+                "grant {} access to {KVM_DEVICE} for the current session",
+                user.name
+            ),
             vec![FixCommand::sudo(&[
                 "setfacl",
                 "-m",
@@ -164,11 +209,18 @@ fn kvm_permission_problem() -> Problem {
             ])],
         ));
     } else {
+        let group = device_group
+            .as_ref()
+            .and_then(|group| group.name.as_deref())
+            .expect("safe KVM group fixes require a named device group");
         problem = problem.with_fix(
             Fix::new(
-                format!("add {user} to the '{group_label}' group and grant access now"),
+                format!(
+                    "add {} to the '{group}' group and grant access now",
+                    user.name
+                ),
                 vec![
-                    FixCommand::sudo(&["usermod", "-aG", group_label.as_str(), user.as_str()]),
+                    FixCommand::sudo(&["usermod", "-aG", group, user.name.as_str()]),
                     FixCommand::sudo(&["setfacl", "-m", acl.as_str(), KVM_DEVICE]),
                 ],
             )
@@ -188,14 +240,8 @@ fn kvm_module() -> Option<&'static str> {
     }
 }
 
-/// Resolve the current effective user's login name.
-fn current_username() -> Option<String> {
-    if let Ok(user) = std::env::var("USER")
-        && !user.is_empty()
-    {
-        return Some(user);
-    }
-
+/// Resolve the current effective user's login name and primary group.
+fn current_user() -> Option<UserInfo> {
     // SAFETY: getpwuid returns a pointer into a shared static buffer; the doctor
     // command is single-threaded, and we copy the name out immediately.
     unsafe {
@@ -203,18 +249,24 @@ fn current_username() -> Option<String> {
         if entry.is_null() {
             return None;
         }
-        Some(
-            CStr::from_ptr((*entry).pw_name)
+        Some(UserInfo {
+            name: CStr::from_ptr((*entry).pw_name)
                 .to_string_lossy()
                 .into_owned(),
-        )
+            primary_gid: (*entry).pw_gid,
+        })
     }
 }
 
-/// Resolve the owning group name of a device path.
-fn device_group(path: &str) -> Option<String> {
-    let gid = std::fs::metadata(path).ok()?.gid();
-    group_name(gid)
+/// Resolve the owning group and group permission bits of a device path.
+fn device_group(path: &str) -> Option<DeviceGroup> {
+    let metadata = std::fs::metadata(path).ok()?;
+    let gid = metadata.gid();
+    Some(DeviceGroup {
+        name: group_name(gid),
+        gid,
+        grants_read_write: metadata.mode() & 0o060 == 0o060,
+    })
 }
 
 /// Resolve a gid to its group name.
@@ -235,8 +287,12 @@ fn group_name(gid: libc::gid_t) -> Option<String> {
     }
 }
 
-/// Whether the current process belongs to the named group.
-fn user_in_group(name: &str) -> bool {
+/// Whether the current process belongs to the given group.
+fn process_has_group(gid: libc::gid_t) -> bool {
+    if unsafe { libc::getegid() } == gid {
+        return true;
+    }
+
     // SAFETY: the first call queries the count; the second fills the buffer.
     let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
     if count <= 0 {
@@ -250,5 +306,52 @@ fn user_in_group(name: &str) -> bool {
     }
     gids.truncate(filled as usize);
 
-    gids.into_iter().filter_map(group_name).any(|g| g == name)
+    gids.into_iter().any(|g| g == gid)
+}
+
+/// Whether the user's account is persistently a member of the target group.
+fn persistent_user_in_group(user: &UserInfo, gid: libc::gid_t) -> bool {
+    user.primary_gid == gid || group_has_member(gid, &user.name)
+}
+
+/// Whether a group database entry lists a user as a member.
+fn group_has_member(gid: libc::gid_t, user: &str) -> bool {
+    // SAFETY: getgrgid returns a pointer into a shared static buffer. We only
+    // read the null-terminated member list during this call and copy names into
+    // Rust strings before comparing.
+    unsafe {
+        let entry = libc::getgrgid(gid);
+        if entry.is_null() {
+            return false;
+        }
+
+        let mut member = (*entry).gr_mem;
+        while !member.is_null() && !(*member).is_null() {
+            if CStr::from_ptr(*member).to_string_lossy() == user {
+                return true;
+            }
+            member = member.add(1);
+        }
+    }
+
+    false
+}
+
+/// Whether it is safe to persist access by adding the user to the device group.
+fn can_offer_group_fix(group: Option<&DeviceGroup>) -> bool {
+    matches!(
+        group,
+        Some(DeviceGroup {
+            name: Some(name),
+            grants_read_write: true,
+            ..
+        }) if name == "kvm"
+    )
+}
+
+fn group_label(group: &DeviceGroup) -> String {
+    group
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("gid {}", group.gid))
 }

--- a/sdk/rust/lib/setup/macos.rs
+++ b/sdk/rust/lib/setup/macos.rs
@@ -1,0 +1,41 @@
+//! macOS host prerequisite checks for local sandbox execution.
+//!
+//! The local runtime requires Apple silicon; Intel Macs (and x86_64 binaries
+//! running under Rosetta) cannot run sandboxes. macOS needs no separate
+//! hypervisor feature toggle, so there is nothing to fix automatically.
+
+use super::host::{Check, Problem, Section};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Diagnose macOS host virtualization prerequisites.
+pub(super) fn host_section() -> (Section, Vec<Problem>) {
+    let arch = std::env::consts::ARCH;
+    let mut checks = vec![Check::info("Platform", &format!("macOS {arch}"))];
+    let mut problems = Vec::new();
+
+    if arch == "aarch64" {
+        checks.push(Check::pass("Architecture", "Apple silicon (arm64)"));
+    } else {
+        checks.push(Check::fail("Architecture", "unsupported"));
+        problems.push(Problem::new(
+            "this Mac cannot run local sandboxes",
+            vec![
+                "local execution requires Apple silicon (arm64)".to_string(),
+                format!("this process is running as {arch} (Intel, or x86_64 under Rosetta)"),
+                "no automatic fix is available; use an Apple silicon host or a remote runtime"
+                    .to_string(),
+            ],
+        ));
+    }
+
+    (
+        Section {
+            title: "Host".to_string(),
+            checks,
+        },
+        problems,
+    )
+}

--- a/sdk/rust/lib/setup/mod.rs
+++ b/sdk/rust/lib/setup/mod.rs
@@ -1,7 +1,13 @@
 //! Setup and installation utilities for microsandbox runtime dependencies.
 
 mod download;
+mod host;
 mod verify;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
 #[cfg(windows)]
 mod windows;
 
@@ -10,5 +16,6 @@ mod windows;
 //--------------------------------------------------------------------------------------------------
 
 pub use download::*;
+pub use host::*;
 #[cfg(windows)]
 pub use windows::*;

--- a/sdk/rust/lib/setup/verify.rs
+++ b/sdk/rust/lib/setup/verify.rs
@@ -18,9 +18,9 @@ pub(super) fn verify_installation(bin_dir: &Path, lib_dir: &Path) -> Microsandbo
         (libkrunfw_name.as_str(), lib_dir),
     ] {
         let path = dir.join(name);
-        if !path.exists() {
+        if !path.is_file() {
             return Err(MicrosandboxError::Custom(format!(
-                "{name} not found in {}",
+                "{name} not found as a file in {}",
                 dir.display()
             )));
         }

--- a/sdk/rust/lib/setup/windows.rs
+++ b/sdk/rust/lib/setup/windows.rs
@@ -207,6 +207,37 @@ pub fn verify_windows_host_prerequisites() -> Result<(), WindowsHostSetupError> 
 }
 
 //--------------------------------------------------------------------------------------------------
+// Functions: Doctor
+//--------------------------------------------------------------------------------------------------
+
+/// Diagnose Windows host virtualization prerequisites for `msb doctor`.
+pub(super) fn host_section() -> (super::host::Section, Vec<super::host::Problem>) {
+    use super::host::{Check, Problem, Section};
+
+    let arch = std::env::consts::ARCH;
+    let mut checks = vec![Check::info("Platform", &format!("Windows {arch}"))];
+    let mut problems = Vec::new();
+
+    match verify_windows_host_prerequisites() {
+        Ok(()) => checks.push(Check::pass("Hypervisor", "Windows Hypervisor Platform")),
+        Err(err) => {
+            checks.push(Check::fail("Hypervisor", "unavailable"));
+            let mut hints = vec![err.cause()];
+            hints.extend(err.hints().iter().map(|hint| (*hint).to_string()));
+            problems.push(Problem::new(err.title(), hints));
+        }
+    }
+
+    (
+        Section {
+            title: "Host".to_string(),
+            checks,
+        },
+        problems,
+    )
+}
+
+//--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## TL;DR
Make `msb doctor` work across Linux, macOS, and Windows instead of only handling the Windows hypervisor case, and turn `--fix` into something that actually applies safe fixes instead of just printing advice.

## Description
- Add a presentation-agnostic diagnosis model in the SDK (`Diagnosis`, `Section`, `Check`, `Problem`, `Fix`, `FixCommand`) plus a `diagnose()` entry point, so the CLI only renders and the platform logic stays testable.
- Build a Runtime section (install root, `msb`, `libkrunfw`) and a per-platform Host section: Linux checks CPU virt flags (vmx/svm, x86 only), `/dev/kvm` presence, and a side-effect-free read/write probe; macOS checks for Apple silicon; Windows reuses the existing WHP verification through the same model.
- Render the result as a flat log in the shared `ui` vocabulary: `info <label>: <value>` facts grouped at the top, then `✓`/`✗ <label> <detail>` completion rows for checks, and `error:`/`warn:` + `->` blocks for problems, closing with `done`; exit non-zero when the host can't run sandboxes.
- Drive the slow steps with the existing braille spinner: the whole diagnosis runs behind a `Checking host` spinner, and each `--fix` command animates `Applying` then leaves a `✓ Applied` row; instant checks use `ui::success` (same row, no transient spinner).
- Add the missing `ui` primitives this needs: `ui::failure` and `Spinner::finish_fail` (red `✗` completion) and `ui::warn_with_lines` (the yellow sibling of `error_with_lines`).
- Make `--fix` apply safe, idempotent remediations after a `[y/N]` prompt, then re-check: Linux kvm-group failures run `usermod -aG` (persistent) plus `setfacl` (current session), a missing module runs `modprobe kvm_intel`/`kvm_amd` by detected vendor, and Windows keeps its elevated enable flow. Sudo is pre-authenticated once so its password prompt doesn't fight the spinner.
- Keep genuinely unfixable conditions advisory (BIOS virtualization off, container not exposing `/dev/kvm`, Intel/Rosetta Macs), and refuse to mutate the host on a non-interactive `--fix` unless `--yes` is passed.

Usage:

```bash
# Diagnose the host (also available as `msb self doctor` / `msb self check`)
msb doctor

# Apply safe fixes, prompting before each one
msb doctor --fix

# Apply without prompts (CI/scripts)
msb doctor --fix --yes
```

Healthy host output:

```text
info Platform: Linux x86_64
info Install root: ~/.microsandbox
   ✓ msb          present
   ✓ libkrunfw    present
   ✓ CPU virt     vmx
   ✓ KVM device   /dev/kvm
   ✓ KVM access   read/write
done Host setup is ready.
```

`--fix` on a kvm-group failure:

```text
info Platform: Linux x86_64
   ✗ KVM access   permission denied
error: /dev/kvm is not accessible by your user
  → /dev/kvm is owned by group 'kvm', which you're not in
  → fix: add me to the 'kvm' group and grant access now
  →   sudo usermod -aG kvm me
  →   sudo setfacl -m u:me:rw /dev/kvm
Apply fix — add me to the 'kvm' group and grant access now? [y/N] y
   ✓ Applied      sudo usermod -aG kvm me
   ✓ Applied      sudo setfacl -m u:me:rw /dev/kvm
   ✓ KVM access   read/write
done Host setup is ready.
```

## Test Plan
- [x] `cargo build -p microsandbox-cli --bin msb` exits 0
- [x] `cargo clippy -p microsandbox -p microsandbox-cli -- -D warnings` is clean
- [x] `cargo fmt -p microsandbox -p microsandbox-cli -- --check` is clean
- [x] `msb doctor` on a healthy macOS host renders the flat log and exits 0
- [x] `MSB_HOME=$(mktemp -d) msb doctor` reports the missing runtime and exits 1
- [x] `msb doctor --fix` with no fixable problem and no TTY refuses to mutate and exits 1
- [x] `--fix` apply path renders `Applying`/`✓ Applied` rows, re-checks, and shows the `warn:` relogin block (verified via a temporary injected fix on macOS)
- [ ] Linux `/dev/kvm` permission path runs `usermod`/`setfacl` and re-checks green (needs a real Linux host; verified by compile + host-typecheck only)
- [ ] Windows `--fix` enables WHP (needs native Windows build; runs in CI)
