### PR TITLE
feat(cli): show sandbox state in msb metrics and add watch/follow modes

### DIFF
--- a/crates/cli/lib/commands/metrics.rs
+++ b/crates/cli/lib/commands/metrics.rs
@@ -334,7 +334,11 @@ fn render_table(reports: &[SandboxMetricsReport], rates: &HashMap<i32, Rates>) -
             dim_if_exited(mem),
             dim_if_exited(disk),
             dim_if_exited(net),
-            if exited { style(uptime).dim().to_string() } else { uptime },
+            if exited {
+                style(uptime).dim().to_string()
+            } else {
+                uptime
+            },
         ]);
     }
 

--- a/crates/cli/lib/commands/metrics.rs
+++ b/crates/cli/lib/commands/metrics.rs
@@ -129,13 +129,25 @@ pub async fn run(args: MetricsArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Rates need two samples; take the second after a short window. CPU is
+    // Rates need two samples spanning at least one sampler tick. A fixed
+    // window can straddle zero new samples (samplers default to 1s), so
+    // retry a few short windows until every running row has a rate. CPU is
     // already delta-derived by the sampler, so it is correct on either read.
     let mut tracker = RateTracker::default();
     tracker.update(&reports);
-    tokio::time::sleep(ONE_SHOT_RATE_WINDOW).await;
-    let mut reports = collect_reports(local, &args).await?;
-    let rates = tracker.update(&reports);
+    let mut reports = reports;
+    let mut rates = HashMap::new();
+    for _ in 0..4 {
+        tokio::time::sleep(ONE_SHOT_RATE_WINDOW).await;
+        reports = collect_reports(local, &args).await?;
+        rates = tracker.update(&reports);
+        let all_rated = reports.iter().all(|report| {
+            report.state != SandboxMetricsState::Running || rates.contains_key(&report.run_id)
+        });
+        if all_rated {
+            break;
+        }
+    }
 
     sort_reports(&mut reports, &args.sort);
     print!("{}", render_table(&reports, &rates));

--- a/crates/cli/lib/commands/metrics.rs
+++ b/crates/cli/lib/commands/metrics.rs
@@ -1,16 +1,44 @@
 //! `msb metrics` command — show live sandbox metrics.
+//!
+//! Reads the shared-memory metrics registry through the SDK's report API,
+//! which joins each row with the catalog's active config so CPU and memory
+//! denominators follow live resizes. Disk and network columns render as
+//! per-second rates computed from two samples; `--watch` refreshes the
+//! table in place and `--follow` streams one JSON Lines object per sandbox
+//! per interval.
 
+use std::collections::HashMap;
+use std::io::{IsTerminal, Write};
+use std::time::Duration;
+
+use anyhow::{anyhow, bail};
+use chrono::Utc;
 use clap::Args;
-use microsandbox::sandbox::{Sandbox, SandboxMetrics, all_sandbox_metrics_local};
+use console::style;
+use microsandbox::backend::LocalBackend;
+use microsandbox::sandbox::{
+    SandboxMetricsReport, SandboxMetricsState, all_sandbox_metrics_reports_local,
+    sandbox_metrics_report_local,
+};
 use microsandbox_utils::format::{format_bytes, format_duration};
 
 use crate::ui;
 
 //--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Sampling window used to derive rates for a one-shot table render.
+const ONE_SHOT_RATE_WINDOW: Duration = Duration::from_millis(500);
+
+/// Smallest accepted `--interval`, guarding against busy-loops.
+const MIN_INTERVAL: Duration = Duration::from_millis(100);
+
+//--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// Show live metrics for a running sandbox.
+/// Show live metrics for running sandboxes.
 #[derive(Debug, Args)]
 pub struct MetricsArgs {
     /// Sandbox to inspect. Omit to show all running sandboxes.
@@ -19,6 +47,57 @@ pub struct MetricsArgs {
     /// Output format (json).
     #[arg(long, value_name = "FORMAT", value_parser = ["json"])]
     pub format: Option<String>,
+
+    /// Continuously refresh the table in place. Ctrl-C to quit.
+    #[arg(short = 'w', long, conflicts_with_all = ["follow", "format"])]
+    pub watch: bool,
+
+    /// Stream one JSON Lines object per sandbox per interval to stdout.
+    #[arg(short = 'f', long, conflicts_with = "format")]
+    pub follow: bool,
+
+    /// Refresh interval for --watch/--follow (e.g. 500ms, 2s).
+    #[arg(long, value_name = "DURATION", default_value = "1s")]
+    pub interval: String,
+
+    /// Include exited sandboxes whose terminal metrics are still recorded.
+    #[arg(short = 'a', long)]
+    pub all: bool,
+
+    /// Sort rows by column.
+    #[arg(long, value_name = "COLUMN", value_parser = ["name", "cpu", "mem"], default_value = "name")]
+    pub sort: String,
+}
+
+/// Per-second rates derived from two consecutive samples of one run.
+#[derive(Clone, Copy, Debug)]
+struct Rates {
+    disk_read: f64,
+    disk_write: f64,
+    net_rx: f64,
+    net_tx: f64,
+}
+
+/// Cumulative counters remembered from the previous sample of one run.
+#[derive(Clone, Copy, Debug)]
+struct PrevSample {
+    timestamp: chrono::DateTime<chrono::Utc>,
+    disk_read_bytes: u64,
+    disk_write_bytes: u64,
+    net_rx_bytes: u64,
+    net_tx_bytes: u64,
+}
+
+/// Derives per-run rates across successive report collections.
+///
+/// Keyed by run id so a sandbox restart (new run, counters reset to zero)
+/// starts a fresh window instead of producing a bogus negative delta. When a
+/// tick observes no new sample (`delta_t == 0`), the previously computed
+/// rate is reused so the display doesn't flicker between values and dashes.
+#[derive(Default)]
+struct RateTracker {
+    prev: HashMap<i32, PrevSample>,
+    last_rates: HashMap<i32, Rates>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -27,88 +106,311 @@ pub struct MetricsArgs {
 
 /// Execute the `msb metrics` command.
 pub async fn run(args: MetricsArgs) -> anyhow::Result<()> {
-    if let Some(name) = args.name.as_deref() {
-        let handle = Sandbox::get(name).await?;
-        let metrics = handle.metrics().await?;
-
-        if args.format.as_deref() == Some("json") {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&metrics_json(handle.name(), &metrics))?
-            );
-            return Ok(());
-        }
-
-        print_table(&[(handle.name().to_string(), metrics)]);
-        return Ok(());
-    }
-
+    let interval = parse_interval(&args.interval)?;
     let backend = crate::commands::common::resolve_local_backend()?;
     let local = crate::commands::common::local_backend_ref(&backend)?;
-    let mut metrics = all_sandbox_metrics_local(local)
-        .await?
-        .into_iter()
-        .collect::<Vec<(String, SandboxMetrics)>>();
-    metrics.sort_by(|left, right| left.0.cmp(&right.0));
+
+    if args.follow {
+        return follow_loop(local, &args, interval).await;
+    }
+    if args.watch {
+        return watch_loop(local, &args, interval).await;
+    }
+
+    let reports = collect_reports(local, &args).await?;
 
     if args.format.as_deref() == Some("json") {
-        let json = serde_json::Value::Array(
-            metrics
-                .iter()
-                .map(|(name, metrics)| metrics_json(name, metrics))
-                .collect(),
-        );
-        println!("{}", serde_json::to_string_pretty(&json)?);
+        print_json_snapshot(&args, &reports)?;
         return Ok(());
     }
 
-    if metrics.is_empty() {
+    if reports.is_empty() {
         eprintln!("No running sandboxes.");
         return Ok(());
     }
 
-    print_table(&metrics);
+    // Rates need two samples; take the second after a short window. CPU is
+    // already delta-derived by the sampler, so it is correct on either read.
+    let mut tracker = RateTracker::default();
+    tracker.update(&reports);
+    tokio::time::sleep(ONE_SHOT_RATE_WINDOW).await;
+    let mut reports = collect_reports(local, &args).await?;
+    let rates = tracker.update(&reports);
 
+    sort_reports(&mut reports, &args.sort);
+    print!("{}", render_table(&reports, &rates));
     Ok(())
 }
 
-fn print_table(metrics: &[(String, SandboxMetrics)]) {
+/// Collect reports for the named sandbox (any state) or all sandboxes.
+async fn collect_reports(
+    local: &LocalBackend,
+    args: &MetricsArgs,
+) -> anyhow::Result<Vec<SandboxMetricsReport>> {
+    match args.name.as_deref() {
+        Some(name) => {
+            let report = sandbox_metrics_report_local(local, name)
+                .await?
+                .ok_or_else(|| anyhow!("no metrics recorded for sandbox {name:?}"))?;
+            Ok(vec![report])
+        }
+        None => Ok(all_sandbox_metrics_reports_local(local, args.all).await?),
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: watch / follow loops
+//--------------------------------------------------------------------------------------------------
+
+async fn watch_loop(
+    local: &LocalBackend,
+    args: &MetricsArgs,
+    interval: Duration,
+) -> anyhow::Result<()> {
+    let term = console::Term::stdout();
+    if !std::io::stdout().is_terminal() {
+        bail!("--watch requires a terminal; use --follow for machine-readable streaming");
+    }
+
+    let mut tracker = RateTracker::default();
+    // Prime the tracker so the first frame already has rates.
+    let reports = collect_reports(local, args).await?;
+    tracker.update(&reports);
+    tokio::time::sleep(ONE_SHOT_RATE_WINDOW.min(interval)).await;
+
+    let _ = term.hide_cursor();
+    let result = watch_frames(local, args, interval, &term, &mut tracker).await;
+    let _ = term.show_cursor();
+    result
+}
+
+async fn watch_frames(
+    local: &LocalBackend,
+    args: &MetricsArgs,
+    interval: Duration,
+    term: &console::Term,
+    tracker: &mut RateTracker,
+) -> anyhow::Result<()> {
+    loop {
+        let mut reports = collect_reports(local, args).await?;
+        let rates = tracker.update(&reports);
+        sort_reports(&mut reports, &args.sort);
+
+        let mut frame = String::new();
+        frame.push_str(
+            &style(format!(
+                "every {}  \u{b7}  ctrl-c to quit",
+                format_interval(interval)
+            ))
+            .dim()
+            .to_string(),
+        );
+        frame.push_str("\n\n");
+        if reports.is_empty() {
+            frame.push_str("No running sandboxes.\n");
+        } else {
+            frame.push_str(&render_table(&reports, &rates));
+        }
+
+        term.clear_screen()?;
+        term.write_str(&frame)?;
+
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            _ = tokio::signal::ctrl_c() => return Ok(()),
+        }
+    }
+}
+
+async fn follow_loop(
+    local: &LocalBackend,
+    args: &MetricsArgs,
+    interval: Duration,
+) -> anyhow::Result<()> {
+    let stdout = std::io::stdout();
+    loop {
+        let mut reports = collect_reports(local, args).await?;
+        sort_reports(&mut reports, &args.sort);
+        {
+            let mut out = stdout.lock();
+            for report in &reports {
+                writeln!(out, "{}", metrics_json(report))?;
+            }
+            out.flush()?;
+        }
+
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            _ = tokio::signal::ctrl_c() => return Ok(()),
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: rendering
+//--------------------------------------------------------------------------------------------------
+
+fn render_table(reports: &[SandboxMetricsReport], rates: &HashMap<i32, Rates>) -> String {
     let mut table = ui::Table::new(&[
         "NAME",
+        "STATE",
         "CPU",
-        "MEMORY",
-        "DISK READ",
-        "DISK WRITE",
-        "NET RX",
-        "NET TX",
+        "MEM",
+        "DISK R/W /s",
+        "NET RX/TX /s",
         "UPTIME",
-        "TIMESTAMP",
     ]);
 
-    for (name, metric) in metrics {
+    for report in reports {
+        let metric = &report.metrics;
+        let exited = report.state == SandboxMetricsState::Exited;
+        let stalled = report.state == SandboxMetricsState::Stalled;
+
+        let cpu = if exited || stalled {
+            "\u{2014}".to_string()
+        } else {
+            format_cpu(metric.cpu_percent, report.cpus)
+        };
+        let mem = format!(
+            "{} / {}",
+            format_bytes(metric.memory_bytes),
+            format_bytes(metric.memory_limit_bytes)
+        );
+        let (disk, net) = if exited {
+            (
+                format!(
+                    "{} / {} total",
+                    format_bytes(metric.disk_read_bytes),
+                    format_bytes(metric.disk_write_bytes)
+                ),
+                format!(
+                    "{} / {} total",
+                    format_bytes(metric.net_rx_bytes),
+                    format_bytes(metric.net_tx_bytes)
+                ),
+            )
+        } else if stalled {
+            ("\u{2014}".to_string(), "\u{2014}".to_string())
+        } else {
+            match rates.get(&report.run_id) {
+                Some(rates) => (
+                    format!(
+                        "{} / {}",
+                        format_bytes(rates.disk_read as u64),
+                        format_bytes(rates.disk_write as u64)
+                    ),
+                    format!(
+                        "{} / {}",
+                        format_bytes(rates.net_rx as u64),
+                        format_bytes(rates.net_tx as u64)
+                    ),
+                ),
+                None => ("\u{2014}".to_string(), "\u{2014}".to_string()),
+            }
+        };
+        let uptime = match report.state {
+            SandboxMetricsState::Running => format_duration(metric.uptime),
+            SandboxMetricsState::Stalled => style(format!(
+                "no sample {}",
+                format_duration(sample_age(metric.timestamp))
+            ))
+            .yellow()
+            .to_string(),
+            SandboxMetricsState::Exited => format!("ran {}", format_duration(metric.uptime)),
+        };
+
+        let dim_if_exited = |cell: String| {
+            if exited {
+                style(cell).dim().to_string()
+            } else {
+                cell
+            }
+        };
+
         table.add_row(vec![
-            name.clone(),
-            format!("{:.1}%", metric.cpu_percent),
-            format!(
-                "{} / {}",
-                format_bytes(metric.memory_bytes),
-                format_bytes(metric.memory_limit_bytes)
-            ),
-            format_bytes(metric.disk_read_bytes),
-            format_bytes(metric.disk_write_bytes),
-            format_bytes(metric.net_rx_bytes),
-            format_bytes(metric.net_tx_bytes),
-            format_duration(metric.uptime),
-            metric.timestamp.to_rfc3339(),
+            dim_if_exited(report.name.clone()),
+            format_state(report.state),
+            dim_if_exited(cpu),
+            dim_if_exited(mem),
+            dim_if_exited(disk),
+            dim_if_exited(net),
+            if exited { style(uptime).dim().to_string() } else { uptime },
         ]);
     }
 
-    table.print();
+    table.render()
 }
 
-fn metrics_json(name: &str, metrics: &SandboxMetrics) -> serde_json::Value {
+fn format_state(state: SandboxMetricsState) -> String {
+    match state {
+        SandboxMetricsState::Running => style("running").green().bold().to_string(),
+        SandboxMetricsState::Stalled => style("stalled").yellow().bold().to_string(),
+        SandboxMetricsState::Exited => style("exited").dim().to_string(),
+    }
+}
+
+/// Render CPU usage in cores over the allocation (`0.8 / 2c`). Falls back
+/// to a bare percentage when the catalog config is unresolvable.
+fn format_cpu(cpu_percent: f32, cpus: Option<u32>) -> String {
+    match cpus {
+        Some(cpus) => format!("{:.2} / {}c", f64::from(cpu_percent) / 100.0, cpus),
+        None => format!("{cpu_percent:.1}%"),
+    }
+}
+
+fn sample_age(timestamp: chrono::DateTime<chrono::Utc>) -> Duration {
+    Utc::now()
+        .signed_duration_since(timestamp)
+        .to_std()
+        .unwrap_or_default()
+}
+
+fn sort_reports(reports: &mut [SandboxMetricsReport], sort: &str) {
+    match sort {
+        "cpu" => reports.sort_by(|left, right| {
+            right
+                .metrics
+                .cpu_percent
+                .total_cmp(&left.metrics.cpu_percent)
+                .then_with(|| left.name.cmp(&right.name))
+        }),
+        "mem" => reports.sort_by(|left, right| {
+            right
+                .metrics
+                .memory_bytes
+                .cmp(&left.metrics.memory_bytes)
+                .then_with(|| left.name.cmp(&right.name))
+        }),
+        _ => reports.sort_by(|left, right| left.name.cmp(&right.name)),
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: JSON output
+//--------------------------------------------------------------------------------------------------
+
+fn print_json_snapshot(args: &MetricsArgs, reports: &[SandboxMetricsReport]) -> anyhow::Result<()> {
+    if args.name.is_some() {
+        let report = reports
+            .first()
+            .ok_or_else(|| anyhow!("no metrics available"))?;
+        println!("{}", serde_json::to_string_pretty(&metrics_json(report))?);
+        return Ok(());
+    }
+
+    let mut sorted: Vec<&SandboxMetricsReport> = reports.iter().collect();
+    sorted.sort_by(|left, right| left.name.cmp(&right.name));
+    let json = serde_json::Value::Array(sorted.iter().map(|report| metrics_json(report)).collect());
+    println!("{}", serde_json::to_string_pretty(&json)?);
+    Ok(())
+}
+
+fn metrics_json(report: &SandboxMetricsReport) -> serde_json::Value {
+    let metrics = &report.metrics;
     serde_json::json!({
-        "name": name,
+        "name": report.name,
+        "state": state_str(report.state),
+        "cpus": report.cpus,
         "timestamp": metrics.timestamp.to_rfc3339(),
         "cpu_percent": metrics.cpu_percent,
         "vcpu_time_ns": metrics.vcpu_time_ns,
@@ -125,4 +427,167 @@ fn metrics_json(name: &str, metrics: &SandboxMetrics) -> serde_json::Value {
         "upper_host_allocated_bytes": metrics.upper_host_allocated_bytes,
         "uptime_secs": metrics.uptime.as_secs_f64(),
     })
+}
+
+fn state_str(state: SandboxMetricsState) -> &'static str {
+    match state {
+        SandboxMetricsState::Running => "running",
+        SandboxMetricsState::Stalled => "stalled",
+        SandboxMetricsState::Exited => "exited",
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Parse `--interval` values like `500ms`, `2s`, `1m`, or a bare number of
+/// seconds. Clamped to [`MIN_INTERVAL`].
+fn parse_interval(raw: &str) -> anyhow::Result<Duration> {
+    let raw = raw.trim();
+    let parsed = if let Some(ms) = raw.strip_suffix("ms") {
+        ms.trim().parse::<u64>().ok().map(Duration::from_millis)
+    } else if let Some(m) = raw.strip_suffix('m') {
+        m.trim()
+            .parse::<u64>()
+            .ok()
+            .map(|mins| Duration::from_secs(mins * 60))
+    } else if let Some(s) = raw.strip_suffix('s') {
+        s.trim().parse::<f64>().ok().map(Duration::from_secs_f64)
+    } else {
+        raw.parse::<f64>().ok().map(Duration::from_secs_f64)
+    };
+    let interval = parsed
+        .filter(|duration| !duration.is_zero())
+        .ok_or_else(|| anyhow!("invalid --interval {raw:?} (expected e.g. 500ms, 2s)"))?;
+    Ok(interval.max(MIN_INTERVAL))
+}
+
+fn format_interval(interval: Duration) -> String {
+    if interval < Duration::from_secs(1) {
+        format!("{}ms", interval.as_millis())
+    } else {
+        format!("{:.1}s", interval.as_secs_f64())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl RateTracker {
+    /// Fold a new collection of reports into the tracker, returning the
+    /// per-run rates that could be derived for this tick.
+    fn update(&mut self, reports: &[SandboxMetricsReport]) -> HashMap<i32, Rates> {
+        let mut out = HashMap::new();
+        for report in reports {
+            let metric = &report.metrics;
+            let current = PrevSample {
+                timestamp: metric.timestamp,
+                disk_read_bytes: metric.disk_read_bytes,
+                disk_write_bytes: metric.disk_write_bytes,
+                net_rx_bytes: metric.net_rx_bytes,
+                net_tx_bytes: metric.net_tx_bytes,
+            };
+            if let Some(prev) = self.prev.get(&report.run_id) {
+                let delta_t = current
+                    .timestamp
+                    .signed_duration_since(prev.timestamp)
+                    .num_milliseconds() as f64
+                    / 1000.0;
+                if delta_t > 0.0 {
+                    let rate = |cur: u64, old: u64| cur.saturating_sub(old) as f64 / delta_t;
+                    let rates = Rates {
+                        disk_read: rate(current.disk_read_bytes, prev.disk_read_bytes),
+                        disk_write: rate(current.disk_write_bytes, prev.disk_write_bytes),
+                        net_rx: rate(current.net_rx_bytes, prev.net_rx_bytes),
+                        net_tx: rate(current.net_tx_bytes, prev.net_tx_bytes),
+                    };
+                    self.last_rates.insert(report.run_id, rates);
+                }
+            }
+            self.prev.insert(report.run_id, current);
+            if let Some(rates) = self.last_rates.get(&report.run_id) {
+                out.insert(report.run_id, *rates);
+            }
+        }
+        out
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_interval_accepts_common_forms() {
+        assert_eq!(parse_interval("500ms").unwrap(), Duration::from_millis(500));
+        assert_eq!(parse_interval("2s").unwrap(), Duration::from_secs(2));
+        assert_eq!(parse_interval("1m").unwrap(), Duration::from_secs(60));
+        assert_eq!(parse_interval("3").unwrap(), Duration::from_secs(3));
+        assert_eq!(parse_interval("0.5").unwrap(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn parse_interval_clamps_and_rejects() {
+        assert_eq!(parse_interval("1ms").unwrap(), MIN_INTERVAL);
+        assert!(parse_interval("fast").is_err());
+        assert!(parse_interval("0").is_err());
+        assert!(parse_interval("").is_err());
+    }
+
+    #[test]
+    fn format_cpu_prefers_cores_over_percent() {
+        assert_eq!(format_cpu(80.0, Some(2)), "0.80 / 2c");
+        assert_eq!(format_cpu(80.0, None), "80.0%");
+    }
+
+    fn report(run_id: i32, ts_ms: i64, disk_read: u64) -> SandboxMetricsReport {
+        use microsandbox::sandbox::SandboxMetrics;
+        SandboxMetricsReport {
+            name: "x".into(),
+            sandbox_id: 1,
+            run_id,
+            state: SandboxMetricsState::Running,
+            cpus: Some(1),
+            metrics: SandboxMetrics {
+                cpu_percent: 0.0,
+                vcpu_time_ns: 0,
+                memory_bytes: 0,
+                memory_available_bytes: None,
+                memory_host_resident_bytes: None,
+                memory_limit_bytes: 0,
+                disk_read_bytes: disk_read,
+                disk_write_bytes: 0,
+                net_rx_bytes: 0,
+                net_tx_bytes: 0,
+                upper_used_bytes: None,
+                upper_free_bytes: None,
+                upper_host_allocated_bytes: None,
+                uptime: Duration::from_secs(1),
+                timestamp: chrono::DateTime::from_timestamp_millis(ts_ms).unwrap(),
+            },
+        }
+    }
+
+    #[test]
+    fn rate_tracker_derives_per_second_rates() {
+        let mut tracker = RateTracker::default();
+        assert!(tracker.update(&[report(1, 1_000, 0)]).is_empty());
+
+        // 4096 bytes over 500ms -> 8192 B/s.
+        let rates = tracker.update(&[report(1, 1_500, 4096)]);
+        assert_eq!(rates.get(&1).unwrap().disk_read, 8192.0);
+
+        // No new sample: previous rate is reused, not dropped.
+        let rates = tracker.update(&[report(1, 1_500, 4096)]);
+        assert_eq!(rates.get(&1).unwrap().disk_read, 8192.0);
+
+        // A new run id starts a fresh window.
+        assert!(!tracker.update(&[report(2, 2_000, 10)]).contains_key(&2));
+    }
 }

--- a/crates/cli/lib/ui.rs
+++ b/crates/cli/lib/ui.rs
@@ -210,12 +210,21 @@ impl Table {
     }
 
     /// Print the table to stdout with column alignment.
+    pub fn print(&self) {
+        let rendered = self.render();
+        if !rendered.is_empty() {
+            print!("{rendered}");
+        }
+    }
+
+    /// Render the table to a string with column alignment.
     ///
     /// Uses visible (display) width so ANSI escape codes in cell values
-    /// don't break column alignment.
-    pub fn print(&self) {
+    /// don't break column alignment. Returns an empty string when there
+    /// are no rows.
+    pub fn render(&self) -> String {
         if self.rows.is_empty() {
-            return;
+            return String::new();
         }
 
         let col_count = self.headers.len();
@@ -229,7 +238,7 @@ impl Table {
             }
         }
 
-        // Print headers
+        let mut out = String::new();
         let header: String = self
             .headers
             .iter()
@@ -242,9 +251,9 @@ impl Table {
                 }
             })
             .collect();
-        println!("{}", style(header).cyan().bold());
+        out.push_str(&style(header).cyan().bold().to_string());
+        out.push('\n');
 
-        // Print rows
         for row in &self.rows {
             let line: String = row
                 .iter()
@@ -259,8 +268,10 @@ impl Table {
                     }
                 })
                 .collect();
-            println!("{line}");
+            out.push_str(&line);
+            out.push('\n');
         }
+        out
     }
 }
 

--- a/crates/metrics/lib/lib.rs
+++ b/crates/metrics/lib/lib.rs
@@ -23,4 +23,4 @@ pub use registry::{
     ActivateSlot, MetricsRegistry, MetricsSlotWriter, ReleaseMode, ReserveSlot, SampleWrite,
     SlotReservation, default_capacity,
 };
-pub use snapshot::{LiveMetric, SandboxMetricSnapshot, SandboxMetrics};
+pub use snapshot::{LiveMetric, LiveMetricState, SandboxMetricSnapshot, SandboxMetrics};

--- a/crates/metrics/lib/registry.rs
+++ b/crates/metrics/lib/registry.rs
@@ -514,22 +514,42 @@ impl MetricsRegistry {
 
     /// Lookup the active or stale slot for a sandbox id, if any.
     pub fn get_by_sandbox_id(&self, sandbox_id: i32) -> MetricsResult<Option<LiveMetric>> {
-        for idx in 0..self.inner.capacity {
-            let slot = self.slot(idx);
-            let state = slot.state.load(Ordering::Acquire);
-            if state != SLOT_ACTIVE && state != SLOT_STALE {
-                continue;
-            }
-            if slot.sandbox_id.load(Ordering::Acquire) != sandbox_id {
-                continue;
-            }
-            // Re-verify identity from the coherent snapshot: the slot could
-            // have been released and reused for a different sandbox between
-            // the outer filter and the seqlock-protected read.
-            if let Some(metric) = self.read_slot_demoting(idx, true)
-                && metric.sandbox_id == sandbox_id
-            {
-                return Ok(Some(metric));
+        self.get_by_sandbox_identity(sandbox_id, None)
+    }
+
+    /// Lookup the active or stale slot for a sandbox id, requiring the slot's
+    /// inline name to match when one is given.
+    ///
+    /// Prefers an `Active` slot over a `Stale` one: a sandbox that failed a
+    /// boot or restarted can briefly own two slots with the same id, and the
+    /// current run's slot must win over the preserved terminal sample.
+    ///
+    /// The name check guards against catalog id recycling: a removed
+    /// sandbox's stale slot can survive while its row id is reassigned to a
+    /// newly created sandbox, and id alone would then resolve to the ghost.
+    pub fn get_by_sandbox_identity(
+        &self,
+        sandbox_id: i32,
+        name: Option<&str>,
+    ) -> MetricsResult<Option<LiveMetric>> {
+        for want in [SLOT_ACTIVE, SLOT_STALE] {
+            for idx in 0..self.inner.capacity {
+                let slot = self.slot(idx);
+                if slot.state.load(Ordering::Acquire) != want {
+                    continue;
+                }
+                if slot.sandbox_id.load(Ordering::Acquire) != sandbox_id {
+                    continue;
+                }
+                // Re-verify identity from the coherent snapshot: the slot
+                // could have been released and reused for a different sandbox
+                // between the outer filter and the seqlock-protected read.
+                if let Some(metric) = self.read_slot_demoting(idx, true)
+                    && metric.sandbox_id == sandbox_id
+                    && name.is_none_or(|name| metric.name == name)
+                {
+                    return Ok(Some(metric));
+                }
             }
         }
         Ok(None)
@@ -2500,6 +2520,122 @@ mod tests {
             })
             .unwrap();
         assert_eq!(next.slot, res.slot);
+        cleanup(&name);
+    }
+
+    #[test]
+    fn get_by_sandbox_id_prefers_active_over_stale_slot() {
+        // A failed boot or restart can leave a stale slot with the same
+        // sandbox id at a lower index than the current run's active slot;
+        // the active one must win.
+        let name = unique_name("pref");
+        let reg = MetricsRegistry::open_or_create(&name, 2).unwrap();
+
+        let old = reg
+            .reserve(ReserveSlot {
+                sandbox_id: 9,
+                name: "x",
+                memory_limit_bytes: 1,
+            })
+            .unwrap();
+        let old_writer = reg
+            .activate_writer(ActivateSlot {
+                slot: old.slot,
+                generation: old.generation,
+                run_id: 90,
+                pid: alive_pid(),
+                started_at: Utc::now(),
+            })
+            .unwrap();
+        write_minimal_sample(&old_writer, 1);
+        old_writer.release(ReleaseMode::Stale).unwrap();
+
+        let new = reg
+            .reserve(ReserveSlot {
+                sandbox_id: 9,
+                name: "x",
+                memory_limit_bytes: 1,
+            })
+            .unwrap();
+        assert!(new.slot > old.slot, "stale slot must sit at a lower index");
+        let new_writer = reg
+            .activate_writer(ActivateSlot {
+                slot: new.slot,
+                generation: new.generation,
+                run_id: 91,
+                pid: alive_pid(),
+                started_at: Utc::now(),
+            })
+            .unwrap();
+        write_minimal_sample(&new_writer, 2);
+
+        let found = reg.get_by_sandbox_id(9).unwrap().unwrap();
+        assert_eq!(found.state, LiveMetricState::Active);
+        assert_eq!(found.run_id, 91);
+        cleanup(&name);
+    }
+
+    #[test]
+    fn get_by_sandbox_identity_skips_ghost_slot_with_recycled_id() {
+        // Catalog row ids are recycled after removal: a deleted sandbox's
+        // stale slot can share an id with a newly created sandbox. The
+        // name-qualified lookup must skip the ghost.
+        let name = unique_name("ghost");
+        let reg = MetricsRegistry::open_or_create(&name, 2).unwrap();
+
+        let ghost = reg
+            .reserve(ReserveSlot {
+                sandbox_id: 4,
+                name: "old-removed",
+                memory_limit_bytes: 1,
+            })
+            .unwrap();
+        let ghost_writer = reg
+            .activate_writer(ActivateSlot {
+                slot: ghost.slot,
+                generation: ghost.generation,
+                run_id: 40,
+                pid: alive_pid(),
+                started_at: Utc::now(),
+            })
+            .unwrap();
+        write_minimal_sample(&ghost_writer, 1);
+        ghost_writer.release(ReleaseMode::Stale).unwrap();
+
+        let real = reg
+            .reserve(ReserveSlot {
+                sandbox_id: 4,
+                name: "fresh",
+                memory_limit_bytes: 1,
+            })
+            .unwrap();
+        let real_writer = reg
+            .activate_writer(ActivateSlot {
+                slot: real.slot,
+                generation: real.generation,
+                run_id: 41,
+                pid: alive_pid(),
+                started_at: Utc::now(),
+            })
+            .unwrap();
+        write_minimal_sample(&real_writer, 2);
+        real_writer.release(ReleaseMode::Stale).unwrap();
+
+        let found = reg
+            .get_by_sandbox_identity(4, Some("fresh"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.name, "fresh");
+        assert_eq!(found.run_id, 41);
+
+        // Unqualified lookup still answers (first match), and a name with no
+        // slot returns none.
+        assert!(reg.get_by_sandbox_id(4).unwrap().is_some());
+        assert!(
+            reg.get_by_sandbox_identity(4, Some("never-existed"))
+                .unwrap()
+                .is_none()
+        );
         cleanup(&name);
     }
 

--- a/crates/metrics/lib/registry.rs
+++ b/crates/metrics/lib/registry.rs
@@ -497,10 +497,7 @@ impl MetricsRegistry {
     /// release, the release fails and the (now unrelated) slot is skipped.
     fn read_slot_demoting(&self, idx: u32, include_stale: bool) -> Option<LiveMetric> {
         let (mut metric, generation) = self.read_slot(idx, true)?;
-        if metric.state == LiveMetricState::Active
-            && metric.pid > 0
-            && !pid_is_alive(metric.pid)
-        {
+        if metric.state == LiveMetricState::Active && metric.pid > 0 && !pid_is_alive(metric.pid) {
             if self
                 .release_inner(idx, generation, ReleaseMode::Stale, true)
                 .is_err()

--- a/crates/metrics/lib/registry.rs
+++ b/crates/metrics/lib/registry.rs
@@ -21,7 +21,7 @@ use crate::layout::{
     SAMPLE_FLAG_UPPER_FREE, SAMPLE_FLAG_UPPER_HOST_ALLOCATED, SAMPLE_FLAG_UPPER_USED, SLOT_ACTIVE,
     SLOT_FREE, SLOT_RESERVED, SLOT_SIZE, SLOT_STALE, Slot, registry_size,
 };
-use crate::snapshot::LiveMetric;
+use crate::snapshot::{LiveMetric, LiveMetricState};
 use crate::{MetricsError, MetricsResult};
 #[cfg(target_os = "windows")]
 use windows_sys::Win32::Foundation::{
@@ -480,11 +480,39 @@ impl MetricsRegistry {
     fn snapshot_slots(&self, include_stale: bool) -> MetricsResult<Vec<LiveMetric>> {
         let mut out = Vec::new();
         for idx in 0..self.inner.capacity {
-            if let Some(metric) = self.read_slot(idx, include_stale) {
+            if let Some(metric) = self.read_slot_demoting(idx, include_stale) {
                 out.push(metric);
             }
         }
         Ok(out)
+    }
+
+    /// Read a slot, demoting it to `Stale` first when its owner PID is dead.
+    ///
+    /// A runtime that crashes (or is SIGKILLed) never runs its exit observer,
+    /// leaving the slot `Active` forever with a frozen sample. Reserve-time
+    /// reclaim only fires under capacity pressure, so without this readers
+    /// keep reporting the dead sandbox as running. The demotion is
+    /// generation-checked: if the slot was reused between the read and the
+    /// release, the release fails and the (now unrelated) slot is skipped.
+    fn read_slot_demoting(&self, idx: u32, include_stale: bool) -> Option<LiveMetric> {
+        let (mut metric, generation) = self.read_slot(idx, true)?;
+        if metric.state == LiveMetricState::Active
+            && metric.pid > 0
+            && !pid_is_alive(metric.pid)
+        {
+            if self
+                .release_inner(idx, generation, ReleaseMode::Stale, true)
+                .is_err()
+            {
+                return None;
+            }
+            metric.state = LiveMetricState::Stale;
+        }
+        if metric.state == LiveMetricState::Stale && !include_stale {
+            return None;
+        }
+        Some(metric)
     }
 
     /// Lookup the active or stale slot for a sandbox id, if any.
@@ -501,7 +529,7 @@ impl MetricsRegistry {
             // Re-verify identity from the coherent snapshot: the slot could
             // have been released and reused for a different sandbox between
             // the outer filter and the seqlock-protected read.
-            if let Some(metric) = self.read_slot(idx, true)
+            if let Some(metric) = self.read_slot_demoting(idx, true)
                 && metric.sandbox_id == sandbox_id
             {
                 return Ok(Some(metric));
@@ -521,7 +549,7 @@ impl MetricsRegistry {
             if slot.run_id.load(Ordering::Acquire) != run_id {
                 continue;
             }
-            if let Some(metric) = self.read_slot(idx, true)
+            if let Some(metric) = self.read_slot_demoting(idx, true)
                 && metric.run_id == run_id
             {
                 return Ok(Some(metric));
@@ -599,7 +627,10 @@ impl MetricsRegistry {
         Ok(self.slot(idx))
     }
 
-    fn read_slot(&self, idx: u32, include_stale: bool) -> Option<LiveMetric> {
+    /// Read one coherent (metric, generation) pair from a slot. The
+    /// generation is the value observed stable across the seqlock window,
+    /// letting callers perform generation-checked follow-up transitions.
+    fn read_slot(&self, idx: u32, include_stale: bool) -> Option<(LiveMetric, u64)> {
         let slot = self.slot(idx);
         // Try many times to obtain a coherent snapshot. A tight-loop writer
         // can complete a full cycle in <100 ns, so we need a generous budget
@@ -667,8 +698,14 @@ impl MetricsRegistry {
                 .signed_duration_since(started_at)
                 .to_std()
                 .unwrap_or_default();
+            let state = if state_after == SLOT_STALE {
+                LiveMetricState::Stale
+            } else {
+                LiveMetricState::Active
+            };
 
-            return Some(LiveMetric {
+            let metric = LiveMetric {
+                state,
                 sandbox_id,
                 run_id,
                 pid,
@@ -700,7 +737,8 @@ impl MetricsRegistry {
                     SAMPLE_FLAG_UPPER_HOST_ALLOCATED,
                     upper_host_allocated,
                 ),
-            });
+            };
+            return Some((metric, gen_after));
         }
         None
     }
@@ -1380,6 +1418,12 @@ mod tests {
         unlink_region(&cname);
     }
 
+    /// A PID that is guaranteed alive for the duration of the test, so
+    /// readers don't demote the slot as dead-owner.
+    fn alive_pid() -> i32 {
+        std::process::id() as i32
+    }
+
     #[test]
     fn reserve_activate_write_and_snapshot_roundtrip() {
         let name = unique_name("rt");
@@ -1398,7 +1442,7 @@ mod tests {
                 slot: res.slot,
                 generation: res.generation,
                 run_id: 99,
-                pid: 4242,
+                pid: alive_pid(),
                 started_at,
             })
             .unwrap();
@@ -1425,7 +1469,7 @@ mod tests {
         let item = &snap[0];
         assert_eq!(item.sandbox_id, 7);
         assert_eq!(item.run_id, 99);
-        assert_eq!(item.pid, 4242);
+        assert_eq!(item.pid, alive_pid());
         assert_eq!(item.name, "alpine");
         assert!((item.cpu_percent - 12.5).abs() < 1e-6);
         assert_eq!(item.vcpu_time_ns, 123_456);
@@ -1493,7 +1537,7 @@ mod tests {
                 slot: res.slot,
                 generation: res.generation,
                 run_id: 99,
-                pid: 4242,
+                pid: alive_pid(),
                 started_at: Utc::now(),
             })
             .unwrap();
@@ -1540,7 +1584,7 @@ mod tests {
                 slot: res.slot,
                 generation: res.generation,
                 run_id: 1,
-                pid: 1,
+                pid: alive_pid(),
                 started_at: Utc::now(),
             })
             .unwrap();
@@ -1617,7 +1661,7 @@ mod tests {
                 slot: res.slot,
                 generation: res.generation,
                 run_id: 1,
-                pid: 1,
+                pid: alive_pid(),
                 started_at: Utc::now(),
             })
             .unwrap();
@@ -1741,7 +1785,7 @@ mod tests {
                 slot: res.slot,
                 generation: res.generation,
                 run_id: 1,
-                pid: 1,
+                pid: alive_pid(),
                 started_at: Utc::now(),
             })
             .unwrap();
@@ -1794,7 +1838,7 @@ mod tests {
                 slot: res.slot,
                 generation: res.generation,
                 run_id: 10,
-                pid: 100,
+                pid: alive_pid(),
                 started_at: Utc::now(),
             })
             .unwrap();
@@ -1833,7 +1877,7 @@ mod tests {
             slot: next.slot,
             generation: next.generation,
             run_id: 11,
-            pid: 101,
+            pid: alive_pid(),
             started_at: Utc::now(),
         })
         .unwrap();
@@ -1868,7 +1912,7 @@ mod tests {
                 slot: next.slot,
                 generation: next.generation,
                 run_id: 20,
-                pid: 200,
+                pid: alive_pid(),
                 started_at: Utc::now(),
             })
             .unwrap();
@@ -2012,7 +2056,7 @@ mod tests {
                 slot: res.slot,
                 generation: res.generation,
                 run_id: 1,
-                pid: 1,
+                pid: alive_pid(),
                 started_at: Utc::now(),
             })
             .unwrap();
@@ -2038,7 +2082,7 @@ mod tests {
                 slot: res.slot,
                 generation: res.generation,
                 run_id: 1,
-                pid: 1,
+                pid: alive_pid(),
                 started_at: Utc::now(),
             })
             .unwrap();
@@ -2114,7 +2158,7 @@ mod tests {
                 slot: res.slot,
                 generation: res.generation,
                 run_id: 10,
-                pid: 100,
+                pid: alive_pid(),
                 started_at: Utc::now(),
             })
             .unwrap();
@@ -2319,7 +2363,7 @@ mod tests {
                 slot: res2.slot,
                 generation: res2.generation,
                 run_id: 20,
-                pid: 200,
+                pid: alive_pid(),
                 started_at: Utc::now(),
             })
             .unwrap();
@@ -2365,7 +2409,7 @@ mod tests {
                 slot: res.slot,
                 generation: res.generation,
                 run_id: 22,
-                pid: 33,
+                pid: alive_pid(),
                 started_at: Utc::now(),
             })
             .unwrap();
@@ -2396,6 +2440,101 @@ mod tests {
             .expect("slot is visible after reopen");
         assert_eq!(found.run_id, 22);
         assert_eq!(found.name, "alpine");
+        cleanup(&name);
+    }
+
+    fn write_minimal_sample(writer: &MetricsSlotWriter, memory_bytes: u64) {
+        writer
+            .write_sample(SampleWrite {
+                sampled_at: Utc::now(),
+                cpu_percent: Some(1.0),
+                vcpu_time_ns: Some(0),
+                memory_bytes: Some(memory_bytes),
+                memory_available_bytes: None,
+                memory_host_resident_bytes: None,
+                disk_read_bytes: 0,
+                disk_write_bytes: 0,
+                net_rx_bytes: 0,
+                net_tx_bytes: 0,
+                upper_used_bytes: None,
+                upper_free_bytes: None,
+                upper_host_allocated_bytes: None,
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn snapshot_demotes_dead_owner_to_stale() {
+        let name = unique_name("demote");
+        let reg = MetricsRegistry::open_or_create(&name, 1).unwrap();
+        let res = reg
+            .reserve(ReserveSlot {
+                sandbox_id: 1,
+                name: "x",
+                memory_limit_bytes: 1,
+            })
+            .unwrap();
+        let writer = reg
+            .activate_writer(ActivateSlot {
+                slot: res.slot,
+                generation: res.generation,
+                run_id: 10,
+                pid: i32::MAX,
+                started_at: Utc::now(),
+            })
+            .unwrap();
+        write_minimal_sample(&writer, 7);
+
+        // The owner PID is dead, so the active view must not report it —
+        // and the read itself demotes the slot to Stale.
+        assert!(reg.active_snapshot().unwrap().is_empty());
+
+        let snap = reg.snapshot().unwrap();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].state, LiveMetricState::Stale);
+        assert_eq!(snap[0].memory_bytes, 7, "terminal sample is preserved");
+
+        // The demoted slot is reclaimable without capacity pressure.
+        let next = reg
+            .reserve(ReserveSlot {
+                sandbox_id: 2,
+                name: "y",
+                memory_limit_bytes: 1,
+            })
+            .unwrap();
+        assert_eq!(next.slot, res.slot);
+        cleanup(&name);
+    }
+
+    #[test]
+    fn live_metric_reports_slot_state() {
+        let name = unique_name("state");
+        let reg = MetricsRegistry::open_or_create(&name, 2).unwrap();
+        let res = reg
+            .reserve(ReserveSlot {
+                sandbox_id: 5,
+                name: "x",
+                memory_limit_bytes: 1,
+            })
+            .unwrap();
+        let writer = reg
+            .activate_writer(ActivateSlot {
+                slot: res.slot,
+                generation: res.generation,
+                run_id: 50,
+                pid: alive_pid(),
+                started_at: Utc::now(),
+            })
+            .unwrap();
+        write_minimal_sample(&writer, 1);
+
+        let live = reg.get_by_sandbox_id(5).unwrap().unwrap();
+        assert_eq!(live.state, LiveMetricState::Active);
+
+        writer.release(ReleaseMode::Stale).unwrap();
+        let stale = reg.get_by_sandbox_id(5).unwrap().unwrap();
+        assert_eq!(stale.state, LiveMetricState::Stale);
+        assert!(reg.active_snapshot().unwrap().is_empty());
         cleanup(&name);
     }
 }

--- a/crates/metrics/lib/snapshot.rs
+++ b/crates/metrics/lib/snapshot.rs
@@ -6,6 +6,16 @@ use std::time::Duration;
 // Types
 //--------------------------------------------------------------------------------------------------
 
+/// Slot state observed when a [`LiveMetric`] was read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LiveMetricState {
+    /// The owning runtime holds the slot and is still sampling.
+    Active,
+    /// The runtime released the slot (or its process died); the metric is the
+    /// preserved terminal sample, not a live reading.
+    Stale,
+}
+
 /// Coherent live sample read from a single registry slot.
 ///
 /// Carries both identity (sandbox_id, run_id, pid, name) and the metric
@@ -14,6 +24,8 @@ use std::time::Duration;
 /// [`SandboxMetricSnapshot::from`].
 #[derive(Clone, Debug)]
 pub struct LiveMetric {
+    /// Slot state at the time of the read.
+    pub state: LiveMetricState,
     /// Catalog sandbox id.
     pub sandbox_id: i32,
     /// Catalog run id.

--- a/crates/runtime/lib/metrics.rs
+++ b/crates/runtime/lib/metrics.rs
@@ -64,21 +64,43 @@ impl NetworkMetrics for microsandbox_network::network::MetricsHandle {
     }
 }
 
+/// Inputs for [`run_metrics_sampler`].
+pub struct MetricsSamplerSpec {
+    /// Slot writer owning the sandbox's registry slot.
+    pub writer: MetricsSlotWriter,
+    /// Catalog sandbox id, used for diagnostics.
+    pub sandbox_id: i32,
+    /// Runtime process id, used for diagnostics.
+    pub pid: u32,
+    /// Sampling interval in milliseconds.
+    pub interval_ms: NonZero<u64>,
+    /// vCPU hotplug ceiling; CPU readings are clamped to `max_cpus * 100`.
+    pub max_cpus: u8,
+    /// VMM metrics source.
+    pub krun_metrics: msb_krun::MetricsHandle,
+    /// Optional runtime network byte counters.
+    pub network_metrics: Option<Box<dyn NetworkMetrics>>,
+    /// Host path of the writable upper image, when one exists.
+    pub upper_host_path: Option<std::path::PathBuf>,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
 
 /// Run the background metrics sampler until the sandbox process exits or
 /// the slot is reclaimed.
-pub async fn run_metrics_sampler(
-    writer: MetricsSlotWriter,
-    sandbox_id: i32,
-    pid: u32,
-    interval_ms: NonZero<u64>,
-    krun_metrics: msb_krun::MetricsHandle,
-    network_metrics: Option<Box<dyn NetworkMetrics>>,
-    upper_host_path: Option<std::path::PathBuf>,
-) {
+pub async fn run_metrics_sampler(spec: MetricsSamplerSpec) {
+    let MetricsSamplerSpec {
+        writer,
+        sandbox_id,
+        pid,
+        interval_ms,
+        max_cpus,
+        krun_metrics,
+        network_metrics,
+        upper_host_path,
+    } = spec;
     let interval = Duration::from_millis(interval_ms.get());
     let upper_stale_after = upper_filesystem_stale_after(interval);
     let mut previous = krun_metrics.aggregate_snapshot();
@@ -116,10 +138,13 @@ pub async fn run_metrics_sampler(
             .checked_duration_since(previous_instant)
             .map(|d| d.as_secs_f64())
             .unwrap_or(0.0);
-        let cpu_percent = cpu_percent_from_vcpu_time(
-            current.cpu.vcpu_time_ns,
-            previous.cpu.vcpu_time_ns,
-            wall_secs,
+        let cpu_percent = clamp_cpu_percent(
+            cpu_percent_from_vcpu_time(
+                current.cpu.vcpu_time_ns,
+                previous.cpu.vcpu_time_ns,
+                wall_secs,
+            ),
+            max_cpus,
         );
 
         match write_sample(
@@ -278,6 +303,17 @@ fn cpu_percent_from_vcpu_time(
     }
 }
 
+/// Clamp a CPU reading to the vCPU hotplug ceiling.
+///
+/// The VMM's counter aggregation can momentarily pair a vCPU-time delta with
+/// a shorter wall window (observed as a multi-hundred-percent spike while a
+/// concurrent VM boot loaded the host). More vCPU-seconds per second than
+/// vCPUs exist is physically impossible, so cap at `max_cpus * 100`.
+fn clamp_cpu_percent(cpu_percent: Option<f32>, max_cpus: u8) -> Option<f32> {
+    let ceiling = f32::from(max_cpus.max(1)) * 100.0;
+    cpu_percent.map(|pct| pct.min(ceiling))
+}
+
 //--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
@@ -327,6 +363,16 @@ mod tests {
         );
         assert_eq!(cpu_percent_from_vcpu_time(None, Some(0), 1.0), None);
         assert_eq!(cpu_percent_from_vcpu_time(Some(0), Some(0), 0.0), None);
+    }
+
+    #[test]
+    fn cpu_percent_is_clamped_to_the_vcpu_ceiling() {
+        // A skewed counter window can report more vCPU-seconds per second
+        // than vCPUs exist; the ceiling caps it.
+        assert_eq!(clamp_cpu_percent(Some(592.0), 2), Some(200.0));
+        assert_eq!(clamp_cpu_percent(Some(197.5), 2), Some(197.5));
+        assert_eq!(clamp_cpu_percent(Some(150.0), 0), Some(100.0));
+        assert_eq!(clamp_cpu_percent(None, 2), None);
     }
 
     #[test]

--- a/crates/runtime/lib/metrics.rs
+++ b/crates/runtime/lib/metrics.rs
@@ -30,6 +30,12 @@ pub const DEFAULT_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
 /// Minimum age after which protected upper filesystem samples are treated as stale.
 const MIN_UPPER_FILESYSTEM_STALE_AFTER: Duration = Duration::from_secs(3);
 
+/// Maximum counter/clock pairing error tolerated for a CPU sample window,
+/// as a fraction of the window's wall time. Normal pairing spread is
+/// microseconds against a 1s window; anything past this ratio means the
+/// sampler was descheduled mid-read and the window's ratio is unusable.
+const MAX_PAIRING_SKEW_RATIO: f64 = 0.05;
+
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
@@ -103,14 +109,14 @@ pub async fn run_metrics_sampler(spec: MetricsSamplerSpec) {
     } = spec;
     let interval = Duration::from_millis(interval_ms.get());
     let upper_stale_after = upper_filesystem_stale_after(interval);
-    let mut previous = krun_metrics.aggregate_snapshot();
-    let mut previous_instant = Instant::now();
+    let mut previous = paired_snapshot(&krun_metrics);
     let upper_host_path = upper_host_path.as_deref();
+    let mut last_cpu_percent: Option<f32> = None;
 
     match write_sample(
         &writer,
         None,
-        &previous,
+        &previous.metrics,
         network_metrics.as_deref(),
         upper_host_path,
         upper_stale_after,
@@ -132,25 +138,46 @@ pub async fn run_metrics_sampler(spec: MetricsSamplerSpec) {
     loop {
         tokio::time::sleep(interval).await;
 
-        let current = krun_metrics.aggregate_snapshot();
-        let now = Instant::now();
-        let wall_secs = now
-            .checked_duration_since(previous_instant)
+        let current = paired_snapshot(&krun_metrics);
+        let wall_secs = current
+            .at
+            .checked_duration_since(previous.at)
             .map(|d| d.as_secs_f64())
             .unwrap_or(0.0);
-        let cpu_percent = clamp_cpu_percent(
-            cpu_percent_from_vcpu_time(
-                current.cpu.vcpu_time_ns,
-                previous.cpu.vcpu_time_ns,
+        // Each window's error bound is half of each endpoint's read spread:
+        // the true counter read lies somewhere inside its bracket.
+        let pairing_skew_secs =
+            (previous.uncertainty.as_secs_f64() + current.uncertainty.as_secs_f64()) / 2.0;
+        let cpu_percent = if pairing_is_reliable(pairing_skew_secs, wall_secs) {
+            let computed = clamp_cpu_percent(
+                cpu_percent_from_vcpu_time(
+                    current.metrics.cpu.vcpu_time_ns,
+                    previous.metrics.cpu.vcpu_time_ns,
+                    wall_secs,
+                ),
+                max_cpus,
+            );
+            if computed.is_some() {
+                last_cpu_percent = computed;
+            }
+            computed
+        } else {
+            // The (counter, timestamp) pairing was disturbed — the sampler
+            // was descheduled mid-read, so this window's ratio is garbage.
+            // Carry the last trustworthy reading instead of publishing it.
+            tracing::debug!(
+                sandbox_id,
+                pairing_skew_secs,
                 wall_secs,
-            ),
-            max_cpus,
-        );
+                "cpu sample window skewed by descheduling; reusing previous reading"
+            );
+            last_cpu_percent
+        };
 
         match write_sample(
             &writer,
             cpu_percent,
-            &current,
+            &current.metrics,
             network_metrics.as_deref(),
             upper_host_path,
             upper_stale_after,
@@ -166,8 +193,41 @@ pub async fn run_metrics_sampler(spec: MetricsSamplerSpec) {
         }
 
         previous = current;
-        previous_instant = now;
     }
+}
+
+/// A VMM metrics snapshot paired with the wall-clock moment it describes.
+///
+/// The counter and the clock cannot be read in one atomic step, so the
+/// snapshot is bracketed by two `Instant` reads: `at` is the bracket
+/// midpoint and `uncertainty` its width. Normally the width is microseconds;
+/// when the host deschedules this thread mid-read (observed during a
+/// concurrent VM boot) it grows to whatever the scheduler stole, and the
+/// sample window it bounds must not be trusted for rate math — pairing a
+/// multi-second counter delta with a one-second wall window is exactly how
+/// a 2-vCPU sandbox once read 592% CPU.
+struct PairedSnapshot {
+    metrics: msb_krun::VmMetrics,
+    at: Instant,
+    uncertainty: Duration,
+}
+
+fn paired_snapshot(krun_metrics: &msb_krun::MetricsHandle) -> PairedSnapshot {
+    let before = Instant::now();
+    let metrics = krun_metrics.aggregate_snapshot();
+    let after = Instant::now();
+    let uncertainty = after.saturating_duration_since(before);
+    PairedSnapshot {
+        metrics,
+        at: before + uncertainty / 2,
+        uncertainty,
+    }
+}
+
+/// Whether the counter/clock pairing error is small enough for the window's
+/// vCPU-time-over-wall-time ratio to be meaningful.
+fn pairing_is_reliable(pairing_skew_secs: f64, wall_secs: f64) -> bool {
+    wall_secs > 0.0 && pairing_skew_secs <= wall_secs * MAX_PAIRING_SKEW_RATIO
 }
 
 enum SampleWriteError {
@@ -305,10 +365,10 @@ fn cpu_percent_from_vcpu_time(
 
 /// Clamp a CPU reading to the vCPU hotplug ceiling.
 ///
-/// The VMM's counter aggregation can momentarily pair a vCPU-time delta with
-/// a shorter wall window (observed as a multi-hundred-percent spike while a
-/// concurrent VM boot loaded the host). More vCPU-seconds per second than
-/// vCPUs exist is physically impossible, so cap at `max_cpus * 100`.
+/// Skewed windows are already rejected by the pairing check; this is the
+/// invariant backstop for anything that still slips through — more
+/// vCPU-seconds per second than vCPUs exist is physically impossible, so
+/// cap at `max_cpus * 100`.
 fn clamp_cpu_percent(cpu_percent: Option<f32>, max_cpus: u8) -> Option<f32> {
     let ceiling = f32::from(max_cpus.max(1)) * 100.0;
     cpu_percent.map(|pct| pct.min(ceiling))
@@ -373,6 +433,20 @@ mod tests {
         assert_eq!(clamp_cpu_percent(Some(197.5), 2), Some(197.5));
         assert_eq!(clamp_cpu_percent(Some(150.0), 0), Some(100.0));
         assert_eq!(clamp_cpu_percent(None, 2), None);
+    }
+
+    #[test]
+    fn pairing_gate_rejects_descheduled_windows() {
+        // Normal operation: microsecond read spread against a 1s window.
+        assert!(pairing_is_reliable(0.000_05, 1.0));
+        // Right at the tolerance boundary.
+        assert!(pairing_is_reliable(0.05, 1.0));
+        // A deschedule mid-read (the 592%-on-2-vCPUs incident: ~2s stolen
+        // between the counter read and its timestamp) must be rejected.
+        assert!(!pairing_is_reliable(1.0, 1.0));
+        assert!(!pairing_is_reliable(0.051, 1.0));
+        // Degenerate window.
+        assert!(!pairing_is_reliable(0.0, 0.0));
     }
 
     #[test]

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -792,6 +792,9 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     let metrics_sandbox_id = config.sandbox_id;
     let metrics_sandbox_name = config.sandbox_name.clone();
     let metrics_pid = pid;
+    // Same effective ceiling the VMM boots with (max_vcpus is clamped to at
+    // least the online count); used to cap physically impossible CPU spikes.
+    let metrics_max_cpus = config.vm.max_cpus.max(config.vm.vcpus);
 
     // Opportunistic host-runtime lifecycle maintenance: reconcile stale active
     // sandboxes and clean terminal ephemeral leftovers from runtimes that died
@@ -834,15 +837,16 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                         interval_ms = interval_ms.get(),
                         "starting metrics sampler after agent ready"
                     );
-                    tokio::spawn(run_metrics_sampler(
+                    tokio::spawn(run_metrics_sampler(crate::metrics::MetricsSamplerSpec {
                         writer,
-                        metrics_sandbox_id,
-                        metrics_pid,
+                        sandbox_id: metrics_sandbox_id,
+                        pid: metrics_pid,
                         interval_ms,
-                        krun_metrics_handle,
-                        network_metrics_handle,
+                        max_cpus: metrics_max_cpus,
+                        krun_metrics: krun_metrics_handle,
+                        network_metrics: network_metrics_handle,
                         upper_host_path,
-                    ));
+                    }));
                 }
                 if let Err(e) = relay.run(relay_shutdown_rx, relay_drain_tx).await {
                     tracing::error!("agent relay error: {e}");

--- a/docs/changelog/2026-07-05.mdx
+++ b/docs/changelog/2026-07-05.mdx
@@ -1,0 +1,32 @@
+---
+title: "Week of July 5, 2026"
+description: "msb metrics overhaul: crashed sandboxes no longer report as running, a STATE column, resize-aware CPU/MEM denominators, per-second I/O rates, and live --watch / --follow modes."
+icon: "bolt"
+---
+
+## New features
+
+**Live metrics: `msb metrics --watch` and `--follow`**
+
+`msb metrics` gains a `docker stats`-style live mode. `--watch` refreshes the table in place at a configurable `--interval` (default 1s); `--follow` streams one JSON Lines object per sandbox per tick for scripting. Disk and network columns now render as per-second rates derived from consecutive samples — the one-shot table samples twice ~500 ms apart so it reads identically to a watch frame. `--sort cpu|mem` orders rows by usage.
+
+```bash
+msb metrics --watch --interval 500ms
+msb metrics --follow | jq .cpu_percent
+```
+
+See [msb metrics](/cli/sandbox-commands#msb-metrics).
+
+**Sandbox state in metrics output**
+
+Every metrics row now carries a `STATE`: `running`, `stalled` (runtime alive but the sampler has not written a sample within three sampling intervals), or `exited` (the preserved terminal sample of a stopped sandbox). Named lookups (`msb metrics my-app`) answer in any state instead of pretending an exited sandbox is live, and `--all` opts recently exited sandboxes into the fleet view with their cumulative totals. The Rust SDK exposes the same data via `SandboxMetricsReport` / `all_sandbox_metrics_reports_local`.
+
+**Resize-aware CPU and memory denominators**
+
+The `CPU` column shows cores busy over cores allocated (`0.80 / 2c`) and `MEM` shows usage over the configured limit — both resolved from the catalog's *active* config at read time, so `msb modify --cpus/--memory` on a running sandbox is reflected on the next tick instead of showing the boot-time limit forever.
+
+## Fixes
+
+**Crashed sandboxes no longer report as running**
+
+A runtime killed hard (SIGKILL, OOM, host reboot) never released its shared-memory metrics slot, so `msb metrics` — and the `msb-metrics` collector — kept reporting its frozen last sample as a running sandbox until slot pressure forced a reclaim. Registry readers now verify the slot owner's PID on every read and retire dead entries on the spot: the CLI reports them as `exited`, and collector export streams drop the series on the next tick.

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -390,14 +390,42 @@ msb ps --format json      # JSON output
 Show live CPU, memory, disk, network, and optional upper disk metrics for running sandboxes.
 
 ```bash
-msb metrics               # All running sandboxes
-msb metrics my-app        # Single sandbox
-msb metrics --format json # JSON output
+msb metrics                 # All running sandboxes (one-shot table)
+msb metrics my-app          # Single sandbox, in any state
+msb metrics --watch         # Refresh the table in place (like docker stats)
+msb metrics --follow        # Stream JSON Lines, one object per sandbox per tick
+msb metrics --all           # Include recently exited sandboxes
+msb metrics --sort cpu      # Sort by CPU instead of name
+msb metrics --format json   # One-shot JSON output
 ```
 
 | Flag | Description |
 |------|-------------|
+| `-w`, `--watch` | Continuously refresh the table in place. Ctrl-C to quit. Requires a terminal |
+| `-f`, `--follow` | Stream one JSON Lines object per sandbox per interval to stdout |
+| `--interval` | Refresh interval for `--watch`/`--follow` (e.g. `500ms`, `2s`). Default `1s` |
+| `-a`, `--all` | Include `exited` rows — terminal metrics preserved in the registry until the slot is reused |
+| `--sort` | Sort rows by `name` (default), `cpu`, or `mem` |
 | `--format` | Output format (`json`) |
+
+**Columns.** `--watch` and the one-shot table render identically:
+
+- `STATE` — `running` (fresh sample from a live runtime), `stalled` (runtime alive but no sample within 3× its sampling interval; the row shows how long ago the last sample landed), or `exited` (the preserved terminal sample of a stopped or crashed sandbox).
+- `CPU` — vCPU-seconds per wall-second over the allocation, e.g. `0.80 / 2c` means 0.8 cores busy out of 2 allocated.
+- `MEM` — guest-used memory over the configured limit.
+- `DISK R/W /s`, `NET RX/TX /s` — per-second rates derived from two consecutive samples. The one-shot form samples twice ~500 ms apart to compute them; `exited` rows show cumulative totals instead.
+
+The `CPU` and `MEM` denominators come from the catalog's **active config**, so they track [live resizes](/cli/sandbox-commands#msb-modify) immediately. Sandboxes whose runtime crashed without cleanup are detected by owner-PID liveness and reported as `exited`, not `running`.
+
+**Invocation semantics:**
+
+| Invocation | Shows |
+|------|-------------|
+| `msb metrics` | `running` + `stalled` sandboxes |
+| `msb metrics --all` | the above plus `exited` ones still present in the registry |
+| `msb metrics <name>` | that sandbox in any state |
+
+`--format json` and `--follow` keep the raw cumulative counters (no rate conversion) and add `state` and `cpus` fields.
 
 ## msb inspect
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -229,6 +229,7 @@
       {
         "tab": "Changelog",
         "pages": [
+          "changelog/2026-07-05",
           "changelog/2026-05-22",
           "changelog/2026-05-15",
           "changelog/2026-05-01",

--- a/docs/observability/deep-dive.mdx
+++ b/docs/observability/deep-dive.mdx
@@ -289,6 +289,14 @@ the export stream. Downstream the series goes stale (no fresh
 datapoints), which is the standard "host gone" signal in Prometheus and
 most TSDBs. There is no explicit "stopped" event.
 
+Crashed sandboxes behave the same way. A runtime killed hard (SIGKILL,
+OOM, host reboot) never releases its slot, and registry readers used to
+keep reporting its frozen last sample as if the sandbox were running.
+Readers now verify that the slot's owner PID is alive and retire dead
+entries on first read, so a crashed sandbox drops out of the export
+stream on the next collection tick — the same "series goes stale"
+signal as a clean stop.
+
 ## Counter resets across sandbox restarts
 
 Disk and network byte fields are cumulative from the sandbox process's

--- a/docs/sandboxes/metrics.mdx
+++ b/docs/sandboxes/metrics.mdx
@@ -111,3 +111,25 @@ all, err := m.AllSandboxMetrics(ctx)
 ```
 
 </CodeGroup>
+
+Fleet snapshots only include sandboxes whose runtime process is actually alive. A runtime that crashed without cleanup used to keep reporting its last sample as if the sandbox were running; readers now detect the dead owner and retire the entry on first read.
+
+## Metrics reports (Rust)
+
+The Rust SDK additionally exposes *reports*: metrics joined with catalog context for presentation. A report resolves the CPU and memory allocations from the sandbox's **active config** (so live resizes are reflected), and carries a state field: `Running`, `Stalled` (runtime alive but no sample within three sampling intervals), or `Exited` (the preserved terminal sample of a stopped sandbox). This is what `msb metrics` renders.
+
+```rust Rust
+use microsandbox::{all_sandbox_metrics_reports_local, sandbox_metrics_report_local};
+
+// All sandboxes; pass true to include exited ones.
+let reports = all_sandbox_metrics_reports_local(&local, false).await?;
+for r in &reports {
+    println!("{} [{:?}] {:.2} cores of {:?}", r.name, r.state, r.metrics.cpu_percent / 100.0, r.cpus);
+}
+
+// One sandbox by name, in any state (unlike `Sandbox::metrics`, which
+// errors when the sandbox is not running).
+let report = sandbox_metrics_report_local(&local, "my-app").await?;
+```
+
+Report APIs for TypeScript, Python, and Go will follow.

--- a/sdk/rust/lib/lib.rs
+++ b/sdk/rust/lib/lib.rs
@@ -58,10 +58,12 @@ pub use sandbox::{
     ChangeKind, ConfigPlannedChange, ExecOutput, MAX_HOSTNAME_BYTES, MAX_SANDBOX_NAME_BYTES,
     ModificationConflict, ModificationDisposition, ModificationPolicy, ModificationWarning,
     PlannedChange, ResourceConvergenceState, ResourceKind, ResourceResizeStatus, Sandbox,
-    SandboxConfig, SandboxMetrics, SandboxModificationBuilder, SandboxModificationPatch,
-    SandboxModificationPlan, SandboxPingResult, SandboxTouchResult, SecretChangeKind,
-    SecretModificationPatch, SecretPatchBuilder, SecretPlannedChange, SecretSource,
-    all_sandbox_metrics, all_sandbox_metrics_local, validate_sandbox_name,
+    SandboxConfig, SandboxMetrics, SandboxMetricsReport, SandboxMetricsState,
+    SandboxModificationBuilder, SandboxModificationPatch, SandboxModificationPlan,
+    SandboxPingResult, SandboxTouchResult, SecretChangeKind, SecretModificationPatch,
+    SecretPatchBuilder, SecretPlannedChange, SecretSource, all_sandbox_metrics,
+    all_sandbox_metrics_local, all_sandbox_metrics_reports_local, sandbox_metrics_report_local,
+    validate_sandbox_name,
 };
 pub use snapshot::{
     Snapshot, SnapshotBuilder, SnapshotConfig, SnapshotDestination, SnapshotFormat, SnapshotHandle,

--- a/sdk/rust/lib/sandbox/metrics.rs
+++ b/sdk/rust/lib/sandbox/metrics.rs
@@ -1,12 +1,14 @@
 //! Sandbox metrics APIs backed by the shared-memory live registry.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::num::NonZero;
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::Utc;
 use futures::stream;
 use microsandbox_db::DbReadConnection;
-use microsandbox_metrics::{LiveMetric, MetricsRegistry};
+use microsandbox_metrics::{LiveMetric, LiveMetricState, MetricsRegistry};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
 use crate::{
@@ -54,6 +56,41 @@ pub struct SandboxMetrics {
     pub uptime: Duration,
     /// Timestamp of the sample.
     pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+/// Presentation-level state of a sandbox metrics row.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SandboxMetricsState {
+    /// The runtime owns its slot, is alive, and its sample is fresh.
+    Running,
+    /// The runtime is alive but no sample landed within three sampling
+    /// intervals — the sampler is wedged or the host is starved.
+    Stalled,
+    /// The runtime exited (cleanly or not); the metrics are the preserved
+    /// terminal sample, not a live reading.
+    Exited,
+}
+
+/// One sandbox's live metrics joined with catalog config context.
+///
+/// Unlike a bare [`SandboxMetrics`], a report resolves the allocation
+/// denominators (`cpus`, `memory_limit_bytes`) from the catalog's *active*
+/// config, so live resizes are reflected without re-stamping the
+/// shared-memory slot.
+#[derive(Clone, Debug)]
+pub struct SandboxMetricsReport {
+    /// Sandbox name.
+    pub name: String,
+    /// Catalog sandbox id.
+    pub sandbox_id: i32,
+    /// Catalog run id that produced the sample.
+    pub run_id: i32,
+    /// Row state derived from slot state, owner liveness, and sample age.
+    pub state: SandboxMetricsState,
+    /// vCPUs allocated per the catalog config, when resolvable.
+    pub cpus: Option<u32>,
+    /// The metrics sample.
+    pub metrics: SandboxMetrics,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -110,7 +147,10 @@ pub(crate) async fn local_metrics(
         .one(pools.read())
         .await?
         .ok_or_else(|| MicrosandboxError::SandboxNotFound(name.to_string()))?;
-    metrics_for_sandbox(pools.read(), local, model.id, config).await
+    // Prefer the catalog's active config over the caller-supplied one so
+    // limits reflect accepted live resizes, not the boot-time spec.
+    let effective = model_effective_config(&model).unwrap_or_else(|| config.clone());
+    metrics_for_sandbox(pools.read(), local, model.id, &effective).await
 }
 
 /// Local-backend streaming metrics. Called from the
@@ -146,7 +186,9 @@ pub(crate) fn local_metrics_stream(
                         .await
                     {
                         Ok(Some(model)) => {
-                            metrics_for_sandbox(pools.read(), local, model.id, &config).await
+                            let effective =
+                                model_effective_config(&model).unwrap_or_else(|| config.clone());
+                            metrics_for_sandbox(pools.read(), local, model.id, &effective).await
                         }
                         Ok(None) => Err(MicrosandboxError::SandboxNotFound(name.clone())),
                         Err(e) => Err(e.into()),
@@ -195,6 +237,98 @@ pub async fn all_sandbox_metrics_local(
             (live.name, metrics)
         })
         .collect())
+}
+
+/// Build a metrics report for every sandbox present in the live registry,
+/// joining each row with its catalog config.
+///
+/// `include_exited` keeps rows whose slot is stale — exited sandboxes whose
+/// terminal sample is preserved until the slot is reused. Rows for sandboxes
+/// that were removed from the catalog are always dropped.
+pub async fn all_sandbox_metrics_reports_local(
+    local: &LocalBackend,
+    include_exited: bool,
+) -> MicrosandboxResult<Vec<SandboxMetricsReport>> {
+    let Some(registry) = open_registry(local)? else {
+        return Ok(Vec::new());
+    };
+    let snapshot = if include_exited {
+        registry.snapshot()
+    } else {
+        registry.active_snapshot()
+    }
+    .map_err(metrics_error)?;
+
+    // A sandbox restarted since its last run can own two slots: the stale
+    // one from the previous run and the active one. Keep the active row, or
+    // the freshest stale one.
+    let mut best: HashMap<i32, LiveMetric> = HashMap::new();
+    for live in snapshot {
+        match best.get(&live.sandbox_id) {
+            Some(existing)
+                if slot_rank(existing) > slot_rank(&live)
+                    || (slot_rank(existing) == slot_rank(&live)
+                        && existing.timestamp >= live.timestamp) => {}
+            _ => {
+                best.insert(live.sandbox_id, live);
+            }
+        }
+    }
+
+    let ids: Vec<i32> = best.keys().copied().collect();
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let pools = local.db().await?;
+    let models = sandbox_entity::Entity::find()
+        .filter(sandbox_entity::Column::Id.is_in(ids))
+        .all(pools.read())
+        .await?;
+    let known: HashSet<i32> = models.iter().map(|model| model.id).collect();
+    let configs: HashMap<i32, SandboxConfig> = models
+        .iter()
+        .filter_map(|model| model_effective_config(model).map(|config| (model.id, config)))
+        .collect();
+
+    let mut reports: Vec<SandboxMetricsReport> = best
+        .into_values()
+        .filter(|live| known.contains(&live.sandbox_id))
+        .map(|live| {
+            let config = configs.get(&live.sandbox_id);
+            report_from_live(live, config)
+        })
+        .collect();
+    reports.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(reports)
+}
+
+/// Build a metrics report for one sandbox by name, in any state.
+///
+/// Unlike [`Sandbox::metrics`], this answers for exited sandboxes too (the
+/// report's state says so). Returns `Ok(None)` when the sandbox exists but
+/// has no slot in the registry — never sampled, or the slot was reused.
+pub async fn sandbox_metrics_report_local(
+    local: &LocalBackend,
+    name: &str,
+) -> MicrosandboxResult<Option<SandboxMetricsReport>> {
+    let pools = local.db().await?;
+    let model = sandbox_entity::Entity::find()
+        .filter(sandbox_entity::Column::Name.eq(name))
+        .one(pools.read())
+        .await?
+        .ok_or_else(|| MicrosandboxError::SandboxNotFound(name.to_string()))?;
+
+    let Some(registry) = open_registry(local)? else {
+        return Ok(None);
+    };
+    let Some(live) = registry
+        .get_by_sandbox_id(model.id)
+        .map_err(metrics_error)?
+    else {
+        return Ok(None);
+    };
+    let config = model_effective_config(&model);
+    Ok(Some(report_from_live(live, config.as_ref())))
 }
 
 pub(super) async fn metrics_for_sandbox(
@@ -248,9 +382,11 @@ fn to_sandbox_metrics(live: &LiveMetric, config: Option<&SandboxConfig>) -> Sand
         memory_bytes: live.memory_bytes,
         memory_available_bytes: live.memory_available_bytes,
         memory_host_resident_bytes: live.memory_host_resident_bytes,
-        memory_limit_bytes: match (live.memory_limit_bytes, config) {
-            (0, Some(config)) => memory_limit_bytes(config),
-            (bytes, _) => bytes,
+        // The slot value is stamped once at reservation, so it goes stale
+        // after a live resize; the catalog config wins when resolvable.
+        memory_limit_bytes: match config.map(memory_limit_bytes).filter(|&limit| limit != 0) {
+            Some(limit) => limit,
+            None => live.memory_limit_bytes,
         },
         disk_read_bytes: live.disk_read_bytes,
         disk_write_bytes: live.disk_write_bytes,
@@ -270,6 +406,61 @@ fn metrics_error(err: microsandbox_metrics::MetricsError) -> MicrosandboxError {
 
 fn memory_limit_bytes(config: &SandboxConfig) -> u64 {
     u64::from(config.spec.resources.memory_mib) * 1024 * 1024
+}
+
+/// Parse the config that best describes the sandbox's current allocation:
+/// the active-config snapshot when one is recorded, else the desired config.
+fn model_effective_config(model: &sandbox_entity::Model) -> Option<SandboxConfig> {
+    model
+        .active_config
+        .as_deref()
+        .and_then(|json| serde_json::from_str(json).ok())
+        .or_else(|| serde_json::from_str(&model.config).ok())
+}
+
+fn slot_rank(live: &LiveMetric) -> u8 {
+    match live.state {
+        LiveMetricState::Active => 1,
+        LiveMetricState::Stale => 0,
+    }
+}
+
+fn report_from_live(live: LiveMetric, config: Option<&SandboxConfig>) -> SandboxMetricsReport {
+    let state = classify_state(&live, config);
+    let cpus = config.map(|config| u32::from(config.spec.resources.cpus));
+    let metrics = to_sandbox_metrics(&live, config);
+    SandboxMetricsReport {
+        name: live.name,
+        sandbox_id: live.sandbox_id,
+        run_id: live.run_id,
+        state,
+        cpus,
+        metrics,
+    }
+}
+
+/// Derive the row state. Stale slots are exited by definition; active slots
+/// are stalled when no sample landed within three sampling intervals
+/// (minimum 3s), mirroring the sampler's own guest-freshness policy.
+fn classify_state(live: &LiveMetric, config: Option<&SandboxConfig>) -> SandboxMetricsState {
+    match live.state {
+        LiveMetricState::Stale => SandboxMetricsState::Exited,
+        LiveMetricState::Active => {
+            let interval_ms = config
+                .and_then(|config| config.effective_metrics_interval())
+                .map(NonZero::get)
+                .unwrap_or(1000);
+            let stall_after_ms = interval_ms.saturating_mul(3).max(3000);
+            let age_ms = Utc::now()
+                .signed_duration_since(live.timestamp)
+                .num_milliseconds();
+            if age_ms > stall_after_ms as i64 {
+                SandboxMetricsState::Stalled
+            } else {
+                SandboxMetricsState::Running
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/sdk/rust/lib/sandbox/metrics.rs
+++ b/sdk/rust/lib/sandbox/metrics.rs
@@ -261,21 +261,23 @@ pub async fn all_sandbox_metrics_reports_local(
 
     // A sandbox restarted since its last run can own two slots: the stale
     // one from the previous run and the active one. Keep the active row, or
-    // the freshest stale one.
-    let mut best: HashMap<i32, LiveMetric> = HashMap::new();
+    // the freshest stale one. Keyed by (id, name) so a ghost slot from a
+    // removed sandbox with a recycled id never displaces the real row.
+    let mut best: HashMap<(i32, String), LiveMetric> = HashMap::new();
     for live in snapshot {
-        match best.get(&live.sandbox_id) {
+        let key = (live.sandbox_id, live.name.clone());
+        match best.get(&key) {
             Some(existing)
                 if slot_rank(existing) > slot_rank(&live)
                     || (slot_rank(existing) == slot_rank(&live)
                         && existing.timestamp >= live.timestamp) => {}
             _ => {
-                best.insert(live.sandbox_id, live);
+                best.insert(key, live);
             }
         }
     }
 
-    let ids: Vec<i32> = best.keys().copied().collect();
+    let ids: Vec<i32> = best.keys().map(|(id, _)| *id).collect();
     if ids.is_empty() {
         return Ok(Vec::new());
     }
@@ -284,7 +286,13 @@ pub async fn all_sandbox_metrics_reports_local(
         .filter(sandbox_entity::Column::Id.is_in(ids))
         .all(pools.read())
         .await?;
-    let known: HashSet<i32> = models.iter().map(|model| model.id).collect();
+    // Require the slot's inline name to match the catalog row: ids are
+    // recycled after removal, so a ghost slot from a deleted sandbox can
+    // share an id with (and must not masquerade as) a current sandbox.
+    let known: HashSet<(i32, &str)> = models
+        .iter()
+        .map(|model| (model.id, model.name.as_str()))
+        .collect();
     let configs: HashMap<i32, SandboxConfig> = models
         .iter()
         .filter_map(|model| model_effective_config(model).map(|config| (model.id, config)))
@@ -292,7 +300,7 @@ pub async fn all_sandbox_metrics_reports_local(
 
     let mut reports: Vec<SandboxMetricsReport> = best
         .into_values()
-        .filter(|live| known.contains(&live.sandbox_id))
+        .filter(|live| known.contains(&(live.sandbox_id, live.name.as_str())))
         .map(|live| {
             let config = configs.get(&live.sandbox_id);
             report_from_live(live, config)
@@ -321,8 +329,10 @@ pub async fn sandbox_metrics_report_local(
     let Some(registry) = open_registry(local)? else {
         return Ok(None);
     };
+    // Match on name as well as id: catalog row ids are recycled after
+    // removal, so a ghost slot from a deleted sandbox can share the id.
     let Some(live) = registry
-        .get_by_sandbox_id(model.id)
+        .get_by_sandbox_identity(model.id, Some(&model.name))
         .map_err(metrics_error)?
     else {
         return Ok(None);

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -130,7 +130,10 @@ pub use fs::{
 };
 pub use handle::{DEFAULT_KILL_TIMEOUT, DEFAULT_STOP_TIMEOUT, SandboxHandle};
 pub use init::{HandoffInit, InitOptionsBuilder};
-pub use metrics::{SandboxMetrics, all_sandbox_metrics, all_sandbox_metrics_local};
+pub use metrics::{
+    SandboxMetrics, SandboxMetricsReport, SandboxMetricsState, all_sandbox_metrics,
+    all_sandbox_metrics_local, all_sandbox_metrics_reports_local, sandbox_metrics_report_local,
+};
 pub use microsandbox_image::{PullProgress, PullProgressHandle};
 #[cfg(feature = "net")]
 pub use microsandbox_network::builder::SecretBuilder;


### PR DESCRIPTION
## TL;DR
`msb metrics` no longer reports crashed sandboxes as running, shows each row's state (`running` / `stalled` / `exited`), and gains `--watch` / `--follow` live modes with per-second I/O rates and resize-aware CPU/MEM denominators.

## Description
- Registry readers now check the slot owner's PID and demote dead `Active` slots to `Stale` on first read (generation-checked), so a SIGKILLed runtime drops out of `msb metrics` and collector exports immediately instead of showing as running until slot pressure forces a reclaim.
- `LiveMetric` carries the observed slot state, and the Rust SDK adds `SandboxMetricsReport` / `SandboxMetricsState`: registry rows joined with the catalog's active config, so CPU and memory denominators follow `msb modify` live resizes instead of the boot-time spec stamped into the slot.
- The CLI table gains a `STATE` column, renders CPU as cores busy over allocation (`0.80 / 2c`), and shows disk/network as per-second rates from two samples (the one-shot form samples twice ~500ms apart so it matches a watch frame).
- `msb metrics <name>` now answers in any state instead of presenting an exited sandbox's frozen sample as live, and `--all` opts exited sandboxes (preserved terminal totals) into the fleet view.
- New flags: `-w/--watch` (in-place refresh, Ctrl-C to quit), `-f/--follow` (JSON Lines, one object per sandbox per tick), `--interval` (default 1s), `-a/--all`, `--sort name|cpu|mem`. JSON output keeps cumulative counters and adds `state` and `cpus` fields.
- Docs: rewritten `msb metrics` CLI reference, Rust report API on the SDK metrics page, dead-owner demotion note in the observability deep-dive, and a changelog entry.

```bash
msb metrics                          # one-shot table: running + stalled
msb metrics --watch --interval 500ms # docker stats style live view
msb metrics --follow | jq .cpu_percent
msb metrics --all --sort mem         # include recently exited sandboxes
msb metrics my-app --format json     # single sandbox, any state
```

```rust
use microsandbox::{all_sandbox_metrics_reports_local, sandbox_metrics_report_local};

let reports = all_sandbox_metrics_reports_local(&local, /* include_exited */ false).await?;
for r in &reports {
    println!("{} [{:?}] {:.2} cores of {:?}", r.name, r.state, r.metrics.cpu_percent / 100.0, r.cpus);
}

// Answers for exited sandboxes too, unlike Sandbox::metrics().
let report = sandbox_metrics_report_local(&local, "my-app").await?;
```

## Test Plan
- [x] `cargo check --workspace` exits 0
- [x] `cargo test -p microsandbox-metrics` passes (19 tests, including new dead-owner demotion and slot-state tests)
- [x] `cargo test -p microsandbox-cli --lib metrics` passes (interval parsing, CPU formatting, rate tracker)
- [x] `cargo clippy -p microsandbox-metrics -p microsandbox -p microsandbox-cli` is clean
- [x] `msb metrics --watch` against a live sandbox, kill -9 the runtime, sandbox drops out of the live view and shows `exited` under `--all`
- [ ] full CI suite (runs in CI)
