### PR TITLE
docs: add a Reconfigure page and split the secrets page headings

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -39,6 +39,7 @@
             "pages": [
               "sandboxes/overview",
               "sandboxes/lifecycle",
+              "sandboxes/reconfigure",
               "sandboxes/commands",
               "sandboxes/ssh",
               "sandboxes/filesystem",

--- a/docs/sandboxes/reconfigure.mdx
+++ b/docs/sandboxes/reconfigure.mdx
@@ -1,0 +1,113 @@
+---
+title: Reconfigure
+description: Resize and change a running sandbox in place
+icon: "sliders"
+---
+
+Use `msb modify`, or the SDK `modify()` methods, to change a sandbox after it is created, without rebuilding it: resize its CPUs and memory, update environment variables, labels, and the working directory, and add, rotate, or remove secrets.
+
+Changes that can apply to a running sandbox take effect immediately; the rest are saved and take effect on its next start.
+
+## Resize CPU and memory
+
+Raise or lower a running sandbox's CPUs and memory on the fly:
+
+<CodeGroup>
+```rust Rust
+sb.modify().cpus(4).memory(4096).apply().await?;
+```
+
+```typescript TypeScript
+await sandbox.modify({ cpus: 4, memory: 4096 });
+```
+
+```python Python
+await sb.modify(cpus=4, memory=4096)
+```
+
+```go Go
+sb.Modify(ctx, m.ModifyOptions{CPUs: 4, MemoryMiB: 4096})
+```
+
+```bash CLI
+msb modify api --cpus 4 --memory 4G
+```
+</CodeGroup>
+
+A running sandbox can only grow up to the ceilings reserved when it was created. These default to its starting size, so if you expect to scale up later, set `max_cpus` and `max_memory` higher at creation time; reserving spare capacity costs almost nothing. Raising a ceiling afterward takes a restart.
+
+A live resize does not always take hold at once, since the guest applies it in the background. The result reports per-resource progress so you can tell when it has fully settled.
+
+## Update environment, labels, and workdir
+
+<CodeGroup>
+```rust Rust
+sb.modify().env("MODE", "prod").apply().await?;
+```
+
+```typescript TypeScript
+await sandbox.modify({ env: { MODE: "prod" } });
+```
+
+```python Python
+await sb.modify(env={"MODE": "prod"})
+```
+
+```go Go
+sb.Modify(ctx, m.ModifyOptions{Env: map[string]string{"MODE": "prod"}})
+```
+
+```bash CLI
+msb modify api --env MODE=prod
+```
+</CodeGroup>
+
+These apply to future commands only. Processes already running keep the environment they started with.
+
+## Rotate secrets
+
+Add, rotate, or remove a secret without a restart. Guest code keeps using the same placeholder; only the value swapped in at the network boundary changes.
+
+<CodeGroup>
+```rust Rust
+sb.modify()
+    .secret(|s| s
+        .env("API_KEY")
+        .source(SecretSource::Env { var: "API_KEY".into() })
+        .allow_host("api.example.com"))
+    .apply()
+    .await?;
+```
+
+```bash CLI
+msb modify worker --secret GITHUB_TOKEN@api.github.com   # add or rotate
+msb modify worker --secret-rm SERVICE_API_KEY            # remove
+```
+</CodeGroup>
+
+Secret changes are available through the Rust SDK and CLI for now. See [Secrets](/sandboxes/secrets) for the full model.
+
+## Preview a change
+
+Do a dry run to see what a change would do without applying it:
+
+```bash
+msb modify api --cpus 8 --dry-run
+```
+
+The SDKs take the same option (`dryRun` / `dry_run`), returning the same plan the apply would carry out.
+
+## Apply changes that need a restart
+
+Some changes cannot take effect on a running sandbox. Choose when they apply: save them for the next start, or restart now.
+
+```bash
+msb modify api --max-memory 16G --next-start   # apply on the next start
+msb modify api --env MODE=prod --restart       # restart to apply now
+```
+
+In the SDKs, pass the equivalent `policy`. Modifying a stopped sandbox never starts it; the changes are saved for its next boot.
+
+---
+
+For the full flag list, see [`msb modify`](/cli/sandbox-commands#msb-modify). For the API, see the sandbox reference for [Rust](/sdk/rust/sandbox), [TypeScript](/sdk/typescript/sandbox), [Python](/sdk/python/sandbox), and [Go](/sdk/go/sandbox).

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -12,6 +12,10 @@ That means the guest can call APIs without ever holding the credential itself.
 
 Allowed hosts are checked against the sandbox's observed DNS and TLS identity. Keep allow lists narrow so placeholders can only turn into credentials at the destinations that actually need them.
 
+## Add secrets when creating a sandbox
+
+Bind secrets to environment variables when you create the sandbox, each scoped to the hosts allowed to receive it:
+
 <CodeGroup>
 ```rust Rust
 use microsandbox::Sandbox;


### PR DESCRIPTION
two related guide changes for the modify/resize feature area.

**Reconfigure page (draft to evaluate).** a dedicated sandboxes page that gives the modify/resize model one home in guide voice: resize cpu/memory, update env/labels/workdir, rotate secrets, preview, and apply changes that need a restart. placed after lifecycle in the nav. if kept, the follow-up is to collapse the cli `msb modify` intro, the sdk `modify()` descriptions, and the lifecycle section into pointers here; dropping it is just deleting the page and its nav line.

**Secrets page headings.** added an 'add secrets when creating a sandbox' heading so the page's two distinct tasks, defining secrets at create time and changing them on a running sandbox, each show up in the on-this-page nav. previously only the running-sandbox heading existed.