### PR TITLE
build(deps): bump msb_krun crates to 0.1.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "174a6af36603e7b8ca43a4cd9be454788f105087d9814e8cac40c99b9a9cb662"
+checksum = "1b9458681a824744f5151c3ab376edb77ae159696fa6bfe9654bacf0091adb00"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3591,9 +3591,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0026b8b432fd99568721f32c7862541fd42af6d3528173757b3296eceadba5"
+checksum = "418bd6efec30b38b1b82b9393ff1200a782e8e7a656ce79b9a6b0edcc867a55e"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3606,15 +3606,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14896360633cf317b2af2341855d07fba875fb427685bb76462897f7e445cab"
+checksum = "9c6d3e765e4a117975d53ab363109eef3b1ab63e0ed663ddf0315ecbfa0772a0"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0664861e8f2c2a29a6a4bb637621b4f125bafae9a8ede18ccd08b02ef7a6d84"
+checksum = "946ce25cc75945412c68704e27807ccd77d5e7e95894cf8120460800d6b6b3b3"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3623,9 +3623,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1aebd9a391e642ab935444b40a1db92f476481ad9754bd7123eddc4482f582b"
+checksum = "6c3875773ad80ecadb52d35c7f31fd9d53c583e2afe9059edd108d58cf734e57"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3653,9 +3653,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a41d094d6716046697c72a1b47825742a2550bb14ea9c4f4dd8ac58a006d058"
+checksum = "95ee0eec747f8a8773a94b1d8e8c168958f19fe92ee2181cc626211126d268c4"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -3665,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d628eafcc1ae7b73f1126793e753b247e5978c68c44bed43fc4c930476a9d7"
+checksum = "1843eeafd6896b5763cf35f31bb172494cbf41b83f4845129b0ccfc15d86453e"
 dependencies = [
  "msb_krun_utils",
  "vm-memory",
@@ -3675,9 +3675,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c828985916e1000b19e04671663a5e39d556bd9f39706a436260c995d0532f"
+checksum = "59180729455df2db92a57de39974cf7608519dbc85181684979752da3999c222"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3685,18 +3685,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8244cc8daa7f0e86f25232700e5a3a79244388b6b96b31145992f07f785556"
+checksum = "49d6bde053acede288b3529c282b3087053e203180692199c85d8431b27a988e"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc49096b2cd62e1e591a79c9e7c78676146e719c5b45d5990f413c1f791169e"
+checksum = "21d28debd96b2ede1152eb3db67ba28b62f340e91521cde7f8501a769c562183"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3710,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e81a83e198c05fea7bdcfba857f7d644af8e3fb2afc3a9baea9998ff97f53ca"
+checksum = "1baa2e71e66a699210fa9f862de496e941d473c49ad59b445a3670035ad250e5"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,8 @@ microsandbox-network = { version = "=0.6.3", path = "crates/network" }
 microsandbox-protocol = { version = "=0.6.3", path = "crates/protocol" }
 microsandbox-runtime = { version = "=0.6.3", path = "crates/runtime", default-features = false }
 microsandbox-utils = { version = "=0.6.3", path = "crates/utils" }
-msb_krun = "=0.1.21"
-msb_krun_utils = "=0.1.21"
+msb_krun = "=0.1.22"
+msb_krun_utils = "=0.1.22"
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }
 


### PR DESCRIPTION
## TL;DR
Pin msb_krun and msb_krun_utils to 0.1.22 so the next release carries the WHP fixes from libkrun #79 and #80. Needs to land before the 0.6.4 release in #1102 is cut, otherwise Windows users stay on the broken 0.1.21 bits.

## Description
- Bumps the `=0.1.21` pins to `=0.1.22` and refreshes the lockfile (11 family crates resolve at 0.1.22).
- What 0.1.22 brings on Windows: application processors start via INIT/SIPI so multi-vCPU guests actually boot, device interrupts follow the guest-programmed IOAPIC routing, guest CPUID is normalized so boot no longer depends on the host CPU or Windows build, and the PIT ticks at the guest-programmed rate. Candidate fix for the boot failures in #1092.
- Verified on the Azure WHP box before publish: 1/2/4-vCPU alpine boots with all CPUs online, SMP bring-up in ~12 ms, per-vCPU APIC IDs, exact sleep timing.

## Test Plan
- [x] `cargo check -p microsandbox-runtime` against the published crates exits 0
- [x] pre-commit suite (fmt, clippy, doc, msb build) passed on commit
- [ ] full Windows box run against a release build of this pin (covered by the libkrun-side verification of identical sources)