### PR TITLE
feat(windows): support bind mounts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,6 +77,39 @@ jobs:
           name: kernel-c-aarch64
           path: vendor/libkrunfw/kernel.c
 
+  build-kernel-x86_64:
+    name: Build kernel.c (x86_64)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+
+      - name: Cache kernel.c
+        id: cache-kernel
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        with:
+          path: vendor/libkrunfw/kernel.c
+          key: kernel-c-x86_64-${{ hashFiles('vendor/libkrunfw/**') }}
+
+      - name: Install kernel build deps
+        if: steps.cache-kernel.outputs.cache-hit != 'true'
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev gcc make flex bison libelf-dev bc python3-pyelftools
+
+      - name: Build kernel.c
+        if: steps.cache-kernel.outputs.cache-hit != 'true'
+        run: |
+          cd vendor/libkrunfw
+          make -j$(nproc)
+
+      - name: Upload kernel.c
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kernel-c-x86_64
+          path: vendor/libkrunfw/kernel.c
+
   # ---------------------------------------------------------------------------
   # Build agentd on Linux for macOS packaging
   # ---------------------------------------------------------------------------
@@ -110,6 +143,38 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: agentd-aarch64-linux-musl
+          path: build/agentd
+
+  build-agentd-x86_64:
+    name: Build agentd (x86_64-linux-musl)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-bin: false
+
+      - name: Install agentd build deps
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Build agentd
+        run: |
+          rustup target add --toolchain stable x86_64-unknown-linux-musl
+          cargo +stable build --release --manifest-path crates/agentd/Cargo.toml --target x86_64-unknown-linux-musl
+          mkdir -p build
+          cp target/x86_64-unknown-linux-musl/release/agentd build/agentd
+
+      - name: Upload agentd
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: agentd-x86_64-linux-musl
           path: build/agentd
 
   # ---------------------------------------------------------------------------
@@ -388,6 +453,112 @@ jobs:
           "
           npm install --no-package-lock --ignore-scripts
           npm run build
+
+  # ---------------------------------------------------------------------------
+  # Windows build/check only.
+  #
+  # These jobs verify the WHP host targets compile on both Windows architectures.
+  # VM smoke and integration coverage intentionally stays Linux/KVM-only below.
+  # ---------------------------------------------------------------------------
+  windows-check:
+    name: Check Windows (${{ matrix.target }})
+    needs: [build-kernel, build-kernel-x86_64, build-agentd-aarch64, build-agentd-x86_64, changes]
+    if: always() && needs.changes.outputs.code == 'true'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: windows-aarch64
+            runner: windows-11-arm
+            rust_target: aarch64-pc-windows-msvc
+            kernel_artifact: kernel-c-aarch64
+            agentd_artifact: agentd-aarch64-linux-musl
+            vs_arch: arm64
+            vs_host_arch: arm64
+          - target: windows-x86_64
+            runner: windows-latest
+            rust_target: x86_64-pc-windows-msvc
+            kernel_artifact: kernel-c-x86_64
+            agentd_artifact: agentd-x86_64-linux-musl
+            vs_arch: amd64
+            vs_host_arch: amd64
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy, rustfmt
+          targets: ${{ matrix.rust_target }}
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-bin: false
+
+      - name: Download kernel.c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ matrix.kernel_artifact }}
+          path: vendor/libkrunfw/
+
+      - name: Download agentd
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ matrix.agentd_artifact }}
+          path: build/
+
+      - name: Build libkrunfw.dll
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          & .\vendor\libkrunfw\scripts\build-windows.ps1 `
+            -SkipKernelBundle `
+            -AbiVersion ${{ env.LIBKRUNFW_ABI }} `
+            -Architecture ${{ matrix.vs_arch }} `
+            -HostArchitecture ${{ matrix.vs_host_arch }} `
+            -Output libkrunfw.dll `
+            -ImportLibrary libkrunfw.lib
+          New-Item -ItemType Directory -Force -Path build | Out-Null
+          Copy-Item vendor\libkrunfw\libkrunfw.dll build\libkrunfw.dll -Force
+
+      - name: Format
+        shell: pwsh
+        run: cargo +stable fmt --all -- --check
+
+      - name: Check msb
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"
+          Set-MsvcEnvironment -Architecture ${{ matrix.vs_arch }} -HostArchitecture ${{ matrix.vs_host_arch }}
+          cargo +stable check --no-default-features --features net,ssh -p microsandbox-cli --target ${{ matrix.rust_target }}
+
+      - name: Clippy msb
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"
+          Set-MsvcEnvironment -Architecture ${{ matrix.vs_arch }} -HostArchitecture ${{ matrix.vs_host_arch }}
+          cargo +stable clippy --no-default-features --features net,ssh -p microsandbox-cli --target ${{ matrix.rust_target }} -- -D warnings
+
+      - name: Test bind rootfs backend
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"
+          Set-MsvcEnvironment -Architecture ${{ matrix.vs_arch }} -HostArchitecture ${{ matrix.vs_host_arch }}
+          cargo +stable test --no-default-features --features net -p microsandbox-runtime --lib --target ${{ matrix.rust_target }} test_bind_rootfs_backend_exposes_host_file_and_init
+
+      - name: Build msb
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"
+          Set-MsvcEnvironment -Architecture ${{ matrix.vs_arch }} -HostArchitecture ${{ matrix.vs_host_arch }}
+          cargo +stable build --release --no-default-features --features net,ssh -p microsandbox-cli --target ${{ matrix.rust_target }}
 
   # ---------------------------------------------------------------------------
   # CLI smoke tests (requires KVM)
