### PR TITLE
fix(network): handle IPv6 DNS edge cases

### DIFF
--- a/crates/agentd/lib/network.rs
+++ b/crates/agentd/lib/network.rs
@@ -128,12 +128,19 @@ fn hosts_file_contents(
 
 mod linux {
     use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::os::unix::fs::PermissionsExt;
     use std::{fs, io, mem, ptr};
 
     use nix::unistd;
 
     use crate::config::{NetIpv4Spec, NetIpv6Spec, NetSpec};
     use crate::error::{AgentdError, AgentdResult};
+
+    //----------------------------------------------------------------------------------------------
+    // Constants
+    //----------------------------------------------------------------------------------------------
+
+    const ETC_NETWORK_FILE_MODE: u32 = 0o644;
 
     //----------------------------------------------------------------------------------------------
     // Types
@@ -550,6 +557,11 @@ mod linux {
             super::hosts_file_contents(hostname, host_alias, gateway_ipv4, gateway_ipv6),
         )
         .map_err(|e| AgentdError::Init(format!("failed to write /etc/hosts: {e}")))?;
+        fs::set_permissions(
+            "/etc/hosts",
+            fs::Permissions::from_mode(ETC_NETWORK_FILE_MODE),
+        )
+        .map_err(|e| AgentdError::Init(format!("failed to chmod /etc/hosts: {e}")))?;
         Ok(())
     }
 
@@ -569,6 +581,11 @@ mod linux {
 
         fs::write("/etc/resolv.conf", &content)
             .map_err(|e| AgentdError::Init(format!("failed to write /etc/resolv.conf: {e}")))?;
+        fs::set_permissions(
+            "/etc/resolv.conf",
+            fs::Permissions::from_mode(ETC_NETWORK_FILE_MODE),
+        )
+        .map_err(|e| AgentdError::Init(format!("failed to chmod /etc/resolv.conf: {e}")))?;
 
         Ok(())
     }

--- a/crates/network/lib/addr.rs
+++ b/crates/network/lib/addr.rs
@@ -1,0 +1,55 @@
+//! IP address helpers shared by network policy and DNS code.
+
+use std::net::IpAddr;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Collapse IPv4-mapped IPv6 addresses into their embedded IPv4 address.
+///
+/// Some runtimes and resolvers can represent an IPv4 endpoint as `::ffff:a.b.c.d`.
+/// Normalizing keeps policy classification, CIDR checks, DNS rebind protection, and
+/// resolved-hostname cache lookups aligned with the actual IPv4 endpoint.
+pub(crate) fn normalize_ip_addr(addr: IpAddr) -> IpAddr {
+    match addr {
+        IpAddr::V4(_) => addr,
+        IpAddr::V6(v6) => v6
+            .to_ipv4_mapped()
+            .map(IpAddr::V4)
+            .unwrap_or(IpAddr::V6(v6)),
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::*;
+
+    #[test]
+    fn normalize_ip_addr_unwraps_ipv4_mapped_ipv6() {
+        assert_eq!(
+            normalize_ip_addr(IpAddr::V6("::ffff:169.254.169.254".parse().unwrap())),
+            IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254)),
+        );
+    }
+
+    #[test]
+    fn normalize_ip_addr_keeps_native_ipv6() {
+        let addr = IpAddr::V6("2606:4700:4700::1111".parse().unwrap());
+
+        assert_eq!(normalize_ip_addr(addr), addr);
+    }
+
+    #[test]
+    fn normalize_ip_addr_keeps_ipv4() {
+        let addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+        assert_eq!(normalize_ip_addr(addr), addr);
+    }
+}

--- a/crates/network/lib/dns/common/filter.rs
+++ b/crates/network/lib/dns/common/filter.rs
@@ -5,6 +5,10 @@
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
 /// Check if an IPv4 address is in a private/reserved range (for rebind protection).
 pub(in crate::dns) fn is_private_ipv4(addr: Ipv4Addr) -> bool {
     let octets = addr.octets();
@@ -19,9 +23,45 @@ pub(in crate::dns) fn is_private_ipv4(addr: Ipv4Addr) -> bool {
 
 /// Check if an IPv6 address is in a private/reserved range (for rebind protection).
 pub(in crate::dns) fn is_private_ipv6(addr: Ipv6Addr) -> bool {
+    if let Some(addr) = addr.to_ipv4_mapped() {
+        return is_private_ipv4(addr);
+    }
+
     let segments = addr.segments();
     addr.is_loopback()                       // ::1
         || (segments[0] & 0xfe00) == 0xfc00  // fc00::/7 (ULA)
         || (segments[0] & 0xffc0) == 0xfe80  // fe80::/10 (link-local)
         || addr.is_unspecified() // ::
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn private_ipv6_rejects_ipv4_mapped_private_ranges() {
+        for addr in [
+            "::ffff:127.0.0.1",
+            "::ffff:10.0.0.1",
+            "::ffff:172.16.0.1",
+            "::ffff:192.168.1.10",
+            "::ffff:100.64.0.1",
+            "::ffff:169.254.169.254",
+            "::ffff:0.0.0.0",
+        ] {
+            assert!(
+                is_private_ipv6(addr.parse().unwrap()),
+                "expected {addr} to trip rebind protection"
+            );
+        }
+    }
+
+    #[test]
+    fn private_ipv6_allows_ipv4_mapped_public_addresses() {
+        assert!(!is_private_ipv6("::ffff:8.8.8.8".parse().unwrap()));
+    }
 }

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -174,6 +174,16 @@ impl DnsForwarder {
             return build_status_response(&query_msg, ResponseCode::NXDomain);
         }
 
+        if let Some(family) = inactive_query_family(query_type, self.gateway) {
+            tracing::debug!(
+                domain = %domain,
+                ?family,
+                "DNS query family is inactive for this sandbox",
+            );
+            self.shared.clear_resolved_hostname(&domain, family);
+            return build_status_response(&query_msg, ResponseCode::NoError);
+        }
+
         // Locally synthesize answers for the host alias; MX / TXT / etc.
         // fall through to upstream.
         if is_host_alias_query(&domain)
@@ -510,6 +520,18 @@ fn family_for_query_type(query_type: RecordType) -> Option<ResolvedHostnameFamil
     }
 }
 
