### PR TITLE
packaging(winget): declare VCRedist 2015+ dependency

### DIFF
--- a/packaging/winget/SuperRadCompany.Microsandbox/SuperRadCompany.Microsandbox.installer.yaml
+++ b/packaging/winget/SuperRadCompany.Microsandbox/SuperRadCompany.Microsandbox.installer.yaml
@@ -14,8 +14,14 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/superradcompany/microsandbox/releases/download/{{TAG}}/microsandbox-windows-x86_64.zip
   InstallerSha256: "{{SHA256_X64}}"
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 - Architecture: arm64
   InstallerUrl: https://github.com/superradcompany/microsandbox/releases/download/{{TAG}}/microsandbox-windows-aarch64.zip
   InstallerSha256: "{{SHA256_ARM64}}"
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/manifests/s/SuperRadCompany/Microsandbox/0.6.0/SuperRadCompany.Microsandbox.installer.yaml
+++ b/packaging/winget/manifests/s/SuperRadCompany/Microsandbox/0.6.0/SuperRadCompany.Microsandbox.installer.yaml
@@ -14,8 +14,14 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/superradcompany/microsandbox/releases/download/v0.6.0/microsandbox-windows-x86_64.zip
   InstallerSha256: 33EE7A3D986E3008C04B06C1D3E2F00BC4218E2447053324AED449147D1DE653
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 - Architecture: arm64
   InstallerUrl: https://github.com/superradcompany/microsandbox/releases/download/v0.6.0/microsandbox-windows-aarch64.zip
   InstallerSha256: AE72DAEAB204E8A3CD9DA11D94999B29734F0FB9BFB8507E137048ABA2995A7B
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## Why
winget-pkgs validation of [microsoft/winget-pkgs#394540](https://github.com/microsoft/winget-pkgs/pull/394540) flagged `Validation-Executable-Error`: on a clean VM, `msb.exe` fails to launch with `STATUS_DLL_NOT_FOUND` (0xC0000135). `msb.exe` imports `VCRUNTIME140.dll`, which ships with the Visual C++ Redistributable — present on dev machines but absent on a clean image.

## Change
Declare the matching VCRedist as a per-architecture installer dependency (x64 → `Microsoft.VCRedist.2015+.x64`, arm64 → `Microsoft.VCRedist.2015+.arm64`) so winget installs the runtime before microsandbox. Applied to:
- the staged 0.6.0 manifest
- the reusable `{{VERSION}}` template (so future renders / Komac auto-submissions inherit it)

The same fix is already pushed to the live winget-pkgs PR #394540 to re-trigger its validation.

## Validation
- `winget validate` passes on the updated 0.6.0 manifest set.