### PR TITLE
fix(sdk)!: type guest paths as strings and fix Windows path handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,6 +3397,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "typed-builder",
+ "typed-path",
  "which",
  "windows-sys 0.61.2",
  "zeroize",
@@ -3676,6 +3677,7 @@ dependencies = [
  "pyo3-async-runtimes",
  "serde_json",
  "tokio",
+ "typed-path",
 ]
 
 [[package]]
@@ -7528,6 +7530,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ts-rs = "12.0.1"
 typed-builder = "0.23"
+typed-path = "0.12"
 which = "8"
 xattr = "1.3"
 zeroize = { version = "1.8", features = ["derive", "serde"] }

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -645,9 +645,9 @@ pub fn apply_sandbox_opts(
         // `auto` is the magic sentinel that asks agentd to probe a
         // candidate list inside the guest rootfs. Anything else must
         // be an absolute path so the eventual execve can find it.
-        if init_path != microsandbox_protocol::HANDOFF_INIT_AUTO
-            && !std::path::Path::new(init_path).is_absolute()
-        {
+        // Checked textually — `Path::is_absolute` follows host semantics
+        // and treats `/sbin/init` as relative on Windows.
+        if init_path != microsandbox_protocol::HANDOFF_INIT_AUTO && !init_path.starts_with('/') {
             anyhow::bail!("--init must be an absolute path or `auto`, got: {init_path}");
         }
         if opts.init_arg.is_empty() && opts.init_env.is_empty() {

--- a/packages/microsandbox-types/rust/lib/domain.rs
+++ b/packages/microsandbox-types/rust/lib/domain.rs
@@ -494,9 +494,9 @@ pub enum PortProtocol {
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 pub struct HandoffInit {
     /// Init binary: absolute path inside the guest rootfs, or the literal `auto`.
-    #[cfg_attr(feature = "ts", ts(type = "string"))]
-    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
-    pub cmd: PathBuf,
+    ///
+    /// Always a Linux-style `/`-separated path — never build it with host OS path APIs, whose semantics diverge on Windows (`\` separators, `/sbin/init` treated as relative).
+    pub cmd: String,
 
     /// Supplemental argv. `argv[0]` is implicitly `cmd`.
     #[serde(default)]

--- a/packages/microsandbox-types/typescript/src/domain.ts
+++ b/packages/microsandbox-types/typescript/src/domain.ts
@@ -14,6 +14,8 @@ export type EnvVar = {
 export type HandoffInit = {
   /**
    * Init binary: absolute path inside the guest rootfs, or the literal `auto`.
+   *
+   * Always a Linux-style `/`-separated path — never build it with host OS path APIs, whose semantics diverge on Windows (`\` separators, `/sbin/init` treated as relative).
    */
   cmd: string;
   /**

--- a/sdk/node-ts/native/sandbox_builder.rs
+++ b/sdk/node-ts/native/sandbox_builder.rs
@@ -1,5 +1,4 @@
 use std::net::IpAddr;
-use std::path::PathBuf;
 use std::time::Duration;
 
 use napi::bindgen_prelude::*;
@@ -299,10 +298,9 @@ impl JsSandboxBuilder {
     #[napi]
     pub fn init(&mut self, cmd: String, args: Option<Vec<String>>) -> &Self {
         let prev = self.take_inner();
-        let cmd_path = PathBuf::from(cmd);
         self.inner = Some(match args {
-            Some(args) if !args.is_empty() => prev.init_with(cmd_path, |i| i.args(args)),
-            _ => prev.init(cmd_path),
+            Some(args) if !args.is_empty() => prev.init_with(cmd, |i| i.args(args)),
+            _ => prev.init(cmd),
         });
         self
     }
@@ -324,7 +322,7 @@ impl JsSandboxBuilder {
         let mut returned = configure.call(initial)?;
         let init_builder = returned.take_inner_builder()?;
         let prev = self.take_inner();
-        self.inner = Some(prev.init_with(PathBuf::from(cmd), |_default| init_builder));
+        self.inner = Some(prev.init_with(cmd, |_default| init_builder));
         Ok(self)
     }
 

--- a/sdk/node-ts/src/rootfs.ts
+++ b/sdk/node-ts/src/rootfs.ts
@@ -20,25 +20,47 @@ export type RootfsSource =
 
 /**
  * Resolve a string to a `RootfsSource`:
- *   - leading `/`, `./`, `../` → bind (or disk if extension matches)
+ *   - a local-path anchor (`/`, `./`, `../`; plus `.\`, `..\`, `\`, `C:\`,
+ *     `C:/` on Windows hosts) → bind (or disk if extension matches)
  *   - `.qcow2`/`.raw`/`.vmdk` extension → disk image
  *   - otherwise → OCI reference
  */
 export function intoRootfsSource(input: string | RootfsSource): RootfsSource {
   if (typeof input !== "string") return input;
-  const isPath =
-    input.startsWith("/") || input.startsWith("./") || input.startsWith("../");
   const ext = lastExtension(input);
   if (ext && (ext === "qcow2" || ext === "raw" || ext === "vmdk")) {
     return { kind: "disk", path: input, format: ext };
   }
-  if (isPath) return { kind: "bind", path: input };
+  if (looksLikeLocalPath(input)) return { kind: "bind", path: input };
   return { kind: "oci", reference: input };
 }
 
+/**
+ * Mirrors `microsandbox_utils::looks_like_local_path_text`: POSIX anchors on
+ * every platform, Windows anchors only on Windows hosts — keep in sync.
+ */
+function looksLikeLocalPath(s: string): boolean {
+  if (
+    s === "." ||
+    s === ".." ||
+    s.startsWith("/") ||
+    s.startsWith("./") ||
+    s.startsWith("../")
+  ) {
+    return true;
+  }
+  if (process.platform !== "win32") return false;
+  return (
+    s.startsWith(".\\") ||
+    s.startsWith("..\\") ||
+    s.startsWith("\\") ||
+    /^[A-Za-z]:[\\/]/.test(s)
+  );
+}
+
 function lastExtension(p: string): string | null {
-  const slash = p.lastIndexOf("/");
-  const tail = slash === -1 ? p : p.slice(slash + 1);
+  const sep = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  const tail = sep === -1 ? p : p.slice(sep + 1);
   const dot = tail.lastIndexOf(".");
   if (dot <= 0) return null;
   return tail.slice(dot + 1).toLowerCase();

--- a/sdk/node-ts/tests/unit/builders.test.ts
+++ b/sdk/node-ts/tests/unit/builders.test.ts
@@ -53,6 +53,45 @@ describe("intoRootfsSource", () => {
     const src = { kind: "oci" as const, reference: "alpine" };
     expect(intoRootfsSource(src)).toBe(src);
   });
+
+  it("treats Windows-style paths as bind mounts on Windows hosts", () => {
+    const original = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      expect(intoRootfsSource("C:\\images\\rootfs")).toEqual({
+        kind: "bind",
+        path: "C:\\images\\rootfs",
+      });
+      expect(intoRootfsSource("C:/images/rootfs")).toEqual({
+        kind: "bind",
+        path: "C:/images/rootfs",
+      });
+      expect(intoRootfsSource(".\\rootfs")).toEqual({
+        kind: "bind",
+        path: ".\\rootfs",
+      });
+      expect(intoRootfsSource("C:\\images\\disk.qcow2")).toEqual({
+        kind: "disk",
+        path: "C:\\images\\disk.qcow2",
+        format: "qcow2",
+      });
+      // OCI references stay OCI even on Windows.
+      expect(intoRootfsSource("python:3.12")).toEqual({
+        kind: "oci",
+        reference: "python:3.12",
+      });
+    } finally {
+      Object.defineProperty(process, "platform", { value: original });
+    }
+  });
+
+  it("does not treat Windows-style paths as bind mounts on POSIX hosts", () => {
+    if (process.platform === "win32") return;
+    expect(intoRootfsSource("C:\\images\\rootfs")).toEqual({
+      kind: "oci",
+      reference: "C:\\images\\rootfs",
+    });
+  });
 });
 
 describe("MountBuilder", () => {

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -22,3 +22,4 @@ pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
+typed-path = { workspace = true }

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -1410,14 +1410,36 @@ fn extract_required<'py, T: FromPyObject<'py>>(
 }
 
 /// Resolve a snapshot reference (bare name or path) to its on-disk
-/// directory. Mirrors the convention used by `Snapshot::open`.
+/// directory. Mirrors the convention used by `Snapshot::open`
+/// (`snapshot::store::looks_like_path`) — keep the heuristics in sync.
 fn resolve_snapshot_dir(s: &str) -> std::path::PathBuf {
-    if s.contains('/') || s.starts_with('.') || s.starts_with('~') {
+    if snapshot_ref_looks_like_path(s) {
         std::path::PathBuf::from(s)
     } else {
         microsandbox::backend::default_backend()
             .as_local()
             .map(|local| local.snapshots_dir().join(s))
             .unwrap_or_else(|| std::path::PathBuf::from(s))
+    }
+}
+
+/// Heuristic split between a bare snapshot name and a filesystem path.
+fn snapshot_ref_looks_like_path(s: &str) -> bool {
+    if s.contains('/') || s.starts_with('.') || s.starts_with('~') {
+        return true;
+    }
+    // On Windows hosts, native separators and drive/UNC prefixes (`C:\snaps\foo`, `C:foo`, `\\server\share`) mark a path even when no forward slash appears.
+    #[cfg(windows)]
+    {
+        use typed_path::{Utf8WindowsComponent, Utf8WindowsPath};
+        s.contains('\\')
+            || matches!(
+                Utf8WindowsPath::new(s).components().next(),
+                Some(Utf8WindowsComponent::Prefix(_))
+            )
+    }
+    #[cfg(not(windows))]
+    {
+        false
     }
 }

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -70,6 +70,7 @@ tokio.workspace = true
 tokio-tungstenite.workspace = true
 tracing.workspace = true
 typed-builder.workspace = true
+typed-path.workspace = true
 which.workspace = true
 zeroize.workspace = true
 

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -2479,15 +2479,11 @@ fn sandbox_cli_args(
     }
 
     // Handoff-init: PID 1 hand-off to a user-supplied init binary.
-    // The builder's `validate()` rejects non-UTF-8 cmd paths, args/env
-    // containing NUL, and env keys containing `=`, so the JSON payloads
-    // below can't produce a corrupted execve wire format.
+    // The builder's `validate()` rejects cmd paths containing NUL or `\`,
+    // args/env containing NUL, and env keys containing `=`, so the JSON
+    // payloads below can't produce a corrupted execve wire format.
     if let Some(ref init) = config.spec.init {
-        let cmd = init
-            .cmd
-            .to_str()
-            .expect("validate() rejects non-UTF-8 cmd paths");
-        launch.env.push(format!("{ENV_HANDOFF_INIT}={cmd}"));
+        launch.env.push(format!("{ENV_HANDOFF_INIT}={}", init.cmd));
 
         if !init.args.is_empty() {
             let argv_val = encode_handoff_json(&init.args);
@@ -3063,7 +3059,7 @@ mod tests {
             .await
             .unwrap();
         config.spec.init = Some(HandoffInit {
-            cmd: PathBuf::from("/init"),
+            cmd: "/init".to_string(),
             args: vec![
                 "/opt/hermes/docker/main-wrapper.sh".to_string(),
                 "gateway".to_string(),

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -385,7 +385,7 @@ impl SandboxBuilder {
     /// `init` and `entrypoint` are orthogonal: `init` is the guest's
     /// PID 1; `entrypoint` is the user workload that agentd exec's
     /// per request. They can be combined freely.
-    pub fn init(mut self, cmd: impl Into<PathBuf>) -> Self {
+    pub fn init(mut self, cmd: impl Into<String>) -> Self {
         self.config.spec.init = Some(HandoffInit {
             cmd: cmd.into(),
             args: Vec::new(),
@@ -410,7 +410,7 @@ impl SandboxBuilder {
     /// pre-boot and one-shot.
     pub fn init_with(
         mut self,
-        cmd: impl Into<PathBuf>,
+        cmd: impl Into<String>,
         f: impl FnOnce(InitOptionsBuilder) -> InitOptionsBuilder,
     ) -> Self {
         let (args, env) = f(InitOptionsBuilder::default()).build();

--- a/sdk/rust/lib/sandbox/config.rs
+++ b/sdk/rust/lib/sandbox/config.rs
@@ -252,7 +252,7 @@ impl SandboxConfig {
         let Some(init) = self.spec.init.as_ref() else {
             return;
         };
-        if init.cmd.as_os_str() != HANDOFF_INIT_AUTO {
+        if init.cmd != HANDOFF_INIT_AUTO {
             return;
         }
         let Some(entrypoint) = image_entrypoint else {
@@ -272,7 +272,7 @@ impl SandboxConfig {
                 .init
                 .as_mut()
                 .expect("init was present at start of auto resolution");
-            init.cmd = PathBuf::from(init_path);
+            init.cmd = init_path.to_string();
             init.env = merge_init_env(&self.spec.env, &init.env);
             return;
         }
@@ -297,7 +297,7 @@ impl SandboxConfig {
             .init
             .as_mut()
             .expect("init was present at start of auto resolution");
-        init.cmd = PathBuf::from(init_path);
+        init.cmd = init_path.to_string();
         init.args.extend(init_args);
         init.env = merge_init_env(&self.spec.env, &init.env);
 
@@ -598,8 +598,6 @@ impl Default for SandboxConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use super::{SandboxConfig, merge_env};
     use crate::sandbox::{
         HandoffInit, MountOptions, NamedVolumeMode, RootfsSource, StatVirtualization, VolumeMount,
@@ -727,7 +725,7 @@ mod tests {
         let mut config = SandboxConfig {
             spec: SandboxSpec {
                 init: Some(HandoffInit {
-                    cmd: PathBuf::from("auto"),
+                    cmd: "auto".to_string(),
                     args: Vec::new(),
                     env: Vec::new(),
                 }),
@@ -742,7 +740,7 @@ mod tests {
             .init
             .as_ref()
             .expect("init should remain configured");
-        assert_eq!(init.cmd, PathBuf::from("/init"));
+        assert_eq!(init.cmd, "/init");
         assert_eq!(
             init.args,
             vec!["/opt/hermes/docker/main-wrapper.sh".to_string()]
@@ -766,7 +764,7 @@ mod tests {
         let mut config = SandboxConfig {
             spec: SandboxSpec {
                 init: Some(HandoffInit {
-                    cmd: PathBuf::from("auto"),
+                    cmd: "auto".to_string(),
                     args: Vec::new(),
                     env: Vec::new(),
                 }),
@@ -782,7 +780,7 @@ mod tests {
             .init
             .as_ref()
             .expect("init should remain configured");
-        assert_eq!(init.cmd, PathBuf::from("/init"));
+        assert_eq!(init.cmd, "/init");
         assert_eq!(
             init.args,
             vec![
@@ -815,7 +813,7 @@ mod tests {
         let mut config = SandboxConfig {
             spec: SandboxSpec {
                 init: Some(HandoffInit {
-                    cmd: PathBuf::from("auto"),
+                    cmd: "auto".to_string(),
                     args: Vec::new(),
                     env: vec![
                         ("PATH".to_string(), "/init/bin:/usr/bin:/bin".to_string()),
@@ -863,7 +861,7 @@ mod tests {
         let mut config = SandboxConfig {
             spec: SandboxSpec {
                 init: Some(HandoffInit {
-                    cmd: PathBuf::from("auto"),
+                    cmd: "auto".to_string(),
                     args: Vec::new(),
                     env: Vec::new(),
                 }),
@@ -875,7 +873,7 @@ mod tests {
         config.merge_image_defaults(&image);
 
         let init = config.spec.init.as_ref().expect("runtime init");
-        assert_eq!(init.cmd, PathBuf::from("/init"));
+        assert_eq!(init.cmd, "/init");
         assert_eq!(
             init.args,
             vec![
@@ -938,7 +936,7 @@ mod tests {
         let config = SandboxConfig {
             spec: SandboxSpec {
                 init: Some(HandoffInit {
-                    cmd: PathBuf::from("/lib/systemd/systemd"),
+                    cmd: "/lib/systemd/systemd".to_string(),
                     args: vec!["--unit=multi-user.target".to_string()],
                     env: Vec::new(),
                 }),
@@ -1002,7 +1000,7 @@ mod tests {
         let mut config = SandboxConfig {
             spec: SandboxSpec {
                 init: Some(HandoffInit {
-                    cmd: PathBuf::from("auto"),
+                    cmd: "auto".to_string(),
                     args: Vec::new(),
                     env: Vec::new(),
                 }),
@@ -1018,7 +1016,7 @@ mod tests {
             .init
             .as_ref()
             .expect("init should remain configured");
-        assert_eq!(init.cmd, PathBuf::from("/init"));
+        assert_eq!(init.cmd, "/init");
         assert_eq!(
             init.args,
             vec!["/app/server".to_string(), "--serve".to_string()]
@@ -1040,7 +1038,7 @@ mod tests {
         let mut config = SandboxConfig {
             spec: SandboxSpec {
                 init: Some(HandoffInit {
-                    cmd: PathBuf::from("auto"),
+                    cmd: "auto".to_string(),
                     args: Vec::new(),
                     env: Vec::new(),
                 }),
@@ -1056,7 +1054,7 @@ mod tests {
             .init
             .as_ref()
             .expect("init should remain configured");
-        assert_eq!(init.cmd, PathBuf::from("/lib/systemd/systemd"));
+        assert_eq!(init.cmd, "/lib/systemd/systemd");
         assert_eq!(init.args, vec!["bash".to_string()]);
         assert_eq!(config.spec.runtime.entrypoint, None);
     }
@@ -1078,7 +1076,7 @@ mod tests {
                     ..Default::default()
                 },
                 init: Some(HandoffInit {
-                    cmd: PathBuf::from("auto"),
+                    cmd: "auto".to_string(),
                     args: Vec::new(),
                     env: Vec::new(),
                 }),
@@ -1094,7 +1092,7 @@ mod tests {
             .init
             .as_ref()
             .expect("init should remain configured");
-        assert_eq!(init.cmd, PathBuf::from("/init"));
+        assert_eq!(init.cmd, "/init");
         assert!(init.args.is_empty());
         assert_eq!(
             config.spec.runtime.entrypoint,
@@ -1112,7 +1110,7 @@ mod tests {
         let mut config = SandboxConfig {
             spec: SandboxSpec {
                 init: Some(HandoffInit {
-                    cmd: PathBuf::from("auto"),
+                    cmd: "auto".to_string(),
                     args: Vec::new(),
                     env: Vec::new(),
                 }),
@@ -1124,7 +1122,7 @@ mod tests {
 
         assert_eq!(
             config.spec.init.expect("init should remain configured").cmd,
-            PathBuf::from("auto")
+            "auto"
         );
         assert_eq!(
             config.spec.runtime.entrypoint,

--- a/sdk/rust/lib/sandbox/init.rs
+++ b/sdk/rust/lib/sandbox/init.rs
@@ -24,8 +24,6 @@
 //!     .build().await?;
 //! ```
 
-use std::path::Path;
-
 use microsandbox_protocol::HANDOFF_INIT_AUTO;
 
 use crate::{MicrosandboxError, MicrosandboxResult};
@@ -100,11 +98,12 @@ impl InitOptionsBuilder {
 /// vars.
 ///
 /// Constraints (each violation produces an `InvalidConfig` error):
-/// - `cmd` must be valid UTF-8 (the host→guest transport is
-///   `String`-only and `PathBuf` JSON serde drops non-UTF-8 bytes).
 /// - `cmd` must be either an absolute path or the literal sentinel
 ///   [`HANDOFF_INIT_AUTO`] (which agentd resolves at boot time).
 /// - `cmd` must not contain a NUL byte (CString incompatibility).
+/// - `cmd` must not contain `\` — it's a guest (Linux) path, where
+///   backslash is a valid filename byte but in practice always means
+///   the caller built it with host `Path` APIs on Windows.
 /// - Each argv entry must be free of `\0` (CString terminator).
 /// - Each env key must be non-empty and free of `=` and `\0`
 ///   (POSIX disallows `=` in keys).
@@ -120,21 +119,20 @@ pub(crate) fn validate(spec: &HandoffInit) -> MicrosandboxResult<()> {
     Ok(())
 }
 
-fn validate_cmd(cmd: &Path) -> MicrosandboxResult<()> {
-    let s = cmd.to_str().ok_or_else(|| {
-        MicrosandboxError::InvalidConfig(format!(
-            "init cmd path must be valid UTF-8: {}",
-            cmd.display()
-        ))
-    })?;
+fn validate_cmd(s: &str) -> MicrosandboxResult<()> {
     if s.contains('\0') {
         return Err(MicrosandboxError::InvalidConfig(format!(
             "init cmd path must not contain a NUL byte: {s:?}"
         )));
     }
+    if s.contains('\\') {
+        return Err(MicrosandboxError::InvalidConfig(format!(
+            "init cmd is a guest (Linux) path and must not contain '\\' — use '/' separators: {s:?}"
+        )));
+    }
     // The sentinel `auto` is resolved guest-side; everything else must be a
-    // Linux guest absolute path. Do not use `Path::is_absolute` here because it
-    // follows host semantics and treats `/sbin/init` as relative on Windows.
+    // Linux guest absolute path, checked textually — never via `Path::is_absolute`,
+    // which follows host semantics and treats `/sbin/init` as relative on Windows.
     if s != HANDOFF_INIT_AUTO && !s.starts_with('/') {
         return Err(MicrosandboxError::InvalidConfig(format!(
             "init cmd must be an absolute path or `{HANDOFF_INIT_AUTO}`, got: {s:?}"
@@ -183,11 +181,10 @@ fn validate_env_pair(key: &str, value: &str) -> MicrosandboxResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     fn ok(cmd: &str, args: &[&str], env: &[(&str, &str)]) -> HandoffInit {
         HandoffInit {
-            cmd: PathBuf::from(cmd),
+            cmd: cmd.to_string(),
             args: args.iter().map(|s| s.to_string()).collect(),
             env: env
                 .iter()
@@ -252,14 +249,10 @@ mod tests {
         assert!(format!("{err}").contains("absolute path or `auto`"));
     }
 
-    #[cfg(unix)]
     #[test]
-    fn validate_rejects_non_utf8_cmd() {
-        use std::ffi::OsStr;
-        use std::os::unix::ffi::OsStrExt;
-        let mut spec = ok("/sbin/init", &[], &[]);
-        spec.cmd = PathBuf::from(OsStr::from_bytes(b"/\xff/init"));
+    fn validate_rejects_backslash_in_cmd() {
+        let spec = ok("/opt\\init", &[], &[]);
         let err = validate(&spec).unwrap_err();
-        assert!(format!("{err}").contains("valid UTF-8"));
+        assert!(format!("{err}").contains("guest (Linux) path"));
     }
 }

--- a/sdk/rust/lib/sandbox/patch.rs
+++ b/sdk/rust/lib/sandbox/patch.rs
@@ -880,7 +880,7 @@ fn os_str_bytes(value: &OsStr) -> Vec<u8> {
 /// Collapses `..` components lexically before checking containment, so that
 /// paths like `/etc/foo/../../bar` are caught even without filesystem access.
 fn resolve_guest_path(target_dir: &Path, guest_path: &str) -> MicrosandboxResult<PathBuf> {
-    use std::path::Component;
+    use typed_path::{Utf8UnixComponent, Utf8UnixPath};
 
     if !guest_path.starts_with('/') {
         return Err(crate::MicrosandboxError::PatchFailed(format!(
@@ -889,26 +889,27 @@ fn resolve_guest_path(target_dir: &Path, guest_path: &str) -> MicrosandboxResult
     }
 
     // Build a normalized relative path by collapsing `.` and `..` lexically.
+    // Parsed with Unix semantics regardless of host — `std::path` would treat
+    // `\` as a separator on Windows and mis-split guest components.
     let mut normalized = PathBuf::new();
-    for component in Path::new(guest_path).components() {
+    for component in Utf8UnixPath::new(guest_path).components() {
         match component {
-            Component::RootDir | Component::CurDir => {}
-            Component::ParentDir => {
+            Utf8UnixComponent::RootDir | Utf8UnixComponent::CurDir => {}
+            Utf8UnixComponent::ParentDir => {
                 if !normalized.pop() {
                     return Err(crate::MicrosandboxError::PatchFailed(format!(
                         "patch path escapes rootfs: '{guest_path}'"
                     )));
                 }
             }
-            Component::Normal(c) => {
-                if c.as_encoded_bytes().contains(&b'\0') {
+            Utf8UnixComponent::Normal(c) => {
+                if c.contains('\0') {
                     return Err(crate::MicrosandboxError::PatchFailed(format!(
                         "patch path contains null byte: '{guest_path}'"
                     )));
                 }
                 normalized.push(c);
             }
-            Component::Prefix(_) => {}
         }
     }
 

--- a/sdk/rust/lib/snapshot/create.rs
+++ b/sdk/rust/lib/snapshot/create.rs
@@ -15,7 +15,7 @@ use crate::db::entity::sandbox as sandbox_entity;
 use crate::sandbox::{SandboxConfig, SandboxStatus};
 use crate::{MicrosandboxError, MicrosandboxResult};
 
-use super::store::index_upsert;
+use super::store::{index_upsert, looks_like_path};
 use super::{Snapshot, SnapshotConfig, SnapshotDestination};
 
 //--------------------------------------------------------------------------------------------------
@@ -197,7 +197,7 @@ fn resolve_destination(
                     "snapshot name must not be empty".into(),
                 ));
             }
-            if name.contains('/') || name.starts_with('.') {
+            if looks_like_path(name) {
                 return Err(MicrosandboxError::InvalidConfig(format!(
                     "snapshot name must be a bare identifier, not a path: '{name}'"
                 )));

--- a/sdk/rust/lib/snapshot/store.rs
+++ b/sdk/rust/lib/snapshot/store.rs
@@ -175,8 +175,25 @@ pub(super) async fn index_upsert(
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
-fn looks_like_path(s: &str) -> bool {
-    s.contains('/') || s.starts_with('.') || s.starts_with('~')
+/// Heuristic split between a bare snapshot name and a filesystem path.
+pub(super) fn looks_like_path(s: &str) -> bool {
+    if s.contains('/') || s.starts_with('.') || s.starts_with('~') {
+        return true;
+    }
+    // On Windows hosts, native separators and drive/UNC prefixes (`C:\snaps\foo`, `C:foo`, `\\server\share`) mark a path even when no forward slash appears.
+    #[cfg(windows)]
+    {
+        use typed_path::{Utf8WindowsComponent, Utf8WindowsPath};
+        s.contains('\\')
+            || matches!(
+                Utf8WindowsPath::new(s).components().next(),
+                Some(Utf8WindowsComponent::Prefix(_))
+            )
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
 }
 
 pub(super) async fn list_indexed(local: &LocalBackend) -> MicrosandboxResult<Vec<SnapshotHandle>> {
@@ -365,5 +382,37 @@ fn handle_from_model(m: snapshot_entity::Model) -> SnapshotHandle {
         size_bytes: m.size_bytes.map(|n| n as u64),
         created_at: m.created_at,
         artifact_path: PathBuf::from(m.artifact_path),
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::looks_like_path;
+
+    #[test]
+    fn bare_names_are_not_paths() {
+        assert!(!looks_like_path("nightly"));
+        assert!(!looks_like_path("my-snapshot_2"));
+    }
+
+    #[test]
+    fn posix_anchors_and_separators_are_paths() {
+        assert!(looks_like_path("/srv/snaps/foo"));
+        assert!(looks_like_path("snaps/foo"));
+        assert!(looks_like_path("./foo"));
+        assert!(looks_like_path("~/snaps"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_forms_are_paths() {
+        assert!(looks_like_path(r"C:\snaps\foo"));
+        assert!(looks_like_path(r"C:foo"));
+        assert!(looks_like_path(r"\\server\share\foo"));
+        assert!(looks_like_path(r"snaps\foo"));
     }
 }

--- a/sdk/rust/lib/volume/fs.rs
+++ b/sdk/rust/lib/volume/fs.rs
@@ -347,6 +347,28 @@ pub(crate) mod local {
         resolve_relative(&volume_root(local, name), path)
     }
 
+    /// Normalize a volume-relative path to `/`-separated absolute form
+    /// (`""`/`"/"` → `"/"`, `"a//./b/../c"` → `"/a/c"`). Purely textual —
+    /// volume paths are platform-independent and must not route through
+    /// host `Path` APIs, whose separator semantics differ on Windows.
+    fn normalize_slash_path(path: &str) -> String {
+        let mut parts: Vec<&str> = Vec::new();
+        for seg in path.split('/') {
+            match seg {
+                "" | "." => {}
+                ".." => {
+                    parts.pop();
+                }
+                seg => parts.push(seg),
+            }
+        }
+        if parts.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", parts.join("/"))
+        }
+    }
+
     pub(crate) async fn read(
         local: &LocalBackend,
         name: &str,
@@ -388,23 +410,29 @@ pub(crate) mod local {
     ) -> MicrosandboxResult<Vec<FsEntry>> {
         let root = volume_root(local, name);
         let full = resolve_relative(&root, path)?;
+        // Present entries as the request path joined with '/'. Deriving them from
+        // host paths instead (strip_prefix + display) breaks on Windows: `display()`
+        // renders host separators, and canonicalization adds a `\\?\` verbatim
+        // prefix that defeats the strip against the un-canonicalized root.
+        let base = normalize_slash_path(path);
         let mut dir = tokio::fs::read_dir(&full).await?;
         let mut entries = Vec::new();
 
         while let Some(entry) = dir.next_entry().await? {
-            let entry_path = entry.path();
-            let rel_path = entry_path.strip_prefix(&root).unwrap_or(&entry_path);
+            let entry_name = entry.file_name();
+            let entry_path = if base == "/" {
+                format!("/{}", entry_name.to_string_lossy())
+            } else {
+                format!("{base}/{}", entry_name.to_string_lossy())
+            };
 
             match entry.metadata().await {
                 Ok(meta) => {
-                    entries.push(metadata_to_entry(
-                        &format!("/{}", rel_path.display()),
-                        &meta,
-                    ));
+                    entries.push(metadata_to_entry(&entry_path, &meta));
                 }
                 Err(_) => {
                     entries.push(FsEntry {
-                        path: format!("/{}", rel_path.display()),
+                        path: entry_path,
                         kind: FsEntryKind::Other,
                         size: 0,
                         mode: 0,
@@ -689,6 +717,27 @@ mod tests {
         );
         assert!(root.is_dir());
         assert!(root.join("nested/file.txt").is_file());
+    }
+
+    #[tokio::test]
+    async fn list_returns_slash_paths_anchored_at_request() {
+        let (_temp, backend) = local_backend().await;
+        local::write(&backend, "vol", "nested/inner/file.txt", b"data")
+            .await
+            .unwrap();
+
+        let root_entries = local::list(&backend, "vol", "/").await.unwrap();
+        assert_eq!(root_entries.len(), 1);
+        assert_eq!(root_entries[0].path, "/nested");
+
+        let nested = local::list(&backend, "vol", "/nested").await.unwrap();
+        assert_eq!(nested.len(), 1);
+        assert_eq!(nested[0].path, "/nested/inner");
+
+        // Trailing slash and missing leading slash normalize to the same form.
+        let inner = local::list(&backend, "vol", "nested/inner/").await.unwrap();
+        assert_eq!(inner.len(), 1);
+        assert_eq!(inner[0].path, "/nested/inner/file.txt");
     }
 
     #[tokio::test]

--- a/sdk/rust/tests/init_handoff.rs
+++ b/sdk/rust/tests/init_handoff.rs
@@ -52,15 +52,18 @@ fn require_test_init() -> Option<PathBuf> {
     Some(path)
 }
 
-/// Build a sandbox with the test init patched in at `/sbin/init`.
+/// Build a sandbox with the test init patched in at `/sbin/test-init`.
+///
+/// The destination basename must be `test-init`: the kernel sets `/proc/1/comm` from the basename of the execve'd path, and the comm assertion below relies on it to
+/// distinguish our init from the image's own `/sbin/init` (busybox on alpine).
 async fn boot_with_test_init(name: &str, init_bin: &Path) -> Sandbox {
     Sandbox::builder(name)
         .image("mirror.gcr.io/library/alpine")
         .cpus(1)
         .memory(256)
         .replace()
-        .patch(|p| p.copy_file(init_bin, "/sbin/init", Some(0o755), true))
-        .init("/sbin/init")
+        .patch(|p| p.copy_file(init_bin, "/sbin/test-init", Some(0o755), true))
+        .init("/sbin/test-init")
         .create()
         .await
         .expect("create sandbox with handoff")


### PR DESCRIPTION
## TL;DR
Guest paths are always Linux paths, but `HandoffInit.cmd` was typed as `PathBuf` and a handful of spots handled paths with host OS semantics that break on Windows. This types the last guest path as a string and fixes every place a path crossed the host/guest fence with the wrong semantics.

## Description
- `HandoffInit.cmd` is now `String` and `SandboxBuilder::init`/`init_with` take `impl Into<String>`, breaking for Rust callers passing `Path`/`PathBuf` values, wire format and TS bindings unchanged (already plain strings)
- `validate_cmd` now also rejects `\` in the init cmd, since a backslash in a guest path in practice always means the caller built it with host `Path` APIs on Windows
- `msb --init` checks absoluteness textually instead of via `Path::is_absolute`, which treats `/sbin/init` as relative on Windows and rejected every valid guest init path
- volume fs `list` builds its returned entry paths by slash-joining the request path with entry names instead of `strip_prefix` + `display()` on host `PathBuf`s, which emitted backslash separators on Windows and leaked full host paths whenever canonicalization (`\\?\` verbatim prefixes, symlinked roots like macOS `/var`) broke the prefix match
- patch `resolve_guest_path` parses guest components with `typed-path`'s `Utf8UnixPath` instead of `std::path`, so a guest filename containing `\` can no longer be mis-split on Windows hosts
- the snapshot name-vs-path classifiers (`snapshot/store.rs`, reused by `snapshot/create.rs`, plus the pyo3 duplicate) and node-ts `intoRootfsSource` now recognize Windows-style paths (drive prefixes, UNC, backslash anchors) on Windows hosts, so `C:\snaps\foo` is no longer treated as a bare snapshot name and `C:\images\rootfs` no longer parses as an OCI reference
- `typed-path` (MIT OR Apache-2.0, zero deps) is added as an internal-only dependency and appears in no public signature
- the `init_handoff` integration test now patches the test binary at `/sbin/test-init`, since `/proc/1/comm` derives from the execve'd basename and the old `/sbin/init` destination could never produce the asserted `test-init`

Usage is unchanged for string callers, only `Path` arguments stop compiling:

```rust
Sandbox::builder("dev")
    .image("debian:bookworm")
    .init("/lib/systemd/systemd")
    .create()
    .await?;
```

## Test Plan
- [x] `cargo test -p microsandbox --no-default-features --features keyring,net --lib` passes (437 tests, includes new volume listing, backslash rejection, and classifier tests)
- [x] `cargo test -p microsandbox-types --features ts` passes and confirms the regenerated `typescript/src/index.ts` is fresh
- [x] `cd sdk/node-ts && npm run test:unit` passes (91 tests, includes new Windows rootfs classification cases)
- [x] `MSB_TEST_INIT_PATH=<static test-init> cargo test -p microsandbox --no-default-features --features keyring,net --test init_handoff -- --ignored` boots real VMs and passes (3 tests)
- [x] Windows build compiles the `#[cfg(windows)]` classifier code (Check Windows passed in CI on both architectures)
- [x] `cargo deny check licenses` accepts `typed-path` (passed in CI)
