### PR TITLE
feat(cli): add --no-tty execution mode

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -1872,7 +1872,7 @@ fn parse_pull_policy(s: &str) -> anyhow::Result<microsandbox::sandbox::PullPolic
 }
 
 //--------------------------------------------------------------------------------------------------
-// Trait Implementations
+// Functions: Command resolution
 //--------------------------------------------------------------------------------------------------
 
 /// Parse a log level string.
@@ -1886,6 +1886,11 @@ fn parse_log_level(s: &str) -> anyhow::Result<microsandbox::LogLevel> {
         "trace" => Ok(LogLevel::Trace),
         _ => anyhow::bail!("invalid log level: {s} (expected: error, warn, info, debug, trace)"),
     }
+}
+
+/// Return whether this invocation should use the terminal-attached PTY path.
+pub(crate) fn use_interactive_tty(stdin_is_terminal: bool, no_tty: bool) -> bool {
+    stdin_is_terminal && !no_tty
 }
 
 /// Resolve the command to run following OCI semantics.

--- a/crates/cli/lib/commands/exec.rs
+++ b/crates/cli/lib/commands/exec.rs
@@ -33,8 +33,12 @@ pub struct ExecArgs {
     pub user: Option<String>,
 
     /// Allocate a pseudo-terminal (enables colors, line editing).
-    #[arg(short = 't', long)]
+    #[arg(short = 't', long, conflicts_with = "no_tty")]
     pub tty: bool,
+
+    /// Disable pseudo-terminal allocation and run non-interactively.
+    #[arg(long = "no-tty", conflicts_with = "tty")]
+    pub no_tty: bool,
 
     /// Kill the command after this duration (e.g. 30s, 5m, 1h).
     #[arg(long)]
@@ -89,14 +93,19 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
         .collect::<anyhow::Result<Vec<_>>>()?;
 
     let workdir = args.workdir;
-    let interactive = std::io::stdin().is_terminal();
+    let stdin_is_terminal = std::io::stdin().is_terminal();
+    let interactive = super::common::use_interactive_tty(stdin_is_terminal, args.no_tty);
 
     // Read piped stdin upfront so it can be forwarded into the sandbox.
     // Skipped in `--stream` mode, where stdin is forwarded incrementally.
-    let piped_stdin = if !interactive && !args.stream {
+    let piped_stdin = if should_read_buffered_stdin(stdin_is_terminal, interactive, args.stream) {
         let mut buf = Vec::new();
         tokio::io::stdin().read_to_end(&mut buf).await.ok();
         Some(buf)
+    } else if !interactive && !args.stream {
+        // `--no-tty` with terminal stdin means "non-interactive", so give the
+        // guest EOF instead of blocking on the host terminal.
+        Some(Vec::new())
     } else {
         None
     };
@@ -223,6 +232,11 @@ fn apply_common_exec_opts(
         e = e.rlimit_range(resource, soft, hard);
     }
     e
+}
+
+/// Return whether buffered exec should consume host stdin before starting.
+fn should_read_buffered_stdin(stdin_is_terminal: bool, interactive: bool, stream: bool) -> bool {
+    !stdin_is_terminal && !interactive && !stream
 }
 
 /// Drive a non-PTY bidirectional streaming exec session (`--stream`).
@@ -363,4 +377,54 @@ async fn write_chunk<W: tokio::io::AsyncWrite + Unpin>(
     w.write_all(data).await?;
     w.flush().await?;
     Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use clap::error::ErrorKind;
+
+    use super::*;
+
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: ExecArgs,
+    }
+
+    fn parse_exec_args(args: &[&str]) -> ExecArgs {
+        TestCli::parse_from(std::iter::once("msb").chain(args.iter().copied())).args
+    }
+
+    #[test]
+    fn no_tty_parses_before_command_delimiter() {
+        let args = parse_exec_args(&["box", "--no-tty", "--", "python3", "-c", "print('ok')"]);
+
+        assert!(args.no_tty);
+        assert_eq!(args.name, "box");
+        assert_eq!(
+            args.command,
+            vec![
+                "python3".to_string(),
+                "-c".to_string(),
+                "print('ok')".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn no_tty_conflicts_with_tty() {
+        let err = TestCli::try_parse_from(["msb", "--tty", "--no-tty", "box"]).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn no_tty_with_terminal_stdin_does_not_buffer_stdin() {
+        assert!(!should_read_buffered_stdin(true, false, false));
+    }
 }

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -37,8 +37,12 @@ pub struct RunArgs {
     pub detach: bool,
 
     /// Allocate a pseudo-terminal (enables colors, line editing).
-    #[arg(short = 't', long)]
+    #[arg(short = 't', long, conflicts_with = "no_tty")]
     pub tty: bool,
+
+    /// Disable pseudo-terminal allocation and run non-interactively.
+    #[arg(long = "no-tty", conflicts_with = "tty")]
+    pub no_tty: bool,
 
     /// Kill the command after this duration (e.g. 30s, 5m, 1h).
     #[arg(long)]
@@ -130,7 +134,8 @@ async fn run_existing(name: String, args: RunArgs) -> anyhow::Result<()> {
     }
 
     let exec_opts = ExecOpts::parse(&args)?;
-    let interactive = std::io::stdin().is_terminal();
+    let interactive =
+        super::common::use_interactive_tty(std::io::stdin().is_terminal(), args.no_tty);
 
     let result: anyhow::Result<i32> = async {
         let (cmd, cmd_args) =
@@ -219,7 +224,8 @@ async fn run_new(
     }
 
     let exec_opts = ExecOpts::parse(&args)?;
-    let interactive = std::io::stdin().is_terminal();
+    let interactive =
+        super::common::use_interactive_tty(std::io::stdin().is_terminal(), args.no_tty);
 
     let (cmd, cmd_args) =
         super::common::resolve_command(sandbox.config(), args.command, interactive)?;
@@ -357,10 +363,11 @@ fn warn_detached_command_ignored(name: &str, args: &RunArgs) {
 #[cfg(test)]
 mod tests {
     use clap::Parser;
+    use clap::error::ErrorKind;
 
     use super::*;
 
-    #[derive(Parser)]
+    #[derive(Debug, Parser)]
     struct TestCli {
         #[command(flatten)]
         args: RunArgs,
@@ -368,6 +375,38 @@ mod tests {
 
     fn parse_run_args(args: &[&str]) -> RunArgs {
         TestCli::parse_from(std::iter::once("msb").chain(args.iter().copied())).args
+    }
+
+    #[test]
+    fn no_tty_parses_after_image_before_command_delimiter() {
+        let args = parse_run_args(&[
+            "-q",
+            "python:3-alpine",
+            "--no-tty",
+            "--",
+            "python3",
+            "-c",
+            "print('ok')",
+        ]);
+
+        assert!(args.no_tty);
+        assert_eq!(args.image.as_deref(), Some("python:3-alpine"));
+        assert_eq!(
+            args.command,
+            vec![
+                "python3".to_string(),
+                "-c".to_string(),
+                "print('ok')".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn no_tty_conflicts_with_tty() {
+        let err =
+            TestCli::try_parse_from(["msb", "--tty", "--no-tty", "python:3-alpine"]).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -48,6 +48,7 @@ Common flags:
 | `--label` | Attach a label for metric attribution (`KEY=VALUE`, or bare `KEY`). Repeatable |
 | `-w`, `--workdir` | Set the working directory |
 | `-d`, `--detach` | Boot in the background. Run work later with `msb exec` |
+| `--no-tty` | Disable PTY allocation and run non-interactively |
 | `--replace` | Replace an existing sandbox with the same name |
 | `--no-net` | Disable network access |
 | `--net-rule` | Add a network policy rule |
@@ -166,6 +167,7 @@ msb exec devbox -- ls -la /app
 | Flag | Description |
 |------|-------------|
 | `-t`, `--tty` | Allocate a pseudo-terminal (enables colors, line editing) |
+| `--no-tty` | Disable PTY allocation and run non-interactively |
 | `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
 | `-w`, `--workdir` | Override working directory |
 | `-u`, `--user` | Run the command as the specified guest user |
@@ -174,7 +176,7 @@ msb exec devbox -- ls -la /app
 | `-q`, `--quiet` | Suppress progress output |
 
 <Tip>
-  The CLI auto-detects whether stdin is a terminal. When interactive, `msb exec` uses `attach` mode (TTY, line editing). When piped, it captures output. No `-i` flag is needed.
+  The CLI auto-detects whether stdin is a terminal. When interactive, `msb exec` uses `attach` mode (TTY, line editing). When piped, it captures output. Use `--no-tty` to force captured, non-interactive execution even from a terminal.
 </Tip>
 
 ## msb copy


### PR DESCRIPTION
## TL;DR
Add `--no-tty` to `msb run` and `msb exec` so scripts can force non-interactive, captured execution even when launched from a terminal.

## Description
- Add `--no-tty` to `msb run` and `msb exec`, with parser conflicts so it cannot be combined with `--tty`.
- Route interactive mode through a shared helper so `--no-tty` skips the attached PTY path.
- Treat terminal stdin as EOF for `msb exec --no-tty`, so the buffered non-PTY path does not block on the host terminal.
- Add focused parser and stdin-decision tests for the new flag.
- Document the flag in the CLI sandbox command reference.

```bash
msb run -q python:3-alpine --no-tty -- python3 -c 'print("ok")'
msb exec worker --no-tty -- python3 -c 'print("ok")'
```

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p microsandbox-cli no_tty`
- [x] `just build-msb`
- [x] `for i in $(seq 1 10); do msb run -q python:3-alpine -- python3 -c 'print("ok")' < /dev/null > /tmp/vm_$i.log 2>&1 & done; wait; grep -L ok /tmp/vm_*.log`
- [x] `for i in $(seq 1 10); do msb run -q python:3-alpine --no-tty -- python3 -c 'print("ok")' > /tmp/vm_$i.log 2>&1 & done; wait; grep -L ok /tmp/vm_*.log`