### PR TITLE
fix(filesystem): stream readdir snapshot entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3574,9 +3574,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2cab1e5485ec037c19788a4cc6d72bf332d07b6e2789976200523f57c7ab3"
+checksum = "70bc09516a8ed366b6f20504f434d619991dc879101462d86b24ae133937bd3b"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3594,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad72e49855b1e2d9498aa2d365e2f348103a6679469a4154628ba2eb7312d8"
+checksum = "0d63ddae3ce5ba871a2b90bad6d789bf43583b8e587620580376222aed65e96a"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3609,15 +3609,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6718d0e1881ad45e5d380f4556325ba11277480b88c613bdedc1e527a166119a"
+checksum = "b14a030e7cd5740010a9d6eedd1002d2d42cc1481670cfa22a4dc5a89143048f"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942a5e396d1c227c6baa06f465d9e59640c5d22190e96d9df9603fca7308c66f"
+checksum = "f33e9fbcbf5e27657d62177689a499a0dd64d4321afde53463f17b66c1acc2d7"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3626,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552e29b5fcf95a749843d92a71ed4a1276c6275edbc726ceb20a0fcc210e9bf8"
+checksum = "ca9d5c0ea156c5253c18c880aa29f038e639e9f5526d93ebb848e60d46b2bdca"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3656,9 +3656,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106e8b8b2337e8f426b0b0ca9c7b31f421f164692131565188fabdf39b5c1fd1"
+checksum = "500d2d1d56525119b374ca622c351115eade0a75fb4ff8a16d1cc7117b29d169"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -3668,9 +3668,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aabf06ccd486d852f232877bb1e05250685f83b43c6ac9b9145379a68f124c8"
+checksum = "836b43c16a0932baebf32b657f34153fd90f2e839a33e0002d54c6f91b4019b7"
 dependencies = [
  "msb_krun_utils",
  "vm-memory",
@@ -3678,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662bb434db3a7ab7b043dc0ba5db55b998e5f33359c732532ffd535713f93191"
+checksum = "6457213dc30bdb1a8bcb3ceba3a548f442fc913874f11b970745f779a6bf4842"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3688,18 +3688,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228d8097064ad1ab753f54a1278dc709e95424a0268a0fced6f3a771af008ae6"
+checksum = "91f33a174635431e57a0d59a4aed487599c2ff2ac9ca1ea2346626112a2499af"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15217824575be075fc0d66a7e7f1db455ef45ea27be3eafdc4e8bd47c28463c"
+checksum = "54d6f5ee4b160d020de8c91d9237a9592472ee6353b1b72cd08d51b2149c9433"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3713,9 +3713,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d41a7c300db95d490f8074ee35ba6dd117ea957f77c664808f971950b428db4"
+checksum = "816b34f9bf7eef3f101e84452e663cf9ac6e173377d5ff277192fb8c82cf3199"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,8 @@ microsandbox-network = { version = "=0.6.5", path = "crates/network" }
 microsandbox-protocol = { version = "=0.6.5", path = "crates/protocol" }
 microsandbox-runtime = { version = "=0.6.5", path = "crates/runtime", default-features = false }
 microsandbox-utils = { version = "=0.6.5", path = "crates/utils" }
-msb_krun = "=0.1.24"
-msb_krun_utils = "=0.1.24"
+msb_krun = "=0.1.25"
+msb_krun_utils = "=0.1.25"
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }
 