@@ -865,8 +1036,11 @@ jobs:
     needs:
       - changes
       - build-kernel
+      - build-kernel-x86_64
       - build-agentd-aarch64
+      - build-agentd-x86_64
       - check
+      - windows-check
       - cli-smoke-test
       - integration-test
       - node-sdk-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3561,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2056e23685de155d8a910bf1a2617e856bd21ced656ac442490df973812fc69"
+checksum = "c0fb3437734ef4103d3891d3cbd51a8726f196af350c68cb044a1860207c64d3"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3581,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5645c3721d9a65c8887da750b70e5ca56ee6d583c82920924b464f42192377c9"
+checksum = "e25fe665643d66900ec9407ef0d3afdb5cd4ca97ad394c46b8243bfa6344bfc0"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3596,15 +3596,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71adce997cb6fecc01c49c9fcd523f5620005f70fc49900b8ba38eaaa37d118"
+checksum = "7e50dfac228ad088917f8ffb2920c4a56d762ebc5a90950ee7bf5414253b02aa"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b765b590a3f8e9a8c338b12d9dd3ba9f72ae343b33c0994058f9149ae13ffd4a"
+checksum = "fd5221749c0224858b075b61f3f2a0964dbfe367093e9ee650b6b0e3d690c3b2"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3613,9 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189eb43f486c539058df8e65c687180ac5d4728f88fe96aee35af8ec8c59e947"
+checksum = "4fee50bfdf1a1258e33bcf0ee8631bb805db79b8d442161ab63d700689a992a8"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3643,9 +3643,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3803b2ddabc1de061dd89fed560c9cf83531be58ff7a6797a6583c8ceb7c048"
+checksum = "3f2300bbe4dbd56bdc3ffc2384baf82e299fff8a45e844f41c4a0be64210ed47"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -3655,9 +3655,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d162cf9076f336c396276326ab91967bf46064e0aaf5d6fe2795974b1e08d79"
+checksum = "3402b8879bd5b91f33d069fefa00fd0416f12cd660cfd7538da8e77201f2dda5"
 dependencies = [
  "msb_krun_utils",
  "vm-memory",
@@ -3665,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65006b25aa67bb43304a9ca46e7b5ed4e8c4785436a7029f81915ad9a2e395e4"
+checksum = "da550bf268cb9217255ed152bfca9f61275a2796237fd180989958c7f54dc137"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3675,18 +3675,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e72f780e8add110df1c5b77cebf73f92a382e1c765ed6d0c9531b08f3fed45"
+checksum = "2c0737818e69346348f8ba2a7197cbec2336e807e5f7f094c80e0ca1635ca054"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16d982c2f6894cf6e2786940351f04dee2c69d7b640432314722a8fed88f2d3"
+checksum = "fb370035195bfd6d60e0b4ad8b0d68dcf9d138f144d033087a960117920a126e"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3700,9 +3700,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f19898b23d6b4327f09eacae6a48e7bc7d91cfdf7b97a25672af7188ef8d29b"
+checksum = "68e9f485f720981fda9071b2711d4f8406b6c67ebf6bfa2bb8e83f3cc6c2aaea"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,8 @@ microsandbox-network = { version = "=0.6.0", path = "crates/network" }
 microsandbox-protocol = { version = "=0.6.0", path = "crates/protocol" }
 microsandbox-runtime = { version = "=0.6.0", path = "crates/runtime", default-features = false }
 microsandbox-utils = { version = "=0.6.0", path = "crates/utils" }
-msb_krun = "=0.1.18"
-msb_krun_utils = "=0.1.18"
+msb_krun = "=0.1.19"
+msb_krun_utils = "=0.1.19"
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }
 

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -338,7 +338,7 @@ fn uninstall_all(base_dir: &Path) -> anyhow::Result<()> {
 
     #[cfg(windows)]
     {
-        return uninstall_all_windows(base_dir);
+        uninstall_all_windows(base_dir)
     }
 
     #[cfg(not(windows))]
@@ -610,7 +610,7 @@ fn link_public_commands(base_dir: &Path) -> anyhow::Result<()> {
             "Add {} to PATH to run msb from any terminal.",
             base_dir.join(microsandbox_utils::BIN_SUBDIR).display()
         ));
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(unix)]
@@ -654,7 +654,7 @@ fn remove_public_command_links(base_dir: &Path) -> anyhow::Result<()> {
     #[cfg(not(unix))]
     {
         let _ = base_dir;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(unix)]

--- a/crates/filesystem/lib/backends/passthroughfs/windows/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/mod.rs
@@ -576,12 +576,17 @@ fn mode_from_metadata(metadata: &std::fs::Metadata) -> u32 {
         0
     };
 
+    // NTFS has no Unix execute bit, so synthesize a default mode for files
+    // that have no virtual override yet. Default to executable (matching
+    // libkrun's own Windows fs passthrough and WSL DrvFs's no-metadata
+    // behavior) so binaries on a bind mount or bind rootfs can run: without
+    // this, every host file is exposed as 0o666 and the guest cannot exec
+    // anything before it has a chance to chmod it. Precise per-file modes
+    // still come from the virtual stat store once the guest sets them.
     let perms = if metadata.file_attributes() & FILE_ATTRIBUTE_READONLY != 0 {
         0o555
-    } else if metadata.file_type().is_dir() {
-        0o777
     } else {
-        0o666
+        0o777
     };
     type_bits | perms
 }

