### PR TITLE
docs(readme): remove winget install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,6 @@
 > ```
 >
 > ```sh
-> winget install SuperRadCompany.Microsandbox
-> ```
->
-> ```sh
 > npm i -g microsandbox
 > ```
 >


### PR DESCRIPTION
## TL;DR
Remove the winget install command from the README while the package is still in review, so users only see install paths that are available now.

## Description
- Remove the stale winget command from the README package manager list.
- Keep the PowerShell installer as the Windows install path.
- Leave the other package manager install commands unchanged.

## Test Plan
- [x] `git diff origin/main..HEAD --name-only` prints only `README.md`
- [x] `git diff --check origin/main..HEAD` exits 0
- [x] `! rg -n "winget install|SuperRadCompany.Microsandbox" README.md` succeeds