### PR TITLE
feat(snapshot): finalize descriptor and api contract

### DIFF
--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -18,17 +18,20 @@ use crate::ui;
 pub struct RunArgs {
     /// Image to use (e.g. alpine, python, ./rootfs, ./disk.qcow2).
     ///
-    /// Mutually exclusive with `--snapshot`; one of the two is required.
-    #[arg(required_unless_present = "snapshot", conflicts_with = "snapshot")]
+    /// Mutually exclusive with `--from-snapshot`; one of the two is required.
+    #[arg(
+        required_unless_present = "from_snapshot",
+        conflicts_with = "from_snapshot"
+    )]
     pub image: Option<String>,
 
     /// Boot a fresh sandbox from a snapshot artifact (path or name).
     ///
-    /// The snapshot pins the image; passing `--snapshot` is equivalent
+    /// The snapshot pins the image; passing `--from-snapshot` is equivalent
     /// to specifying the snapshot's image plus pre-populating the
     /// upper layer from the artifact.
-    #[arg(long, value_name = "PATH_OR_NAME")]
-    pub snapshot: Option<String>,
+    #[arg(long = "from-snapshot", value_name = "PATH_OR_NAME")]
+    pub from_snapshot: Option<String>,
 
     /// Start the sandbox in the background and print its name.
     ///
@@ -162,12 +165,12 @@ async fn run_new(
     log_level: Option<microsandbox::LogLevel>,
 ) -> anyhow::Result<()> {
     let mut builder = Sandbox::builder(&name);
-    if let Some(ref snap) = args.snapshot {
+    if let Some(ref snap) = args.from_snapshot {
         builder = builder.from_snapshot(snap.clone());
     } else if let Some(ref image) = args.image {
         builder = builder.image(image.as_str());
     } else {
-        anyhow::bail!("either an image or --snapshot is required");
+        anyhow::bail!("either an image or --from-snapshot is required");
     }
     if args.sandbox.log_level.is_none()
         && let Some(log_level) = log_level
@@ -197,7 +200,7 @@ async fn run_new(
     };
 
     let display_label = args
-        .snapshot
+        .from_snapshot
         .clone()
         .or_else(|| args.image.clone())
         .unwrap_or_else(|| name.clone());
@@ -337,9 +340,12 @@ fn handle_exit(exit_code: i32) -> anyhow::Result<()> {
 /// Describe creation-only inputs that are ignored when reusing an
 /// existing named sandbox.
 fn ignored_existing_inputs(args: &RunArgs) -> Option<&'static str> {
-    match (args.snapshot.is_some(), args.sandbox.has_creation_flags()) {
-        (true, true) => Some("--snapshot and creation flags"),
-        (true, false) => Some("--snapshot"),
+    match (
+        args.from_snapshot.is_some(),
+        args.sandbox.has_creation_flags(),
+    ) {
+        (true, true) => Some("--from-snapshot and creation flags"),
+        (true, false) => Some("--from-snapshot"),
         (false, true) => Some("creation flags"),
         (false, false) => None,
     }
@@ -418,18 +424,25 @@ mod tests {
 
     #[test]
     fn existing_reuse_warns_for_snapshot() {
-        let args = parse_run_args(&["--name", "box", "--detach", "--snapshot", "clean"]);
+        let args = parse_run_args(&["--name", "box", "--detach", "--from-snapshot", "clean"]);
 
-        assert_eq!(ignored_existing_inputs(&args), Some("--snapshot"));
+        assert_eq!(ignored_existing_inputs(&args), Some("--from-snapshot"));
     }
 
     #[test]
     fn existing_reuse_warns_for_snapshot_and_creation_flags() {
-        let args = parse_run_args(&["--name", "box", "--memory", "1G", "--snapshot", "clean"]);
+        let args = parse_run_args(&[
+            "--name",
+            "box",
+            "--memory",
+            "1G",
+            "--from-snapshot",
+            "clean",
+        ]);
 
         assert_eq!(
             ignored_existing_inputs(&args),
-            Some("--snapshot and creation flags")
+            Some("--from-snapshot and creation flags")
         );
     }
 }

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -30,7 +30,11 @@ pub struct RunArgs {
     /// The snapshot pins the image; passing `--from-snapshot` is equivalent
     /// to specifying the snapshot's image plus pre-populating the
     /// upper layer from the artifact.
-    #[arg(long = "from-snapshot", value_name = "PATH_OR_NAME")]
+    #[arg(
+        long = "from-snapshot",
+        alias = "from-snap",
+        value_name = "PATH_OR_NAME"
+    )]
     pub from_snapshot: Option<String>,
 
     /// Start the sandbox in the background and print its name.
@@ -427,6 +431,25 @@ mod tests {
         let args = parse_run_args(&["--name", "box", "--detach", "--from-snapshot", "clean"]);
 
         assert_eq!(ignored_existing_inputs(&args), Some("--from-snapshot"));
+    }
+
+    #[test]
+    fn from_snap_is_an_alias_for_from_snapshot() {
+        let args = parse_run_args(&["--name", "box", "--from-snap", "clean"]);
+
+        assert_eq!(args.from_snapshot.as_deref(), Some("clean"));
+    }
+
+    #[test]
+    fn from_snap_alias_is_hidden_from_help() {
+        let mut help = Vec::new();
+        <TestCli as clap::CommandFactory>::command()
+            .write_long_help(&mut help)
+            .unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(help.contains("--from-snapshot"));
+        assert!(!help.contains("--from-snap "));
     }
 
     #[test]

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -2464,11 +2464,9 @@ mod tests {
         .unwrap();
         Migrator::up(db.inner(), None).await.unwrap();
 
-        // Three steps: the two latest migrations (root disk, bind rootfs shape)
-        // have no-op downs; `snapshot_index.scope` sits directly below them.
-        // Roll back through all three so the newest observable schema change
-        // (the scope column) is undone while everything older stays intact.
-        rollback_schema(db.inner(), 3).await.unwrap();
+        // The scope migration is the latest; one step must drop the column
+        // while everything older (including root disk) stays intact.
+        rollback_schema(db.inner(), 1).await.unwrap();
 
         let columns = db
             .query_all(Statement::from_string(

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -2465,25 +2465,27 @@ mod tests {
         Migrator::up(db.inner(), None).await.unwrap();
 
         // Three steps: the two latest migrations (root disk, bind rootfs shape)
-        // have no-op downs; `sandbox.active_config` sits below them. Roll back
-        // through all three so the observable schema change (the column) is undone.
+        // have no-op downs; `snapshot_index.scope` sits directly below them.
+        // Roll back through all three so the newest observable schema change
+        // (the scope column) is undone while everything older stays intact.
         rollback_schema(db.inner(), 3).await.unwrap();
 
-        // Rolling back through the active_config migration must drop the column
-        // while leaving older tables intact.
+        let columns = db
+            .query_all(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                "PRAGMA table_info(snapshot_index)",
+            ))
+            .await
+            .unwrap();
+        let has_scope = columns
+            .iter()
+            .any(|row| row.try_get_by_index::<String>(1).unwrap() == "scope");
+        assert!(!has_scope);
+
         let rows = db
             .query_all(Statement::from_string(
                 DatabaseBackend::Sqlite,
                 "SELECT name FROM pragma_table_info('sandbox') WHERE name = 'active_config'",
-            ))
-            .await
-            .unwrap();
-        assert!(rows.is_empty());
-
-        let rows = db
-            .query_all(Statement::from_string(
-                DatabaseBackend::Sqlite,
-                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'maintenance_lease'",
             ))
             .await
             .unwrap();

--- a/crates/cli/lib/commands/snapshot.rs
+++ b/crates/cli/lib/commands/snapshot.rs
@@ -310,6 +310,16 @@ async fn inspect(args: SnapshotInspectArgs) -> anyhow::Result<()> {
     ui::detail_kv("Upper File", &m.upper.file);
     ui::detail_kv("Upper Size", &format_size(m.upper.size_bytes));
     ui::detail_kv("Integrity", &format_integrity(m.upper.integrity.as_ref()));
+    if !m.requires.is_empty() {
+        ui::detail_kv("Requires", &m.requires.join(", "));
+        let unsupported = m.unsupported_requires();
+        if !unsupported.is_empty() {
+            ui::detail_kv(
+                "Restore",
+                &format!("blocked: needs {}", unsupported.join(", ")),
+            );
+        }
+    }
     if args.verify {
         let report = snap.verify().await?;
         ui::detail_kv("Verification", &format_verify_status(&report.upper));

--- a/crates/cli/lib/commands/snapshot.rs
+++ b/crates/cli/lib/commands/snapshot.rs
@@ -1,7 +1,7 @@
 //! `msb snapshot` command — manage disk snapshots.
 
 use clap::{Args, Subcommand};
-use microsandbox::{Snapshot, SnapshotDestination};
+use microsandbox::Snapshot;
 
 use crate::ui;
 
@@ -40,23 +40,28 @@ pub enum SnapshotCommands {
     /// Rebuild the local index from artifacts on disk.
     Reindex(SnapshotReindexArgs),
 
-    /// Bundle a snapshot into a `.tar.zst` archive.
-    Export(SnapshotExportArgs),
+    /// Save a snapshot into a `.tar.zst` archive.
+    Save(SnapshotSaveArgs),
 
-    /// Unpack a snapshot archive into the snapshots directory.
-    Import(SnapshotImportArgs),
+    /// Load a snapshot archive into the snapshots directory.
+    Load(SnapshotLoadArgs),
 }
 
 /// Arguments for `msb snapshot create`.
 #[derive(Debug, Args)]
 pub struct SnapshotCreateArgs {
-    /// Destination — bare name (resolved under `~/.microsandbox/snapshots/`)
-    /// or an explicit path to an artifact directory.
-    pub destination: String,
+    /// Snapshot name, resolved under `~/.microsandbox/snapshots/<name>/`
+    /// (or under `--dest-dir` when given).
+    pub name: String,
 
     /// Source sandbox name. Must be stopped (or crashed).
     #[arg(long, value_name = "SANDBOX")]
     pub from: String,
+
+    /// Parent directory to create the artifact in, instead of the
+    /// default snapshots directory. The artifact lands at `DIR/<name>`.
+    #[arg(long = "dest-dir", value_name = "DIR")]
+    pub dest_dir: Option<std::path::PathBuf>,
 
     /// Add a `key=value` label. May be repeated.
     #[arg(long = "label", value_name = "K=V")]
@@ -69,6 +74,14 @@ pub struct SnapshotCreateArgs {
     /// Compute and record content integrity while creating the snapshot.
     #[arg(long)]
     pub integrity: bool,
+
+    /// Request a resumable snapshot with memory/device state.
+    ///
+    /// This flag is reserved by the public contract. Current runtimes
+    /// return an unsupported-feature error instead of creating a
+    /// misleading disk-only artifact.
+    #[arg(long)]
+    pub resumable: bool,
 
     /// Suppress output.
     #[arg(short, long)]
@@ -128,10 +141,10 @@ pub struct SnapshotReindexArgs {
     pub dir: Option<std::path::PathBuf>,
 }
 
-/// Arguments for `msb snapshot export`.
+/// Arguments for `msb snapshot save`.
 #[derive(Debug, Args)]
-pub struct SnapshotExportArgs {
-    /// Snapshot to export (path, name, or digest).
+pub struct SnapshotSaveArgs {
+    /// Snapshot to save (path, name, or digest).
     pub snapshot: String,
 
     /// Output archive path (`.tar.zst` recommended).
@@ -152,9 +165,9 @@ pub struct SnapshotExportArgs {
     pub plain_tar: bool,
 }
 
-/// Arguments for `msb snapshot import`.
+/// Arguments for `msb snapshot load`.
 #[derive(Debug, Args)]
-pub struct SnapshotImportArgs {
+pub struct SnapshotLoadArgs {
     /// Archive to unpack.
     pub archive: std::path::PathBuf,
 
@@ -175,15 +188,16 @@ pub async fn run(args: SnapshotArgs) -> anyhow::Result<()> {
         SnapshotCommands::Verify(args) => verify(args).await,
         SnapshotCommands::Remove(args) => remove(args).await,
         SnapshotCommands::Reindex(args) => reindex(args).await,
-        SnapshotCommands::Export(args) => export(args).await,
-        SnapshotCommands::Import(args) => import(args).await,
+        SnapshotCommands::Save(args) => save(args).await,
+        SnapshotCommands::Load(args) => load(args).await,
     }
 }
 
 async fn create(args: SnapshotCreateArgs) -> anyhow::Result<()> {
-    let dest = parse_destination(&args.destination)?;
-
-    let mut builder = Snapshot::builder(&args.from).destination(dest);
+    let mut builder = Snapshot::builder(&args.name).from_sandbox(&args.from);
+    if let Some(ref dest_dir) = args.dest_dir {
+        builder = builder.dest_dir(dest_dir);
+    }
     for label in &args.labels {
         let (k, v) = label
             .split_once('=')
@@ -195,6 +209,9 @@ async fn create(args: SnapshotCreateArgs) -> anyhow::Result<()> {
     }
     if args.integrity {
         builder = builder.record_integrity();
+    }
+    if args.resumable {
+        builder = builder.resumable();
     }
 
     let spinner = if args.quiet {
@@ -229,8 +246,9 @@ async fn list(args: SnapshotListArgs) -> anyhow::Result<()> {
                 serde_json::json!({
                     "digest": s.digest(),
                     "name": s.name(),
-                    "image_ref": s.image_ref(),
                     "parent_digest": s.parent_digest(),
+                    "scope": format_scope(s.scope()),
+                    "image_ref": s.image_ref(),
                     "format": format_str(s.format()),
                     "size_bytes": s.size_bytes(),
                     "created_at": ui::format_json_datetime(&s.created_at().and_utc()),
@@ -254,7 +272,7 @@ async fn list(args: SnapshotListArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let mut table = ui::Table::new(&["NAME", "IMAGE", "SIZE", "CREATED", "DIGEST"]);
+    let mut table = ui::Table::new(&["NAME", "SCOPE", "IMAGE", "SIZE", "CREATED", "DIGEST"]);
     for s in &snapshots {
         let name = s.name().unwrap_or("-").to_string();
         let size = s
@@ -263,7 +281,14 @@ async fn list(args: SnapshotListArgs) -> anyhow::Result<()> {
             .unwrap_or_else(|| "-".to_string());
         let created = ui::format_datetime(&s.created_at().and_utc());
         let digest = short_digest(s.digest());
-        table.add_row(vec![name, s.image_ref().to_string(), size, created, digest]);
+        table.add_row(vec![
+            name,
+            format_scope(s.scope()).to_string(),
+            s.image_ref().to_string(),
+            size,
+            created,
+            digest,
+        ]);
     }
     table.print();
     Ok(())
@@ -277,6 +302,7 @@ async fn inspect(args: SnapshotInspectArgs) -> anyhow::Result<()> {
     ui::detail_kv("Path", &snap.path().display().to_string());
     ui::detail_kv("Image", &m.image.reference);
     ui::detail_kv("Image Manifest", &m.image.manifest_digest);
+    ui::detail_kv("Scope", format_scope(m.scope));
     ui::detail_kv("Format", format_str(snap.manifest().format));
     ui::detail_kv("Filesystem", &m.fstype);
     ui::detail_kv("Parent", m.parent.as_deref().unwrap_or("-"));
@@ -351,19 +377,19 @@ async fn reindex(args: SnapshotReindexArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn export(args: SnapshotExportArgs) -> anyhow::Result<()> {
-    let opts = microsandbox::snapshot::ExportOpts {
+async fn save(args: SnapshotSaveArgs) -> anyhow::Result<()> {
+    let opts = microsandbox::snapshot::SaveOpts {
         with_parents: args.with_parents,
         with_image: args.with_image,
         plain_tar: args.plain_tar,
     };
-    Snapshot::export(&args.snapshot, &args.out, opts).await?;
+    Snapshot::save(&args.snapshot, &args.out, opts).await?;
     println!("{}", args.out.display());
     Ok(())
 }
 
-async fn import(args: SnapshotImportArgs) -> anyhow::Result<()> {
-    let handle = Snapshot::import(&args.archive, args.dest.as_deref()).await?;
+async fn load(args: SnapshotLoadArgs) -> anyhow::Result<()> {
+    let handle = Snapshot::load(&args.archive, args.dest.as_deref()).await?;
     println!("{}", handle.digest());
     println!("{}", handle.path().display());
     Ok(())
@@ -373,21 +399,17 @@ async fn import(args: SnapshotImportArgs) -> anyhow::Result<()> {
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
-fn parse_destination(s: &str) -> anyhow::Result<SnapshotDestination> {
-    if s.is_empty() {
-        anyhow::bail!("destination must not be empty");
-    }
-    if s.contains('/') || s.starts_with('.') || s.starts_with('~') {
-        Ok(SnapshotDestination::Path(std::path::PathBuf::from(s)))
-    } else {
-        Ok(SnapshotDestination::Name(s.to_string()))
-    }
-}
-
 fn format_str(f: microsandbox::SnapshotFormat) -> &'static str {
     match f {
         microsandbox::SnapshotFormat::Raw => "raw",
         microsandbox::SnapshotFormat::Qcow2 => "qcow2",
+    }
+}
+
+fn format_scope(scope: microsandbox::SnapshotScope) -> &'static str {
+    match scope {
+        microsandbox::SnapshotScope::Disk => "disk",
+        microsandbox::SnapshotScope::Resumable => "resumable",
     }
 }
 
@@ -429,5 +451,86 @@ fn format_verify_status(status: &microsandbox::snapshot::UpperVerifyStatus) -> S
         microsandbox::snapshot::UpperVerifyStatus::Verified { algorithm, digest } => {
             format!("verified ({algorithm} {digest})")
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: SnapshotArgs,
+    }
+
+    fn parse_snapshot_args(args: &[&str]) -> SnapshotArgs {
+        TestCli::parse_from(std::iter::once("msb").chain(args.iter().copied())).args
+    }
+
+    #[test]
+    fn create_parses_resumable_contract_flag() {
+        let args = parse_snapshot_args(&["create", "clean", "--from", "box", "--resumable"]);
+        let SnapshotCommands::Create(args) = args.command else {
+            panic!("expected create command");
+        };
+        assert_eq!(args.name, "clean");
+        assert_eq!(args.from, "box");
+        assert!(args.resumable);
+    }
+
+    #[test]
+    fn create_parses_dest_dir() {
+        let args =
+            parse_snapshot_args(&["create", "clean", "--from", "box", "--dest-dir", "/mnt/big"]);
+        let SnapshotCommands::Create(args) = args.command else {
+            panic!("expected create command");
+        };
+        assert_eq!(
+            args.dest_dir.as_deref(),
+            Some(std::path::Path::new("/mnt/big"))
+        );
+    }
+
+    #[test]
+    fn reindex_parses_dir() {
+        let parsed = parse_snapshot_args(&["reindex", "/tmp/snaps"]);
+        let SnapshotCommands::Reindex(args) = parsed.command else {
+            panic!("expected reindex command");
+        };
+        assert_eq!(
+            args.dir.as_deref(),
+            Some(std::path::Path::new("/tmp/snaps"))
+        );
+    }
+
+    #[test]
+    fn save_parses_args() {
+        let parsed = parse_snapshot_args(&["save", "clean", "bundle.tar", "--plain-tar"]);
+        let SnapshotCommands::Save(args) = parsed.command else {
+            panic!("expected save command");
+        };
+        assert_eq!(args.snapshot, "clean");
+        assert_eq!(args.out, std::path::PathBuf::from("bundle.tar"));
+        assert!(args.plain_tar);
+    }
+
+    #[test]
+    fn load_parses_args() {
+        let parsed = parse_snapshot_args(&["load", "bundle.tar", "/tmp/snaps"]);
+        let SnapshotCommands::Load(args) = parsed.command else {
+            panic!("expected load command");
+        };
+        assert_eq!(args.archive, std::path::PathBuf::from("bundle.tar"));
+        assert_eq!(
+            args.dest.as_deref(),
+            Some(std::path::Path::new("/tmp/snaps"))
+        );
     }
 }

--- a/crates/db/lib/entity/snapshot.rs
+++ b/crates/db/lib/entity/snapshot.rs
@@ -1,7 +1,7 @@
 //! Entity definition for the `snapshot_index` table.
 //!
 //! This table is a local cache that mirrors snapshot artifacts on disk.
-//! The artifact (`manifest.json` + upper file) is the source of truth;
+//! The artifact (`snapshot.json` + upper file) is the source of truth;
 //! these rows exist for fast queries and parent-edge bookkeeping.
 
 use sea_orm::entity::prelude::*;
@@ -21,6 +21,8 @@ pub struct Model {
     pub name: Option<String>,
     /// Manifest digest of the parent snapshot, or NULL for a root.
     pub parent_digest: Option<String>,
+    /// Snapshot payload scope (`disk` today, `resumable` in the future).
+    pub scope: String,
     /// Human-readable image reference.
     pub image_ref: String,
     /// OCI manifest digest of the image.

--- a/crates/image/lib/snapshot/manifest.rs
+++ b/crates/image/lib/snapshot/manifest.rs
@@ -1,9 +1,9 @@
-//! Snapshot manifest schema and canonical (de)serialization.
+//! Snapshot descriptor schema and canonical (de)serialization.
 //!
-//! The manifest is the source of truth for a snapshot artifact. Its
-//! SHA-256 digest over the canonical byte form is the snapshot's
-//! identity. Canonical form means: no insignificant whitespace, struct
-//! fields in declaration order, map keys sorted, no fields elided.
+//! The descriptor (`snapshot.json`) is the source of truth for a snapshot
+//! artifact. Its SHA-256 digest over the canonical byte form is the
+//! snapshot's identity. Canonical form means: no insignificant whitespace,
+//! struct fields in declaration order, map keys sorted, no fields elided.
 
 use std::collections::BTreeMap;
 use std::path::{Component, Path};
@@ -17,12 +17,15 @@ use crate::error::{ImageError, ImageResult};
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-/// Current snapshot manifest schema version. Readers reject unknown
+/// Current snapshot descriptor schema version. Readers reject unknown
 /// schemas with a clear error.
 pub const SCHEMA_VERSION: u32 = 1;
 
-/// Canonical filename for the manifest inside an artifact directory.
-pub const MANIFEST_FILENAME: &str = "manifest.json";
+/// Canonical filename for the descriptor inside an artifact directory.
+pub const DESCRIPTOR_FILENAME: &str = "snapshot.json";
+
+/// Expected artifact kind for snapshot descriptors.
+pub const SNAPSHOT_ARTIFACT_KIND: &str = "snapshot";
 
 /// Default filename for the upper-layer file when format is `raw`.
 pub const DEFAULT_UPPER_FILE: &str = "upper.ext4";
@@ -45,6 +48,19 @@ pub enum SnapshotFormat {
     Raw,
     /// qcow2 with optional backing chain (future).
     Qcow2,
+}
+
+/// Snapshot payload scope.
+///
+/// Parsing accepts every known scope so older runtimes can still list and
+/// inspect artifacts they cannot restore; restore paths enforce support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SnapshotScope {
+    /// Disk-only snapshot. Captures the writable filesystem state.
+    Disk,
+    /// Resumable snapshot. Reserved for future memory/device-state capture.
+    Resumable,
 }
 
 /// Reference to the OCI image the snapshot was taken from.
@@ -73,7 +89,7 @@ pub struct UpperLayer {
     /// Optional content integrity descriptor.
     ///
     /// Local hot paths are allowed to leave this as `None`; explicit verify
-    /// and import/export boundaries use it when present.
+    /// and save/load boundaries use it when present.
     #[serde(deserialize_with = "deserialize_required_option")]
     pub integrity: Option<UpperIntegrity>,
 }
@@ -88,22 +104,26 @@ pub struct UpperIntegrity {
     pub digest: String,
 }
 
-/// Snapshot artifact manifest.
+/// Snapshot artifact descriptor.
 ///
 /// Field order matters: it determines the byte layout of the canonical
-/// form, and therefore the manifest digest. Do not reorder.
+/// form, and therefore the descriptor digest. Do not reorder.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Manifest {
-    /// Schema version of this manifest. Readers reject unknown values.
+    /// Schema version of this descriptor. Readers reject unknown values.
     pub schema: u32,
+    /// Artifact kind. Always `"snapshot"` for snapshot descriptors.
+    pub artifact: String,
+    /// Payload scope. Only disk snapshots are created and restored today.
+    pub scope: SnapshotScope,
     /// On-disk format of the upper layer.
     pub format: SnapshotFormat,
     /// Filesystem type inside the upper (e.g. `ext4`).
     pub fstype: String,
     /// Image the snapshot was taken from.
     pub image: ImageRef,
-    /// Manifest digest of the parent snapshot, or `null` for a root.
+    /// Descriptor digest of the parent snapshot, or `null` for a root.
     /// Always `null` today; populated once chained snapshots land.
     #[serde(deserialize_with = "deserialize_required_option")]
     pub parent: Option<String>,
@@ -123,25 +143,34 @@ pub struct Manifest {
 //--------------------------------------------------------------------------------------------------
 
 impl Manifest {
-    /// Validate basic invariants of a manifest.
+    /// Validate basic invariants of a descriptor.
     ///
     /// Called automatically by `from_bytes`; exposed for callers that
-    /// construct manifests programmatically.
+    /// construct descriptors programmatically. Scope is deliberately not
+    /// restricted here — validation answers "is this a well-formed snapshot
+    /// descriptor", while create/restore paths answer "can this runtime
+    /// handle it".
     pub fn validate(&self) -> ImageResult<()> {
         if self.schema != SCHEMA_VERSION {
             return Err(ImageError::ManifestParse(format!(
-                "snapshot manifest: unsupported schema version {} (expected {})",
+                "snapshot descriptor: unsupported schema version {} (expected {})",
                 self.schema, SCHEMA_VERSION
+            )));
+        }
+        if self.artifact != SNAPSHOT_ARTIFACT_KIND {
+            return Err(ImageError::ManifestParse(format!(
+                "snapshot descriptor: unsupported artifact kind {} (expected {})",
+                self.artifact, SNAPSHOT_ARTIFACT_KIND
             )));
         }
         if self.fstype.is_empty() {
             return Err(ImageError::ManifestParse(
-                "snapshot manifest: empty fstype".into(),
+                "snapshot descriptor: empty fstype".into(),
             ));
         }
         if self.image.reference.is_empty() {
             return Err(ImageError::ManifestParse(
-                "snapshot manifest: empty image.ref".into(),
+                "snapshot descriptor: empty image.ref".into(),
             ));
         }
         validate_digest_form(&self.image.manifest_digest, "image.manifest_digest")?;
@@ -150,14 +179,14 @@ impl Manifest {
         }
         if self.upper.file.is_empty() {
             return Err(ImageError::ManifestParse(
-                "snapshot manifest: empty upper.file".into(),
+                "snapshot descriptor: empty upper.file".into(),
             ));
         }
         validate_artifact_filename(&self.upper.file, "upper.file")?;
         if let Some(ref integrity) = self.upper.integrity {
             if integrity.algorithm.is_empty() {
                 return Err(ImageError::ManifestParse(
-                    "snapshot manifest: empty upper.integrity.algorithm".into(),
+                    "snapshot descriptor: empty upper.integrity.algorithm".into(),
                 ));
             }
             validate_digest_form(&integrity.digest, "upper.integrity.digest")?;
@@ -174,23 +203,23 @@ impl Manifest {
     /// - all fields present (no `skip_serializing_if`).
     pub fn to_canonical_bytes(&self) -> ImageResult<Vec<u8>> {
         serde_json::to_vec(self).map_err(|e| {
-            ImageError::ManifestParse(format!("snapshot manifest: serialize failed: {e}"))
+            ImageError::ManifestParse(format!("snapshot descriptor: serialize failed: {e}"))
         })
     }
 
-    /// Parse a manifest from canonical byte form.
+    /// Parse a descriptor from canonical byte form.
     ///
     /// Validates the schema version and required fields. Unknown fields
     /// are rejected so schema mistakes are surfaced immediately.
     pub fn from_bytes(bytes: &[u8]) -> ImageResult<Self> {
         let m: Manifest = serde_json::from_slice(bytes).map_err(|e| {
-            ImageError::ManifestParse(format!("snapshot manifest: parse failed: {e}"))
+            ImageError::ManifestParse(format!("snapshot descriptor: parse failed: {e}"))
         })?;
         m.validate()?;
         Ok(m)
     }
 
-    /// Compute this manifest's content digest (`sha256:hex`).
+    /// Compute this descriptor's content digest (`sha256:hex`).
     ///
     /// Hashes the canonical byte form. Stable across processes,
     /// platforms, and serde_json versions as long as the field set and
@@ -210,12 +239,12 @@ impl Manifest {
 fn validate_digest_form(s: &str, field: &str) -> ImageResult<()> {
     let (algo, hex) = s.split_once(':').ok_or_else(|| {
         ImageError::ManifestParse(format!(
-            "snapshot manifest: {field} is not a digest (missing ':'): {s}"
+            "snapshot descriptor: {field} is not a digest (missing ':'): {s}"
         ))
     })?;
     if algo.is_empty() || hex.is_empty() {
         return Err(ImageError::ManifestParse(format!(
-            "snapshot manifest: {field} has empty component: {s}"
+            "snapshot descriptor: {field} has empty component: {s}"
         )));
     }
     Ok(())
@@ -225,12 +254,12 @@ fn validate_artifact_filename(s: &str, field: &str) -> ImageResult<()> {
     let mut components = Path::new(s).components();
     let Some(Component::Normal(_)) = components.next() else {
         return Err(ImageError::ManifestParse(format!(
-            "snapshot manifest: {field} must be a relative artifact filename: {s}"
+            "snapshot descriptor: {field} must be a relative artifact filename: {s}"
         )));
     };
     if components.next().is_some() {
         return Err(ImageError::ManifestParse(format!(
-            "snapshot manifest: {field} must be a single artifact filename: {s}"
+            "snapshot descriptor: {field} must be a single artifact filename: {s}"
         )));
     }
     Ok(())
@@ -258,6 +287,8 @@ mod tests {
         labels.insert("owner".into(), "alice".into());
         Manifest {
             schema: SCHEMA_VERSION,
+            artifact: SNAPSHOT_ARTIFACT_KIND.into(),
+            scope: SnapshotScope::Disk,
             format: SnapshotFormat::Raw,
             fstype: "ext4".into(),
             image: ImageRef {
@@ -333,6 +364,31 @@ mod tests {
     }
 
     #[test]
+    fn rejects_unknown_artifact_kind() {
+        let mut m = sample_manifest();
+        m.artifact = "checkpoint".into();
+        let bytes = serde_json::to_vec(&m).unwrap();
+        let err = Manifest::from_bytes(&bytes).unwrap_err();
+        assert!(format!("{err}").contains("unsupported artifact kind"));
+    }
+
+    #[test]
+    fn rejects_descriptor_missing_artifact_and_scope() {
+        let bytes = br#"{"schema":1,"format":"raw","fstype":"ext4","image":{"ref":"docker.io/library/python:3.12","manifest_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"parent":null,"created_at":"2026-05-01T12:00:00Z","labels":{},"upper":{"file":"upper.ext4","size_bytes":4294967296,"integrity":null},"source_sandbox":null}"#;
+        let err = Manifest::from_bytes(bytes).unwrap_err();
+        assert!(format!("{err}").contains("missing field"));
+    }
+
+    #[test]
+    fn parses_resumable_scope() {
+        let mut m = sample_manifest();
+        m.scope = SnapshotScope::Resumable;
+        let bytes = m.to_canonical_bytes().unwrap();
+        let parsed = Manifest::from_bytes(&bytes).unwrap();
+        assert_eq!(parsed.scope, SnapshotScope::Resumable);
+    }
+
+    #[test]
     fn rejects_invalid_digest_form() {
         let mut m = sample_manifest();
         m.image.manifest_digest = "not-a-digest".into();
@@ -382,14 +438,14 @@ mod tests {
 
     #[test]
     fn rejects_missing_integrity_field() {
-        let bytes = br#"{"schema":1,"format":"raw","fstype":"ext4","image":{"ref":"docker.io/library/python:3.12","manifest_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"parent":null,"created_at":"2026-05-01T12:00:00Z","labels":{},"upper":{"file":"upper.ext4","size_bytes":4294967296},"source_sandbox":null}"#;
+        let bytes = br#"{"schema":1,"artifact":"snapshot","scope":"disk","format":"raw","fstype":"ext4","image":{"ref":"docker.io/library/python:3.12","manifest_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"parent":null,"created_at":"2026-05-01T12:00:00Z","labels":{},"upper":{"file":"upper.ext4","size_bytes":4294967296},"source_sandbox":null}"#;
         let err = Manifest::from_bytes(bytes).unwrap_err();
         assert!(format!("{err}").contains("integrity"));
     }
 
     #[test]
     fn rejects_legacy_upper_sha256_field() {
-        let bytes = br#"{"schema":1,"format":"raw","fstype":"ext4","image":{"ref":"docker.io/library/python:3.12","manifest_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"parent":null,"created_at":"2026-05-01T12:00:00Z","labels":{},"upper":{"file":"upper.ext4","size_bytes":4294967296,"sha256":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"source_sandbox":null}"#;
+        let bytes = br#"{"schema":1,"artifact":"snapshot","scope":"disk","format":"raw","fstype":"ext4","image":{"ref":"docker.io/library/python:3.12","manifest_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"parent":null,"created_at":"2026-05-01T12:00:00Z","labels":{},"upper":{"file":"upper.ext4","size_bytes":4294967296,"sha256":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"source_sandbox":null}"#;
         let err = Manifest::from_bytes(bytes).unwrap_err();
         assert!(format!("{err}").contains("sha256"));
     }
@@ -400,10 +456,14 @@ mod tests {
         let bytes = m.to_canonical_bytes().unwrap();
         let s = std::str::from_utf8(&bytes).unwrap();
         let schema_pos = s.find("\"schema\"").unwrap();
+        let artifact_pos = s.find("\"artifact\"").unwrap();
+        let scope_pos = s.find("\"scope\"").unwrap();
         let format_pos = s.find("\"format\"").unwrap();
         let upper_pos = s.find("\"upper\"").unwrap();
         let source_pos = s.find("\"source_sandbox\"").unwrap();
-        assert!(schema_pos < format_pos);
+        assert!(schema_pos < artifact_pos);
+        assert!(artifact_pos < scope_pos);
+        assert!(scope_pos < format_pos);
         assert!(format_pos < upper_pos);
         assert!(upper_pos < source_pos);
     }

--- a/crates/image/lib/snapshot/manifest.rs
+++ b/crates/image/lib/snapshot/manifest.rs
@@ -33,6 +33,10 @@ pub const DEFAULT_UPPER_FILE: &str = "upper.ext4";
 /// Sparse representation-aware digest for raw upper files.
 pub const SPARSE_SHA256_V1: &str = "msb-sparse-sha256-v1";
 
+/// Extension keys this runtime understands (see [`Manifest::requires`]).
+/// Empty today; resumable-era capabilities register here as they land.
+pub const SUPPORTED_REQUIRES: &[&str] = &[];
+
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
@@ -136,6 +140,15 @@ pub struct Manifest {
     /// Best-effort name of the source sandbox (informational).
     #[serde(deserialize_with = "deserialize_required_option")]
     pub source_sandbox: Option<String>,
+    /// Namespaced additive data. Readers must tolerate keys they do not
+    /// recognize and may ignore them; load-bearing keys are named in
+    /// `requires`. This is how schema 1 evolves without breaking parsers.
+    pub extensions: BTreeMap<String, serde_json::Value>,
+    /// Extension keys a reader must understand to restore or start from
+    /// this snapshot. Readers that do not recognize a listed key must
+    /// refuse restore with a clear error but may still list and inspect
+    /// the artifact. Sorted and unique in canonical form.
+    pub requires: Vec<String>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -191,7 +204,37 @@ impl Manifest {
             }
             validate_digest_form(&integrity.digest, "upper.integrity.digest")?;
         }
+        let mut prev: Option<&str> = None;
+        for key in &self.requires {
+            if key.is_empty() {
+                return Err(ImageError::ManifestParse(
+                    "snapshot descriptor: empty requires entry".into(),
+                ));
+            }
+            if !self.extensions.contains_key(key) {
+                return Err(ImageError::ManifestParse(format!(
+                    "snapshot descriptor: requires names '{key}' but extensions has no such key"
+                )));
+            }
+            if prev.is_some_and(|p| p >= key.as_str()) {
+                return Err(ImageError::ManifestParse(format!(
+                    "snapshot descriptor: requires must be sorted and unique (at '{key}')"
+                )));
+            }
+            prev = Some(key);
+        }
         Ok(())
+    }
+
+    /// Extension keys named in `requires` that this runtime does not
+    /// understand. Non-empty means the artifact can be listed and
+    /// inspected but must not be restored or booted from.
+    pub fn unsupported_requires(&self) -> Vec<&str> {
+        self.requires
+            .iter()
+            .map(String::as_str)
+            .filter(|k| !SUPPORTED_REQUIRES.contains(k))
+            .collect()
     }
 
     /// Serialize to the canonical byte form used for digest computation.
@@ -310,6 +353,8 @@ mod tests {
                 }),
             },
             source_sandbox: Some("build-1".into()),
+            extensions: BTreeMap::new(),
+            requires: Vec::new(),
         }
     }
 
@@ -461,10 +506,73 @@ mod tests {
         let format_pos = s.find("\"format\"").unwrap();
         let upper_pos = s.find("\"upper\"").unwrap();
         let source_pos = s.find("\"source_sandbox\"").unwrap();
+        let extensions_pos = s.find("\"extensions\"").unwrap();
+        let requires_pos = s.find("\"requires\"").unwrap();
         assert!(schema_pos < artifact_pos);
         assert!(artifact_pos < scope_pos);
         assert!(scope_pos < format_pos);
         assert!(format_pos < upper_pos);
         assert!(upper_pos < source_pos);
+        assert!(source_pos < extensions_pos);
+        assert!(extensions_pos < requires_pos);
+    }
+
+    #[test]
+    fn extensions_round_trip_and_may_be_ignored() {
+        let mut m = sample_manifest();
+        m.extensions
+            .insert("msb.example/1".into(), serde_json::json!({ "answer": 42 }));
+        let bytes = m.to_canonical_bytes().unwrap();
+        let parsed = Manifest::from_bytes(&bytes).unwrap();
+        assert_eq!(parsed.extensions["msb.example/1"]["answer"], 42);
+        assert!(parsed.unsupported_requires().is_empty());
+    }
+
+    #[test]
+    fn unknown_required_extension_blocks_restore_but_parses() {
+        let mut m = sample_manifest();
+        m.extensions
+            .insert("msb.future/1".into(), serde_json::json!({}));
+        m.requires.push("msb.future/1".into());
+        let bytes = m.to_canonical_bytes().unwrap();
+        let parsed = Manifest::from_bytes(&bytes).unwrap();
+        assert_eq!(parsed.unsupported_requires(), vec!["msb.future/1"]);
+    }
+
+    #[test]
+    fn rejects_require_without_extension() {
+        let mut m = sample_manifest();
+        m.requires.push("msb.future/1".into());
+        let bytes = serde_json::to_vec(&m).unwrap();
+        let err = Manifest::from_bytes(&bytes).unwrap_err();
+        assert!(format!("{err}").contains("no such key"));
+    }
+
+    #[test]
+    fn rejects_unsorted_or_duplicate_requires() {
+        let mut m = sample_manifest();
+        m.extensions.insert("msb.a/1".into(), serde_json::json!({}));
+        m.extensions.insert("msb.b/1".into(), serde_json::json!({}));
+        m.requires = vec!["msb.b/1".into(), "msb.a/1".into()];
+        let bytes = serde_json::to_vec(&m).unwrap();
+        let err = Manifest::from_bytes(&bytes).unwrap_err();
+        assert!(format!("{err}").contains("sorted and unique"));
+
+        m.requires = vec!["msb.a/1".into(), "msb.a/1".into()];
+        let bytes = serde_json::to_vec(&m).unwrap();
+        let err = Manifest::from_bytes(&bytes).unwrap_err();
+        assert!(format!("{err}").contains("sorted and unique"));
+    }
+
+    #[test]
+    fn descriptor_without_extensions_and_requires_is_rejected() {
+        let m = sample_manifest();
+        let mut v: serde_json::Value = serde_json::to_value(&m).unwrap();
+        let obj = v.as_object_mut().unwrap();
+        obj.remove("extensions");
+        obj.remove("requires");
+        let bytes = serde_json::to_vec(&v).unwrap();
+        let err = Manifest::from_bytes(&bytes).unwrap_err();
+        assert!(format!("{err}").contains("missing field"));
     }
 }

--- a/crates/image/lib/snapshot/mod.rs
+++ b/crates/image/lib/snapshot/mod.rs
@@ -5,7 +5,8 @@
 //! lower (image) it was taken from. The artifact is the source of truth;
 //! databases are caches.
 //!
-//! See `planning/microsandbox/implementation/snapshots.md` for the full design.
+//! See `planning/microsandbox/implementation/snapshot-api-resumable-cloning.md`
+//! for the full design.
 
 pub mod manifest;
 
@@ -14,6 +15,7 @@ pub mod manifest;
 //--------------------------------------------------------------------------------------------------
 
 pub use manifest::{
-    DEFAULT_UPPER_FILE, ImageRef, MANIFEST_FILENAME, Manifest, SCHEMA_VERSION, SPARSE_SHA256_V1,
-    SnapshotFormat, UpperIntegrity, UpperLayer,
+    DEFAULT_UPPER_FILE, DESCRIPTOR_FILENAME, ImageRef, Manifest, SCHEMA_VERSION,
+    SNAPSHOT_ARTIFACT_KIND, SPARSE_SHA256_V1, SnapshotFormat, SnapshotScope, UpperIntegrity,
+    UpperLayer,
 };

--- a/crates/image/lib/snapshot/mod.rs
+++ b/crates/image/lib/snapshot/mod.rs
@@ -16,6 +16,6 @@ pub mod manifest;
 
 pub use manifest::{
     DEFAULT_UPPER_FILE, DESCRIPTOR_FILENAME, ImageRef, Manifest, SCHEMA_VERSION,
-    SNAPSHOT_ARTIFACT_KIND, SPARSE_SHA256_V1, SnapshotFormat, SnapshotScope, UpperIntegrity,
-    UpperLayer,
+    SNAPSHOT_ARTIFACT_KIND, SPARSE_SHA256_V1, SUPPORTED_REQUIRES, SnapshotFormat, SnapshotScope,
+    UpperIntegrity, UpperLayer,
 };

--- a/crates/migration/lib/lib.rs
+++ b/crates/migration/lib/lib.rs
@@ -14,9 +14,9 @@ mod m20260606_000001_named_volume_kinds;
 mod m20260621_000001_add_sandbox_ephemeral;
 mod m20260621_000002_create_maintenance_lease;
 mod m20260703_000001_add_sandbox_active_config;
-mod m20260705_000001_add_snapshot_scope;
 mod m20260708_000001_migrate_bind_rootfs_source;
 mod m20260710_000001_migrate_root_disk;
+mod m20260714_000001_add_snapshot_scope;
 pub mod schema_metadata;
 
 use sea_orm_migration::prelude::*;
@@ -56,9 +56,9 @@ impl MigratorTrait for Migrator {
             Box::new(m20260621_000001_add_sandbox_ephemeral::Migration),
             Box::new(m20260621_000002_create_maintenance_lease::Migration),
             Box::new(m20260703_000001_add_sandbox_active_config::Migration),
-            Box::new(m20260705_000001_add_snapshot_scope::Migration),
             Box::new(m20260708_000001_migrate_bind_rootfs_source::Migration),
             Box::new(m20260710_000001_migrate_root_disk::Migration),
+            Box::new(m20260714_000001_add_snapshot_scope::Migration),
         ]
     }
 }

--- a/crates/migration/lib/lib.rs
+++ b/crates/migration/lib/lib.rs
@@ -14,6 +14,7 @@ mod m20260606_000001_named_volume_kinds;
 mod m20260621_000001_add_sandbox_ephemeral;
 mod m20260621_000002_create_maintenance_lease;
 mod m20260703_000001_add_sandbox_active_config;
+mod m20260705_000001_add_snapshot_scope;
 mod m20260708_000001_migrate_bind_rootfs_source;
 mod m20260710_000001_migrate_root_disk;
 pub mod schema_metadata;
@@ -55,6 +56,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260621_000001_add_sandbox_ephemeral::Migration),
             Box::new(m20260621_000002_create_maintenance_lease::Migration),
             Box::new(m20260703_000001_add_sandbox_active_config::Migration),
+            Box::new(m20260705_000001_add_snapshot_scope::Migration),
             Box::new(m20260708_000001_migrate_bind_rootfs_source::Migration),
             Box::new(m20260710_000001_migrate_root_disk::Migration),
         ]

--- a/crates/migration/lib/m20260705_000001_add_snapshot_scope.rs
+++ b/crates/migration/lib/m20260705_000001_add_snapshot_scope.rs
@@ -1,0 +1,63 @@
+//! Migration: Add snapshot payload scope to the local snapshot index.
+
+use sea_orm_migration::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+pub struct Migration;
+
+//--------------------------------------------------------------------------------------------------
+// Types: Identifiers
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Iden)]
+enum SnapshotIndex {
+    Table,
+    Scope,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260705_000001_add_snapshot_scope"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(SnapshotIndex::Table)
+                    .add_column(
+                        ColumnDef::new(SnapshotIndex::Scope)
+                            .text()
+                            .not_null()
+                            .default("disk"),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(SnapshotIndex::Table)
+                    .drop_column(SnapshotIndex::Scope)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/migration/lib/m20260714_000001_add_snapshot_scope.rs
+++ b/crates/migration/lib/m20260714_000001_add_snapshot_scope.rs
@@ -24,7 +24,7 @@ enum SnapshotIndex {
 
 impl MigrationName for Migration {
     fn name(&self) -> &str {
-        "m20260705_000001_add_snapshot_scope"
+        "m20260714_000001_add_snapshot_scope"
     }
 }
 

--- a/crates/migration/lib/schema_metadata.rs
+++ b/crates/migration/lib/schema_metadata.rs
@@ -22,7 +22,7 @@ pub const MAINTENANCE_LEASE_MIGRATION_ID: &str = "m20260621_000002_create_mainte
 pub const ACTIVE_CONFIG_MIGRATION_ID: &str = "m20260703_000001_add_sandbox_active_config";
 
 /// Migration that adds payload scope metadata to the snapshot index.
-pub const SNAPSHOT_SCOPE_MIGRATION_ID: &str = "m20260705_000001_add_snapshot_scope";
+pub const SNAPSHOT_SCOPE_MIGRATION_ID: &str = "m20260714_000001_add_snapshot_scope";
 
 /// Frozen migration baseline for the transitional 0.6.0 release.
 ///
@@ -147,13 +147,6 @@ pub const MIGRATION_METADATA: &[MigrationMetadata] = &[
         summary: "remove active sandbox config snapshots",
     },
     MigrationMetadata {
-        id: SNAPSHOT_SCOPE_MIGRATION_ID,
-        reversible: true,
-        affects_cache: false,
-        affects_user_data: false,
-        summary: "remove snapshot scope index metadata",
-    },
-    MigrationMetadata {
         id: "m20260708_000001_migrate_bind_rootfs_source",
         reversible: false,
         affects_cache: false,
@@ -166,6 +159,13 @@ pub const MIGRATION_METADATA: &[MigrationMetadata] = &[
         affects_cache: false,
         affects_user_data: false,
         summary: "rewrite root disk config back to the upper size shape",
+    },
+    MigrationMetadata {
+        id: SNAPSHOT_SCOPE_MIGRATION_ID,
+        reversible: true,
+        affects_cache: false,
+        affects_user_data: false,
+        summary: "remove snapshot scope index metadata",
     },
 ];
 

--- a/crates/migration/lib/schema_metadata.rs
+++ b/crates/migration/lib/schema_metadata.rs
@@ -21,6 +21,9 @@ pub const MAINTENANCE_LEASE_MIGRATION_ID: &str = "m20260621_000002_create_mainte
 /// Migration that introduced desired-vs-active sandbox config tracking.
 pub const ACTIVE_CONFIG_MIGRATION_ID: &str = "m20260703_000001_add_sandbox_active_config";
 
+/// Migration that adds payload scope metadata to the snapshot index.
+pub const SNAPSHOT_SCOPE_MIGRATION_ID: &str = "m20260705_000001_add_snapshot_scope";
+
 /// Frozen migration baseline for the transitional 0.6.0 release.
 ///
 /// The released 0.6.0 binary predates `msb __schema-baseline --json`, so
@@ -142,6 +145,13 @@ pub const MIGRATION_METADATA: &[MigrationMetadata] = &[
         affects_cache: false,
         affects_user_data: false,
         summary: "remove active sandbox config snapshots",
+    },
+    MigrationMetadata {
+        id: SNAPSHOT_SCOPE_MIGRATION_ID,
+        reversible: true,
+        affects_cache: false,
+        affects_user_data: false,
+        summary: "remove snapshot scope index metadata",
     },
     MigrationMetadata {
         id: "m20260708_000001_migrate_bind_rootfs_source",

--- a/docs/sandboxes/snapshots.mdx
+++ b/docs/sandboxes/snapshots.mdx
@@ -158,7 +158,7 @@ let h = Snapshot::get("after-pip-install").await?; // By name, digest, or path
 println!("{} ({})", h.name().unwrap_or("-"), h.digest());
 
 Snapshot::remove("after-pip-install", false).await?;
-Snapshot::reindex("~/.microsandbox/snapshots").await?;
+Snapshot::reindex("/data/snapshots").await?;
 ```
 
 ```typescript TypeScript
@@ -169,7 +169,7 @@ const h = await Snapshot.get("after-pip-install");       // By name, digest, or 
 console.log(`${h.name ?? "-"} (${h.digest})`);
 
 await Snapshot.remove("after-pip-install");
-await Snapshot.reindex("~/.microsandbox/snapshots");
+await Snapshot.reindex();                               // Default snapshots directory
 ```
 
 ```python Python
@@ -180,11 +180,12 @@ h = await Snapshot.get("after-pip-install")              # By name, digest, or p
 print(f"{h.name or '-'} ({h.digest})")
 
 await Snapshot.remove("after-pip-install")
-await Snapshot.reindex("~/.microsandbox/snapshots")
+await Snapshot.reindex()                                 # Default snapshots directory
 ```
 
 ```go Go
 all, err := m.Snapshot.List(ctx)            // Indexed snapshots
+fmt.Printf("%d snapshots\n", len(all))
 h, err := m.Snapshot.Get(ctx, "after-pip-install") // By name, digest, or path
 name := "-"
 if h.Name() != nil {
@@ -193,7 +194,7 @@ if h.Name() != nil {
 fmt.Printf("%s (%s)\n", name, h.Digest())
 
 err = m.Snapshot.Remove(ctx, "after-pip-install", false)
-_, err = m.Snapshot.Reindex(ctx, "~/.microsandbox/snapshots")
+_, err = m.Snapshot.Reindex(ctx, "/data/snapshots")
 ```
 
 ```bash CLI

--- a/docs/sandboxes/snapshots.mdx
+++ b/docs/sandboxes/snapshots.mdx
@@ -34,7 +34,7 @@ msb stop baseline
 msb snapshot create after-pip-install --from baseline
 
 # 3. Boot a fresh sandbox from the snapshot
-msb run --name worker --snapshot after-pip-install \
+msb run --name worker --from-snapshot after-pip-install \
     -- python -c "import requests; print(requests.__version__)"
 ```
 
@@ -44,7 +44,7 @@ By default, the snapshot lives at `~/.microsandbox/snapshots/after-pip-install/`
 
 ## Snapshot a sandbox
 
-Snapshot under a bare name (resolved to `~/.microsandbox/snapshots/<name>/`) or to an explicit path:
+Snapshot under a bare name, resolved to `~/.microsandbox/snapshots/<name>/` by default. The name is the snapshot's identity; pass a destination directory to create the artifact on a different volume (`DIR/<name>`). Either way the directory is the whole artifact; move it with save/load (or plain `mv`):
 
 <CodeGroup>
 ```rust Rust
@@ -52,11 +52,8 @@ use microsandbox::Sandbox;
 
 let h = Sandbox::get("baseline").await?;
 
-// Bare name resolves under ~/.microsandbox/snapshots/<name>/
+// Resolves under ~/.microsandbox/snapshots/<name>/
 let snap = h.snapshot("after-pip-install").await?;
-
-// Or write to an explicit path
-let snap = h.snapshot_to("/tmp/snaps/v1").await?;
 
 println!("{}", snap.digest()); // sha256:...
 ```
@@ -66,11 +63,8 @@ import { Sandbox } from "microsandbox";
 
 const h = await Sandbox.get("baseline");
 
-// Bare name resolves under ~/.microsandbox/snapshots/<name>/
+// Resolves under ~/.microsandbox/snapshots/<name>/
 const snap = await h.snapshot("after-pip-install");
-
-// Or write to an explicit path
-const snap2 = await h.snapshotTo("/tmp/snaps/v1");
 
 console.log(snap.digest); // sha256:...
 ```
@@ -80,11 +74,8 @@ from microsandbox import Sandbox
 
 h = await Sandbox.get("baseline")
 
-# Bare name resolves under ~/.microsandbox/snapshots/<name>/
+# Resolves under ~/.microsandbox/snapshots/<name>/
 snap = await h.snapshot("after-pip-install")
-
-# Or write to an explicit path
-snap2 = await h.snapshot_to("/tmp/snaps/v1")
 
 print(snap.digest)  # sha256:...
 ```
@@ -95,19 +86,18 @@ if err != nil {
     return err
 }
 
-// Bare name resolves under ~/.microsandbox/snapshots/<name>/
+// Resolves under ~/.microsandbox/snapshots/<name>/
 snap, err := h.Snapshot(ctx, "after-pip-install")
-
-// Or write to an explicit path
-snap2, err := h.SnapshotTo(ctx, "/tmp/snaps/v1")
 
 fmt.Println(snap.Digest()) // sha256:...
 ```
 
 ```bash CLI
 msb snapshot create after-pip-install --from baseline
-msb snapshot create ./snaps/v1     --from baseline   # Explicit path
 msb snapshot create after-pip-install --from baseline --label stage=ready
+
+# Create the artifact on another volume: lands at /mnt/big/after-pip-install
+msb snapshot create after-pip-install --from baseline --dest-dir /mnt/big
 ```
 
 </CodeGroup>
@@ -139,18 +129,18 @@ const sb = await Sandbox.builder("worker")
 ```python Python
 from microsandbox import Sandbox
 
-# `snapshot=` is a peer of `image=` and mutually exclusive with it
-sb = await Sandbox.create("worker", snapshot="after-pip-install")
+# `from_snapshot=` is a peer of `image=` and mutually exclusive with it
+sb = await Sandbox.create("worker", from_snapshot="after-pip-install")
 ```
 
 ```go Go
 sb, err := m.CreateSandbox(ctx, "worker",
-    m.WithSnapshot("after-pip-install"),
+    m.WithFromSnapshot("after-pip-install"),
 )
 ```
 
 ```bash CLI
-msb run --name worker --snapshot after-pip-install -- python -V
+msb run --name worker --from-snapshot after-pip-install -- python -V
 ```
 
 </CodeGroup>
@@ -224,24 +214,24 @@ msb snapshot reindex
 
 ## Move snapshots between machines
 
-The snapshot directory is the whole artifact; there is no hidden daemon state. Copy the directory directly, or export it as an archive:
+The snapshot directory is the whole artifact; there is no hidden daemon state. Copy the directory directly, or save it as an archive:
 
 ```bash
 # Copy the directory directly with scp (image must be cached or pullable on the target)
 scp -r ~/.microsandbox/snapshots/after-pip-install \
     other-host:~/.microsandbox/snapshots/
 
-# Bundle into a .tar.zst, transport, then import
-msb snapshot export after-pip-install /tmp/snap.tar.zst
+# Bundle into a .tar.zst, transport, then load
+msb snapshot save after-pip-install /tmp/snap.tar.zst
 scp /tmp/snap.tar.zst other-host:
-ssh other-host msb snapshot import /tmp/snap.tar.zst
+ssh other-host msb snapshot load /tmp/snap.tar.zst
 
 # Fully offline: include the OCI image cache so the target needs no network
-msb snapshot export after-pip-install /tmp/snap.tar.zst --with-image
-ssh other-host msb snapshot import /tmp/snap.tar.zst
+msb snapshot save after-pip-install /tmp/snap.tar.zst --with-image
+ssh other-host msb snapshot load /tmp/snap.tar.zst
 ```
 
-Archives default to `.tar.zst`. Pass `--plain-tar` for a plain `.tar`. SDKs expose the same export and import operations as the CLI.
+Archives default to `.tar.zst`. Pass `--plain-tar` for a plain `.tar`. SDKs expose the same save and load operations as the CLI.
 
 ## Integrity verification
 
@@ -252,8 +242,8 @@ By default, snapshot creation records enough metadata to validate the artifact w
 use microsandbox::Snapshot;
 
 // Compute and record an integrity hash at create time
-let snap = Snapshot::builder("baseline")
-    .name("after-pip-install")
+let snap = Snapshot::builder("after-pip-install")
+    .from_sandbox("baseline")
     .record_integrity()
     .create()
     .await?;
@@ -267,8 +257,8 @@ let report = snap.verify().await?;
 import { Snapshot } from "microsandbox";
 
 // Compute and record an integrity hash at create time
-const snap = await Snapshot.builder("baseline")
-  .name("after-pip-install")
+const snap = await Snapshot.builder("after-pip-install")
+  .fromSandbox("baseline")
   .recordIntegrity()
   .create();
 
@@ -281,8 +271,8 @@ from microsandbox import Snapshot
 
 # Compute and record an integrity hash at create time
 snap = await Snapshot.create(
-    "baseline",
-    name="after-pip-install",
+    "after-pip-install",
+    from_sandbox="baseline",
     record_integrity=True,
 )
 
@@ -292,9 +282,10 @@ report = await snap.verify()
 
 ```go Go
 // Compute and record an integrity hash at create time
-snap, err := m.Snapshot.Create(ctx, "baseline",
+snap, err := m.Snapshot.Create(ctx,
     m.SnapshotCreateOptions{
         Name:            "after-pip-install",
+        FromSandbox:     "baseline",
         RecordIntegrity: true,
     },
 )
@@ -314,11 +305,11 @@ msb snapshot inspect after-pip-install --verify
 
 </CodeGroup>
 
-`msb snapshot export` bundles the snapshot as it exists on disk. `msb snapshot import` verifies recorded integrity when the archive includes it, so create snapshots with `--integrity` before exporting across a trust boundary.
+`msb snapshot save` bundles the snapshot as it exists on disk. `msb snapshot load` verifies recorded integrity when the archive includes it, so create snapshots with `--integrity` before saving across a trust boundary.
 
 ## Use cases
 
-- **Reusable build state.** Install dependencies once, snapshot, then `msb run --snapshot ...` repeatedly without paying the install cost. Common pattern for CI, agent workloads, and reproducible dev environments.
+- **Reusable build state.** Install dependencies once, snapshot, then `msb run --from-snapshot ...` repeatedly without paying the install cost. Common pattern for CI, agent workloads, and reproducible dev environments.
 - **Portable scratch state.** Capture a sandbox after a long setup, hand the artifact to a teammate or push it to shared storage, and let them boot from the same starting point.
 - **Local fork-by-copy.** Multiple sandboxes from one snapshot are independent; each copy of the upper layer diverges on its own.
-- **Disaster recovery.** Snapshot a sandbox before a risky migration; if it goes wrong, `msb rm` the broken one and `msb run --snapshot` from the pre-migration artifact.
+- **Disaster recovery.** Snapshot a sandbox before a risky migration; if it goes wrong, `msb rm` the broken one and `msb run --from-snapshot` from the pre-migration artifact.

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -1119,7 +1119,7 @@ Functional options for [`CreateSandbox`](#m-createsandbox). Map and slice option
 func WithImage(image string) SandboxOption
 ```
 
-Set the root filesystem source: an OCI image name, local directory path, or disk image path (e.g. `"python:3.12"`, `"docker.io/library/alpine"`). Required unless [`WithSnapshot`](#withsnapshot) is used. Use [`WithImageDisk`](#withimagedisk) when a disk-image root needs an explicit filesystem type.
+Set the root filesystem source: an OCI image name, local directory path, or disk image path (e.g. `"python:3.12"`, `"docker.io/library/alpine"`). Required unless [`WithFromSnapshot`](#withfromsnapshot) is used. Use [`WithImageDisk`](#withimagedisk) when a disk-image root needs an explicit filesystem type.
 
 <p className="msb-label">Parameters</p>
 
@@ -1176,11 +1176,11 @@ Use a disk image as the root filesystem and optionally provide the inner filesys
 
 ---
 
-#### <span className="msb-recv"></span><span className="msb-hn">WithSnapshot()</span>
+#### <span className="msb-recv"></span><span className="msb-hn">WithFromSnapshot()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">option</span></div>
 
 ```go
-func WithSnapshot(pathOrName string) SandboxOption
+func WithFromSnapshot(pathOrName string) SandboxOption
 ```
 
 Boot from a snapshot artifact by bare name or filesystem path. Mutually exclusive with [`WithImage`](#withimage). See [Snapshots](/sdk/go/snapshots).
@@ -2207,7 +2207,6 @@ A lightweight reference to a sandbox's persisted state. Carries metadata (name, 
 | `WaitUntilStopped(ctx)` | `(*`[`SandboxStopResult`](#sandboxstopresult)`, error)` | Block until terminal state |
 | `Remove(ctx)` | `error` | Delete sandbox and persisted state |
 | `Snapshot(ctx, name)` | `(*SnapshotArtifact, error)` | Snapshot a stopped sandbox under a bare name |
-| `SnapshotTo(ctx, path)` | `(*SnapshotArtifact, error)` | Snapshot a stopped sandbox to an explicit path |
 
 ### SandboxPingResult
 

--- a/docs/sdk/go/snapshots.mdx
+++ b/docs/sdk/go/snapshots.mdx
@@ -3,7 +3,7 @@ title: Snapshots
 description: Go SDK - Snapshot API reference
 ---
 
-Disk-only snapshots of a sandbox that is not running. Create artifacts from a stopped sandbox, list and verify them, export to an archive, and import elsewhere. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Go SDK reference.
+Disk-only snapshots of a sandbox that is not running. Create artifacts from a stopped sandbox, list and verify them, save to an archive, and load elsewhere. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Go SDK reference.
 
 <Note>
   Snapshots are **disk-only** and require a sandbox that is stopped or crashed.
@@ -19,14 +19,13 @@ Disk-only snapshots of a sandbox that is not running. Create artifacts from a st
   <a className="msb-row" href="#snapshot-listdir"><span className="msb-rn">Snapshot.ListDir()</span><span className="msb-rg">walk a directory</span></a>
   <a className="msb-row" href="#snapshot-remove"><span className="msb-rn">Snapshot.Remove()</span><span className="msb-rg">delete artifact + index row</span></a>
   <a className="msb-row" href="#snapshot-reindex"><span className="msb-rn">Snapshot.Reindex()</span><span className="msb-rg">rebuild the local index</span></a>
-  <a className="msb-row" href="#snapshot-export"><span className="msb-rn">Snapshot.Export()</span><span className="msb-rg">bundle into an archive</span></a>
-  <a className="msb-row" href="#snapshot-import"><span className="msb-rn">Snapshot.Import()</span><span className="msb-rg">unpack an archive</span></a>
+  <a className="msb-row" href="#snapshot-save"><span className="msb-rn">Snapshot.Save()</span><span className="msb-rg">bundle into an archive</span></a>
+  <a className="msb-row" href="#snapshot-load"><span className="msb-rn">Snapshot.Load()</span><span className="msb-rg">unpack an archive</span></a>
 
-  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *SandboxHandle<span className="msb-ct">2</span></p>
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *SandboxHandle<span className="msb-ct">1</span></p>
   <a className="msb-row" href="#h-snapshot"><span className="msb-rn">h.Snapshot()</span><span className="msb-rg">snapshot to a bare name</span></a>
-  <a className="msb-row" href="#h-snapshotto"><span className="msb-rn">h.SnapshotTo()</span><span className="msb-rg">snapshot to a directory</span></a>
 
-  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *SnapshotArtifact<span className="msb-ct">12</span></p>
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *SnapshotArtifact<span className="msb-ct">13</span></p>
   <a className="msb-row" href="#s-verify"><span className="msb-rn">s.Verify()</span><span className="msb-rg">recompute content integrity</span></a>
   <a className="msb-row" href="#s-path"><span className="msb-rn">s.Path()</span><span className="msb-rg">artifact directory</span></a>
   <a className="msb-row" href="#s-digest"><span className="msb-rn">s.Digest()</span><span className="msb-rg">manifest digest</span></a>
@@ -34,13 +33,14 @@ Disk-only snapshots of a sandbox that is not running. Create artifacts from a st
   <a className="msb-row" href="#s-imageref"><span className="msb-rn">s.ImageRef()</span><span className="msb-rg">source image reference</span></a>
   <a className="msb-row" href="#s-imagemanifestdigest"><span className="msb-rn">s.ImageManifestDigest()</span><span className="msb-rg">pinned OCI manifest digest</span></a>
   <a className="msb-row" href="#s-format"><span className="msb-rn">s.Format()</span><span className="msb-rg">raw or qcow2</span></a>
+  <a className="msb-row" href="#s-scope"><span className="msb-rn">s.Scope()</span><span className="msb-rg">disk or resumable</span></a>
   <a className="msb-row" href="#s-fstype"><span className="msb-rn">s.Fstype()</span><span className="msb-rg">upper filesystem type</span></a>
   <a className="msb-row" href="#s-parent"><span className="msb-rn">s.Parent()</span><span className="msb-rg">parent digest, or nil</span></a>
   <a className="msb-row" href="#s-createdat"><span className="msb-rn">s.CreatedAt()</span><span className="msb-rg">RFC 3339 timestamp</span></a>
   <a className="msb-row" href="#s-labels"><span className="msb-rn">s.Labels()</span><span className="msb-rg">user labels</span></a>
   <a className="msb-row" href="#s-sourcesandbox"><span className="msb-rn">s.SourceSandbox()</span><span className="msb-rg">source sandbox name</span></a>
 
-  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *SnapshotHandle<span className="msb-ct">10</span></p>
+  <p className="msb-gl"><span className="msb-dot instance"></span>Methods · *SnapshotHandle<span className="msb-ct">11</span></p>
   <a className="msb-row" href="#h-open"><span className="msb-rn">h.Open()</span><span className="msb-rg">open the artifact</span></a>
   <a className="msb-row" href="#h-remove"><span className="msb-rn">h.Remove()</span><span className="msb-rg">delete this snapshot</span></a>
   <a className="msb-row" href="#h-digest"><span className="msb-rn">h.Digest()</span><span className="msb-rg">manifest digest</span></a>
@@ -48,13 +48,14 @@ Disk-only snapshots of a sandbox that is not running. Create artifacts from a st
   <a className="msb-row" href="#h-parentdigest"><span className="msb-rn">h.ParentDigest()</span><span className="msb-rg">parent digest, or nil</span></a>
   <a className="msb-row" href="#h-imageref"><span className="msb-rn">h.ImageRef()</span><span className="msb-rg">pinned image reference</span></a>
   <a className="msb-row" href="#h-format"><span className="msb-rn">h.Format()</span><span className="msb-rg">raw or qcow2</span></a>
+  <a className="msb-row" href="#h-scope"><span className="msb-rn">h.Scope()</span><span className="msb-rg">disk or resumable</span></a>
   <a className="msb-row" href="#h-sizebytes"><span className="msb-rn">h.SizeBytes()</span><span className="msb-rg">upper size at index time</span></a>
   <a className="msb-row" href="#h-path"><span className="msb-rn">h.Path()</span><span className="msb-rg">artifact directory</span></a>
   <a className="msb-row" href="#h-createdat"><span className="msb-rn">h.CreatedAt()</span><span className="msb-rg">creation time</span></a>
 
   <p className="msb-gl"><span className="msb-dot static"></span>Options<span className="msb-ct">1</span></p>
   <div className="msb-chiprow">
-    <a className="msb-chip" href="/sdk/go/sandbox#withsnapshot">WithSnapshot()</a>
+    <a className="msb-chip" href="/sdk/go/sandbox#withfromsnapshot">WithFromSnapshot()</a>
   </div>
 
   <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
@@ -62,7 +63,7 @@ Disk-only snapshots of a sandbox that is not running. Create artifacts from a st
     <a className="msb-typepill" href="#snapshotartifactstruct">SnapshotArtifact</a>
     <a className="msb-typepill" href="#snapshothandlestruct">SnapshotHandle</a>
     <a className="msb-typepill" href="#snapshotcreateoptionsstruct">SnapshotCreateOptions</a>
-    <a className="msb-typepill" href="#snapshotexportoptionsstruct">SnapshotExportOptions</a>
+    <a className="msb-typepill" href="#snapshotsaveoptionsstruct">SnapshotSaveOptions</a>
     <a className="msb-typepill" href="#snapshotverifyreportstruct">SnapshotVerifyReport</a>
     <a className="msb-typepill" href="#snapshotupperverifystatusstruct">SnapshotUpperVerifyStatus</a>
   </div>
@@ -79,8 +80,9 @@ _ = sb.Stop(ctx)
 _ = sb.Close()
 
 // 2. snapshot it under a bare name
-snap, err := m.Snapshot.Create(ctx, "baseline", m.SnapshotCreateOptions{
+snap, err := m.Snapshot.Create(ctx, m.SnapshotCreateOptions{
     Name:            "after-pip-install",
+    FromSandbox:     "baseline",
     RecordIntegrity: true,
 })
 if err != nil {
@@ -89,7 +91,7 @@ if err != nil {
 
 // 3. boot a fresh sandbox from the snapshot
 sb2, err := m.CreateSandbox(ctx, "worker",
-    m.WithSnapshot("after-pip-install"),
+    m.WithFromSnapshot("after-pip-install"),
 )
 ```
 
@@ -103,10 +105,10 @@ Package-level helpers for snapshot artifacts. Access them through the exported `
 <div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
-func (snapshotFactory) Create(ctx context.Context, sourceSandbox string, opts SnapshotCreateOptions) (*SnapshotArtifact, error)
+func (snapshotFactory) Create(ctx context.Context, opts SnapshotCreateOptions) (*SnapshotArtifact, error)
 ```
 
-Create a snapshot from a stopped or crashed sandbox. Set exactly one of [`SnapshotCreateOptions.Name`](#snapshotcreateoptionsstruct) (resolved under the default snapshots directory) or [`SnapshotCreateOptions.Path`](#snapshotcreateoptionsstruct) (an explicit artifact directory).
+Create a snapshot from a stopped or crashed sandbox. [`SnapshotCreateOptions.Name`](#snapshotcreateoptionsstruct) (resolved under the default snapshots directory) and [`SnapshotCreateOptions.FromSandbox`](#snapshotcreateoptionsstruct) (the sandbox to capture) are both required.
 
 <p className="msb-label">Parameters</p>
 
@@ -116,12 +118,8 @@ Create a snapshot from a stopped or crashed sandbox. Set exactly one of [`Snapsh
     <div className="msb-param-desc">Cancellation and deadline.</div>
   </div>
   <div className="msb-param">
-    <div className="msb-param-key"><code>sourceSandbox</code><span className="msb-type">string</span></div>
-    <div className="msb-param-desc">Name of the stopped or crashed sandbox to snapshot.</div>
-  </div>
-  <div className="msb-param">
     <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#snapshotcreateoptionsstruct">SnapshotCreateOptions</a></div>
-    <div className="msb-param-desc">Destination, labels, and integrity options.</div>
+    <div className="msb-param-desc">Name, source sandbox, labels, and integrity options.</div>
   </div>
 </div>
 
@@ -137,8 +135,9 @@ Create a snapshot from a stopped or crashed sandbox. Set exactly one of [`Snapsh
 <Accordion title="Example">
 
 ```go
-snap, err := m.Snapshot.Create(ctx, "baseline", m.SnapshotCreateOptions{
+snap, err := m.Snapshot.Create(ctx, m.SnapshotCreateOptions{
     Name:            "after-pip-install",
+    FromSandbox:     "baseline",
     Labels:          map[string]string{"stage": "post-deps"},
     RecordIntegrity: true,
 })
@@ -372,14 +371,14 @@ fmt.Printf("indexed %d snapshots\n", n)
 
 ---
 
-#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">Export()</span>
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">Save()</span>
 <div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
-func (snapshotFactory) Export(ctx context.Context, nameOrPath, outPath string, opts SnapshotExportOptions) error
+func (snapshotFactory) Save(ctx context.Context, nameOrPath, outPath string, opts SnapshotSaveOptions) error
 ```
 
-Bundle a snapshot into a `.tar.zst` archive at `outPath`. Set [`SnapshotExportOptions.PlainTar`](#snapshotexportoptionsstruct) to skip compression.
+Bundle a snapshot into a `.tar.zst` archive at `outPath`. Set [`SnapshotSaveOptions.PlainTar`](#snapshotsaveoptionsstruct) to skip compression.
 
 <p className="msb-label">Parameters</p>
 
@@ -390,14 +389,14 @@ Bundle a snapshot into a `.tar.zst` archive at `outPath`. Set [`SnapshotExportOp
   </div>
   <div className="msb-param">
     <div className="msb-param-key"><code>nameOrPath</code><span className="msb-type">string</span></div>
-    <div className="msb-param-desc">Bare name or artifact path to export.</div>
+    <div className="msb-param-desc">Bare name or artifact path to save.</div>
   </div>
   <div className="msb-param">
     <div className="msb-param-key"><code>outPath</code><span className="msb-type">string</span></div>
     <div className="msb-param-desc">Destination archive path.</div>
   </div>
   <div className="msb-param">
-    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#snapshotexportoptionsstruct">SnapshotExportOptions</a></div>
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#snapshotsaveoptionsstruct">SnapshotSaveOptions</a></div>
     <div className="msb-param-desc">Whether to include parents, the base image, and compression.</div>
   </div>
 </div>
@@ -405,8 +404,8 @@ Bundle a snapshot into a `.tar.zst` archive at `outPath`. Set [`SnapshotExportOp
 <Accordion title="Example">
 
 ```go
-err := m.Snapshot.Export(ctx, "after-pip-install", "/tmp/snap.tar.zst",
-    m.SnapshotExportOptions{WithParents: true},
+err := m.Snapshot.Save(ctx, "after-pip-install", "/tmp/snap.tar.zst",
+    m.SnapshotSaveOptions{WithParents: true},
 )
 ```
 
@@ -414,11 +413,11 @@ err := m.Snapshot.Export(ctx, "after-pip-install", "/tmp/snap.tar.zst",
 
 ---
 
-#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">Import()</span>
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">Load()</span>
 <div className="msb-tags"><span className="msb-tag is-static">function</span></div>
 
 ```go
-func (snapshotFactory) Import(ctx context.Context, archive, dest string) (*SnapshotHandle, error)
+func (snapshotFactory) Load(ctx context.Context, archive, dest string) (*SnapshotHandle, error)
 ```
 
 Unpack a snapshot archive into the snapshots directory or an explicit `dest` directory. Pass `""` for the default destination.
@@ -445,14 +444,14 @@ Unpack a snapshot archive into the snapshots directory or an explicit `dest` dir
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><a className="msb-type" href="#snapshothandlestruct">*SnapshotHandle</a></div>
-    <div className="msb-param-desc">Handle to the imported snapshot.</div>
+    <div className="msb-param-desc">Handle to the loaded snapshot.</div>
   </div>
 </div>
 
 <Accordion title="Example">
 
 ```go
-h, err := m.Snapshot.Import(ctx, "/tmp/snap.tar.zst", "")
+h, err := m.Snapshot.Load(ctx, "/tmp/snap.tar.zst", "")
 ```
 
 </Accordion>
@@ -481,7 +480,7 @@ snap, err := h.Snapshot(ctx, "after-pip-install")
 func (h *SandboxHandle) Snapshot(ctx context.Context, name string) (*SnapshotArtifact, error)
 ```
 
-Snapshot this sandbox under a bare name in the default snapshots directory. The sandbox must be stopped or crashed.
+Snapshot this sandbox under a bare name in the default snapshots directory. The sandbox must be stopped or crashed. To place the artifact elsewhere, use [`Snapshot.Save`](#snapshot-save) / [`Snapshot.Load`](#snapshot-load) or move the self-contained artifact directory.
 
 <p className="msb-label">Parameters</p>
 
@@ -509,47 +508,6 @@ Snapshot this sandbox under a bare name in the default snapshots directory. The 
 
 ```go
 snap, err := h.Snapshot(ctx, "after-pip-install")
-```
-
-</Accordion>
-
----
-
-#### <span className="msb-recv">h.</span><span className="msb-hn">SnapshotTo()</span>
-<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
-
-```go
-func (h *SandboxHandle) SnapshotTo(ctx context.Context, path string) (*SnapshotArtifact, error)
-```
-
-Snapshot this sandbox to an explicit artifact directory. The sandbox must be stopped or crashed.
-
-<p className="msb-label">Parameters</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
-    <div className="msb-param-desc">Cancellation and deadline.</div>
-  </div>
-  <div className="msb-param">
-    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
-    <div className="msb-param-desc">Destination artifact directory.</div>
-  </div>
-</div>
-
-<p className="msb-label">Returns</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><a className="msb-type" href="#snapshotartifactstruct">*SnapshotArtifact</a></div>
-    <div className="msb-param-desc">The created artifact.</div>
-  </div>
-</div>
-
-<Accordion title="Example">
-
-```go
-snap, err := h.SnapshotTo(ctx, "/srv/snapshots/baseline")
 ```
 
 </Accordion>
@@ -655,6 +613,17 @@ func (s *SnapshotArtifact) Format() string
 ```
 
 Upper-layer disk format: `"raw"` or `"qcow2"`.
+
+---
+
+#### <span className="msb-recv">s.</span><span className="msb-hn">Scope()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (s *SnapshotArtifact) Scope() string
+```
+
+Snapshot scope: `SnapshotScopeDisk` (`"disk"`) or `SnapshotScopeResumable` (`"resumable"`). Always `SnapshotScopeDisk` today; `SnapshotScopeResumable` is reserved for resumable snapshots.
 
 ---
 
@@ -832,6 +801,17 @@ Upper-layer disk format: `"raw"` or `"qcow2"`.
 
 ---
 
+#### <span className="msb-recv">h.</span><span className="msb-hn">Scope()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
+
+```go
+func (h *SnapshotHandle) Scope() string
+```
+
+Snapshot scope: `SnapshotScopeDisk` (`"disk"`) or `SnapshotScopeResumable` (`"resumable"`). Always `SnapshotScopeDisk` today.
+
+---
+
 #### <span className="msb-recv">h.</span><span className="msb-hn">SizeBytes()</span>
 <div className="msb-tags"><span className="msb-tag is-instance">method</span></div>
 
@@ -867,7 +847,7 @@ Snapshot creation time, decoded from the index's Unix timestamp.
 
 ### SnapshotArtifact<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
 
-<p className="msb-backref">Returned by <a href="#snapshot-create">Snapshot.Create()</a> · <a href="#snapshot-open">Snapshot.Open()</a> · <a href="#snapshot-listdir">Snapshot.ListDir()</a> · <a href="#h-snapshot">h.Snapshot()</a> · <a href="#h-snapshotto">h.SnapshotTo()</a> · <a href="#h-open">h.Open()</a></p>
+<p className="msb-backref">Returned by <a href="#snapshot-create">Snapshot.Create()</a> · <a href="#snapshot-open">Snapshot.Open()</a> · <a href="#snapshot-listdir">Snapshot.ListDir()</a> · <a href="#h-snapshot">h.Snapshot()</a> · <a href="#h-open">h.Open()</a></p>
 
 A snapshot artifact on disk. Fields are unexported; read them through the accessor methods below.
 
@@ -879,6 +859,7 @@ A snapshot artifact on disk. Fields are unexported; read them through the access
 | [`ImageRef()`](#s-imageref) | `string` | Image reference the snapshot was taken from |
 | [`ImageManifestDigest()`](#s-imagemanifestdigest) | `string` | Pinned OCI manifest digest |
 | [`Format()`](#s-format) | `string` | `"raw"` or `"qcow2"` |
+| [`Scope()`](#s-scope) | `string` | `SnapshotScopeDisk` or `SnapshotScopeResumable` |
 | [`Fstype()`](#s-fstype) | `string` | Filesystem type inside the upper layer |
 | [`Parent()`](#s-parent) | `*string` | Parent digest, or nil |
 | [`CreatedAt()`](#s-createdat) | `string` | RFC 3339 timestamp |
@@ -888,7 +869,7 @@ A snapshot artifact on disk. Fields are unexported; read them through the access
 
 ### SnapshotHandle<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
 
-<p className="msb-backref">Returned by <a href="#snapshot-get">Snapshot.Get()</a> · <a href="#snapshot-list">Snapshot.List()</a> · <a href="#snapshot-import">Snapshot.Import()</a></p>
+<p className="msb-backref">Returned by <a href="#snapshot-get">Snapshot.Get()</a> · <a href="#snapshot-list">Snapshot.List()</a> · <a href="#snapshot-load">Snapshot.Load()</a></p>
 
 A lightweight handle backed by the local snapshot index. Fields are unexported; read them through the accessor methods below.
 
@@ -899,6 +880,7 @@ A lightweight handle backed by the local snapshot index. Fields are unexported; 
 | [`ParentDigest()`](#h-parentdigest) | `*string` | Parent digest, or nil |
 | [`ImageRef()`](#h-imageref) | `string` | Pinned image reference |
 | [`Format()`](#h-format) | `string` | `"raw"` or `"qcow2"` |
+| [`Scope()`](#h-scope) | `string` | `SnapshotScopeDisk` or `SnapshotScopeResumable` |
 | [`SizeBytes()`](#h-sizebytes) | `*uint64` | Apparent upper size at index time |
 | [`Path()`](#h-path) | `string` | Artifact directory |
 | [`CreatedAt()`](#h-createdat) | `time.Time` | Snapshot creation time |
@@ -909,21 +891,23 @@ A lightweight handle backed by the local snapshot index. Fields are unexported; 
 
 <p className="msb-backref">Accepted by <a href="#snapshot-create">Snapshot.Create()</a></p>
 
-Configures [`Snapshot.Create`](#snapshot-create). Set exactly one of `Name` or `Path`.
+Configures [`Snapshot.Create`](#snapshot-create). `Name` and `FromSandbox` are both required.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| Name | `string` | Bare name; the artifact is written under the default snapshots directory |
-| Path | `string` | Explicit artifact directory (mutually exclusive with `Name`) |
+| Name | `string` | Bare name; always the artifact directory's basename |
+| FromSandbox | `string` | Name of the stopped or crashed sandbox to capture |
+| DestDir | `string` | Parent directory for the artifact (`DestDir/<name>`); empty = the default snapshots directory |
 | Labels | `map[string]string` | Arbitrary user labels recorded in the manifest |
-| Force | `bool` | Overwrite an existing artifact at the destination |
+| Force | `bool` | Overwrite an existing artifact with the same name |
 | RecordIntegrity | `bool` | Record content hashes so [`Verify`](#s-verify) can recompute them later |
+| Resumable | `bool` | Request a resumable snapshot; returns an unsupported-feature error today |
 
-### SnapshotExportOptions<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
+### SnapshotSaveOptions<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
 
-<p className="msb-backref">Accepted by <a href="#snapshot-export">Snapshot.Export()</a></p>
+<p className="msb-backref">Accepted by <a href="#snapshot-save">Snapshot.Save()</a></p>
 
-Configures [`Snapshot.Export`](#snapshot-export).
+Configures [`Snapshot.Save`](#snapshot-save).
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -954,3 +938,14 @@ Upper-layer integrity details inside a [`SnapshotVerifyReport`](#snapshotverifyr
 | Kind | `string` | Integrity record kind |
 | Algorithm | `string` | Hash algorithm used |
 | Digest | `string` | Recomputed upper-layer digest |
+
+### Snapshot scope constants
+
+<p className="msb-backref">Returned by <a href="#s-scope">s.Scope()</a> · <a href="#h-scope">h.Scope()</a></p>
+
+Scope of what a snapshot captures. Every snapshot today is disk-only; the resumable scope (disk plus VM state) is reserved for resumable snapshots.
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `SnapshotScopeDisk` | `"disk"` | Disk-only snapshot |
+| `SnapshotScopeResumable` | `"resumable"` | Disk plus VM state (not yet supported) |

--- a/docs/sdk/go/snapshots.mdx
+++ b/docs/sdk/go/snapshots.mdx
@@ -525,7 +525,7 @@ An artifact on disk. The accessors below are plain field reads; only [`Verify`](
 func (s *SnapshotArtifact) Verify(ctx context.Context) (*SnapshotVerifyReport, error)
 ```
 
-Recompute recorded content integrity for this snapshot. Requires that the artifact was created with [`RecordIntegrity`](#snapshotcreateoptionsstruct) set.
+Recompute the upper layer's content hash and compare against the manifest. Walks data extents only, so a 4 GiB sparse file with a few MB of data verifies in milliseconds. The report's `Upper.Kind` is `"not_recorded"` when the artifact was created without [`RecordIntegrity`](#snapshotcreateoptionsstruct), and `"verified"` when the recorded hash matched.
 
 <p className="msb-label">Returns</p>
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -1199,8 +1199,8 @@ The keyword arguments accepted by [`create()`](#sandbox-create) and [`create_wit
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| image | `str \| `[`ImageSource`](/sdk/python/images) | - | OCI image, local path, or disk image. Required unless `snapshot=` is passed. Use `Image.oci("python:3.12", upper_size_mib=8192)` to set an OCI upper size |
-| snapshot | `str \| os.PathLike` | - | Snapshot artifact to boot from instead of `image=`. Mutually exclusive with `image=` |
+| image | `str \| `[`ImageSource`](/sdk/python/images) | - | OCI image, local path, or disk image. Required unless `from_snapshot=` is passed. Use `Image.oci("python:3.12", upper_size_mib=8192)` to set an OCI upper size |
+| from_snapshot | `str \| os.PathLike` | - | Snapshot artifact to boot from instead of `image=`. Mutually exclusive with `image=` |
 | cpus | `int` | `1` | Virtual CPUs. This is a limit, not a reservation |
 | max_cpus | `int` | same as `cpus` | Boot-time maximum possible virtual CPUs |
 | memory | `int` | `512` | Guest memory in MiB. This is a limit, not a reservation |
@@ -1313,7 +1313,6 @@ A lightweight handle to an existing sandbox (running or stopped). Provides statu
 | logs(...) | `Awaitable[list[`[`LogEntry`](#logentry)`]]` | Read captured `exec.log` (works without starting) |
 | log_stream(...) | `Awaitable[`[`LogStream`](#logstream)`]` | Stream captured log entries (works without starting) |
 | snapshot(name) | `Awaitable[Snapshot]` | Create a named [snapshot](/sdk/python/snapshots) of the sandbox |
-| snapshot_to(path) | `Awaitable[Snapshot]` | Create a [snapshot](/sdk/python/snapshots) at a path |
 
 ### SandboxPingResult
 

--- a/docs/sdk/python/snapshots.mdx
+++ b/docs/sdk/python/snapshots.mdx
@@ -7,13 +7,12 @@ Capture the disk state of a stopped sandbox as a reusable artifact, then boot fr
 
 <div className="msb-glance">
 
-  <p className="msb-gl"><span className="msb-dot static"></span>Take a snapshot<span className="msb-ct">3</span></p>
+  <p className="msb-gl"><span className="msb-dot static"></span>Take a snapshot<span className="msb-ct">2</span></p>
   <a className="msb-row" href="#handle-snapshot"><span className="msb-rn">handle.snapshot()</span><span className="msb-rg">snapshot under a name</span></a>
-  <a className="msb-row" href="#handle-snapshot_to"><span className="msb-rn">handle.snapshot_to()</span><span className="msb-rg">snapshot to a path</span></a>
   <a className="msb-row" href="#snapshot-create"><span className="msb-rn">Snapshot.create()</span><span className="msb-rg">snapshot a stopped sandbox by name</span></a>
 
   <p className="msb-gl"><span className="msb-dot static"></span>Boot from a snapshot<span className="msb-ct">1</span></p>
-  <a className="msb-row" href="#sandbox-create"><span className="msb-rn">Sandbox.create(snapshot=...)</span><span className="msb-rg">boot a fresh sandbox from an artifact</span></a>
+  <a className="msb-row" href="#sandbox-create"><span className="msb-rn">Sandbox.create(from_snapshot=...)</span><span className="msb-rg">boot a fresh sandbox from an artifact</span></a>
 
   <p className="msb-gl"><span className="msb-dot static"></span>Manage artifacts<span className="msb-ct">7</span></p>
   <a className="msb-row" href="#snapshot-open"><span className="msb-rn">Snapshot.open()</span><span className="msb-rg">open an artifact by name or path</span></a>
@@ -22,10 +21,10 @@ Capture the disk state of a stopped sandbox as a reusable artifact, then boot fr
   <a className="msb-row" href="#snapshot-list_dir"><span className="msb-rn">Snapshot.list_dir()</span><span className="msb-rg">parse a directory of artifacts</span></a>
   <a className="msb-row" href="#snapshot-remove"><span className="msb-rn">Snapshot.remove()</span><span className="msb-rg">delete an artifact</span></a>
   <a className="msb-row" href="#snapshot-reindex"><span className="msb-rn">Snapshot.reindex()</span><span className="msb-rg">rebuild the local index</span></a>
-  <a className="msb-row" href="#snapshot-export"><span className="msb-rn">Snapshot.export()</span><span className="msb-rg">bundle into an archive</span></a>
+  <a className="msb-row" href="#snapshot-save"><span className="msb-rn">Snapshot.save()</span><span className="msb-rg">bundle into an archive</span></a>
 
   <p className="msb-gl"><span className="msb-dot static"></span>Move artifacts<span className="msb-ct">1</span></p>
-  <a className="msb-row" href="#snapshot-import_"><span className="msb-rn">Snapshot.import_()</span><span className="msb-rg">unpack an archive</span></a>
+  <a className="msb-row" href="#snapshot-load"><span className="msb-rn">Snapshot.load()</span><span className="msb-rg">unpack an archive</span></a>
 
   <p className="msb-gl"><span className="msb-dot instance"></span>Inspect<span className="msb-ct">3</span></p>
   <a className="msb-row" href="#snap-verify"><span className="msb-rn">snap.verify()</span><span className="msb-rg">recompute and check integrity</span></a>
@@ -51,11 +50,11 @@ async with await Sandbox.create("baseline", image="python:3.12") as sb:
     await sb.stop()
 
 # Capture its disk state under a name
-snap = await Snapshot.create("baseline", name="after-pip-install")
+snap = await Snapshot.create("after-pip-install", from_sandbox="baseline")
 print(snap.digest)
 
 # Boot a fresh sandbox from the artifact
-sb2 = await Sandbox.create("worker", snapshot="after-pip-install")
+sb2 = await Sandbox.create("worker", from_snapshot="after-pip-install")
 ```
 
 ## Take a snapshot
@@ -69,7 +68,7 @@ sb2 = await Sandbox.create("worker", snapshot="after-pip-install")
 async def snapshot(self, name: str) -> Snapshot
 ```
 
-Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). The sandbox must be stopped or crashed. For an explicit filesystem destination, see [`snapshot_to()`](#handle-snapshot_to). Called on a [`SandboxHandle`](/sdk/python/sandbox#sandboxhandle), obtained from [`Sandbox.get()`](/sdk/python/sandbox#sandbox-get).
+Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). The sandbox must be stopped or crashed. To place the artifact elsewhere, use [`Snapshot.save()`](#snapshot-save) / [`Snapshot.load()`](#snapshot-load) or move the self-contained artifact directory. Called on a [`SandboxHandle`](/sdk/python/sandbox#sandboxhandle), obtained from [`Sandbox.get()`](/sdk/python/sandbox#sandbox-get).
 
 <p className="msb-label">Parameters</p>
 
@@ -101,76 +100,39 @@ print(snap.digest)
 
 ---
 
-#### <span className="msb-recv">handle.</span><span className="msb-hn">snapshot_to()</span>
-<div className="msb-tags"><span className="msb-tag is-instance">SandboxHandle</span><span className="msb-tag is-async">async</span></div>
-
-```python
-async def snapshot_to(self, path: str | os.PathLike) -> Snapshot
-```
-
-Snapshot this sandbox to an explicit filesystem path. The sandbox must be stopped or crashed.
-
-<p className="msb-label">Parameters</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><code>path</code><span className="msb-type">str | os.PathLike</span></div>
-    <div className="msb-param-desc">Destination artifact directory.</div>
-  </div>
-</div>
-
-<p className="msb-label">Returns</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><a className="msb-type" href="#snapshot">Snapshot</a></div>
-    <div className="msb-param-desc">The captured snapshot.</div>
-  </div>
-</div>
-
-<Accordion title="Example">
-
-```python
-handle = await Sandbox.get("baseline")
-snap = await handle.snapshot_to("/data/snapshots/baseline")
-```
-
-</Accordion>
-
----
-
 #### <span className="msb-recv">Snapshot.</span><span className="msb-hn">create()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @staticmethod
 async def create(
-    source_sandbox: str,
+    name: str,
     *,
-    name: str | None = None,
-    path: str | os.PathLike | None = None,
+    from_sandbox: str,
+    dest_dir: str | os.PathLike[str] | None = None,
     labels: dict[str, str] | None = None,
     force: bool = False,
     record_integrity: bool = False,
+    resumable: bool = False,
 ) -> Snapshot
 ```
 
-Create a snapshot from a stopped or crashed sandbox. Exactly one of `name=` (resolved under the default snapshots directory) or `path=` (explicit filesystem destination) is required.
+Create a snapshot from a stopped or crashed sandbox. `name` is resolved under the default snapshots directory (`~/.microsandbox/snapshots/<name>/`), or under `dest_dir=` when given; `from_sandbox=` names the sandbox to capture and is required.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
-    <div className="msb-param-key"><code>source_sandbox</code><span className="msb-type">str</span></div>
-    <div className="msb-param-desc">Name of the stopped or crashed sandbox to capture.</div>
+    <div className="msb-param-key"><code>name</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Bare snapshot name; resolved under the default snapshots directory.</div>
   </div>
   <div className="msb-param">
-    <div className="msb-param-key"><code>name</code><span className="msb-type">str | None</span></div>
-    <div className="msb-param-desc">Snapshot name under the default snapshots directory. Mutually exclusive with <code>path</code>.</div>
+    <div className="msb-param-key"><code>from_sandbox</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Name of the stopped or crashed sandbox to capture. Required.</div>
   </div>
   <div className="msb-param">
-    <div className="msb-param-key"><code>path</code><span className="msb-type">str | os.PathLike | None</span></div>
-    <div className="msb-param-desc">Explicit destination directory. Mutually exclusive with <code>name</code>.</div>
+    <div className="msb-param-key"><code>dest_dir</code><span className="msb-type">str | os.PathLike[str] | None</span></div>
+    <div className="msb-param-desc">Parent directory to create the artifact in; the artifact lands at <code>dest_dir/&lt;name&gt;</code>. Defaults to the snapshots directory.</div>
   </div>
   <div className="msb-param">
     <div className="msb-param-key"><code>labels</code><span className="msb-type">dict[str, str] | None</span></div>
@@ -178,11 +140,15 @@ Create a snapshot from a stopped or crashed sandbox. Exactly one of `name=` (res
   </div>
   <div className="msb-param">
     <div className="msb-param-key"><code>force</code><span className="msb-type">bool</span></div>
-    <div className="msb-param-desc">Overwrite an existing destination. Default <code>False</code>.</div>
+    <div className="msb-param-desc">Overwrite an existing artifact with the same name. Default <code>False</code>.</div>
   </div>
   <div className="msb-param">
     <div className="msb-param-key"><code>record_integrity</code><span className="msb-type">bool</span></div>
     <div className="msb-param-desc">Record an integrity hash in the manifest so the artifact can be verified later. Default <code>False</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>resumable</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Request a <code>"resumable"</code> snapshot (disk plus VM state). Accepted, but currently fails with an <code>Unsupported</code> error; resumable snapshots have not landed yet. Default <code>False</code>.</div>
   </div>
 </div>
 
@@ -199,8 +165,8 @@ Create a snapshot from a stopped or crashed sandbox. Exactly one of `name=` (res
 
 ```python
 snap = await Snapshot.create(
-    "baseline",
-    name="after-pip-install",
+    "after-pip-install",
+    from_sandbox="baseline",
     labels={"stage": "post-deps"},
     record_integrity=True,
 )
@@ -219,10 +185,10 @@ snap = await Snapshot.create(
 
 ```python
 @staticmethod
-async def create(name: str, *, snapshot: str | os.PathLike | None = None, **kwargs) -> Sandbox
+async def create(name: str, *, from_snapshot: str | os.PathLike | None = None, **kwargs) -> Sandbox
 ```
 
-Boot a fresh sandbox from a snapshot artifact by passing `snapshot=` as a peer of `image=`. The two are mutually exclusive: pass exactly one. See [`Sandbox.create()`](/sdk/python/sandbox#sandbox-create) for the full set of configuration kwargs.
+Boot a fresh sandbox from a snapshot artifact by passing `from_snapshot=` as a peer of `image=`. The two are mutually exclusive: pass exactly one. See [`Sandbox.create()`](/sdk/python/sandbox#sandbox-create) for the full set of configuration kwargs.
 
 <p className="msb-label">Parameters</p>
 
@@ -232,7 +198,7 @@ Boot a fresh sandbox from a snapshot artifact by passing `snapshot=` as a peer o
     <div className="msb-param-desc">Sandbox name, up to 128 UTF-8 bytes.</div>
   </div>
   <div className="msb-param">
-    <div className="msb-param-key"><code>snapshot</code><span className="msb-type">str | os.PathLike | None</span></div>
+    <div className="msb-param-key"><code>from_snapshot</code><span className="msb-type">str | os.PathLike | None</span></div>
     <div className="msb-param-desc">Snapshot bare name or artifact path to boot from instead of <code>image=</code>.</div>
   </div>
 </div>
@@ -250,7 +216,7 @@ Boot a fresh sandbox from a snapshot artifact by passing `snapshot=` as a peer o
 
 ```python
 # Boot from a snapshot
-sb = await Sandbox.create("worker", snapshot="after-pip-install")
+sb = await Sandbox.create("worker", from_snapshot="after-pip-install")
 
 # Or from an image (existing flow, unchanged)
 sb = await Sandbox.create("worker", image="python:3.12")
@@ -380,7 +346,7 @@ for h in await Snapshot.list():
 async def list_dir(dir: str | os.PathLike) -> list[Snapshot]
 ```
 
-Walk a directory and parse each subdirectory's manifest. Does not touch the index, useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never imported). Skips entries that don't look like snapshot artifacts.
+Walk a directory and parse each subdirectory's manifest. Does not touch the index, useful for inspecting external snapshot collections (e.g. a mounted volume of artifacts that were never loaded). Skips entries that don't look like snapshot artifacts.
 
 <p className="msb-label">Parameters</p>
 
@@ -483,12 +449,12 @@ print(f"indexed {count} snapshots")
 
 ---
 
-#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">export()</span>
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">save()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @staticmethod
-async def export(
+async def save(
     name_or_path: str,
     out: str | os.PathLike,
     *,
@@ -505,7 +471,7 @@ Bundle a snapshot into a `.tar.zst` archive. The existing snapshot manifest is a
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>name_or_path</code><span className="msb-type">str</span></div>
-    <div className="msb-param-desc">Snapshot bare name or artifact path to export.</div>
+    <div className="msb-param-desc">Snapshot bare name or artifact path to save.</div>
   </div>
   <div className="msb-param">
     <div className="msb-param-key"><code>out</code><span className="msb-type">str | os.PathLike</span></div>
@@ -528,7 +494,7 @@ Bundle a snapshot into a `.tar.zst` archive. The existing snapshot manifest is a
 <Accordion title="Example">
 
 ```python
-await Snapshot.export(
+await Snapshot.save(
     "after-pip-install",
     "/tmp/after-pip-install.tar.zst",
     with_parents=True,
@@ -543,19 +509,19 @@ await Snapshot.export(
 
 ---
 
-#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">import_()</span>
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">load()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```python
 @staticmethod
-async def import_(
+async def load(
     archive: str | os.PathLike,
     *,
     dest: str | os.PathLike | None = None,
 ) -> SnapshotHandle
 ```
 
-Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity when present. Compression is detected from magic bytes. The trailing underscore is intentional: `import` is a reserved Python keyword.
+Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity when present. Compression is detected from magic bytes.
 
 <p className="msb-label">Parameters</p>
 
@@ -575,14 +541,14 @@ Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, v
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><a className="msb-type" href="#snapshothandle">SnapshotHandle</a></div>
-    <div className="msb-param-desc">Handle to the imported snapshot.</div>
+    <div className="msb-param-desc">Handle to the loaded snapshot.</div>
   </div>
 </div>
 
 <Accordion title="Example">
 
 ```python
-h = await Snapshot.import_("/tmp/after-pip-install.tar.zst")
+h = await Snapshot.load("/tmp/after-pip-install.tar.zst")
 print(h.path)
 ```
 
@@ -702,7 +668,7 @@ await h.remove(force=False)
 
 <div className="msb-tags"><span className="msb-tag is-type">class</span></div>
 
-<p className="msb-backref">Returned by <a href="#handle-snapshot">snapshot()</a> · <a href="#handle-snapshot_to">snapshot_to()</a> · <a href="#snapshot-create">Snapshot.create()</a> · <a href="#snapshot-open">Snapshot.open()</a> · <a href="#snapshot-list_dir">Snapshot.list_dir()</a> · <a href="#handle-open">handle.open()</a></p>
+<p className="msb-backref">Returned by <a href="#handle-snapshot">snapshot()</a> · <a href="#snapshot-create">Snapshot.create()</a> · <a href="#snapshot-open">Snapshot.open()</a> · <a href="#snapshot-list_dir">Snapshot.list_dir()</a> · <a href="#handle-open">handle.open()</a></p>
 
 A fully-parsed snapshot artifact. Properties are read-only attributes (not async).
 
@@ -714,6 +680,7 @@ A fully-parsed snapshot artifact. Properties are read-only attributes (not async
 | `image_ref` | `str` | Image reference the snapshot was taken from |
 | `image_manifest_digest` | `str` | OCI manifest digest of the pinned image |
 | `format` | `str` | `"raw"` or `"qcow2"` (always `"raw"` today) |
+| `scope` | `str` | `"disk"` or `"resumable"` (always `"disk"` today) |
 | `fstype` | `str` | Filesystem type inside the upper (e.g. `"ext4"`) |
 | `parent` | `str \| None` | Parent snapshot's digest, or `None` for a root |
 | `created_at` | `str` | RFC 3339 timestamp |
@@ -725,7 +692,7 @@ A fully-parsed snapshot artifact. Properties are read-only attributes (not async
 
 <div className="msb-tags"><span className="msb-tag is-type">class</span></div>
 
-<p className="msb-backref">Returned by <a href="#snapshot-get">Snapshot.get()</a> · <a href="#snapshot-list">Snapshot.list()</a> · <a href="#snapshot-import_">Snapshot.import_()</a></p>
+<p className="msb-backref">Returned by <a href="#snapshot-get">Snapshot.get()</a> · <a href="#snapshot-list">Snapshot.list()</a> · <a href="#snapshot-load">Snapshot.load()</a></p>
 
 Lightweight handle backed by an index row. Properties are read-only attributes (not async).
 
@@ -736,6 +703,7 @@ Lightweight handle backed by an index row. Properties are read-only attributes (
 | `parent_digest` | `str \| None` | Parent snapshot digest, or `None` for a root |
 | `image_ref` | `str` | Image the snapshot was taken from |
 | `format` | `str` | `"raw"` or `"qcow2"` |
+| `scope` | `str` | `"disk"` or `"resumable"` (always `"disk"` today) |
 | `size_bytes` | `int \| None` | Apparent upper size at index time |
 | `created_at` | `float` | ms since Unix epoch |
 | `path` | `str` | Local artifact directory path |

--- a/docs/sdk/python/snapshots.mdx
+++ b/docs/sdk/python/snapshots.mdx
@@ -44,10 +44,10 @@ Capture the disk state of a stopped sandbox as a reusable artifact, then boot fr
 ```python
 from microsandbox import Sandbox, Snapshot
 
-# Run setup work, then stop the sandbox
-async with await Sandbox.create("baseline", image="python:3.12") as sb:
-    await sb.exec("pip", ["install", "numpy"])
-    await sb.stop()
+# Run setup work, then stop the sandbox (snapshots are stopped-only)
+sb = await Sandbox.create("baseline", image="python:3.12")
+await sb.exec("pip", ["install", "numpy"])
+await sb.stop()
 
 # Capture its disk state under a name
 snap = await Snapshot.create("after-pip-install", from_sandbox="baseline")

--- a/docs/sdk/rust/snapshots.mdx
+++ b/docs/sdk/rust/snapshots.mdx
@@ -3,7 +3,7 @@ title: Snapshots
 description: Rust SDK - Snapshot API reference
 ---
 
-Capture a stopped sandbox's writable upper layer into a self-describing, content-addressed artifact on disk, then list, verify, export, import, or boot a fresh sandbox from it. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Rust SDK reference.
+Capture a stopped sandbox's writable upper layer into a self-describing, content-addressed artifact on disk, then list, verify, save, load, or boot a fresh sandbox from it. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs; this page is the Rust SDK reference.
 
 <div className="msb-glance">
 
@@ -16,8 +16,8 @@ Capture a stopped sandbox's writable upper layer into a self-describing, content
   <a className="msb-row" href="#snapshotlist_dir"><span className="msb-rn">Snapshot::list_dir()</span><span className="msb-rg">artifacts in a directory</span></a>
   <a className="msb-row" href="#snapshotremove"><span className="msb-rn">Snapshot::remove()</span><span className="msb-rg">delete an artifact</span></a>
   <a className="msb-row" href="#snapshotreindex"><span className="msb-rn">Snapshot::reindex()</span><span className="msb-rg">rebuild the index</span></a>
-  <a className="msb-row" href="#snapshotexport"><span className="msb-rn">Snapshot::export()</span><span className="msb-rg">bundle to an archive</span></a>
-  <a className="msb-row" href="#snapshotimport"><span className="msb-rn">Snapshot::import()</span><span className="msb-rg">unpack an archive</span></a>
+  <a className="msb-row" href="#snapshotsave"><span className="msb-rn">Snapshot::save()</span><span className="msb-rg">bundle to an archive</span></a>
+  <a className="msb-row" href="#snapshotload"><span className="msb-rn">Snapshot::load()</span><span className="msb-rg">unpack an archive</span></a>
 
   <p className="msb-gl"><span className="msb-dot instance"></span>Instance · Snapshot<span className="msb-ct">5</span></p>
   <a className="msb-row" href="#snap-digest"><span className="msb-rn">snap.digest()</span><span className="msb-rg">content identity</span></a>
@@ -26,10 +26,11 @@ Capture a stopped sandbox's writable upper layer into a self-describing, content
   <a className="msb-row" href="#snap-size_bytes"><span className="msb-rn">snap.size_bytes()</span><span className="msb-rg">upper-layer size</span></a>
   <a className="msb-row" href="#snap-verify"><span className="msb-rn">snap.verify()</span><span className="msb-rg">recheck integrity</span></a>
 
-  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · SnapshotHandle<span className="msb-ct">10</span></p>
+  <p className="msb-gl"><span className="msb-dot instance"></span>Instance · SnapshotHandle<span className="msb-ct">11</span></p>
   <a className="msb-row" href="#h-digest"><span className="msb-rn">h.digest()</span><span className="msb-rg">manifest digest</span></a>
   <a className="msb-row" href="#h-name"><span className="msb-rn">h.name()</span><span className="msb-rg">name alias</span></a>
   <a className="msb-row" href="#h-parent_digest"><span className="msb-rn">h.parent_digest()</span><span className="msb-rg">parent snapshot</span></a>
+  <a className="msb-row" href="#h-scope"><span className="msb-rn">h.scope()</span><span className="msb-rg">snapshot scope</span></a>
   <a className="msb-row" href="#h-image_ref"><span className="msb-rn">h.image_ref()</span><span className="msb-rg">source image</span></a>
   <a className="msb-row" href="#h-format"><span className="msb-rn">h.format()</span><span className="msb-rg">upper format</span></a>
   <a className="msb-row" href="#h-size_bytes"><span className="msb-rn">h.size_bytes()</span><span className="msb-rg">indexed size</span></a>
@@ -38,16 +39,14 @@ Capture a stopped sandbox's writable upper layer into a self-describing, content
   <a className="msb-row" href="#h-open"><span className="msb-rn">h.open()</span><span className="msb-rg">read the artifact</span></a>
   <a className="msb-row" href="#h-remove"><span className="msb-rn">h.remove()</span><span className="msb-rg">delete this snapshot</span></a>
 
-  <p className="msb-gl"><span className="msb-dot static"></span>Sandbox entry points<span className="msb-ct">3</span></p>
+  <p className="msb-gl"><span className="msb-dot static"></span>Sandbox entry points<span className="msb-ct">2</span></p>
   <a className="msb-row" href="#from_snapshot"><span className="msb-rn">.from_snapshot()</span><span className="msb-rg">boot from a snapshot</span></a>
   <a className="msb-row" href="#h-snapshot"><span className="msb-rn">h.snapshot()</span><span className="msb-rg">snapshot a stopped sandbox</span></a>
-  <a className="msb-row" href="#h-snapshot_to"><span className="msb-rn">h.snapshot_to()</span><span className="msb-rg">snapshot to a path</span></a>
 
-  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SnapshotBuilder<span className="msb-ct">8</span></p>
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SnapshotBuilder<span className="msb-ct">7</span></p>
   <div className="msb-chiprow">
-    <a className="msb-chip" href="#destination">.destination()</a>
-    <a className="msb-chip" href="#name">.name()</a>
-    <a className="msb-chip" href="#path">.path()</a>
+    <a className="msb-chip" href="#from_sandbox">.from_sandbox()</a>
+    <a className="msb-chip" href="#dest_dir">.dest_dir()</a>
     <a className="msb-chip" href="#label">.label()</a>
     <a className="msb-chip" href="#force">.force()</a>
     <a className="msb-chip" href="#record_integrity">.record_integrity()</a>
@@ -59,9 +58,9 @@ Capture a stopped sandbox's writable upper layer into a self-describing, content
   <div className="msb-chiprow">
     <a className="msb-typepill" href="#snapshothandle">SnapshotHandle</a>
     <a className="msb-typepill" href="#snapshotconfig">SnapshotConfig</a>
-    <a className="msb-typepill" href="#snapshotdestination">SnapshotDestination</a>
     <a className="msb-typepill" href="#snapshotformat">SnapshotFormat</a>
-    <a className="msb-typepill" href="#exportopts">ExportOpts</a>
+    <a className="msb-typepill" href="#snapshotscope">SnapshotScope</a>
+    <a className="msb-typepill" href="#saveopts">SaveOpts</a>
     <a className="msb-typepill" href="#snapshotverifyreport">SnapshotVerifyReport</a>
     <a className="msb-typepill" href="#upperverifystatus">UpperVerifyStatus</a>
     <a className="msb-typepill" href="#manifest">Manifest</a>
@@ -86,8 +85,8 @@ let sb = Sandbox::get("api").await?;
 sb.stop().await?;
 
 // 2. capture its writable upper layer
-let snap = Snapshot::builder("api")
-    .name("after-pip-install")     // bare name in the default dir
+let snap = Snapshot::builder("after-pip-install")
+    .from_sandbox("api")           // sandbox to capture
     .record_integrity()            // hash the upper layer
     .create()
     .await?;
@@ -108,17 +107,17 @@ let restored = Sandbox::builder("api-restored")
 <div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```rust
-fn builder(source_sandbox: impl Into<String>) -> SnapshotBuilder
+fn builder(name: impl Into<String>) -> SnapshotBuilder
 ```
 
-Start configuring a new snapshot of `source_sandbox`. The builder lets you set the destination, labels, and whether to record content integrity before capturing. See [`SnapshotBuilder`](#snapshotbuilder) for all options.
+Start configuring a new snapshot named `name`, resolved under the default snapshots directory (`~/.microsandbox/snapshots/<name>/`) or under [`dest_dir()`](#dest_dir) when set. The source sandbox is set with [`from_sandbox()`](#from_sandbox), which is required; the other setters cover labels and whether to record content integrity before capturing. See [`SnapshotBuilder`](#snapshotbuilder) for all options.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
-    <div className="msb-param-key"><code>source_sandbox</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
-    <div className="msb-param-desc">Name of the source sandbox. Must be stopped or crashed, and rooted on an OCI image.</div>
+    <div className="msb-param-key"><code>name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Bare snapshot name. Must not be empty, contain <code>/</code>, or start with <code>.</code>.</div>
   </div>
 </div>
 
@@ -134,8 +133,8 @@ Start configuring a new snapshot of `source_sandbox`. The builder lets you set t
 <Accordion title="Example">
 
 ```rust
-let snap = Snapshot::builder("api")
-    .name("baseline")
+let snap = Snapshot::builder("baseline")
+    .from_sandbox("api")
     .create()
     .await?;
 ```
@@ -151,14 +150,14 @@ let snap = Snapshot::builder("api")
 async fn create(config: SnapshotConfig) -> MicrosandboxResult<Snapshot>
 ```
 
-Create a snapshot artifact from a stopped sandbox. Writes `manifest.json` and the captured `upper.ext4` into the destination directory atomically (the manifest is renamed into place last), then best-effort upserts a row into the local index. Index failures are logged but do not fail the call; the artifact is the source of truth. Most callers use the [builder](#snapshotbuilder)'s [`create()`](#create) instead of constructing a [`SnapshotConfig`](#snapshotconfig) by hand.
+Create a snapshot artifact from a stopped sandbox. Writes the `snapshot.json` descriptor and the captured `upper.ext4` into the artifact directory atomically (the descriptor is renamed into place last), then best-effort upserts a row into the local index. Index failures are logged but do not fail the call; the artifact is the source of truth. Most callers use the [builder](#snapshotbuilder)'s [`create()`](#create) instead of constructing a [`SnapshotConfig`](#snapshotconfig) by hand.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>config</code><a className="msb-type" href="#snapshotconfig">SnapshotConfig</a></div>
-    <div className="msb-param-desc">Source sandbox, destination, labels, and integrity flag.</div>
+    <div className="msb-param-desc">Name, source sandbox, labels, and integrity flag.</div>
   </div>
 </div>
 
@@ -175,7 +174,7 @@ Create a snapshot artifact from a stopped sandbox. Writes `manifest.json` and th
 
 ```rust
 let snap = Snapshot::create(
-    Snapshot::builder("api").name("baseline").build()?
+    Snapshot::builder("baseline").from_sandbox("api").build()?
 ).await?;
 ```
 
@@ -296,7 +295,7 @@ for h in Snapshot::list().await? {
 async fn list_dir(dir: impl AsRef<Path>) -> MicrosandboxResult<Vec<Snapshot>>
 ```
 
-Walk a directory and parse each subdirectory's manifest. Does not touch the index. Skips entries that don't look like snapshot artifacts (no `manifest.json`) and malformed artifacts.
+Walk a directory and parse each subdirectory's manifest. Does not touch the index. Skips entries that don't look like snapshot artifacts (no `snapshot.json`) and malformed artifacts.
 
 <p className="msb-label">Parameters</p>
 
@@ -397,42 +396,42 @@ println!("indexed {n} snapshots");
 
 ---
 
-#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">export()</span>
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">save()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
-async fn export(name_or_path: &str, out: &Path, opts: ExportOpts) -> MicrosandboxResult<()>
+async fn save(name_or_path: &str, out: &Path, opts: SaveOpts) -> MicrosandboxResult<()>
 ```
 
-Bundle a snapshot into a `.tar.zst` archive (or plain `.tar`) at `out`. The head snapshot is verified before bundling. The recorded manifest is archived as-is, so create the snapshot with [`record_integrity()`](#record_integrity) when the archive will cross a trust boundary. See [`ExportOpts`](#exportopts) to also include ancestors and the OCI image cache.
+Bundle a snapshot into a `.tar.zst` archive (or plain `.tar`) at `out`. The head snapshot is verified before bundling. The recorded manifest is archived as-is, so create the snapshot with [`record_integrity()`](#record_integrity) when the archive will cross a trust boundary. See [`SaveOpts`](#saveopts) to also include ancestors and the OCI image cache.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>name_or_path</code><span className="msb-type">&amp;str</span></div>
-    <div className="msb-param-desc">Snapshot name or artifact path to export.</div>
+    <div className="msb-param-desc">Snapshot name or artifact path to save.</div>
   </div>
   <div className="msb-param">
     <div className="msb-param-key"><code>out</code><span className="msb-type">&amp;Path</span></div>
     <div className="msb-param-desc">Output archive path. Parent directories are created if missing.</div>
   </div>
   <div className="msb-param">
-    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#exportopts">ExportOpts</a></div>
-    <div className="msb-param-desc">Bundling options. <code>ExportOpts::default()</code> writes the head snapshot only, zstd-compressed.</div>
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#saveopts">SaveOpts</a></div>
+    <div className="msb-param-desc">Bundling options. <code>SaveOpts::default()</code> writes the head snapshot only, zstd-compressed.</div>
   </div>
 </div>
 
 <Accordion title="Example">
 
 ```rust
-use microsandbox::snapshot::ExportOpts;
+use microsandbox::snapshot::SaveOpts;
 use std::path::Path;
 
-Snapshot::export(
+Snapshot::save(
     "baseline",
     Path::new("/tmp/baseline.tar.zst"),
-    ExportOpts { with_parents: true, with_image: true, ..Default::default() },
+    SaveOpts { with_parents: true, with_image: true, ..Default::default() },
 ).await?;
 ```
 
@@ -440,11 +439,11 @@ Snapshot::export(
 
 ---
 
-#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">import()</span>
+#### <span className="msb-recv">Snapshot::</span><span className="msb-hn">load()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```rust
-async fn import(archive_path: &Path, dest: Option<&Path>) -> MicrosandboxResult<SnapshotHandle>
+async fn load(archive_path: &Path, dest: Option<&Path>) -> MicrosandboxResult<SnapshotHandle>
 ```
 
 Unpack a snapshot archive (`.tar.zst` or `.tar`, detected from magic bytes) into the snapshots directory (or `dest`), routing any bundled image-cache entries into the global cache and registering everything found in the index. Recorded integrity is verified as artifacts land. Returns a handle for the head snapshot.
@@ -476,8 +475,8 @@ Unpack a snapshot archive (`.tar.zst` or `.tar`, detected from magic bytes) into
 ```rust
 use std::path::Path;
 
-let h = Snapshot::import(Path::new("/tmp/baseline.tar.zst"), None).await?;
-println!("imported {}", h.digest());
+let h = Snapshot::load(Path::new("/tmp/baseline.tar.zst"), None).await?;
+println!("loaded {}", h.digest());
 ```
 
 </Accordion>
@@ -517,7 +516,7 @@ Canonical content digest of this snapshot's manifest (`sha256:hex`). This is the
 fn path(&self) -> &Path
 ```
 
-Path to the artifact directory holding the canonical `manifest.json` and the captured upper file.
+Path to the artifact directory holding the canonical `snapshot.json` descriptor and the captured upper file.
 
 <p className="msb-label">Returns</p>
 
@@ -616,7 +615,7 @@ match snap.verify().await?.upper {
 
 ## SnapshotHandle methods
 
-Accessors and lifecycle on a [`SnapshotHandle`](#snapshothandle) (an index row). Returned by [`Snapshot::get()`](#snapshotget), [`Snapshot::list()`](#snapshotlist), and [`Snapshot::import()`](#snapshotimport).
+Accessors and lifecycle on a [`SnapshotHandle`](#snapshothandle) (an index row). Returned by [`Snapshot::get()`](#snapshotget), [`Snapshot::list()`](#snapshotlist), and [`Snapshot::load()`](#snapshotload).
 
 ---
 
@@ -650,6 +649,17 @@ fn parent_digest(&self) -> Option<&str>
 ```
 
 The parent snapshot's digest, or `None` for a root. Always `None` today; populated once chained snapshots land.
+
+---
+
+#### <span className="msb-recv">h.</span><span className="msb-hn">scope()</span>
+<div className="msb-tags"><span className="msb-tag is-instance">instance</span></div>
+
+```rust
+fn scope(&self) -> SnapshotScope
+```
+
+Snapshot payload scope: [`SnapshotScope::Disk`](#snapshotscope) for a disk-only snapshot, `Resumable` once resumable snapshots land. Always `Disk` today.
 
 ---
 
@@ -820,7 +830,7 @@ let sb = Sandbox::builder("api-restored")
 async fn snapshot(&self, name: &str) -> MicrosandboxResult<Snapshot>
 ```
 
-`SandboxHandle` method. Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). The sandbox must be stopped or crashed; running sandboxes are rejected with `SnapshotSandboxRunning`. Local handles only. For an explicit destination see [`snapshot_to()`](#h-snapshot_to).
+`SandboxHandle` method. Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). The sandbox must be stopped or crashed; running sandboxes are rejected with `SnapshotSandboxRunning`. Local handles only. To place the artifact elsewhere, use [`Snapshot::save()`](#snapshotsave) / [`Snapshot::load()`](#snapshotload) or move the self-contained artifact directory.
 
 <p className="msb-label">Parameters</p>
 
@@ -852,52 +862,13 @@ let snap = h.snapshot("baseline").await?;
 
 ---
 
-#### <span className="msb-recv">h.</span><span className="msb-hn">snapshot_to()</span>
-<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
-
-```rust
-async fn snapshot_to(&self, path: impl AsRef<Path>) -> MicrosandboxResult<Snapshot>
-```
-
-`SandboxHandle` method. Snapshot this sandbox to an explicit filesystem path. The sandbox must be stopped or crashed. Local handles only. For the common case of writing under the default snapshots directory see [`snapshot()`](#h-snapshot).
-
-<p className="msb-label">Parameters</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><code>path</code><span className="msb-type">impl AsRef&lt;Path&gt;</span></div>
-    <div className="msb-param-desc">Destination artifact directory.</div>
-  </div>
-</div>
-
-<p className="msb-label">Returns</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><a className="msb-type" href="#instance-methods">Snapshot</a></div>
-    <div className="msb-param-desc">The created artifact handle.</div>
-  </div>
-</div>
-
-<Accordion title="Example">
-
-```rust
-let h = Sandbox::get("api").await?;
-h.stop().await?;
-let snap = h.snapshot_to("/data/snapshots/baseline").await?;
-```
-
-</Accordion>
-
----
-
 ## SnapshotBuilder
 
-Builder for a [`SnapshotConfig`](#snapshotconfig). Obtained via [`Snapshot::builder(source_sandbox)`](#snapshotbuilder). A destination is required ([`name`](#name) or [`path`](#path)); the other setters are optional. Every setter returns `Self`, so calls chain.
+Builder for a [`SnapshotConfig`](#snapshotconfig). Obtained via [`Snapshot::builder(name)`](#snapshotbuilder). A source sandbox is required ([`from_sandbox`](#from_sandbox)); the other setters are optional. Every setter returns `Self`, so calls chain.
 
 ```rust
-let snap = Snapshot::builder("api")
-    .name("after-pip-install")     // bare name in default dir
+let snap = Snapshot::builder("after-pip-install")
+    .from_sandbox("api")           // sandbox to capture
     .label("stage", "post-deps")
     .force()                       // overwrite if it exists
     .record_integrity()            // hash the upper layer
@@ -907,61 +878,41 @@ let snap = Snapshot::builder("api")
 
 ---
 
-#### <span className="msb-recv">.</span><span className="msb-hn">destination()</span>
+#### <span className="msb-recv">.</span><span className="msb-hn">from_sandbox()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn destination(self, dest: SnapshotDestination) -> Self
+fn from_sandbox(self, source_sandbox: impl Into<String>) -> Self
 ```
 
-Set the artifact destination explicitly. The [`name`](#name) and [`path`](#path) setters are convenience wrappers over this.
+Set the sandbox to capture. Required; [`build()`](#build) and [`create()`](#create) fail without it.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
-    <div className="msb-param-key"><code>dest</code><a className="msb-type" href="#snapshotdestination">SnapshotDestination</a></div>
-    <div className="msb-param-desc">Name- or path-based destination.</div>
+    <div className="msb-param-key"><code>source_sandbox</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Name of the source sandbox. Must be stopped or crashed, and rooted on an OCI image.</div>
   </div>
 </div>
 
 ---
 
-#### <span className="msb-recv">.</span><span className="msb-hn">name()</span>
+#### <span className="msb-recv">.</span><span className="msb-hn">dest_dir()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```rust
-fn name(self, name: impl Into<String>) -> Self
+fn dest_dir(self, dest_dir: impl Into<PathBuf>) -> Self
 ```
 
-Convenience: use a bare name resolved under the default snapshots directory. Sets the destination to [`SnapshotDestination::Name`](#snapshotdestination).
+Create the artifact under this parent directory instead of the default snapshots store. The artifact directory is `dest_dir/<name>`; the name stays the snapshot's identity either way.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
-    <div className="msb-param-key"><code>name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
-    <div className="msb-param-desc">Bare snapshot name. Must not be empty, contain <code>/</code>, or start with <code>.</code>.</div>
-  </div>
-</div>
-
----
-
-#### <span className="msb-recv">.</span><span className="msb-hn">path()</span>
-<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
-
-```rust
-fn path(self, path: impl Into<PathBuf>) -> Self
-```
-
-Convenience: write the artifact to an explicit path. Sets the destination to [`SnapshotDestination::Path`](#snapshotdestination).
-
-<p className="msb-label">Parameters</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><code>path</code><span className="msb-type">impl Into&lt;PathBuf&gt;</span></div>
-    <div className="msb-param-desc">Destination artifact directory.</div>
+    <div className="msb-param-key"><code>dest_dir</code><span className="msb-type">impl Into&lt;PathBuf&gt;</span></div>
+    <div className="msb-param-desc">Parent directory to create the artifact in (e.g. a larger volume).</div>
   </div>
 </div>
 
@@ -998,7 +949,7 @@ Add a user label. Can be called multiple times. Labels are sorted by key in the 
 fn force(self) -> Self
 ```
 
-Overwrite an existing artifact at the destination. Without this, creation fails with `SnapshotAlreadyExists` if the destination directory exists.
+Overwrite an existing artifact with the same name. Without this, creation fails with `SnapshotAlreadyExists` if the artifact directory exists.
 
 ---
 
@@ -1009,7 +960,7 @@ Overwrite an existing artifact at the destination. Without this, creation fails 
 fn record_integrity(self) -> Self
 ```
 
-Compute and record an upper-layer content-integrity hash during creation. Recorded integrity is what [`verify()`](#snap-verify) checks and what import/export rely on when crossing a trust boundary.
+Compute and record an upper-layer content-integrity hash during creation. Recorded integrity is what [`verify()`](#snap-verify) checks and what save/load rely on when crossing a trust boundary.
 
 ---
 
@@ -1020,7 +971,7 @@ Compute and record an upper-layer content-integrity hash during creation. Record
 fn build(self) -> MicrosandboxResult<SnapshotConfig>
 ```
 
-Materialize the [`SnapshotConfig`](#snapshotconfig) without creating the snapshot. Errors with `InvalidConfig` if no destination was set. For capturing, use [`create`](#create) instead; it calls `build` internally.
+Materialize the [`SnapshotConfig`](#snapshotconfig) without creating the snapshot. Errors with `InvalidConfig` if [`from_sandbox`](#from_sandbox) was not called. For capturing, use [`create`](#create) instead; it calls `build` internally.
 
 <p className="msb-label">Returns</p>
 
@@ -1059,7 +1010,7 @@ Build and execute the snapshot in one step. Equivalent to [`Snapshot::create(sel
 
 <div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-<p className="msb-backref">Returned by <a href="#snapshotget">Snapshot::get()</a> · <a href="#snapshotlist">Snapshot::list()</a> · <a href="#snapshotimport">Snapshot::import()</a></p>
+<p className="msb-backref">Returned by <a href="#snapshotget">Snapshot::get()</a> · <a href="#snapshotlist">Snapshot::list()</a> · <a href="#snapshotload">Snapshot::load()</a></p>
 
 A lightweight handle backed by a local index row. Use [`open()`](#h-open) to read the artifact metadata, and [`Snapshot::verify()`](#snap-verify) for explicit content verification. All accessors are listed under [SnapshotHandle methods](#snapshothandle-methods).
 
@@ -1068,6 +1019,7 @@ A lightweight handle backed by a local index row. Use [`open()`](#h-open) to rea
 | digest() | `&str` | Manifest digest (`sha256:hex`) |
 | name() | `Option<&str>` | Name alias; `None` for digest-only entries |
 | parent_digest() | `Option<&str>` | Parent snapshot digest, or `None` for a root |
+| scope() | [`SnapshotScope`](#snapshotscope) | Snapshot payload scope (`Disk` today) |
 | image_ref() | `&str` | Source image reference |
 | format() | [`SnapshotFormat`](#snapshotformat) | On-disk upper format |
 | size_bytes() | `Option<u64>` | Upper file size at index time |
@@ -1086,24 +1038,13 @@ Inputs to create a snapshot. A type alias for `SnapshotSpec`. Usually built via 
 
 | Field | Type | Description |
 |-------|------|-------------|
+| name | `String` | Bare snapshot name; always the artifact directory's basename |
+| dest_dir | `Option<PathBuf>` | Parent directory for the artifact; `None` = the default snapshots directory |
 | source_sandbox | `String` | Name of the source sandbox; must be stopped |
-| destination | [`SnapshotDestination`](#snapshotdestination) | Where to write the artifact |
 | labels | `Vec<(String, String)>` | User-supplied labels |
-| force | `bool` | Overwrite an existing artifact at the destination |
+| force | `bool` | Overwrite an existing artifact with the same name |
 | record_integrity | `bool` | Compute and record upper-layer integrity at creation |
-
-### SnapshotDestination
-
-<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
-
-<p className="msb-backref">Used by <a href="#destination">destination()</a> · <a href="#snapshotconfig">SnapshotConfig.destination</a></p>
-
-Where to place a new snapshot artifact. The builder's [`name()`](#name) and [`path()`](#path), and the handle's [`snapshot()`](#h-snapshot) / [`snapshot_to()`](#h-snapshot_to), construct this enum internally so callers rarely import it.
-
-| Variant | Fields | Description |
-|---------|--------|-------------|
-| `Name` | `String` | Bare name resolved under the default snapshots directory |
-| `Path` | `PathBuf` | Explicit absolute or relative path to the artifact directory |
+| resumable | `bool` | Request a resumable snapshot; returns an unsupported-feature error today |
 
 ### SnapshotFormat
 
@@ -1118,13 +1059,26 @@ On-disk format of the captured upper layer. Today only `Raw` is produced; the va
 | `Raw` | Raw ext4 image, sparse on disk |
 | `Qcow2` | qcow2 with optional backing chain (future) |
 
-### ExportOpts
+### SnapshotScope
+
+<div className="msb-tags"><span className="msb-tag is-type">enum</span></div>
+
+<p className="msb-backref">Used by <a href="#h-scope">scope()</a> · <a href="#manifest">Manifest.scope</a></p>
+
+Snapshot payload scope. Parsing accepts every known scope so older runtimes can still list and inspect artifacts they cannot restore; create and restore paths enforce support. Re-exported as `microsandbox::snapshot::SnapshotScope`.
+
+| Value | Description |
+|-------|-------------|
+| `Disk` | Disk-only snapshot; captures the writable filesystem state |
+| `Resumable` | Reserved for future memory/device-state capture |
+
+### SaveOpts
 
 <div className="msb-tags"><span className="msb-tag is-type">struct</span></div>
 
-<p className="msb-backref">Used by <a href="#snapshotexport">Snapshot::export()</a></p>
+<p className="msb-backref">Used by <a href="#snapshotsave">Snapshot::save()</a></p>
 
-Options for [`Snapshot::export()`](#snapshotexport). Implements `Default`; `ExportOpts::default()` writes the head snapshot only, zstd-compressed.
+Options for [`Snapshot::save()`](#snapshotsave). Implements `Default`; `SaveOpts::default()` writes the head snapshot only, zstd-compressed.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -1165,11 +1119,13 @@ Upper-layer content verification result.
 
 <p className="msb-backref">Returned by <a href="#snap-manifest">manifest()</a></p>
 
-The snapshot artifact manifest, the source of truth for an artifact. Re-exported as `microsandbox::snapshot::Manifest`. Its SHA-256 digest over the canonical byte form is the snapshot's identity. Field order is load-bearing (it determines the canonical byte layout) and must not be reordered.
+The snapshot artifact manifest, the source of truth for an artifact, serialized as the `snapshot.json` descriptor (`DESCRIPTOR_FILENAME`). Re-exported as `microsandbox::snapshot::Manifest`. Its SHA-256 digest over the canonical byte form is the snapshot's identity. Field order is load-bearing (it determines the canonical byte layout) and must not be reordered.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | schema | `u32` | Manifest schema version; readers reject unknown values |
+| artifact | `String` | Artifact kind; always `"snapshot"` |
+| scope | [`SnapshotScope`](#snapshotscope) | Payload scope; only disk snapshots are created today |
 | format | [`SnapshotFormat`](#snapshotformat) | On-disk format of the upper layer |
 | fstype | `String` | Filesystem type inside the upper (e.g. `ext4`) |
 | image | [`ImageRef`](#imageref) | Image the snapshot was taken from |

--- a/docs/sdk/rust/snapshots.mdx
+++ b/docs/sdk/rust/snapshots.mdx
@@ -43,13 +43,14 @@ Capture a stopped sandbox's writable upper layer into a self-describing, content
   <a className="msb-row" href="#from_snapshot"><span className="msb-rn">.from_snapshot()</span><span className="msb-rg">boot from a snapshot</span></a>
   <a className="msb-row" href="#h-snapshot"><span className="msb-rn">h.snapshot()</span><span className="msb-rg">snapshot a stopped sandbox</span></a>
 
-  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SnapshotBuilder<span className="msb-ct">7</span></p>
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SnapshotBuilder<span className="msb-ct">8</span></p>
   <div className="msb-chiprow">
     <a className="msb-chip" href="#from_sandbox">.from_sandbox()</a>
     <a className="msb-chip" href="#dest_dir">.dest_dir()</a>
     <a className="msb-chip" href="#label">.label()</a>
     <a className="msb-chip" href="#force">.force()</a>
     <a className="msb-chip" href="#record_integrity">.record_integrity()</a>
+    <a className="msb-chip" href="#resumable">.resumable()</a>
     <a className="msb-chip" href="#build">.build()</a>
     <a className="msb-chip" href="#create">.create()</a>
   </div>
@@ -961,6 +962,17 @@ fn record_integrity(self) -> Self
 ```
 
 Compute and record an upper-layer content-integrity hash during creation. Recorded integrity is what [`verify()`](#snap-verify) checks and what save/load rely on when crossing a trust boundary.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">resumable()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```rust
+fn resumable(self) -> Self
+```
+
+Request a resumable snapshot (disk plus VM state). Accepted by the builder, but [`create()`](#create) currently fails with `Unsupported`; resumable snapshots have not landed yet.
 
 ---
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -2464,7 +2464,6 @@ Handles from `Sandbox.get(name)` are **live** - they expose lifecycle methods (`
 | waitUntilStopped() | `Promise<`[`SandboxStopResult`](#sandboxstopresult)`>` | Block until the sandbox reaches terminal state |
 | remove() | `Promise<void>` | Delete sandbox and state |
 | snapshot(name) | `Promise<Snapshot>` | Snapshot this stopped sandbox under a bare name. See [Snapshots](/sdk/typescript/snapshots) |
-| snapshotTo(path) | `Promise<Snapshot>` | Snapshot this stopped sandbox to an explicit filesystem path |
 
 ### SandboxPingResult
 

--- a/docs/sdk/typescript/snapshots.mdx
+++ b/docs/sdk/typescript/snapshots.mdx
@@ -440,7 +440,7 @@ console.log(`reindexed ${count} snapshots`);
 static save(nameOrPath: string, out: string, opts?: SaveOpts): Promise<void>
 ```
 
-Bundle a snapshot into a `.tar.zst` archive. When the snapshot has no integrity hash yet, one is computed and embedded in the bundled manifest so the receiver can verify. See [`SaveOpts`](#saveopts-interface) for bundling options.
+Bundle a snapshot into a `.tar.zst` archive. The recorded manifest is archived as-is, so create the snapshot with [`recordIntegrity()`](#recordintegrity) if receivers must verify content. See [`SaveOpts`](#saveopts-interface) for bundling options.
 
 <p className="msb-label">Parameters</p>
 
@@ -875,7 +875,7 @@ Bundle options for [`Snapshot.save()`](#snapshot-save). All fields default to `f
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `withParents` | `boolean` | Walk the parent chain and include each ancestor (no-op in v1). |
+| `withParents` | `boolean` | Walk the parent chain and include each ancestor in the archive. |
 | `withImage` | `boolean` | Include the OCI image cache so the archive boots offline. |
 | `plainTar` | `boolean` | Skip zstd compression and write a plain `.tar`. |
 

--- a/docs/sdk/typescript/snapshots.mdx
+++ b/docs/sdk/typescript/snapshots.mdx
@@ -7,7 +7,7 @@ Capture the disk state of a stopped sandbox into a portable artifact, then boot 
 
 ```typescript
 import { Sandbox, Snapshot, SnapshotHandle } from "microsandbox";
-import type { ExportOpts, SnapshotVerifyReport } from "microsandbox";
+import type { SaveOpts, SnapshotScope, SnapshotVerifyReport } from "microsandbox";
 ```
 
 <Note>
@@ -16,10 +16,9 @@ import type { ExportOpts, SnapshotVerifyReport } from "microsandbox";
 
 <div className="msb-glance">
 
-  <p className="msb-gl"><span className="msb-dot static"></span>Capture &amp; boot<span className="msb-ct">3</span></p>
+  <p className="msb-gl"><span className="msb-dot static"></span>Capture &amp; boot<span className="msb-ct">2</span></p>
   <a className="msb-row" href="/sdk/typescript/sandbox#fromsnapshot"><span className="msb-rn">.fromSnapshot()</span><span className="msb-rg">boot a sandbox from a snapshot</span></a>
   <a className="msb-row" href="#handle-snapshot"><span className="msb-rn">handle.snapshot()</span><span className="msb-rg">snapshot a stopped sandbox by name</span></a>
-  <a className="msb-row" href="#handle-snapshotto"><span className="msb-rn">handle.snapshotTo()</span><span className="msb-rg">snapshot to an explicit path</span></a>
 
   <p className="msb-gl"><span className="msb-dot static"></span>Snapshot · static<span className="msb-ct">9</span></p>
   <a className="msb-row" href="#snapshotbuilder"><span className="msb-rn">Snapshot.builder()</span><span className="msb-rg">configure a new snapshot</span></a>
@@ -29,16 +28,17 @@ import type { ExportOpts, SnapshotVerifyReport } from "microsandbox";
   <a className="msb-row" href="#snapshot-listdir"><span className="msb-rn">Snapshot.listDir()</span><span className="msb-rg">parse a directory, no index</span></a>
   <a className="msb-row" href="#snapshot-remove"><span className="msb-rn">Snapshot.remove()</span><span className="msb-rg">delete an artifact</span></a>
   <a className="msb-row" href="#snapshot-reindex"><span className="msb-rn">Snapshot.reindex()</span><span className="msb-rg">rebuild the local index</span></a>
-  <a className="msb-row" href="#snapshot-export"><span className="msb-rn">Snapshot.export()</span><span className="msb-rg">bundle into an archive</span></a>
-  <a className="msb-row" href="#snapshot-import"><span className="msb-rn">Snapshot.import()</span><span className="msb-rg">unpack an archive</span></a>
+  <a className="msb-row" href="#snapshot-save"><span className="msb-rn">Snapshot.save()</span><span className="msb-rg">bundle into an archive</span></a>
+  <a className="msb-row" href="#snapshot-load"><span className="msb-rn">Snapshot.load()</span><span className="msb-rg">unpack an archive</span></a>
 
-  <p className="msb-gl"><span className="msb-dot instance"></span>Snapshot · instance<span className="msb-ct">12</span></p>
+  <p className="msb-gl"><span className="msb-dot instance"></span>Snapshot · instance<span className="msb-ct">13</span></p>
   <a className="msb-row" href="#snap-path"><span className="msb-rn">snap.path</span><span className="msb-rg">artifact directory</span></a>
   <a className="msb-row" href="#snap-digest"><span className="msb-rn">snap.digest</span><span className="msb-rg">canonical content digest</span></a>
   <a className="msb-row" href="#snap-sizebytes"><span className="msb-rn">snap.sizeBytes</span><span className="msb-rg">apparent upper-layer size</span></a>
   <a className="msb-row" href="#snap-imageref"><span className="msb-rn">snap.imageRef</span><span className="msb-rg">source image reference</span></a>
   <a className="msb-row" href="#snap-imagemanifestdigest"><span className="msb-rn">snap.imageManifestDigest</span><span className="msb-rg">pinned image manifest digest</span></a>
   <a className="msb-row" href="#snap-format"><span className="msb-rn">snap.format</span><span className="msb-rg">upper-layer on-disk format</span></a>
+  <a className="msb-row" href="#snap-scope"><span className="msb-rn">snap.scope</span><span className="msb-rg">snapshot scope</span></a>
   <a className="msb-row" href="#snap-fstype"><span className="msb-rn">snap.fstype</span><span className="msb-rg">upper-layer filesystem type</span></a>
   <a className="msb-row" href="#snap-parent"><span className="msb-rn">snap.parent</span><span className="msb-rg">parent digest, or null</span></a>
   <a className="msb-row" href="#snap-createdat"><span className="msb-rn">snap.createdAt</span><span className="msb-rg">creation timestamp</span></a>
@@ -46,13 +46,14 @@ import type { ExportOpts, SnapshotVerifyReport } from "microsandbox";
   <a className="msb-row" href="#snap-sourcesandbox"><span className="msb-rn">snap.sourceSandbox</span><span className="msb-rg">recorded source sandbox</span></a>
   <a className="msb-row" href="#snap-verify"><span className="msb-rn">snap.verify()</span><span className="msb-rg">recheck content hash</span></a>
 
-  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SnapshotBuilder<span className="msb-ct">6</span></p>
+  <p className="msb-gl"><span className="msb-dot builder"></span>Builder · SnapshotBuilder<span className="msb-ct">7</span></p>
   <div className="msb-chiprow">
-    <a className="msb-chip" href="#name">.name()</a>
-    <a className="msb-chip" href="#path">.path()</a>
+    <a className="msb-chip" href="#fromsandbox">.fromSandbox()</a>
+    <a className="msb-chip" href="#destdir">.destDir()</a>
     <a className="msb-chip" href="#label">.label()</a>
     <a className="msb-chip" href="#force">.force()</a>
     <a className="msb-chip" href="#recordintegrity">.recordIntegrity()</a>
+    <a className="msb-chip" href="#resumable">.resumable()</a>
     <a className="msb-chip" href="#create">.create()</a>
   </div>
 
@@ -63,7 +64,8 @@ import type { ExportOpts, SnapshotVerifyReport } from "microsandbox";
   <p className="msb-gl"><span className="msb-dot type"></span>Types</p>
   <div className="msb-chiprow">
     <a className="msb-typepill" href="#snapshothandle-class">SnapshotHandle</a>
-    <a className="msb-typepill" href="#exportopts-interface">ExportOpts</a>
+    <a className="msb-typepill" href="#saveopts-interface">SaveOpts</a>
+    <a className="msb-typepill" href="#snapshotscope-type">SnapshotScope</a>
     <a className="msb-typepill" href="#snapshotverifyreport-union">SnapshotVerifyReport</a>
   </div>
 
@@ -77,8 +79,8 @@ import { Sandbox, Snapshot } from "microsandbox";
 // 1. capture: stop the sandbox, then snapshot its disk
 const sb = await Sandbox.get("baseline");
 await sb.stop();
-const snap = await Snapshot.builder("baseline")
-  .name("after-pip-install")     // bare name in the default dir
+const snap = await Snapshot.builder("after-pip-install")
+  .fromSandbox("baseline")       // sandbox to capture
   .recordIntegrity()             // hash the upper layer
   .create();
 
@@ -140,7 +142,7 @@ const sb = await Sandbox.builder("worker")
 snapshot(name: string): Promise<Snapshot>
 ```
 
-Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). Called on a [`SandboxHandle`](/sdk/typescript/sandbox#sandboxhandle). The sandbox must be stopped or crashed; running sandboxes are rejected with a `SnapshotSandboxRunning` error. For an explicit filesystem destination, see [`snapshotTo()`](#handle-snapshotto).
+Snapshot this sandbox under a bare name in the default snapshots directory (`~/.microsandbox/snapshots/<name>/`). Called on a [`SandboxHandle`](/sdk/typescript/sandbox#sandboxhandle). The sandbox must be stopped or crashed; running sandboxes are rejected with a `SnapshotSandboxRunning` error. To place the artifact elsewhere, use [`Snapshot.save()`](#snapshot-save) / [`Snapshot.load()`](#snapshot-load) or move the self-contained artifact directory.
 
 <p className="msb-label">Parameters</p>
 
@@ -172,43 +174,6 @@ const snap = await h.snapshot("after-pip-install");
 
 ---
 
-#### <span className="msb-recv">handle.</span><span className="msb-hn">snapshotTo()</span>
-<div className="msb-tags"><span className="msb-tag is-instance">instance</span><span className="msb-tag is-async">async</span></div>
-
-```typescript
-snapshotTo(path: string): Promise<Snapshot>
-```
-
-Snapshot this sandbox to an explicit filesystem path. Called on a [`SandboxHandle`](/sdk/typescript/sandbox#sandboxhandle). The sandbox must be stopped or crashed.
-
-<p className="msb-label">Parameters</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
-    <div className="msb-param-desc">Destination artifact directory path.</div>
-  </div>
-</div>
-
-<p className="msb-label">Returns</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><a className="msb-type" href="#snapshot-instance">Promise&lt;Snapshot&gt;</a></div>
-    <div className="msb-param-desc">The created snapshot artifact.</div>
-  </div>
-</div>
-
-<Accordion title="Example">
-
-```typescript
-const snap = await h.snapshotTo("/data/snapshots/baseline-v2");
-```
-
-</Accordion>
-
----
-
 ## Snapshot static methods
 
 ---
@@ -217,17 +182,17 @@ const snap = await h.snapshotTo("/data/snapshots/baseline-v2");
 <div className="msb-tags"><span className="msb-tag is-static">static</span></div>
 
 ```typescript
-static builder(sourceSandbox: string): SnapshotBuilder
+static builder(name: string): SnapshotBuilder
 ```
 
-Begin building a new snapshot of `sourceSandbox` (which must be stopped). The fluent builder is what powers the CLI internally. The bare-name and explicit-path destinations are mutually exclusive — call exactly one of [`.name()`](#name) or [`.path()`](#path). See [`SnapshotBuilder`](#snapshotbuilder) for all setters.
+Begin building a new snapshot named `name`, resolved under the default snapshots directory (`~/.microsandbox/snapshots/<name>/`) or under [`.destDir()`](#destdir) when set. The fluent builder is what powers the CLI internally. The source sandbox is set with [`.fromSandbox()`](#fromsandbox), which is required. See [`SnapshotBuilder`](#snapshotbuilder) for all setters.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
-    <div className="msb-param-key"><code>sourceSandbox</code><span className="msb-type">string</span></div>
-    <div className="msb-param-desc">Name of the stopped sandbox to capture.</div>
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Bare snapshot name; becomes the artifact directory under the default snapshots dir.</div>
   </div>
 </div>
 
@@ -243,8 +208,8 @@ Begin building a new snapshot of `sourceSandbox` (which must be stopped). The fl
 <Accordion title="Example">
 
 ```typescript
-const snap = await Snapshot.builder("baseline")
-  .name("after-pip-install")
+const snap = await Snapshot.builder("after-pip-install")
+  .fromSandbox("baseline")
   .label("stage", "post-deps")
   .recordIntegrity()
   .create();
@@ -367,7 +332,7 @@ for (const h of await Snapshot.list()) {
 static listDir(dir: string): Promise<Snapshot[]>
 ```
 
-Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections that were never imported. Skips entries that don't look like snapshot artifacts.
+Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections that were never loaded. Skips entries that don't look like snapshot artifacts.
 
 <p className="msb-label">Parameters</p>
 
@@ -468,14 +433,14 @@ console.log(`reindexed ${count} snapshots`);
 
 ---
 
-#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">export()</span>
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">save()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
-static export(nameOrPath: string, out: string, opts?: ExportOpts): Promise<void>
+static save(nameOrPath: string, out: string, opts?: SaveOpts): Promise<void>
 ```
 
-Bundle a snapshot into a `.tar.zst` archive. When the snapshot has no integrity hash yet, one is computed and embedded in the bundled manifest so the receiver can verify. See [`ExportOpts`](#exportopts-interface) for bundling options.
+Bundle a snapshot into a `.tar.zst` archive. When the snapshot has no integrity hash yet, one is computed and embedded in the bundled manifest so the receiver can verify. See [`SaveOpts`](#saveopts-interface) for bundling options.
 
 <p className="msb-label">Parameters</p>
 
@@ -489,7 +454,7 @@ Bundle a snapshot into a `.tar.zst` archive. When the snapshot has no integrity 
     <div className="msb-param-desc">Output archive path.</div>
   </div>
   <div className="msb-param">
-    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#exportopts-interface">ExportOpts</a></div>
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#saveopts-interface">SaveOpts</a></div>
     <div className="msb-param-desc">Bundling options. All fields default to <code>false</code>.</div>
   </div>
 </div>
@@ -497,7 +462,7 @@ Bundle a snapshot into a `.tar.zst` archive. When the snapshot has no integrity 
 <Accordion title="Example">
 
 ```typescript
-await Snapshot.export("after-pip-install", "./baseline.tar.zst", {
+await Snapshot.save("after-pip-install", "./baseline.tar.zst", {
   withImage: true,
 });
 ```
@@ -506,11 +471,11 @@ await Snapshot.export("after-pip-install", "./baseline.tar.zst", {
 
 ---
 
-#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">import()</span>
+#### <span className="msb-recv">Snapshot.</span><span className="msb-hn">load()</span>
 <div className="msb-tags"><span className="msb-tag is-static">static</span><span className="msb-tag is-async">async</span></div>
 
 ```typescript
-static import(archive: string, dest?: string): Promise<SnapshotHandle>
+static load(archive: string, dest?: string): Promise<SnapshotHandle>
 ```
 
 Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, verifying recorded integrity on the way in. Compression is detected from magic bytes.
@@ -533,15 +498,15 @@ Unpack a snapshot archive (`.tar.zst` or `.tar`) into the snapshots directory, v
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><a className="msb-type" href="#snapshothandle-class">Promise&lt;SnapshotHandle&gt;</a></div>
-    <div className="msb-param-desc">Handle to the imported snapshot.</div>
+    <div className="msb-param-desc">Handle to the loaded snapshot.</div>
   </div>
 </div>
 
 <Accordion title="Example">
 
 ```typescript
-const h = await Snapshot.import("./baseline.tar.zst");
-console.log("imported", h.digest);
+const h = await Snapshot.load("./baseline.tar.zst");
+console.log("loaded", h.digest);
 ```
 
 </Accordion>
@@ -550,7 +515,7 @@ console.log("imported", h.digest);
 
 ## Snapshot instance members {#snapshot-instance}
 
-A `Snapshot` is a snapshot artifact on disk. The artifact is a directory containing `manifest.json` and the captured `upper.ext4`. The directory is the source of truth; the local DB index is just a rebuildable cache. Returned by [`Snapshot.builder().create()`](#snapshotbuilder), [`Snapshot.open()`](#snapshot-open), [`handle.snapshot()`](#handle-snapshot), and [`handle.snapshotTo()`](#handle-snapshotto).
+A `Snapshot` is a snapshot artifact on disk. The artifact is a directory containing the `snapshot.json` descriptor and the captured `upper.ext4`. The directory is the source of truth; the local DB index is just a rebuildable cache. Returned by [`Snapshot.builder().create()`](#snapshotbuilder), [`Snapshot.open()`](#snapshot-open), and [`handle.snapshot()`](#handle-snapshot).
 
 ---
 
@@ -617,6 +582,17 @@ get format(): "raw" | "qcow2"
 ```
 
 On-disk format of the upper layer.
+
+---
+
+#### <span className="msb-recv">snap.</span><span className="msb-hn">scope</span>
+<div className="msb-tags"><span className="msb-tag is-instance">getter</span></div>
+
+```typescript
+get scope(): SnapshotScope
+```
+
+Snapshot scope: `"disk"` for a disk-only snapshot, `"resumable"` once resumable snapshots land. Always `"disk"` today. See [`SnapshotScope`](#snapshotscope-type).
 
 ---
 
@@ -710,45 +686,45 @@ if (report.upper.kind === "verified") {
 
 ## SnapshotBuilder
 
-Fluent builder for a snapshot, returned by [`Snapshot.builder(name)`](#snapshotbuilder). Every setter mutates in place and returns `this`, so calls chain. Pick exactly one destination: [`.name()`](#name) or [`.path()`](#path).
+Fluent builder for a snapshot, returned by [`Snapshot.builder(name)`](#snapshotbuilder). Every setter mutates in place and returns `this`, so calls chain. The source sandbox is required: call [`.fromSandbox()`](#fromsandbox) before [`.create()`](#create).
 
 ---
 
-#### <span className="msb-recv">.</span><span className="msb-hn">name()</span>
+#### <span className="msb-recv">.</span><span className="msb-hn">fromSandbox()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-name(name: string): this
+fromSandbox(sourceSandbox: string): this
 ```
 
-Set a bare name; the artifact lands under the default snapshots directory. Mutually exclusive with [`.path()`](#path).
+Set the sandbox to capture. Required; [`.create()`](#create) fails without it.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
-    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
-    <div className="msb-param-desc">Bare snapshot name.</div>
+    <div className="msb-param-key"><code>sourceSandbox</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Name of the stopped sandbox to capture.</div>
   </div>
 </div>
 
 ---
 
-#### <span className="msb-recv">.</span><span className="msb-hn">path()</span>
+#### <span className="msb-recv">.</span><span className="msb-hn">destDir()</span>
 <div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
 
 ```typescript
-path(path: string): this
+destDir(destDir: string): this
 ```
 
-Set an explicit filesystem path for the artifact. Mutually exclusive with [`.name()`](#name).
+Create the artifact under this parent directory instead of the default snapshots store. The artifact directory is `destDir/<name>`; the name stays the snapshot's identity either way.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
-    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
-    <div className="msb-param-desc">Destination artifact directory path.</div>
+    <div className="msb-param-key"><code>destDir</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Parent directory to create the artifact in (e.g. a larger volume).</div>
   </div>
 </div>
 
@@ -785,7 +761,7 @@ Add a `key=value` label to the snapshot manifest. May be called repeatedly.
 force(): this
 ```
 
-Overwrite an existing artifact at the destination instead of failing on conflict.
+Overwrite an existing artifact with the same name instead of failing on conflict.
 
 ---
 
@@ -797,6 +773,17 @@ recordIntegrity(): this
 ```
 
 Compute and record a content-integrity hash of the upper layer at creation time, so the snapshot can be verified later or across a trust boundary.
+
+---
+
+#### <span className="msb-recv">.</span><span className="msb-hn">resumable()</span>
+<div className="msb-tags"><span className="msb-tag is-builder">builder</span></div>
+
+```typescript
+resumable(): this
+```
+
+Request a `"resumable"` snapshot (disk plus VM state). Accepted by the builder, but [`.create()`](#create) currently returns an `Unsupported` error — resumable snapshots have not landed yet.
 
 ---
 
@@ -821,8 +808,8 @@ Capture the configured snapshot and return the resulting artifact.
 <Accordion title="Example">
 
 ```typescript
-const snap = await Snapshot.builder("baseline")
-  .path("/data/snapshots/baseline-v2")
+const snap = await Snapshot.builder("baseline-v2")
+  .fromSandbox("baseline")
   .force()
   .recordIntegrity()
   .create();
@@ -840,13 +827,14 @@ const snap = await Snapshot.builder("baseline")
 
 Lightweight handle backed by an index row. Values are snapshotted from the index at construction time — call [`Snapshot.get()`](#snapshot-get) again for a fresh reading if needed. Handles from [`Snapshot.list()`](#snapshot-list) are read-only and throw on [`open()`](#snapshothandleopen) / [`remove()`](#snapshothandleremove); fetch a live handle via [`Snapshot.get()`](#snapshot-get) for those lifecycle methods.
 
-<p className="msb-backref">Returned by <a href="#snapshot-get">Snapshot.get()</a>, <a href="#snapshot-list">Snapshot.list()</a>, <a href="#snapshot-import">Snapshot.import()</a></p>
+<p className="msb-backref">Returned by <a href="#snapshot-get">Snapshot.get()</a>, <a href="#snapshot-list">Snapshot.list()</a>, <a href="#snapshot-load">Snapshot.load()</a></p>
 
 | Member | Type | Description |
 |--------|------|-------------|
 | `digest` | `string` | Manifest digest (`sha256:hex`), the canonical identity. |
 | `name` | `string \| null` | Convenience name; `null` for digest-only entries. |
 | `parentDigest` | `string \| null` | Parent snapshot's manifest digest, or `null` for a root. |
+| `scope` | [`SnapshotScope`](#snapshotscope-type) | Snapshot payload scope (`"disk"` today). |
 | `imageRef` | `string` | Image reference the snapshot was taken from. |
 | `format` | `"raw" \| "qcow2"` | On-disk format of the upper layer. |
 | `sizeBytes` | `bigint \| null` | Apparent size of the upper file at index time. |
@@ -879,17 +867,29 @@ await h.remove({ force: false });     // refuse if it has children
 
 ---
 
-### ExportOpts <span className="msb-tag is-type">interface</span>
+### SaveOpts <span className="msb-tag is-type">interface</span>
 
-Bundle options for [`Snapshot.export()`](#snapshot-export). All fields default to `false`.
+Bundle options for [`Snapshot.save()`](#snapshot-save). All fields default to `false`.
 
-<p className="msb-backref">Used by <a href="#snapshot-export">Snapshot.export()</a></p>
+<p className="msb-backref">Used by <a href="#snapshot-save">Snapshot.save()</a></p>
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `withParents` | `boolean` | Walk the parent chain and include each ancestor (no-op in v1). |
 | `withImage` | `boolean` | Include the OCI image cache so the archive boots offline. |
 | `plainTar` | `boolean` | Skip zstd compression and write a plain `.tar`. |
+
+---
+
+### SnapshotScope <span className="msb-tag is-type">type</span>
+
+Scope of what a snapshot captures. Every snapshot today is `"disk"`; `"resumable"` (disk plus VM state) is reserved for resumable snapshots.
+
+<p className="msb-backref">Returned by <a href="#snap-scope">snap.scope</a> · <a href="#snapshothandle">SnapshotHandle.scope</a></p>
+
+```typescript
+type SnapshotScope = "disk" | "resumable";
+```
 
 ---
 

--- a/examples/python/snapshot-fork/main.py
+++ b/examples/python/snapshot-fork/main.py
@@ -23,11 +23,11 @@ async def main():
     print(f"created snapshot: {snap.digest}")
     print(f"                  {snap.path}")
 
-    # `snapshot=` is a peer of `image=`; the fork starts with the captured
-    # upper layer in place.
+    # `from_snapshot=` is a peer of `image=`; the fork starts with the
+    # captured upper layer in place.
     fork = await Sandbox.create(
         "snapshot-fork",
-        snapshot="snapshot-baseline-state",
+        from_snapshot="snapshot-baseline-state",
         replace=True,
     )
     output = await fork.shell("cat /root/marker.txt")

--- a/packages/microsandbox-types/rust/lib/domain.rs
+++ b/packages/microsandbox-types/rust/lib/domain.rs
@@ -599,30 +599,26 @@ pub struct SandboxPolicy {
 // Types: Snapshots
 //--------------------------------------------------------------------------------------------------
 
-/// Where to place a new snapshot artifact.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
-pub enum SnapshotDestination {
-    /// Bare name resolved under the default snapshots directory.
-    Name(String),
-
-    /// Explicit absolute or relative path to the artifact directory.
-    Path(
-        /// Destination path.
-        #[cfg_attr(feature = "ts", ts(type = "string"))]
-        PathBuf,
-    ),
-}
-
 /// Inputs to create a snapshot.
+///
+/// The snapshot's name is its identity; the artifact directory is
+/// `dest_dir.join(name)`, with `dest_dir` defaulting to the snapshots
+/// store. Archive movement happens through save/load (the artifact
+/// directory is also self-contained and safe to move directly).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 pub struct SnapshotSpec {
+    /// Snapshot name. Always the artifact directory's basename.
+    pub name: String,
+
+    /// Parent directory to create the artifact in. `None` = the default
+    /// snapshots directory.
+    #[serde(default)]
+    #[cfg_attr(feature = "ts", ts(type = "string | null"))]
+    pub dest_dir: Option<PathBuf>,
+
     /// Name of the source sandbox. Must be stopped.
     pub source_sandbox: String,
-
-    /// Where to write the artifact.
-    pub destination: SnapshotDestination,
 
     /// User-supplied labels.
     pub labels: Vec<(String, String)>,
@@ -632,6 +628,14 @@ pub struct SnapshotSpec {
 
     /// Compute and record upper-layer content integrity at creation time.
     pub record_integrity: bool,
+
+    /// Request a future resumable snapshot that includes memory/device state.
+    ///
+    /// This is part of the public contract now so callers can validate shape
+    /// early. The local runtime returns an unsupported-feature error until VM
+    /// pause/resume capture lands.
+    #[serde(default)]
+    pub resumable: bool,
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/packages/microsandbox-types/rust/lib/lib.rs
+++ b/packages/microsandbox-types/rust/lib/lib.rs
@@ -32,8 +32,8 @@ pub use domain::{
     Protocol, PublishedPortSpec, PullPolicy, Rlimit, RlimitResource, RootDisk, RootfsSource, Rule,
     SandboxLogLevel, SandboxPolicy, SandboxResources, SandboxRuntimeOptions, SandboxSpec,
     ScopedUpstreamCaCert, ScopedVerifyUpstream, SecretConfigError, SecretEntry, SecretInjection,
-    SecretsConfig, SecurityProfile, SnapshotSpec, StatVirtualization,
-    TlsConfig, ViolationAction, VolumeKind, VolumeMount, VolumeSpec,
+    SecretsConfig, SecurityProfile, SnapshotSpec, StatVirtualization, TlsConfig, ViolationAction,
+    VolumeKind, VolumeMount, VolumeSpec,
 };
 pub use error::{TypesError, TypesResult};
 pub use modify::{

--- a/packages/microsandbox-types/rust/lib/lib.rs
+++ b/packages/microsandbox-types/rust/lib/lib.rs
@@ -32,7 +32,7 @@ pub use domain::{
     Protocol, PublishedPortSpec, PullPolicy, Rlimit, RlimitResource, RootDisk, RootfsSource, Rule,
     SandboxLogLevel, SandboxPolicy, SandboxResources, SandboxRuntimeOptions, SandboxSpec,
     ScopedUpstreamCaCert, ScopedVerifyUpstream, SecretConfigError, SecretEntry, SecretInjection,
-    SecretsConfig, SecurityProfile, SnapshotDestination, SnapshotSpec, StatVirtualization,
+    SecretsConfig, SecurityProfile, SnapshotSpec, StatVirtualization,
     TlsConfig, ViolationAction, VolumeKind, VolumeMount, VolumeSpec,
 };
 pub use error::{TypesError, TypesResult};

--- a/sdk/go/examples/snapshot-fork/main.go
+++ b/sdk/go/examples/snapshot-fork/main.go
@@ -78,7 +78,7 @@ func main() {
 	}
 	fmt.Printf("snapshot index entry: name=%s digest=%s\n", name, handle.Digest())
 
-	fork, err := microsandbox.CreateSandbox(ctx, forkName, microsandbox.WithSnapshot(snapshotName))
+	fork, err := microsandbox.CreateSandbox(ctx, forkName, microsandbox.WithFromSnapshot(snapshotName))
 	if err != nil {
 		log.Fatalf("CreateSandbox fork: %v", err)
 	}

--- a/sdk/go/integration/snapshot_test.go
+++ b/sdk/go/integration/snapshot_test.go
@@ -13,7 +13,7 @@ import (
 	microsandbox "github.com/superradcompany/microsandbox/sdk/go"
 )
 
-func TestSandboxHandleSnapshotAndWithSnapshotFork(t *testing.T) {
+func TestSandboxHandleSnapshotAndWithFromSnapshotFork(t *testing.T) {
 	ctx := integrationCtx(t)
 	baseName := uniqueIntegrationName(t, "go-sdk-snapshot-base")
 	forkName := uniqueIntegrationName(t, "go-sdk-snapshot-fork")
@@ -96,9 +96,9 @@ func TestSandboxHandleSnapshotAndWithSnapshotFork(t *testing.T) {
 		t.Fatalf("Snapshot.List did not include digest %q", artifact.Digest())
 	}
 
-	fork, err := createSandbox(t, ctx, forkName, microsandbox.WithSnapshot(snapshotName))
+	fork, err := createSandbox(t, ctx, forkName, microsandbox.WithFromSnapshot(snapshotName))
 	if err != nil {
-		t.Fatalf("CreateSandbox with WithSnapshot: %v", err)
+		t.Fatalf("CreateSandbox with WithFromSnapshot: %v", err)
 	}
 	defer func() {
 		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -109,7 +109,7 @@ func TestSandboxHandleSnapshotAndWithSnapshotFork(t *testing.T) {
 
 	// Verify the fork is a working sandbox sourced from the snapshot:
 	// /etc/alpine-release exists in the alpine image's rootfs, so reading
-	// it back via the fork confirms WithSnapshot resolved + mounted the
+	// it back via the fork confirms WithFromSnapshot resolved + mounted the
 	// snapshot's rootfs rather than handing back an empty fs.
 	got, err := fork.FS().ReadString(ctx, "/etc/alpine-release")
 	if err != nil {
@@ -124,14 +124,14 @@ func TestSandboxHandleSnapshotAndWithSnapshotFork(t *testing.T) {
 	// to prove the snapshot captured user data, not just the image.
 }
 
-func TestSandboxHandleSnapshotToAndSnapshotDirectoryOps(t *testing.T) {
+func TestSnapshotCreateAndSnapshotDirectoryOps(t *testing.T) {
 	ctx := integrationCtx(t)
-	baseName := uniqueIntegrationName(t, "go-sdk-snapshotto-base")
-	snapshotDir := filepath.Join(t.TempDir(), "artifact")
+	baseName := uniqueIntegrationName(t, "go-sdk-snapcreate-base")
+	snapshotName := uniqueIntegrationName(t, "go-sdk-snapcreate")
 
 	t.Cleanup(func() {
 		removeSandboxBestEffort(baseName)
-		removeSnapshotBestEffort(snapshotDir)
+		removeSnapshotBestEffort(snapshotName)
 	})
 
 	base, err := createSandbox(t, ctx, baseName, microsandbox.WithImage(goIntegrationImage))
@@ -145,16 +145,16 @@ func TestSandboxHandleSnapshotToAndSnapshotDirectoryOps(t *testing.T) {
 		t.Fatalf("Close base: %v", err)
 	}
 
-	baseHandle, err := microsandbox.GetSandbox(ctx, baseName)
+	artifact, err := microsandbox.Snapshot.Create(ctx, microsandbox.SnapshotCreateOptions{
+		Name:        snapshotName,
+		FromSandbox: baseName,
+	})
 	if err != nil {
-		t.Fatalf("GetSandbox base: %v", err)
+		t.Fatalf("Snapshot.Create: %v", err)
 	}
-	artifact, err := baseHandle.SnapshotTo(ctx, snapshotDir)
-	if err != nil {
-		t.Fatalf("SandboxHandle.SnapshotTo: %v", err)
-	}
-	if artifact.Path() != snapshotDir {
-		t.Fatalf("SnapshotTo path = %q, want %q", artifact.Path(), snapshotDir)
+	snapshotDir := artifact.Path()
+	if filepath.Base(snapshotDir) != snapshotName {
+		t.Fatalf("Snapshot.Create path = %q, want basename %q", snapshotDir, snapshotName)
 	}
 
 	opened, err := microsandbox.Snapshot.Open(ctx, snapshotDir)
@@ -189,21 +189,21 @@ func TestSandboxHandleSnapshotToAndSnapshotDirectoryOps(t *testing.T) {
 	}
 
 	archivePath := filepath.Join(t.TempDir(), "snapshot.tar")
-	if err := microsandbox.Snapshot.Export(ctx, snapshotDir, archivePath,
-		microsandbox.SnapshotExportOptions{PlainTar: true}); err != nil {
-		t.Fatalf("Snapshot.Export: %v", err)
+	if err := microsandbox.Snapshot.Save(ctx, snapshotName, archivePath,
+		microsandbox.SnapshotSaveOptions{PlainTar: true}); err != nil {
+		t.Fatalf("Snapshot.Save: %v", err)
 	}
 
 	importDir := filepath.Join(t.TempDir(), "imported")
-	imported, err := microsandbox.Snapshot.Import(ctx, archivePath, importDir)
+	imported, err := microsandbox.Snapshot.Load(ctx, archivePath, importDir)
 	if err != nil {
-		t.Fatalf("Snapshot.Import: %v", err)
+		t.Fatalf("Snapshot.Load: %v", err)
 	}
 	t.Cleanup(func() {
 		removeSnapshotBestEffort(imported.Path())
 	})
 	if imported.Digest() != artifact.Digest() {
-		t.Fatalf("Snapshot.Import digest = %q, want %q", imported.Digest(), artifact.Digest())
+		t.Fatalf("Snapshot.Load digest = %q, want %q", imported.Digest(), artifact.Digest())
 	}
 }
 

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -172,7 +172,6 @@ typedef char *(*msb_image_load_fn)(uint64_t cancel_id, const char *input_path, c
 typedef char *(*msb_image_save_fn)(uint64_t cancel_id, const char *references_json, const char *output_path, const char *format, uint8_t *buf, size_t buf_len);
 
 typedef char *(*msb_sandbox_handle_snapshot_fn)(uint64_t cancel_id, const char *sandbox_name, const char *snapshot_name, uint8_t *buf, size_t buf_len);
-typedef char *(*msb_sandbox_handle_snapshot_to_fn)(uint64_t cancel_id, const char *sandbox_name, const char *path, uint8_t *buf, size_t buf_len);
 typedef char *(*msb_snapshot_create_fn)(uint64_t cancel_id, const char *source_sandbox, const char *opts_json, uint8_t *buf, size_t buf_len);
 typedef char *(*msb_snapshot_open_fn)(uint64_t cancel_id, const char *path_or_name, uint8_t *buf, size_t buf_len);
 typedef char *(*msb_snapshot_verify_fn)(uint64_t cancel_id, const char *path_or_name, uint8_t *buf, size_t buf_len);
@@ -322,7 +321,6 @@ static msb_image_prune_fn         ptr_msb_image_prune         = NULL;
 static msb_image_load_fn           ptr_msb_image_load           = NULL;
 static msb_image_save_fn           ptr_msb_image_save           = NULL;
 static msb_sandbox_handle_snapshot_fn ptr_msb_sandbox_handle_snapshot = NULL;
-static msb_sandbox_handle_snapshot_to_fn ptr_msb_sandbox_handle_snapshot_to = NULL;
 static msb_snapshot_create_fn      ptr_msb_snapshot_create      = NULL;
 static msb_snapshot_open_fn        ptr_msb_snapshot_open        = NULL;
 static msb_snapshot_verify_fn      ptr_msb_snapshot_verify      = NULL;
@@ -483,7 +481,6 @@ const char *load_microsandbox(const char *path) {
 	RESOLVE(msb_image_load);
 	RESOLVE(msb_image_save);
 	RESOLVE(msb_sandbox_handle_snapshot);
-	RESOLVE(msb_sandbox_handle_snapshot_to);
 	RESOLVE(msb_snapshot_create);
 	RESOLVE(msb_snapshot_open);
 	RESOLVE(msb_snapshot_verify);
@@ -857,9 +854,6 @@ char *call_msb_image_save(uint64_t cancel_id, const char *references_json, const
 }
 char *call_msb_sandbox_handle_snapshot(uint64_t cancel_id, const char *sandbox_name, const char *snapshot_name, uint8_t *buf, size_t buf_len) {
 	return ptr_msb_sandbox_handle_snapshot ? ptr_msb_sandbox_handle_snapshot(cancel_id, sandbox_name, snapshot_name, buf, buf_len) : NULL;
-}
-char *call_msb_sandbox_handle_snapshot_to(uint64_t cancel_id, const char *sandbox_name, const char *path, uint8_t *buf, size_t buf_len) {
-	return ptr_msb_sandbox_handle_snapshot_to ? ptr_msb_sandbox_handle_snapshot_to(cancel_id, sandbox_name, path, buf, buf_len) : NULL;
 }
 char *call_msb_snapshot_create(uint64_t cancel_id, const char *source_sandbox, const char *opts_json, uint8_t *buf, size_t buf_len) {
 	return ptr_msb_snapshot_create ? ptr_msb_snapshot_create(cancel_id, source_sandbox, opts_json, buf, buf_len) : NULL;
@@ -4228,6 +4222,7 @@ type SnapshotInfo struct {
 	SizeBytes           uint64            `json:"size_bytes"`
 	ImageRef            string            `json:"image_ref"`
 	ImageManifestDigest string            `json:"image_manifest_digest"`
+	Scope               string            `json:"scope"`
 	Format              string            `json:"format"`
 	Fstype              string            `json:"fstype"`
 	Parent              *string           `json:"parent"`
@@ -4241,6 +4236,7 @@ type SnapshotHandleInfo struct {
 	Name          *string `json:"name"`
 	ParentDigest  *string `json:"parent_digest"`
 	ImageRef      string  `json:"image_ref"`
+	Scope         string  `json:"scope"`
 	Format        string  `json:"format"`
 	SizeBytes     *uint64 `json:"size_bytes"`
 	CreatedAtUnix int64   `json:"created_at_unix"`
@@ -4259,13 +4255,14 @@ type SnapshotVerifyReport struct {
 
 type SnapshotCreateOptions struct {
 	Name            string            `json:"name,omitempty"`
-	Path            string            `json:"path,omitempty"`
+	DestDir         string            `json:"dest_dir,omitempty"`
 	Labels          map[string]string `json:"labels,omitempty"`
 	Force           bool              `json:"force,omitempty"`
 	RecordIntegrity bool              `json:"record_integrity,omitempty"`
+	Resumable       bool              `json:"resumable,omitempty"`
 }
 
-type SnapshotExportOptions struct {
+type SnapshotSaveOptions struct {
 	WithParents bool `json:"with_parents,omitempty"`
 	WithImage   bool `json:"with_image,omitempty"`
 	PlainTar    bool `json:"plain_tar,omitempty"`
@@ -4281,27 +4278,6 @@ func SandboxHandleSnapshot(ctx context.Context, sandboxName, snapshotName string
 	defer C.free(unsafe.Pointer(cSnapshot))
 	out, err := call(ctx, func(cancelID C.uint64_t, buf *C.uint8_t, bufLen C.size_t) *C.char {
 		return C.call_msb_sandbox_handle_snapshot(cancelID, cSandbox, cSnapshot, buf, bufLen)
-	})
-	if err != nil {
-		return nil, err
-	}
-	var info SnapshotInfo
-	if err := json.Unmarshal([]byte(out), &info); err != nil {
-		return nil, fmt.Errorf("parse snapshot: %w", err)
-	}
-	return &info, nil
-}
-
-func SandboxHandleSnapshotTo(ctx context.Context, sandboxName, path string) (*SnapshotInfo, error) {
-	if err := ensureLoaded(); err != nil {
-		return nil, err
-	}
-	cSandbox := C.CString(sandboxName)
-	defer C.free(unsafe.Pointer(cSandbox))
-	cPath := C.CString(path)
-	defer C.free(unsafe.Pointer(cPath))
-	out, err := call(ctx, func(cancelID C.uint64_t, buf *C.uint8_t, bufLen C.size_t) *C.char {
-		return C.call_msb_sandbox_handle_snapshot_to(cancelID, cSandbox, cPath, buf, bufLen)
 	})
 	if err != nil {
 		return nil, err
@@ -4464,7 +4440,7 @@ func SnapshotReindex(ctx context.Context, dir string) (uint32, error) {
 	return raw.Indexed, nil
 }
 
-func SnapshotExport(ctx context.Context, nameOrPath, outPath string, opts SnapshotExportOptions) error {
+func SnapshotSave(ctx context.Context, nameOrPath, outPath string, opts SnapshotSaveOptions) error {
 	if err := ensureLoaded(); err != nil {
 		return err
 	}
@@ -4484,7 +4460,7 @@ func SnapshotExport(ctx context.Context, nameOrPath, outPath string, opts Snapsh
 	return err
 }
 
-func SnapshotImport(ctx context.Context, archive, dest string) (*SnapshotHandleInfo, error) {
+func SnapshotLoad(ctx context.Context, archive, dest string) (*SnapshotHandleInfo, error) {
 	if err := ensureLoaded(); err != nil {
 		return nil, err
 	}
@@ -4500,7 +4476,7 @@ func SnapshotImport(ctx context.Context, archive, dest string) (*SnapshotHandleI
 	}
 	var info SnapshotHandleInfo
 	if err := json.Unmarshal([]byte(out), &info); err != nil {
-		return nil, fmt.Errorf("parse snapshot import: %w", err)
+		return nil, fmt.Errorf("parse snapshot load: %w", err)
 	}
 	return &info, nil
 }

--- a/sdk/go/native/microsandbox_go_ffi.h
+++ b/sdk/go/native/microsandbox_go_ffi.h
@@ -663,12 +663,6 @@ char *msb_sandbox_handle_snapshot(uint64_t cancel_id,
                                   unsigned char *buf,
                                   uintptr_t buf_len);
 
-char *msb_sandbox_handle_snapshot_to(uint64_t cancel_id,
-                                     const char *sandbox_name,
-                                     const char *path,
-                                     unsigned char *buf,
-                                     uintptr_t buf_len);
-
 char *msb_snapshot_create(uint64_t cancel_id,
                           const char *source_sandbox,
                           const char *opts_json,

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -58,7 +58,7 @@ use microsandbox::{
         fs::{FsReadStream, FsWriteSink},
         ssh::{SftpClient, SshClient, SshServer, SshStdioStream},
     },
-    snapshot::{ExportOpts, SnapshotDestination, SnapshotFormat},
+    snapshot::{SaveOpts, SnapshotFormat, SnapshotScope},
     volume::{Volume, VolumeBuilder, VolumeHandle, VolumeKind},
 };
 use microsandbox_network::{builder::ViolationActionBuilder, secrets::config::ViolationAction};
@@ -1050,17 +1050,19 @@ struct LogStreamOpts {
 #[derive(serde::Deserialize, Default)]
 struct SnapshotCreateOpts {
     name: Option<String>,
-    path: Option<String>,
+    dest_dir: Option<String>,
     #[serde(default)]
     labels: HashMap<String, String>,
     #[serde(default)]
     force: bool,
     #[serde(default)]
     record_integrity: bool,
+    #[serde(default)]
+    resumable: bool,
 }
 
 #[derive(serde::Deserialize, Default)]
-struct SnapshotExportOpts {
+struct SnapshotSaveOptsJson {
     #[serde(default)]
     with_parents: bool,
     #[serde(default)]
@@ -5154,6 +5156,13 @@ fn snapshot_format_str(f: SnapshotFormat) -> &'static str {
     }
 }
 
+fn snapshot_scope_str(scope: SnapshotScope) -> &'static str {
+    match scope {
+        SnapshotScope::Disk => "disk",
+        SnapshotScope::Resumable => "resumable",
+    }
+}
+
 fn snapshot_json(s: &Snapshot) -> serde_json::Value {
     let manifest = s.manifest();
     let labels: HashMap<String, String> = manifest
@@ -5167,6 +5176,7 @@ fn snapshot_json(s: &Snapshot) -> serde_json::Value {
         "size_bytes": s.size_bytes(),
         "image_ref": manifest.image.reference,
         "image_manifest_digest": manifest.image.manifest_digest,
+        "scope": snapshot_scope_str(manifest.scope),
         "format": snapshot_format_str(manifest.format),
         "fstype": manifest.fstype,
         "parent": manifest.parent,
@@ -5182,6 +5192,7 @@ fn snapshot_handle_json(h: &microsandbox::SnapshotHandle) -> serde_json::Value {
         "name": h.name(),
         "parent_digest": h.parent_digest(),
         "image_ref": h.image_ref(),
+        "scope": snapshot_scope_str(h.scope()),
         "format": snapshot_format_str(h.format()),
         "size_bytes": h.size_bytes(),
         "created_at_unix": h.created_at().and_utc().timestamp(),
@@ -5203,27 +5214,16 @@ fn verify_report_json(report: microsandbox::snapshot::SnapshotVerifyReport) -> s
     })
 }
 
-fn apply_snapshot_create_opts(
-    mut builder: microsandbox::SnapshotBuilder,
+fn snapshot_builder_from_opts(
+    source_sandbox: String,
     opts: SnapshotCreateOpts,
 ) -> Result<microsandbox::SnapshotBuilder, FfiError> {
-    match (opts.name, opts.path) {
-        (Some(name), None) => {
-            builder = builder.destination(SnapshotDestination::Name(name));
-        }
-        (None, Some(path)) => {
-            builder = builder.destination(SnapshotDestination::Path(PathBuf::from(path)));
-        }
-        (Some(_), Some(_)) => {
-            return Err(FfiError::invalid_argument(
-                "snapshot create accepts either name or path, not both",
-            ));
-        }
-        (None, None) => {
-            return Err(FfiError::invalid_argument(
-                "snapshot create requires name or path",
-            ));
-        }
+    let Some(name) = opts.name else {
+        return Err(FfiError::invalid_argument("snapshot create requires name"));
+    };
+    let mut builder = Snapshot::builder(name).from_sandbox(source_sandbox);
+    if let Some(dest_dir) = opts.dest_dir {
+        builder = builder.dest_dir(PathBuf::from(dest_dir));
     }
     for (k, v) in opts.labels {
         builder = builder.label(k, v);
@@ -5233,6 +5233,9 @@ fn apply_snapshot_create_opts(
     }
     if opts.record_integrity {
         builder = builder.record_integrity();
+    }
+    if opts.resumable {
+        builder = builder.resumable();
     }
     Ok(builder)
 }
@@ -5257,28 +5260,6 @@ pub unsafe extern "C" fn msb_sandbox_handle_snapshot(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn msb_sandbox_handle_snapshot_to(
-    cancel_id: u64,
-    sandbox_name: *const c_char,
-    path: *const c_char,
-    buf: *mut c_uchar,
-    buf_len: usize,
-) -> *mut c_char {
-    run_c(cancel_id, buf, buf_len, || {
-        let sandbox_name = unsafe { cstr(sandbox_name) }?;
-        let path = unsafe { cstr(path) }?;
-        Ok(Box::pin(async move {
-            let h = Sandbox::get(&sandbox_name).await.map_err(FfiError::from)?;
-            let snap = h
-                .snapshot_to(PathBuf::from(path))
-                .await
-                .map_err(FfiError::from)?;
-            Ok(snapshot_json(&snap).to_string())
-        }))
-    })
-}
-
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn msb_snapshot_create(
     cancel_id: u64,
     source_sandbox: *const c_char,
@@ -5291,7 +5272,7 @@ pub unsafe extern "C" fn msb_snapshot_create(
         let opts_raw = unsafe { cstr(opts_json) }?;
         let opts: SnapshotCreateOpts = serde_json::from_str(&opts_raw)
             .map_err(|e| FfiError::invalid_argument(format!("invalid opts JSON: {e}")))?;
-        let builder = apply_snapshot_create_opts(Snapshot::builder(&source_sandbox), opts)?;
+        let builder = snapshot_builder_from_opts(source_sandbox, opts)?;
         Ok(Box::pin(async move {
             let snap = builder.create().await.map_err(FfiError::from)?;
             Ok(snapshot_json(&snap).to_string())
@@ -5438,13 +5419,13 @@ pub unsafe extern "C" fn msb_snapshot_export(
         let name_or_path = unsafe { cstr(name_or_path) }?;
         let out = unsafe { cstr(out) }?;
         let opts_raw = unsafe { cstr(opts_json) }?;
-        let opts: SnapshotExportOpts = serde_json::from_str(&opts_raw)
+        let opts: SnapshotSaveOptsJson = serde_json::from_str(&opts_raw)
             .map_err(|e| FfiError::invalid_argument(format!("invalid opts JSON: {e}")))?;
         Ok(Box::pin(async move {
-            Snapshot::export(
+            Snapshot::save(
                 &name_or_path,
                 &PathBuf::from(out),
-                ExportOpts {
+                SaveOpts {
                     with_parents: opts.with_parents,
                     with_image: opts.with_image,
                     plain_tar: opts.plain_tar,
@@ -5474,7 +5455,7 @@ pub unsafe extern "C" fn msb_snapshot_import(
             Some(PathBuf::from(dest))
         };
         Ok(Box::pin(async move {
-            let h = Snapshot::import(&PathBuf::from(archive), dest.as_deref())
+            let h = Snapshot::load(&PathBuf::from(archive), dest.as_deref())
                 .await
                 .map_err(FfiError::from)?;
             Ok(snapshot_handle_json(&h).to_string())

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -492,14 +492,14 @@ func WithImageDisk(path string, fstype string) SandboxOption {
 // WithBindRootfs uses a host directory directly as the sandbox root filesystem
 // (a bind rootfs): the directory's contents become the guest root filesystem
 // as-is, with no OCI pull and no overlay. Mutually exclusive with WithImage,
-// WithImageDisk, and WithSnapshot.
+// WithImageDisk, and WithFromSnapshot.
 func WithBindRootfs(path string) SandboxOption {
 	return func(o *SandboxConfig) { o.ImageBind = path }
 }
 
-// WithSnapshot boots from a snapshot artifact by bare name or filesystem path.
+// WithFromSnapshot boots from a snapshot artifact by bare name or filesystem path.
 // It is mutually exclusive with WithImage.
-func WithSnapshot(pathOrName string) SandboxOption {
+func WithFromSnapshot(pathOrName string) SandboxOption {
 	return func(o *SandboxConfig) { o.Snapshot = pathOrName }
 }
 

--- a/sdk/go/options_test.go
+++ b/sdk/go/options_test.go
@@ -95,9 +95,9 @@ func TestWithImageDisk(t *testing.T) {
 	}
 }
 
-func TestWithSnapshot(t *testing.T) {
+func TestWithFromSnapshot(t *testing.T) {
 	o := SandboxConfig{}
-	WithSnapshot("after-pip-install")(&o)
+	WithFromSnapshot("after-pip-install")(&o)
 	if o.Snapshot != "after-pip-install" {
 		t.Errorf("got %q, want %q", o.Snapshot, "after-pip-install")
 	}

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -676,15 +676,6 @@ func (h *SandboxHandle) Snapshot(ctx context.Context, name string) (*SnapshotArt
 	return snapshotFromInfo(info), nil
 }
 
-// SnapshotTo captures this stopped sandbox to an explicit artifact directory.
-func (h *SandboxHandle) SnapshotTo(ctx context.Context, path string) (*SnapshotArtifact, error) {
-	info, err := ffi.SandboxHandleSnapshotTo(ctx, h.name, path)
-	if err != nil {
-		return nil, wrapFFI(err)
-	}
-	return snapshotFromInfo(info), nil
-}
-
 // ---------------------------------------------------------------------------
 // Live sandbox methods
 // ---------------------------------------------------------------------------

--- a/sdk/go/sandbox_options_test.go
+++ b/sdk/go/sandbox_options_test.go
@@ -293,8 +293,8 @@ func TestFFIWireShape_LegacyConfigFieldMapsToRootDisk(t *testing.T) {
 	}
 }
 
-func TestFFIWireShape_WithSnapshot(t *testing.T) {
-	got := marshalCreateOptions(t, WithSnapshot("after-pip-install"))
+func TestFFIWireShape_WithFromSnapshot(t *testing.T) {
+	got := marshalCreateOptions(t, WithFromSnapshot("after-pip-install"))
 	if v := mustField(t, got, "snapshot"); v != "after-pip-install" {
 		t.Fatalf("snapshot = %v, want %q", v, "after-pip-install")
 	}

--- a/sdk/go/smoke_test.go
+++ b/sdk/go/smoke_test.go
@@ -159,7 +159,7 @@ func TestSmokeSnapshotReindexEmpty(t *testing.T) {
 	}
 }
 
-func TestSmokeSnapshotImportBogusErrors(t *testing.T) {
+func TestSmokeSnapshotLoadBogusErrors(t *testing.T) {
 	ctx := smokeSetup(t)
 	tmp := t.TempDir()
 	archive := filepath.Join(tmp, "bogus.tar")
@@ -168,9 +168,9 @@ func TestSmokeSnapshotImportBogusErrors(t *testing.T) {
 	}
 	dest := filepath.Join(tmp, "imported")
 
-	_, err := Snapshot.Import(ctx, archive, dest)
+	_, err := Snapshot.Load(ctx, archive, dest)
 	if err == nil {
-		t.Fatal("expected import of bogus archive to fail")
+		t.Fatal("expected load of bogus archive to fail")
 	}
 	var me *Error
 	if !errors.As(err, &me) {

--- a/sdk/go/snapshot.go
+++ b/sdk/go/snapshot.go
@@ -14,19 +14,33 @@ type snapshotFactory struct{}
 
 // SnapshotCreateOptions configures Snapshot.Create.
 type SnapshotCreateOptions struct {
-	Name            string
-	Path            string
+	// Snapshot name, resolved under the default snapshots directory
+	// (or under DestDir when set).
+	Name string
+	// Source sandbox to snapshot. Must be stopped. Required.
+	FromSandbox string
+	// Parent directory to create the artifact in; empty = the default
+	// snapshots directory. The artifact lands at DestDir/<name>.
+	DestDir         string
 	Labels          map[string]string
 	Force           bool
 	RecordIntegrity bool
+	Resumable       bool
 }
 
-// SnapshotExportOptions configures Snapshot.Export.
-type SnapshotExportOptions struct {
+// SnapshotSaveOptions configures Snapshot.Save.
+type SnapshotSaveOptions struct {
 	WithParents bool
 	WithImage   bool
 	PlainTar    bool
 }
+
+// Snapshot payload scope values, as reported by SnapshotArtifact.Scope
+// and SnapshotHandle.Scope.
+const (
+	SnapshotScopeDisk      = "disk"
+	SnapshotScopeResumable = "resumable"
+)
 
 // SnapshotVerifyReport is returned by SnapshotArtifact.Verify.
 type SnapshotVerifyReport struct {
@@ -48,6 +62,7 @@ type SnapshotArtifact struct {
 	sizeBytes           uint64
 	imageRef            string
 	imageManifestDigest string
+	scope               string
 	format              string
 	fstype              string
 	parent              *string
@@ -63,6 +78,7 @@ func snapshotFromInfo(info *ffi.SnapshotInfo) *SnapshotArtifact {
 		sizeBytes:           info.SizeBytes,
 		imageRef:            info.ImageRef,
 		imageManifestDigest: info.ImageManifestDigest,
+		scope:               normalizeSnapshotScope(info.Scope),
 		format:              info.Format,
 		fstype:              info.Fstype,
 		parent:              info.Parent,
@@ -77,6 +93,7 @@ func (s *SnapshotArtifact) Digest() string              { return s.digest }
 func (s *SnapshotArtifact) SizeBytes() uint64           { return s.sizeBytes }
 func (s *SnapshotArtifact) ImageRef() string            { return s.imageRef }
 func (s *SnapshotArtifact) ImageManifestDigest() string { return s.imageManifestDigest }
+func (s *SnapshotArtifact) Scope() string               { return s.scope }
 func (s *SnapshotArtifact) Format() string              { return s.format }
 func (s *SnapshotArtifact) Fstype() string              { return s.fstype }
 func (s *SnapshotArtifact) Parent() *string             { return cloneStringPtr(s.parent) }
@@ -98,6 +115,7 @@ type SnapshotHandle struct {
 	digest        string
 	name          *string
 	parentDigest  *string
+	scope         string
 	imageRef      string
 	format        string
 	sizeBytes     *uint64
@@ -110,6 +128,7 @@ func snapshotHandleFromInfo(info *ffi.SnapshotHandleInfo) *SnapshotHandle {
 		digest:        info.Digest,
 		name:          info.Name,
 		parentDigest:  info.ParentDigest,
+		scope:         normalizeSnapshotScope(info.Scope),
 		imageRef:      info.ImageRef,
 		format:        info.Format,
 		sizeBytes:     info.SizeBytes,
@@ -121,6 +140,7 @@ func snapshotHandleFromInfo(info *ffi.SnapshotHandleInfo) *SnapshotHandle {
 func (h *SnapshotHandle) Digest() string        { return h.digest }
 func (h *SnapshotHandle) Name() *string         { return cloneStringPtr(h.name) }
 func (h *SnapshotHandle) ParentDigest() *string { return cloneStringPtr(h.parentDigest) }
+func (h *SnapshotHandle) Scope() string         { return h.scope }
 func (h *SnapshotHandle) ImageRef() string      { return h.imageRef }
 func (h *SnapshotHandle) Format() string        { return h.format }
 func (h *SnapshotHandle) SizeBytes() *uint64    { return cloneUint64Ptr(h.sizeBytes) }
@@ -135,13 +155,14 @@ func (h *SnapshotHandle) Remove(ctx context.Context, force bool) error {
 	return Snapshot.Remove(ctx, h.digest, force)
 }
 
-func (snapshotFactory) Create(ctx context.Context, sourceSandbox string, opts SnapshotCreateOptions) (*SnapshotArtifact, error) {
-	info, err := ffi.SnapshotCreate(ctx, sourceSandbox, ffi.SnapshotCreateOptions{
+func (snapshotFactory) Create(ctx context.Context, opts SnapshotCreateOptions) (*SnapshotArtifact, error) {
+	info, err := ffi.SnapshotCreate(ctx, opts.FromSandbox, ffi.SnapshotCreateOptions{
 		Name:            opts.Name,
-		Path:            opts.Path,
+		DestDir:         opts.DestDir,
 		Labels:          opts.Labels,
 		Force:           opts.Force,
 		RecordIntegrity: opts.RecordIntegrity,
+		Resumable:       opts.Resumable,
 	})
 	if err != nil {
 		return nil, wrapFFI(err)
@@ -198,20 +219,27 @@ func (snapshotFactory) Reindex(ctx context.Context, dir string) (uint32, error) 
 	return n, wrapFFI(err)
 }
 
-func (snapshotFactory) Export(ctx context.Context, nameOrPath, outPath string, opts SnapshotExportOptions) error {
-	return wrapFFI(ffi.SnapshotExport(ctx, nameOrPath, outPath, ffi.SnapshotExportOptions{
+func (snapshotFactory) Save(ctx context.Context, nameOrPath, outPath string, opts SnapshotSaveOptions) error {
+	return wrapFFI(ffi.SnapshotSave(ctx, nameOrPath, outPath, ffi.SnapshotSaveOptions{
 		WithParents: opts.WithParents,
 		WithImage:   opts.WithImage,
 		PlainTar:    opts.PlainTar,
 	}))
 }
 
-func (snapshotFactory) Import(ctx context.Context, archive, dest string) (*SnapshotHandle, error) {
-	info, err := ffi.SnapshotImport(ctx, archive, dest)
+func (snapshotFactory) Load(ctx context.Context, archive, dest string) (*SnapshotHandle, error) {
+	info, err := ffi.SnapshotLoad(ctx, archive, dest)
 	if err != nil {
 		return nil, wrapFFI(err)
 	}
 	return snapshotHandleFromInfo(info), nil
+}
+
+func normalizeSnapshotScope(scope string) string {
+	if scope == "" {
+		return SnapshotScopeDisk
+	}
+	return scope
 }
 
 func snapshotVerifyReportFromInfo(info *ffi.SnapshotVerifyReport) *SnapshotVerifyReport {

--- a/sdk/go/snapshot.go
+++ b/sdk/go/snapshot.go
@@ -156,6 +156,12 @@ func (h *SnapshotHandle) Remove(ctx context.Context, force bool) error {
 }
 
 func (snapshotFactory) Create(ctx context.Context, opts SnapshotCreateOptions) (*SnapshotArtifact, error) {
+	if opts.Name == "" {
+		return nil, &Error{Kind: ErrInvalidConfig, Message: "snapshot create requires a non-empty Name"}
+	}
+	if opts.FromSandbox == "" {
+		return nil, &Error{Kind: ErrInvalidConfig, Message: "snapshot create requires a source sandbox (FromSandbox)"}
+	}
 	info, err := ffi.SnapshotCreate(ctx, opts.FromSandbox, ffi.SnapshotCreateOptions{
 		Name:            opts.Name,
 		DestDir:         opts.DestDir,

--- a/sdk/go/snapshot_test.go
+++ b/sdk/go/snapshot_test.go
@@ -1,0 +1,69 @@
+package microsandbox
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/superradcompany/microsandbox/sdk/go/internal/ffi"
+)
+
+func TestSnapshotCreateEmptyName(t *testing.T) {
+	_, err := Snapshot.Create(context.Background(), SnapshotCreateOptions{FromSandbox: "baseline"})
+	if !IsKind(err, ErrInvalidConfig) {
+		t.Fatalf("err = %v, want ErrInvalidConfig", err)
+	}
+	if !strings.Contains(err.Error(), "Name") {
+		t.Fatalf("error should name the missing field: %q", err.Error())
+	}
+}
+
+func TestSnapshotCreateEmptyFromSandbox(t *testing.T) {
+	_, err := Snapshot.Create(context.Background(), SnapshotCreateOptions{Name: "after-pip-install"})
+	if !IsKind(err, ErrInvalidConfig) {
+		t.Fatalf("err = %v, want ErrInvalidConfig", err)
+	}
+	if !strings.Contains(err.Error(), "FromSandbox") {
+		t.Fatalf("error should name the missing field: %q", err.Error())
+	}
+}
+
+func marshalSnapshotCreateOptions(t *testing.T, opts ffi.SnapshotCreateOptions) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(opts)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return out
+}
+
+func TestFFIWireShape_SnapshotCreateResumable(t *testing.T) {
+	got := marshalSnapshotCreateOptions(t, ffi.SnapshotCreateOptions{
+		Name:      "after-pip-install",
+		Resumable: true,
+	})
+	if v := mustField(t, got, "resumable"); v != true {
+		t.Fatalf("resumable = %v, want true", v)
+	}
+	if _, present := got["dest_dir"]; present {
+		t.Fatal("dest_dir must not appear in payload when unset")
+	}
+}
+
+func TestFFIWireShape_SnapshotCreateDestDir(t *testing.T) {
+	got := marshalSnapshotCreateOptions(t, ffi.SnapshotCreateOptions{
+		Name:    "after-pip-install",
+		DestDir: "/data/snapshots",
+	})
+	if v := mustField(t, got, "dest_dir"); v != "/data/snapshots" {
+		t.Fatalf("dest_dir = %v, want %q", v, "/data/snapshots")
+	}
+	if _, present := got["resumable"]; present {
+		t.Fatal("resumable must not appear in payload when unset")
+	}
+}

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -1399,7 +1399,7 @@ export declare class Snapshot {
   get format(): string
   get fstype(): string
   get parent(): string | null
-  get scope(): SnapshotScope
+  get scope(): 'disk' | 'resumable'
   get createdAt(): string
   get labels(): Record<string, string>
   get sourceSandbox(): string | null
@@ -1413,13 +1413,13 @@ export type JsSnapshot = Snapshot
  */
 export declare class SnapshotBuilder {
   constructor(name: string)
-  /** Set the source sandbox to snapshot. Required. */
-  fromSandbox(sourceSandbox: string): this
   /**
    * Create the artifact under this parent directory instead of the
    * default snapshots store. The artifact lands at `destDir/<name>`.
    */
   destDir(destDir: string): this
+  /** Set the source sandbox to snapshot. Required. */
+  fromSandbox(sourceSandbox: string): this
   /** Attach a key-value label. May be called multiple times. */
   label(key: string, value: string): this
   /** Overwrite an existing artifact at the destination. */
@@ -1448,7 +1448,7 @@ export declare class SnapshotHandle {
   get digest(): string
   get name(): string | null
   get parentDigest(): string | null
-  get scope(): SnapshotScope
+  get scope(): 'disk' | 'resumable'
   get imageRef(): string
   get format(): string
   get sizeBytes(): bigint | null
@@ -1676,19 +1676,6 @@ export interface ExecOptions {
 export interface ExitStatus {
   code: number
   success: boolean
-}
-
-/** Snapshot payload scope. */
-export type SnapshotScope = "disk" | "resumable"
-
-/** Options for `Snapshot.save()`. */
-export interface SaveOpts {
-  /** Walk the parent chain and include each ancestor (no-op today). */
-  withParents?: boolean
-  /** Bundle the OCI image cache for offline transport. */
-  withImage?: boolean
-  /** Skip zstd compression and write a plain `.tar`. */
-  plainTar?: boolean
 }
 
 /** Filesystem entry metadata returned by `fs.list()`. */
@@ -2114,6 +2101,16 @@ export interface SandboxTouchResult {
   activitySeq: number
 }
 
+/** Options for `Snapshot.save()`. */
+export interface SaveOpts {
+  /** Walk the parent chain and include each ancestor (no-op today). */
+  withParents?: boolean
+  /** Bundle the OCI image cache for offline transport. */
+  withImage?: boolean
+  /** Skip zstd compression and write a plain `.tar`. */
+  plainTar?: boolean
+}
+
 /** Host-scoped upstream CA certificate path. */
 export interface ScopedUpstreamCaCert {
   pattern: string
@@ -2197,7 +2194,7 @@ export interface SnapshotConfig {
   name: string
   sourceSandbox?: string
   destDir?: string
-  labels: Array<SnapshotLabel>
+  labels: Array<JsSnapshotLabel>
   force: boolean
   recordIntegrity: boolean
   resumable: boolean

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -1389,6 +1389,11 @@ export declare class Snapshot {
   static listDir(dir: string): Promise<Array<Snapshot>>
   static remove(pathOrName: string, opts?: SnapshotRemoveOptions | undefined | null): Promise<void>
   static reindex(dir?: string | undefined | null): Promise<number>
+  /**
+   * Bundle a snapshot into a `.tar.zst` archive. The recorded
+   * manifest is archived as-is, so create the snapshot with
+   * `recordIntegrity()` if receivers must verify content.
+   */
   static save(nameOrPath: string, out: string, opts?: SaveOpts | undefined | null): Promise<void>
   static load(archive: string, dest?: string | undefined | null): Promise<SnapshotHandle>
   get path(): string
@@ -2103,7 +2108,7 @@ export interface SandboxTouchResult {
 
 /** Options for `Snapshot.save()`. */
 export interface SaveOpts {
-  /** Walk the parent chain and include each ancestor (no-op today). */
+  /** Walk the parent chain and include each ancestor in the archive. */
   withParents?: boolean
   /** Bundle the OCI image cache for offline transport. */
   withImage?: boolean

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -1293,13 +1293,10 @@ export declare class SandboxHandle {
   /**
    * Snapshot this (stopped) sandbox under a bare name.
    *
-   * Resolves under `~/.microsandbox/snapshots/<name>/`. Use
-   * [`snapshotTo`](Self::snapshot_to) for an explicit filesystem
-   * destination.
+   * Resolves under `~/.microsandbox/snapshots/<name>/`. Move
+   * artifacts with `Snapshot.save`/`Snapshot.load`.
    */
   snapshot(name: string): Promise<JsSnapshot>
-  /** Snapshot this (stopped) sandbox to an explicit filesystem path. */
-  snapshotTo(path: string): Promise<JsSnapshot>
 }
 export type JsSandboxHandle = SandboxHandle
 
@@ -1384,7 +1381,7 @@ export declare class Snapshot {
   static get(nameOrDigest: string): Promise<SnapshotHandle>
   static list(): Promise<Array<SnapshotInfo>>
   /**
-   * Walk `dir` and parse each subdirectory's `manifest.json`. Does
+   * Walk `dir` and parse each subdirectory's `snapshot.json`. Does
    * not touch the local index — useful for inspecting external
    * snapshot collections (e.g. a mounted volume of artifacts that
    * were never imported).
@@ -1392,8 +1389,8 @@ export declare class Snapshot {
   static listDir(dir: string): Promise<Array<Snapshot>>
   static remove(pathOrName: string, opts?: SnapshotRemoveOptions | undefined | null): Promise<void>
   static reindex(dir?: string | undefined | null): Promise<number>
-  static export(nameOrPath: string, out: string, opts?: ExportOpts | undefined | null): Promise<void>
-  static import(archive: string, dest?: string | undefined | null): Promise<SnapshotHandle>
+  static save(nameOrPath: string, out: string, opts?: SaveOpts | undefined | null): Promise<void>
+  static load(archive: string, dest?: string | undefined | null): Promise<SnapshotHandle>
   get path(): string
   get digest(): string
   get sizeBytes(): bigint
@@ -1402,6 +1399,7 @@ export declare class Snapshot {
   get format(): string
   get fstype(): string
   get parent(): string | null
+  get scope(): SnapshotScope
   get createdAt(): string
   get labels(): Record<string, string>
   get sourceSandbox(): string | null
@@ -1409,19 +1407,27 @@ export declare class Snapshot {
 }
 export type JsSnapshot = Snapshot
 
-/** Fluent builder for a snapshot. Returned by `Snapshot.builder(name)`. */
+/**
+ * Fluent builder for a snapshot. Returned by `Snapshot.builder(name)`.
+ * The source sandbox is set with `fromSandbox()` and is required.
+ */
 export declare class SnapshotBuilder {
-  constructor(sourceSandbox: string)
-  /** Set a bare name (resolved under the default snapshots dir). */
-  name(name: string): this
-  /** Set an explicit destination path. */
-  path(path: string): this
+  constructor(name: string)
+  /** Set the source sandbox to snapshot. Required. */
+  fromSandbox(sourceSandbox: string): this
+  /**
+   * Create the artifact under this parent directory instead of the
+   * default snapshots store. The artifact lands at `destDir/<name>`.
+   */
+  destDir(destDir: string): this
   /** Attach a key-value label. May be called multiple times. */
   label(key: string, value: string): this
   /** Overwrite an existing artifact at the destination. */
   force(): this
   /** Compute and record content integrity at create time. */
   recordIntegrity(): this
+  /** Request a future resumable snapshot. */
+  resumable(): this
   /** Snapshot the accumulated configuration. */
   build(): SnapshotConfig
   /**
@@ -1442,6 +1448,7 @@ export declare class SnapshotHandle {
   get digest(): string
   get name(): string | null
   get parentDigest(): string | null
+  get scope(): SnapshotScope
   get imageRef(): string
   get format(): string
   get sizeBytes(): bigint | null
@@ -1671,8 +1678,11 @@ export interface ExitStatus {
   success: boolean
 }
 
-/** Options for `Snapshot.export()`. */
-export interface ExportOpts {
+/** Snapshot payload scope. */
+export type SnapshotScope = "disk" | "resumable"
+
+/** Options for `Snapshot.save()`. */
+export interface SaveOpts {
   /** Walk the parent chain and include each ancestor (no-op today). */
   withParents?: boolean
   /** Bundle the OCI image cache for offline transport. */
@@ -2184,12 +2194,13 @@ export declare function setRuntimeMsbPath(path: string): void
 
 /** Built snapshot configuration produced by `SnapshotBuilder.build()`. */
 export interface SnapshotConfig {
-  sourceSandbox: string
-  destinationKind: string
-  destinationValue?: string
-  labels: Array<JsSnapshotLabel>
+  name: string
+  sourceSandbox?: string
+  destDir?: string
+  labels: Array<SnapshotLabel>
   force: boolean
   recordIntegrity: boolean
+  resumable: boolean
 }
 
 /** Snapshot index info from the local DB cache. */
@@ -2198,6 +2209,8 @@ export interface SnapshotInfo {
   name?: string
   parentDigest?: string
   imageRef: string
+  /** `"disk"` today; `"resumable"` once memory/device-state restore lands. */
+  scope: string
   /** `"raw"` or `"qcow2"`. */
   format: string
   sizeBytes?: number

--- a/sdk/node-ts/native/sandbox_handle.rs
+++ b/sdk/node-ts/native/sandbox_handle.rs
@@ -248,23 +248,11 @@ impl JsSandboxHandle {
 
     /// Snapshot this (stopped) sandbox under a bare name.
     ///
-    /// Resolves under `~/.microsandbox/snapshots/<name>/`. Use
-    /// [`snapshotTo`](Self::snapshot_to) for an explicit filesystem
-    /// destination.
+    /// Resolves under `~/.microsandbox/snapshots/<name>/`. Move
+    /// artifacts with `Snapshot.save`/`Snapshot.load`.
     #[napi]
     pub async fn snapshot(&self, name: String) -> Result<crate::snapshot::JsSnapshot> {
         let snap = self.inner.snapshot(&name).await.map_err(to_napi_error)?;
-        Ok(crate::snapshot::JsSnapshot::from_rust(snap))
-    }
-
-    /// Snapshot this (stopped) sandbox to an explicit filesystem path.
-    #[napi(js_name = "snapshotTo")]
-    pub async fn snapshot_to(&self, path: String) -> Result<crate::snapshot::JsSnapshot> {
-        let snap = self
-            .inner
-            .snapshot_to(std::path::PathBuf::from(path))
-            .await
-            .map_err(to_napi_error)?;
         Ok(crate::snapshot::JsSnapshot::from_rust(snap))
     }
 }

--- a/sdk/node-ts/native/snapshot.rs
+++ b/sdk/node-ts/native/snapshot.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use microsandbox::snapshot::ExportOpts as RustExportOpts;
+use microsandbox::snapshot::SaveOpts as RustSaveOpts;
 use microsandbox::{
     Snapshot as RustSnapshot, SnapshotFormat as RustSnapshotFormat,
-    SnapshotHandle as RustSnapshotHandle, UpperVerifyStatus as RustUpperVerifyStatus,
+    SnapshotHandle as RustSnapshotHandle, SnapshotScope as RustSnapshotScope,
+    UpperVerifyStatus as RustUpperVerifyStatus,
 };
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -27,10 +28,10 @@ pub struct JsSnapshotHandle {
     inner: RustSnapshotHandle,
 }
 
-/// Options for `Snapshot.export()`.
+/// Options for `Snapshot.save()`.
 #[derive(Default)]
-#[napi(object, js_name = "ExportOpts")]
-pub struct JsExportOpts {
+#[napi(object, js_name = "SaveOpts")]
+pub struct JsSaveOpts {
     /// Walk the parent chain and include each ancestor (no-op today).
     pub with_parents: Option<bool>,
     /// Bundle the OCI image cache for offline transport.
@@ -68,6 +69,8 @@ pub struct JsSnapshotInfo {
     pub name: Option<String>,
     pub parent_digest: Option<String>,
     pub image_ref: String,
+    /// `"disk"` today; `"resumable"` once memory/device-state restore lands.
+    pub scope: String,
     /// `"raw"` or `"qcow2"`.
     pub format: String,
     pub size_bytes: Option<f64>,
@@ -107,7 +110,7 @@ impl JsSnapshot {
         Ok(handles.iter().map(snapshot_handle_to_info).collect())
     }
 
-    /// Walk `dir` and parse each subdirectory's `manifest.json`. Does
+    /// Walk `dir` and parse each subdirectory's `snapshot.json`. Does
     /// not touch the local index — useful for inspecting external
     /// snapshot collections (e.g. a mounted volume of artifacts that
     /// were never imported).
@@ -144,26 +147,22 @@ impl JsSnapshot {
     }
 
     #[napi]
-    pub async fn export(
-        name_or_path: String,
-        out: String,
-        opts: Option<JsExportOpts>,
-    ) -> Result<()> {
+    pub async fn save(name_or_path: String, out: String, opts: Option<JsSaveOpts>) -> Result<()> {
         let opts = opts.unwrap_or_default();
-        let rust_opts = RustExportOpts {
+        let rust_opts = RustSaveOpts {
             with_parents: opts.with_parents.unwrap_or(false),
             with_image: opts.with_image.unwrap_or(false),
             plain_tar: opts.plain_tar.unwrap_or(false),
         };
-        RustSnapshot::export(&name_or_path, &PathBuf::from(out), rust_opts)
+        RustSnapshot::save(&name_or_path, &PathBuf::from(out), rust_opts)
             .await
             .map_err(to_napi_error)
     }
 
-    #[napi(js_name = "import")]
-    pub async fn import_(archive: String, dest: Option<String>) -> Result<JsSnapshotHandle> {
+    #[napi]
+    pub async fn load(archive: String, dest: Option<String>) -> Result<JsSnapshotHandle> {
         let dest = dest.map(PathBuf::from);
-        let h = RustSnapshot::import(&PathBuf::from(archive), dest.as_deref())
+        let h = RustSnapshot::load(&PathBuf::from(archive), dest.as_deref())
             .await
             .map_err(to_napi_error)?;
         Ok(JsSnapshotHandle::from_rust(h))
@@ -211,6 +210,11 @@ impl JsSnapshot {
     #[napi(getter)]
     pub fn parent(&self) -> Option<String> {
         self.inner.manifest().parent.clone()
+    }
+
+    #[napi(getter)]
+    pub fn scope(&self) -> String {
+        format_scope(self.inner.manifest().scope).into()
     }
 
     #[napi(getter)]
@@ -263,6 +267,11 @@ impl JsSnapshotHandle {
     #[napi(getter)]
     pub fn parent_digest(&self) -> Option<String> {
         self.inner.parent_digest().map(|s| s.to_string())
+    }
+
+    #[napi(getter)]
+    pub fn scope(&self) -> String {
+        format_scope(self.inner.scope()).into()
     }
 
     #[napi(getter)]
@@ -320,12 +329,20 @@ fn format_str(f: RustSnapshotFormat) -> &'static str {
     }
 }
 
+fn format_scope(scope: RustSnapshotScope) -> &'static str {
+    match scope {
+        RustSnapshotScope::Disk => "disk",
+        RustSnapshotScope::Resumable => "resumable",
+    }
+}
+
 fn snapshot_handle_to_info(h: &RustSnapshotHandle) -> JsSnapshotInfo {
     JsSnapshotInfo {
         digest: h.digest().to_string(),
         name: h.name().map(|s| s.to_string()),
         parent_digest: h.parent_digest().map(|s| s.to_string()),
         image_ref: h.image_ref().to_string(),
+        scope: format_scope(h.scope()).into(),
         format: format_str(h.format()).into(),
         size_bytes: h.size_bytes().map(|n| n as f64),
         created_at: h.created_at().and_utc().timestamp_millis() as f64,

--- a/sdk/node-ts/native/snapshot.rs
+++ b/sdk/node-ts/native/snapshot.rs
@@ -32,7 +32,7 @@ pub struct JsSnapshotHandle {
 #[derive(Default)]
 #[napi(object, js_name = "SaveOpts")]
 pub struct JsSaveOpts {
-    /// Walk the parent chain and include each ancestor (no-op today).
+    /// Walk the parent chain and include each ancestor in the archive.
     pub with_parents: Option<bool>,
     /// Bundle the OCI image cache for offline transport.
     pub with_image: Option<bool>,
@@ -146,6 +146,9 @@ impl JsSnapshot {
         Ok(n as u32)
     }
 
+    /// Bundle a snapshot into a `.tar.zst` archive. The recorded
+    /// manifest is archived as-is, so create the snapshot with
+    /// `recordIntegrity()` if receivers must verify content.
     #[napi]
     pub async fn save(name_or_path: String, out: String, opts: Option<JsSaveOpts>) -> Result<()> {
         let opts = opts.unwrap_or_default();

--- a/sdk/node-ts/native/snapshot.rs
+++ b/sdk/node-ts/native/snapshot.rs
@@ -212,7 +212,7 @@ impl JsSnapshot {
         self.inner.manifest().parent.clone()
     }
 
-    #[napi(getter)]
+    #[napi(getter, ts_return_type = "'disk' | 'resumable'")]
     pub fn scope(&self) -> String {
         format_scope(self.inner.manifest().scope).into()
     }
@@ -269,7 +269,7 @@ impl JsSnapshotHandle {
         self.inner.parent_digest().map(|s| s.to_string())
     }
 
-    #[napi(getter)]
+    #[napi(getter, ts_return_type = "'disk' | 'resumable'")]
     pub fn scope(&self) -> String {
         format_scope(self.inner.scope()).into()
     }

--- a/sdk/node-ts/native/snapshot_builder.rs
+++ b/sdk/node-ts/native/snapshot_builder.rs
@@ -1,9 +1,4 @@
-use std::path::PathBuf;
-
-use microsandbox::snapshot::{
-    Snapshot as RustSnapshot, SnapshotBuilder as RustSnapshotBuilder,
-    SnapshotDestination as RustSnapshotDestination,
-};
+use microsandbox::snapshot::{Snapshot as RustSnapshot, SnapshotBuilder as RustSnapshotBuilder};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
@@ -18,12 +13,13 @@ use crate::snapshot::JsSnapshot;
 #[derive(Clone)]
 #[napi(object, js_name = "SnapshotConfig")]
 pub struct JsSnapshotConfig {
-    pub source_sandbox: String,
-    pub destination_kind: String, // "name" | "path" | "unset"
-    pub destination_value: Option<String>,
+    pub name: String,
+    pub source_sandbox: Option<String>,
+    pub dest_dir: Option<String>,
     pub labels: Vec<JsSnapshotLabel>,
     pub force: bool,
     pub record_integrity: bool,
+    pub resumable: bool,
 }
 
 #[derive(Clone)]
@@ -34,14 +30,17 @@ pub struct JsSnapshotLabel {
 }
 
 /// Fluent builder for a snapshot. Returned by `Snapshot.builder(name)`.
+/// The source sandbox is set with `fromSandbox()` and is required.
 #[napi(js_name = "SnapshotBuilder")]
 pub struct JsSnapshotBuilder {
     inner: Option<RustSnapshotBuilder>,
-    source_sandbox: String,
-    destination: Option<RustSnapshotDestination>,
+    name: String,
+    source_sandbox: Option<String>,
+    dest_dir: Option<String>,
     labels: Vec<(String, String)>,
     force: bool,
     record_integrity: bool,
+    resumable: bool,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -51,33 +50,38 @@ pub struct JsSnapshotBuilder {
 #[napi]
 impl JsSnapshotBuilder {
     #[napi(constructor)]
-    pub fn new(source_sandbox: String) -> Self {
+    pub fn new(name: String) -> Self {
         Self {
-            inner: Some(RustSnapshot::builder(&source_sandbox)),
-            source_sandbox,
-            destination: None,
+            inner: Some(RustSnapshot::builder(&name)),
+            name,
+            source_sandbox: None,
+            dest_dir: None,
             labels: Vec::new(),
             force: false,
             record_integrity: false,
+            resumable: false,
         }
     }
 
-    /// Set a bare name (resolved under the default snapshots dir).
-    #[napi]
-    pub fn name(&mut self, name: String) -> &Self {
+    /// Create the artifact under this parent directory instead of the
+    /// default snapshots store. The artifact lands at `destDir/<name>`.
+    #[napi(js_name = "destDir")]
+    pub fn dest_dir(&mut self, dest_dir: String) -> &Self {
         let prev = self.take_inner();
-        self.inner = Some(prev.name(name.clone()));
-        self.destination = Some(RustSnapshotDestination::Name(name));
+        self.inner = Some(prev.dest_dir(&dest_dir));
+        self.dest_dir = Some(dest_dir);
         self
     }
 
-    /// Set an explicit destination path.
-    #[napi]
-    pub fn path(&mut self, path: String) -> &Self {
+    /// Set the source sandbox to snapshot. Required.
+    // `from_*` normally takes no self, but napi setters mutate in place and
+    // the JS-facing name `fromSandbox` is the contract.
+    #[allow(clippy::wrong_self_convention)]
+    #[napi(js_name = "fromSandbox")]
+    pub fn from_sandbox(&mut self, source_sandbox: String) -> &Self {
         let prev = self.take_inner();
-        let buf = PathBuf::from(&path);
-        self.inner = Some(prev.path(buf.clone()));
-        self.destination = Some(RustSnapshotDestination::Path(buf));
+        self.inner = Some(prev.from_sandbox(source_sandbox.clone()));
+        self.source_sandbox = Some(source_sandbox);
         self
     }
 
@@ -108,20 +112,22 @@ impl JsSnapshotBuilder {
         self
     }
 
+    /// Request a future resumable snapshot.
+    #[napi]
+    pub fn resumable(&mut self) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.resumable());
+        self.resumable = true;
+        self
+    }
+
     /// Snapshot the accumulated configuration.
     #[napi]
     pub fn build(&self) -> JsSnapshotConfig {
-        let (kind, value) = match &self.destination {
-            Some(RustSnapshotDestination::Name(n)) => ("name".into(), Some(n.clone())),
-            Some(RustSnapshotDestination::Path(p)) => {
-                ("path".into(), Some(p.display().to_string()))
-            }
-            None => ("unset".into(), None),
-        };
         JsSnapshotConfig {
+            name: self.name.clone(),
             source_sandbox: self.source_sandbox.clone(),
-            destination_kind: kind,
-            destination_value: value,
+            dest_dir: self.dest_dir.clone(),
             labels: self
                 .labels
                 .iter()
@@ -132,6 +138,7 @@ impl JsSnapshotBuilder {
                 .collect(),
             force: self.force,
             record_integrity: self.record_integrity,
+            resumable: self.resumable,
         }
     }
 

--- a/sdk/node-ts/src/index.ts
+++ b/sdk/node-ts/src/index.ts
@@ -97,18 +97,22 @@ export {
 export { Snapshot } from "./snapshot.js";
 import { Snapshot as _Snapshot, type SnapshotBuilder as _SnapBT } from "./snapshot.js";
 /**
- * Native fluent builder for a snapshot. `new SnapshotBuilder(sourceSandbox)`
- * is equivalent to `Snapshot.builder(sourceSandbox)`.
+ * Native fluent builder for a snapshot. `new SnapshotBuilder(name)`
+ * is equivalent to `Snapshot.builder(name)`.
  */
 export const SnapshotBuilder = function SnapshotBuilder(
   this: unknown,
-  sourceSandbox: string,
+  name: string,
 ) {
-  return _Snapshot.builder(sourceSandbox);
-} as unknown as new (sourceSandbox: string) => _SnapBT;
+  return _Snapshot.builder(name);
+} as unknown as new (name: string) => _SnapBT;
 export type SnapshotBuilder = _SnapBT;
 export { SnapshotHandle } from "./snapshot-handle.js";
-export type { ExportOpts, SnapshotVerifyReport } from "./snapshot.js";
+export type {
+  SaveOpts,
+  SnapshotScope,
+  SnapshotVerifyReport,
+} from "./snapshot.js";
 
 // Image management
 export { Image, ImageHandle } from "./image.js";

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -271,7 +271,6 @@ export interface NapiSandboxHandle {
   logs(opts?: LogOptions): Promise<LogEntry[]>;
   logStream(opts?: LogStreamOptions): Promise<NapiLogStream>;
   snapshot(name: string): Promise<NapiSnapshot>;
-  snapshotTo(path: string): Promise<NapiSnapshot>;
 }
 
 export interface NapiSandboxStopResult {
@@ -502,18 +501,19 @@ export interface NapiSnapshotStatic {
   listDir(dir: string): Promise<NapiSnapshot[]>;
   remove(pathOrName: string, opts?: NapiSnapshotRemoveOptions): Promise<void>;
   reindex(dir?: string): Promise<number>;
-  export(name: string, out: string, opts?: NapiExportOpts): Promise<void>;
-  import(archive: string, dest?: string): Promise<NapiSnapshotHandle>;
+  save(name: string, out: string, opts?: NapiSaveOpts): Promise<void>;
+  load(archive: string, dest?: string): Promise<NapiSnapshotHandle>;
 }
 
-export type NapiSnapshotBuilderCtor = new (sourceSandbox: string) => NapiSnapshotBuilder;
+export type NapiSnapshotBuilderCtor = new (name: string) => NapiSnapshotBuilder;
 
 export interface NapiSnapshotBuilderSetters {
-  name(name: string): this;
-  path(path: string): this;
+  fromSandbox(sourceSandbox: string): this;
+  destDir(destDir: string): this;
   label(key: string, value: string): this;
   force(): this;
   recordIntegrity(): this;
+  resumable(): this;
 }
 
 export interface NapiSnapshotBuilder extends NapiSnapshotBuilderSetters {
@@ -529,6 +529,7 @@ export interface NapiSnapshot {
   readonly format: string; // "raw" | "qcow2"
   readonly fstype: string;
   readonly parent: string | null | undefined;
+  readonly scope: string; // "disk" | "resumable"
   readonly createdAt: string; // RFC 3339 UTC
   readonly labels: Record<string, string>;
   readonly sourceSandbox: string | null | undefined;
@@ -539,6 +540,7 @@ export interface NapiSnapshotHandle {
   readonly digest: string;
   readonly name: string | null | undefined;
   readonly parentDigest: string | null | undefined;
+  readonly scope: string; // "disk" | "resumable"
   readonly imageRef: string;
   readonly format: string;
   readonly sizeBytes: bigint | null | undefined;
@@ -552,6 +554,7 @@ export interface NapiSnapshotInfo {
   readonly digest: string;
   readonly name: string | null | undefined;
   readonly parentDigest: string | null | undefined;
+  readonly scope: string; // "disk" | "resumable"
   readonly imageRef: string;
   readonly format: string;
   readonly sizeBytes: number | null | undefined;
@@ -559,7 +562,7 @@ export interface NapiSnapshotInfo {
   readonly path: string;
 }
 
-export interface NapiExportOpts {
+export interface NapiSaveOpts {
   withParents?: boolean;
   withImage?: boolean;
   plainTar?: boolean;

--- a/sdk/node-ts/src/sandbox-handle.ts
+++ b/sdk/node-ts/src/sandbox-handle.ts
@@ -214,19 +214,13 @@ export class SandboxHandle {
   /**
    * Snapshot this (stopped) sandbox under a bare name. Resolves under
    * `~/.microsandbox/snapshots/<name>/`. For an explicit filesystem
-   * destination, see `snapshotTo`.
+   * destination, move the artifact with `Snapshot.save`/`Snapshot.load`.
    *
    * The sandbox must be stopped (or crashed); running sandboxes are
    * rejected with a `SnapshotSandboxRunning` error.
    */
   async snapshot(name: string): Promise<Snapshot> {
     const raw = await withMappedErrors(() => this.inner.snapshot(name));
-    return new Snapshot(raw);
-  }
-
-  /** Snapshot this (stopped) sandbox to an explicit filesystem path. */
-  async snapshotTo(path: string): Promise<Snapshot> {
-    const raw = await withMappedErrors(() => this.inner.snapshotTo(path));
     return new Snapshot(raw);
   }
 }

--- a/sdk/node-ts/src/snapshot-handle.ts
+++ b/sdk/node-ts/src/snapshot-handle.ts
@@ -3,7 +3,7 @@ import type {
   NapiSnapshotHandle,
   NapiSnapshotInfo,
 } from "./internal/napi.js";
-import { Snapshot } from "./snapshot.js";
+import { Snapshot, type SnapshotScope } from "./snapshot.js";
 
 const READ_ONLY_MSG =
   "SnapshotHandle is read-only — fetch a live handle via Snapshot.get(name) for lifecycle methods.";
@@ -23,6 +23,8 @@ export class SnapshotHandle {
   readonly name: string | null;
   /** Manifest digest of the parent snapshot, or `null` for a root. */
   readonly parentDigest: string | null;
+  /** Snapshot payload scope. */
+  readonly scope: SnapshotScope;
   /** Image reference the snapshot was taken from. */
   readonly imageRef: string;
   /** On-disk format of the upper layer. */
@@ -40,6 +42,7 @@ export class SnapshotHandle {
     this.digest = inner.digest;
     this.name = (inner.name ?? null) as string | null;
     this.parentDigest = (inner.parentDigest ?? null) as string | null;
+    this.scope = inner.scope as SnapshotScope;
     this.imageRef = inner.imageRef;
     this.format = inner.format as "raw" | "qcow2";
     this.sizeBytes = sizeBytesToBigInt(inner.sizeBytes);

--- a/sdk/node-ts/src/snapshot.ts
+++ b/sdk/node-ts/src/snapshot.ts
@@ -12,9 +12,14 @@ import {
 } from "./snapshot-handle.js";
 
 /**
- * Bundle options for `Snapshot.export`.
+ * Snapshot payload scope.
  */
-export interface ExportOpts {
+export type SnapshotScope = "disk" | "resumable";
+
+/**
+ * Bundle options for `Snapshot.save`.
+ */
+export interface SaveOpts {
   /** Walk the parent chain and include each ancestor (no-op in v1). */
   withParents?: boolean;
   /** Include the OCI image cache so the archive boots offline. */
@@ -59,9 +64,9 @@ export interface SnapshotBuilder extends NapiSnapshotBuilderSetters {
  * A snapshot artifact on disk.
  *
  * Returned by `Snapshot.builder(name).create()`, `Snapshot.open(...)`,
- * `SandboxHandle.snapshot(name)`, and `SandboxHandle.snapshotTo(path)`.
+ * and `SandboxHandle.snapshot(name)`.
  *
- * The artifact is a directory containing `manifest.json` and the
+ * The artifact is a directory containing `snapshot.json` and the
  * captured `upper.ext4`. The directory is the source of truth; the
  * local DB index (used for queries like `Snapshot.list()`) is just a
  * cache and is rebuildable via `Snapshot.reindex()`.
@@ -76,19 +81,18 @@ export class Snapshot {
   }
 
   /**
-   * Begin building a new snapshot of `sourceSandbox` (must be stopped).
+   * Begin building a snapshot named `name`, stored under the default
+   * snapshots directory.
    *
-   * The bare-name and explicit-path destinations are mutually
-   * exclusive — call exactly one of `.name(s)` or `.path(p)`.
+   * The source sandbox is required:
+   * `Snapshot.builder("clean").fromSandbox("box").create()`.
+   *
+   * Snapshots are always created in the snapshots store. To place an
+   * artifact elsewhere, use `save()`/`load()`, or move the
+   * self-contained artifact directory directly.
    */
-  static builder(sourceSandbox: string): SnapshotBuilder {
-    const nb = new napi.SnapshotBuilder(sourceSandbox);
-    const origCreate = nb.create.bind(nb);
-    (nb as unknown as { create: () => Promise<Snapshot> }).create = async () => {
-      const inner = await withMappedErrors(() => origCreate());
-      return new Snapshot(inner);
-    };
-    return nb as unknown as SnapshotBuilder;
+  static builder(name: string): SnapshotBuilder {
+    return wrapBuilder(new napi.SnapshotBuilder(name));
   }
 
   /**
@@ -153,12 +157,12 @@ export class Snapshot {
    * has no integrity hash yet, one is computed and embedded in the
    * bundled manifest so the receiver can verify.
    */
-  static async export(
+  static async save(
     nameOrPath: string,
     out: string,
-    opts?: ExportOpts,
+    opts?: SaveOpts,
   ): Promise<void> {
-    await withMappedErrors(() => napi.Snapshot.export(nameOrPath, out, opts));
+    await withMappedErrors(() => napi.Snapshot.save(nameOrPath, out, opts));
   }
 
   /**
@@ -166,8 +170,8 @@ export class Snapshot {
    * snapshots directory, verifying recorded integrity on the way in.
    * Compression is detected from magic bytes.
    */
-  static async import(archive: string, dest?: string): Promise<SnapshotHandle> {
-    const raw = await withMappedErrors(() => napi.Snapshot.import(archive, dest));
+  static async load(archive: string, dest?: string): Promise<SnapshotHandle> {
+    const raw = await withMappedErrors(() => napi.Snapshot.load(archive, dest));
     return new SnapshotHandle(raw);
   }
 
@@ -215,6 +219,11 @@ export class Snapshot {
     return this.inner.parent ?? null;
   }
 
+  /** Snapshot payload scope. */
+  get scope(): SnapshotScope {
+    return this.inner.scope as SnapshotScope;
+  }
+
   /** RFC 3339 timestamp when the snapshot was created. */
   get createdAt(): string {
     return this.inner.createdAt;
@@ -242,6 +251,16 @@ export class Snapshot {
     const r = await withMappedErrors(() => this.inner.verify());
     return verifyReportToTs(r);
   }
+}
+
+/** @internal */
+function wrapBuilder(nb: InstanceType<typeof napi.SnapshotBuilder>): SnapshotBuilder {
+  const origCreate = nb.create.bind(nb);
+  (nb as unknown as { create: () => Promise<Snapshot> }).create = async () => {
+    const inner = await withMappedErrors(() => origCreate());
+    return new Snapshot(inner);
+  };
+  return nb as unknown as SnapshotBuilder;
 }
 
 /** @internal */

--- a/sdk/node-ts/src/snapshot.ts
+++ b/sdk/node-ts/src/snapshot.ts
@@ -20,7 +20,7 @@ export type SnapshotScope = "disk" | "resumable";
  * Bundle options for `Snapshot.save`.
  */
 export interface SaveOpts {
-  /** Walk the parent chain and include each ancestor (no-op in v1). */
+  /** Walk the parent chain and include each ancestor in the archive. */
   withParents?: boolean;
   /** Include the OCI image cache so the archive boots offline. */
   withImage?: boolean;
@@ -87,9 +87,9 @@ export class Snapshot {
    * The source sandbox is required:
    * `Snapshot.builder("clean").fromSandbox("box").create()`.
    *
-   * Snapshots are always created in the snapshots store. To place an
-   * artifact elsewhere, use `save()`/`load()`, or move the
-   * self-contained artifact directory directly.
+   * Use `destDir(dir)` to create the artifact under a different parent
+   * directory instead; it lands at `destDir/<name>`, and the name stays
+   * the snapshot's identity either way.
    */
   static builder(name: string): SnapshotBuilder {
     return wrapBuilder(new napi.SnapshotBuilder(name));
@@ -153,9 +153,9 @@ export class Snapshot {
   }
 
   /**
-   * Bundle a snapshot into a `.tar.zst` archive. When the snapshot
-   * has no integrity hash yet, one is computed and embedded in the
-   * bundled manifest so the receiver can verify.
+   * Bundle a snapshot into a `.tar.zst` archive. The recorded
+   * manifest is archived as-is, so create the snapshot with
+   * `recordIntegrity()` if receivers must verify content.
    */
   static async save(
     nameOrPath: string,

--- a/sdk/python/integration/test_snapshots.py
+++ b/sdk/python/integration/test_snapshots.py
@@ -45,7 +45,7 @@ async def test_snapshot_create_open_list_and_boot(sandbox_name):
 
         fork = await Sandbox.create(
             fork_name,
-            snapshot=snapshot_name,
+            from_snapshot=snapshot_name,
             cpus=1,
             memory=512,
             replace=True,

--- a/sdk/python/microsandbox/_microsandbox.pyi
+++ b/sdk/python/microsandbox/_microsandbox.pyi
@@ -285,7 +285,6 @@ class SandboxHandle:
     async def wait_until_stopped(self) -> SandboxStopResult: ...
     async def remove(self) -> None: ...
     async def snapshot(self, name: str) -> Snapshot: ...
-    async def snapshot_to(self, path: str | os.PathLike[str]) -> Snapshot: ...
 
 class ExecOutput:
     @property
@@ -657,13 +656,14 @@ class ImagePruneReport:
 class Snapshot:
     @staticmethod
     async def create(
-        source_sandbox: str,
+        name: str,
         *,
-        name: str | None = None,
-        path: str | os.PathLike[str] | None = None,
+        from_sandbox: str,
+        dest_dir: str | os.PathLike[str] | None = None,
         labels: dict[str, str] | None = None,
         force: bool = False,
         record_integrity: bool = False,
+        resumable: bool = False,
     ) -> Snapshot: ...
     @staticmethod
     async def open(path_or_name: str) -> Snapshot: ...
@@ -678,7 +678,7 @@ class Snapshot:
     @staticmethod
     async def reindex(dir: str | os.PathLike[str] | None = None) -> int: ...
     @staticmethod
-    async def export(
+    async def save(
         name_or_path: str,
         out: str | os.PathLike[str],
         *,
@@ -687,7 +687,7 @@ class Snapshot:
         plain_tar: bool = False,
     ) -> None: ...
     @staticmethod
-    async def import_(
+    async def load(
         archive: str | os.PathLike[str],
         *,
         dest: str | os.PathLike[str] | None = None,
@@ -709,6 +709,8 @@ class Snapshot:
     @property
     def parent(self) -> str | None: ...
     @property
+    def scope(self) -> str: ...
+    @property
     def created_at(self) -> str: ...
     @property
     def labels(self) -> dict[str, str]: ...
@@ -723,6 +725,8 @@ class SnapshotHandle:
     def name(self) -> str | None: ...
     @property
     def parent_digest(self) -> str | None: ...
+    @property
+    def scope(self) -> str: ...
     @property
     def image_ref(self) -> str: ...
     @property

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -5,6 +5,46 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
 //--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Kwargs accepted by `Sandbox.create` / `Sandbox.create_with_progress`.
+/// `detached` is consumed by the callers in `sandbox.rs`, not here.
+const KNOWN_CREATE_KWARGS: &[&str] = &[
+    "image",
+    "from_snapshot",
+    "memory",
+    "cpus",
+    "max_memory",
+    "max_cpus",
+    "workdir",
+    "shell",
+    "security",
+    "hostname",
+    "user",
+    "entrypoint",
+    "init",
+    "replace",
+    "replace_with_timeout",
+    "max_duration",
+    "idle_timeout",
+    "ephemeral",
+    "env",
+    "labels",
+    "scripts",
+    "pull_policy",
+    "log_level",
+    "registry_auth",
+    "volumes",
+    "patches",
+    "ports",
+    "network",
+    "secrets",
+    "on_secret_violation",
+    "detached",
+];
+
+//--------------------------------------------------------------------------------------------------
 // Functions: Config Conversion
 //--------------------------------------------------------------------------------------------------
 
@@ -26,6 +66,8 @@ pub fn sandbox_builder_from_args(
             "image= or from_snapshot= is required",
         ));
     };
+
+    reject_unknown_kwargs(kwargs)?;
 
     let image_present = kwargs.get_item("image")?.is_some();
     let snapshot_present = kwargs.get_item("from_snapshot")?.is_some();
@@ -1257,6 +1299,37 @@ fn apply_secret(
 //--------------------------------------------------------------------------------------------------
 // Functions: Extraction Helpers
 //--------------------------------------------------------------------------------------------------
+
+/// Reject kwargs that no consumer of `Sandbox.create` recognizes, so a
+/// typo (or a removed kwarg like `snapshot=`) fails loudly instead of
+/// being silently ignored.
+fn reject_unknown_kwargs(kwargs: &Bound<'_, PyDict>) -> PyResult<()> {
+    let mut unknown: Vec<String> = Vec::new();
+    for key in kwargs.keys() {
+        let key: String = key.extract()?;
+        if !KNOWN_CREATE_KWARGS.contains(&key.as_str()) {
+            unknown.push(key);
+        }
+    }
+    if unknown.is_empty() {
+        return Ok(());
+    }
+    let listed = unknown
+        .iter()
+        .map(|k| {
+            if k == "snapshot" {
+                "'snapshot' (did you mean 'from_snapshot'?)".to_string()
+            } else {
+                format!("'{k}'")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let plural = if unknown.len() == 1 { "" } else { "s" };
+    Err(pyo3::exceptions::PyTypeError::new_err(format!(
+        "unexpected keyword argument{plural} {listed}"
+    )))
+}
 
 /// Convert an object to a PyDict — either it's already a dict, or call _to_dict().
 fn as_dict<'py>(obj: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyDict>> {

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -23,20 +23,20 @@ pub fn sandbox_builder_from_args(
 ) -> PyResult<SandboxBuilder> {
     let Some(kwargs) = kwargs else {
         return Err(pyo3::exceptions::PyValueError::new_err(
-            "image= or snapshot= is required",
+            "image= or from_snapshot= is required",
         ));
     };
 
     let image_present = kwargs.get_item("image")?.is_some();
-    let snapshot_present = kwargs.get_item("snapshot")?.is_some();
+    let snapshot_present = kwargs.get_item("from_snapshot")?.is_some();
     if image_present && snapshot_present {
         return Err(pyo3::exceptions::PyValueError::new_err(
-            "pass either image= or snapshot=, not both",
+            "pass either image= or from_snapshot=, not both",
         ));
     }
     if !image_present && !snapshot_present {
         return Err(pyo3::exceptions::PyValueError::new_err(
-            "image= or snapshot= is required",
+            "image= or from_snapshot= is required",
         ));
     }
 
@@ -44,14 +44,14 @@ pub fn sandbox_builder_from_args(
 
     if snapshot_present {
         // Boot from a snapshot. Accept str or PathLike.
-        let snap_obj = kwargs.get_item("snapshot")?.unwrap();
+        let snap_obj = kwargs.get_item("from_snapshot")?.unwrap();
         let snap_str: String = if let Ok(s) = snap_obj.extract::<String>() {
             s
         } else if let Ok(fspath) = snap_obj.call_method0("__fspath__") {
             fspath.extract()?
         } else {
             return Err(pyo3::exceptions::PyTypeError::new_err(
-                "snapshot must be str or os.PathLike",
+                "from_snapshot must be str or os.PathLike",
             ));
         };
         // Resolve the snapshot synchronously: read the manifest and
@@ -67,18 +67,23 @@ pub fn sandbox_builder_from_args(
             )));
         }
         let manifest_bytes = std::fs::read(
-            snap_dir.join(microsandbox::snapshot::MANIFEST_FILENAME),
+            snap_dir.join(microsandbox::snapshot::DESCRIPTOR_FILENAME),
         )
         .map_err(|e| {
             pyo3::exceptions::PyFileNotFoundError::new_err(format!(
-                "snapshot manifest not readable at {}: {e}",
+                "snapshot descriptor not readable at {}: {e}",
                 snap_dir.display(),
             ))
         })?;
         let manifest =
             microsandbox::snapshot::Manifest::from_bytes(&manifest_bytes).map_err(|e| {
-                pyo3::exceptions::PyValueError::new_err(format!("snapshot manifest invalid: {e}"))
+                pyo3::exceptions::PyValueError::new_err(format!("snapshot descriptor invalid: {e}"))
             })?;
+        if manifest.scope != microsandbox::snapshot::SnapshotScope::Disk {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "restoring non-disk snapshots is not supported by this runtime",
+            ));
+        }
         let upper_path = snap_dir.join(&manifest.upper.file);
         if !upper_path.exists() {
             return Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(

--- a/sdk/python/src/sandbox_handle.rs
+++ b/sdk/python/src/sandbox_handle.rs
@@ -378,27 +378,13 @@ impl PySandboxHandle {
     }
 
     /// Snapshot this (stopped) sandbox under a bare name. Resolves
-    /// under `~/.microsandbox/snapshots/<name>/`. For an explicit
-    /// filesystem destination, see `snapshot_to`.
+    /// under `~/.microsandbox/snapshots/<name>/`. Move artifacts with
+    /// `Snapshot.save`/`Snapshot.load`.
     fn snapshot<'py>(&self, py: Python<'py>, name: String) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let guard = inner.lock().await;
             let snap = guard.snapshot(&name).await.map_err(to_py_err)?;
-            Ok(crate::snapshot::PySnapshot::from_rust(snap))
-        })
-    }
-
-    /// Snapshot this (stopped) sandbox to an explicit filesystem path.
-    fn snapshot_to<'py>(
-        &self,
-        py: Python<'py>,
-        path: std::path::PathBuf,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let inner = self.inner.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let guard = inner.lock().await;
-            let snap = guard.snapshot_to(path).await.map_err(to_py_err)?;
             Ok(crate::snapshot::PySnapshot::from_rust(snap))
         })
     }

--- a/sdk/python/src/snapshot.rs
+++ b/sdk/python/src/snapshot.rs
@@ -4,10 +4,10 @@ use std::path::PathBuf;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use microsandbox::snapshot::ExportOpts as RustExportOpts;
+use microsandbox::snapshot::SaveOpts as RustSaveOpts;
 use microsandbox::{
-    Snapshot as RustSnapshot, SnapshotDestination as RustSnapshotDestination,
-    SnapshotFormat as RustSnapshotFormat, SnapshotHandle as RustSnapshotHandle,
+    Snapshot as RustSnapshot, SnapshotFormat as RustSnapshotFormat,
+    SnapshotHandle as RustSnapshotHandle, SnapshotScope as RustSnapshotScope,
     UpperVerifyStatus as RustUpperVerifyStatus,
 };
 
@@ -35,46 +35,38 @@ pub struct PySnapshotHandle {
 
 #[pymethods]
 impl PySnapshot {
-    /// Create a snapshot from a stopped sandbox.
+    /// Create a snapshot named `name` from a stopped sandbox.
     ///
-    /// Exactly one of `name=` (resolved under
-    /// `~/.microsandbox/snapshots/<name>/`) or `path=` (explicit
-    /// filesystem destination) must be provided.
+    /// The artifact is created under `~/.microsandbox/snapshots/<name>/`,
+    /// or under `dest_dir=` when given; move artifacts with `save`/`load`.
+    // PyO3 kwargs map one-to-one onto function parameters; the count is the contract.
+    #[allow(clippy::too_many_arguments)]
     #[staticmethod]
     #[pyo3(signature = (
-        source_sandbox,
+        name,
         *,
-        name = None,
-        path = None,
+        from_sandbox,
+        dest_dir = None,
         labels = None,
         force = false,
         record_integrity = false,
+        resumable = false,
     ))]
     fn create<'py>(
         py: Python<'py>,
-        source_sandbox: String,
-        name: Option<String>,
-        path: Option<PathBuf>,
+        name: String,
+        from_sandbox: String,
+        dest_dir: Option<PathBuf>,
         labels: Option<HashMap<String, String>>,
         force: bool,
         record_integrity: bool,
+        resumable: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let dest = match (name, path) {
-            (Some(n), None) => RustSnapshotDestination::Name(n),
-            (None, Some(p)) => RustSnapshotDestination::Path(p),
-            (Some(_), Some(_)) => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Snapshot.create: pass either name= or path=, not both",
-                ));
-            }
-            (None, None) => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Snapshot.create: name= or path= is required",
-                ));
-            }
-        };
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let mut builder = RustSnapshot::builder(&source_sandbox).destination(dest);
+            let mut builder = RustSnapshot::builder(name).from_sandbox(&from_sandbox);
+            if let Some(dest_dir) = dest_dir {
+                builder = builder.dest_dir(dest_dir);
+            }
             if let Some(labels) = labels {
                 for (k, v) in labels {
                     builder = builder.label(k, v);
@@ -85,6 +77,9 @@ impl PySnapshot {
             }
             if record_integrity {
                 builder = builder.record_integrity();
+            }
+            if resumable {
+                builder = builder.resumable();
             }
             let snap = builder.create().await.map_err(to_py_err)?;
             Ok(PySnapshot::from_rust(snap))
@@ -125,7 +120,7 @@ impl PySnapshot {
         })
     }
 
-    /// Walk `dir` and parse each subdirectory's `manifest.json`. Does
+    /// Walk `dir` and parse each subdirectory's `snapshot.json`. Does
     /// not touch the local index — useful for inspecting external
     /// snapshot collections (e.g. a mounted volume of artifacts that
     /// were never imported).
@@ -188,7 +183,7 @@ impl PySnapshot {
         with_image = false,
         plain_tar = false,
     ))]
-    fn export<'py>(
+    fn save<'py>(
         py: Python<'py>,
         name_or_path: String,
         out: PathBuf,
@@ -197,12 +192,12 @@ impl PySnapshot {
         plain_tar: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let opts = RustExportOpts {
+            let opts = RustSaveOpts {
                 with_parents,
                 with_image,
                 plain_tar,
             };
-            RustSnapshot::export(&name_or_path, &out, opts)
+            RustSnapshot::save(&name_or_path, &out, opts)
                 .await
                 .map_err(to_py_err)?;
             Ok(())
@@ -212,17 +207,15 @@ impl PySnapshot {
     /// Unpack a snapshot archive (`.tar.zst` or `.tar`) into the
     /// snapshots directory, verifying recorded integrity on the way
     /// in.
-    ///
-    /// Note: spelled `import_` because `import` is a Python keyword.
     #[staticmethod]
-    #[pyo3(name = "import_", signature = (archive, *, dest = None))]
-    fn import_method<'py>(
+    #[pyo3(signature = (archive, *, dest = None))]
+    fn load<'py>(
         py: Python<'py>,
         archive: PathBuf,
         dest: Option<PathBuf>,
     ) -> PyResult<Bound<'py, PyAny>> {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let h = RustSnapshot::import(&archive, dest.as_deref())
+            let h = RustSnapshot::load(&archive, dest.as_deref())
                 .await
                 .map_err(to_py_err)?;
             Ok(PySnapshotHandle::from_rust(h))
@@ -279,6 +272,12 @@ impl PySnapshot {
     #[getter]
     fn parent(&self) -> Option<&str> {
         self.inner.manifest().parent.as_deref()
+    }
+
+    /// Snapshot payload scope (`"disk"` today).
+    #[getter]
+    fn scope(&self) -> &'static str {
+        format_scope(self.inner.manifest().scope)
     }
 
     /// RFC 3339 timestamp when the snapshot was created.
@@ -362,6 +361,11 @@ impl PySnapshotHandle {
     }
 
     #[getter]
+    fn scope(&self) -> &'static str {
+        format_scope(self.inner.scope())
+    }
+
+    #[getter]
     fn image_ref(&self) -> &str {
         self.inner.image_ref()
     }
@@ -420,5 +424,12 @@ fn format_str(f: RustSnapshotFormat) -> &'static str {
     match f {
         RustSnapshotFormat::Raw => "raw",
         RustSnapshotFormat::Qcow2 => "qcow2",
+    }
+}
+
+fn format_scope(scope: RustSnapshotScope) -> &'static str {
+    match scope {
+        RustSnapshotScope::Disk => "disk",
+        RustSnapshotScope::Resumable => "resumable",
     }
 }

--- a/sdk/python/src/snapshot.rs
+++ b/sdk/python/src/snapshot.rs
@@ -172,8 +172,8 @@ impl PySnapshot {
 
     /// Bundle a snapshot into a `.tar.zst` archive.
     ///
-    /// When the snapshot has no integrity hash yet, one is computed
-    /// and embedded in the bundled manifest.
+    /// The recorded manifest is archived as-is, so create the snapshot
+    /// with `record_integrity=True` if receivers must verify content.
     #[staticmethod]
     #[pyo3(signature = (
         name_or_path,

--- a/sdk/rust/lib/lib.rs
+++ b/sdk/rust/lib/lib.rs
@@ -66,7 +66,7 @@ pub use sandbox::{
     validate_sandbox_name,
 };
 pub use snapshot::{
-    Snapshot, SnapshotBuilder, SnapshotConfig, SnapshotDestination, SnapshotFormat, SnapshotHandle,
-    SnapshotSpec, SnapshotVerifyReport, UpperIntegrity, UpperVerifyStatus,
+    SaveOpts, Snapshot, SnapshotBuilder, SnapshotConfig, SnapshotFormat, SnapshotHandle,
+    SnapshotScope, SnapshotSpec, SnapshotVerifyReport, UpperIntegrity, UpperVerifyStatus,
 };
 pub use volume::{Volume, VolumeConfig, VolumeHandle, VolumeKind, VolumeSpec};

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -939,6 +939,16 @@ impl SandboxBuilder {
                     .into(),
             });
         }
+        let unsupported = snap.manifest().unsupported_requires();
+        if !unsupported.is_empty() {
+            return Err(crate::MicrosandboxError::Unsupported {
+                feature: format!(
+                    "snapshot requires capabilities this runtime does not have: {}",
+                    unsupported.join(", ")
+                ),
+                available_when: "in a runtime that understands these snapshot extensions".into(),
+            });
+        }
         let snap_ref = snap.manifest().image.reference.clone();
 
         self.config.spec.image = RootfsSource::oci(snap_ref);

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -932,6 +932,13 @@ impl SandboxBuilder {
         }
 
         let snap = crate::snapshot::Snapshot::open(&snapshot_ref).await?;
+        if snap.manifest().scope != crate::snapshot::SnapshotScope::Disk {
+            return Err(crate::MicrosandboxError::Unsupported {
+                feature: "Restoring non-disk snapshots".into(),
+                available_when: "after resumable restore support lands; upgrade may be required"
+                    .into(),
+            });
+        }
         let snap_ref = snap.manifest().image.reference.clone();
 
         self.config.spec.image = RootfsSource::oci(snap_ref);

--- a/sdk/rust/lib/sandbox/handle.rs
+++ b/sdk/rust/lib/sandbox/handle.rs
@@ -439,27 +439,9 @@ impl SandboxHandle {
                 available_when: "when cloud snapshots land".into(),
             });
         }
-        use super::super::snapshot::{Snapshot, SnapshotDestination};
-        Snapshot::builder(&self.name)
-            .destination(SnapshotDestination::Name(name.to_string()))
-            .create()
-            .await
-    }
-
-    /// Snapshot this sandbox to an explicit filesystem path. **Local handles only.**
-    pub async fn snapshot_to(
-        &self,
-        path: impl AsRef<std::path::Path>,
-    ) -> MicrosandboxResult<super::super::snapshot::Snapshot> {
-        if self.local().is_none() {
-            return Err(crate::MicrosandboxError::Unsupported {
-                feature: "SandboxHandle::snapshot_to on cloud".into(),
-                available_when: "when cloud snapshots land".into(),
-            });
-        }
-        use super::super::snapshot::{Snapshot, SnapshotDestination};
-        Snapshot::builder(&self.name)
-            .destination(SnapshotDestination::Path(path.as_ref().to_path_buf()))
+        use super::super::snapshot::Snapshot;
+        Snapshot::builder(name)
+            .from_sandbox(&self.name)
             .create()
             .await
     }

--- a/sdk/rust/lib/snapshot/archive.rs
+++ b/sdk/rust/lib/snapshot/archive.rs
@@ -1,11 +1,11 @@
-//! Snapshot export / import via `.tar.zst` bundles.
+//! Snapshot save / load via `.tar.zst` bundles.
 //!
-//! Default archive format is zstd-compressed tar. Regular files with holes — notably the sparse `upper.ext4`, whose logical size is the configured upper cap rather than the data
-//! written — are stored as old-GNU sparse entries (type `S`): only allocated extents are read and archived, so export cost scales with the data a sandbox actually wrote instead of
-//! the upper layer's logical size. Dense files keep plain regular entries. Plain `.tar` archives are also accepted on import.
+//! Default archive format is zstd-compressed tar. Regular files with holes, notably the sparse `upper.ext4` whose logical size is the configured upper cap rather than the data
+//! written, are stored as old-GNU sparse entries (type `S`): only allocated extents are read and archived, so save cost scales with the data a sandbox actually wrote instead of
+//! the upper layer's logical size. Dense files keep plain regular entries. Plain `.tar` archives are also accepted on load.
 //!
-//! Import walks the tar records itself rather than going through `tokio_tar::Archive`: the entry grammar is closed (regular files, directories, and old-GNU sparse entries at fixed
-//! depths, produced by our own exporter), and owning the walk lets sparse entries be restored map-driven — data runs copied straight off the wire, holes never written and kept
+//! Load walks the tar records itself rather than going through `tokio_tar::Archive`: the entry grammar is closed (regular files, directories, and old-GNU sparse entries at fixed
+//! depths, produced by our own save path), and owning the walk lets sparse entries be restored map-driven: data runs copied straight off the wire, holes never written and kept
 //! unallocated per platform ([`extent::mark_sparse`] on NTFS, [`extent::punch_hole_aligned`] on APFS). `tokio_tar` remains the header codec and the dense-entry writer.
 
 use std::collections::HashSet;
@@ -13,7 +13,7 @@ use std::path::{Component, Path, PathBuf};
 
 use async_compression::tokio::bufread::ZstdDecoder;
 use async_compression::tokio::write::ZstdEncoder;
-use microsandbox_image::snapshot::MANIFEST_FILENAME;
+use microsandbox_image::snapshot::DESCRIPTOR_FILENAME;
 use microsandbox_utils::extent::{self, ExtentMap};
 use sha2::{Digest as _, Sha256};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
@@ -28,9 +28,9 @@ use super::{Snapshot, SnapshotHandle, store};
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// Options for [`super::Snapshot::export`].
+/// Options for [`super::Snapshot::save`].
 #[derive(Debug, Clone, Default)]
-pub struct ExportOpts {
+pub struct SaveOpts {
     /// Walk parent chain and include each ancestor in the archive.
     pub with_parents: bool,
     /// Include the OCI image artifacts (EROFS layers, VMDK descriptor)
@@ -74,11 +74,11 @@ impl SparseMap {
 
 /// Bundle a snapshot artifact (and optionally its ancestors / image
 /// cache) into an archive at `out`.
-pub(super) async fn export_snapshot(
+pub(super) async fn save_snapshot(
     local: &LocalBackend,
     name_or_path: &str,
     out: &Path,
-    opts: ExportOpts,
+    opts: SaveOpts,
 ) -> MicrosandboxResult<()> {
     // Collect the artifact dirs we need to ship: the head snapshot
     // and (optionally) all ancestors via parent_digest.
@@ -182,7 +182,7 @@ pub(super) async fn export_snapshot(
 /// Unpack an archive into `dest` (defaults to the configured snapshots
 /// dir). Image-cache entries (`cache/...`) are routed into the global
 /// cache. Returns a handle for the head (last-listed) snapshot.
-pub(super) async fn import_snapshot(
+pub(super) async fn load_snapshot(
     local: &LocalBackend,
     archive: &Path,
     dest: Option<&Path>,
@@ -251,6 +251,7 @@ pub(super) async fn import_snapshot(
             .and_then(|s| s.to_str())
             .map(|s| s.to_string()),
         parent_digest: snap.manifest().parent.clone(),
+        scope: snap.manifest().scope,
         image_ref: snap.manifest().image.reference.clone(),
         format,
         size_bytes: Some(snap.manifest().upper.size_bytes),
@@ -274,12 +275,12 @@ where
     W: tokio::io::AsyncWrite + Unpin + Send,
 {
     for (dir, prefix) in dirs {
-        // Append manifest first so import can recognize the layout
+        // Append the descriptor first so load can recognize the layout
         // even on a truncated read.
-        let manifest_src = dir.join(MANIFEST_FILENAME);
+        let manifest_src = dir.join(DESCRIPTOR_FILENAME);
         if manifest_src.exists() {
             builder
-                .append_path_with_name(&manifest_src, format!("{prefix}/{MANIFEST_FILENAME}"))
+                .append_path_with_name(&manifest_src, format!("{prefix}/{DESCRIPTOR_FILENAME}"))
                 .await?;
         }
         let mut entries = tokio::fs::read_dir(dir).await?;
@@ -289,7 +290,7 @@ where
             let name_str = name
                 .to_str()
                 .ok_or_else(|| MicrosandboxError::Custom("non-utf8 artifact filename".into()))?;
-            if name_str == MANIFEST_FILENAME {
+            if name_str == DESCRIPTOR_FILENAME {
                 continue;
             }
             append_artifact_file(builder, &path, format!("{prefix}/{name_str}")).await?;
@@ -572,7 +573,7 @@ where
         if path_in_archive
             .file_name()
             .and_then(|s| s.to_str())
-            .map(|n| n == MANIFEST_FILENAME)
+            .map(|n| n == DESCRIPTOR_FILENAME)
             .unwrap_or(false)
             && !is_cache_entry
             && let Some(parent) = target.parent()
@@ -1323,7 +1324,7 @@ async fn resolve_parent_artifact(
         return Ok(handle.artifact_path);
     }
     Err(MicrosandboxError::SnapshotNotFound(format!(
-        "parent {parent_digest} not in local index; ship it alongside or re-export with --with-parents"
+        "parent {parent_digest} not in local index; ship it alongside or re-save with --with-parents"
     )))
 }
 

--- a/sdk/rust/lib/snapshot/create.rs
+++ b/sdk/rust/lib/snapshot/create.rs
@@ -43,6 +43,15 @@ pub(super) async fn create_snapshot(
         });
     }
 
+    // Validate the destination before anything else so name errors surface
+    // ahead of sandbox lookups and no work happens for an invalid target.
+    let dest_dir = resolve_destination(local, &name, dest_dir)?;
+    if dest_dir.exists() && !force {
+        return Err(MicrosandboxError::SnapshotAlreadyExists(
+            dest_dir.display().to_string(),
+        ));
+    }
+
     let db = local.db().await?.read();
 
     // Look up the sandbox row + parse its persisted config.
@@ -84,21 +93,76 @@ pub(super) async fn create_snapshot(
         )));
     }
 
-    // Resolve and prepare the destination directory.
-    let dest_dir = resolve_destination(local, &name, dest_dir)?;
-    if dest_dir.exists() {
-        if !force {
-            return Err(MicrosandboxError::SnapshotAlreadyExists(
-                dest_dir.display().to_string(),
-            ));
+    // Stage the artifact in a sibling directory, so a failed create never
+    // leaves a partial artifact at the destination (which would poison
+    // retries with SnapshotAlreadyExists) and a force overwrite only
+    // removes the old artifact after the new one is complete.
+    let parent_dir = dest_dir
+        .parent()
+        .ok_or_else(|| {
+            MicrosandboxError::InvalidConfig(format!(
+                "snapshot destination has no parent directory: {}",
+                dest_dir.display()
+            ))
+        })?
+        .to_path_buf();
+    tokio::fs::create_dir_all(&parent_dir).await?;
+    let staging_dir = parent_dir.join(format!(".{name}.staging"));
+    if staging_dir.exists() {
+        tokio::fs::remove_dir_all(&staging_dir).await?;
+    }
+    tokio::fs::create_dir_all(&staging_dir).await?;
+
+    let built = build_artifact(
+        &staging_dir,
+        &src_upper,
+        record_integrity,
+        labels,
+        image_reference,
+        manifest_digest_str,
+        &source_sandbox,
+    )
+    .await;
+    let (digest, manifest) = match built {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+            return Err(e);
         }
+    };
+
+    // Promote the staged artifact into place.
+    if dest_dir.exists() {
         tokio::fs::remove_dir_all(&dest_dir).await?;
     }
-    tokio::fs::create_dir_all(&dest_dir).await?;
+    if let Err(e) = tokio::fs::rename(&staging_dir, &dest_dir).await {
+        let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+        return Err(e.into());
+    }
 
+    // Best-effort index upsert. Failures are logged, not propagated —
+    // the artifact on disk is the source of truth.
+    if let Err(e) = index_upsert(local, &dest_dir, &digest, &manifest).await {
+        tracing::warn!(error = %e, snapshot = %digest, "snapshot_index upsert failed");
+    }
+
+    Ok(Snapshot::from_parts(dest_dir, digest, manifest))
+}
+
+/// Build the artifact contents (upper copy, integrity, descriptor) into
+/// `dir`. Pure staging: the caller promotes or discards the directory.
+async fn build_artifact(
+    dir: &std::path::Path,
+    src_upper: &std::path::Path,
+    record_integrity: bool,
+    labels: Vec<(String, String)>,
+    image_reference: String,
+    manifest_digest_str: String,
+    source_sandbox: &str,
+) -> MicrosandboxResult<(String, Manifest)> {
     // Copy the upper layer (sparse-aware, see microsandbox_utils::copy).
-    let dst_upper = dest_dir.join(DEFAULT_UPPER_FILE);
-    let src_upper_clone = src_upper.clone();
+    let dst_upper = dir.join(DEFAULT_UPPER_FILE);
+    let src_upper_clone = src_upper.to_path_buf();
     let dst_upper_clone = dst_upper.clone();
     let copied_len = tokio::task::spawn_blocking(move || {
         microsandbox_utils::copy::fast_copy(&src_upper_clone, &dst_upper_clone)
@@ -138,7 +202,7 @@ pub(super) async fn create_snapshot(
         fstype: "ext4".into(),
         image: ImageRef {
             reference: image_reference,
-            manifest_digest: manifest_digest_str.clone(),
+            manifest_digest: manifest_digest_str,
         },
         parent: None,
         created_at: Utc::now().to_rfc3339(),
@@ -148,7 +212,9 @@ pub(super) async fn create_snapshot(
             size_bytes: copied_len,
             integrity,
         },
-        source_sandbox: Some(source_sandbox.clone()),
+        source_sandbox: Some(source_sandbox.to_string()),
+        extensions: BTreeMap::new(),
+        requires: Vec::new(),
     };
     manifest.validate()?;
     let canonical = manifest
@@ -159,8 +225,8 @@ pub(super) async fn create_snapshot(
         .map_err(|e| MicrosandboxError::Custom(format!("manifest digest: {e}")))?;
 
     // Atomic descriptor write: stage as `.tmp`, fsync, rename.
-    let manifest_path = dest_dir.join(DESCRIPTOR_FILENAME);
-    let tmp_path = dest_dir.join(format!("{DESCRIPTOR_FILENAME}.tmp"));
+    let manifest_path = dir.join(DESCRIPTOR_FILENAME);
+    let tmp_path = dir.join(format!("{DESCRIPTOR_FILENAME}.tmp"));
     tokio::fs::write(&tmp_path, &canonical).await?;
     let tmp_path_for_sync = tmp_path.clone();
     tokio::task::spawn_blocking(move || -> std::io::Result<()> {
@@ -175,13 +241,7 @@ pub(super) async fn create_snapshot(
     .map_err(|e| MicrosandboxError::Custom(format!("snapshot fsync task: {e}")))??;
     tokio::fs::rename(&tmp_path, &manifest_path).await?;
 
-    // Best-effort index upsert. Failures are logged, not propagated —
-    // the artifact on disk is the source of truth.
-    if let Err(e) = index_upsert(local, &dest_dir, &digest, &manifest).await {
-        tracing::warn!(error = %e, snapshot = %digest, "snapshot_index upsert failed");
-    }
-
-    Ok(Snapshot::from_parts(dest_dir, digest, manifest))
+    Ok((digest, manifest))
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -225,7 +285,15 @@ fn resolve_destination(
             "snapshot name must not be empty".into(),
         ));
     }
-    if name.contains('/') || name.starts_with('.') {
+    // Reject names the open/get/remove resolvers would misread: leading '.'
+    // and '~' or a '/' read as paths, and ':' collides with digest prefixes
+    // (sha256:...). Such a snapshot would be creatable but unaddressable.
+    if name.contains('/')
+        || name.contains('\\')
+        || name.contains(':')
+        || name.starts_with('.')
+        || name.starts_with('~')
+    {
         return Err(MicrosandboxError::InvalidConfig(format!(
             "snapshot name must be a bare identifier, not a path: '{name}' (use dest_dir to choose a parent directory)"
         )));

--- a/sdk/rust/lib/snapshot/create.rs
+++ b/sdk/rust/lib/snapshot/create.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 
 use chrono::Utc;
 use microsandbox_image::snapshot::{
-    DEFAULT_UPPER_FILE, ImageRef, MANIFEST_FILENAME, Manifest, SCHEMA_VERSION, SnapshotFormat,
-    UpperLayer,
+    DEFAULT_UPPER_FILE, DESCRIPTOR_FILENAME, ImageRef, Manifest, SCHEMA_VERSION,
+    SNAPSHOT_ARTIFACT_KIND, SnapshotFormat, SnapshotScope, UpperLayer,
 };
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
@@ -15,8 +15,8 @@ use crate::db::entity::sandbox as sandbox_entity;
 use crate::sandbox::{RootDisk, SandboxConfig, SandboxStatus};
 use crate::{MicrosandboxError, MicrosandboxResult};
 
-use super::store::{index_upsert, looks_like_path};
-use super::{Snapshot, SnapshotConfig, SnapshotDestination};
+use super::store::index_upsert;
+use super::{Snapshot, SnapshotConfig};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -27,12 +27,21 @@ pub(super) async fn create_snapshot(
     config: SnapshotConfig,
 ) -> MicrosandboxResult<Snapshot> {
     let SnapshotConfig {
+        name,
+        dest_dir,
         source_sandbox,
-        destination,
         labels,
         force,
         record_integrity,
+        resumable,
     } = config;
+
+    if resumable {
+        return Err(MicrosandboxError::Unsupported {
+            feature: "Resumable snapshots".into(),
+            available_when: "after VM pause/resume and resumable restore support land".into(),
+        });
+    }
 
     let db = local.db().await?.read();
 
@@ -76,7 +85,7 @@ pub(super) async fn create_snapshot(
     }
 
     // Resolve and prepare the destination directory.
-    let dest_dir = resolve_destination(local, &destination)?;
+    let dest_dir = resolve_destination(local, &name, dest_dir)?;
     if dest_dir.exists() {
         if !force {
             return Err(MicrosandboxError::SnapshotAlreadyExists(
@@ -123,6 +132,8 @@ pub(super) async fn create_snapshot(
 
     let manifest = Manifest {
         schema: SCHEMA_VERSION,
+        artifact: SNAPSHOT_ARTIFACT_KIND.into(),
+        scope: SnapshotScope::Disk,
         format: SnapshotFormat::Raw,
         fstype: "ext4".into(),
         image: ImageRef {
@@ -147,9 +158,9 @@ pub(super) async fn create_snapshot(
         .digest()
         .map_err(|e| MicrosandboxError::Custom(format!("manifest digest: {e}")))?;
 
-    // Atomic manifest write: stage as `.tmp`, fsync, rename.
-    let manifest_path = dest_dir.join(MANIFEST_FILENAME);
-    let tmp_path = dest_dir.join(format!("{MANIFEST_FILENAME}.tmp"));
+    // Atomic descriptor write: stage as `.tmp`, fsync, rename.
+    let manifest_path = dest_dir.join(DESCRIPTOR_FILENAME);
+    let tmp_path = dest_dir.join(format!("{DESCRIPTOR_FILENAME}.tmp"));
     tokio::fs::write(&tmp_path, &canonical).await?;
     let tmp_path_for_sync = tmp_path.clone();
     tokio::task::spawn_blocking(move || -> std::io::Result<()> {
@@ -206,24 +217,20 @@ fn oci_reference_string(config: &SandboxConfig) -> MicrosandboxResult<String> {
 
 fn resolve_destination(
     local: &LocalBackend,
-    dest: &SnapshotDestination,
+    name: &str,
+    dest_dir: Option<PathBuf>,
 ) -> MicrosandboxResult<PathBuf> {
-    match dest {
-        SnapshotDestination::Path(p) => Ok(p.clone()),
-        SnapshotDestination::Name(name) => {
-            if name.is_empty() {
-                return Err(MicrosandboxError::InvalidConfig(
-                    "snapshot name must not be empty".into(),
-                ));
-            }
-            if looks_like_path(name) {
-                return Err(MicrosandboxError::InvalidConfig(format!(
-                    "snapshot name must be a bare identifier, not a path: '{name}'"
-                )));
-            }
-            Ok(local.snapshots_dir().join(name))
-        }
+    if name.is_empty() {
+        return Err(MicrosandboxError::InvalidConfig(
+            "snapshot name must not be empty".into(),
+        ));
     }
+    if name.contains('/') || name.starts_with('.') {
+        return Err(MicrosandboxError::InvalidConfig(format!(
+            "snapshot name must be a bare identifier, not a path: '{name}' (use dest_dir to choose a parent directory)"
+        )));
+    }
+    Ok(dest_dir.unwrap_or_else(|| local.snapshots_dir()).join(name))
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/sdk/rust/lib/snapshot/mod.rs
+++ b/sdk/rust/lib/snapshot/mod.rs
@@ -6,7 +6,7 @@
 //! artifact is the source of truth; the local DB index is just a
 //! cache of "snapshots I happen to know about on this machine."
 //!
-//! See `planning/microsandbox/implementation/snapshots.md` for the
+//! See `planning/microsandbox/implementation/snapshot-api-resumable-cloning.md` for the
 //! full design. Today snapshots are stopped-sandbox / raw-format only;
 //! the manifest schema and DB columns are forward-compatible with
 //! qcow2 backing chains landing later.
@@ -28,7 +28,7 @@ use crate::{MicrosandboxError, MicrosandboxResult};
 ///
 /// Returned by [`Snapshot::create`] and [`Snapshot::open`]. The
 /// directory at [`path()`](Snapshot::path) holds the canonical
-/// `manifest.json` and the captured upper file.
+/// `snapshot.json` and the captured upper file.
 #[derive(Debug, Clone)]
 pub struct Snapshot {
     path: PathBuf,
@@ -37,12 +37,18 @@ pub struct Snapshot {
 }
 
 /// Builder for [`SnapshotConfig`].
+///
+/// Constructed via [`Snapshot::builder`]. The snapshot name is fixed at
+/// construction; the source sandbox is set with
+/// [`from_sandbox`](Self::from_sandbox) and is required.
 pub struct SnapshotBuilder {
-    source_sandbox: String,
-    destination: Option<SnapshotDestination>,
+    name: String,
+    source_sandbox: Option<String>,
+    dest_dir: Option<PathBuf>,
     labels: Vec<(String, String)>,
     force: bool,
     record_integrity: bool,
+    resumable: bool,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -50,20 +56,31 @@ pub struct SnapshotBuilder {
 //--------------------------------------------------------------------------------------------------
 
 impl Snapshot {
-    /// Start configuring a new snapshot of `source_sandbox`.
-    pub fn builder(source_sandbox: impl Into<String>) -> SnapshotBuilder {
+    /// Start configuring a snapshot named `name`, stored under the
+    /// default snapshots directory.
+    ///
+    /// The source sandbox is required:
+    /// `Snapshot::builder("clean").from_sandbox("box").create()`.
+    ///
+    /// The name is the artifact's identity; by default the artifact is
+    /// created in the snapshots store, and [`dest_dir`](SnapshotBuilder::dest_dir)
+    /// selects a different parent directory. Archive movement happens
+    /// through [`save`](Self::save)/[`load`](Self::load).
+    pub fn builder(name: impl Into<String>) -> SnapshotBuilder {
         SnapshotBuilder {
-            source_sandbox: source_sandbox.into(),
-            destination: None,
+            name: name.into(),
+            source_sandbox: None,
+            dest_dir: None,
             labels: Vec::new(),
             force: false,
             record_integrity: false,
+            resumable: false,
         }
     }
 
     /// Create a snapshot artifact from a stopped sandbox.
     ///
-    /// Writes `manifest.json` and the captured `upper.ext4` into the
+    /// Writes `snapshot.json` and the captured `upper.ext4` into the
     /// destination directory atomically (manifest renamed last). On
     /// success, also upserts a row into the local `snapshot_index`
     /// cache; index failures are logged but do not fail the call —
@@ -160,25 +177,25 @@ impl Snapshot {
     }
 
     /// Bundle a snapshot into a `.tar.zst` archive.
-    pub async fn export(
+    pub async fn save(
         name_or_path: &str,
         out: &Path,
-        opts: archive::ExportOpts,
+        opts: archive::SaveOpts,
     ) -> MicrosandboxResult<()> {
         let backend = crate::backend::default_backend();
         let local = backend.as_local().ok_or_else(snapshots_require_local)?;
-        archive::export_snapshot(local, name_or_path, out, opts).await
+        archive::save_snapshot(local, name_or_path, out, opts).await
     }
 
     /// Unpack a snapshot archive (`.tar.zst` or `.tar`) into the
     /// snapshots dir, registering anything found in the index.
-    pub async fn import(
+    pub async fn load(
         archive_path: &Path,
         dest: Option<&Path>,
     ) -> MicrosandboxResult<SnapshotHandle> {
         let backend = crate::backend::default_backend();
         let local = backend.as_local().ok_or_else(snapshots_require_local)?;
-        archive::import_snapshot(local, archive_path, dest).await
+        archive::load_snapshot(local, archive_path, dest).await
     }
 }
 
@@ -201,6 +218,7 @@ pub struct SnapshotHandle {
     pub(crate) digest: String,
     pub(crate) name: Option<String>,
     pub(crate) parent_digest: Option<String>,
+    pub(crate) scope: SnapshotScope,
     pub(crate) image_ref: String,
     pub(crate) format: SnapshotFormat,
     pub(crate) size_bytes: Option<u64>,
@@ -222,6 +240,11 @@ impl SnapshotHandle {
     /// Parent snapshot's digest, or `None` for a root.
     pub fn parent_digest(&self) -> Option<&str> {
         self.parent_digest.as_deref()
+    }
+
+    /// Snapshot payload scope.
+    pub fn scope(&self) -> SnapshotScope {
+        self.scope
     }
 
     /// Image reference the snapshot was taken from.
@@ -261,23 +284,17 @@ impl SnapshotHandle {
 }
 
 impl SnapshotBuilder {
-    /// Place the artifact at the given path or under the default
-    /// snapshots directory by name.
-    pub fn destination(mut self, dest: SnapshotDestination) -> Self {
-        self.destination = Some(dest);
+    /// Set the source sandbox to snapshot. Required.
+    pub fn from_sandbox(mut self, source_sandbox: impl Into<String>) -> Self {
+        self.source_sandbox = Some(source_sandbox.into());
         self
     }
 
-    /// Convenience: use a bare name resolved under the default
-    /// snapshots directory.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.destination = Some(SnapshotDestination::Name(name.into()));
-        self
-    }
-
-    /// Convenience: write the artifact to an explicit path.
-    pub fn path(mut self, path: impl Into<PathBuf>) -> Self {
-        self.destination = Some(SnapshotDestination::Path(path.into()));
+    /// Create the artifact under this parent directory instead of the
+    /// default snapshots store. The artifact directory is
+    /// `dest_dir/<name>`; the name stays the snapshot's identity.
+    pub fn dest_dir(mut self, dest_dir: impl Into<PathBuf>) -> Self {
+        self.dest_dir = Some(dest_dir.into());
         self
     }
 
@@ -299,19 +316,30 @@ impl SnapshotBuilder {
         self
     }
 
+    /// Request a future resumable snapshot.
+    ///
+    /// The builder accepts this stable option now, but creation returns
+    /// `Unsupported` until VM pause/resume capture is implemented.
+    pub fn resumable(mut self) -> Self {
+        self.resumable = true;
+        self
+    }
+
     /// Build the [`SnapshotConfig`].
     pub fn build(self) -> MicrosandboxResult<SnapshotConfig> {
-        let destination = self.destination.ok_or_else(|| {
+        let source_sandbox = self.source_sandbox.ok_or_else(|| {
             crate::MicrosandboxError::InvalidConfig(
-                "snapshot builder requires a destination (.name() or .path())".into(),
+                "snapshot builder requires a source sandbox (.from_sandbox())".into(),
             )
         })?;
         Ok(SnapshotConfig {
-            source_sandbox: self.source_sandbox,
-            destination,
+            name: self.name,
+            dest_dir: self.dest_dir,
+            source_sandbox,
             labels: self.labels,
             force: self.force,
             record_integrity: self.record_integrity,
+            resumable: self.resumable,
         })
     }
 
@@ -325,13 +353,14 @@ impl SnapshotBuilder {
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
 
-pub use archive::ExportOpts;
+pub use archive::SaveOpts;
 #[cfg(feature = "fuzzing")]
 pub use archive::fuzz_unpack_archive;
 pub use microsandbox_image::snapshot::{
-    ImageRef, MANIFEST_FILENAME, Manifest, SnapshotFormat, UpperIntegrity, UpperLayer,
+    DESCRIPTOR_FILENAME, ImageRef, Manifest, SnapshotFormat, SnapshotScope, UpperIntegrity,
+    UpperLayer,
 };
-pub use microsandbox_types::{SnapshotDestination, SnapshotSpec, SnapshotSpec as SnapshotConfig};
+pub use microsandbox_types::{SnapshotSpec, SnapshotSpec as SnapshotConfig};
 pub use verify::{SnapshotVerifyReport, UpperVerifyStatus};
 
 //--------------------------------------------------------------------------------------------------

--- a/sdk/rust/lib/snapshot/mod.rs
+++ b/sdk/rust/lib/snapshot/mod.rs
@@ -62,10 +62,12 @@ impl Snapshot {
     /// The source sandbox is required:
     /// `Snapshot::builder("clean").from_sandbox("box").create()`.
     ///
-    /// The name is the artifact's identity; by default the artifact is
-    /// created in the snapshots store, and [`dest_dir`](SnapshotBuilder::dest_dir)
-    /// selects a different parent directory. Archive movement happens
-    /// through [`save`](Self::save)/[`load`](Self::load).
+    /// The name is the artifact's human-readable address and directory
+    /// basename; the descriptor digest is its identity. By default the
+    /// artifact is created in the snapshots store, and
+    /// [`dest_dir`](SnapshotBuilder::dest_dir) selects a different parent
+    /// directory. Archive movement happens through
+    /// [`save`](Self::save)/[`load`](Self::load).
     pub fn builder(name: impl Into<String>) -> SnapshotBuilder {
         SnapshotBuilder {
             name: name.into(),
@@ -329,7 +331,7 @@ impl SnapshotBuilder {
     pub fn build(self) -> MicrosandboxResult<SnapshotConfig> {
         let source_sandbox = self.source_sandbox.ok_or_else(|| {
             crate::MicrosandboxError::InvalidConfig(
-                "snapshot builder requires a source sandbox (.from_sandbox())".into(),
+                "snapshot builder requires a source sandbox; set from_sandbox before create".into(),
             )
         })?;
         Ok(SnapshotConfig {

--- a/sdk/rust/lib/snapshot/store.rs
+++ b/sdk/rust/lib/snapshot/store.rs
@@ -123,17 +123,30 @@ pub(super) async fn index_upsert(
     // Delete any prior row for this digest, name, or path, then insert.
     // This keeps the rebuildable index aligned when an artifact is
     // replaced in-place or when a manifest rewrite changes its digest.
-    snapshot_entity::Entity::delete_by_id(digest.to_string())
-        .exec(db)
-        .await?;
+    // The superseded rows' parent edges disappear with them, so their
+    // parents' child_count must come down first; the fresh insert re-adds
+    // its own edge below.
+    let mut supersede = sea_orm::Condition::any()
+        .add(snapshot_entity::Column::Digest.eq(digest.to_string()))
+        .add(snapshot_entity::Column::ArtifactPath.eq(artifact_path_str.clone()));
     if let Some(name) = artifact_name.as_ref() {
-        snapshot_entity::Entity::delete_many()
-            .filter(snapshot_entity::Column::Name.eq(name.clone()))
-            .exec(db)
+        supersede = supersede.add(snapshot_entity::Column::Name.eq(name.clone()));
+    }
+    let superseded = snapshot_entity::Entity::find()
+        .filter(supersede.clone())
+        .all(db)
+        .await?;
+    for row in &superseded {
+        if let Some(parent) = row.parent_digest.as_ref() {
+            db.execute_unprepared(&format!(
+                "UPDATE snapshot_index SET child_count = MAX(0, child_count - 1) WHERE digest = '{}'",
+                parent.replace('\'', "''")
+            ))
             .await?;
+        }
     }
     snapshot_entity::Entity::delete_many()
-        .filter(snapshot_entity::Column::ArtifactPath.eq(artifact_path_str.clone()))
+        .filter(supersede)
         .exec(db)
         .await?;
 
@@ -222,6 +235,16 @@ pub(super) async fn list_dir(
     while let Some(entry) = entries.next_entry().await? {
         let path = entry.path();
         if !path.is_dir() {
+            continue;
+        }
+        // Dot-prefixed directories are never artifacts; create() stages
+        // in-progress snapshots as `.<name>.staging` siblings, and a crashed
+        // staging dir must not be listed or indexed as a snapshot.
+        if path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .is_some_and(|s| s.starts_with('.'))
+        {
             continue;
         }
         if !path.join(DESCRIPTOR_FILENAME).exists() {

--- a/sdk/rust/lib/snapshot/store.rs
+++ b/sdk/rust/lib/snapshot/store.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
-use microsandbox_image::snapshot::{MANIFEST_FILENAME, Manifest};
+use microsandbox_image::snapshot::{DESCRIPTOR_FILENAME, Manifest};
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter,
     QueryOrder,
@@ -13,7 +13,7 @@ use crate::backend::LocalBackend;
 use crate::db::entity::snapshot as snapshot_entity;
 use crate::{MicrosandboxError, MicrosandboxResult};
 
-use super::{Snapshot, SnapshotFormat, SnapshotHandle};
+use super::{Snapshot, SnapshotFormat, SnapshotHandle, SnapshotScope};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -46,7 +46,7 @@ pub(super) async fn open_snapshot(
         ));
     }
 
-    let manifest_path = dir.join(MANIFEST_FILENAME);
+    let manifest_path = dir.join(DESCRIPTOR_FILENAME);
     let bytes = tokio::fs::read(&manifest_path).await.map_err(|e| {
         MicrosandboxError::SnapshotNotFound(format!("{}: {e}", manifest_path.display()))
     })?;
@@ -141,11 +141,16 @@ pub(super) async fn index_upsert(
         microsandbox_image::snapshot::SnapshotFormat::Raw => "raw",
         microsandbox_image::snapshot::SnapshotFormat::Qcow2 => "qcow2",
     };
+    let scope_str = match manifest.scope {
+        SnapshotScope::Disk => "disk",
+        SnapshotScope::Resumable => "resumable",
+    };
 
     let row = snapshot_entity::ActiveModel {
         digest: Set(digest.to_string()),
         name: Set(artifact_name),
         parent_digest: Set(manifest.parent.clone()),
+        scope: Set(scope_str.into()),
         image_ref: Set(manifest.image.reference.clone()),
         image_manifest_digest: Set(manifest.image.manifest_digest.clone()),
         format: Set(format_str.into()),
@@ -219,7 +224,7 @@ pub(super) async fn list_dir(
         if !path.is_dir() {
             continue;
         }
-        if !path.join(MANIFEST_FILENAME).exists() {
+        if !path.join(DESCRIPTOR_FILENAME).exists() {
             continue;
         }
         match open_snapshot(local, path.to_string_lossy().as_ref()).await {
@@ -373,10 +378,19 @@ fn handle_from_model(m: snapshot_entity::Model) -> SnapshotHandle {
         "qcow2" => SnapshotFormat::Qcow2,
         _ => SnapshotFormat::Raw,
     };
+    let scope = match m.scope.as_str() {
+        "disk" => SnapshotScope::Disk,
+        "resumable" => SnapshotScope::Resumable,
+        other => {
+            tracing::warn!(digest = %m.digest, scope = other, "unknown snapshot scope in index; treating as disk");
+            SnapshotScope::Disk
+        }
+    };
     SnapshotHandle {
         digest: m.digest,
         name: m.name,
         parent_digest: m.parent_digest,
+        scope,
         image_ref: m.image_ref,
         format,
         size_bytes: m.size_bytes.map(|n| n as u64),

--- a/sdk/rust/tests/snapshot_artifact.rs
+++ b/sdk/rust/tests/snapshot_artifact.rs
@@ -82,7 +82,31 @@ fn sample_manifest(upper_size: u64) -> Manifest {
             integrity: None,
         },
         source_sandbox: Some("synthetic".into()),
+        extensions: BTreeMap::new(),
+        requires: Vec::new(),
     }
+}
+
+/// Build an artifact whose manifest names a required extension this
+/// runtime does not understand.
+fn make_artifact_with_unknown_require(
+    parent: &Path,
+    name: &str,
+    upper_bytes: &[u8],
+) -> (std::path::PathBuf, String) {
+    let dir = parent.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(DEFAULT_UPPER_FILE), upper_bytes).unwrap();
+
+    let mut manifest = sample_manifest(upper_bytes.len() as u64);
+    manifest
+        .extensions
+        .insert("msb.future/1".into(), serde_json::json!({}));
+    manifest.requires = vec!["msb.future/1".into()];
+    let bytes = manifest.to_canonical_bytes().unwrap();
+    let digest = manifest.digest().unwrap();
+    std::fs::write(dir.join(DESCRIPTOR_FILENAME), bytes).unwrap();
+    (dir, digest)
 }
 
 fn make_artifact_with_integrity(
@@ -1251,4 +1275,115 @@ async fn load_streams_large_archive_without_buffering() {
         msg.contains("no snapshot manifest") || msg.contains("manifest"),
         "got: {msg}"
     );
+}
+
+#[tokio::test]
+async fn create_rejects_resumable_before_touching_anything() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let backend = isolated_backend(&home).await;
+
+    microsandbox::with_backend(backend, async {
+        let err = Snapshot::builder("warm")
+            .from_sandbox("box")
+            .resumable()
+            .create()
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("Resumable snapshots"),
+            "unexpected error: {err}"
+        );
+    })
+    .await;
+
+    assert!(!home.join("snapshots").join("warm").exists());
+}
+
+#[tokio::test]
+async fn create_rejects_unaddressable_names() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let backend = isolated_backend(&home).await;
+
+    microsandbox::with_backend(backend, async {
+        for name in ["~cache", "sha256:v1", "a\\b"] {
+            let err = Snapshot::builder(name)
+                .from_sandbox("box")
+                .create()
+                .await
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("bare identifier"),
+                "{name}: unexpected error: {err}"
+            );
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn from_snapshot_rejects_unknown_required_extension_but_open_works() {
+    let tmp = TempDir::new().unwrap();
+    let (dir, _) = make_artifact_with_unknown_require(tmp.path(), "future-snap", b"upper");
+
+    let snap = Snapshot::open(dir.to_string_lossy().as_ref())
+        .await
+        .unwrap();
+    assert_eq!(snap.manifest().requires, vec!["msb.future/1".to_string()]);
+
+    let err = microsandbox::Sandbox::builder("requires-gate-test")
+        .from_snapshot(dir.to_string_lossy().to_string())
+        .build()
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("msb.future/1"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn replacing_child_in_place_does_not_inflate_parent_child_count() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let backend = isolated_backend(&home).await;
+    let snapshots = home.join("snapshots");
+    std::fs::create_dir_all(&snapshots).unwrap();
+
+    microsandbox::with_backend(backend, async {
+        let (_pdir, pdigest) = make_artifact(&snapshots, "parent", b"parent upper");
+        let (cdir, _c1) =
+            make_artifact_with_parent(&snapshots, "child", b"child v1", Some(pdigest.clone()));
+        Snapshot::reindex(&snapshots).await.unwrap();
+
+        // Replace the child in place: same name and path, different digest,
+        // same parent. Opening it runs the auto-reindex upsert, which must
+        // not double-count the parent edge.
+        std::fs::remove_dir_all(&cdir).unwrap();
+        make_artifact_with_parent(
+            &snapshots,
+            "child",
+            b"child v2 with different size",
+            Some(pdigest.clone()),
+        );
+        Snapshot::open("child").await.unwrap();
+
+        Snapshot::remove("child", false).await.unwrap();
+        Snapshot::remove("parent", false)
+            .await
+            .expect("parent should be removable once its only child is gone");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn list_dir_skips_dot_prefixed_staging_directories() {
+    let tmp = TempDir::new().unwrap();
+    make_artifact(tmp.path(), "real", b"upper");
+    make_artifact(tmp.path(), ".ghost.staging", b"upper");
+
+    let snaps = Snapshot::list_dir(tmp.path()).await.unwrap();
+    assert_eq!(snaps.len(), 1);
+    assert!(snaps[0].path().ends_with("real"));
 }

--- a/sdk/rust/tests/snapshot_artifact.rs
+++ b/sdk/rust/tests/snapshot_artifact.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use microsandbox::Snapshot;
 use microsandbox::backend::{Backend, LocalBackend};
 use microsandbox_image::snapshot::{
-    DEFAULT_UPPER_FILE, ImageRef, MANIFEST_FILENAME, Manifest, SCHEMA_VERSION, SnapshotFormat,
-    UpperIntegrity, UpperLayer,
+    DEFAULT_UPPER_FILE, DESCRIPTOR_FILENAME, ImageRef, Manifest, SCHEMA_VERSION,
+    SNAPSHOT_ARTIFACT_KIND, SnapshotFormat, SnapshotScope, UpperIntegrity, UpperLayer,
 };
 use sha2::{Digest, Sha256};
 use tar::{Builder, EntryType, Header};
@@ -39,6 +39,50 @@ struct SeededImageCache {
 /// file. Returns `(artifact_dir, manifest_digest)`.
 fn make_artifact(parent: &Path, name: &str, upper_bytes: &[u8]) -> (std::path::PathBuf, String) {
     make_artifact_with_parent_and_integrity(parent, name, upper_bytes, None, false)
+}
+
+fn make_artifact_with_scope(
+    parent: &Path,
+    name: &str,
+    upper_bytes: &[u8],
+    scope: SnapshotScope,
+) -> (std::path::PathBuf, String) {
+    let dir = parent.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(DEFAULT_UPPER_FILE), upper_bytes).unwrap();
+
+    let manifest = Manifest {
+        scope,
+        ..sample_manifest(upper_bytes.len() as u64)
+    };
+    let bytes = manifest.to_canonical_bytes().unwrap();
+    let digest = manifest.digest().unwrap();
+    std::fs::write(dir.join(DESCRIPTOR_FILENAME), bytes).unwrap();
+    (dir, digest)
+}
+
+fn sample_manifest(upper_size: u64) -> Manifest {
+    Manifest {
+        schema: SCHEMA_VERSION,
+        artifact: SNAPSHOT_ARTIFACT_KIND.into(),
+        scope: SnapshotScope::Disk,
+        format: SnapshotFormat::Raw,
+        fstype: "ext4".into(),
+        image: ImageRef {
+            reference: "docker.io/library/alpine:3.20".into(),
+            manifest_digest:
+                "sha256:0000000000000000000000000000000000000000000000000000000000000001".into(),
+        },
+        parent: None,
+        created_at: "2026-05-01T12:00:00Z".into(),
+        labels: BTreeMap::new(),
+        upper: UpperLayer {
+            file: DEFAULT_UPPER_FILE.into(),
+            size_bytes: upper_size,
+            integrity: None,
+        },
+        source_sandbox: Some("synthetic".into()),
+    }
 }
 
 fn make_artifact_with_integrity(
@@ -79,28 +123,12 @@ fn make_artifact_with_parent_and_integrity(
         digest: format!("sha256:{}", hex::encode(hasher.finalize())),
     });
 
-    let manifest = Manifest {
-        schema: SCHEMA_VERSION,
-        format: SnapshotFormat::Raw,
-        fstype: "ext4".into(),
-        image: ImageRef {
-            reference: "docker.io/library/alpine:3.20".into(),
-            manifest_digest:
-                "sha256:0000000000000000000000000000000000000000000000000000000000000001".into(),
-        },
-        parent: parent_digest,
-        created_at: "2026-05-01T12:00:00Z".into(),
-        labels: BTreeMap::new(),
-        upper: UpperLayer {
-            file: DEFAULT_UPPER_FILE.into(),
-            size_bytes: upper_bytes.len() as u64,
-            integrity: upper_integrity,
-        },
-        source_sandbox: Some("synthetic".into()),
-    };
+    let mut manifest = sample_manifest(upper_bytes.len() as u64);
+    manifest.parent = parent_digest;
+    manifest.upper.integrity = upper_integrity;
     let bytes = manifest.to_canonical_bytes().unwrap();
     let digest = manifest.digest().unwrap();
-    std::fs::write(dir.join(MANIFEST_FILENAME), bytes).unwrap();
+    std::fs::write(dir.join(DESCRIPTOR_FILENAME), bytes).unwrap();
     (dir, digest)
 }
 
@@ -115,27 +143,14 @@ fn make_artifact_with_image(
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(dir.join(DEFAULT_UPPER_FILE), upper_bytes).unwrap();
 
-    let manifest = Manifest {
-        schema: SCHEMA_VERSION,
-        format: SnapshotFormat::Raw,
-        fstype: "ext4".into(),
-        image: ImageRef {
-            reference: image_reference,
-            manifest_digest: image_manifest_digest,
-        },
-        parent: None,
-        created_at: "2026-05-01T12:00:00Z".into(),
-        labels: BTreeMap::new(),
-        upper: UpperLayer {
-            file: DEFAULT_UPPER_FILE.into(),
-            size_bytes: upper_bytes.len() as u64,
-            integrity: None,
-        },
-        source_sandbox: Some("synthetic".into()),
+    let mut manifest = sample_manifest(upper_bytes.len() as u64);
+    manifest.image = ImageRef {
+        reference: image_reference,
+        manifest_digest: image_manifest_digest,
     };
     let bytes = manifest.to_canonical_bytes().unwrap();
     let digest = manifest.digest().unwrap();
-    std::fs::write(dir.join(MANIFEST_FILENAME), bytes).unwrap();
+    std::fs::write(dir.join(DESCRIPTOR_FILENAME), bytes).unwrap();
     (dir, digest)
 }
 
@@ -196,31 +211,14 @@ fn make_sparse_artifact(
         microsandbox_utils::extent::punch_hole_aligned(&f, cursor, len - cursor).unwrap();
     }
 
-    let manifest = Manifest {
-        schema: SCHEMA_VERSION,
-        format: SnapshotFormat::Raw,
-        fstype: "ext4".into(),
-        image: ImageRef {
-            reference: "docker.io/library/alpine:3.20".into(),
-            manifest_digest:
-                "sha256:0000000000000000000000000000000000000000000000000000000000000001".into(),
-        },
-        parent: None,
-        created_at: "2026-05-01T12:00:00Z".into(),
-        labels: BTreeMap::new(),
-        upper: UpperLayer {
-            file: DEFAULT_UPPER_FILE.into(),
-            size_bytes: len,
-            integrity: Some(UpperIntegrity {
-                algorithm: "sha256".into(),
-                digest: sha256_digest(&logical),
-            }),
-        },
-        source_sandbox: Some("synthetic".into()),
-    };
+    let mut manifest = sample_manifest(len);
+    manifest.upper.integrity = Some(UpperIntegrity {
+        algorithm: "sha256".into(),
+        digest: sha256_digest(&logical),
+    });
     let bytes = manifest.to_canonical_bytes().unwrap();
     let digest = manifest.digest().unwrap();
-    std::fs::write(dir.join(MANIFEST_FILENAME), bytes).unwrap();
+    std::fs::write(dir.join(DESCRIPTOR_FILENAME), bytes).unwrap();
     (dir, digest, logical)
 }
 
@@ -292,8 +290,8 @@ fn write_archive_from_artifacts(archive: &Path, artifacts: &[(&Path, &str)]) {
     for (artifact, archive_name) in artifacts {
         builder
             .append_path_with_name(
-                artifact.join(MANIFEST_FILENAME),
-                format!("{archive_name}/{MANIFEST_FILENAME}"),
+                artifact.join(DESCRIPTOR_FILENAME),
+                format!("{archive_name}/{DESCRIPTOR_FILENAME}"),
             )
             .unwrap();
         builder
@@ -370,6 +368,97 @@ async fn open_reads_valid_artifact_metadata() {
     assert_eq!(snap.size_bytes(), b"upper data goes here".len() as u64);
 }
 
+#[test]
+fn builder_supports_name_first_contract() {
+    let config = Snapshot::builder("clean-python")
+        .from_sandbox("build-box")
+        .label("stage", "deps")
+        .build()
+        .unwrap();
+
+    assert_eq!(config.name, "clean-python");
+    assert_eq!(config.source_sandbox, "build-box");
+    assert_eq!(config.labels, vec![("stage".into(), "deps".into())]);
+}
+
+#[test]
+fn builder_carries_dest_dir() {
+    let config = Snapshot::builder("clean")
+        .from_sandbox("box")
+        .dest_dir("/mnt/big")
+        .build()
+        .unwrap();
+    assert_eq!(config.name, "clean");
+    assert_eq!(
+        config.dest_dir.as_deref(),
+        Some(std::path::Path::new("/mnt/big"))
+    );
+}
+
+#[test]
+fn builder_requires_source_sandbox() {
+    let err = Snapshot::builder("clean").build().unwrap_err();
+    assert!(err.to_string().contains("from_sandbox"));
+}
+
+#[tokio::test]
+async fn legacy_manifest_json_artifacts_are_not_recognized() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join("legacy");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(DEFAULT_UPPER_FILE), b"old upper bytes").unwrap();
+    std::fs::write(
+        dir.join("manifest.json"),
+        br#"{"schema":1,"format":"raw","fstype":"ext4","image":{"ref":"docker.io/library/alpine:3.20","manifest_digest":"sha256:0000000000000000000000000000000000000000000000000000000000000001"},"parent":null,"created_at":"2026-05-01T12:00:00Z","labels":{},"upper":{"file":"upper.ext4","size_bytes":15,"integrity":null},"source_sandbox":"synthetic"}"#,
+    )
+    .unwrap();
+
+    let err = Snapshot::open(dir.to_string_lossy().as_ref())
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains(DESCRIPTOR_FILENAME));
+
+    let snaps = Snapshot::list_dir(tmp.path()).await.unwrap();
+    assert!(snaps.is_empty());
+}
+
+#[tokio::test]
+async fn open_accepts_resumable_scope_artifact() {
+    let tmp = TempDir::new().unwrap();
+    let (dir, _) = make_artifact_with_scope(
+        tmp.path(),
+        "resumable-snap",
+        b"upper",
+        SnapshotScope::Resumable,
+    );
+
+    let snap = Snapshot::open(dir.to_string_lossy().as_ref())
+        .await
+        .unwrap();
+    assert_eq!(snap.manifest().scope, SnapshotScope::Resumable);
+}
+
+#[tokio::test]
+async fn from_snapshot_rejects_resumable_scope_at_restore() {
+    let tmp = TempDir::new().unwrap();
+    let (dir, _) = make_artifact_with_scope(
+        tmp.path(),
+        "resumable-snap",
+        b"upper",
+        SnapshotScope::Resumable,
+    );
+
+    let err = microsandbox::Sandbox::builder("restore-scope-test")
+        .from_snapshot(dir.to_string_lossy().to_string())
+        .build()
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("non-disk"),
+        "unexpected error: {err}"
+    );
+}
+
 #[tokio::test]
 async fn open_rejects_tampered_upper_size() {
     let tmp = TempDir::new().unwrap();
@@ -426,7 +515,7 @@ async fn open_rejects_unknown_schema() {
     std::fs::write(dir.join(DEFAULT_UPPER_FILE), b"data").unwrap();
     // Hand-write a manifest with an unknown schema version.
     std::fs::write(
-        dir.join(MANIFEST_FILENAME),
+        dir.join(DESCRIPTOR_FILENAME),
         br#"{"schema":42,"format":"raw","fstype":"ext4","image":{"ref":"x","manifest_digest":"sha256:01"},"parent":null,"created_at":"2026-05-01T12:00:00Z","labels":{},"upper":{"file":"upper.ext4","size_bytes":4,"integrity":null},"source_sandbox":null}"#,
     )
     .unwrap();
@@ -449,15 +538,15 @@ async fn list_dir_skips_non_artifact_directories() {
 }
 
 #[tokio::test]
-async fn export_then_import_round_trips_via_zstd() {
+async fn save_then_load_round_trips_via_zstd() {
     let tmp = TempDir::new().unwrap();
     let (dir, original_digest) = make_artifact(tmp.path(), "src-snap", b"the upper bytes");
 
     let archive = tmp.path().join("bundle.tar.zst");
-    Snapshot::export(
+    Snapshot::save(
         dir.to_string_lossy().as_ref(),
         &archive,
-        microsandbox::snapshot::ExportOpts::default(),
+        microsandbox::snapshot::SaveOpts::default(),
     )
     .await
     .unwrap();
@@ -465,7 +554,7 @@ async fn export_then_import_round_trips_via_zstd() {
     assert!(std::fs::metadata(&archive).unwrap().len() > 0);
 
     let dest = tmp.path().join("imported");
-    let handle = Snapshot::import(&archive, Some(&dest)).await.unwrap();
+    let handle = Snapshot::load(&archive, Some(&dest)).await.unwrap();
     assert_eq!(handle.digest(), original_digest);
 
     // Re-open the imported artifact via path; integrity should hold.
@@ -476,15 +565,15 @@ async fn export_then_import_round_trips_via_zstd() {
 }
 
 #[tokio::test]
-async fn export_then_import_round_trips_via_plain_tar() {
+async fn save_then_load_round_trips_via_plain_tar() {
     let tmp = TempDir::new().unwrap();
     let (dir, original_digest) = make_artifact(tmp.path(), "src-plain", b"plain tar bytes");
 
     let archive = tmp.path().join("bundle.tar");
-    Snapshot::export(
+    Snapshot::save(
         dir.to_string_lossy().as_ref(),
         &archive,
-        microsandbox::snapshot::ExportOpts {
+        microsandbox::snapshot::SaveOpts {
             plain_tar: true,
             ..Default::default()
         },
@@ -493,12 +582,12 @@ async fn export_then_import_round_trips_via_plain_tar() {
     .unwrap();
 
     let dest = tmp.path().join("imported-plain");
-    let handle = Snapshot::import(&archive, Some(&dest)).await.unwrap();
+    let handle = Snapshot::load(&archive, Some(&dest)).await.unwrap();
     assert_eq!(handle.digest(), original_digest);
 }
 
 #[tokio::test]
-async fn export_sparse_upper_round_trips_and_preserves_holes() {
+async fn save_sparse_upper_round_trips_and_preserves_holes() {
     let tmp = TempDir::new().unwrap();
     let len: u64 = 16 * 1024 * 1024;
     // Data at the start, in the middle, and at a 512-unaligned offset;
@@ -511,23 +600,23 @@ async fn export_sparse_upper_round_trips_and_preserves_holes() {
     let (dir, original_digest, logical) =
         make_sparse_artifact(tmp.path(), "src-sparse", len, &extents);
     if allocated_bytes(&dir.join(DEFAULT_UPPER_FILE)) >= len / 2 {
-        eprintln!("filesystem did not sparsify the upper; sparse export not exercised");
+        eprintln!("filesystem did not sparsify the upper; sparse save not exercised");
         return;
     }
 
     let archive = tmp.path().join("sparse.tar.zst");
-    Snapshot::export(
+    Snapshot::save(
         dir.to_string_lossy().as_ref(),
         &archive,
-        microsandbox::snapshot::ExportOpts::default(),
+        microsandbox::snapshot::SaveOpts::default(),
     )
     .await
     .unwrap();
 
-    // Import verifies the recorded sha256 over the unpacked upper's
+    // Load verifies the recorded sha256 over the unpacked upper's
     // logical content; compare the bytes explicitly as well.
     let dest = tmp.path().join("imported-sparse");
-    let handle = Snapshot::import(&archive, Some(&dest)).await.unwrap();
+    let handle = Snapshot::load(&archive, Some(&dest)).await.unwrap();
     assert_eq!(handle.digest(), original_digest);
     let imported_upper = handle.path().join(DEFAULT_UPPER_FILE);
     assert_eq!(std::fs::read(&imported_upper).unwrap(), logical);
@@ -541,7 +630,7 @@ async fn export_sparse_upper_round_trips_and_preserves_holes() {
 }
 
 #[tokio::test]
-async fn sparse_export_stores_only_data_extents_in_plain_tar() {
+async fn sparse_save_stores_only_data_extents_in_plain_tar() {
     let tmp = TempDir::new().unwrap();
     let len: u64 = 16 * 1024 * 1024;
     let extents = vec![
@@ -550,15 +639,15 @@ async fn sparse_export_stores_only_data_extents_in_plain_tar() {
     ];
     let (dir, _, logical) = make_sparse_artifact(tmp.path(), "src-plain-sparse", len, &extents);
     if allocated_bytes(&dir.join(DEFAULT_UPPER_FILE)) >= len / 2 {
-        eprintln!("filesystem did not sparsify the upper; sparse export not exercised");
+        eprintln!("filesystem did not sparsify the upper; sparse save not exercised");
         return;
     }
 
     let archive = tmp.path().join("sparse.tar");
-    Snapshot::export(
+    Snapshot::save(
         dir.to_string_lossy().as_ref(),
         &archive,
-        microsandbox::snapshot::ExportOpts {
+        microsandbox::snapshot::SaveOpts {
             plain_tar: true,
             ..Default::default()
         },
@@ -601,7 +690,7 @@ async fn sparse_export_stores_only_data_extents_in_plain_tar() {
 }
 
 #[tokio::test]
-async fn sparse_export_many_extents_round_trips() {
+async fn sparse_save_many_extents_round_trips() {
     // Enough extents to spill past the 4 inline sparse-map slots into
     // chained extended sparse headers (21 slots each). The file ends
     // with data, so no trailing-hole terminator is needed.
@@ -614,48 +703,48 @@ async fn sparse_export_many_extents_round_trips() {
     let (dir, original_digest, logical) =
         make_sparse_artifact(tmp.path(), "src-many-extents", len, &extents);
     if allocated_bytes(&dir.join(DEFAULT_UPPER_FILE)) >= len / 2 {
-        eprintln!("filesystem did not sparsify the upper; sparse export not exercised");
+        eprintln!("filesystem did not sparsify the upper; sparse save not exercised");
         return;
     }
 
     let archive = tmp.path().join("many.tar.zst");
-    Snapshot::export(
+    Snapshot::save(
         dir.to_string_lossy().as_ref(),
         &archive,
-        microsandbox::snapshot::ExportOpts::default(),
+        microsandbox::snapshot::SaveOpts::default(),
     )
     .await
     .unwrap();
 
     let dest = tmp.path().join("imported-many");
-    let handle = Snapshot::import(&archive, Some(&dest)).await.unwrap();
+    let handle = Snapshot::load(&archive, Some(&dest)).await.unwrap();
     assert_eq!(handle.digest(), original_digest);
     let imported_upper = handle.path().join(DEFAULT_UPPER_FILE);
     assert_eq!(std::fs::read(&imported_upper).unwrap(), logical);
 }
 
 #[tokio::test]
-async fn sparse_export_all_hole_upper_round_trips() {
+async fn sparse_save_all_hole_upper_round_trips() {
     let tmp = TempDir::new().unwrap();
     let len: u64 = 4 * 1024 * 1024;
     let (dir, original_digest, logical) =
         make_sparse_artifact(tmp.path(), "src-all-hole", len, &[]);
     if allocated_bytes(&dir.join(DEFAULT_UPPER_FILE)) >= len / 2 {
-        eprintln!("filesystem did not sparsify the upper; sparse export not exercised");
+        eprintln!("filesystem did not sparsify the upper; sparse save not exercised");
         return;
     }
 
     let archive = tmp.path().join("hole.tar.zst");
-    Snapshot::export(
+    Snapshot::save(
         dir.to_string_lossy().as_ref(),
         &archive,
-        microsandbox::snapshot::ExportOpts::default(),
+        microsandbox::snapshot::SaveOpts::default(),
     )
     .await
     .unwrap();
 
     let dest = tmp.path().join("imported-hole");
-    let handle = Snapshot::import(&archive, Some(&dest)).await.unwrap();
+    let handle = Snapshot::load(&archive, Some(&dest)).await.unwrap();
     assert_eq!(handle.digest(), original_digest);
     let imported_upper = handle.path().join(DEFAULT_UPPER_FILE);
     assert_eq!(std::fs::read(&imported_upper).unwrap(), logical);
@@ -667,10 +756,10 @@ async fn dense_upper_keeps_regular_entry() {
     let (dir, _) = make_artifact(tmp.path(), "src-dense", b"fully allocated upper");
 
     let archive = tmp.path().join("dense.tar");
-    Snapshot::export(
+    Snapshot::save(
         dir.to_string_lossy().as_ref(),
         &archive,
-        microsandbox::snapshot::ExportOpts {
+        microsandbox::snapshot::SaveOpts {
             plain_tar: true,
             ..Default::default()
         },
@@ -690,9 +779,9 @@ async fn dense_upper_keeps_regular_entry() {
     assert_eq!(upper_entry_type, Some(EntryType::Regular));
 }
 
-/// The import walker's grammar is closed: GNU long-name entries (which our exporter never produces — archive names are two short components) must be rejected, not resolved.
+/// The load walker's grammar is closed: GNU long-name entries (which our save path never produces; archive names are two short components) must be rejected, not resolved.
 #[tokio::test]
-async fn import_rejects_long_name_entries() {
+async fn load_rejects_long_name_entries() {
     let tmp = TempDir::new().unwrap();
     let long_name = format!("sha256-0000000000000000/{}", "x".repeat(120));
 
@@ -713,7 +802,7 @@ async fn import_rejects_long_name_entries() {
     let archive = tmp.path().join("longname.tar");
     std::fs::write(&archive, &bytes).unwrap();
 
-    let err = Snapshot::import(&archive, Some(&tmp.path().join("dest")))
+    let err = Snapshot::load(&archive, Some(&tmp.path().join("dest")))
         .await
         .unwrap_err()
         .to_string();
@@ -725,15 +814,15 @@ async fn import_rejects_long_name_entries() {
 
 /// A header whose recorded checksum disagrees with its bytes is corruption, not something to unpack around.
 #[tokio::test]
-async fn import_rejects_corrupt_header_checksum() {
+async fn load_rejects_corrupt_header_checksum() {
     let tmp = TempDir::new().unwrap();
     let (dir, _) = make_artifact(tmp.path(), "src-cksum", b"upper bytes");
 
     let archive = tmp.path().join("ok.tar");
-    Snapshot::export(
+    Snapshot::save(
         dir.to_string_lossy().as_ref(),
         &archive,
-        microsandbox::snapshot::ExportOpts {
+        microsandbox::snapshot::SaveOpts {
             plain_tar: true,
             ..Default::default()
         },
@@ -748,7 +837,7 @@ async fn import_rejects_corrupt_header_checksum() {
     let corrupt = tmp.path().join("corrupt.tar");
     std::fs::write(&corrupt, &bytes).unwrap();
 
-    let err = Snapshot::import(&corrupt, Some(&tmp.path().join("dest")))
+    let err = Snapshot::load(&corrupt, Some(&tmp.path().join("dest")))
         .await
         .unwrap_err()
         .to_string();
@@ -760,7 +849,7 @@ async fn import_rejects_corrupt_header_checksum() {
 
 /// A sparse map whose runs overlap or run backwards is malformed and must be rejected before any data is written.
 #[tokio::test]
-async fn import_rejects_overlapping_sparse_map() {
+async fn load_rejects_overlapping_sparse_map() {
     fn octal12(field: &mut [u8; 12], value: u64) {
         let octal = format!("{value:011o}");
         field[..11].copy_from_slice(octal.as_bytes());
@@ -795,7 +884,7 @@ async fn import_rejects_overlapping_sparse_map() {
     let archive = tmp.path().join("overlap.tar");
     std::fs::write(&archive, &bytes).unwrap();
 
-    let err = Snapshot::import(&archive, Some(&tmp.path().join("dest")))
+    let err = Snapshot::load(&archive, Some(&tmp.path().join("dest")))
         .await
         .unwrap_err()
         .to_string();
@@ -806,7 +895,7 @@ async fn import_rejects_overlapping_sparse_map() {
 }
 
 #[tokio::test]
-async fn export_with_image_includes_only_pinned_cache_artifacts() {
+async fn save_with_image_includes_only_pinned_cache_artifacts() {
     let tmp = TempDir::new().unwrap();
     let home = tmp.path().join("home");
     let backend = isolated_backend(&home).await;
@@ -826,10 +915,10 @@ async fn export_with_image_includes_only_pinned_cache_artifacts() {
     let archive = tmp.path().join("with-image.tar");
 
     microsandbox::with_backend(backend, async {
-        Snapshot::export(
+        Snapshot::save(
             dir.to_string_lossy().as_ref(),
             &archive,
-            microsandbox::snapshot::ExportOpts {
+            microsandbox::snapshot::SaveOpts {
                 with_image: true,
                 plain_tar: true,
                 ..Default::default()
@@ -873,7 +962,7 @@ async fn export_with_image_includes_only_pinned_cache_artifacts() {
 }
 
 #[tokio::test]
-async fn import_rejects_symlink_entries_without_writing_outside_dest() {
+async fn load_rejects_symlink_entries_without_writing_outside_dest() {
     let tmp = TempDir::new().unwrap();
     let archive = tmp.path().join("malicious.tar");
     let dest = tmp.path().join("dest");
@@ -883,7 +972,7 @@ async fn import_rejects_symlink_entries_without_writing_outside_dest() {
 
     write_symlink_traversal_archive(&archive, &escape_dir);
 
-    let err = Snapshot::import(&archive, Some(&dest))
+    let err = Snapshot::load(&archive, Some(&dest))
         .await
         .expect_err("expected import to reject symlink archive entry");
 
@@ -904,7 +993,7 @@ async fn import_rejects_symlink_entries_without_writing_outside_dest() {
 
 #[cfg(unix)]
 #[tokio::test]
-async fn import_does_not_follow_preexisting_symlink_parent() {
+async fn load_does_not_follow_preexisting_symlink_parent() {
     let tmp = TempDir::new().unwrap();
     let archive = tmp.path().join("regular.tar");
     let dest = tmp.path().join("dest");
@@ -915,7 +1004,7 @@ async fn import_does_not_follow_preexisting_symlink_parent() {
     std::os::unix::fs::symlink(&escape_dir, dest.join("snap")).unwrap();
     write_regular_file_archive(&archive, "snap/pwned.txt", b"should not escape\n");
 
-    let err = Snapshot::import(&archive, Some(&dest))
+    let err = Snapshot::load(&archive, Some(&dest))
         .await
         .expect_err("expected import without a manifest to fail");
 
@@ -937,27 +1026,10 @@ async fn open_rejects_manifest_upper_file_that_escapes_artifact() {
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(tmp.path().join("outside.ext4"), b"data").unwrap();
 
-    let manifest = Manifest {
-        schema: SCHEMA_VERSION,
-        format: SnapshotFormat::Raw,
-        fstype: "ext4".into(),
-        image: ImageRef {
-            reference: "docker.io/library/alpine:3.20".into(),
-            manifest_digest:
-                "sha256:0000000000000000000000000000000000000000000000000000000000000001".into(),
-        },
-        parent: None,
-        created_at: "2026-05-01T12:00:00Z".into(),
-        labels: BTreeMap::new(),
-        upper: UpperLayer {
-            file: "../outside.ext4".into(),
-            size_bytes: 4,
-            integrity: None,
-        },
-        source_sandbox: Some("synthetic".into()),
-    };
+    let mut manifest = sample_manifest(4);
+    manifest.upper.file = "../outside.ext4".into();
     std::fs::write(
-        dir.join(MANIFEST_FILENAME),
+        dir.join(DESCRIPTOR_FILENAME),
         manifest.to_canonical_bytes().unwrap(),
     )
     .unwrap();
@@ -972,7 +1044,7 @@ async fn open_rejects_manifest_upper_file_that_escapes_artifact() {
 }
 
 #[tokio::test]
-async fn import_verifies_every_snapshot_manifest_before_indexing() {
+async fn load_verifies_every_snapshot_manifest_before_indexing() {
     let tmp = TempDir::new().unwrap();
     let (bad_dir, _) = make_artifact_with_integrity(tmp.path(), "bad-snap", b"original", true);
     std::fs::write(bad_dir.join(DEFAULT_UPPER_FILE), b"tampered").unwrap();
@@ -987,7 +1059,7 @@ async fn import_verifies_every_snapshot_manifest_before_indexing() {
     );
 
     let dest = tmp.path().join("imported");
-    let err = Snapshot::import(&archive, Some(&dest))
+    let err = Snapshot::load(&archive, Some(&dest))
         .await
         .expect_err("expected tampered sibling to fail import");
 
@@ -1002,26 +1074,26 @@ async fn import_verifies_every_snapshot_manifest_before_indexing() {
 }
 
 #[tokio::test]
-async fn import_detects_zstd_by_magic_bytes() {
+async fn load_detects_zstd_by_magic_bytes() {
     let tmp = TempDir::new().unwrap();
     let (dir, original_digest) = make_artifact(tmp.path(), "src-magic", b"magic zstd");
 
     let archive = tmp.path().join("bundle.snapshot");
-    Snapshot::export(
+    Snapshot::save(
         dir.to_string_lossy().as_ref(),
         &archive,
-        microsandbox::snapshot::ExportOpts::default(),
+        microsandbox::snapshot::SaveOpts::default(),
     )
     .await
     .unwrap();
 
     let dest = tmp.path().join("imported-magic");
-    let handle = Snapshot::import(&archive, Some(&dest)).await.unwrap();
+    let handle = Snapshot::load(&archive, Some(&dest)).await.unwrap();
     assert_eq!(handle.digest(), original_digest);
 }
 
 #[tokio::test]
-async fn import_selects_child_head_when_parents_are_present() {
+async fn load_selects_child_head_when_parents_are_present() {
     let tmp = TempDir::new().unwrap();
     let (parent_dir, parent_digest) = make_artifact(tmp.path(), "parent", b"parent");
     let (child_dir, child_digest) =
@@ -1036,13 +1108,13 @@ async fn import_selects_child_head_when_parents_are_present() {
     );
 
     let dest = tmp.path().join("imported-chain");
-    let handle = Snapshot::import(&archive, Some(&dest)).await.unwrap();
+    let handle = Snapshot::load(&archive, Some(&dest)).await.unwrap();
     assert_eq!(handle.digest(), child_digest);
     assert_eq!(handle.path(), dest.join("child"));
 }
 
 #[tokio::test]
-async fn failed_import_does_not_install_staged_cache_entries() {
+async fn failed_load_does_not_install_staged_cache_entries() {
     let tmp = TempDir::new().unwrap();
     let home = tmp.path().join("home");
     let backend = isolated_backend(&home).await;
@@ -1055,7 +1127,7 @@ async fn failed_import_does_not_install_staged_cache_entries() {
     let dest = tmp.path().join("dest");
 
     microsandbox::with_backend(backend, async {
-        let err = Snapshot::import(&archive, Some(&dest))
+        let err = Snapshot::load(&archive, Some(&dest))
             .await
             .expect_err("expected cache-only import to fail");
         assert!(
@@ -1072,7 +1144,7 @@ async fn failed_import_does_not_install_staged_cache_entries() {
 }
 
 #[tokio::test]
-async fn failed_import_with_conflicting_cache_target_does_not_install_cache_entries() {
+async fn failed_load_with_conflicting_cache_target_does_not_install_cache_entries() {
     let tmp = TempDir::new().unwrap();
     let export_home = tmp.path().join("export-home");
     let export_backend = isolated_backend(&export_home).await;
@@ -1090,10 +1162,10 @@ async fn failed_import_with_conflicting_cache_target_does_not_install_cache_entr
     microsandbox::with_backend(
         export_backend,
         Box::pin(async {
-            Snapshot::export(
+            Snapshot::save(
                 dir.to_string_lossy().as_ref(),
                 &archive,
-                microsandbox::snapshot::ExportOpts {
+                microsandbox::snapshot::SaveOpts {
                     with_image: true,
                     plain_tar: true,
                     ..Default::default()
@@ -1118,7 +1190,7 @@ async fn failed_import_with_conflicting_cache_target_does_not_install_cache_entr
     microsandbox::with_backend(
         import_backend,
         Box::pin(async {
-            let err = Snapshot::import(&archive, Some(&dest))
+            let err = Snapshot::load(&archive, Some(&dest))
                 .await
                 .expect_err("expected conflicting cache target to fail import");
             assert!(
@@ -1161,7 +1233,7 @@ async fn manifest_digest_is_stable_across_processes() {
 // A slurp implementation would allocate 4 GiB and OOM the runner;
 // a streaming implementation reads a few tar blocks and errors fast.
 #[tokio::test]
-async fn import_streams_large_archive_without_buffering() {
+async fn load_streams_large_archive_without_buffering() {
     let tmp = TempDir::new().unwrap();
     let archive = tmp.path().join("sparse.tar");
 
@@ -1170,7 +1242,7 @@ async fn import_streams_large_archive_without_buffering() {
     drop(file);
 
     let dest = tmp.path().join("dest");
-    let err = Snapshot::import(&archive, Some(&dest))
+    let err = Snapshot::load(&archive, Some(&dest))
         .await
         .expect_err("expected import of sparse archive to fail");
 


### PR DESCRIPTION
## TL;DR
Locks in the snapshot contract across the CLI and all four SDKs: snapshot.json is the only descriptor, save/load/reindex are the only verbs, and creation is name-first with an optional dest_dir for placing artifacts on another volume. We are pre-1.0, so all legacy shapes are removed outright instead of kept behind aliases.

## Description
- `snapshot.json` is the only descriptor (constant renamed to `DESCRIPTOR_FILENAME`) with required `artifact` and `scope` fields; legacy `manifest.json` reading, the transitional compat copy, and the digest byte-sniffing fallback are gone, and the speculative `locality` field is dropped
- the descriptor carries `extensions` (namespaced additive data readers must tolerate and may ignore) and `requires` (extension keys a reader must understand to restore: unknown required keys block restore and from-snapshot start with a typed error while list/inspect keep working), so schema 1 can evolve additively despite strict unknown-field rejection
- scope enforcement moved out of `Manifest::validate` into the create and restore paths, so older runtimes can still list and inspect future resumable artifacts and only fail with a clear error when asked to restore one
- creation stages the artifact in a sibling directory and promotes it by rename (failed creates cannot poison retries; force overwrite only removes the old artifact after the new one is complete), unaddressable names (leading `~`/`.`, or containing `/`, `\`, `:`) are rejected at create, and in-place artifact replacement no longer inflates the parent's `child_count` in the index
- archive verbs are `save`/`load` (export/import removed) and the index maintenance verb stays `reindex` (repair was rejected because it implies fixing artifact contents); no compatibility aliases anywhere
- creation is name-first with a required source; the source-first builder shape, the `.name()`/`.path()`/`.destination()` setters, the `SnapshotDestination` type, and `snapshot_to`/`snapshotTo`/`SnapshotTo` are all removed so identity and location can no longer contradict each other
- a new optional `dest_dir` (CLI `--dest-dir`) creates the artifact at `DIR/<name>` on another volume without touching its identity, replacing what path destinations were actually used for
- boot-from-snapshot naming is unified everywhere: `--from-snapshot`, `from_snapshot=`, `fromSnapshot`, and Go `WithFromSnapshot` (renamed from `WithSnapshot`); `msb run` additionally accepts `--from-snap` as a hidden arg alias (absent from help, docs keep the canonical spelling), the only flag alias in the contract
- resumable snapshots are reserved in the contract (`--resumable`, `.resumable()`, `resumable=True`) and return an unsupported-feature error at create until VM pause/resume capture lands; `snapshot_index` gains a `scope` column via migration `m20260714_000001_add_snapshot_scope`, ordered last (after the released `migrate_root_disk`) so name order matches apply order on fresh and upgraded databases alike
- BREAKING: legacy `manifest.json` artifacts are no longer readable, `SnapshotSpec`'s wire shape replaces `destination` with `name`/`dest_dir`, Python `Snapshot.create` and Go `Snapshot.Create` have new signatures, and `msb run --snapshot` / `Sandbox.create(snapshot=)` are now `--from-snapshot` / `from_snapshot=`

```bash
msb snapshot create clean --from box --label stage=ready
msb snapshot create clean --from box --dest-dir /mnt/big   # artifact at /mnt/big/clean
msb snapshot save clean /tmp/clean.tar.zst --with-image
msb snapshot load /tmp/clean.tar.zst
msb run --name worker --from-snapshot clean -- python -V
```

```rust
let snap = Snapshot::builder("clean")
    .from_sandbox("box")
    .dest_dir("/mnt/big")
    .record_integrity()
    .create()
    .await?;
Snapshot::save("clean", Path::new("/tmp/clean.tar.zst"), SaveOpts::default()).await?;
```

```typescript
const snap = await Snapshot.builder("clean").fromSandbox("box").destDir("/mnt/big").create();
await Snapshot.save("clean", "/tmp/clean.tar.zst");
const handle = await Snapshot.load("/tmp/clean.tar.zst");
```

```python
snap = await Snapshot.create("clean", from_sandbox="box", dest_dir="/mnt/big")
fork = await Sandbox.create("worker", from_snapshot="clean")
```

```go
snap, err := microsandbox.Snapshot.Create(ctx, microsandbox.SnapshotCreateOptions{
    Name:        "clean",
    FromSandbox: "box",
})
fork, err := microsandbox.CreateSandbox(ctx, "worker", microsandbox.WithFromSnapshot("clean"))
```

## Test Plan
- [x] `cargo fmt --all -- --check`, `cargo check --workspace`, and `cargo clippy -D warnings` on all touched crates pass
- [x] `cargo test -p microsandbox --test snapshot_artifact` (38, including create-time `resumable` rejection, requires-gate on restore, child_count regression, staging-dir skip, and the sparse-codec round-trips renamed to save/load), `-p microsandbox-cli --lib` (233, including the hidden `--from-snap` alias), `-p microsandbox-image --lib` (180, including extensions/requires canonical-form tests), `-p microsandbox-migration --lib` (11, including the metadata/migrator order guard), and `-p microsandbox-types --features ts` including the checked-in bindings staleness test
- [x] Go unit tests include Snapshot.Create required-field validation and wire-shape tests for `resumable`/`dest_dir` marshaling
- [x] Node: `npm run build`, `npm run typecheck`, and `npm run test:unit` (100 tests) pass against a freshly built debug native module
- [x] rebased onto main at v0.6.6: #1130 pinned-digest restore, #1143 revert, #1165 root-disk, #1150/#1166 sparse codec, #1169 root-disk snapshot guards, and #1151/#1174/#1161 all reconciled; microsandbox-mcp#19 rebased onto mcp main and the submodule repointed
- [x] Python: `maturin develop` then `pytest tests` (22 passed), and `inspect.signature(Snapshot.create)` matches the new contract with the old methods absent
- [x] Go: `go build ./...`, unit and smoke tests against a fresh dylib, and both snapshot integration tests pass on real VMs (`WithFromSnapshot` fork restore plus create/open/reindex/save/load round trip)
- [x] real VM CLI pass: `snapshot create --dest-dir` lands the artifact on a scratch volume, `snapshot inspect` shows `Scope: disk`, and `msb run --from-snapshot <path>` boots a fork that reads back a pre-snapshot marker file
- [ ] full non-snapshot Go and Node integration suites (runs in CI; local `core.ping` smoke check is blocked by released runtime artifacts still speaking protocol generation 5)