--- a/crates/filesystem/lib/backends/passthroughfs/windows/ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/ops.rs
@@ -336,7 +336,6 @@ impl DynFileSystem for PassthroughFs {
             f_files: self.inodes.read().unwrap().by_inode.len() as u64,
             f_ffree: 0,
             f_namemax: 255,
-            ..Default::default()
         })
     }
 

--- a/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
@@ -410,6 +410,46 @@ fn seeded_virtual_permissions_are_visible_after_backend_start() {
 }
 
 #[test]
+fn host_files_without_override_are_executable() {
+    let temp = TempDir::new();
+    std::fs::write(temp.path.join("program"), b"\x7fELFbinary").unwrap();
+
+    let fs = fs_for(&temp.path);
+    let entry = fs.lookup(context(), ROOT_INODE, c"program").unwrap();
+    let (st, _) = fs.getattr(context(), entry.inode, None).unwrap();
+
+    // NTFS has no Unix exec bit, but a freshly bound host file must still be
+    // runnable (e.g. binaries in a bind rootfs) before the guest chmods it.
+    assert_eq!(st.st_mode & S_IFMT, S_IFREG);
+    assert_eq!(st.st_mode & 0o7777, 0o777);
+    assert_ne!(
+        st.st_mode & 0o111,
+        0,
+        "host file should be executable by default"
+    );
+
+    // Root must pass an X_OK access check against the synthesized mode.
+    check_access(context(), &st, LINUX_ACCESS_X_OK).unwrap();
+}
+
+#[test]
+fn readonly_host_files_without_override_are_read_execute_only() {
+    let temp = TempDir::new();
+    let file = temp.path.join("locked");
+    std::fs::write(&file, b"data").unwrap();
+    let mut perms = std::fs::metadata(&file).unwrap().permissions();
+    perms.set_readonly(true);
+    std::fs::set_permissions(&file, perms).unwrap();
+
+    let fs = fs_for(&temp.path);
+    let entry = fs.lookup(context(), ROOT_INODE, c"locked").unwrap();
+    let (st, _) = fs.getattr(context(), entry.inode, None).unwrap();
+
+    assert_eq!(st.st_mode & S_IFMT, S_IFREG);
+    assert_eq!(st.st_mode & 0o7777, 0o555);
+}
+
+#[test]
 fn strict_uses_ads_and_does_not_create_sidecar() {
     let temp = TempDir::new();
     let fs = fs_for(&temp.path);

--- a/crates/network/lib/icmp_relay.rs
+++ b/crates/network/lib/icmp_relay.rs
@@ -340,10 +340,10 @@ fn open_icmp_socket_v4(dst: Ipv4Addr) -> std::io::Result<tokio::net::UdpSocket> 
     #[cfg(windows)]
     {
         let _ = dst;
-        return Err(std::io::Error::new(
+        Err(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
             "external ICMPv4 relay is not implemented on Windows",
-        ));
+        ))
     }
 
     #[cfg(unix)]
