### PR TITLE
docs(sdk): refresh sdk readmes

### DIFF
--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -5,6 +5,8 @@ description: Go SDK - Sandbox API reference
 
 Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management. Examples assume the package is imported as `m "github.com/superradcompany/microsandbox/sdk/go"`.
 
+For local sandboxes, call [`EnsureInstalled`](#m-ensureinstalled) once at process startup. It installs the `msb` + `libkrunfw` runtime into `~/.microsandbox/` when needed, is idempotent, and surfaces runtime setup failures before the first sandbox operation. Use [`IsInstalled`](#m-isinstalled) when you only need to check whether the runtime is already present.
+
 <div className="msb-glance">
 
   <p className="msb-gl"><span className="msb-dot static"></span>Functions<span className="msb-ct">13</span></p>
@@ -98,20 +100,24 @@ Create and control a microVM sandbox: boot it from an image, run commands, strea
 ```go
 import m "github.com/superradcompany/microsandbox/sdk/go"
 
-sb, err := m.CreateSandbox(ctx, "api",              // 1. configure + boot
+if err := m.EnsureInstalled(ctx); err != nil {      // 1. prepare local runtime
+    return err
+}
+
+sb, err := m.CreateSandbox(ctx, "api",              // 2. configure + boot
     m.WithImage("python"),
     m.WithMemory(1024),
 )
 if err != nil {
     return err
 }
-defer sb.Close()                                    // 4. shut down
+defer sb.Close()                                    // 5. release handle
 
-out, err := sb.Exec(ctx, "python", []string{"-V"})  // 2. run
+out, err := sb.Exec(ctx, "python", []string{"-V"})  // 3. run
 if err != nil {
     return err
 }
-fmt.Println(out.Stdout())                           // 3. read output
+fmt.Println(out.Stdout())                           // 4. read output
 ```
 
 ## Functions
@@ -444,7 +450,7 @@ for name, metrics := range all {
 func EnsureInstalled(ctx context.Context, opts ...SetupOption) error
 ```
 
-Optional. Ensure msb + libkrunfw are present under `~/.microsandbox/`, downloading them from the matching GitHub release if not. Call at startup to surface install errors up front; otherwise the first sandbox call handles it. The FFI library is embedded in the Go binary and loads automatically, `EnsureInstalled` does not govern it. Idempotent; options apply only to the first call.
+Ensure `msb` + `libkrunfw` are present under `~/.microsandbox/`, downloading them from the matching GitHub release if needed. Call this at process startup when the program will create local sandboxes so runtime download/setup failures surface before the first sandbox operation. The Go FFI library is embedded in the Go binary and loads automatically on first use; `EnsureInstalled` only governs the `msb` + `libkrunfw` runtime install. Idempotent; options apply only to the first call.
 
 <p className="msb-label">Parameters</p>
 
@@ -463,7 +469,7 @@ Optional. Ensure msb + libkrunfw are present under `~/.microsandbox/`, downloadi
 
 ```go
 if err := m.EnsureInstalled(ctx); err != nil {
-    log.Fatal(err)
+    log.Fatalf("microsandbox setup: %v", err)
 }
 ```
 
@@ -478,7 +484,7 @@ if err := m.EnsureInstalled(ctx); err != nil {
 func IsInstalled() bool
 ```
 
-Report whether msb + libkrunfw are present on disk at the SDK's pinned version. Does **not** dlopen the FFI library (which ships embedded).
+Report whether `msb` + `libkrunfw` are present on disk at the SDK's pinned version. Use this when you only need to check whether the runtime is already available at the SDK install location. Does **not** dlopen the FFI library, which ships embedded.
 
 <p className="msb-label">Returns</p>
 
@@ -505,7 +511,7 @@ Return the microsandbox release version this SDK was compiled against.
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><span className="msb-type">string</span></div>
-    <div className="msb-param-desc">Pinned release version, e.g. <code>"0.5.8"</code>.</div>
+    <div className="msb-param-desc">Pinned release version for this SDK build.</div>
   </div>
 </div>
 

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -91,12 +91,17 @@ import (
 
 func main() {
     ctx := context.Background()
+
+    if err := m.EnsureInstalled(ctx); err != nil {
+        log.Fatal(err)
+    }
+
     sb, err := m.CreateSandbox(ctx, "hello", m.WithImage("python"))
     if err != nil {
         log.Fatal(err)
     }
     defer func() {
-        _, _ = sb.Stop(context.Background())
+        _ = sb.Stop(context.Background())
         _ = sb.Close()
     }()
 

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-- Node.js >= 18
-- `msb` + `libkrunfw` installed (auto-downloaded by the npm postinstall script)
+- Node.js >= 22
+- `msb` + `libkrunfw` available from the `microsandbox` platform package installed through optional dependencies, or `MSB_PATH` pointing at a working `msb` binary
 - For `root-bind` and `root-block`: `git submodule update --init --recursive`
 
 ## Setup

--- a/examples/typescript/net-dns/main.ts
+++ b/examples/typescript/net-dns/main.ts
@@ -1,13 +1,19 @@
-import { Sandbox } from "microsandbox";
+import { NetworkPolicy, Sandbox } from "microsandbox";
 
 await using sandbox = await Sandbox.builder("net-dns")
   .image("alpine")
   .cpus(1)
   .memory(512)
   .network((n) =>
-    n
-      .denyDomains("blocked.example.com")
-      .denyDomainSuffixes(".evil.com"),
+    n.policy(
+      NetworkPolicy.builder()
+        .defaultAllow()
+        .egress((e) =>
+          e
+            .denyDomain("blocked.example.com")
+            .denyDomainSuffix(".evil.com"),
+        ),
+    ),
   )
   .replace()
   .create();
@@ -31,7 +37,6 @@ const unrelated = await sandbox.shell(
   "nslookup cloudflare.com 2>&1 | grep -c Address || echo 0",
 );
 console.log(`cloudflare.com: ${unrelated.stdout().trim()} address(es)`);
-
 
 function lastLine(s: string): string {
   const lines = s.split("\n");

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,40 +1,45 @@
 # microsandbox
 
-Lightweight VM sandboxes for Go — run AI agents and untrusted code with hardware-level isolation.
+Lightweight VM sandboxes for Go applications that need hardware-level isolation for AI agents, tools, tests, and untrusted code.
 
-The `microsandbox` Go module provides native bindings to the [microsandbox](https://github.com/superradcompany/microsandbox) runtime. It spins up real microVMs (not containers) in under 100ms, runs standard OCI (Docker) images, and gives you full control over execution, filesystem, networking, and secrets — all from a simple, idiomatic Go API.
+The `github.com/superradcompany/microsandbox/sdk/go` module provides Go bindings to the [microsandbox](https://github.com/superradcompany/microsandbox) runtime. It creates microVM-backed sandboxes from OCI images or other rootfs sources, then exposes command execution, guest filesystem access, networking, secrets, volumes, metrics, logs, snapshots, and SSH/SFTP through an idiomatic Go API.
 
-The API documentation can be found on [pkg.go.dev](https://pkg.go.dev/github.com/superradcompany/microsandbox/sdk/go) and [docs.microsandbox.dev](https://docs.microsandbox.dev/sdk/go).
+For the full API reference and longer guides, use Go docs and the microsandbox docs site:
+
+- [pkg.go.dev](https://pkg.go.dev/github.com/superradcompany/microsandbox/sdk/go)
+- [Go SDK guide](https://docs.microsandbox.dev/sdk/go/sandbox)
+- [SDK overview](https://docs.microsandbox.dev/sdk/overview)
+- [Repository examples](./examples)
 
 ## Features
 
-- **Hardware isolation** — Each sandbox is a real VM with its own Linux kernel
-- **Sub-100ms boot** — No daemon, no server setup, embedded directly in your app
-- **OCI image support** — Pull and run images from Docker Hub, GHCR, ECR, or any OCI registry
-- **Command execution** — Run commands with collected or streaming output
-- **Guest filesystem access** — Read, write, list, copy files inside a running sandbox
-- **Named volumes** — Persistent storage across sandbox restarts, with quotas
-- **Network policies** — Public-only (default), allow-all, or fully airgapped
-- **DNS filtering** — Block specific domains or domain suffixes
-- **TLS interception** — Transparent HTTPS inspection and secret substitution
-- **Secrets** — Credentials that never enter the VM; placeholder substitution at the network layer
-- **Port publishing** — Expose guest TCP services on host ports
-- **Rootfs patches** — Modify the filesystem before the VM boots
-- **Detached mode** — Sandboxes can outlive the Go process
-- **Metrics** — CPU, memory, disk I/O, network I/O, and optional upper disk usage per sandbox
+- Hardware VM isolation with a guest Linux kernel
+- Go API over an embedded CGO FFI library
+- Collected and streaming command execution
+- Guest filesystem read, write, list, copy, stat, and stream operations
+- Named volumes, bind mounts, tmpfs mounts, and disk-image mounts
+- Network policies, DNS filtering, TLS interception, secrets, and port publishing
+- Rootfs patches before boot
+- Detached sandboxes that can outlive the Go process
+- Metrics, logs, snapshots, SSH/SFTP, image cache, and local/cloud backend helpers
 
 ## Requirements
 
-- **Go** >= 1.22
-- **Linux** with KVM enabled, or **macOS** with Apple Silicon (M-series)
+- Go 1.22+
+- CGO enabled and a C compiler/toolchain available
+- Linux with KVM or macOS with Apple Silicon
+- The broader microsandbox runtime has Windows preview support, but the Go SDK currently bundles FFI libraries only for macOS ARM64, Linux x86_64, and Linux ARM64.
 
 ## Supported Platforms
 
-| Platform | Architecture |
-|----------|-------------|
-| macOS    | ARM64 (Apple Silicon) |
-| Linux    | x86_64 |
-| Linux    | ARM64 |
+| Platform | Architecture | Notes |
+| --- | --- | --- |
+| macOS | ARM64 / Apple Silicon | Embedded FFI library |
+| Linux | x86_64 | Embedded FFI library |
+| Linux | ARM64 | Embedded FFI library |
+| Windows | x86_64, ARM64 | Runtime preview exists, but no bundled Go FFI library in this SDK yet |
+
+The Go binary embeds the SDK FFI library and extracts it on first use. The `msb` runtime and `libkrunfw` are installed separately into `~/.microsandbox/` by `EnsureInstalled`.
 
 ## Installation
 
@@ -42,49 +47,55 @@ The API documentation can be found on [pkg.go.dev](https://pkg.go.dev/github.com
 go get github.com/superradcompany/microsandbox/sdk/go
 ```
 
-The SDK works out of the box — the FFI library is embedded in the Go binary and loads on first use. The first sandbox call also downloads `msb` + `libkrunfw` to `~/.microsandbox/` if they aren't already there.
-
-For long-lived processes, you can call `EnsureInstalled` explicitly at startup to surface any install errors up front instead of at first sandbox-spawn time. It's optional and idempotent:
+Call `EnsureInstalled` at process startup when your program will create local sandboxes. It is idempotent and surfaces runtime download/setup failures before the first sandbox operation.
 
 ```go
-import microsandbox "github.com/superradcompany/microsandbox/sdk/go"
-
-func main() {
-    ctx := context.Background()
-    if err := microsandbox.EnsureInstalled(ctx); err != nil {
-        log.Fatalf("microsandbox setup: %v", err)
-    }
-    // ...
+if err := microsandbox.EnsureInstalled(ctx); err != nil {
+    log.Fatalf("microsandbox setup: %v", err)
 }
 ```
+
+Use `IsInstalled` if you only need to check whether `msb` and `libkrunfw` are already present at the SDK install location.
 
 ## Quick Start
 
 ```go
+package main
+
 import (
     "context"
     "fmt"
     "log"
+    "time"
 
     microsandbox "github.com/superradcompany/microsandbox/sdk/go"
 )
 
 func main() {
-    ctx := context.Background()
+    ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+    defer cancel()
 
     if err := microsandbox.EnsureInstalled(ctx); err != nil {
         log.Fatal(err)
     }
 
-    sb, err := microsandbox.CreateSandbox(ctx, "my-sandbox",
+    name := "go-readme"
+    sb, err := microsandbox.CreateSandbox(ctx, name,
         microsandbox.WithImage("alpine:3.19"),
         microsandbox.WithMemory(512),
         microsandbox.WithCPUs(1),
+        microsandbox.WithReplace(),
     )
     if err != nil {
         log.Fatal(err)
     }
-    defer sb.Stop(ctx)
+    defer func() {
+        stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
+        defer stopCancel()
+        _ = sb.Stop(stopCtx)
+        _ = sb.Close()
+        _ = microsandbox.RemoveSandbox(context.Background(), name)
+    }()
 
     out, err := sb.Shell(ctx, "echo 'Hello from microsandbox!'")
     if err != nil {
@@ -94,63 +105,53 @@ func main() {
 }
 ```
 
-## Examples
+## Common Examples
+
+These snippets assume you already have a live `sb *microsandbox.Sandbox` and `ctx context.Context`. See [sdk/go/examples](./examples) for complete runnable programs.
 
 ### Command Execution
 
 ```go
-// Exec: explicit binary + args.
 out, err := sb.Exec(ctx, "python3", []string{"-c", "print(1 + 1)"})
 if err != nil {
     log.Fatal(err)
 }
-fmt.Println(out.Stdout())   // "2\n"
-fmt.Println(out.ExitCode()) // 0
+fmt.Println(out.Stdout())
+fmt.Println(out.ExitCode())
 
-// Shell: passes command to /bin/sh -c (pipes, redirects, etc.).
 out, err = sb.Shell(ctx, "echo hello && pwd")
 
-// Non-zero exit is NOT a Go error — inspect ExitCode.
-out, err = sb.Shell(ctx, "exit 42")
-// err == nil, out.ExitCode() == 42, out.Success() == false
-
-// Per-command options.
 out, err = sb.Exec(ctx, "make", []string{"build"},
     microsandbox.WithExecCwd("/app"),
     microsandbox.WithExecTimeout(30*time.Second),
 )
 ```
 
+Non-zero process exits are represented on `ExecOutput`; they are not Go errors by themselves.
+
 ### Streaming Execution
 
 ```go
-h, err := sb.ShellStream(ctx, "tail -f /var/log/app.log")
+handle, err := sb.ShellStream(ctx, "tail -f /var/log/app.log")
 if err != nil {
     log.Fatal(err)
 }
-defer h.Close()
+defer handle.Close()
 
 for {
-    ev, err := h.Recv(ctx)
+    event, err := handle.Recv(ctx)
     if err != nil {
         break
     }
-    switch ev.Kind {
-    case microsandbox.ExecEventStarted:
-        fmt.Printf("started pid=%d\n", ev.PID)
+    switch event.Kind {
     case microsandbox.ExecEventStdout:
-        os.Stdout.Write(ev.Data)
+        _, _ = os.Stdout.Write(event.Data)
     case microsandbox.ExecEventStderr:
-        os.Stderr.Write(ev.Data)
-    case microsandbox.ExecEventExited:
-        fmt.Printf("exited code=%d\n", ev.ExitCode)
-    case microsandbox.ExecEventDone:
+        _, _ = os.Stderr.Write(event.Data)
+    case microsandbox.ExecEventExited, microsandbox.ExecEventDone:
         return
     }
 }
-
-// Send a signal to the running process.
-h.Signal(ctx, int(syscall.SIGTERM))
 ```
 
 ### Filesystem Operations
@@ -158,512 +159,248 @@ h.Signal(ctx, int(syscall.SIGTERM))
 ```go
 fs := sb.FS()
 
-// Write and read files.
-err = fs.WriteString(ctx, "/tmp/config.json", `{"debug": true}`)
-content, err := fs.ReadString(ctx, "/tmp/config.json")
-
-// Read as bytes.
-data, err := fs.Read(ctx, "/tmp/binary")
-
-// List a directory.
-entries, err := fs.List(ctx, "/etc")
-for _, e := range entries {
-    fmt.Printf("%s (%s)\n", e.Path, e.Kind) // Kind: "file"|"directory"|"symlink"|"other"
+if err := fs.WriteString(ctx, "/tmp/config.json", `{"debug": true}`); err != nil {
+    log.Fatal(err)
 }
 
-// File metadata.
-stat, err := fs.Stat(ctx, "/tmp/config.json")
-fmt.Printf("size=%d isDir=%v\n", stat.Size, stat.IsDir)
+content, err := fs.ReadString(ctx, "/tmp/config.json")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(content)
 
-// Copy between host and guest.
-err = fs.CopyFromHost(ctx, "./local-file.txt", "/tmp/file.txt")
-err = fs.CopyToHost(ctx, "/tmp/output.txt", "./output.txt")
-
-// Directory and file manipulation inside the guest.
-err = fs.Mkdir(ctx, "/app/data")          // creates parents as needed
-err = fs.Copy(ctx, "/etc/hosts", "/tmp/hosts.bak")
-err = fs.Rename(ctx, "/tmp/a.txt", "/tmp/b.txt")
-ok, err := fs.Exists(ctx, "/tmp/b.txt")
-err = fs.Remove(ctx, "/tmp/b.txt")        // single file
-err = fs.RemoveDir(ctx, "/app/data")      // recursive
+entries, err := fs.List(ctx, "/etc")
+if err != nil {
+    log.Fatal(err)
+}
+for _, entry := range entries {
+    fmt.Printf("%s (%s)\n", entry.Path, entry.Kind)
+}
 ```
 
 ### Named Volumes
 
 ```go
-// Create a 100 MiB named volume with labels.
-vol, err := microsandbox.CreateVolume(ctx, "my-data",
+volume, err := microsandbox.CreateVolume(ctx, "go-readme-data",
     microsandbox.WithVolumeQuota(100),
-    microsandbox.WithVolumeLabels(map[string]string{"team": "agents"}),
+    microsandbox.WithVolumeLabels(map[string]string{"purpose": "readme"}),
 )
 if err != nil {
     log.Fatal(err)
 }
-defer microsandbox.RemoveVolume(ctx, "my-data")
+defer volume.Remove(ctx)
 
-// Mount volumes into a sandbox. Mount factories take an option struct so
-// readonly / size / disk format can be passed at the call site.
-sb, err := microsandbox.CreateSandbox(ctx, "worker",
-    microsandbox.WithImage("python:3.12"),
+writer, err := microsandbox.CreateSandbox(ctx, "go-readme-writer",
+    microsandbox.WithImage("alpine:3.19"),
     microsandbox.WithMounts(map[string]microsandbox.MountConfig{
-        "/data":    microsandbox.Mount.Named("my-data", microsandbox.MountOptions{}),
-        "/src":     microsandbox.Mount.Bind("./src", microsandbox.MountOptions{Readonly: true}),
-        "/scratch": microsandbox.Mount.Tmpfs(microsandbox.TmpfsOptions{SizeMiB: 256}),
-        "/blob":    microsandbox.Mount.Disk("./pool.img", microsandbox.DiskOptions{Format: "raw"}),
+        "/data": microsandbox.Mount.Named("go-readme-data", microsandbox.MountOptions{}),
     }),
+    microsandbox.WithReplace(),
 )
-
-// Look up volume metadata.
-handle, err := microsandbox.GetVolume(ctx, "my-data")
-fmt.Println(handle.Path())       // host filesystem path
-fmt.Println(handle.UsedBytes())  // bytes in use
-fmt.Println(handle.Labels())     // map[string]string
-
-// Direct host-side file ops via VolumeFs (no agent protocol). Paths that
-// would escape the volume root via "../" or absolute components return
-// ErrPathEscape.
-vfs := handle.FS()
-err = vfs.WriteString("notes.txt", "hello")
-content, err := vfs.ReadString("notes.txt")
-
-// List all volumes — returns rich VolumeHandle metadata.
-vols, err := microsandbox.ListVolumes(ctx)
-for _, v := range vols {
-    fmt.Println(v.Name(), v.Path(), v.QuotaMiB())
+if err != nil {
+    log.Fatal(err)
 }
+defer writer.Close()
 
-// ErrVolumeAlreadyExists on duplicate create.
-_, err = microsandbox.CreateVolume(ctx, "my-data")
-if microsandbox.IsKind(err, microsandbox.ErrVolumeAlreadyExists) {
-    // handle
-}
-
-// Remove.
-err = vol.Remove(ctx)
+_, err = writer.Shell(ctx, "echo 'hello' > /data/message.txt")
 ```
 
-### Network Policies
+### Network, DNS, and Ports
 
 ```go
-// Default: public internet only (blocks RFC-1918 private ranges).
-sb, err := microsandbox.CreateSandbox(ctx, "public", microsandbox.WithImage("alpine:3.19"))
-
-// Fully airgapped.
-sb, err = microsandbox.CreateSandbox(ctx, "isolated",
+isolated, err := microsandbox.CreateSandbox(ctx, "go-readme-isolated",
     microsandbox.WithImage("alpine:3.19"),
     microsandbox.WithNetwork(microsandbox.NetworkPolicy.None()),
+    microsandbox.WithReplace(),
 )
+if err != nil {
+    log.Fatal(err)
+}
+defer isolated.Close()
 
-// Unrestricted.
-sb, err = microsandbox.CreateSandbox(ctx, "open",
-    microsandbox.WithImage("alpine:3.19"),
-    microsandbox.WithNetwork(microsandbox.NetworkPolicy.AllowAll()),
-)
-
-// Allow public + private/LAN, deny loopback/link-local/metadata.
-sb, err = microsandbox.CreateSandbox(ctx, "lan",
-    microsandbox.WithImage("alpine:3.19"),
-    microsandbox.WithNetwork(microsandbox.NetworkPolicy.NonLocal()),
-)
-
-// Custom rule set with port ranges and asymmetric defaults.
-sb, err = microsandbox.CreateSandbox(ctx, "custom",
-    microsandbox.WithImage("alpine:3.19"),
-    microsandbox.WithNetwork(&microsandbox.NetworkConfig{
-        DefaultEgress:  microsandbox.PolicyActionDeny,
-        DefaultIngress: microsandbox.PolicyActionAllow,
-        Rules: []microsandbox.PolicyRule{
-            {
-                Action:      microsandbox.PolicyActionAllow,
-                Direction:   microsandbox.PolicyDirectionEgress,
-                Destination: "api.openai.com",
-                Protocol:    microsandbox.PolicyProtocolTCP,
-                Port:        "443",
-            },
-            {
-                Action:      microsandbox.PolicyActionAllow,
-                Direction:   microsandbox.PolicyDirectionEgress,
-                Destination: ".internal",
-                Ports:       []string{"8000-9000"},
-                Protocols:   []microsandbox.PolicyProtocol{microsandbox.PolicyProtocolTCP},
-            },
-        },
-    }),
-)
-```
-
-### DNS Filtering
-
-```go
-sb, err := microsandbox.CreateSandbox(ctx, "filtered",
+filtered, err := microsandbox.CreateSandbox(ctx, "go-readme-filtered",
     microsandbox.WithImage("alpine:3.19"),
     microsandbox.WithNetwork(&microsandbox.NetworkConfig{
         DenyDomains:        []string{"blocked.example.com"},
-        DenyDomainSuffixes: []string{".ads"},
+        DenyDomainSuffixes: []string{".evil.com"},
         DNS: &microsandbox.DNSConfig{
             Nameservers: []string{"1.1.1.1:53"},
         },
     }),
+    microsandbox.WithReplace(),
 )
-```
+if err != nil {
+    log.Fatal(err)
+}
+defer filtered.Close()
 
-### Port Publishing
-
-```go
-// host:8080 → guest:80
-sb, err := microsandbox.CreateSandbox(ctx, "web",
+web, err := microsandbox.CreateSandbox(ctx, "go-readme-web",
     microsandbox.WithImage("python:3.12"),
     microsandbox.WithPorts(map[uint16]uint16{8080: 80}),
+    microsandbox.WithReplace(),
 )
 ```
 
 ### Secrets
 
-Secrets use placeholder substitution — the real value never enters the VM. It is only swapped in at the network layer for HTTPS requests to allowed hosts.
+Secrets use placeholder substitution. The real value stays on the host and is substituted only for allowed network destinations.
 
 ```go
-sb, err := microsandbox.CreateSandbox(ctx, "agent",
+sb, err := microsandbox.CreateSandbox(ctx, "go-readme-agent",
     microsandbox.WithImage("python:3.12"),
     microsandbox.WithSecrets(microsandbox.Secret.Env(
         "OPENAI_API_KEY",
         os.Getenv("OPENAI_API_KEY"),
         microsandbox.SecretEnvOptions{AllowHosts: []string{"api.openai.com"}},
     )),
+    microsandbox.WithReplace(),
 )
-
-// Guest sees: OPENAI_API_KEY=$MSB_OPENAI_API_KEY (a placeholder)
-// HTTPS to api.openai.com: placeholder is transparently replaced with the real key
-// HTTPS to any other host carrying the placeholder: request is blocked
 ```
 
 ### Rootfs Patches
 
-Modify the filesystem before the VM boots:
-
 ```go
-sb, err := microsandbox.CreateSandbox(ctx, "patched",
+sb, err := microsandbox.CreateSandbox(ctx, "go-readme-patched",
     microsandbox.WithImage("alpine:3.19"),
     microsandbox.WithPatches(
         microsandbox.Patch.Text("/etc/greeting.txt", "Hello!\n", microsandbox.PatchOptions{}),
         microsandbox.Patch.Mkdir("/app", microsandbox.PatchOptions{}),
-        microsandbox.Patch.Text("/app/config.json", `{"debug":true}`, microsandbox.PatchOptions{}),
-        microsandbox.Patch.CopyDir("./scripts", "/app/scripts", microsandbox.PatchOptions{}),
+        microsandbox.Patch.Text("/app/config.json", `{"debug": true}`, microsandbox.PatchOptions{}),
         microsandbox.Patch.Append("/etc/hosts", "127.0.0.1 myapp.local\n"),
     ),
+    microsandbox.WithReplace(),
 )
 ```
 
 ### Detached Mode
 
-Sandboxes in detached mode survive the Go process:
-
 ```go
-// Create and detach.
-sb, err := microsandbox.CreateSandbox(ctx, "background",
+sb, err := microsandbox.CreateSandbox(ctx, "go-readme-background",
     microsandbox.WithImage("python:3.12"),
     microsandbox.WithDetached(),
+    microsandbox.WithReplace(),
 )
 if err != nil {
     log.Fatal(err)
 }
-sb.Detach(ctx) // release local handle; sandbox keeps running
+_ = sb.Detach(ctx)
 
-// Later, from another process — get metadata then connect:
-handle, err := microsandbox.GetSandbox(ctx, "background")
+handle, err := microsandbox.GetSandbox(ctx, "go-readme-background")
 if err != nil {
     log.Fatal(err)
 }
-sb2, err := handle.Connect(ctx)
+reconnected, err := handle.Connect(ctx)
 if err != nil {
     log.Fatal(err)
 }
-out, err := sb2.Shell(ctx, "echo reconnected")
-```
-
-### TLS Interception
-
-```go
-sb, err := microsandbox.CreateSandbox(ctx, "tls-inspect",
-    microsandbox.WithImage("python:3.12"),
-    microsandbox.WithNetwork(&microsandbox.NetworkConfig{
-        TLS: &microsandbox.TlsConfig{
-            Bypass:           []string{"*.googleapis.com"},
-            InterceptedPorts: []uint16{443},
-        },
-    }),
-)
+out, err := reconnected.Shell(ctx, "echo reconnected")
 ```
 
 ### Metrics
 
 ```go
-// Point-in-time snapshot.
-m, err := sb.Metrics(ctx)
+metrics, err := sb.Metrics(ctx)
 if err != nil {
     log.Fatal(err)
 }
-fmt.Printf("CPU: %.1f%%\n", m.CPUPercent)
-fmt.Printf("Memory: %.1f MiB\n", float64(m.MemoryBytes)/1024/1024)
-fmt.Printf("Uptime: %s\n", m.Uptime)
+fmt.Printf("CPU: %.1f%%\n", metrics.CPUPercent)
+fmt.Printf("Memory: %.1f MiB\n", float64(metrics.MemoryBytes)/1024/1024)
 
-// Streaming metrics — snapshot every 500ms.
 stream, err := sb.MetricsStream(ctx, 500*time.Millisecond)
 if err != nil {
     log.Fatal(err)
 }
 defer stream.Close()
 
-for {
-    m, err := stream.Recv(ctx)
-    if err != nil || m == nil {
-        break
-    }
-    fmt.Printf("CPU: %.1f%%  Mem: %d bytes\n", m.CPUPercent, m.MemoryBytes)
-}
-
-// All running sandboxes at once.
-all, err := microsandbox.AllSandboxMetrics(ctx)
-for name, m := range all {
-    fmt.Printf("%s: %.1f%% CPU\n", name, m.CPUPercent)
+sample, err := stream.Recv(ctx)
+if err == nil && sample != nil {
+    fmt.Printf("CPU: %.1f%%\n", sample.CPUPercent)
 }
 ```
 
-### Exec — advanced
+### Typed Errors
+
+Go SDK errors can be checked with `IsKind` and unwrapped with `errors.As`.
 
 ```go
-// Per-command user and environment overrides.
-out, err := sb.Exec(ctx, "whoami", nil,
-    microsandbox.WithExecUser("nobody"),
-    microsandbox.WithExecEnv(map[string]string{"DEBUG": "1"}),
-)
-
-// ExecHandle: collect or wait.
-h, err := sb.ExecStream(ctx, "sleep", []string{"10"})
-if err != nil {
-    log.Fatal(err)
+_, err := microsandbox.GetSandbox(ctx, "missing")
+if microsandbox.IsKind(err, microsandbox.ErrSandboxNotFound) {
+    fmt.Println("sandbox does not exist")
 }
 
-// Get the correlation ID assigned by the agent.
-id, err := h.ID()
-fmt.Println("exec id:", id)
-
-// Collect all output after the process finishes.
-out2, err := h.Collect(ctx)
-fmt.Println(out2.Stdout())
-
-// Or just wait for the exit code, discarding output.
-code, err := h.Wait(ctx)
-
-// Kill if needed.
-err = h.Kill(ctx)
-h.Close()
-```
-
-### Sandbox Listing
-
-```go
-// ListSandboxes returns rich SandboxHandle metadata, ordered newest first.
-handles, err := microsandbox.ListSandboxes(ctx)
-for _, h := range handles {
-    fmt.Printf("%s [%s] created %s\n", h.Name(), h.Status(), h.CreatedAt())
+var msbErr *microsandbox.Error
+if errors.As(err, &msbErr) {
+    fmt.Printf("microsandbox error kind: %s\n", msbErr.Kind)
 }
-
-// Reattach to a running sandbox by name.
-h, err := microsandbox.GetSandbox(ctx, "worker")
-sb, err := h.Connect(ctx)
 ```
-
-## API Reference
-
-### Top-level Functions
-
-| Function | Description |
-|----------|-------------|
-| `EnsureInstalled(ctx, opts...)` | Optional — download msb + libkrunfw to `~/.microsandbox/` up front (idempotent) |
-| `CreateSandbox(ctx, name, ...opts)` | Create and start a sandbox |
-| `StartSandbox(ctx, name)` | Boot a stopped sandbox by name |
-| `StartSandboxDetached(ctx, name)` | Boot a stopped sandbox in detached mode |
-| `GetSandbox(ctx, name)` | Fetch sandbox metadata; returns `*SandboxHandle` |
-| `ListSandboxes(ctx)` | Rich metadata for all known sandboxes (newest first) |
-| `SDKVersion()` / `RuntimeVersion()` | SDK and loaded-runtime versions |
-| `RemoveSandbox(ctx, name)` | Remove a stopped sandbox by name |
-| `AllSandboxMetrics(ctx)` | Point-in-time metrics for all running sandboxes |
-| `CreateVolume(ctx, name, ...opts)` | Create a named persistent volume |
-| `GetVolume(ctx, name)` | Fetch volume metadata; returns `*VolumeHandle` |
-| `ListVolumes(ctx)` | List all named volumes |
-| `RemoveVolume(ctx, name)` | Remove a named volume |
-| `IsKind(err, kind)` | Test an error's `ErrorKind` |
-
-### Types
-
-| Type | Description |
-|------|-------------|
-| `Sandbox` | Live handle to a running sandbox — lifecycle, execution, filesystem |
-| `SandboxHandle` | Lightweight metadata reference; obtain via `GetSandbox`. Methods: `Connect`, `Start`, `StartDetached`, `Stop`, `Kill`, `Remove` |
-| `ExecOutput` | Captured stdout/stderr with exit status; inspect via `Stdout()`, `Stderr()`, `ExitCode()`, `Success()` |
-| `ExecHandle` | Streaming exec handle — `Recv`, `Collect`, `Wait`, `Kill`, `Signal`, `ID`, `TakeStdin` |
-| `ExecEvent` | Stream event with `Kind`, `PID`, `Data`, `ExitCode` fields |
-| `SandboxFSOps` | Guest filesystem operations — obtain via `sandbox.FS()` |
-| `FsReadStream` | Streaming file read from guest — implements `io.WriterTo` |
-| `FsWriteStream` | Streaming file write to guest — implements `io.Writer` |
-| `MetricsStreamHandle` | Live metrics subscription — `Recv(ctx)`, `Close()` |
-| `Volume` | Named persistent volume — `Name()`, `Path()`, `FS()` |
-| `VolumeHandle` | Volume metadata from DB — `Name()`, `Path()`, `QuotaMiB()`, `UsedBytes()`, `Labels()`, `CreatedAt()`, `FS()` |
-| `VolumeFs` | Host-side file ops on a volume directory — no agent protocol |
-| `Metrics` | Resource metrics (CPU %, memory bytes, disk I/O, network I/O, optional upper disk usage, uptime) |
-| `SandboxConfig` / `NetworkConfig` / `TlsConfig` / `ExecConfig` / `VolumeConfig` | Configuration structs |
-| `SecretEntry`, `PolicyRule`, `PatchConfig`, `MountConfig` | Value types for secrets, network rules, rootfs patches, and volume mounts |
-| `Patch`, `Secret`, `NetworkPolicy`, `Mount` | Helper namespaces — `Patch.Text`, `Secret.Env`, `NetworkPolicy.None`, `Mount.Named`, etc. |
-
-### Sandbox Methods
-
-| Method | Description |
-|--------|-------------|
-| `Exec(ctx, cmd, args, ...opts)` | Run a command; non-zero exit is not a Go error |
-| `Shell(ctx, cmd, ...opts)` | Run a shell command via `/bin/sh -c` |
-| `ExecStream(ctx, cmd, args)` | Streaming exec; returns `*ExecHandle` |
-| `ShellStream(ctx, cmd)` | Streaming shell; returns `*ExecHandle` |
-| `FS()` | Return a `*SandboxFSOps` for guest filesystem access |
-| `Metrics(ctx)` | Return current resource metrics |
-| `MetricsStream(ctx, interval)` | Live metrics subscription; returns `*MetricsStreamHandle` |
-| `Logs(ctx, opts)` | Read persisted sandbox logs |
-| `Attach(ctx, cmd, args...)` | Interactive PTY session; blocks until exit |
-| `AttachShell(ctx)` | Interactive PTY session in the default shell |
-| `RequestDrain(ctx)` | Request graceful drain signal (SIGUSR1) |
-| `WaitUntilStopped(ctx)` | Block until the sandbox reaches terminal state |
-| `OwnsLifecycle()` | Whether this handle controls the VM process; returns `(bool, error)` |
-| `OwnsLifecycleOrFalse()` | Best-effort variant that swallows the error |
-| `RemoveSandbox(ctx, name)` | Remove persisted state after the sandbox is stopped |
-| `Stop(ctx)` | Gracefully stop the sandbox and wait until stopped state is observed |
-| `RequestStop(ctx)` | Request graceful shutdown without waiting |
-| `Kill(ctx)` | Force-kill the sandbox and wait until stopped state is observed |
-| `RequestKill(ctx)` | Request force termination without waiting |
-| `Detach(ctx)` | Release the local handle; detached sandbox keeps running |
-| `Close()` | Release the Rust-side handle; for detached sandboxes prefer `Detach` |
-
-### Functional Options
-
-| Option | Description |
-|--------|-------------|
-| `WithImage(image)` | OCI image to run (e.g. `"python:3.12"`) |
-| `WithOCIUpperSize(mib)` | Writable overlay upper size for OCI images |
-| `WithImageDisk(path, fstype)` | Disk-image rootfs with optional filesystem hint |
-| `WithMemory(mib)` | Memory limit in MiB |
-| `WithCPUs(n)` | CPU core limit |
-| `WithWorkdir(path)` | Default working directory inside the sandbox |
-| `WithEnv(map)` | Environment variables (merged across repeated calls) |
-| `WithDetached()` | Sandbox outlives the Go process |
-| `WithPorts(map)` | Publish host→guest TCP ports |
-| `WithPortsUDP(map)` | Publish host→guest UDP ports |
-| `WithNetwork(opts)` | Network policy, DNS filtering, TLS interception |
-| `WithSecrets(secrets...)` | Credential placeholders substituted at the network layer |
-| `WithPatches(patches...)` | Pre-boot rootfs modifications |
-| `WithMounts(map)` | Volume mounts keyed by guest path — use `Mount.Bind/Named/Tmpfs/Disk` |
-| `WithVolumeQuota(mib)` | Volume quota in MiB (zero = unlimited) |
-| `WithVolumeLabels(map)` | Key-value labels for organising volumes |
-| `WithHostname(hostname)` | Guest hostname |
-| `WithUser(user)` | User to run the sandbox process as (UID or name) |
-| `WithSecurityProfile(profile)` | In-guest security profile (`SecurityProfileDefault` or `SecurityProfileRestricted`) |
-| `WithReplace()` | Kill any existing sandbox with the same name before creating |
-| `WithShell(path)` | Default shell binary inside the guest |
-| `WithEntrypoint(cmd...)` | Override the user-workload entrypoint |
-| `WithInit(cfg)` | Hand off PID 1 (use `Init.Auto()` or `Init.Cmd(...)`) |
-| `WithLogLevel(level)` / `WithQuietLogs()` | Sandbox-process logging |
-| `WithScripts(map)` | Named scripts the agent can run by key |
-| `WithPullPolicy(p)` | `PullPolicyAlways` / `PullPolicyIfMissing` / `PullPolicyNever` |
-| `WithMaxDuration(d)` / `WithIdleTimeout(d)` | Lifecycle caps |
-| `WithRegistryAuth(auth)` | Credentials for private OCI registries |
-| `WithMounts(map)` | Volume mounts keyed by guest path — use `Mount.Named/Bind/Tmpfs` |
-| `WithExecCwd(path)` | Working directory for a single `Exec`/`Shell` call |
-| `WithExecTimeout(d)` | Per-command timeout; returns `ErrExecTimeout` on breach |
-| `WithExecUser(user)` | User to run a single command as |
-| `WithExecEnv(map)` | Per-command environment variables (merged across repeated calls) |
-
-### Error Kinds
-
-| Constant | Meaning |
-|----------|---------|
-| `ErrSandboxNotFound` | No sandbox with that name |
-| `ErrSandboxAlreadyExists` | Name is taken; pass `WithReplace()` or drop the live handle first |
-| `ErrSandboxStillRunning` | Cannot remove a running sandbox |
-| `ErrVolumeNotFound` | No volume with that name |
-| `ErrVolumeAlreadyExists` | Volume name already in use |
-| `ErrExecTimeout` | Command exceeded `WithExecTimeout` |
-| `ErrFilesystem` | Guest filesystem operation failed |
-| `ErrImageNotFound` | OCI image reference did not resolve |
-| `ErrImageInUse` | Image is still referenced by a sandbox |
-| `ErrPatchFailed` | A rootfs patch could not be applied |
-| `ErrIO` | Host-side I/O error |
-| `ErrInvalidConfig` | Configuration rejected by the runtime |
-| `ErrInvalidArgument` | Malformed argument across the FFI boundary |
-| `ErrInvalidHandle` | Handle is stale, closed, or was never valid |
-| `ErrBufferTooSmall` | Response exceeded the fixed output buffer (stream instead) |
-| `ErrCancelled` | Operation cancelled via the caller's context |
-| `ErrLibraryNotLoaded` | FFI library failed to load (e.g. unsupported platform or GLIBC too old) |
-| `ErrInternal` | Catch-all for unrecognised runtime errors |
-
-Additional kinds declared for forward compatibility with the Node/Python SDKs — currently surface as `ErrInternal` / `ErrInvalidConfig` / `ErrFilesystem` / `ErrImageNotFound`: `ErrSandboxNotRunning`, `ErrExecFailed`, `ErrPathNotFound`, `ErrImagePullFailed`, `ErrNetworkPolicy`, `ErrSecretViolation`, `ErrTLS`.
-
-Use `microsandbox.IsKind(err, microsandbox.ErrSandboxNotFound)` to test.
 
 ## Runnable Examples
 
-Each example is a self-contained `main.go` under `sdk/go/examples/`. Run any of them with `go run ./examples/<name>`:
+Each example is a self-contained `main.go` under [sdk/go/examples](./examples). Run them from `sdk/go`:
+
+```bash
+go run ./examples/basic
+go run ./examples/network
+go run ./examples/snapshot-fork
+```
 
 | Example | Covers |
-|---------|--------|
-| `basic` | end-to-end smoke: create, exec, read/write, metrics, stop, remove |
-| `filesystem` | Read/Write/List/Stat/Copy/Rename/Remove/Mkdir, host↔guest copy, ReadStream/WriteStream/WriterTo |
-| `network` | each policy preset (`None`, `PublicOnly`, `AllowAll`, `NonLocal`) and a custom rule list with port ranges and asymmetric egress/ingress defaults |
-| `ports` | TCP port publishing — listener inside the guest, dial from the host |
-| `secrets` | placeholder substitution at the network proxy; verifies the real value never enters the VM |
-| `patches` | each rootfs patch kind (`Text`, `Append`, `Mkdir`, `Symlink`, `CopyFile`, `CopyDir`, `Remove`) applied before boot |
-| `streaming` | streaming exec: events, signals, ctx cancellation |
-| `volumes` | named volumes with quotas/labels, ListVolumes, duplicate-create error |
-| `disk` | builds a tiny ext4 image at runtime, mounts it via `Mount.Disk`, then re-mounts read-only |
-| `detached` | detached lifecycle: detach, list, reattach by name, run, stop |
-| `tls` | TLS interception with a bypass list, intercepted-port set, and HTTP/3 fallback |
-| `metrics` | point-in-time `Metrics()`, streaming `MetricsStream()`, `AllSandboxMetrics()` |
-| `image-cache` | `Image.List` / `Get` / `Inspect` / `Prune` with full handle metadata, config, and layer listing |
-| `errors` | typed-error categories via `IsKind`, `errors.As`, and `*microsandbox.Error` |
+| --- | --- |
+| `basic` | Create, exec, filesystem, metrics, stop, close, remove |
+| `cloud-backend` | Cloud backend lifecycle and live logs |
+| `detached` | Detached lifecycle, reattach, stop, and remove |
+| `disk` | Build and mount a raw ext4 disk image |
+| `errors` | Error categories with `IsKind` and `errors.As` |
+| `filesystem` | Guest filesystem operations and streaming |
+| `image-cache` | Cached OCI image list, inspect, remove, and prune |
+| `metrics` | Point-in-time and streaming metrics |
+| `network` | Presets, DNS, TLS, and custom network settings |
+| `patches` | Pre-boot rootfs patches |
+| `ports` | Guest TCP port publishing |
+| `secrets` | Secret placeholder injection |
+| `snapshot-fork` | Snapshot a stopped sandbox and boot a fork |
+| `streaming` | Streaming exec, signals, and cancellation |
+| `tls` | TLS interception configuration |
+| `volumes` | Named volume lifecycle |
+
+## More Documentation
+
+- [Sandbox lifecycle](https://docs.microsandbox.dev/sdk/go/sandbox)
+- [Execution](https://docs.microsandbox.dev/sdk/go/execution)
+- [Filesystem](https://docs.microsandbox.dev/sdk/go/filesystem)
+- [Networking](https://docs.microsandbox.dev/sdk/go/networking)
+- [Secrets](https://docs.microsandbox.dev/sdk/go/secrets)
+- [Volumes](https://docs.microsandbox.dev/sdk/go/volumes)
+- [Snapshots](https://docs.microsandbox.dev/sdk/go/snapshots)
+- [Images](https://docs.microsandbox.dev/sdk/go/images)
+- [SSH](https://docs.microsandbox.dev/sdk/go/ssh)
+- [Agent client](https://docs.microsandbox.dev/sdk/go/agent-client)
 
 ## Development
 
-The SDK embeds the FFI library at build time, so a normal `go build` /
-`go test` needs no Rust toolchain. To iterate on the FFI shim itself,
-build the library locally and point the SDK at it via the
-`microsandbox_ffi_path` build tag:
+The SDK embeds the FFI library at build time, so normal unit tests do not require a Rust toolchain:
 
 ```bash
-# Build the FFI crate from the repo root.
+cd sdk/go
+go test -count=1 ./...
+```
+
+To iterate on the FFI shim itself, build the native library from the repository root, then run Go commands from `sdk/go` with `MICROSANDBOX_FFI_PATH` and the `microsandbox_ffi_path` build tag:
+
+```bash
 cargo build -p microsandbox-go
 
-# Run against the freshly-built .so instead of the embed.
-export MICROSANDBOX_FFI_PATH=$PWD/target/debug/libmicrosandbox_go_ffi.dylib  # macOS
-export MICROSANDBOX_FFI_PATH=$PWD/target/debug/libmicrosandbox_go_ffi.so     # Linux
-
+cd sdk/go
+export MICROSANDBOX_FFI_PATH=../../target/debug/libmicrosandbox_go_ffi.dylib
 go run -tags microsandbox_ffi_path ./examples/basic
 ```
 
-Run the unit tests (no FFI library required):
+Use `libmicrosandbox_go_ffi.so` for Linux. Full integration tests require local virtualization support and runtime artifacts:
 
 ```bash
-go test ./...
-```
-
-Run the full integration suite under `sdk/go/integration/` (requires a
-built FFI library and a live microsandbox runtime):
-
-```bash
+go test -tags "smoke microsandbox_ffi_path" -count=1 .
 go test -tags "integration microsandbox_ffi_path" -v -count=1 ./integration/...
 ```
-
-The integration package is a black-box test suite organised by feature
-(`config_test.go`, `network_test.go`, `volume_test.go`, `fs_test.go`,
-`exec_test.go`, `metrics_test.go`, `lifecycle_test.go`, `sandbox_test.go`)
-and is built only with the `integration` tag.
-
-<small>Release version pins, download URLs, and on-disk runtime layout are kept consistent across the Go, Node, and Python SDKs in this repository.</small>
 
 ## License
 

--- a/sdk/node-ts/README.md
+++ b/sdk/node-ts/README.md
@@ -1,41 +1,50 @@
 # microsandbox
 
-Lightweight VM sandboxes for Node.js — run AI agents and untrusted code with hardware-level isolation.
+Lightweight VM sandboxes for Node.js and TypeScript applications that need hardware-level isolation for AI agents, tools, tests, and untrusted code.
 
-The `microsandbox` npm package provides native bindings to the [microsandbox](https://github.com/superradcompany/microsandbox) runtime. It spins up real microVMs (not containers) in under 100ms, runs standard OCI (Docker) images, and gives you full control over execution, filesystem, networking, and secrets — all from a simple async API.
+The `microsandbox` npm package provides TypeScript bindings to the [microsandbox](https://github.com/superradcompany/microsandbox) runtime through a native addon. It creates microVM-backed sandboxes from OCI images or other rootfs sources, then exposes command execution, guest filesystem access, networking, secrets, volumes, metrics, logs, snapshots, and SSH/SFTP through an async TypeScript API.
+
+For the full API reference and longer guides, use the docs site:
+
+- [TypeScript SDK guide](https://docs.microsandbox.dev/sdk/typescript/sandbox)
+- [SDK overview](https://docs.microsandbox.dev/sdk/overview)
+- [Repository examples](../../examples/typescript)
 
 ## Features
 
-- **Hardware isolation** — Each sandbox is a real VM with its own Linux kernel
-- **Sub-100ms boot** — No daemon, no server setup, embedded directly in your app
-- **OCI image support** — Pull and run images from Docker Hub, GHCR, ECR, or any OCI registry
-- **Command execution** — Run commands with collected or streaming output, interactive shells
-- **Guest filesystem access** — Read, write, list, copy files inside a running sandbox
-- **Named volumes** — Persistent storage across sandbox restarts, with quotas
-- **Network policies** — Public-only (default), allow-all, or fully airgapped
-- **DNS filtering** — Block specific domains or domain suffixes
-- **TLS interception** — Transparent HTTPS inspection and secret substitution
-- **Secrets** — Credentials that never enter the VM; placeholder substitution at the network layer
-- **Port publishing** — Expose guest TCP/UDP services on host ports
-- **Rootfs patches** — Modify the filesystem before the VM boots
-- **Detached mode** — Sandboxes can outlive the Node.js process
-- **Metrics** — CPU, memory, disk I/O, network I/O, and optional upper disk usage per sandbox
+- Hardware VM isolation with a guest Linux kernel
+- ESM-first TypeScript API with generated native bindings
+- Collected and streaming command execution
+- Guest filesystem read, write, list, copy, stat, and stream operations
+- Named volumes, bind mounts, tmpfs mounts, and disk-image mounts
+- Network policies, DNS filtering, TLS interception, secrets, and port publishing
+- Rootfs patches before boot
+- Detached sandboxes that can outlive the Node.js process
+- Metrics, logs, snapshots, SSH/SFTP, image cache, and local/cloud backend helpers
 
 ## Requirements
 
-- **Node.js** >= 22 (the SDK relies on `Symbol.asyncDispose` and `await using`)
-- **Linux** with KVM enabled, or **macOS** with Apple Silicon (M-series)
-- The `msb` runtime ships inside the matching `@superradcompany/microsandbox-<triple>` platform package. If your install resolved without one, run `npx microsandbox install` once or set `MSB_PATH` to a working binary.
+- Node.js 22+
+- Linux with KVM, macOS with Apple Silicon, or Windows with Windows Hypervisor Platform
+- Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/getting-started/windows-troubleshooting) for WHP and runtime setup notes.
+
+The package root is ESM-only for normal imports:
+
+```typescript
+import { Sandbox } from "microsandbox";
+```
 
 ## Supported Platforms
 
-| Platform | Architecture | Package |
-|----------|-------------|---------|
-| macOS | ARM64 (Apple Silicon) | `@superradcompany/microsandbox-darwin-arm64` |
+| Platform | Architecture | Platform package |
+| --- | --- | --- |
+| macOS | ARM64 / Apple Silicon | `@superradcompany/microsandbox-darwin-arm64` |
 | Linux | x86_64 | `@superradcompany/microsandbox-linux-x64-gnu` |
 | Linux | ARM64 | `@superradcompany/microsandbox-linux-arm64-gnu` |
+| Windows | x86_64 | `@superradcompany/microsandbox-win32-x64-msvc` |
+| Windows | ARM64 | `@superradcompany/microsandbox-win32-arm64-msvc` |
 
-Platform-specific binaries are installed automatically via optional dependencies.
+The matching platform package is installed through npm optional dependencies and carries the native addon plus runtime binaries. If optional dependencies are omitted, reinstall with optional dependencies enabled, install the matching platform package explicitly, or set `MSB_PATH` to a working `msb` binary.
 
 ## Installation
 
@@ -43,62 +52,50 @@ Platform-specific binaries are installed automatically via optional dependencies
 npm install microsandbox
 ```
 
-The matching platform package (`@superradcompany/microsandbox-<triple>`) carries the `msb` binary and the `libkrunfw` shared library. If your install resolves without one (rare — typically a manual `--no-optional` install), run `npx microsandbox install` once to populate `~/.microsandbox/` or set `MSB_PATH` to a working binary.
-
 ## Quick Start
 
 ```typescript
-import { Sandbox, MiB } from "microsandbox";
+import { MiB, Sandbox } from "microsandbox";
 
-// Build and boot a sandbox in attached mode (auto-disposed at scope exit).
-await using sandbox = await Sandbox.builder("my-sandbox")
+await using sandbox = await Sandbox.builder("ts-readme")
   .image("alpine")
   .cpus(1)
   .memory(MiB(512))
+  .replace()
   .create();
 
 const output = await sandbox.shell("echo 'Hello from microsandbox!'");
-console.log(output.stdout());
+console.log(output.stdout().trim());
 ```
 
-The `await using` form (Node.js 22+) automatically calls `Sandbox.stop` when
-`sandbox` falls out of scope. If you need finer control, drop the `using` and
-call `sandbox.stop()` explicitly.
+`await using` calls `Sandbox.stop()` when the handle leaves scope. Use a plain `const sandbox = ...` and call lifecycle methods yourself when you need finer control.
 
-## Examples
+## Common Examples
+
+These snippets assume you already have a live `sandbox: Sandbox`.
 
 ### Command Execution
 
 ```typescript
-import { Sandbox } from "microsandbox";
-
-await using sandbox = await Sandbox.builder("exec-demo")
-  .image("python")
-  .replace()
-  .create();
-
-// Collected output.
 const result = await sandbox.exec("python3", ["-c", "print(1 + 1)"]);
-console.log(result.stdout()); // "2\n"
-console.log(result.code);     // 0
+console.log(result.stdout());
+console.log(result.code);
 
-// Shell command (pipes, redirects, etc.).
 const output = await sandbox.shell("echo hello && pwd");
 console.log(output.stdout());
 
-// Full configuration via the chainable options builder.
-const configured = await sandbox.execWith("python3", (e) =>
-  e.args(["script.py"])
+const configured = await sandbox.execWith("python3", (exec) =>
+  exec
+    .args(["script.py"])
     .cwd("/app")
     .env("PYTHONPATH", "/app/lib")
     .timeout(30_000),
 );
 
-// Streaming output. ExecHandle is AsyncIterable<ExecEvent>; the union
-// is discriminated on `kind` so `event.data` narrows correctly.
 const handle = await sandbox.execStream("tail", ["-f", "/var/log/app.log"]);
 for await (const event of handle) {
   if (event.kind === "stdout") process.stdout.write(event.data);
+  if (event.kind === "stderr") process.stderr.write(event.data);
   if (event.kind === "exited") break;
 }
 ```
@@ -108,452 +105,222 @@ for await (const event of handle) {
 ```typescript
 const fs = sandbox.fs();
 
-// Write and read files. write() accepts Uint8Array or string.
 await fs.write("/tmp/config.json", '{"debug": true}');
-const content = await fs.readToString("/tmp/config.json");
+console.log(await fs.readToString("/tmp/config.json"));
 
-// List a directory. `entry.kind` narrows to "file" | "directory" | "symlink" | "other".
-const entries = await fs.list("/etc");
-for (const entry of entries) {
+for (const entry of await fs.list("/etc")) {
   console.log(`${entry.path} (${entry.kind})`);
 }
 
-// Streaming reads/writes (e.g. for large files).
-for await (const chunk of await fs.readStream("/var/log/syslog")) {
-  process.stdout.write(chunk); // chunk is a Uint8Array
-}
-
-await using sink = await fs.writeStream("/tmp/big.bin");
-await sink.write(new Uint8Array(1 << 20));
-// `await using` calls sink.close() automatically.
-
-// Copy between host and guest.
 await fs.copyFromHost("./local-file.txt", "/tmp/file.txt");
 await fs.copyToHost("/tmp/output.txt", "./output.txt");
 
-// Check existence and metadata.
 if (await fs.exists("/tmp/config.json")) {
   const meta = await fs.stat("/tmp/config.json");
-  console.log(`size: ${meta.size}, kind: ${meta.kind}, modified: ${meta.modified}`);
+  console.log(`size: ${meta.size}, kind: ${meta.kind}`);
 }
 ```
 
 ### Named Volumes
 
 ```typescript
-import { Sandbox, Volume, MiB } from "microsandbox";
+import { MiB, Sandbox, Volume } from "microsandbox";
 
-// Create a 100 MiB named volume.
-const data = await Volume.builder("my-data").quota(MiB(100)).create();
+const data = await Volume.builder("ts-readme-data").quota(MiB(100)).create();
 
-// Writer sandbox.
 {
-  await using writer = await Sandbox.builder("writer")
+  await using writer = await Sandbox.builder("ts-readme-writer")
     .image("alpine")
-    .volume("/data", (m) => m.named(data.name))
+    .volume("/data", (mount) => mount.named(data.name))
     .replace()
     .create();
   await writer.shell("echo 'hello' > /data/message.txt");
 }
 
-// Reader sandbox — same volume mounted read-only.
 {
-  await using reader = await Sandbox.builder("reader")
+  await using reader = await Sandbox.builder("ts-readme-reader")
     .image("alpine")
-    .volume("/data", (m) => m.named(data.name).readonly())
+    .volume("/data", (mount) => mount.named(data.name).readonly())
     .replace()
     .create();
-  console.log((await reader.shell("cat /data/message.txt")).stdout());
+  console.log((await reader.shell("cat /data/message.txt")).stdout().trim());
 }
 
-// Host-side filesystem ops on the volume — no sandbox needed.
-const vfs = data.fs();
-console.log(await vfs.list("")); // ["message.txt"]
-
-// Cleanup.
-await Sandbox.remove("writer");
-await Sandbox.remove("reader");
-await Volume.remove("my-data");
+const entries = await data.fs().list("");
+for (const entry of entries) {
+  console.log(`${entry.path} (${entry.kind})`);
+}
 ```
 
-### Disk Image Volumes
-
-Mount a host disk image at a guest path. Format defaults to the file
-extension; call `.format(...)` to override. `.fstype(...)` is the inner
-filesystem agentd will mount; omit to let agentd autodetect.
+### Network, DNS, and Ports
 
 ```typescript
-import { Sandbox, MiB } from "microsandbox";
+import { NetworkPolicy, Rule, Destination, Sandbox } from "microsandbox";
 
-await using sb = await Sandbox.builder("worker")
+await using isolated = await Sandbox.builder("ts-readme-isolated")
   .image("alpine")
-  .volume("/data",    (m) => m.disk("./data.qcow2").fstype("ext4"))
-  .volume("/seed",    (m) => m.disk("./seed.raw").readonly())
-  .volume("/scratch", (m) => m.tmpfs().size(MiB(128)).readonly())
+  .network((network) => network.policy(NetworkPolicy.none()))
+  .replace()
+  .create();
+
+const filteredPolicy = NetworkPolicy.builder()
+  .defaultAllow()
+  .egress((egress) =>
+    egress
+      .denyDomain("blocked.example.com")
+      .denyDomainSuffix(".evil.com"),
+  )
+  .build();
+
+await using filtered = await Sandbox.builder("ts-readme-filtered")
+  .image("alpine")
+  .network((network) => network.policy(filteredPolicy))
+  .replace()
+  .create();
+
+const allowlisted = {
+  defaultEgress: "deny",
+  defaultIngress: "allow",
+  rules: [
+    Rule.allowEgress(Destination.domain("api.openai.com")),
+  ],
+} satisfies NetworkPolicy;
+
+await using web = await Sandbox.builder("ts-readme-web")
+  .image("python")
+  .network((network) => network.policy(allowlisted))
+  .port(8080, 80)
+  .create();
+```
+
+Domain blocking is network policy behavior. `DnsBuilder` configures DNS resolver behavior such as rebinding protection, nameservers, and query timeouts.
+
+### Secrets
+
+Secrets use placeholder substitution. The real value stays on the host and is substituted only for allowed network destinations.
+
+```typescript
+import { Sandbox } from "microsandbox";
+
+await using sandbox = await Sandbox.builder("ts-readme-agent")
+  .image("python")
+  .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
   .replace()
   .create();
 ```
 
-### Network Policies
-
-```typescript
-import { Sandbox, NetworkPolicy, Rule, Destination, PortRange } from "microsandbox";
-
-// Default — public internet only (blocks private ranges).
-await using publicOnly = await Sandbox.builder("public").image("alpine").create();
-
-// Fully airgapped.
-await using isolated = await Sandbox.builder("isolated")
-  .image("alpine")
-  .network((n) => n.policy(NetworkPolicy.none()))
-  .create();
-
-// Unrestricted.
-await using open = await Sandbox.builder("open")
-  .image("alpine")
-  .network((n) => n.policy(NetworkPolicy.allowAll()))
-  .create();
-
-// Domain filtering via policy rules.
-await using filtered = await Sandbox.builder("filtered")
-  .image("alpine")
-  .network((n) => n.policy(
-    NetworkPolicy.builder()
-      .defaultAllow()
-      .denyDomain("blocked.example.com")
-      .denyDomainSuffix(".evil.com")
-      .build(),
-  ))
-  .create();
-
-// Custom rule list — first match wins, evaluated independently per direction.
-await using custom = await Sandbox.builder("custom")
-  .image("alpine")
-  .network((n) => n.policy({
-    defaultEgress: "deny",
-    defaultIngress: "allow",
-    rules: [
-      Rule.allowEgress(Destination.domain("api.openai.com")),
-      Rule.denyEgress(Destination.group("metadata")),
-    ],
-  }))
-  .create();
-```
-
-### Port Publishing
-
-```typescript
-await using sb = await Sandbox.builder("web")
-  .image("python")
-  .port(8080, 80)        // TCP host:8080 -> guest:80
-  .portUdp(5353, 5353)   // UDP host:5353 -> guest:5353
-  .create();
-```
-
-### Secrets
-
-Secrets use placeholder substitution — the real value never enters the VM. It is only swapped in at the network layer for HTTPS requests to allowed hosts.
-
-```typescript
-import { Sandbox } from "microsandbox";
-
-// Shorthand: auto-generates the placeholder as `$MSB_<ENV_VAR>`.
-await using sb = await Sandbox.builder("agent")
-  .image("python")
-  .secretEnv("OPENAI_API_KEY", process.env.OPENAI_API_KEY!, "api.openai.com")
-  .create();
-
-// Or with full control via SecretBuilder.
-await using sb2 = await Sandbox.builder("agent2")
-  .image("python")
-  .secret((s) =>
-    s.env("STRIPE_KEY")
-      .value(process.env.STRIPE_KEY!)
-      .allowHost("api.stripe.com")
-      .allowHostPattern("*.stripe.com")
-      .injectHeaders(true)
-      .injectQuery(false),
-  )
-  .create();
-
-// Guest sees: OPENAI_API_KEY=$MSB_OPENAI_API_KEY (a placeholder).
-// HTTPS to api.openai.com  → placeholder transparently replaced with the real key.
-// HTTPS anywhere else      → request blocked.
-```
-
 ### Rootfs Patches
 
-Modify the filesystem before the VM boots:
-
 ```typescript
-import { Sandbox } from "microsandbox";
-
-await using sandbox = await Sandbox.builder("patched")
+await using sandbox = await Sandbox.builder("ts-readme-patched")
   .image("alpine")
-  .patch((p) => p
-    .text("/etc/greeting.txt", "Hello!\n")
-    .mkdir("/app", { mode: 0o755 })
-    .text("/app/config.json", '{"debug": true}', { mode: 0o644 })
-    .copyDir("./scripts", "/app/scripts")
-    .append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+  .patch((patch) =>
+    patch
+      .text("/etc/greeting.txt", "Hello!\n")
+      .mkdir("/app", { mode: 0o755 })
+      .text("/app/config.json", '{"debug": true}', { mode: 0o644 })
+      .append("/etc/hosts", "127.0.0.1 myapp.local\n"),
   )
+  .replace()
   .create();
 ```
 
 ### Detached Mode
 
-Detached sandboxes survive the Node.js process:
-
 ```typescript
-// Create detached — drops the lifecycle on this handle's `Symbol.asyncDispose`.
-const sb = await Sandbox.builder("background")
+const sandbox = await Sandbox.builder("ts-readme-background")
   .image("python")
   .detached(true)
+  .replace()
   .create();
+await sandbox.detach();
 
-// Later, from another process:
-const handle = await Sandbox.get("background");
-const live = await handle.openClient();              // no lifecycle ownership
-await live.shell("echo reconnected");
-```
-
-### TLS Interception
-
-```typescript
-await using sandbox = await Sandbox.builder("tls-inspect")
-  .image("python")
-  .network((n) => n.tls((t) =>
-    t.bypass("*.googleapis.com")
-      .verifyUpstream(true)
-      .interceptedPorts([443]),
-  ))
-  .create();
+const handle = await Sandbox.get("ts-readme-background");
+const reconnected = await handle.connect();
+const output = await reconnected.shell("echo reconnected");
+console.log(output.stdout().trim());
 ```
 
 ### Metrics
 
 ```typescript
-import { allSandboxMetrics, Sandbox } from "microsandbox";
+import { allSandboxMetrics } from "microsandbox";
 
-await using sandbox = await Sandbox.builder("metrics-demo")
-  .image("python")
-  .create();
+const metrics = await sandbox.metrics();
+console.log(`CPU: ${metrics.cpuPercent.toFixed(1)}%`);
+console.log(`Memory: ${(metrics.memoryBytes / 1024 / 1024).toFixed(1)} MiB`);
 
-const m = await sandbox.metrics();
-console.log(`CPU: ${m.cpuPercent.toFixed(1)}%`);
-console.log(`Memory: ${(m.memoryBytes / 1024 / 1024).toFixed(1)} MiB`);
-console.log(`Uptime: ${(m.uptimeMs / 1000).toFixed(1)}s`);
-
-// Stream snapshots every second.
 for await (const sample of await sandbox.metricsStream(1000)) {
   console.log(sample.timestamp.toISOString(), sample.cpuPercent);
-  if (sample.uptimeMs > 10_000) break;
+  break;
 }
 
-// All sandboxes at once.
-const all = await allSandboxMetrics();
-for (const [name, metrics] of Object.entries(all)) {
-  console.log(`${name}: ${metrics.cpuPercent.toFixed(1)}%`);
+for (const [name, sample] of Object.entries(await allSandboxMetrics())) {
+  console.log(`${name}: ${sample.cpuPercent.toFixed(1)}%`);
 }
-```
-
-### Image Cache
-
-```typescript
-import { Image } from "microsandbox";
-
-const cached = await Image.list();
-for (const h of cached) console.log(h.reference, h.architecture, h.layerCount);
-
-const detail = await Image.inspect("python:3.12");
-console.log(detail.config?.entrypoint, detail.config?.workingDir);
-
-await Image.remove("old:tag", { force: true });
-const report = await Image.prune();
-console.log(`removed ${report.imageRefsRemoved} unused image refs`);
-```
-
-### Replace Existing
-
-`replace()` stops a sandbox with the same name (if any) and recreates
-it. By default the existing sandbox gets 10 seconds to exit cleanly
-after `SIGTERM` before `SIGKILL`; pass `replaceWithTimeout(ms)` to
-override.
-
-```typescript
-import { Sandbox } from "microsandbox";
-
-// Default 10s SIGTERM timeout.
-await using sb = await Sandbox.builder("worker")
-  .image("alpine")
-  .replace()
-  .create();
-
-// Wait longer for a workload that needs more time to shut down.
-await using slow = await Sandbox.builder("worker")
-  .image("alpine")
-  .replaceWithTimeout(30_000)
-  .create();
-
-// Skip SIGTERM entirely; SIGKILL immediately.
-await using fast = await Sandbox.builder("worker")
-  .image("alpine")
-  .replaceWithTimeout(0)
-  .create();
 ```
 
 ### Typed Errors
 
-Every `MicrosandboxError` variant has a dedicated subclass — use
-`instanceof` instead of parsing message strings.
+TypeScript exports typed errors for the common SDK categories and falls back to `MicrosandboxError` for unmapped runtime variants. Catch specific errors when you need category-specific handling, and catch `MicrosandboxError` as the broad SDK base class.
 
 ```typescript
-import { ExecTimeoutError, Sandbox, SandboxAlreadyExistsError, SandboxNotFoundError } from "microsandbox";
-
-try {
-  await Sandbox.remove("ghost");
-} catch (e) {
-  if (e instanceof SandboxNotFoundError) {
-    console.log("nothing to remove:", e.message);
-  } else {
-    throw e;
-  }
-}
+import {
+  MicrosandboxError,
+  Sandbox,
+  SandboxAlreadyExistsError,
+} from "microsandbox";
 
 try {
   await Sandbox.builder("worker").image("alpine").create();
-} catch (e) {
-  if (e instanceof SandboxAlreadyExistsError) {
-    console.log("already exists; resume or pass replace()");
+} catch (error) {
+  if (error instanceof SandboxAlreadyExistsError) {
+    console.log("already exists; resume it or pass replace()");
+  } else if (error instanceof MicrosandboxError) {
+    console.log(`microsandbox error: ${error.message}`);
   } else {
-    throw e;
-  }
-}
-
-try {
-  await sandbox.execWith("sleep", (e) => e.args(["10"]).timeout(500));
-} catch (e) {
-  if (e instanceof ExecTimeoutError) {
-    console.log(`timed out after ${e.timeoutMs}ms`);
+    throw error;
   }
 }
 ```
 
-### Runtime Setup
+## Runtime Notes
 
-```typescript
-import { install, isInstalled, setup } from "microsandbox";
+- The `microsandbox` package depends on platform packages through optional dependencies.
+- The platform package carries the native addon, `msb`, and `libkrunfw`.
+- The `microsandbox` and `msb` bin shims forward to the resolved `msb` binary. They do not install runtime files.
+- If no platform package is present, reinstall with optional dependencies enabled, install the matching `@superradcompany/microsandbox-<platform>` package, or set `MSB_PATH`.
 
-if (!isInstalled()) {
-  await install();        // simple — bundled version, default location
-}
+## More Documentation
 
-// Or with full control:
-await setup()
-  .baseDir("/opt/microsandbox")
-  .skipVerify(false)
-  .force(false)
-  .install();
+- [Sandbox lifecycle](https://docs.microsandbox.dev/sdk/typescript/sandbox)
+- [Execution](https://docs.microsandbox.dev/sdk/typescript/execution)
+- [Filesystem](https://docs.microsandbox.dev/sdk/typescript/filesystem)
+- [Networking](https://docs.microsandbox.dev/sdk/typescript/networking)
+- [Secrets](https://docs.microsandbox.dev/sdk/typescript/secrets)
+- [Volumes](https://docs.microsandbox.dev/sdk/typescript/volumes)
+- [Snapshots](https://docs.microsandbox.dev/sdk/typescript/snapshots)
+- [SSH](https://docs.microsandbox.dev/sdk/typescript/ssh)
+- [Agent client](https://docs.microsandbox.dev/sdk/typescript/agent-client)
+
+## Development
+
+From `sdk/node-ts`:
+
+```bash
+npm ci
+npm run build
+npm run typecheck
+npm test
 ```
 
-## API Reference
+Run repository examples from the specific example directory:
 
-### Lifecycle
-
-| Symbol | Description |
-|---|---|
-| `Sandbox` | Live sandbox — lifecycle, exec, fs, metrics. Implements `AsyncDisposable`. |
-| `SandboxBuilder` | Fluent builder — every Rust setter, terminal `.create()`. |
-| `SandboxHandle` | Lightweight DB handle — `connect()`, `start()`, `stop()`, `kill()`. |
-| `SandboxConfig` | Built sandbox configuration (output of `SandboxBuilder.build()`). |
-| `SandboxStatus` | `"running" \| "stopped" \| "crashed" \| "draining"` |
-
-### Execution
-
-| Symbol | Description |
-|---|---|
-| `ExecOutput` | Captured stdout/stderr + exit status. |
-| `ExecHandle` | Streaming handle — `AsyncIterable<ExecEvent>`, `recv()`, `wait()`, `collect()`, `Symbol.asyncDispose`. |
-| `ExecSink` | Stdin sink — `write()`, `close()`. |
-| `ExecOptionsBuilder` / `ExecOptions` | Chained options used by `Sandbox.execWith` / `execStreamWith`. |
-| `AttachOptionsBuilder` / `AttachOptions` | PTY-attach options. |
-| `ExecEvent` | Discriminated union: `{kind:"started", pid}` \| `{kind:"stdout", data}` \| `{kind:"stderr", data}` \| `{kind:"exited", code}`. |
-| `Stdin` | Factory for `StdinMode`: `Stdin.null()`, `Stdin.pipe()`, `Stdin.bytes(...)`. |
-| `Rlimit` / `RlimitResource` | Per-exec resource limits. |
-| `ExitStatus` | `{ code, success }`. |
-
-### Filesystem
-
-| Symbol | Description |
-|---|---|
-| `SandboxFsOps` | Guest fs ops (read, write, list, mkdir, copy, rename, stat, exists, copyFromHost, copyToHost, readStream, writeStream). |
-| `FsReadStream` | Streaming reader — `AsyncIterable<Uint8Array>`. |
-| `FsWriteSink` | Streaming writer — `write()`, `close()`, `Symbol.asyncDispose`. |
-| `FsEntry` / `FsMetadata` / `FsEntryKind` | Listing entry, stat metadata, kind union. |
-
-### Volumes
-
-| Symbol | Description |
-|---|---|
-| `Volume` / `VolumeBuilder` / `VolumeHandle` | Named persistent storage with quotas and labels. |
-| `VolumeFs` | Host-side fs ops on a volume's directory (no sandbox required). |
-| `VolumeFsReadStream` / `VolumeFsWriteSink` | Streaming variants. |
-| `MountBuilder` | Mount-spec builder — `bind`, `named`, `tmpfs`, `disk`, `format`, `fstype`, `readonly`, `noexec`, `nosuid`, `nodev`, `size`. |
-| `VolumeMount` | Discriminated union of mount kinds. |
-
-### Image Cache
-
-| Symbol | Description |
-|---|---|
-| `Image` | Static API: `get`, `list`, `inspect`, `remove`, `prune`. |
-| `ImageHandle` / `ImageDetail` / `ImageConfigDetail` / `ImageLayerDetail` | Cached image metadata. |
-| `RootfsSource` / `DiskImageFormat` | Discriminated rootfs union and disk format literal type. |
-| `intoRootfsSource(input)` | Resolve a string into the right `RootfsSource`. |
-
-### Networking
-
-| Symbol | Description |
-|---|---|
-| `NetworkBuilder` / `NetworkConfig` | Top-level network builder — ports, policy, DNS, TLS, secrets. |
-| `DnsBuilder` / `DnsConfig` | DNS interception (block lists, nameservers, query timeout). |
-| `TlsBuilder` / `TlsConfig` | TLS interception (bypass list, intercepted ports, custom CAs). |
-| `SecretBuilder` / `SecretEntry` / `SecretInjection` / `ViolationAction` | Secret entries with host allowlists and injection points. |
-| `NetworkPolicy` | Factory + interface — `NetworkPolicy.none()` / `.allowAll()` / `.publicOnly()` / `.nonLocal()`. |
-| `Rule` | Factory + interface — `Rule.allowEgress(...)`, `Rule.denyIngress(...)`, `Rule.allowAny(...)`, etc. |
-| `Destination` / `DestinationGroup` | Factory + union for rule destinations. |
-| `PortRange` | `PortRange.single(port)`, `PortRange.range(start, end)`. |
-| `Action` / `Direction` / `Protocol` | String-literal unions used by rules. |
-
-### Patches & Registry
-
-| Symbol | Description |
-|---|---|
-| `PatchBuilder` / `Patch` | Pre-boot rootfs modifications — `text`, `file`, `copyFile`, `copyDir`, `symlink`, `mkdir`, `remove`, `append`. |
-| `RegistryConfigBuilder` / `RegistryConfig` / `RegistryAuth` | Registry connection (auth, insecure, CA certs). |
-| `PullPolicy` | `"always" \| "if-missing" \| "never"`. |
-
-### Metrics & Setup
-
-| Symbol | Description |
-|---|---|
-| `SandboxMetrics` | CPU%, memory, disk I/O, net I/O, optional upper disk usage, uptime, timestamp. |
-| `MetricsStream` | `AsyncIterable<SandboxMetrics>` returned by `Sandbox.metricsStream(intervalMs)`. |
-| `allSandboxMetrics()` | Snapshot of metrics for every running sandbox. |
-| `Setup` / `setup()` | Builder for advanced installs (custom base dir, version, force). |
-| `install()` / `isInstalled()` | Simple bootstrapping helpers. |
-
-### Sizes & Logging
-
-| Symbol | Description |
-|---|---|
-| `Mebibytes` (branded type) + `KiB` / `MiB` / `GiB` / `TiB` | Type-safe size helpers; bare numbers are accepted as MiB. |
-| `LogLevel` | `"trace" \| "debug" \| "info" \| "warn" \| "error"`. |
-
-### Errors
-
-`MicrosandboxError` is the base class; every Rust variant has a typed subclass:
-
-`IoError`, `HttpError`, `LibkrunfwNotFoundError`, `DatabaseError`, `InvalidConfigError`, `SandboxNotFoundError`, `SandboxStillRunningError`, `RuntimeError`, `JsonError`, `ProtocolError`, `NixError`, `ExecTimeoutError` (carries `timeoutMs`), `TerminalError`, `SandboxFsOpsError`, `ImageNotFoundError`, `ImageInUseError`, `VolumeNotFoundError`, `VolumeAlreadyExistsError`, `ImageError`, `PatchFailedError`, `CustomError`.
+```bash
+cd examples/typescript/root-oci
+npm install
+npm start
+```
 
 ## License
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,41 +1,42 @@
 # microsandbox
 
-Lightweight VM sandboxes for Python — run AI agents and untrusted code with hardware-level isolation.
+Lightweight VM sandboxes for Python applications that need hardware-level isolation for AI agents, tools, tests, and untrusted code.
 
-The `microsandbox` Python package provides native bindings to the [microsandbox](https://github.com/superradcompany/microsandbox) runtime via pyo3. It spins up real microVMs (not containers) in under 100ms, runs standard OCI (Docker) images, and gives you full control over execution, filesystem, networking, and secrets — all from a simple async API.
+The `microsandbox` Python package provides async Python bindings to the [microsandbox](https://github.com/superradcompany/microsandbox) runtime. It creates microVM-backed sandboxes from OCI images or other rootfs sources, then exposes command execution, guest filesystem access, networking, secrets, volumes, metrics, logs, snapshots, and SSH/SFTP through Python-friendly classes and dataclasses.
+
+For the full API reference and longer guides, use the docs site:
+
+- [Python SDK guide](https://docs.microsandbox.dev/sdk/python/sandbox)
+- [SDK overview](https://docs.microsandbox.dev/sdk/overview)
+- [Repository examples](../../examples/python)
 
 ## Features
 
-- **Hardware isolation** — Each sandbox is a real VM with its own Linux kernel
-- **Sub-100ms boot** — No daemon, no server setup, embedded directly in your app
-- **OCI image support** — Pull and run images from Docker Hub, GHCR, ECR, or any OCI registry
-- **Command execution** — Run commands with collected or streaming output, interactive shells
-- **Guest filesystem access** — Read, write, list, copy files inside a running sandbox
-- **Named volumes** — Persistent storage across sandbox restarts, with quotas
-- **Network policies** — Public-only (default), allow-all, or fully airgapped
-- **DNS filtering** — Block specific domains or domain suffixes
-- **TLS interception** — Transparent HTTPS inspection and secret substitution
-- **Secrets** — Credentials that never enter the VM; placeholder substitution at the network layer
-- **Port publishing** — Expose guest TCP/UDP services on host ports
-- **Rootfs patches** — Modify the filesystem before the VM boots
-- **Detached mode** — Sandboxes can outlive the Python process
-- **Metrics** — CPU, memory, disk I/O, network I/O, and optional upper disk usage per sandbox
-- **Typed** — Frozen dataclasses, `StrEnum`s, event objects, `.pyi` stubs
+- Hardware VM isolation with a guest Linux kernel
+- Async sandbox lifecycle, execution, filesystem, metrics, and logs APIs
+- OCI image, bind-rootfs, disk-image, and snapshot-based sandboxes
+- Named volumes, bind mounts, tmpfs mounts, and disk-image mounts
+- Network policies, DNS filtering, TLS interception, secrets, and port publishing
+- Rootfs patches before boot
+- Detached sandboxes that can outlive the Python process
+- Typed Python surface with `StrEnum`s, frozen dataclasses, event objects, `.pyi` stubs, and `py.typed`
 
 ## Requirements
 
-- **Python** >= 3.10
-- **Linux** with KVM enabled, or **macOS** with Apple Silicon (M-series)
+- Python 3.10+
+- Linux with KVM, macOS with Apple Silicon, or Windows with Windows Hypervisor Platform
+- Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/getting-started/windows-troubleshooting) for WHP and runtime setup notes.
 
 ## Supported Platforms
 
-| Platform | Architecture | Wheel tag |
-|----------|-------------|-----------|
-| macOS | ARM64 (Apple Silicon) | `macosx_11_0_arm64` |
-| Linux | x86_64 | `manylinux_2_28_x86_64` |
-| Linux | ARM64 | `manylinux_2_28_aarch64` |
+| Platform | Architecture | Notes |
+| --- | --- | --- |
+| macOS | ARM64 / Apple Silicon | Wheel bundles `msb` and `libkrunfw` |
+| Linux | x86_64 | Wheel bundles `msb` and `libkrunfw` |
+| Linux | ARM64 | Wheel bundles `msb` and `libkrunfw` |
+| Windows | x86_64, ARM64 | Preview; requires WHP |
 
-Runtime binaries (`msb` + `libkrunfw`) are bundled in the wheel. One wheel per platform, all Python 3.10+ versions via `abi3`.
+Python wheels bundle the matching `msb` runtime and `libkrunfw` library. Source checkouts and unreleased local builds can override runtime paths with `MSB_PATH`, `MSB_LIBKRUNFW_PATH`, or `microsandbox.set_libkrunfw_path(...)`.
 
 ## Installation
 
@@ -47,46 +48,37 @@ pip install microsandbox
 
 ```python
 import asyncio
+
 from microsandbox import Sandbox
 
-async def main():
-    # Create a sandbox from an OCI image.
-    sandbox = await Sandbox.create(
-        "my-sandbox",
-        image="alpine",
-        cpus=1,
-        memory=512,
-    )
 
-    # Run a command.
-    output = await sandbox.shell("echo 'Hello from microsandbox!'")
-    print(output.stdout_text)
+async def main() -> None:
+    async with await Sandbox.create("python-readme", image="alpine", replace=True) as sandbox:
+        output = await sandbox.shell("echo 'Hello from microsandbox!'")
+        print(output.stdout_text.strip())
 
-    # Stop the sandbox.
-    await sandbox.stop()
 
 asyncio.run(main())
 ```
 
-## Examples
+`async with` stops and removes the sandbox when the block exits. Use `Sandbox.create(...)` without a context manager when you want to control `stop()`, `kill()`, or `remove()` yourself.
+
+## Common Examples
+
+These snippets assume you already have a live `sandbox: Sandbox`.
 
 ### Command Execution
 
 ```python
 import sys
 
-from microsandbox import Sandbox
-
-# Collected output.
 output = await sandbox.exec("python3", ["-c", "print(1 + 1)"])
-print(output.stdout_text)   # "2\n"
-print(output.exit_code)      # 0
+print(output.stdout_text)
+print(output.exit_code)
 
-# Shell command (pipes, redirects, etc.).
 output = await sandbox.shell("echo hello && pwd")
 print(output.stdout_text)
 
-# Full configuration via keyword-only options.
 output = await sandbox.exec(
     "python3",
     ["script.py"],
@@ -95,15 +87,15 @@ output = await sandbox.exec(
     timeout=30.0,
 )
 
-# Streaming output.
 handle = await sandbox.exec_stream("tail", ["-f", "/var/log/app.log"])
 async for event in handle:
     match event.event_type:
-        case "stdout": sys.stdout.buffer.write(event.data)
-        case "stderr": sys.stderr.buffer.write(event.data)
-        case "exited": break
-
-await sandbox.stop()
+        case "stdout":
+            sys.stdout.buffer.write(event.data)
+        case "stderr":
+            sys.stderr.buffer.write(event.data)
+        case "exited":
+            break
 ```
 
 ### Filesystem Operations
@@ -111,27 +103,18 @@ await sandbox.stop()
 ```python
 fs = sandbox.fs
 
-# Write and read files.
 await fs.write("/tmp/config.json", b'{"debug": true}')
-content = await fs.read_text("/tmp/config.json")
+print(await fs.read_text("/tmp/config.json"))
 
-# List a directory.
-entries = await fs.list("/etc")
-for entry in entries:
+for entry in await fs.list("/etc"):
     print(f"{entry.path} ({entry.kind})")
 
-# Copy between host and guest.
 await fs.copy_from_host("./local-file.txt", "/tmp/file.txt")
 await fs.copy_to_host("/tmp/output.txt", "./output.txt")
 
-# Check existence and metadata.
 if await fs.exists("/tmp/config.json"):
     meta = await fs.stat("/tmp/config.json")
     print(f"size: {meta.size}, kind: {meta.kind}")
-
-# Streaming read.
-async for chunk in await fs.read_stream("/tmp/large-file.bin"):
-    process(chunk)
 ```
 
 ### Named Volumes
@@ -139,392 +122,196 @@ async for chunk in await fs.read_stream("/tmp/large-file.bin"):
 ```python
 from microsandbox import Sandbox, Volume
 
-# Create a 100 MiB named volume.
-data = await Volume.create("my-data", quota_mib=100)
+data = await Volume.create("python-readme-data", quota_mib=100)
 
-# Mount it in a sandbox.
 writer = await Sandbox.create(
-    "writer",
+    "python-readme-writer",
     image="alpine",
     volumes={"/data": Volume.named(data.name)},
     replace=True,
 )
-
 await writer.shell("echo 'hello' > /data/message.txt")
 await writer.stop()
 
-# Mount the same volume in another sandbox (read-only).
 reader = await Sandbox.create(
-    "reader",
+    "python-readme-reader",
     image="alpine",
     volumes={"/data": Volume.named(data.name, readonly=True)},
     replace=True,
 )
-
 output = await reader.shell("cat /data/message.txt")
-print(output.stdout_text)  # "hello\n"
-
+print(output.stdout_text.strip())
 await reader.stop()
-
-# Cleanup.
-await Sandbox.remove("writer")
-await Sandbox.remove("reader")
-await Volume.remove("my-data")
 ```
 
-### Disk Image Volumes
+### Network, DNS, and Ports
 
 ```python
-from microsandbox import Sandbox, Volume, DiskImageFormat
+from microsandbox import Network, Sandbox
+from microsandbox.types import DnsConfig
 
-# Mount a host disk image at a guest path. Format is inferred from the
-# extension; pass `format=` to override. `fstype` is the inner FS agentd
-# will mount; omit to let agentd autodetect.
-sb = await Sandbox.create(
-    "worker",
-    image="alpine",
-    volumes={
-        "/data": Volume.disk("./data.qcow2", format=DiskImageFormat.QCOW2, fstype="ext4"),
-        "/seed": Volume.disk("./seed.raw", readonly=True),
-        "/scratch": Volume.tmpfs(size_mib=128, readonly=True),
-    },
-    replace=True,
-)
-```
-
-### Network Policies
-
-```python
-from microsandbox import Destination, Network, NetworkPolicy, Protocol, Rule, Sandbox
-
-# Default: public internet only (blocks private ranges).
-sandbox = await Sandbox.create("public", image="alpine")
-
-# Fully airgapped.
-sandbox = await Sandbox.create(
-    "isolated",
+isolated = await Sandbox.create(
+    "python-readme-isolated",
     image="alpine",
     network=Network.none(),
+    replace=True,
 )
 
-# Unrestricted.
-sandbox = await Sandbox.create(
-    "open",
-    image="alpine",
-    network=Network.allow_all(),
-)
-
-# DNS filtering.
-sandbox = await Sandbox.create(
-    "filtered",
+filtered = await Sandbox.create(
+    "python-readme-filtered",
     image="alpine",
     network=Network(
         deny_domains=("blocked.example.com",),
         deny_domain_suffixes=(".evil.com",),
+        dns=DnsConfig(nameservers=("1.1.1.1:53",)),
     ),
+    replace=True,
 )
 
-# Explicit allowlist with typed destinations.
-sandbox = await Sandbox.create(
-    "allowlisted",
-    image="alpine",
-    network=Network(
-        policy=NetworkPolicy(
-            default_egress="deny",
-            rules=(
-                Rule.allow(
-                    destination=Destination.ip("1.1.1.1"),
-                    protocol=Protocol.TCP,
-                    port=443,
-                ),
-                Rule.allow(
-                    destination=Destination.domain("api.github.com"),
-                    protocol=Protocol.TCP,
-                    port=443,
-                ),
-            ),
-        ),
-    ),
-)
-```
-
-### Port Publishing
-
-```python
-sandbox = await Sandbox.create(
-    "web",
+web = await Sandbox.create(
+    "python-readme-web",
     image="python",
-    ports={8080: 80},  # host:8080 → guest:80
+    ports={8080: 80},
+    network=Network.public_only(),
+    replace=True,
 )
 ```
 
 ### Secrets
 
-Secrets use placeholder substitution — the real value never enters the VM. It is only swapped in at the network layer for HTTPS requests to allowed hosts.
+Secrets use placeholder substitution. The real value stays on the host and is substituted only for allowed network destinations.
 
 ```python
+import os
+
 from microsandbox import Sandbox, Secret
 
 sandbox = await Sandbox.create(
-    "agent",
+    "python-readme-agent",
     image="python",
     secrets=[
-        Secret.env("OPENAI_API_KEY",
-                    value=os.environ["OPENAI_API_KEY"],
-                    allow_hosts=["api.openai.com"]),
+        Secret.env(
+            "OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
     ],
+    replace=True,
 )
-
-# Guest sees: OPENAI_API_KEY=$MSB_OPENAI_API_KEY (a placeholder)
-# HTTPS to api.openai.com: placeholder is transparently replaced with the real key
-# HTTPS to any other host with the placeholder: request is blocked
 ```
 
 ### Rootfs Patches
-
-Modify the filesystem before the VM boots:
 
 ```python
 from microsandbox import Patch, Sandbox
 
 sandbox = await Sandbox.create(
-    "patched",
+    "python-readme-patched",
     image="alpine",
     patches=[
         Patch.text("/etc/greeting.txt", "Hello!\n"),
         Patch.mkdir("/app", mode=0o755),
         Patch.text("/app/config.json", '{"debug": true}', mode=0o644),
-        Patch.copy_dir("./scripts", "/app/scripts"),
         Patch.append("/etc/hosts", "127.0.0.1 myapp.local\n"),
     ],
+    replace=True,
 )
 ```
 
 ### Detached Mode
 
-Sandboxes in detached mode survive the Python process. The returned sandbox can still issue operations by name, but it does not own the host process lifecycle:
-
 ```python
-# Create in detached mode.
 sandbox = await Sandbox.create(
-    "background",
+    "python-readme-background",
     image="python",
     detached=True,
+    replace=True,
 )
 
-# Later, from another process:
-handle = await Sandbox.get("background")
+handle = await Sandbox.get("python-readme-background")
 reconnected = await handle.connect()
 output = await reconnected.shell("echo reconnected")
-```
-
-### Context Manager
-
-```python
-async with await Sandbox.create("temp", image="alpine", replace=True) as sb:
-    output = await sb.shell("echo hello")
-    print(output.stdout_text)
-# Sandbox is automatically killed and removed on exit.
-```
-
-### Replace Existing
-
-`replace=True` stops a sandbox with the same name (if any) and
-recreates it. By default the existing one gets 10 seconds to exit
-cleanly after `SIGTERM` before `SIGKILL`; pass `replace_with_timeout`
-(in seconds, fractional allowed) to override. Setting
-`replace_with_timeout` implies `replace=True`.
-
-```python
-# Default 10s SIGTERM timeout.
-sb = await Sandbox.create("worker", image="alpine", replace=True)
-
-# Wait longer for a workload that needs more time to shut down.
-sb = await Sandbox.create("worker", image="alpine", replace_with_timeout=30)
-
-# Skip SIGTERM entirely; SIGKILL immediately.
-sb = await Sandbox.create("worker", image="alpine", replace_with_timeout=0)
-```
-
-If you'd rather handle the conflict yourself, catch the typed error:
-
-```python
-from microsandbox import SandboxAlreadyExistsError
-
-try:
-    sb = await Sandbox.create("worker", image="alpine")
-except SandboxAlreadyExistsError:
-    print("already exists; resume or pass replace=True")
-```
-
-### TLS Interception
-
-```python
-from microsandbox import Network, Sandbox, TlsConfig
-
-sandbox = await Sandbox.create(
-    "tls-inspect",
-    image="python",
-    network=Network(
-        tls=TlsConfig(
-            bypass=("*.googleapis.com",),
-            verify_upstream=True,
-            intercepted_ports=(443,),
-        ),
-    ),
-)
+print(output.stdout_text.strip())
 ```
 
 ### Metrics
 
 ```python
-from microsandbox import Sandbox, all_sandbox_metrics, MiB
+from microsandbox import MiB, all_sandbox_metrics
 
-sandbox = await Sandbox.create("metrics-demo", image="python")
+metrics = await sandbox.metrics()
+print(f"CPU: {metrics.cpu_percent:.1f}%")
+print(f"Memory: {metrics.memory_bytes // MiB} MiB")
 
-# Per-sandbox metrics.
-m = await sandbox.metrics()
-print(f"CPU: {m.cpu_percent:.1f}%")
-print(f"Memory: {m.memory_bytes // MiB} MiB")
-print(f"Uptime: {m.uptime_ms / 1000:.1f}s")
+async for sample in sandbox.metrics_stream(interval=1.0):
+    print(f"CPU: {sample.cpu_percent:.1f}%")
+    break
 
-# Streaming metrics.
-async for m in sandbox.metrics_stream(interval=1.0):
-    print(f"CPU: {m.cpu_percent:.1f}%")
-
-# All sandboxes at once.
-all_metrics = await all_sandbox_metrics()
-for name, metrics in all_metrics.items():
-    print(f"{name}: {metrics.cpu_percent:.1f}%")
+for name, sample in (await all_sandbox_metrics()).items():
+    print(f"{name}: {sample.cpu_percent:.1f}%")
 ```
 
-### Runtime Setup
+### Typed Errors
+
+Python exports typed errors for the common SDK categories and falls back to `MicrosandboxError` for unmapped runtime variants. Catch specific errors when you need category-specific handling, and catch `MicrosandboxError` as the broad SDK base class.
 
 ```python
-from microsandbox import is_installed, install
+from microsandbox import MicrosandboxError, Sandbox, SandboxAlreadyExistsError
 
-if not is_installed():
-    await install()  # Downloads msb + libkrunfw to ~/.microsandbox/
+try:
+    await Sandbox.create("worker", image="alpine")
+except SandboxAlreadyExistsError:
+    print("already exists; resume it or pass replace=True")
+except MicrosandboxError as exc:
+    print(f"microsandbox error: {exc}")
 ```
 
-## API Reference
+## Runtime Setup
 
-### Classes (native)
+Installed wheels bundle the runtime files. The setup helpers are useful for source checkouts, shared runtime installs, and surfacing setup failures at process startup.
 
-| Class | Description |
-|-------|-------------|
-| `Sandbox` | Live handle to a running sandbox — lifecycle, execution, filesystem |
-| `SandboxHandle` | Lightweight database handle — use `connect()` or `start()` to get a live `Sandbox` |
-| `ExecOutput` | Captured stdout/stderr with exit status |
-| `ExecHandle` | Streaming execution handle — async iterator over events |
-| `ExecSink` | Writable stdin channel for streaming exec |
-| `SandboxFsOps` | Guest filesystem operations (read, write, list, copy, stat) |
-| `FsReadStream` | Async iterator over file data chunks |
-| `FsWriteSink` | Async context manager for streaming writes |
-| `Volume` | Persistent named volume |
-| `VolumeHandle` | Lightweight volume handle from the database |
-| `Image` | Image source factories and local OCI image-cache management |
-| `ImageHandle` | Lightweight cached image handle from the database |
-| `ImagePruneReport` | Summary returned by `Image.prune()` |
-| `MetricsStream` | Async iterator over metrics snapshots |
-| `PullSession` | Async context manager for creation with pull progress |
+```python
+from microsandbox import install, is_installed
 
-### Factories (Python)
+if not is_installed():
+    await install()
+```
 
-| Class | Description |
-|-------|-------------|
-| `Volume.bind()` / `.named()` / `.tmpfs()` / `.disk()` | Volume mount configuration |
-| `Network.none()` / `.public_only()` / `.allow_all()` | Network presets |
-| `Secret.env()` | Secret entry with host allowlist |
-| `Patch.text()` / `.mkdir()` / `.copy_file()` / `.append()` / ... | Pre-boot filesystem modifications |
-| `Image.oci(..., upper_size_mib=...)` / `.bind()` / `.disk()` | Explicit rootfs source configuration |
-| `Rlimit.nofile()` / `.cpu()` / `.as_()` / ... | POSIX resource limits |
+## More Documentation
 
-### Enums (Python `StrEnum`)
-
-| Enum | Values |
-|------|--------|
-| `PullPolicy` | `ALWAYS`, `IF_MISSING`, `NEVER` |
-| `LogLevel` | `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR` |
-| `SecurityProfile` | `DEFAULT`, `RESTRICTED` |
-| `SandboxStatus` | `RUNNING`, `STOPPED`, `CRASHED`, `DRAINING`, `PAUSED` |
-| `Action` | `ALLOW`, `DENY` |
-| `Direction` | `EGRESS`, `INGRESS` |
-| `Protocol` | `TCP`, `UDP`, `ICMPV4`, `ICMPV6` |
-| `DestGroup` | `LOOPBACK`, `PRIVATE`, `LINK_LOCAL`, `METADATA`, `MULTICAST` |
-| `ViolationAction` | `BLOCK`, `BLOCK_AND_LOG`, `BLOCK_AND_TERMINATE` |
-| `FsEntryKind` | `FILE`, `DIRECTORY`, `SYMLINK`, `OTHER` |
-| `RlimitResource` | `CPU`, `FSIZE`, `NOFILE`, `AS`, ... (16 variants) |
-
-### Dataclasses (Python, frozen)
-
-| Type | Description |
-|------|-------------|
-| `ExitStatus` | Exit code and success flag |
-| `MountConfig` | Volume mount (bind, named, tmpfs, or disk) |
-| `PatchConfig` | Pre-boot filesystem modification |
-| `SecretEntry` | Secret binding to env var with host allowlist |
-| `NetworkPolicy` | Custom network policy with rules |
-| `TlsConfig` | TLS interception options |
-| `Network` | Full network configuration |
-| `Rule` | Network policy rule |
-| `RegistryAuth` | Docker registry credentials |
-| `Size` | Memory/storage size value type |
-| `Rlimit` | POSIX resource limit |
-
-### Event Types
-
-| Type | Description |
-|------|-------------|
-| Streaming exec events | Event objects returned by `exec_stream()` / `shell_stream()`. Inspect `event_type`, `pid`, `data`, and `code`. |
-| Pull progress events | Event objects yielded by `PullSession.progress`. Inspect `event_type` and the optional detail fields for that event. |
-
-### Functions
-
-| Function | Description |
-|----------|-------------|
-| `is_installed()` | Check if `msb` and `libkrunfw` are available |
-| `install()` | Download and install runtime dependencies |
-| `all_sandbox_metrics()` | Get metrics for all running sandboxes |
-| `version()` | Return the SDK version string |
+- [Sandbox lifecycle](https://docs.microsandbox.dev/sdk/python/sandbox)
+- [Execution](https://docs.microsandbox.dev/sdk/python/execution)
+- [Filesystem](https://docs.microsandbox.dev/sdk/python/filesystem)
+- [Networking](https://docs.microsandbox.dev/sdk/python/networking)
+- [Secrets](https://docs.microsandbox.dev/sdk/python/secrets)
+- [Volumes](https://docs.microsandbox.dev/sdk/python/volumes)
+- [Snapshots](https://docs.microsandbox.dev/sdk/python/snapshots)
+- [Images](https://docs.microsandbox.dev/sdk/python/images)
+- [SSH](https://docs.microsandbox.dev/sdk/python/ssh)
+- [Agent client](https://docs.microsandbox.dev/sdk/python/agent-client)
 
 ## Development
 
-### Prerequisites
-
-- [Rust](https://rustup.rs/) (2024 edition)
-- [uv](https://docs.astral.sh/uv/) (Python package manager)
-- [maturin](https://www.maturin.rs/) (`uv tool install maturin`)
-
-### Setup
+From `sdk/python`:
 
 ```bash
-cd sdk/python
 uv sync --group dev
+uv run maturin develop --release
+uv run pytest tests
+uv run ruff check .
 ```
 
-### Build the extension
-
-```bash
-maturin develop --release
-```
-
-### Run tests
-
-```bash
-uv run pytest tests/
-```
-
-### Run an example
+From the repository root, run an example against the SDK project:
 
 ```bash
 uv run --project sdk/python python examples/python/root-oci/main.py
 ```
 
-### Lint
+Runtime integration tests require local virtualization support and runtime artifacts:
 
 ```bash
-uv run ruff check .
+cd sdk/python
+uv run pytest integration/test_create_kwargs.py integration/test_exec.py
 ```
 
 ## License

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -1,50 +1,52 @@
 # microsandbox
 
-Lightweight VM sandboxes for running AI agents and untrusted code with hardware-level isolation.
+Lightweight VM sandboxes for Rust applications that need hardware-level isolation for AI agents, tools, tests, and untrusted code.
 
-`microsandbox` is the core Rust library for the [microsandbox](https://github.com/superradcompany/microsandbox) project. It provides a high-level async API for creating, managing, and interacting with microVM sandboxes — real virtual machines that boot in under 100ms and run standard OCI (Docker) images.
+`microsandbox` is the Rust SDK for the [microsandbox](https://github.com/superradcompany/microsandbox) runtime. It exposes an async API for creating microVM-backed sandboxes, running commands, reading and writing guest files, managing volumes, configuring network policy, and working with secrets.
+
+For full API documentation, use the docs site and generated Rust docs:
+
+- [Rust SDK guide](https://docs.microsandbox.dev/sdk/rust/sandbox)
+- [SDK overview](https://docs.microsandbox.dev/sdk/overview)
+- [Repository examples](../../examples/rust)
 
 ## Features
 
-- **Hardware isolation** — Each sandbox is a real VM with its own Linux kernel, not a container
-- **Sub-100ms boot** — MicroVMs start nearly instantly, no daemon or server required
-- **OCI image support** — Pull and run images from Docker Hub, GHCR, ECR, or any OCI registry
-- **Command execution** — Run commands with streaming or collected output, interactive shells
-- **Guest filesystem access** — Read, write, list, copy files inside a running sandbox
-- **Named volumes** — Persistent storage that survives sandbox restarts, with quotas
-- **Network policies** — Control outbound access: public-only (default), allow-all, or fully airgapped
-- **DNS filtering** — Block specific domains or domain suffixes
-- **TLS interception** — Transparent MITM proxy for HTTPS inspection and secret substitution
-- **Secrets** — Credentials that never enter the VM; placeholder substitution at the network layer
-- **Port publishing** — Expose guest TCP/UDP services on host ports
-- **Rootfs patches** — Modify the filesystem before the VM boots
-- **Detached mode** — Sandboxes can outlive the parent process
-- **Metrics** — CPU, memory, disk I/O, and network I/O per sandbox
+- Hardware VM isolation with a guest Linux kernel
+- OCI image, bind-rootfs, disk-image, and snapshot-based sandboxes
+- Collected and streaming command execution
+- Guest filesystem read, write, list, copy, stat, and stream operations
+- Named volumes, bind mounts, tmpfs mounts, and disk-image mounts
+- Network policies, DNS filtering, TLS interception, secrets, and port publishing
+- Rootfs patches before boot
+- Detached sandboxes that can outlive the Rust process
+- Metrics, logs, snapshots, SSH/SFTP, image cache, and local/cloud backend helpers
 
 ## Requirements
 
-- **Linux** with KVM enabled, or **macOS** with Apple Silicon (M-series)
-- Rust 2024 edition
+- Rust toolchain with Rust 2024 edition support
+- Linux with KVM, macOS with Apple Silicon, or Windows with Windows Hypervisor Platform
+- Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/getting-started/windows-troubleshooting) for WHP and runtime setup notes.
 
 ## Installation
 
-```toml
-[dependencies]
-microsandbox = "0.4"
+```bash
+cargo add microsandbox
 ```
 
 ### Cargo Features
 
-| Feature    | Default | Description                                         |
-| ---------- | ------- | --------------------------------------------------- |
-| `prebuilt` | yes     | Use pre-built runtime binaries                      |
-| `net`      | yes     | Networking: port publishing, policies, TLS, secrets |
+| Feature | Default | Description |
+| --- | --- | --- |
+| `keyring` | yes | Registry credential lookup through the platform keyring |
+| `net` | yes | Networking, port publishing, policies, TLS interception, and secrets |
+| `prebuilt` | yes | Use prebuilt runtime artifacts where available |
+| `ssh` | no | SSH, SFTP, and interactive SSH helpers |
 
-To disable networking:
+To build without the networking stack while keeping the default keyring and prebuilt-runtime behavior:
 
-```toml
-[dependencies]
-microsandbox = { version = "0.4", default-features = false, features = ["prebuilt"] }
+```bash
+cargo add microsandbox --no-default-features --features keyring,prebuilt
 ```
 
 ## Quick Start
@@ -54,44 +56,52 @@ use microsandbox::Sandbox;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Create a sandbox from an OCI image.
-    let sandbox = Sandbox::builder("my-sandbox")
+    let sandbox = Sandbox::builder("rust-readme")
         .image("alpine")
         .cpus(1)
         .memory(512)
+        .replace()
         .create()
         .await?;
 
-    // Run a command.
     let output = sandbox.shell("echo 'Hello from microsandbox!'").await?;
-    println!("{}", output.stdout()?);
+    println!("{}", output.stdout()?.trim());
 
-    // Stop the sandbox.
     sandbox.stop().await?;
+    Sandbox::remove("rust-readme").await?;
+
     Ok(())
 }
 ```
 
-## Examples
+## Common Examples
+
+These snippets assume you already have a live `sandbox: Sandbox`. See [examples/rust](../../examples/rust) for complete runnable crates.
 
 ### Command Execution
 
 ```rust
-use microsandbox::Sandbox;
+use microsandbox::ExecEvent;
 
-// Collected output.
 let output = sandbox.exec("python3", ["-c", "print(1 + 1)"]).await?;
 println!("stdout: {}", output.stdout()?);
 println!("exit code: {}", output.status().code);
 
-// Streaming output.
 let mut handle = sandbox.exec_stream("tail", ["-f", "/var/log/app.log"]).await?;
 while let Some(event) = handle.recv().await {
     match event {
         ExecEvent::Stdout(data) => print!("{}", String::from_utf8_lossy(&data)),
         ExecEvent::Stderr(data) => eprint!("{}", String::from_utf8_lossy(&data)),
-        ExecEvent::Exited { code } => break,
-        _ => {}
+        ExecEvent::Exited { code } => {
+            println!("exited with {code}");
+            break;
+        }
+        ExecEvent::Started { .. } => {}
+        ExecEvent::Failed(err) => {
+            eprintln!("exec failed: {err:?}");
+            break;
+        }
+        ExecEvent::StdinError(err) => eprintln!("stdin error: {err:?}"),
     }
 }
 ```
@@ -101,14 +111,11 @@ while let Some(event) = handle.recv().await {
 ```rust
 let fs = sandbox.fs();
 
-// Write a file.
-fs.write("/tmp/config.json", b"{\"debug\": true}").await?;
+fs.write("/tmp/config.json", br#"{"debug": true}"#).await?;
 
-// Read it back.
 let data = fs.read("/tmp/config.json").await?;
 println!("{}", String::from_utf8_lossy(&data));
 
-// List a directory.
 for entry in fs.list("/etc").await? {
     println!("{} ({:?})", entry.path, entry.kind);
 }
@@ -119,187 +126,124 @@ for entry in fs.list("/etc").await? {
 ```rust
 use microsandbox::{Sandbox, Volume, size::SizeExt};
 
-// Create a 100 MiB named volume.
-let data = Volume::builder("my-data").quota(100.mib()).create().await?;
+let data = Volume::builder("readme-data").quota(100.mib()).create().await?;
 
-// Mount it in a sandbox.
-let sandbox = Sandbox::builder("writer")
+let writer = Sandbox::builder("readme-writer")
     .image("alpine")
     .volume("/data", |v| v.named(data.name()))
+    .replace()
     .create()
     .await?;
 
-sandbox.shell("echo 'hello' > /data/message.txt").await?;
-sandbox.stop().await?;
+writer.shell("echo 'hello' > /data/message.txt").await?;
+writer.stop().await?;
 
-// Mount the same volume in another sandbox (read-only).
-let reader = Sandbox::builder("reader")
+let reader = Sandbox::builder("readme-reader")
     .image("alpine")
     .volume("/data", |v| v.named(data.name()).readonly())
+    .replace()
     .create()
     .await?;
 
 let output = reader.shell("cat /data/message.txt").await?;
-println!("{}", output.stdout()?); // "hello"
+println!("{}", output.stdout()?.trim());
 ```
 
 ### Network Policies
 
 ```rust
-use microsandbox::{Sandbox, NetworkPolicy};
+use microsandbox::{NetworkPolicy, Sandbox};
 
-// Default: public internet only (blocks private ranges).
-let sandbox = Sandbox::builder("public")
-    .image("alpine")
-    .create()
-    .await?;
-
-// Fully airgapped.
-let sandbox = Sandbox::builder("isolated")
+let isolated = Sandbox::builder("readme-isolated")
     .image("alpine")
     .network(|n| n.policy(NetworkPolicy::none()))
+    .replace()
     .create()
     .await?;
 
-// Domain blocking via policy rules (refused at DNS and at TCP egress).
-use microsandbox_network::policy::{Destination, Rule};
+let filtered_policy = NetworkPolicy::builder()
+    .default_allow()
+    .rule(|r| r.egress().deny().domain("blocked.example.com"))
+    .rule(|r| r.egress().deny().domain_suffix(".evil.com"))
+    .build()?;
 
-let mut policy = NetworkPolicy::default();
-policy.rules.push(Rule::deny_egress(Destination::Domain(
-    "blocked.example.com".parse()?,
-)));
-policy.rules.push(Rule::deny_egress(Destination::DomainSuffix(
-    ".evil.com".parse()?,
-)));
-let sandbox = Sandbox::builder("filtered")
+let filtered = Sandbox::builder("readme-filtered")
     .image("alpine")
-    .network(|n| n.policy(policy))
+    .network(|n| n.policy(filtered_policy))
+    .replace()
     .create()
     .await?;
 ```
 
+Use `.disable_network()` when the sandbox should not receive a network interface at all. Use `NetworkPolicy::none()` when the interface should exist but policy should deny traffic.
+
 ### Port Publishing
 
 ```rust
-let sandbox = Sandbox::builder("web")
+let sandbox = Sandbox::builder("readme-web")
     .image("python")
-    .port(8080, 80) // host:8080 → guest:80
+    .port(8080, 80)
+    .replace()
     .create()
     .await?;
 ```
 
 ### Secrets
 
-Secrets use placeholder substitution — the real value never enters the VM. It is only swapped in at the network layer for HTTPS requests to allowed hosts.
+Secrets use placeholder substitution. The real value stays on the host and is substituted only for allowed network destinations.
 
 ```rust
-let sandbox = Sandbox::builder("agent")
+let sandbox = Sandbox::builder("readme-agent")
     .image("python")
-    .secret_env("API_KEY", "sk-real-secret-123", "api.openai.com")
+    .secret_env("OPENAI_API_KEY", "sk-real-secret-123", "api.openai.com")
+    .replace()
     .create()
     .await?;
-
-// Guest sees: API_KEY=$MSB_API_KEY (a placeholder)
-// HTTPS to api.openai.com: placeholder is transparently replaced with the real key
-// HTTPS to any other host with the placeholder: request is blocked
 ```
 
 ### Rootfs Patches
 
-Modify the filesystem before the VM boots:
-
 ```rust
-let sandbox = Sandbox::builder("patched")
+let sandbox = Sandbox::builder("readme-patched")
     .image("alpine")
     .patch(|p| {
         p.text("/etc/greeting.txt", "Hello!\n", None, false)
-         .mkdir("/app", Some(0o755))
-         .append("/etc/hosts", "127.0.0.1 myapp.local\n")
+            .mkdir("/app", Some(0o755))
+            .append("/etc/hosts", "127.0.0.1 myapp.local\n")
     })
+    .replace()
     .create()
     .await?;
 ```
 
 ### Detached Mode
 
-Sandboxes in detached mode survive the parent process:
-
 ```rust
-// Create and detach.
-let sandbox = Sandbox::builder("background")
+let sandbox = Sandbox::builder("readme-background")
     .image("python")
     .detached(true)
+    .replace()
     .create()
     .await?;
 
-// Later, from another process:
-let sandbox = Sandbox::start("background").await?;
-let output = sandbox.shell("echo reconnected").await?;
+sandbox.detach().await;
+
+let handle = Sandbox::get("readme-background").await?;
+let reconnected = handle.connect().await?;
+let output = reconnected.shell("echo reconnected").await?;
+println!("{}", output.stdout()?.trim());
 ```
 
-### Image Sources
+## More Documentation
 
-```rust
-use microsandbox::Sandbox;
-
-// OCI image (most common).
-Sandbox::builder("a").image("python")
-
-// Local bind-mounted rootfs.
-Sandbox::builder("b").image("/path/to/rootfs")
-
-// QCOW2 disk image.
-Sandbox::builder("c").image_with(|img| img.disk("/path/to/disk.qcow2").fstype("ext4"))
-```
-
-## API Overview
-
-### Core Types
-
-| Type             | Description                                                         |
-| ---------------- | ------------------------------------------------------------------- |
-| `Sandbox`        | Live handle to a running sandbox — lifecycle, execution, filesystem |
-| `SandboxBuilder` | Fluent builder for configuring and creating sandboxes               |
-| `SandboxConfig`  | Serializable sandbox configuration                                  |
-| `SandboxHandle`  | Lightweight metadata handle from the database                       |
-| `Volume`         | Persistent named volume                                             |
-| `VolumeBuilder`  | Fluent builder for creating volumes                                 |
-| `Image`          | OCI image metadata and inspection                                   |
-
-### Execution Types
-
-| Type                                 | Description                                                |
-| ------------------------------------ | ---------------------------------------------------------- |
-| `ExecOutput`                         | Captured stdout/stderr with exit status                    |
-| `ExecHandle`                         | Streaming execution handle with event channel              |
-| `ExecOptions` / `ExecOptionsBuilder` | Execution configuration (args, env, cwd, timeout, rlimits) |
-| `ExecEvent`                          | Stream event: `Started`, `Stdout`, `Stderr`, `Exited`      |
-| `ExecSink`                           | Writable stdin channel for streaming exec                  |
-| `ExitStatus`                         | Exit code and success flag                                 |
-
-### Filesystem Types
-
-| Type         | Description                              |
-| ------------ | ---------------------------------------- |
-| `SandboxFsOps`  | Gateway for guest filesystem operations  |
-| `FsEntry`    | Directory entry (name, kind, size, mode) |
-| `FsMetadata` | File metadata (size, mode, timestamps)   |
-
-### Configuration Types
-
-| Type                     | Description                                         |
-| ------------------------ | --------------------------------------------------- |
-| `RootfsSource`           | Image source: `Oci`, `Bind`, or `DiskImage`         |
-| `VolumeMount`            | Mount type: `Bind`, `Named`, or `Tmpfs`             |
-| `Patch` / `PatchBuilder` | Pre-boot filesystem modifications                   |
-| `NetworkPolicy`          | Network access control (requires `net` feature)     |
-| `RegistryAuth`           | Docker registry credentials                         |
-| `PullPolicy`             | Image pull strategy: `Always`, `IfMissing`, `Never` |
-| `LogLevel`               | Logging verbosity                                   |
-
-### Error Handling
-
-All fallible operations return `MicrosandboxResult<T>`, which uses `MicrosandboxError` — an enum covering I/O, network, database, configuration, runtime, and timeout errors.
+- [Sandbox lifecycle](https://docs.microsandbox.dev/sdk/rust/sandbox)
+- [Execution](https://docs.microsandbox.dev/sdk/rust/execution)
+- [Filesystem](https://docs.microsandbox.dev/sdk/rust/filesystem)
+- [Networking](https://docs.microsandbox.dev/sdk/rust/networking)
+- [Secrets](https://docs.microsandbox.dev/sdk/rust/secrets)
+- [Volumes](https://docs.microsandbox.dev/sdk/rust/volumes)
+- [Snapshots](https://docs.microsandbox.dev/sdk/rust/snapshots)
+- [SSH](https://docs.microsandbox.dev/sdk/rust/ssh)
 
 ## License
 


### PR DESCRIPTION
## TL;DR
Refresh the SDK READMEs so they match the current install and runtime story, with links to the docs site for full references. Also align the Go docs with the explicit EnsureInstalled flow and fix the TypeScript DNS example.

## Description
- Rewrite the Rust, Python, TypeScript, and Go SDK READMEs around current setup, platform notes, and compact realistic examples.
- Add concrete docs-site links for each SDK instead of trying to duplicate the full API surface in README files.
- Clarify Windows mentions, Node platform package behavior, and the Go `EnsureInstalled` / `IsInstalled` runtime setup path.
- Update the Go SDK docs intro and overview example to call `EnsureInstalled` before creating local sandboxes.
- Fix the TypeScript DNS example to use `NetworkPolicy.builder().defaultAllow().egress(...)` with the current DNS deny methods.

## Test Plan
- [x] `git diff --check origin/main..HEAD` exits 0
- [x] `bash -lc 'files=$(git diff --name-only origin/main..HEAD); if rg -n "0\\.5\\.8|npx microsandbox install|postinstall|openClient|TlsConfig|denyDomains\\(|Sub-100ms" $files; then exit 1; fi'` exits 0
- [x] `cd sdk/node-ts && npm run typecheck` exits 0
- [x] `cd sdk/node-ts && npm run test:unit` exits 0
- [x] `cd sdk/go && go test -count=1 ./...` exits 0