### PR TITLE
feat(cli): show resource allocations in msb ps

### DIFF
--- a/crates/cli/lib/commands/ps.rs
+++ b/crates/cli/lib/commands/ps.rs
@@ -39,6 +39,8 @@ struct StatusRow {
     name: String,
     image: String,
     command: String,
+    cpus: String,
+    mem: String,
     status: String,
     ports: String,
 }
@@ -85,12 +87,14 @@ pub async fn run(args: PsArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let mut table = ui::Table::new(&["NAME", "IMAGE", "COMMAND", "STATUS", "PORTS"]);
+    let mut table = ui::Table::new(&["NAME", "IMAGE", "COMMAND", "CPUS", "MEM", "STATUS", "PORTS"]);
     for row in handles.iter().map(status_row) {
         table.add_row(vec![
             row.name,
             row.image,
             row.command,
+            row.cpus,
+            row.mem,
             row.status,
             row.ports,
         ]);
@@ -130,11 +134,18 @@ fn status_row(handle: &SandboxHandle) -> StatusRow {
         .map(format_ports)
         .unwrap_or_else(|| "-".to_string());
     let status = format!("{:?}", handle.status_snapshot());
+    let resources = resource_config(handle, config.as_ref());
+    let (cpus, mem) = resources
+        .as_ref()
+        .map(format_resources)
+        .unwrap_or_else(|| ("-".to_string(), "-".to_string()));
 
     StatusRow {
         name: handle.name().to_string(),
         image,
         command,
+        cpus,
+        mem,
         status: ui::format_status(&status),
         ports,
     }
@@ -143,14 +154,59 @@ fn status_row(handle: &SandboxHandle) -> StatusRow {
 fn status_json(handle: &SandboxHandle) -> serde_json::Value {
     let config = serde_json::from_str::<SandboxConfig>(handle.config_json()).ok();
     let status = format!("{:?}", handle.status_snapshot());
+    let resources = resource_config(handle, config.as_ref());
+    let resources = resources.as_ref().map(|c| &c.spec.resources);
 
     serde_json::json!({
         "name": handle.name(),
         "status": status,
         "image": config.as_ref().map(extract_image_raw).unwrap_or_else(|| "-".to_string()),
         "command": config.as_ref().map(format_command_raw).unwrap_or_else(|| "-".to_string()),
+        "cpus": resources.map(|r| r.cpus),
+        "max_cpus": resources.map(|r| r.max_cpus.max(r.cpus)),
+        "memory_mib": resources.map(|r| r.memory_mib),
+        "max_memory_mib": resources.map(|r| r.max_memory_mib.max(r.memory_mib)),
         "ports": config.as_ref().map(format_ports_raw).unwrap_or_default(),
     })
+}
+
+/// Resolve the config whose resource allocations describe the sandbox now:
+/// the active-config snapshot for running sandboxes (tracks live resizes),
+/// falling back to the desired config.
+fn resource_config(
+    handle: &SandboxHandle,
+    desired: Option<&SandboxConfig>,
+) -> Option<SandboxConfig> {
+    handle
+        .active_config()
+        .ok()
+        .flatten()
+        .or_else(|| desired.cloned())
+}
+
+/// Render `(CPUS, MEM)` cells as `effective / max`, where max is the boot-time
+/// hotplug ceiling — the headroom available to a live resize.
+fn format_resources(config: &SandboxConfig) -> (String, String) {
+    let resources = &config.spec.resources;
+    let cpus = format!(
+        "{} / {}",
+        resources.cpus,
+        resources.max_cpus.max(resources.cpus)
+    );
+    let mem = format!(
+        "{} / {}",
+        format_mem_mib(resources.memory_mib),
+        format_mem_mib(resources.max_memory_mib.max(resources.memory_mib)),
+    );
+    (cpus, mem)
+}
+
+fn format_mem_mib(mib: u32) -> String {
+    if mib >= 1024 && mib.is_multiple_of(1024) {
+        format!("{} GiB", mib / 1024)
+    } else {
+        format!("{mib} MiB")
+    }
 }
 
 fn extract_image(config: &SandboxConfig) -> String {

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -385,6 +385,8 @@ msb ps --format json      # JSON output
 | `--format` | Output format (`json`) |
 | `-q`, `--quiet` | Show only sandbox names |
 
+The `CPUS` and `MEM` columns show the sandbox's allocation as `effective / max`, where max is the boot-time hotplug ceiling — the headroom available to a [live resize](/cli/sandbox-commands#msb-modify). Values come from the active config for running sandboxes (so an accepted `msb modify` shows immediately) and from the stored config for stopped ones. For *usage* rather than allocation, see [`msb metrics`](/cli/sandbox-commands#msb-metrics).
+
 ## msb metrics
 
 Show live CPU, memory, disk, network, and optional upper disk metrics for running sandboxes.


### PR DESCRIPTION
## TL;DR
`msb ps` now shows each sandbox's CPU and memory allocation as `effective / max`, so you can see at a glance what a sandbox has and how much live-resize headroom is left.

## Description
- Adds `CPUS` and `MEM` columns to the `msb ps` / `msb status` table, rendered as `effective / max` where max is the boot-time hotplug ceiling.
- Values resolve from the active config for running sandboxes, so an accepted `msb modify --cpus/--memory` shows on the next `ps`; stopped sandboxes fall back to the stored config.
- `--format json` gains `cpus`, `max_cpus`, `memory_mib`, and `max_memory_mib` fields.
- Usage stays out of `ps` on purpose: allocation is catalog truth and free to read, while usage lives in `msb metrics` behind a sampling wait.
- Documents the new columns in the CLI reference.

```bash
$ msb ps
NAME       IMAGE     COMMAND      CPUS     MEM                  STATUS     PORTS
pstest     alpine    "/bin/sh"    1 / 4    512 MiB / 2 GiB      running    -

$ msb modify pstest --cpus 2 --memory 1G && msb ps
NAME       IMAGE     COMMAND      CPUS     MEM                  STATUS     PORTS
pstest     alpine    "/bin/sh"    2 / 4    1 GiB / 2 GiB        running    -
```

## Test Plan
- [x] `cargo build -p microsandbox-cli` exits 0
- [x] `cargo test -p microsandbox-cli --lib` passes (217 tests)
- [x] `cargo clippy -p microsandbox-cli` is clean
- [x] `cargo +stable fmt --all -- --check` is clean
- [x] Manual: booted an alpine sandbox with `--max-cpus 4 --max-memory 2G`, confirmed `1 / 4` and `512 MiB / 2 GiB` in `msb ps`, live-resized with `msb modify --cpus 2 --memory 1G`, confirmed columns flipped to `2 / 4` and `1 GiB / 2 GiB`
- [x] Manual: `msb ps pstest --format json` includes the four new allocation fields