@@ -396,10 +396,10 @@ fn open_icmp_socket_v6(dst: Ipv6Addr) -> std::io::Result<tokio::net::UdpSocket> 
     #[cfg(windows)]
     {
         let _ = dst;
-        return Err(std::io::Error::new(
+        Err(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
             "external ICMPv6 relay is not implemented on Windows",
-        ));
+        ))
     }
 
     #[cfg(unix)]

--- a/crates/runtime/lib/bootstrap_fs.rs
+++ b/crates/runtime/lib/bootstrap_fs.rs
@@ -133,9 +133,8 @@ impl DirState {
         Ok(self
             .children
             .iter()
-            .filter_map(|((parent, name), child)| {
-                (*parent == inode).then(|| (*child, name.clone()))
-            })
+            .filter(|((parent, _), _)| *parent == inode)
+            .map(|((_, name), child)| (*child, name.clone()))
             .collect())
     }
 }
@@ -359,15 +358,31 @@ impl DynFileSystem for AgentBootstrapFs {
     }
 
     fn statfs(&self, _ctx: Context, _inode: u64) -> io::Result<statvfs64> {
-        let mut stat = statvfs64::default();
-        stat.f_bsize = 4096;
-        stat.f_frsize = 4096;
-        stat.f_blocks = 1;
-        stat.f_bfree = 0;
-        stat.f_bavail = 0;
-        stat.f_files = 2;
-        stat.f_ffree = 0;
-        stat.f_namemax = 255;
+        #[cfg(windows)]
+        let stat = statvfs64 {
+            f_bsize: 4096,
+            f_frsize: 4096,
+            f_blocks: 1,
+            f_bfree: 0,
+            f_bavail: 0,
+            f_files: 2,
+            f_ffree: 0,
+            f_namemax: 255,
+        };
+
+        #[cfg(not(windows))]
+        let stat = statvfs64 {
+            f_bsize: 4096,
+            f_frsize: 4096,
+            f_blocks: 1,
+            f_bfree: 0,
+            f_bavail: 0,
+            f_files: 2,
+            f_ffree: 0,
+            f_namemax: 255,
+            ..Default::default()
+        };
+
         Ok(stat)
     }
 }

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 use std::num::NonZero;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 #[cfg(unix)]
 use std::sync::OnceLock;
