### PR TITLE
fix(agentd): kill the exec process group, not just the direct child

### DIFF
--- a/crates/agentd/lib/session.rs
+++ b/crates/agentd/lib/session.rs
@@ -316,12 +316,21 @@ impl ExecSession {
         Ok(())
     }
 
-    /// Sends a signal to the spawned process.
+    /// Sends a signal to the spawned process and everything it started.
+    ///
+    /// The child is made a session leader at spawn (both pipe and PTY modes),
+    /// so signalling the negative pid reaches its whole process group. A bare
+    /// kill(pid) here leaked orphans: killing `sh -c "job &"` took out the
+    /// shell while its backgrounded children survived reparented to init,
+    /// silently accumulating load in the guest.
     pub fn send_signal(&self, signum: i32) -> AgentdResult<()> {
         let sig = Signal::try_from(signum)
             .map_err(|e| AgentdError::ExecSession(format!("invalid signal {signum}: {e}")))?;
-        signal::kill(Pid::from_raw(self.pid), sig)?;
-        Ok(())
+        match signal::kill(Pid::from_raw(-self.pid), sig) {
+            // The group can already be gone when the signal races the exit.
+            Err(nix::errno::Errno::ESRCH) => Ok(()),
+            other => Ok(other?),
+        }
     }
 
     /// Closes the process's stdin.
@@ -559,6 +568,13 @@ impl ExecSession {
         let parsed_rlimits = rlimit::to_libc(&req.rlimits);
         unsafe {
             cmd.pre_exec(move || {
+                // Become a session (and process-group) leader so signals sent
+                // to the group reach every descendant the command spawns, not
+                // just the direct child. The PTY path does the same for its
+                // controlling terminal; here it exists purely for group kills.
+                if libc::setsid() < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
                 apply_exec_security_profile(security_profile).map_err(agentd_to_io_error)?;
                 if let Some(ref user) = resolved_user {
                     apply_resolved_user(user).map_err(agentd_to_io_error)?;


### PR DESCRIPTION
## TL;DR
Killing an exec only signalled the direct child pid, so any background jobs the command had spawned survived as orphans inside the guest. Enough of them and the guest CPU is silently saturated, which is why later execs crawled while pings stayed fast. Exec children are now session leaders and signals go to the whole process group.

## Description
- send_signal delivered to a single pid; killing `sh -c "job &"` killed the shell while its children were reparented to init and kept running, invisible to the session.
- Measured on main: three timeout-killed spinner execs leave six live spin loops with a guest load of 4.9; the next exec still answers but every leaked kill compounds, and a saturated guest starves fresh spawns while the agent's ping handler stays responsive.
- Fix: pipe-mode children call setsid in pre_exec (the PTY path already did, for its controlling terminal), and send_signal uses the negative pid so the whole group is signalled, tolerating ESRCH when the group already exited.
- Semantics now match intent: killing an exec kills everything the exec started. This also closes the pipe read-ends orphans held open.

```bash
for i in 1 2 3; do timeout 2 msb exec box -- sh -c 'for j in 1 2; do (while :; do :; done)& done; sleep 28'; done
msb exec box -- sh -c 'ps aux | grep -v "\["; cat /proc/loadavg'
# main: 6 surviving spinners, load ~4.9 · this branch: only init, load ~0.2
```

## Test Plan
- [x] repro before/after on macOS HVF: identical 3-killed-execs recipe leaves 6 orphans and load 4.9 on main, zero processes and load 0.2 with the fix
- [x] repro before/after on Linux KVM: pre-fix binary leaves the same 6 orphans; rebuilt agentd on this branch leaves only init, load 0.16
- [x] normal exec, PTY exec, and signal forwarding still work (exec suite via pre-commit build; manual exec checks on the fixed sandbox)
- [x] `cargo clippy` workspace clean; full pre-commit hooks green
- [ ] CI on this PR