--- a/crates/filesystem/lib/backends/dualfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/dir_ops.rs
@@ -8,14 +8,14 @@ use std::{
 
 use super::{
     DualFs,
-    lookup::{auto_register_readdir, backend, get_node},
+    lookup::{auto_register_readdir, backend, do_forget, get_node},
     policy::{BackendChoice, DualDispatchPlan, DualNamespaceView, HintBag, OpKind, RequestCtx},
     types::{
         BackendId, DirSnapshot, DualDirHandle, FileKind, MergedDirEntry, NodeState, ROOT_INODE,
     },
 };
 use crate::{
-    Context, DirEntry, Entry, OpenOptions,
+    AddDirEntry, AddDirEntryPlus, Context, DirEntry, Entry, OpenOptions,
     backends::shared::{
         dir_snapshot::{self, SnapshotEntry},
         init_binary, platform,
@@ -128,6 +128,27 @@ pub(crate) fn do_readdir(
     serve_readdir(snapshot, offset)
 }
 
+/// Handle readdir by streaming entries from the snapshot.
+pub(crate) fn do_readdir_for_each(
+    fs: &DualFs,
+    ctx: Context,
+    _ino: u64,
+    handle: u64,
+    _size: u32,
+    offset: u64,
+    add_entry: &mut AddDirEntry<'_>,
+) -> io::Result<()> {
+    let dh = get_dir_handle(fs, handle)?;
+    let mut snapshot_guard = dh.snapshot.lock().unwrap();
+
+    if snapshot_guard.is_none() {
+        *snapshot_guard = Some(build_readdir_snapshot(fs, ctx, dh.guest_inode, &dh)?);
+    }
+
+    let snapshot = snapshot_guard.as_ref().unwrap();
+    dir_snapshot::serve_snapshot_entries_for_each(&snapshot.entries, offset, add_entry)
+}
+
 /// Handle readdirplus.
 pub(crate) fn do_readdirplus(
     fs: &DualFs,
@@ -194,6 +215,98 @@ pub(crate) fn do_readdirplus(
     }
 
     Ok(result)
+}
+
+/// Handle readdirplus by streaming entries with attributes.
+pub(crate) fn do_readdirplus_for_each(
+    fs: &DualFs,
+    ctx: Context,
+    _ino: u64,
+    handle: u64,
+    _size: u32,
+    offset: u64,
+    add_entry: &mut AddDirEntryPlus<'_>,
+) -> io::Result<()> {
+    let dh = get_dir_handle(fs, handle)?;
+    let mut snapshot_guard = dh.snapshot.lock().unwrap();
+
+    if snapshot_guard.is_none() {
+        *snapshot_guard = Some(build_readdir_snapshot(fs, ctx, dh.guest_inode, &dh)?);
+    }
+
+    let snapshot = snapshot_guard.as_ref().unwrap();
+    let mut emitted_lookup_refs = Vec::new();
+
+    for snapshot_entry in dir_snapshot::snapshot_entries_after(&snapshot.entries, offset) {
+        let dir_entry = DirEntry {
+            ino: snapshot_entry.inode(),
+            offset: snapshot_entry.offset(),
+            type_: snapshot_entry.file_type(),
+            name: snapshot_entry.name(),
+        };
+
+        let lookup_ref = if dir_entry.ino == init_binary::INIT_INODE {
+            None
+        } else {
+            fs.state
+                .nodes
+                .read()
+                .unwrap()
+                .get(&dir_entry.ino)
+                .cloned()
+                .map(|node| {
+                    node.lookup_refs.fetch_add(1, Ordering::Relaxed);
+                    dir_entry.ino
+                })
+        };
+
+        let entry = if dir_entry.ino == init_binary::INIT_INODE {
+            init_binary::init_entry(fs.cfg.entry_timeout, fs.cfg.attr_timeout)
+        } else if let Some(node) = fs.state.nodes.read().unwrap().get(&dir_entry.ino).cloned() {
+            let (backend_id, child_inode) = super::lookup::resolve_active_backend_inode(&node);
+            match backend(fs, backend_id).getattr(ctx, child_inode, None) {
+                Ok((mut st, _)) => {
+                    st.st_ino = dir_entry.ino;
+                    Entry {
+                        inode: dir_entry.ino,
+                        generation: 0,
+                        attr: st,
+                        attr_flags: 0,
+                        attr_timeout: fs.cfg.attr_timeout,
+                        entry_timeout: fs.cfg.entry_timeout,
+                    }
+                }
+                Err(_) => fallback_entry(fs, dir_entry.ino),
+            }
+        } else {
+            fallback_entry(fs, dir_entry.ino)
+        };
+
+        match add_entry(dir_entry, entry) {
+            Ok(0) => {
+                if let Some(inode) = lookup_ref {
+                    do_forget(fs, ctx, inode, 1);
+                }
+                break;
+            }
+            Ok(_) => {
+                if let Some(inode) = lookup_ref {
+                    emitted_lookup_refs.push(inode);
+                }
+            }
+            Err(err) => {
+                if let Some(inode) = lookup_ref {
+                    do_forget(fs, ctx, inode, 1);
+                }
+                for inode in emitted_lookup_refs {
+                    do_forget(fs, ctx, inode, 1);
+                }
+                return Err(err);
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Handle releasedir.
@@ -528,6 +641,18 @@ fn serve_readdir(snapshot: &DirSnapshot, offset: u64) -> io::Result<Vec<DirEntry
         &snapshot.entries,
         offset,
     ))
+}
+
+/// Build a minimal fallback entry when backend attributes cannot be read.
+fn fallback_entry(fs: &DualFs, inode: u64) -> Entry {
+    Entry {
+        inode,
+        generation: 0,
+        attr: unsafe { std::mem::zeroed() },
+        attr_flags: 0,
+        attr_timeout: fs.cfg.attr_timeout,
+        entry_timeout: fs.cfg.entry_timeout,
+    }
 }
 
 /// Get a directory handle by guest handle ID.

--- a/crates/filesystem/lib/backends/dualfs/mod.rs
+++ b/crates/filesystem/lib/backends/dualfs/mod.rs
@@ -39,9 +39,9 @@ use policy::DualDispatchPolicy;
 use types::{AtomicBackendId, BackendId, DualState, FileKind, GuestNode, NodeState, ROOT_INODE};
 
 use crate::{
-    Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
-    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, backends::shared::init_binary,
-    stat64, statvfs64,
+    AddDirEntry, AddDirEntryPlus, Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions,
+    GetxattrReply, ListxattrReply, OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+    backends::shared::init_binary, stat64, statvfs64,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -501,6 +501,18 @@ impl DynFileSystem for DualFs {
         dir_ops::do_readdir(self, ctx, ino, handle, size, offset)
     }
 
+    fn readdir_for_each(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+        add_entry: &mut AddDirEntry<'_>,
+    ) -> io::Result<()> {
+        dir_ops::do_readdir_for_each(self, ctx, ino, handle, size, offset, add_entry)
+    }
+
     fn readdirplus(
         &self,
         ctx: Context,
@@ -510,6 +522,18 @@ impl DynFileSystem for DualFs {
         offset: u64,
     ) -> io::Result<Vec<(DirEntry<'static>, Entry)>> {
         dir_ops::do_readdirplus(self, ctx, ino, handle, size, offset)
+    }
+
+    fn readdirplus_for_each(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+        add_entry: &mut AddDirEntryPlus<'_>,
+    ) -> io::Result<()> {
+        dir_ops::do_readdirplus_for_each(self, ctx, ino, handle, size, offset, add_entry)
     }
 
     fn fsyncdir(&self, ctx: Context, ino: u64, datasync: bool, handle: u64) -> io::Result<()> {

--- a/crates/filesystem/lib/backends/memfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/dir_ops.rs
@@ -14,7 +14,7 @@ use super::{
     types::{DirHandle, DirSnapshot, InodeContent, MemDirEntry, ROOT_INODE},
 };
 use crate::{
-    Context, DirEntry, Entry, OpenOptions,
+    AddDirEntry, AddDirEntryPlus, Context, DirEntry, Entry, OpenOptions,
     backends::shared::{
         dir_snapshot::{self, SnapshotEntry},
         init_binary, platform,
@@ -60,6 +60,19 @@ pub(crate) fn do_readdir(
     serve_snapshot_entries(fs, ino, handle, offset)
 }
 
+/// Stream directory entries from a snapshot.
+pub(crate) fn do_readdir_for_each(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    handle: u64,
+    _size: u32,
+    offset: u64,
+    add_entry: &mut AddDirEntry<'_>,
+) -> io::Result<()> {
+    stream_snapshot_entries(fs, ino, handle, offset, add_entry)
+}
+
 /// Read directory entries with attributes (readdirplus).
 pub(crate) fn do_readdirplus(
     fs: &MemFs,
@@ -97,6 +110,72 @@ pub(crate) fn do_readdirplus(
     }
 
     Ok(result)
+}
+
+/// Stream directory entries with attributes.
+pub(crate) fn do_readdirplus_for_each(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    handle: u64,
+    _size: u32,
+    offset: u64,
+    add_entry: &mut AddDirEntryPlus<'_>,
+) -> io::Result<()> {
+    let dh = dir_handle(fs, handle)?;
+    let mut snapshot_lock = dh.snapshot.lock().unwrap();
+    if snapshot_lock.is_none() {
+        *snapshot_lock = Some(build_snapshot(fs, ino, &dh.node)?);
+    }
+    let snapshot = snapshot_lock.as_ref().unwrap();
+    let mut emitted_lookup_refs = Vec::new();
+
+    for snapshot_entry in dir_snapshot::snapshot_entries_after(&snapshot.entries, offset) {
+        let name_bytes = snapshot_entry.name();
+        if name_bytes == b"." || name_bytes == b".." {
+            continue;
+        }
+
+        let dir_entry = DirEntry {
+            ino: snapshot_entry.inode(),
+            offset: snapshot_entry.offset(),
+            type_: snapshot_entry.file_type(),
+            name: name_bytes,
+        };
+
+        if name_bytes == init_binary::INIT_FILENAME {
+            let entry = init_binary::init_entry(fs.cfg.entry_timeout, fs.cfg.attr_timeout);
+            if add_entry(dir_entry, entry)? == 0 {
+                break;
+            }
+            continue;
+        }
+
+        let node = match inode::get_node(fs, dir_entry.ino) {
+            Ok(node) => node,
+            Err(_) => continue,
+        };
+        inode::inc_lookup(&node);
+        let entry = inode::build_entry(fs, &node);
+        let looked_up_inode = entry.inode;
+
+        match add_entry(dir_entry, entry) {
+            Ok(0) => {
+                inode::forget_one(fs, looked_up_inode, 1);
+                break;
+            }
+            Ok(_) => emitted_lookup_refs.push(looked_up_inode),
+            Err(err) => {
+                inode::forget_one(fs, looked_up_inode, 1);
+                for emitted_inode in emitted_lookup_refs {
+                    inode::forget_one(fs, emitted_inode, 1);
+                }
+                return Err(err);
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Release an open directory handle.
@@ -158,6 +237,34 @@ fn serve_snapshot_entries(
         &snapshot.entries,
         offset,
     ))
+}
+
+/// Build or retrieve the snapshot and stream entries from the given offset.
+fn stream_snapshot_entries(
+    fs: &MemFs,
+    ino: u64,
+    handle: u64,
+    offset: u64,
+    add_entry: &mut AddDirEntry<'_>,
+) -> io::Result<()> {
+    let dh = dir_handle(fs, handle)?;
+    let mut snapshot_lock = dh.snapshot.lock().unwrap();
+    if snapshot_lock.is_none() {
+        *snapshot_lock = Some(build_snapshot(fs, ino, &dh.node)?);
+    }
+    let snapshot = snapshot_lock.as_ref().unwrap();
+
+    dir_snapshot::serve_snapshot_entries_for_each(&snapshot.entries, offset, add_entry)
+}
+
+/// Get a directory handle by handle ID.
+fn dir_handle(fs: &MemFs, handle: u64) -> io::Result<Arc<DirHandle>> {
+    fs.dir_handles
+        .read()
+        .unwrap()
+        .get(&handle)
+        .cloned()
+        .ok_or_else(platform::ebadf)
 }
 
 /// Build a point-in-time snapshot of a directory's entries.

--- a/crates/filesystem/lib/backends/memfs/mod.rs
+++ b/crates/filesystem/lib/backends/memfs/mod.rs
@@ -32,9 +32,9 @@ use std::{
 use types::{DirHandle, FileHandle, MemNode, ROOT_INODE};
 
 use crate::{
-    Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
-    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, backends::shared::init_binary,
-    stat64, statvfs64,
+    AddDirEntry, AddDirEntryPlus, Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions,
+    GetxattrReply, ListxattrReply, OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+    backends::shared::init_binary, stat64, statvfs64,
 };
 
 // Guest Linux open flag constants. MemFs interprets flags directly instead of
@@ -443,6 +443,18 @@ impl DynFileSystem for MemFs {
         dir_ops::do_readdir(self, ctx, ino, handle, size, offset)
     }
 
+    fn readdir_for_each(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+        add_entry: &mut AddDirEntry<'_>,
+    ) -> io::Result<()> {
+        dir_ops::do_readdir_for_each(self, ctx, ino, handle, size, offset, add_entry)
+    }
+
     fn readdirplus(
         &self,
         ctx: Context,
@@ -452,6 +464,18 @@ impl DynFileSystem for MemFs {
         offset: u64,
     ) -> io::Result<Vec<(DirEntry<'static>, Entry)>> {
         dir_ops::do_readdirplus(self, ctx, ino, handle, size, offset)
+    }
+
+    fn readdirplus_for_each(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+        add_entry: &mut AddDirEntryPlus<'_>,
+    ) -> io::Result<()> {
+        dir_ops::do_readdirplus_for_each(self, ctx, ino, handle, size, offset, add_entry)
     }
 
     fn fsyncdir(&self, ctx: Context, ino: u64, datasync: bool, handle: u64) -> io::Result<()> {

--- a/crates/filesystem/lib/backends/passthroughfs/unix/dir_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/dir_ops.rs
@@ -13,7 +13,7 @@ use std::{
 
 use super::{DirSnapshot, PassthroughDirEntry, PassthroughDirHandle, PassthroughFs, inode};
 use crate::{
-    Context, DirEntry, Entry, OpenOptions,
+    AddDirEntry, AddDirEntryPlus, Context, DirEntry, Entry, OpenOptions,
     backends::shared::{
         dir_snapshot::{self, SnapshotEntry},
         init_binary, platform,
@@ -71,6 +71,31 @@ pub(crate) fn do_readdir(
     ))
 }
 
+/// Stream directory entries from a point-in-time snapshot.
+pub(crate) fn do_readdir_for_each(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    handle: u64,
+    _size: u32,
+    offset: u64,
+    add_entry: &mut AddDirEntry<'_>,
+) -> io::Result<()> {
+    let handles = fs.dir_handles.read().unwrap();
+    let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+
+    let mut snapshot_lock = data.snapshot.lock().unwrap();
+    if snapshot_lock.is_none() {
+        #[allow(clippy::readonly_write_lock)]
+        let file = data.file.write().unwrap();
+        let inject_init = fs.injects_init() && inode == 1;
+        *snapshot_lock = Some(build_snapshot(file.as_raw_fd(), inject_init)?);
+    }
+
+    let snapshot = snapshot_lock.as_ref().unwrap();
+    dir_snapshot::serve_snapshot_entries_for_each(&snapshot.entries, offset, add_entry)
+}
+
 /// Read directory entries with attributes (readdirplus).
 pub(crate) fn do_readdirplus(
     fs: &PassthroughFs,
@@ -111,6 +136,84 @@ pub(crate) fn do_readdirplus(
     }
 
     Ok(result)
+}
+
+/// Stream directory entries with attributes.
+pub(crate) fn do_readdirplus_for_each(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    handle: u64,
+    _size: u32,
+    offset: u64,
+    add_entry: &mut AddDirEntryPlus<'_>,
+) -> io::Result<()> {
+    let handles = fs.dir_handles.read().unwrap();
+    let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+
+    let mut snapshot_lock = data.snapshot.lock().unwrap();
+    if snapshot_lock.is_none() {
+        #[allow(clippy::readonly_write_lock)]
+        let file = data.file.write().unwrap();
+        let inject_init = fs.injects_init() && inode == 1;
+        *snapshot_lock = Some(build_snapshot(file.as_raw_fd(), inject_init)?);
+    }
+
+    let snapshot = snapshot_lock.as_ref().unwrap();
+    let mut emitted_lookup_refs = Vec::new();
+
+    for snapshot_entry in dir_snapshot::snapshot_entries_after(&snapshot.entries, offset) {
+        let name_bytes = snapshot_entry.name();
+        if name_bytes == b"." || name_bytes == b".." {
+            continue;
+        }
+
+        let dir_entry = DirEntry {
+            ino: snapshot_entry.inode(),
+            offset: snapshot_entry.offset(),
+            type_: snapshot_entry.file_type(),
+            name: name_bytes,
+        };
+
+        if name_bytes == init_binary::INIT_FILENAME {
+            let entry = init_binary::init_entry(fs.cfg.entry_timeout, fs.cfg.attr_timeout);
+            if add_entry(dir_entry, entry)? == 0 {
+                break;
+            }
+            continue;
+        }
+
+        let name_cstr = match std::ffi::CString::new(name_bytes.to_vec()) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let entry = match inode::do_lookup(fs, inode, &name_cstr) {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+
+        let mut dir_entry = dir_entry;
+        let file_type = platform::mode_file_type(entry.attr.st_mode);
+        dir_entry.type_ = mode_to_dtype(file_type);
+        let looked_up_inode = entry.inode;
+
+        match add_entry(dir_entry, entry) {
+            Ok(0) => {
+                inode::forget_one(fs, looked_up_inode, 1);
+                break;
+            }
+            Ok(_) => emitted_lookup_refs.push(looked_up_inode),
+            Err(err) => {
+                inode::forget_one(fs, looked_up_inode, 1);
+                for emitted_inode in emitted_lookup_refs {
+                    inode::forget_one(fs, emitted_inode, 1);
+                }
+                return Err(err);
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Release an open directory handle.

--- a/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
@@ -30,8 +30,8 @@ use std::{
 };
 
 use crate::{
-    Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
-    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+    AddDirEntry, AddDirEntryPlus, Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions,
+    GetxattrReply, ListxattrReply, OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
     backends::shared::{
         handle_table::HandleData,
         init_binary,
@@ -802,6 +802,18 @@ impl DynFileSystem for PassthroughFs {
         dir_ops::do_readdir(self, ctx, ino, handle, size, offset)
     }
 
+    fn readdir_for_each(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+        add_entry: &mut AddDirEntry<'_>,
+    ) -> io::Result<()> {
+        dir_ops::do_readdir_for_each(self, ctx, ino, handle, size, offset, add_entry)
+    }
+
     fn readdirplus(
         &self,
         ctx: Context,
@@ -811,6 +823,18 @@ impl DynFileSystem for PassthroughFs {
         offset: u64,
     ) -> io::Result<Vec<(DirEntry<'static>, Entry)>> {
         dir_ops::do_readdirplus(self, ctx, ino, handle, size, offset)
+    }
+
+    fn readdirplus_for_each(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+        add_entry: &mut AddDirEntryPlus<'_>,
+    ) -> io::Result<()> {
+        dir_ops::do_readdirplus_for_each(self, ctx, ino, handle, size, offset, add_entry)
     }
 
     fn fsyncdir(&self, ctx: Context, ino: u64, datasync: bool, handle: u64) -> io::Result<()> {

--- a/crates/filesystem/lib/backends/passthroughfs/windows/dir_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/dir_ops.rs
@@ -74,6 +74,97 @@ impl PassthroughFs {
         Ok(entries)
     }
 
+    pub(super) fn dir_entries_for_each(
+        &self,
+        inode: u64,
+        offset: u64,
+        add_entry: &mut AddDirEntryPlus<'_>,
+    ) -> io::Result<()> {
+        let data = self.inode(inode)?;
+        let metadata = self.safe_metadata(&data.path)?;
+        if !metadata.file_type().is_dir() {
+            return Err(linux_error(LINUX_ENOTDIR));
+        }
+
+        let mut index = 0u64;
+        let mut emit = |ino: u64,
+                        type_: u32,
+                        name: &[u8],
+                        entry: Entry,
+                        add_entry: &mut AddDirEntryPlus<'_>| {
+            let dir_entry = DirEntry {
+                ino,
+                offset: index + 1,
+                type_,
+                name,
+            };
+            index += 1;
+
+            if dir_entry.offset <= offset {
+                return Ok(false);
+            }
+
+            add_entry(dir_entry, entry).map(|written| written == 0)
+        };
+
+        if emit(
+            inode,
+            DT_DIR,
+            b".",
+            self.entry_from_metadata(&metadata, data.as_ref())?,
+            add_entry,
+        )? {
+            return Ok(());
+        }
+        if emit(
+            ROOT_INODE,
+            DT_DIR,
+            b"..",
+            self.parent_entry(data.as_ref())?,
+            add_entry,
+        )? {
+            return Ok(());
+        }
+
+        if self.cfg.inject_init
+            && inode == ROOT_INODE
+            && emit(
+                INIT_INODE,
+                DT_REG,
+                INIT_NAME,
+                init_entry(self.cfg.entry_timeout, self.cfg.attr_timeout),
+                add_entry,
+            )?
+        {
+            return Ok(());
+        }
+
+        for entry in std::fs::read_dir(&data.path).map_err(host_error)? {
+            let entry = entry.map_err(host_error)?;
+            let name = entry.file_name();
+            let name = name.to_str().ok_or_else(|| linux_error(LINUX_EINVAL))?;
+            if is_reserved_name(name) {
+                continue;
+            }
+            let name_buffer = format!("{name}\0");
+            let name = CStr::from_bytes_with_nul(name_buffer.as_bytes())
+                .map_err(|_| linux_error(LINUX_EINVAL))?;
+            validate_component(name)?;
+
+            let path = entry.path();
+            let metadata = self.safe_metadata(&path)?;
+            let child = self.intern_path(path);
+            let full_entry = self.entry_from_metadata(&metadata, child.as_ref())?;
+            let type_ = dirent_type_from_mode(full_entry.attr.st_mode);
+
+            if emit(child.inode, type_, name.to_bytes(), full_entry, add_entry)? {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
     pub(super) fn parent_entry(&self, data: &InodeData) -> io::Result<Entry> {
         let parent_path = data.path.parent().unwrap_or(&self.root);
         let parent_path = if data.inode == ROOT_INODE || !parent_path.starts_with(&self.root) {

--- a/crates/filesystem/lib/backends/passthroughfs/windows/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/mod.rs
@@ -18,8 +18,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::agentd::AGENTD_BYTES;
 use crate::{
-    Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
-    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,
+    AddDirEntry, AddDirEntryPlus, Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions,
+    GetxattrReply, ListxattrReply, OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+    stat64, statvfs64,
 };
 
 mod builder;

--- a/crates/filesystem/lib/backends/passthroughfs/windows/ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/ops.rs
@@ -425,6 +425,28 @@ impl DynFileSystem for PassthroughFs {
             .collect())
     }
 
+    fn readdir_for_each(
+        &self,
+        _ctx: Context,
+        inode: u64,
+        handle: u64,
+        _size: u32,
+        offset: u64,
+        add_entry: &mut AddDirEntry<'_>,
+    ) -> io::Result<()> {
+        let dir_handle = self
+            .dir_handles
+            .read()
+            .unwrap()
+            .get(&handle)
+            .filter(|data| data.inode == inode)
+            .cloned()
+            .ok_or_else(|| linux_error(LINUX_EBADF))?;
+        let _ = dir_handle;
+
+        self.dir_entries_for_each(inode, offset, &mut |dir_entry, _entry| add_entry(dir_entry))
+    }
+
     fn readdirplus(
         &self,
         _ctx: Context,
@@ -448,6 +470,28 @@ impl DynFileSystem for PassthroughFs {
             .into_iter()
             .skip(offset as usize)
             .collect())
+    }
+
+    fn readdirplus_for_each(
+        &self,
+        _ctx: Context,
+        inode: u64,
+        handle: u64,
+        _size: u32,
+        offset: u64,
+        add_entry: &mut AddDirEntryPlus<'_>,
+    ) -> io::Result<()> {
+        let dir_handle = self
+            .dir_handles
+            .read()
+            .unwrap()
+            .get(&handle)
+            .filter(|data| data.inode == inode)
+            .cloned()
+            .ok_or_else(|| linux_error(LINUX_EBADF))?;
+        let _ = dir_handle;
+
+        self.dir_entries_for_each(inode, offset, add_entry)
     }
 
     fn fsyncdir(&self, _ctx: Context, inode: u64, _datasync: bool, handle: u64) -> io::Result<()> {

--- a/crates/filesystem/lib/backends/shared/dir_snapshot.rs
+++ b/crates/filesystem/lib/backends/shared/dir_snapshot.rs
@@ -1,5 +1,7 @@
 //! Shared helpers for serving snapshot-backed directory entries.
 
+use std::io;
+
 use crate::DirEntry;
 
 //--------------------------------------------------------------------------------------------------
@@ -66,4 +68,40 @@ pub(crate) fn serve_snapshot_entries<T: SnapshotEntry>(
             name: &leaked[start..start + len],
         })
         .collect()
+}
+
+/// Stream directory entries from a snapshot starting strictly after `offset`.
+pub(crate) fn serve_snapshot_entries_for_each<T, F>(
+    entries: &[T],
+    offset: u64,
+    mut add_entry: F,
+) -> io::Result<()>
+where
+    T: SnapshotEntry,
+    F: for<'name> FnMut(DirEntry<'name>) -> io::Result<usize>,
+{
+    for entry in snapshot_entries_after(entries, offset) {
+        let dir_entry = DirEntry {
+            ino: entry.inode(),
+            offset: entry.offset(),
+            type_: entry.file_type(),
+            name: entry.name(),
+        };
+
+        if add_entry(dir_entry)? == 0 {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+/// Return snapshot entries strictly after `offset`.
+pub(crate) fn snapshot_entries_after<T: SnapshotEntry>(entries: &[T], offset: u64) -> &[T] {
+    let start = entries
+        .iter()
+        .position(|entry| entry.offset() > offset)
+        .unwrap_or(entries.len());
+
+    &entries[start..]
 }

--- a/crates/filesystem/lib/lib.rs
+++ b/crates/filesystem/lib/lib.rs
@@ -42,6 +42,7 @@ pub use backends::{
 pub use microsandbox_utils::size::{ByteSize, Bytes, Mebibytes, SizeExt};
 #[cfg(any(unix, windows))]
 pub use msb_krun::backends::fs::{
-    Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
-    OpenOptions, RemovemappingOne, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,
+    AddDirEntry, AddDirEntryPlus, Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions,
+    GetxattrReply, ListxattrReply, OpenOptions, RemovemappingOne, SetattrValid, ZeroCopyReader,
+    ZeroCopyWriter, stat64, statvfs64,
 };


### PR DESCRIPTION
## TL;DR
Stream directory entries through libkrun's dynamic filesystem callbacks so repeated readdir calls stop retaining leaked name buffers. This fixes the host RSS growth reproduced in issue #1115 and now uses the published `msb_krun` 0.1.25 crates.

Closes #1115.

## Description
- Uses the published `msb_krun` and `msb_krun_utils` 0.1.25 crates that include superradcompany/libkrun#88.
- Adds snapshot streaming helpers that borrow names from backend-owned snapshots instead of creating leaked static buffers.
- Implements streaming readdir and readdirplus paths for Unix passthrough, memfs, dualfs, and Windows passthrough backends.
- Rolls back lookup references when readdirplus stops on a full FUSE response buffer or returns an error.
- Removes the temporary libkrun git dependency that was used while the fix was waiting to be published.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p microsandbox-filesystem --no-default-features`
- [x] `cargo test -p microsandbox-filesystem --no-default-features readdir -- --nocapture`
- [x] `cargo check -p microsandbox-runtime --no-default-features` passes with existing warnings in `crates/runtime/lib/vm.rs`
- [x] `cargo check -p microsandbox-filesystem --no-default-features --locked`
- [x] Linux KVM repro on `ci-runner-ubuntu-2404-x64`: warmed patched run stayed at `132608 kB -> 133132 kB`, fds `130 -> 130`