@@ -1053,24 +1053,8 @@ fn build_vm(
 
     // Root filesystem.
     if let Some(ref rootfs_path) = vm.rootfs_path {
-        #[cfg(unix)]
-        {
-            let cfg = PassthroughConfig {
-                root_dir: rootfs_path.clone(),
-                ..Default::default()
-            };
-            let backend = PassthroughFs::new(cfg)
-                .map_err(|e| RuntimeError::Custom(format!("rootfs: {e}")))?;
-            builder = builder.fs(move |fs| fs.tag("/dev/root").custom(Box::new(backend)));
-        }
-
-        #[cfg(windows)]
-        {
-            let _ = rootfs_path;
-            return Err(RuntimeError::Custom(
-                "host-directory rootfs is unsupported on Windows; use a disk-image rootfs".into(),
-            ));
-        }
+        let backend = bind_rootfs_backend(rootfs_path)?;
+        builder = builder.fs(move |fs| fs.tag("/dev/root").custom(Box::new(backend)));
     } else if let Some(ref vmdk_path) = vm.rootfs_vmdk {
         // EROFS fsmerge OCI rootfs: VMDK (read-only) + upper.ext4 (writable).
         #[cfg(unix)]
@@ -1340,6 +1324,15 @@ fn build_vm(
 //--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
+
+/// Build the host-directory rootfs backend used for `ImageSource::bind`.
+fn bind_rootfs_backend(rootfs_path: &Path) -> RuntimeResult<PassthroughFs> {
+    let cfg = PassthroughConfig {
+        root_dir: rootfs_path.to_path_buf(),
+        ..Default::default()
+    };
+    PassthroughFs::new(cfg).map_err(|e| RuntimeError::Custom(format!("rootfs: {e}")))
+}
 
 /// Open the shared-memory registry and promote the host-reserved slot to
 /// `Active`, returning a writer handle for the sampler.
@@ -1925,16 +1918,40 @@ mod tests {
     };
     use super::{
         ConsoleSharedState, HostPermissions, StatVirtualization, append_block_root_env,
-        guest_shutdown_flush_timeout, parse_mount_spec, prepend_scripts_path,
+        bind_rootfs_backend, guest_shutdown_flush_timeout, parse_mount_spec, prepend_scripts_path,
         request_guest_shutdown, request_guest_shutdown_with_timeout, validate_disk_format,
     };
 
+    use microsandbox_filesystem::{Context, DynFileSystem, FsOptions};
     use microsandbox_protocol::{codec, message::MessageType};
     #[cfg(unix)]
     use std::io::Write;
     #[cfg(unix)]
     use std::sync::Arc;
     use std::time::Duration;
+
+    fn fs_context() -> Context {
+        Context {
+            uid: 0,
+            gid: 0,
+            pid: 1,
+        }
+    }
+
+    #[test]
+    fn test_bind_rootfs_backend_exposes_host_file_and_init() {
+        let rootfs = tempfile::tempdir().unwrap();
+        std::fs::write(rootfs.path().join("host.txt"), b"from host").unwrap();
+
+        let fs = bind_rootfs_backend(rootfs.path()).unwrap();
+        fs.init(FsOptions::empty()).unwrap();
+
+        let host = fs.lookup(fs_context(), 1, c"host.txt").unwrap();
+        let init = fs.lookup(fs_context(), 1, c"init.krun").unwrap();
+
+        assert_ne!(host.inode, init.inode);
+        assert_eq!(init.inode, 2);
+    }
 
     #[test]
     fn test_parse_mount_spec_minimal() {

--- a/crates/utils/lib/copy.rs
+++ b/crates/utils/lib/copy.rs
@@ -200,7 +200,7 @@ fn is_reflink_unsupported(e: &io::Error) -> bool {
     #[cfg(windows)]
     {
         let win32_code = (code as u32 & 0xffff) as i32;
-        return aliases.contains(&code) || aliases.contains(&win32_code);
+        aliases.contains(&code) || aliases.contains(&win32_code)
     }
 
     #[cfg(unix)]

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -564,14 +564,14 @@ pub async fn spawn_sandbox(
     tracing::debug!(pid = _pid, sandbox = %config.spec.name, "spawn_sandbox: process started");
 
     #[cfg(windows)]
-    if let Some(job) = &child_job {
-        if let Err(err) = job.assign_pid(_pid) {
-            let status = terminate_startup_process(&mut child).await;
-            release_metrics_reservation(config, metrics_reservation.as_ref());
-            return Err(crate::MicrosandboxError::Runtime(format!(
-                "failed to assign sandbox process to Windows job (status: {status:?}): {err}"
-            )));
-        }
+    if let Some(job) = &child_job
+        && let Err(err) = job.assign_pid(_pid)
+    {
+        let status = terminate_startup_process(&mut child).await;
+        release_metrics_reservation(config, metrics_reservation.as_ref());
+        return Err(crate::MicrosandboxError::Runtime(format!(
+            "failed to assign sandbox process to Windows job (status: {status:?}): {err}"
+        )));
     }
 
     let line = match tokio::time::timeout(
@@ -1749,7 +1749,7 @@ async fn stage_file_mounts(
                     "file mount: hard-linked"
                 );
             }
-            Err(e) if e.raw_os_error() == Some(libc::EXDEV) => {
+            Err(e) if is_cross_device_link_error(&e) => {
                 if !readonly {
                     tracing::warn!(
                         host = %host.display(),
@@ -1773,6 +1773,29 @@ async fn stage_file_mounts(
     }
 
     Ok((staged, Some(tempdir)))
+}
+
+/// Return whether a host hard-link failed because the target is on another device.
+fn is_cross_device_link_error(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::CrossesDevices || is_platform_cross_device_link_error(error)
+}
+
+#[cfg(unix)]
+fn is_platform_cross_device_link_error(error: &std::io::Error) -> bool {
+    error.raw_os_error() == Some(libc::EXDEV)
+}
+
+#[cfg(windows)]
+fn is_platform_cross_device_link_error(error: &std::io::Error) -> bool {
+    // CreateHardLinkW reports cross-volume links as ERROR_NOT_SAME_DEVICE.
+    const ERROR_NOT_SAME_DEVICE: i32 = 17;
+
+    error.raw_os_error() == Some(ERROR_NOT_SAME_DEVICE)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn is_platform_cross_device_link_error(_error: &std::io::Error) -> bool {
+    false
 }
 
 /// Push a `--mount tag:host_path[:ro]` arg pair.
@@ -3403,6 +3426,70 @@ mod tests {
                 .windows(2)
                 .any(|pair| pair[0] == "--mount" && pair[1] == expected),
             "missing override-quota --mount arg in {rendered:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(windows)]
+    async fn test_sandbox_cli_args_windows_drive_bind_mount_preserves_drive_colon() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/data", |m| {
+                m.bind(r"C:\Users\Stephen\data")
+                    .readonly()
+                    .stat_virtualization(StatVirtualization::Relaxed)
+                    .host_permissions(HostPermissions::Mirror)
+            })
+            .build()
+            .await
+            .unwrap();
+
+        let rendered = render_args(&config);
+        let data_tag = super::guest_mount_tag("/data");
+        let expected = format!(
+            r"{data_tag}:C:\Users\Stephen\data:ro,stat-virt=relaxed,host-perms=mirror,quota={}",
+            crate::sandbox::config::DEFAULT_BIND_QUOTA_MIB
+        );
+
+        assert!(
+            rendered
+                .windows(2)
+                .any(|pair| pair[0] == "--mount" && pair[1] == expected),
+            "missing Windows drive bind --mount arg in {rendered:?}"
+        );
+        assert!(rendered.contains(&format!("MSB_DIR_MOUNTS={data_tag}:/data:ro")));
+    }
+
+    #[tokio::test]
+    #[cfg(windows)]
+    async fn test_sandbox_cli_args_windows_drive_file_mount_preserves_drive_colon() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/guest/config.txt", |m| {
+                m.bind(r"C:\Users\Stephen\config.txt").readonly()
+            })
+            .build()
+            .await
+            .unwrap();
+
+        let mut staged_file_mounts = HashMap::new();
+        staged_file_mounts.insert(
+            "/guest/config.txt".to_string(),
+            (
+                PathBuf::from(r"C:\Users\Stephen\AppData\Local\Temp\msb\fm_deadbeef"),
+                "config.txt".to_string(),
+                "fm_deadbeef".to_string(),
+            ),
+        );
+
+        let rendered = render_args_with_file_mounts(&config, &staged_file_mounts);
+
+        assert!(rendered.windows(2).any(|pair| pair[0] == "--mount"
+            && pair[1] == r"fm_deadbeef:C:\Users\Stephen\AppData\Local\Temp\msb\fm_deadbeef:ro"));
+        assert!(
+            rendered.contains(
+                &"MSB_FILE_MOUNTS=fm_deadbeef:config.txt:/guest/config.txt:ro".to_string()
+            )
         );
     }
 

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -1003,7 +1003,7 @@ pub(crate) async fn drain_local(
                 ))
             })?;
         }
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## TL;DR
Enable Windows host bind roots and bind mounts through the existing passthrough filesystem path, and add Windows build/check CI for both supported host architectures.

## Description
- Use the passthrough backend for `ImageSource::bind` roots on Windows instead of rejecting host-directory rootfs sources.
- Treat Windows cross-device hard-link failures like Unix `EXDEV` when staging file bind mounts, keeping the existing copy fallback.
- Add Windows drive-letter render coverage for bind directory and bind file mounts.
- Add Windows x86_64 and arm64 build/check CI, including format, check, clippy, build, and the focused bind-rootfs backend test.
- Keep Windows smoke and integration tests out of this PR; they still need a real WHP-capable runner and remain separate from the Linux-only smoke jobs.
- Refs superradcompany/microsandbox#1049.

```powershell
msb run --mount-dir C:\Users\me\data:/data alpine -- ls /data
msb run --mount-file C:\Users\me\config.txt:/app/config.txt:ro alpine -- cat /app/config.txt
```

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p microsandbox-runtime --lib bind_rootfs_backend`
- [x] Azure Windows x86_64: `cargo test --no-default-features --features net -p microsandbox-runtime --lib test_bind_rootfs_backend_exposes_host_file_and_init`
- [x] Azure Windows x86_64: `cargo test --no-default-features --features net,ssh -p microsandbox --lib windows_drive`
- [x] Azure Windows x86_64: `cargo check --no-default-features --features net,ssh -p microsandbox-cli`
- [x] Windows arm64 CI matrix (runs in GitHub Actions)