### PR TITLE
fix(windows): remove VC runtime requirement from installs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -555,6 +555,8 @@ jobs:
 
       - name: Build msb
         shell: pwsh
+        env:
+          RUSTFLAGS: -C target-feature=+crt-static
         run: |
           $ErrorActionPreference = "Stop"
           . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -475,6 +475,8 @@ jobs:
 
       - name: Build msb
         shell: pwsh
+        env:
+          RUSTFLAGS: -C target-feature=+crt-static
         run: |
           $ErrorActionPreference = "Stop"
           . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"
@@ -485,6 +487,8 @@ jobs:
 
       - name: Build msb-metrics
         shell: pwsh
+        env:
+          RUSTFLAGS: -C target-feature=+crt-static
         run: |
           $ErrorActionPreference = "Stop"
           . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"

--- a/scripts/dev-windows.ps1
+++ b/scripts/dev-windows.ps1
@@ -1043,7 +1043,19 @@ function Invoke-BuildMsb {
     }
 
     $profileArg = if ($Mode -eq "release") { "--release" } else { "" }
-    Invoke-MsvcCommand -CommandLine "cargo build -p microsandbox-cli --target $($target.RustTarget) $profileArg"
+    $previousRustflags = $env:RUSTFLAGS
+    if ($Mode -eq "release") {
+        # Match release CI so installed Windows builds do not require a separate VC++ runtime.
+        $env:RUSTFLAGS = (@($previousRustflags, "-C target-feature=+crt-static") | Where-Object {
+                -not [string]::IsNullOrWhiteSpace($_)
+            }) -join " "
+    }
+
+    try {
+        Invoke-MsvcCommand -CommandLine "cargo build -p microsandbox-cli --target $($target.RustTarget) $profileArg"
+    } finally {
+        $env:RUSTFLAGS = $previousRustflags
+    }
 
     $profile = if ($Mode -eq "release") { "release" } else { "debug" }
     $msbSource = Join-Path $RepoRoot "target\$($target.RustTarget)\$profile\msb.exe"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -68,11 +68,42 @@ function Resolve-InstallRoot {
     return [System.IO.Path]::GetFullPath((Join-Path $env:USERPROFILE ".microsandbox"))
 }
 
+function Resolve-Architecture {
+    try {
+        $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+        if ($null -ne $architecture) {
+            return [string]$architecture
+        }
+    } catch {
+        # Some Windows PowerShell/.NET Framework combinations do not expose
+        # RuntimeInformation.OSArchitecture even though the rest of the
+        # installer can run normally.
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:PROCESSOR_ARCHITEW6432)) {
+        return $env:PROCESSOR_ARCHITEW6432
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:PROCESSOR_ARCHITECTURE)) {
+        return $env:PROCESSOR_ARCHITECTURE
+    }
+
+    try {
+        $operatingSystem = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
+        if ($null -ne $operatingSystem -and -not [string]::IsNullOrWhiteSpace($operatingSystem.OSArchitecture)) {
+            return [string]$operatingSystem.OSArchitecture
+        }
+    } catch {
+    }
+
+    throw "could not determine Windows architecture"
+}
+
 function Resolve-Target {
-    $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-    switch ($architecture) {
-        "Arm64" { return "windows-aarch64" }
-        "X64" { return "windows-x86_64" }
+    $architecture = Resolve-Architecture
+    switch -Regex ($architecture.ToUpperInvariant()) {
+        "^(ARM64|AARCH64)$" { return "windows-aarch64" }
+        "^(X64|AMD64|X86_64|64-BIT)$" { return "windows-x86_64" }
         default { throw "unsupported Windows architecture: $architecture" }
     }
 }


### PR DESCRIPTION
## TL;DR
Build Windows release binaries with the static CRT and make installer architecture detection more resilient so clean Windows installs no longer fail when the VC++ runtime or RuntimeInformation.OSArchitecture is missing.

## Description
- Build Windows `msb.exe` release and check artifacts with `-C target-feature=+crt-static`.
- Build Windows `msb-metrics.exe` release artifacts with the same static CRT setting.
- Make `scripts/dev-windows.ps1` match release CI for release-mode `msb` builds while restoring any previous `RUSTFLAGS`.
- Make the Windows installer fall back from `RuntimeInformation.OSArchitecture` to processor architecture environment variables and CIM before failing platform detection.

## Test Plan
- [x] `git diff --check origin/appcypher/add-shutdown-flush-timeout-override..HEAD`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --no-default-features --features net,ssh -p microsandbox-cli`
- [x] `cargo check -p microsandbox-metrics-collector`
- [x] Parse `scripts/install.ps1` and `scripts/dev-windows.ps1` with PowerShell on Windows Server 2025
- [x] Run the patched installer to a temp `MSB_HOME` and run static `msb` on the Windows VM without `vcruntime140.dll`
- [ ] Windows release workflow builds `msb.exe` and `msb-metrics.exe` on CI (runs in CI)