+/// Return the queried address family when the sandbox has no gateway for it.
+fn inactive_query_family(
+    query_type: RecordType,
+    gateway: GatewayIps,
+) -> Option<ResolvedHostnameFamily> {
+    match query_type {
+        RecordType::A if gateway.ipv4.is_none() => Some(ResolvedHostnameFamily::Ipv4),
+        RecordType::AAAA if gateway.ipv6.is_none() => Some(ResolvedHostnameFamily::Ipv6),
+        _ => None,
+    }
+}
+
 /// Extract resolved IP addresses and the minimum TTL across answers of
 /// the requested family. Zero-TTL answers are floored to
 /// [`RESOLVED_HOSTNAME_MIN_TTL_SECS`] so an immediate connect following
@@ -647,6 +669,17 @@ mod tests {
     }
 
     #[test]
+    fn build_status_response_noerror_variant_is_nodata() {
+        let query = make_query("example.com.", RecordType::AAAA);
+        let bytes = build_status_response(&query, ResponseCode::NoError).expect("built");
+        let msg = Message::from_bytes(&bytes).expect("parse response");
+        assert_eq!(msg.response_code(), ResponseCode::NoError);
+        assert_eq!(msg.answers().len(), 0);
+        assert_eq!(msg.queries().len(), 1);
+        assert_eq!(msg.queries()[0].query_type(), RecordType::AAAA);
+    }
+
+    #[test]
     fn build_truncated_response_sets_tc_and_keeps_question() {
         let query = make_query("example.com.", RecordType::TXT);
         let bytes = build_truncated_response(&query).expect("built");
@@ -689,6 +722,44 @@ mod tests {
         let query = make_query("example.com.", RecordType::A);
         assert!(query.extensions().is_none());
         assert_eq!(query.max_payload(), 512);
+    }
+
+    #[test]
+    fn inactive_query_family_detects_missing_ipv6_gateway() {
+        let gateway = GatewayIps {
+            ipv4: Some(std::net::Ipv4Addr::new(172, 16, 0, 1)),
+            ipv6: None,
+        };
+
+        assert_eq!(
+            inactive_query_family(RecordType::AAAA, gateway),
+            Some(ResolvedHostnameFamily::Ipv6)
+        );
+        assert_eq!(inactive_query_family(RecordType::A, gateway), None);
+    }
+
+    #[test]
+    fn inactive_query_family_detects_missing_ipv4_gateway() {
+        let gateway = GatewayIps {
+            ipv4: None,
+            ipv6: Some("fd42:6d73:62::1".parse().unwrap()),
+        };
+
+        assert_eq!(
+            inactive_query_family(RecordType::A, gateway),
+            Some(ResolvedHostnameFamily::Ipv4)
+        );
+        assert_eq!(inactive_query_family(RecordType::AAAA, gateway), None);
+    }
+
+    #[test]
+    fn inactive_query_family_ignores_non_address_queries() {
+        let gateway = GatewayIps {
+            ipv4: None,
+            ipv6: None,
+        };
+
+        assert_eq!(inactive_query_family(RecordType::MX, gateway), None);
     }
 
     fn gateway_set() -> HashSet<IpAddr> {

--- a/crates/network/lib/lib.rs
+++ b/crates/network/lib/lib.rs
@@ -11,6 +11,8 @@
     clippy::manual_c_str_literals
 )]
 
+mod addr;
+
 pub mod backend;
 pub mod builder;
 pub mod config;

--- a/crates/network/lib/policy/destination.rs
+++ b/crates/network/lib/policy/destination.rs
@@ -6,6 +6,7 @@ use std::net::IpAddr;
 use ipnetwork::IpNetwork;
 
 use super::DestinationGroup;
+use crate::addr::normalize_ip_addr;
 use crate::shared::SharedState;
 
 //--------------------------------------------------------------------------------------------------
