### PR TITLE
docs(sdk): document modify() in all four SDK references

### DIFF
--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -621,6 +621,66 @@ Explicitly refresh the running sandbox's idle activity. This sends `core.touch`,
   </div>
 </div>
 
+#### <span className="msb-recv">sb.</span><span className="msb-hn">Modify()</span>
+
+```go
+func (s *Sandbox) Modify(ctx context.Context, opts ModifyOptions) (*SandboxModificationPlan, error)
+```
+
+<Accordion title="Example">
+
+```go
+// Live resize: applies to the running VM when within the booted capacity
+plan, err := sb.Modify(ctx, m.ModifyOptions{CPUs: 4, MemoryMiB: 4096})
+if err != nil {
+    return err
+}
+for _, r := range plan.ResizeStatus {
+    fmt.Printf("%s: %s -> %s (%s)\n", r.Resource, r.Requested, r.Actual, r.State)
+}
+
+// Preview a change without applying it
+preview, err := sb.Modify(ctx, m.ModifyOptions{MaxMemoryMiB: 16384, DryRun: true})
+if err != nil {
+    return err
+}
+for _, c := range preview.Changes {
+    fmt.Printf("%s: %s\n", c.Field, c.Disposition)
+}
+
+// Make an env change active now by restarting
+_, err = sb.Modify(ctx, m.ModifyOptions{
+    Env:    map[string]string{"MODE": "prod"},
+    Policy: m.ModificationPolicyRestart,
+})
+```
+
+</Accordion>
+
+Plan or apply a configuration change. Every requested change is classified as `"live"`, `"next start"`, `"requires restart"`, or `"unsupported"`, and apply is all-or-nothing: a patch with conflicts, unsupported changes, or restart-required changes under the default policy returns an error without changing anything. `CPUs` and `MemoryMiB` apply live to a running sandbox when the target fits inside the boot-time capacity ([`WithMaxCPUs`](#withmaxcpus) / [`WithMaxMemory`](#withmaxmemory)); raising the capacity itself is restart-backed. Env and workdir changes on a running sandbox apply to future execs only — running processes keep their current environment — and the plan reports this as a warning. The CLI equivalent is [`msb modify`](/cli/sandbox-commands#msb-modify).
+
+The same method is available on [`SandboxHandle`](#sandboxhandle); it never starts a stopped sandbox — changes on a stopped sandbox persist for the next boot. Secret changes are Rust-SDK and CLI only for now.
+
+Live resize is not necessarily instant: enforcement applies immediately, and the returned plan's `ResizeStatus` reports whether the guest has finished converging (onlining CPUs, plugging memory blocks). See [`SandboxModificationPlan`](#sandboxmodificationplan).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#modifyoptions">ModifyOptions</a></div>
+    <div className="msb-param-desc">Requested changes plus <code>Policy</code> and <code>DryRun</code>. Zero-valued fields are left unchanged.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxmodificationplan">*SandboxModificationPlan</a></div>
+    <div className="msb-param-desc">The modification plan, applied unless <code>DryRun</code> is set.</div>
+  </div>
+</div>
+
 #### <span className="msb-recv">sb.</span><span className="msb-hn">Metrics()</span>
 
 ```go
@@ -1841,6 +1901,7 @@ A lightweight reference to a sandbox's persisted state. Carries metadata (name, 
 | `Refresh(ctx)` | `(*SandboxHandle, error)` | Fresh handle for the same name |
 | `Ping(ctx)` | `(*`[`SandboxPingResult`](#sandboxpingresult)`, error)` | Check agent reachability without refreshing idle activity; does not start stopped sandboxes |
 | `Touch(ctx)` | `(*`[`SandboxTouchResult`](#sandboxtouchresult)`, error)` | Explicitly refresh idle activity; does not start stopped sandboxes |
+| `Modify(ctx, opts)` | `(*`[`SandboxModificationPlan`](#sandboxmodificationplan)`, error)` | Plan or apply a configuration change; same [`ModifyOptions`](#modifyoptions) as [`Modify()`](#sb-modify). Does not start stopped sandboxes — changes persist for the next boot |
 | `Metrics(ctx)` | `(*`[`Metrics`](#metrics)`, error)` | Point-in-time resource metrics |
 | `Logs(ctx, opts)` | `([]`[`LogEntry`](#logentry)`, error)` | Read captured `exec.log` (works without starting) |
 | `LogStream(ctx, opts)` | `(*`[`LogStreamHandle`](#logstreamhandle)`, error)` | Stream captured output |
@@ -1878,6 +1939,67 @@ Explicit idle-refresh result.
 |-------|------|-------------|
 | Name | `string` | Sandbox name |
 | ActivitySeq | `uint64` | Monotonic activity sequence after the touch |
+
+### ModifyOptions
+
+<p className="msb-backref">Used by <a href="#sb-modify">Modify()</a></p>
+
+A requested sandbox modification. Zero-valued fields are left unchanged (`0` is not a valid CPU or memory size). Secret changes are Rust-SDK and CLI only for now.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| CPUs | `uint8` | Desired effective vCPU count. Live when within the booted `MaxCPUs` |
+| MaxCPUs | `uint8` | Boot-time maximum possible vCPUs (restart-backed) |
+| MemoryMiB | `uint32` | Desired effective guest memory in MiB. Live when within the booted `MaxMemoryMiB` |
+| MaxMemoryMiB | `uint32` | Boot-time maximum hotpluggable memory in MiB (restart-backed) |
+| Env | `map[string]string` | Environment variables to set for future execs |
+| EnvRemove | `[]string` | Environment variable keys to remove |
+| Labels | `map[string]string` | Labels to set |
+| LabelsRemove | `[]string` | Label keys to remove |
+| Workdir | `string` | Working directory for future execs |
+| Policy | `ModificationPolicy` | `ModificationPolicyNoRestart` (default) applies only changes that can complete without restarting; `ModificationPolicyNextStart` persists changes for the next start without mutating a running VM; `ModificationPolicyRestart` restarts if needed so restart-required changes become active now |
+| DryRun | `bool` | Compute the plan without applying anything |
+
+### SandboxModificationPlan
+
+<p className="msb-backref">Returned by <a href="#sb-modify">Modify()</a></p>
+
+Dry-run or apply plan for a sandbox modification. Values never appear in a plan: secret entries carry only guest-visible references.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Sandbox | `string` | Sandbox being modified |
+| Status | `string` | Status used for classification (`"running"`, `"stopped"`, ...) |
+| Applied | `bool` | Whether the changes were applied; `false` for dry runs |
+| Policy | `ModificationPolicy` | Policy used to produce the plan |
+| Changes | `[]PlannedChange` | Planned changes, one entry per field or secret (see below) |
+| Conflicts | `[]ModificationConflict` | Conflicts (`Field` + `Message`) that must be resolved before the patch can apply |
+| Warnings | `[]ModificationWarning` | Non-fatal warnings (`Field` + `Message`), e.g. the future-execs-only env caveat |
+| ResizeStatus | `[]ResourceResizeStatus` | Live resource resize outcomes, populated by apply when a live change ran (see below) |
+
+`PlannedChange` is one planned entry. `Kind` is `"config"` or `"secret"`; config entries carry `Before` / `After` while secret entries carry `Name`, `BeforeRef` / `AfterRef` (guest-visible references, values are omitted by construction), and `AllowHosts`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Kind | `string` | `"config"` or `"secret"` |
+| Field | `string` | Config field being changed; always `"secret"` for secret entries |
+| Name | `string` | Secret name (secret entries only) |
+| Change | `string` | `"added"`, `"updated"`, or `"removed"` for config; `"added"`, `"rotated"`, `"removed"`, `"renamed"`, `"hosts updated"`, or `"placeholder updated"` for secrets |
+| Before / After | `*string` | Previous / new visible state (config entries) |
+| BeforeRef / AfterRef | `*string` | Previous / new guest-visible reference (secret entries) |
+| Disposition | `string` | `"live"`, `"next start"`, `"requires restart"`, or `"unsupported"` |
+| AllowHosts | `[]string` | Allowed hosts after the requested change (secret entries) |
+| Reason | `*string` | Human-readable reason for the classification, when useful |
+
+`ResourceResizeStatus` reports runtime convergence for a live resize — enforcement applies immediately, the guest converges asynchronously:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Resource | `string` | `"cpus"` or `"memory"` |
+| Requested | `string` | Requested value |
+| Actual | `string` | Actual value observed in the guest/runtime |
+| Enforced | `string` | Host/VMM-enforced value |
+| State | `string` | `"applied"` when requested, actual, and enforced match; `"converging"` while the guest is still onlining CPUs or plugging memory; `"guest-refused"` when the guest would not cooperate (the host enforces the new limit anyway); `"accepted"` or `"failed"` otherwise |
 
 ### SandboxFilter
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -485,6 +485,122 @@ Explicitly refresh the running sandbox's idle activity. This sends `core.touch`,
   </div>
 </div>
 
+#### <span className="msb-recv">sb.</span><span className="msb-hn">modify()</span>
+
+```python
+async def modify(
+    self,
+    *,
+    cpus: int | None = None,
+    max_cpus: int | None = None,
+    memory: int | None = None,
+    max_memory: int | None = None,
+    env: Mapping[str, str] | None = None,
+    env_rm: list[str] | None = None,
+    labels: Mapping[str, str] | None = None,
+    labels_rm: list[str] | None = None,
+    workdir: str | None = None,
+    policy: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]
+```
+
+<Accordion title="Example">
+
+```python
+# Live resize: applies to the running VM when within the booted capacity
+plan = await sb.modify(cpus=4, memory=4096)
+for r in plan.get("resize_status", []):
+    print(f'{r["resource"]}: {r["requested"]} -> {r["actual"]} ({r["state"]})')
+
+# Preview a change without applying it
+plan = await sb.modify(max_memory=16384, dry_run=True)
+for change in plan["changes"]:
+    print(f'{change["field"]}: {change["disposition"]}')
+
+# Make an env change active now by restarting
+await sb.modify(env={"MODE": "prod"}, policy="restart")
+```
+
+</Accordion>
+
+Plan or apply a configuration change. Every requested change is classified as `"live"`, `"next start"`, `"requires restart"`, or `"unsupported"`, and apply is all-or-nothing: a patch with conflicts, unsupported changes, or restart-required changes under the default policy raises without changing anything. `cpus` and `memory` apply live to a running sandbox when the target fits inside the boot-time capacity (`max_cpus` / `max_memory`); raising the capacity itself is restart-backed. Env and workdir changes on a running sandbox apply to future execs only — running processes keep their current environment — and the plan reports this as a warning. The CLI equivalent is [`msb modify`](/cli/sandbox-commands#msb-modify).
+
+The same method is available on [`SandboxHandle`](#sandboxhandle); it never starts a stopped sandbox — changes on a stopped sandbox persist for the next boot. Secret changes are Rust-SDK and CLI only for now.
+
+The returned plan dict mirrors the canonical JSON shape:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `sandbox` | `str` | Sandbox being modified |
+| `status` | `str` | Status used for classification (`"running"`, `"stopped"`, ...) |
+| `applied` | `bool` | Whether the changes were applied; `False` with `dry_run=True` |
+| `policy` | `str` | Policy used to produce the plan |
+| `changes` | `list[dict]` | One entry per field: `field`, `change` (`"added"`, `"updated"`, `"removed"`), `before`, `after`, `disposition`, optional `reason` |
+| `conflicts` | `list[dict]` | Conflicts (`field` + `message`) that must be resolved before the patch can apply |
+| `warnings` | `list[dict]` | Non-fatal warnings (`field` + `message`), e.g. the future-execs-only env caveat |
+| `resize_status` | `list[dict]` | Live resize outcomes after apply, per resource: `resource` (`"cpus"` / `"memory"`), `requested`, `actual`, `enforced`, `state` (`"applied"`, `"converging"`, `"guest-refused"`, `"failed"`). Omitted when no live resize ran |
+
+Live resize is not necessarily instant: enforcement applies immediately, and `resize_status` reports whether the guest has finished converging (onlining CPUs, plugging memory blocks).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cpus</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Desired effective vCPU count. Live when within the booted <code>max_cpus</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>max_cpus</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Boot-time maximum possible vCPUs (restart-backed).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>memory</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Desired effective guest memory in MiB. Live when within the booted <code>max_memory</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>max_memory</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Boot-time maximum hotpluggable memory in MiB (restart-backed).</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>env</code><span className="msb-type">Mapping[str, str] | None</span></div>
+    <div className="msb-param-desc">Environment variables to set for future execs.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>env_rm</code><span className="msb-type">list[str] | None</span></div>
+    <div className="msb-param-desc">Environment variable keys to remove.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>labels</code><span className="msb-type">Mapping[str, str] | None</span></div>
+    <div className="msb-param-desc">Labels to set.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>labels_rm</code><span className="msb-type">list[str] | None</span></div>
+    <div className="msb-param-desc">Label keys to remove.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>workdir</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Working directory for future execs.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>policy</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc"><code>"no_restart"</code> (default) applies only changes that can complete without restarting; <code>"next_start"</code> persists changes for the next start without mutating a running VM; <code>"restart"</code> restarts if needed so restart-required changes become active now.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>dry_run</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">When <code>True</code>, compute the plan without applying anything. Default <code>False</code>.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">dict[str, Any]</span></div>
+    <div className="msb-param-desc">The modification plan, applied unless <code>dry_run=True</code>.</div>
+  </div>
+</div>
+
 #### <span className="msb-recv">sb.</span><span className="msb-hn">metrics()</span>
 
 ```python
@@ -1114,6 +1230,7 @@ A lightweight handle to an existing sandbox (running or stopped). Provides statu
 | refresh() | `Awaitable[`[`SandboxHandle`](#sandboxhandle)`]` | Re-fetch status and metadata, returning a fresh handle |
 | ping() | `Awaitable[`[`SandboxPingResult`](#sandboxpingresult)`]` | Check agent reachability without refreshing idle activity; does not start stopped sandboxes |
 | touch() | `Awaitable[`[`SandboxTouchResult`](#sandboxtouchresult)`]` | Explicitly refresh idle activity; does not start stopped sandboxes |
+| modify(...) | `Awaitable[dict[str, Any]]` | Plan or apply a configuration change; same kwargs as [`modify()`](#sb-modify). Does not start stopped sandboxes — changes persist for the next boot |
 | connect(timeout=None) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Connect to a running sandbox, optionally with an explicit timeout in seconds |
 | start(*, detached=False) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Start in attached or detached mode |
 | stop(timeout=None) | `Awaitable[None]` | Gracefully shut down and wait until stopped state is observed |

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -519,6 +519,42 @@ Explicitly refresh the running sandbox's idle timer. This sends `core.touch`; us
   </div>
 </div>
 
+#### <span className="msb-recv">sb.</span><span className="msb-hn">modify()</span>
+
+```rust
+fn modify(&self) -> SandboxModificationBuilder
+```
+
+<Accordion title="Example">
+
+```rust
+let plan = sb.modify()
+    .cpus(4)             // live when 4 <= max_cpus
+    .memory(4096)        // live when 4096 MiB <= max_memory
+    .env("MODE", "prod") // future execs only; the plan warns about this
+    .apply()
+    .await?;
+
+for r in &plan.resize_status {
+    println!("{:?}: requested {} · actual {} · {:?}", r.resource, r.requested, r.actual, r.state);
+}
+```
+
+</Accordion>
+
+Start planning a configuration change for this sandbox. The returned builder accumulates a patch — CPUs, memory, env vars, labels, workdir, secrets — and terminates with [`dry_run()`](#dry_run) or [`apply()`](#apply). The resulting [`SandboxModificationPlan`](#sandboxmodificationplan) classifies every requested change as `live`, `next start`, `requires restart`, or `unsupported`, and apply is all-or-nothing. CPU count and memory apply live to a running sandbox when the target fits inside the boot-time capacity ([`max_cpus`](#max_cpus) / [`max_memory`](#max_memory)); raising the capacity itself is restart-backed. See [`SandboxModificationBuilder`](#sandboxmodificationbuilder) for the full builder API and [`msb modify`](/cli/sandbox-commands#msb-modify) for the CLI equivalent.
+
+The same method is available on [`SandboxHandle`](#sandboxhandle) for callers that don't want to connect first. It never starts a stopped sandbox; changes on a stopped sandbox persist for the next boot.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxmodificationbuilder">SandboxModificationBuilder</a></div>
+    <div className="msb-param-desc">Fluent builder; terminate with <code>dry_run()</code> or <code>apply()</code>.</div>
+  </div>
+</div>
+
 #### <span className="msb-recv">sb.</span><span className="msb-hn">name()</span>
 
 ```rust
@@ -1604,6 +1640,335 @@ Write UTF-8 text content at `path`.
   </div>
 </div>
 
+## SandboxModificationBuilder
+
+Fluent builder for changing an existing sandbox's configuration. Obtained via [`sb.modify()`](#sb-modify) or [`SandboxHandle::modify()`](#sandboxhandle). Setters accumulate a patch; nothing happens until the terminal [`dry_run()`](#dry_run) or [`apply()`](#apply) call. Both return a [`SandboxModificationPlan`](#sandboxmodificationplan) that classifies every requested change as `live`, `next start`, `requires restart`, or `unsupported`.
+
+Apply is all-or-nothing: a patch with conflicts, unsupported changes, or restart-required changes under the default policy fails without changing anything. CPU count and memory apply live to a running sandbox when the target fits inside the boot-time capacity ([`max_cpus`](#max_cpus) / [`max_memory`](#max_memory)); raising the capacity itself is restart-backed, so pick capacity headroom at create time. Env and workdir changes on a running sandbox apply to future execs only — running processes keep their current environment — and the plan reports this as a warning. The CLI equivalent is [`msb modify`](/cli/sandbox-commands#msb-modify).
+
+#### <span className="msb-recv">.</span><span className="msb-hn">apply()</span>
+
+```rust
+async fn apply(self) -> MicrosandboxResult<SandboxModificationPlan>
+```
+
+Apply the accumulated patch atomically. Live-capable changes mutate the running VM first (CPU hotplug, memory resize, secret rotation through the runtime control socket); the desired config is persisted only after the live step succeeds. For stopped sandboxes or [`next_start()`](#next_start) requests, changes persist for the next start. With [`restart()`](#restart), the existing stop/start lifecycle path makes restart-required changes active.
+
+Live resize is not necessarily instant: when an accepted resize has not fully settled, the returned plan's `resize_status` reports per-resource convergence — see [`ResourceResizeStatus`](#resourceresizestatus).
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxmodificationplan">SandboxModificationPlan</a></div>
+    <div className="msb-param-desc">The applied plan, with <code>applied: true</code> and live resize outcomes in <code>resize_status</code>.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">cpus()</span>
+
+```rust
+fn cpus(self, cpus: u8) -> Self
+```
+
+Set the desired effective vCPU count. Applies live to a running sandbox when the target fits inside the booted `max_cpus`; otherwise it requires a restart.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>cpus</code><span className="msb-type">u8</span></div>
+    <div className="msb-param-desc">Number of vCPUs.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">max_cpus()</span>
+
+```rust
+fn max_cpus(self, max_cpus: u8) -> Self
+```
+
+Set the desired boot-time maximum possible vCPU count. Capacity is fixed at boot, so this is always restart-backed on a running sandbox.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>max_cpus</code><span className="msb-type">u8</span></div>
+    <div className="msb-param-desc">Maximum possible vCPUs.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">dry_run()</span>
+
+```rust
+async fn dry_run(self) -> MicrosandboxResult<SandboxModificationPlan>
+```
+
+<Accordion title="Example">
+
+```rust
+let plan = sb.modify().cpus(8).dry_run().await?;
+
+for change in &plan.changes {
+    if let PlannedChange::Config(c) = change {
+        println!("{}: {:?} -> {:?} ({:?})", c.field, c.before, c.after, c.disposition);
+    }
+}
+```
+
+</Accordion>
+
+Compute the modification plan without applying anything. Use it to preview how each change classifies and whether conflicts block the patch.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxmodificationplan">SandboxModificationPlan</a></div>
+    <div className="msb-param-desc">The plan, with <code>applied: false</code>.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">env()</span>
+
+```rust
+fn env(self, key: impl Into<String>, value: impl Into<String>) -> Self
+```
+
+Set an environment variable for future execs. Can be called multiple times. On a running sandbox this applies to future execs only; running processes keep their current environment.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Variable name.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Variable value.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">remove_env()</span>
+
+```rust
+fn remove_env(self, key: impl Into<String>) -> Self
+```
+
+Remove an environment variable. Same future-execs-only semantics as [`env()`](#env-2).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Variable name to remove.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">label()</span>
+
+```rust
+fn label(self, key: impl Into<String>, value: impl Into<String>) -> Self
+```
+
+Set a sandbox label. Can be called multiple times.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Label key.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Label value.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">remove_label()</span>
+
+```rust
+fn remove_label(self, key: impl Into<String>) -> Self
+```
+
+Remove a sandbox label.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>key</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Label key to remove.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">memory()</span>
+
+```rust
+fn memory(self, size: impl Into<Mebibytes>) -> Self
+```
+
+Set the desired effective guest memory. Applies live to a running sandbox when the target fits inside the booted `max_memory`; otherwise it requires a restart.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>size</code><span className="msb-type">impl Into&lt;Mebibytes&gt;</span></div>
+    <div className="msb-param-desc">Memory in MiB.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">memory_mib()</span>
+
+```rust
+fn memory_mib(self, memory_mib: u32) -> Self
+```
+
+Set the desired effective guest memory in MiB. Same as [`memory()`](#memory-2) with an explicit unit.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>memory_mib</code><span className="msb-type">u32</span></div>
+    <div className="msb-param-desc">Memory in MiB.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">max_memory()</span>
+
+```rust
+fn max_memory(self, size: impl Into<Mebibytes>) -> Self
+```
+
+Set the desired boot-time maximum hotpluggable memory. Capacity is fixed at boot, so this is always restart-backed on a running sandbox.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>size</code><span className="msb-type">impl Into&lt;Mebibytes&gt;</span></div>
+    <div className="msb-param-desc">Maximum memory in MiB.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">max_memory_mib()</span>
+
+```rust
+fn max_memory_mib(self, max_memory_mib: u32) -> Self
+```
+
+Set the desired boot-time maximum hotpluggable memory in MiB. Same as [`max_memory()`](#max_memory-2) with an explicit unit.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>max_memory_mib</code><span className="msb-type">u32</span></div>
+    <div className="msb-param-desc">Maximum memory in MiB.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">next_start()</span>
+
+```rust
+fn next_start(self) -> Self
+```
+
+Persist the requested changes for the next start, leaving any running VM unchanged. Every change classifies as `next start`.
+
+#### <span className="msb-recv">.</span><span className="msb-hn">restart()</span>
+
+```rust
+fn restart(self) -> Self
+```
+
+Plan under restart-backed apply semantics. When the patch contains restart-required changes, [`apply()`](#apply) stops the sandbox, persists the config, and starts it again so the changes become active now.
+
+#### <span className="msb-recv">.</span><span className="msb-hn">secret()</span>
+
+```rust
+fn secret(self, f: impl FnOnce(SecretPatchBuilder) -> SecretPatchBuilder) -> Self
+```
+
+<Accordion title="Example">
+
+```rust
+use microsandbox::sandbox::SecretSource;
+
+let plan = sb.modify()
+    .secret(|s| s
+        .env("API_KEY")
+        .source(SecretSource::Env { var: "API_KEY".into() })
+        .allow_host("api.example.com"))
+    .apply()
+    .await?;
+```
+
+</Accordion>
+
+Declare the desired state of one secret via a closure. The spec mirrors the create-time [`SecretBuilder`](/sdk/rust/secrets#secretbuilder) vocabulary, and the planner diffs it against the existing config to infer the change: a secret that does not exist yet is `added`, material on an existing secret `rotated`, and host or placeholder differences update those aspects. Declaring the same secret again replaces the earlier spec; removal is always explicit through [`remove_secret()`](#remove_secret).
+
+The `SecretPatchBuilder` closure exposes:
+
+| Method | Description |
+|--------|-------------|
+| `env(name)` | Name the secret (required). This is the environment variable that exposes the placeholder inside the guest |
+| `source(source)` | Provide the material as a host-side `SecretSource` reference — `SecretSource::Env { var }` (host environment variable, resolved at apply time) or `SecretSource::Store { reference }`. The durable config records only the reference. Mutually exclusive with `value` |
+| `value(value)` | Provide the material as a raw value, for embedders that hold only a value. Zeroized on drop, redacted from `Debug`, never enters the plan — but a value-based apply persists the value into the durable config until a later source-based rotate migrates it to a reference, the same at-rest property as [`secret_env()`](#secret_env) |
+| `placeholder(text)` | Set the guest-visible placeholder. Placeholder changes cannot reach already-running processes, so they classify as `requires restart` on a running sandbox |
+| `allow_host(host)` | Add an allowed host pattern (`api.example.com`, `*.example.org`, or `*`). A non-empty list replaces the secret's current allow-list; an empty list leaves it unchanged. A new secret needs at least one |
+
+Prefer `source(..)` over `value(..)` when the value can be referenced — see the at-rest note on [`secret_env()`](#secret_env) and [Secrets](/sandboxes/secrets) for the full model.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>f</code><span className="msb-type">FnOnce(SecretPatchBuilder)</span></div>
+    <div className="msb-param-desc">Closure declaring the secret's desired state.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">remove_secret()</span>
+
+```rust
+fn remove_secret(self, name: impl Into<String>) -> Self
+```
+
+Remove a secret. Removal is always explicit; omitting a secret from the patch never removes it.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Secret name (its environment variable name).</div>
+  </div>
+</div>
+
+#### <span className="msb-recv">.</span><span className="msb-hn">workdir()</span>
+
+```rust
+fn workdir(self, path: impl Into<String>) -> Self
+```
+
+Set the working directory for future execs. On a running sandbox this applies to future execs only.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Absolute path inside the guest.</div>
+  </div>
+</div>
+
 ## Types
 
 ### LogEntry
@@ -1755,6 +2120,7 @@ A lightweight handle to an existing sandbox (running or stopped). Obtained via [
 | kill_with_timeout(timeout) | `Result<()>` | Same as `kill()` with an explicit observation timeout |
 | logs() | `Result<Vec<`[`LogEntry`](#logentry)`>>` | Read captured `exec.log` (works without starting) |
 | metrics() | `Result<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
+| modify() | [`SandboxModificationBuilder`](#sandboxmodificationbuilder) | Start planning a configuration change (works without starting; changes on a stopped sandbox persist for the next boot) |
 | name() | `&str` | Sandbox name, up to 128 UTF-8 bytes |
 | ping() | `Result<`[`SandboxPingResult`](#sandboxpingresult)`>` | Check agent reachability without refreshing idle activity |
 | remove() | `Result<()>` | Delete sandbox and state |
@@ -1769,6 +2135,69 @@ A lightweight handle to an existing sandbox (running or stopped). Obtained via [
 | touch() | `Result<`[`SandboxTouchResult`](#sandboxtouchresult)`>` | Explicitly refresh the sandbox idle timer |
 | updated_at() | `Option<DateTime<Utc>>` | Last update timestamp |
 | wait_until_stopped() | `Result<`[`SandboxStopResult`](#sandboxstopresult)`>` | Block until terminal state is observed |
+
+### SandboxModificationPlan
+
+<p className="msb-backref">Returned by <a href="#dry_run">dry_run()</a> · <a href="#apply">apply()</a></p>
+
+Dry-run or apply plan for a sandbox modification. Values never appear in a plan: secret entries carry only guest-visible references.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sandbox | `String` | Sandbox being modified |
+| status | `String` | Sandbox status used for classification (`"running"`, `"stopped"`, ...) |
+| applied | `bool` | Whether the changes were applied; `false` for dry runs |
+| policy | `ModificationPolicy` | Policy used to produce the plan: `NoRestart` (default), `NextStart`, or `Restart` |
+| changes | `Vec<`[`PlannedChange`](#plannedchange)`>` | Planned changes, one entry per field or secret |
+| conflicts | `Vec<ModificationConflict>` | Conflicts (`field` + `message`) that must be resolved before the patch can apply |
+| warnings | `Vec<ModificationWarning>` | Non-fatal warnings (`field` + `message`) about the patch or current runtime capabilities, e.g. the future-execs-only env caveat |
+| resize_status | `Vec<`[`ResourceResizeStatus`](#resourceresizestatus)`>` | Live resource resize outcomes, populated by `apply()` when a live change ran |
+
+### PlannedChange
+
+<p className="msb-backref">Used by <a href="#sandboxmodificationplan">SandboxModificationPlan.changes</a></p>
+
+One planned modification entry.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Config` | - `field: String` <br/> - `change: ChangeKind` (`Added`, `Updated`, `Removed`) <br/> - `before: Option<String>` <br/> - `after: Option<String>` <br/> - `disposition:` [`ModificationDisposition`](#modificationdisposition) <br/> - `reason: Option<String>` | Ordinary config change |
+| `Secret` | - `field: String` (always `"secret"`) <br/> - `name: String` <br/> - `change: SecretChangeKind` (`Added`, `Rotated`, `Removed`, `Renamed`, `HostsUpdated`, `PlaceholderUpdated`) <br/> - `before_ref: Option<String>` <br/> - `after_ref: Option<String>` <br/> - `disposition:` [`ModificationDisposition`](#modificationdisposition) <br/> - `allow_hosts: Vec<String>` <br/> - `reason: Option<String>` | Secret change. Values are omitted by construction; `before_ref` / `after_ref` are guest-visible references |
+
+### ModificationDisposition
+
+<p className="msb-backref">Used by <a href="#plannedchange">PlannedChange.disposition</a></p>
+
+When or whether a planned change can take effect. Serializes as the quoted strings below.
+
+| Value | Description |
+|-------|-------------|
+| `Live` (`"live"`) | Applies to the running VM now |
+| `NextStart` (`"next start"`) | Persists to the desired config and applies the next time the sandbox starts |
+| `RequiresRestart` (`"requires restart"`) | Needs a restart before it can take effect; `apply()` refuses it unless the [`restart()`](#restart) policy is selected |
+| `Unsupported` (`"unsupported"`) | Cannot be changed by `modify` |
+
+### ResourceResizeStatus
+
+<p className="msb-backref">Used by <a href="#sandboxmodificationplan">SandboxModificationPlan.resize_status</a></p>
+
+Runtime convergence status for a live resource resize. Enforcement applies immediately; the guest converges asynchronously (onlining CPUs, plugging memory blocks).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| resource | `ResourceKind` | `Cpus` or `Memory` |
+| requested | `String` | Requested value |
+| actual | `String` | Actual value observed in the guest/runtime |
+| enforced | `String` | Host/VMM-enforced value |
+| state | `ResourceConvergenceState` | Convergence state, see below |
+
+| State | Description |
+|-------|-------------|
+| `Accepted` | The runtime accepted the request |
+| `Converging` | The guest and VMM are still converging on the requested state |
+| `Applied` | Desired, actual, and enforced state match |
+| `GuestRefused` | The guest would not cooperate; the host enforces the new limit anyway |
+| `Failed` | The resize failed |
 
 ### SandboxStopResult
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -515,6 +515,57 @@ Explicitly refresh the running sandbox's idle activity. This sends `core.touch`,
   </div>
 </div>
 
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">modify()</span>
+
+```typescript
+modify(opts?: ModifyOptions): Promise<SandboxModificationPlan>
+```
+
+<Accordion title="Example">
+
+```typescript
+// Live resize: applies to the running VM when within the booted capacity
+const plan = await sandbox.modify({ cpus: 4, memory: 4096 });
+for (const r of plan.resizeStatus) {
+  console.log(`${r.resource}: ${r.requested} -> ${r.actual} (${r.state})`);
+}
+
+// Preview a change without applying it
+const preview = await sandbox.modify({ maxMemory: 16384, dryRun: true });
+for (const c of preview.changes) {
+  console.log(`${c.field}: ${c.disposition}`);
+}
+
+// Make an env change active now by restarting
+await sandbox.modify({ env: { MODE: "prod" }, policy: "restart" });
+```
+
+</Accordion>
+
+Plan or apply a configuration change. Every requested change is classified as `"live"`, `"next start"`, `"requires restart"`, or `"unsupported"`, and apply is all-or-nothing: a patch with conflicts, unsupported changes, or restart-required changes under the default policy rejects without changing anything. `cpus` and `memory` apply live to a running sandbox when the target fits inside the boot-time capacity ([`maxCpus`](#maxcpus) / [`maxMemory`](#maxmemory)); raising the capacity itself is restart-backed. Env and workdir changes on a running sandbox apply to future execs only — running processes keep their current environment — and the plan reports this as a warning. The CLI equivalent is [`msb modify`](/cli/sandbox-commands#msb-modify).
+
+The same method is available on [`SandboxHandle`](#sandboxhandle); it never starts a stopped sandbox — changes on a stopped sandbox persist for the next boot. Secret changes are Rust-SDK and CLI only for now.
+
+Live resize is not necessarily instant: enforcement applies immediately, and the returned plan's `resizeStatus` reports whether the guest has finished converging (onlining CPUs, plugging memory blocks). See [`SandboxModificationPlan`](#sandboxmodificationplan).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#modifyoptions">ModifyOptions</a></div>
+    <div className="msb-param-desc">Requested changes plus <code>policy</code> and <code>dryRun</code>. Omitted fields are left unchanged.</div>
+  </div>
+</div>
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#sandboxmodificationplan">Promise&lt;SandboxModificationPlan&gt;</a></div>
+    <div className="msb-param-desc">The modification plan, applied unless <code>dryRun: true</code>.</div>
+  </div>
+</div>
+
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">metrics()</span>
 
 ```typescript
@@ -1983,6 +2034,26 @@ Async stream for receiving periodic metrics snapshots. Implements `AsyncDisposab
 | `[Symbol.asyncIterator]()` | `AsyncIterator<`[`SandboxMetrics`](#sandboxmetrics)`>` | Use with `for await...of` |
 | `[Symbol.asyncDispose]()` | `Promise<void>` | Stop iterating; safe to use with `await using` |
 
+### ModifyOptions
+
+<p className="msb-backref">Used by <a href="#sandbox-modify">modify()</a></p>
+
+A requested sandbox modification. Omitted fields are left unchanged. Secret changes are Rust-SDK and CLI only for now.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpus | `number` | Desired effective vCPU count. Live when within the booted `maxCpus` |
+| maxCpus | `number` | Boot-time maximum possible vCPUs (restart-backed) |
+| memory | `number` | Desired effective guest memory in MiB. Live when within the booted `maxMemory` |
+| maxMemory | `number` | Boot-time maximum hotpluggable memory in MiB (restart-backed) |
+| env | `Record<string, string>` | Environment variables to set for future execs |
+| envRemove | `string[]` | Environment variable keys to remove |
+| labels | `Record<string, string>` | Labels to set |
+| labelsRemove | `string[]` | Label keys to remove |
+| workdir | `string` | Working directory for future execs |
+| policy | `"no_restart" \| "next_start" \| "restart"` | `"no_restart"` (default) applies only changes that can complete without restarting; `"next_start"` persists changes for the next start without mutating a running VM; `"restart"` restarts if needed so restart-required changes become active now |
+| dryRun | `boolean` | Compute the plan without applying anything. Defaults to `false` |
+
 ### PullPolicy
 
 <p className="msb-backref">Used by <a href="#pullpolicy">pullPolicy()</a></p>
@@ -2090,6 +2161,7 @@ Handles from `Sandbox.get(name)` are **live** - they expose lifecycle methods (`
 | refresh() | `Promise<`[`SandboxHandle`](#sandboxhandle)`>` | Re-read the handle's state from the database |
 | ping() | `Promise<`[`SandboxPingResult`](#sandboxpingresult)`>` | Check agent reachability without refreshing idle activity; does not start stopped sandboxes |
 | touch() | `Promise<`[`SandboxTouchResult`](#sandboxtouchresult)`>` | Explicitly refresh idle activity; does not start stopped sandboxes |
+| modify(opts?) | `Promise<`[`SandboxModificationPlan`](#sandboxmodificationplan)`>` | Plan or apply a configuration change; same options as [`modify()`](#sandbox-modify). Does not start stopped sandboxes — changes persist for the next boot |
 | metrics() | `Promise<`[`SandboxMetrics`](#sandboxmetrics)`>` | Point-in-time resource metrics |
 | logs() | `Promise<`[`LogEntry`](#logentry)`[]>` | Read captured `exec.log` (works without starting) |
 | logStream() | `Promise<`[`LogStream`](#logstream)`>` | Stream captured `exec.log`, with optional follow |
@@ -2108,6 +2180,40 @@ Handles from `Sandbox.get(name)` are **live** - they expose lifecycle methods (`
 | remove() | `Promise<void>` | Delete sandbox and state |
 | snapshot(name) | `Promise<Snapshot>` | Snapshot this stopped sandbox under a bare name. See [Snapshots](/sdk/typescript/snapshots) |
 | snapshotTo(path) | `Promise<Snapshot>` | Snapshot this stopped sandbox to an explicit filesystem path |
+
+### SandboxModificationPlan
+
+<p className="msb-backref">Returned by <a href="#sandbox-modify">modify()</a></p>
+
+Dry-run or apply plan for a sandbox modification. Values never appear in a plan: secret entries carry only guest-visible references.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sandbox | `string` | Sandbox being modified |
+| status | `string` | Status used for classification (`"running"`, `"stopped"`, ...) |
+| applied | `boolean` | Whether the changes were applied; `false` for dry runs |
+| policy | `"no_restart" \| "next_start" \| "restart"` | Policy used to produce the plan |
+| changes | `PlannedChange[]` | Planned changes, one entry per field or secret (see below) |
+| conflicts | `{ field, message }[]` | Conflicts that must be resolved before the patch can apply |
+| warnings | `{ field, message }[]` | Non-fatal warnings, e.g. the future-execs-only env caveat |
+| resizeStatus | `ResourceResizeStatus[]` | Live resource resize outcomes, populated by apply when a live change ran (see below) |
+
+`PlannedChange` is a discriminated union on `kind`. Both variants carry `field`, `change`, a `disposition` of `"live"`, `"next start"`, `"requires restart"`, or `"unsupported"`, and an optional `reason`:
+
+| Variant | Extra fields | Description |
+|---------|--------------|-------------|
+| `kind: "config"` | `change: "added" \| "updated" \| "removed"`, `before?`, `after?` | Ordinary config change |
+| `kind: "secret"` | `name`, `change: "added" \| "rotated" \| "removed" \| "renamed" \| "hosts updated" \| "placeholder updated"`, `beforeRef?`, `afterRef?`, `allowHosts` | Secret change. Values are omitted by construction; `beforeRef` / `afterRef` are guest-visible references |
+
+`ResourceResizeStatus` reports runtime convergence for a live resize — enforcement applies immediately, the guest converges asynchronously:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| resource | `"cpus" \| "memory"` | Resource being resized |
+| requested | `string` | Requested value |
+| actual | `string` | Actual value observed in the guest/runtime |
+| enforced | `string` | Host/VMM-enforced value |
+| state | `"accepted" \| "converging" \| "applied" \| "guest-refused" \| "failed"` | `"applied"` when requested, actual, and enforced match; `"converging"` while the guest is still onlining CPUs or plugging memory; `"guest-refused"` when the guest would not cooperate (the host enforces the new limit anyway) |
 
 ### SandboxPingResult
 


### PR DESCRIPTION
## TL;DR
The live-modify feature merged with CLI and guide docs but no SDK reference for modify() in any language page. This adds the missing sections, with every signature verified against the shipped code.

## Description
- Rust page gains sb.modify() plus a full SandboxModificationBuilder reference: resource, env/label/workdir, and secret patch methods (including the .secret sub-builder with the value-vs-source distinction and a pointer to the existing secret_env at-rest warning), the next_start/restart policies, dry_run/apply terminals, and the plan, disposition, and resize-status types with all convergence states.
- Python, TypeScript, and Go pages gain modify() with each binding's exact options shape (kwargs, ModifyOptions object, ModifyOptions struct) and the plan return shape in each language's casing, verified against the .pyi, modify.ts, and modify.go respectively.
- Each non-Rust page notes explicitly that secret changes are Rust-SDK and CLI only for now, since those bindings do not expose secret options yet.
- Rebased onto the mintlify branch and re-fitted to its layout: example accordions sit directly under signatures, no glance boxes or kind tags or section rules, SandboxHandle tables updated in place; classification and convergence wording mirrors the msb modify CLI section, with cross-links to /cli/sandbox-commands#msb-modify.

## Test Plan
- [x] every documented signature and field cross-checked against sdk/rust/lib/sandbox/modify.rs, packages/microsandbox-types/rust/lib/modify.rs, _microsandbox.pyi, sdk/node-ts/src/modify.ts, and sdk/go/modify.go
- [x] MDX well-formedness checked: balanced JSX in added rows, escaped pipes in tables, no unescaped angle brackets outside code
- [ ] Mintlify preview render of the four pages (no local docs build exists; renders on deploy)
