### PR TITLE
feat(cli): msb load progress + msb-imago 0.1.1 (#1071 fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1692,7 +1692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3545,9 +3545,9 @@ dependencies = [
 
 [[package]]
 name = "msb-imago"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16db000f7280d4c8a78b8b95f64a41006d447fd116ecd69d984d93774cb85d09"
+checksum = "c3077f41d73d78575dd706fcb626778eea7942ab2f1402ec040a4e11badc5dfa"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4862,7 +4862,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5373,7 +5373,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5441,7 +5441,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6023,7 +6023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6469,7 +6469,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6999,7 +6999,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/cli/lib/commands/image.rs
+++ b/crates/cli/lib/commands/image.rs
@@ -585,6 +585,34 @@ pub async fn run_load(args: ImageLoadArgs) -> anyhow::Result<()> {
     let backend = crate::commands::common::resolve_local_backend()?;
     let local = crate::commands::common::local_backend_ref(&backend)?;
     let cache_dir = local.cache_dir();
+    // Start the progress display before reading the archive, so a piped
+    // `docker save | msb load` shows activity while stdin is consumed.
+    let quiet = args.quiet;
+    let label = args
+        .tag
+        .first()
+        .cloned()
+        .or_else(|| {
+            args.input
+                .as_ref()
+                .and_then(|p| p.file_name())
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .unwrap_or_else(|| "archive".to_string());
+    let (progress, sender) = microsandbox_image::progress_channel();
+    let (display_ready_tx, display_ready_rx) = mpsc::sync_channel(1);
+    let display_thread = std::thread::spawn(move || -> anyhow::Result<()> {
+        let mut display = ui::PullProgressDisplay::load(&label, quiet);
+        let _ = display_ready_tx.send(());
+        let mut receiver = progress.into_receiver();
+        while let Some(event) = receiver.blocking_recv() {
+            display.handle_event(event);
+        }
+        display.finish();
+        Ok(())
+    });
+    let _ = display_ready_rx.recv();
+
     let temp_input;
     let input_path = if let Some(path) = args.input.as_ref() {
         path
@@ -602,9 +630,17 @@ pub async fn run_load(args: ImageLoadArgs) -> anyhow::Result<()> {
         input_path,
         ImageLoadOptions {
             tags: args.tag.clone(),
+            progress: Some(sender),
         },
     )
-    .await?;
+    .await;
+
+    match display_thread.join() {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => tracing::warn!(error = %error, "failed to render load progress"),
+        Err(_) => tracing::warn!("load progress thread panicked"),
+    }
+    let loaded = loaded?;
 
     for image in &loaded {
         Image::persist(local, &image.reference, image.metadata.clone()).await?;

--- a/crates/cli/lib/ui.rs
+++ b/crates/cli/lib/ui.rs
@@ -543,6 +543,7 @@ pub struct PullProgressDisplay {
     download_style: ProgressStyle,
     materialize_style: ProgressStyle,
     done_style: ProgressStyle,
+    verb: &'static str,
     _echo_guard: Option<EchoGuard>,
 }
 
@@ -553,15 +554,20 @@ pub struct PullProgressDisplay {
 impl PullProgressDisplay {
     /// Create a new pull progress display for the given image reference.
     pub fn new(reference: &str) -> Self {
-        Self::new_inner(reference, false)
+        Self::new_inner(reference, false, "Pulling")
     }
 
     /// Create a no-op pull progress display that produces no output.
     pub fn quiet(reference: &str) -> Self {
-        Self::new_inner(reference, true)
+        Self::new_inner(reference, true, "Pulling")
     }
 
-    fn new_inner(reference: &str, quiet: bool) -> Self {
+    /// Create a progress display for `msb image load` (header reads "Loading").
+    pub fn load(reference: &str, quiet: bool) -> Self {
+        Self::new_inner(reference, quiet, "Loading")
+    }
+
+    fn new_inner(reference: &str, quiet: bool, verb: &'static str) -> Self {
         let is_tty = !quiet && std::io::stderr().is_terminal();
 
         let mp = MultiProgress::new();
@@ -578,7 +584,7 @@ impl PullProgressDisplay {
                 .template("   {spinner} {msg}")
                 .unwrap(),
         );
-        header.set_message(format!("{:<12} {}", "Pulling", reference));
+        header.set_message(format!("{:<12} {}", verb, reference));
         header.enable_steady_tick(Duration::from_millis(80));
 
         Self {
@@ -586,6 +592,7 @@ impl PullProgressDisplay {
             header,
             layer_bars: Vec::new(),
             reference: reference.to_string(),
+            verb,
             _echo_guard: if is_tty { EchoGuard::acquire() } else { None },
             download_style: ProgressStyle::default_bar()
                 .template(
@@ -603,6 +610,21 @@ impl PullProgressDisplay {
         }
     }
 
+    /// Ensure a materialize-styled bar exists for `index`, creating any missing
+    /// bars up to it. No-op when the bar already exists (pull pre-creates them on
+    /// its `Resolved` event); load has no such event, so bars are made lazily as
+    /// each layer starts materializing.
+    fn ensure_layer_bar(&mut self, index: usize) {
+        while self.layer_bars.len() <= index {
+            let n = self.layer_bars.len() + 1;
+            let pb = self.mp.add(ProgressBar::new(1));
+            pb.set_style(self.materialize_style.clone());
+            pb.set_prefix(format!("layer {n}"));
+            pb.set_message("materializing");
+            self.layer_bars.push(pb);
+        }
+    }
+
     /// Process a single pull progress event, updating the display.
     pub fn handle_event(&mut self, event: PullProgress) {
         match event {
@@ -613,7 +635,7 @@ impl PullProgressDisplay {
             PullProgress::Resolved { layer_count, .. } => {
                 self.header.set_message(format!(
                     "{:<12} {} ({} layer{})",
-                    "Pulling",
+                    self.verb,
                     self.reference,
                     layer_count,
                     if layer_count == 1 { "" } else { "s" }
@@ -657,6 +679,7 @@ impl PullProgressDisplay {
                 }
             }
             PullProgress::LayerMaterializeStarted { layer_index, .. } => {
+                self.ensure_layer_bar(layer_index);
                 if let Some(pb) = self.layer_bars.get(layer_index) {
                     pb.set_style(self.materialize_style.clone());
                     pb.set_position(0);
@@ -669,18 +692,21 @@ impl PullProgressDisplay {
                 bytes_read,
                 total_bytes,
             } => {
+                self.ensure_layer_bar(layer_index);
                 if let Some(pb) = self.layer_bars.get(layer_index) {
                     pb.set_length(total_bytes);
                     pb.set_position(bytes_read);
                 }
             }
             PullProgress::LayerMaterializeWriting { layer_index } => {
+                self.ensure_layer_bar(layer_index);
                 if let Some(pb) = self.layer_bars.get(layer_index) {
                     pb.set_position(pb.length().unwrap_or(0));
                     pb.set_message("writing image");
                 }
             }
             PullProgress::LayerMaterializeComplete { layer_index, .. } => {
+                self.ensure_layer_bar(layer_index);
                 if let Some(pb) = self.layer_bars.get(layer_index) {
                     pb.set_position(pb.length().unwrap_or(0));
                     pb.set_style(self.done_style.clone());

--- a/crates/image/lib/archive/docker.rs
+++ b/crates/image/lib/archive/docker.rs
@@ -45,6 +45,8 @@ static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 pub struct ImageLoadOptions {
     /// Extra tags to apply to the first image in the archive.
     pub tags: Vec<String>,
+    /// Optional sink for materialization progress events. `None` stays silent.
+    pub progress: Option<crate::progress::PullProgressSender>,
 }
 
 /// Archive format to use when saving images.
@@ -254,6 +256,7 @@ pub async fn load_archive(
 ) -> ImageResult<Vec<LoadedImage>> {
     let cache_dir_for_blocking = cache_dir.to_path_buf();
     let input = input.to_path_buf();
+    let progress = options.progress.clone();
     let prepared = tokio::task::spawn_blocking(move || {
         load_archive_blocking(&cache_dir_for_blocking, &input, options)
     })
@@ -284,6 +287,7 @@ pub async fn load_archive(
                     &image.metadata,
                     false,
                     Arc::clone(&staged_layers),
+                    progress.clone(),
                 )
                 .await?;
 

--- a/crates/image/lib/progress.rs
+++ b/crates/image/lib/progress.rs
@@ -128,7 +128,7 @@ pub struct PullProgressHandle {
 }
 
 /// Emits progress events. Uses `try_send` — never blocks downloads.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PullProgressSender {
     tx: mpsc::Sender<PullProgress>,
 }

--- a/crates/image/lib/registry/client.rs
+++ b/crates/image/lib/registry/client.rs
@@ -173,7 +173,7 @@ impl Registry {
         metadata: &CachedImageMetadata,
         force: bool,
     ) -> ImageResult<PullResult> {
-        self.materialize_cached_layers_inner(reference, metadata, force, None)
+        self.materialize_cached_layers_inner(reference, metadata, force, None, None)
             .await
     }
 
@@ -183,9 +183,16 @@ impl Registry {
         metadata: &CachedImageMetadata,
         force: bool,
         staged_layers: Arc<HashMap<String, PathBuf>>,
+        progress: Option<PullProgressSender>,
     ) -> ImageResult<PullResult> {
-        self.materialize_cached_layers_inner(reference, metadata, force, Some(staged_layers))
-            .await
+        self.materialize_cached_layers_inner(
+            reference,
+            metadata,
+            force,
+            Some(staged_layers),
+            progress,
+        )
+        .await
     }
 
     async fn materialize_cached_layers_inner(
@@ -194,6 +201,7 @@ impl Registry {
         metadata: &CachedImageMetadata,
         force: bool,
         staged_layers: Option<Arc<HashMap<String, PathBuf>>>,
+        progress: Option<PullProgressSender>,
     ) -> ImageResult<PullResult> {
         let manifest_digest: Digest = metadata.manifest_digest.parse()?;
         let layer_descriptors = metadata
@@ -219,7 +227,7 @@ impl Registry {
             layer_descriptors: &layer_descriptors,
             diff_ids: &diff_ids,
             force,
-            progress: None,
+            progress,
             staged_layers,
         })
         .await?;


### PR DESCRIPTION
## TL;DR
Two changes on this branch:
1. **`msb load` progress UI** — load now renders the same progress bars as `pull` (it was a silent ~11 s blackbox), including a spinner while a piped `docker save | msb load` streams in.
2. **Bump `msb-imago` 0.1.0 → 0.1.1** — pulls the published VMDK FLAT sector-offset fix (superradcompany/imago#2), resolving data corruption in OCI images whose layer EROFS exceeds 2 GiB.

Closes #1071.

## 1. msb load progress
Threads the existing `PullProgress` channel through the load path (`ImageLoadOptions.progress` → `load_archive` → `materialize_cached_layers_*`, replacing the hardcoded `progress: None`) and gives `run_load` the same display-thread scaffold as `run_pull_inner`. Adds a `verb` + lazy `ensure_layer_bar` to `PullProgressDisplay` so the header reads "Loading" without pull's `Resolved` event. Reuses the renderer and event enum as-is — no new event types. The display starts before the archive is read, so a piped stdin load isn't silent during the slurp.

## 2. msb-imago 0.1.1 (#1071)
The VMDK FLAT extent offset field is in 512-byte sectors, but `msb-imago` 0.1.0 consumed it as bytes, so reads past the first 2 GiB of a split backing file (any layer EROFS > 2 GiB) resolved 512× too low and returned unrelated data. Fixed in the fork (superradcompany/imago#2) and published as 0.1.1; this bumps the lockfile to it — no local patch (`^0.1.0` accepts it via `msb_krun_devices`).

## Test Plan
- [x] `cargo build` / `cargo clippy` clean against published `msb-imago 0.1.1`
- [x] **load progress:** full materialize + stitch event stream renders; piped `docker save | msb load` shows the read spinner + per-layer bars
- [x] **#1071 end-to-end** (matched 0.6.1 build, no patch, published 0.1.1): a 2.3 GiB-layer OCI image's post-2 GiB file reads `AFTER_BOUNDARY_222222` (sha `5b44123b…`) — correct, vs garbage on 0.1.0
