### PR TITLE
feat(cli): add top-level update, upgrade, and downgrade aliases

### DIFF
--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -35,7 +35,14 @@ const TOP_LEVEL_COMMAND_GROUPS: &[CommandGroup] = &[
     },
     CommandGroup {
         heading: "Installation",
-        commands: &["install", "uninstall", "doctor", "self"],
+        commands: &[
+            "install",
+            "uninstall",
+            "doctor",
+            "update",
+            "downgrade",
+            "self",
+        ],
     },
 ];
 
@@ -174,6 +181,13 @@ enum Commands {
 
     /// Check local runtime and host virtualization prerequisites.
     Doctor(self_cmd::DoctorArgs),
+
+    /// Update msb and libkrunfw to the latest release (alias for `self update`).
+    #[command(visible_alias = "upgrade")]
+    Update(self_cmd::SelfUpdateArgs),
+
+    /// Downgrade msb and local state to an older supported release (alias for `self downgrade`).
+    Downgrade(self_cmd::SelfDowngradeArgs),
 
     /// Manage the msb installation.
     #[command(name = "self")]
@@ -641,6 +655,8 @@ fn run_async_command_anyhow(
             Commands::Install(args) => install::run(args).await,
             Commands::Uninstall(args) => uninstall::run(args).await,
             Commands::Doctor(args) => self_cmd::run_doctor(args),
+            Commands::Update(args) => self_cmd::run_update(args).await,
+            Commands::Downgrade(args) => self_cmd::run_downgrade(args).await,
             Commands::Self_(args) => self_cmd::run(args).await,
         }
     })

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -658,7 +658,8 @@ fn enable_windows_hypervisor_platform() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn run_update(args: SelfUpdateArgs) -> anyhow::Result<()> {
+/// Update msb and libkrunfw to the latest release.
+pub async fn run_update(args: SelfUpdateArgs) -> anyhow::Result<()> {
     info(&format!("Current version: v{CURRENT_VERSION}"));
 
     let spinner = ui::Spinner::start("Checking", "latest release");
@@ -703,7 +704,8 @@ async fn run_update(args: SelfUpdateArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn run_downgrade(args: SelfDowngradeArgs) -> anyhow::Result<()> {
+/// Downgrade msb and local state to an older supported release.
+pub async fn run_downgrade(args: SelfDowngradeArgs) -> anyhow::Result<()> {
     run_downgrade_local(args).await
 }
 


### PR DESCRIPTION
## TL;DR
Adds `msb update`, `msb upgrade`, and `msb downgrade` as top-level commands so you don't have to type the full `msb self ...` form.

## Description
- Add `Update` (with visible alias `upgrade`) and `Downgrade` variants to the top-level `Commands` enum, reusing the existing `SelfUpdateArgs`/`SelfDowngradeArgs` so the flags stay identical.
- Dispatch the new commands to the same handlers as their `self` counterparts, mirroring how `msb doctor` already shadows `msb self doctor`.
- Make `run_update` and `run_downgrade` public in `self_cmd.rs` so the top-level dispatch can call them.
- List the new commands under the Installation group in the grouped `--help` output.

```bash
# these now work at the top level, same flags as `msb self ...`
msb update
msb upgrade -f
msb downgrade 0.6.0 --yes
```

## Test Plan
- [x] `cargo build -p microsandbox-cli --bin msb` exits 0
- [x] `msb --help` lists `update`, `downgrade`, and the `upgrade` alias under Installation
- [x] `msb update --help` and `msb downgrade --help` show the same options as their `self` counterparts
- [x] `msb upgrade --help` resolves to the update command