### PR TITLE
docs: give the secrets page create-time and running-sandbox headings

### DIFF
--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -12,6 +12,10 @@ That means the guest can call APIs without ever holding the credential itself.
 
 Allowed hosts are checked against the sandbox's observed DNS and TLS identity. Keep allow lists narrow so placeholders can only turn into credentials at the destinations that actually need them.
 
+## Add secrets when creating a sandbox
+
+Bind secrets to environment variables when you create the sandbox, each scoped to the hosts allowed to receive it:
+
 <CodeGroup>
 ```rust Rust
 use microsandbox::Sandbox;


### PR DESCRIPTION
the secrets page had a single heading (changing secrets on a running sandbox), so the create-time setup that fills most of the page had no entry in the on-this-page nav. added an 'add secrets when creating a sandbox' heading before the create example, leaving the placeholder-model intro as the page lead.