@@ -36,6 +37,8 @@ pub fn matches_group(group: DestinationGroup, addr: IpAddr, shared: &SharedState
 /// `Metadata` before `LinkLocal` because `169.254.169.254` is in the
 /// link-local CIDR.
 fn addr_classify(addr: IpAddr, shared: &SharedState) -> DestinationGroup {
+    let addr = normalize_ip_addr(addr);
+
     if matches_host(addr, shared) {
         DestinationGroup::Host
     } else if is_metadata(addr) {
@@ -125,6 +128,8 @@ fn is_multicast(addr: IpAddr) -> bool {
 
 /// Returns `true` if `addr` matches a CIDR network.
 pub fn matches_cidr(network: &IpNetwork, addr: IpAddr) -> bool {
+    let addr = normalize_ip_addr(addr);
+
     network.contains(addr)
 }
 
@@ -222,6 +227,32 @@ mod tests {
     }
 
     #[test]
+    fn ipv4_mapped_ipv6_uses_embedded_ipv4_group() {
+        let s = no_host();
+
+        assert!(matches_group(
+            DestinationGroup::Metadata,
+            IpAddr::V6("::ffff:169.254.169.254".parse().unwrap()),
+            &s,
+        ));
+        assert!(matches_group(
+            DestinationGroup::Loopback,
+            IpAddr::V6("::ffff:127.0.0.1".parse().unwrap()),
+            &s,
+        ));
+        assert!(matches_group(
+            DestinationGroup::Private,
+            IpAddr::V6("::ffff:10.0.0.1".parse().unwrap()),
+            &s,
+        ));
+        assert!(!matches_group(
+            DestinationGroup::Public,
+            IpAddr::V6("::ffff:10.0.0.1".parse().unwrap()),
+            &s,
+        ));
+    }
+
+    #[test]
     fn link_local() {
         let s = no_host();
         assert!(matches_group(
@@ -292,6 +323,16 @@ mod tests {
         let net: IpNetwork = "10.0.0.0/8".parse().unwrap();
         assert!(matches_cidr(&net, IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))));
         assert!(!matches_cidr(&net, IpAddr::V4(Ipv4Addr::new(11, 0, 0, 1))));
+    }
+
+    #[test]
+    fn cidr_match_uses_embedded_ipv4_for_ipv4_mapped_ipv6() {
+        let net: IpNetwork = "169.254.0.0/16".parse().unwrap();
+
+        assert!(matches_cidr(
+            &net,
+            IpAddr::V6("::ffff:169.254.169.254".parse().unwrap()),
+        ));
     }
 
     #[test]

--- a/crates/network/lib/shared.rs
+++ b/crates/network/lib/shared.rs
@@ -16,6 +16,8 @@ use microsandbox_utils::ttl_reverse_index::TtlReverseIndex;
 pub use microsandbox_utils::wake_pipe::WakePipe;
 use parking_lot::RwLock;
 
+use crate::addr::normalize_ip_addr;
+
 //--------------------------------------------------------------------------------------------------
 // Constants
 //--------------------------------------------------------------------------------------------------
@@ -167,6 +169,7 @@ impl SharedState {
     ) {
         let hostname = normalize_hostname(domain);
         let key = ResolvedHostnameKey { hostname, family };
+        let addrs = addrs.into_iter().map(normalize_ip_addr);
         self.resolved_hostnames
             .write()
             .insert(key, addrs, ttl, Instant::now());
@@ -185,6 +188,8 @@ impl SharedState {
         addr: IpAddr,
         mut predicate: impl FnMut(&str) -> bool,
     ) -> bool {
+        let addr = normalize_ip_addr(addr);
+
         self.resolved_hostnames
             .read()
             .member_matches(&addr, Instant::now(), |key| predicate(&key.hostname))
@@ -324,5 +329,22 @@ mod tests {
         assert!(state.any_resolved_hostname(v4, |h| h == "example.com"));
         assert!(state.any_resolved_hostname(v6, |h| h == "example.com"));
         assert!(!state.any_resolved_hostname(v4, |h| h == "other.example"));
+    }
+
+    #[test]
+    fn resolved_hostnames_normalize_ipv4_mapped_ipv6() {
+        let state = SharedState::new(4);
+        let mapped: IpAddr = "::ffff:169.254.169.254".parse().unwrap();
+        let embedded: IpAddr = "169.254.169.254".parse().unwrap();
+
+        state.cache_resolved_hostname(
+            "metadata.example",
+            ResolvedHostnameFamily::Ipv6,
+            [mapped],
+            Duration::from_secs(30),
+        );
+
+        assert!(state.any_resolved_hostname(embedded, |h| h == "metadata.example"));
+        assert!(state.any_resolved_hostname(mapped, |h| h == "metadata.example"));
     }
 }


### PR DESCRIPTION
## Summary
- suppress unusable DNS answers for inactive address families
- make generated network config files readable
- normalize IPv4-mapped IPv6 addresses

## Test Plan
- cargo fmt --all -- --check
- cargo fmt --manifest-path crates/agentd/Cargo.toml -- --check
- cargo test -p microsandbox-network dns::forwarder
- cargo test -p microsandbox-network ipv4_mapped
- cargo test --manifest-path crates/agentd/Cargo.toml network