### PR TITLE
fix(filesystem): survive host fd exhaustion on virtiofs shares

### DIFF
--- a/crates/filesystem/lib/backends/passthroughfs/unix/dir_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/dir_ops.rs
@@ -9,6 +9,7 @@ use std::{
     io,
     os::fd::{AsRawFd, FromRawFd},
     sync::{Arc, RwLock, atomic::Ordering},
+    time::Duration,
 };
 
 use super::{DirSnapshot, PassthroughDirEntry, PassthroughDirHandle, PassthroughFs, inode};
@@ -131,7 +132,8 @@ pub(crate) fn do_readdirplus(
                 de.type_ = mode_to_dtype(file_type);
                 result.push((de, entry));
             }
-            Err(_) => continue,
+            Err(err) if lookup_says_gone(&err) => continue,
+            Err(_) => result.push((de, no_lookup_entry())),
         }
     }
 
@@ -168,7 +170,7 @@ pub(crate) fn do_readdirplus_for_each(
             continue;
         }
 
-        let dir_entry = DirEntry {
+        let mut dir_entry = DirEntry {
             ino: snapshot_entry.inode(),
             offset: snapshot_entry.offset(),
             type_: snapshot_entry.file_type(),
@@ -187,24 +189,33 @@ pub(crate) fn do_readdirplus_for_each(
             Ok(c) => c,
             Err(_) => continue,
         };
-        let entry = match inode::do_lookup(fs, inode, &name_cstr) {
-            Ok(entry) => entry,
-            Err(_) => continue,
+        let (entry, looked_up_inode) = match inode::do_lookup(fs, inode, &name_cstr) {
+            Ok(entry) => {
+                let file_type = platform::mode_file_type(entry.attr.st_mode);
+                dir_entry.type_ = mode_to_dtype(file_type);
+                let looked_up_inode = entry.inode;
+                (entry, Some(looked_up_inode))
+            }
+            Err(err) if lookup_says_gone(&err) => continue,
+            Err(_) => (no_lookup_entry(), None),
         };
-
-        let mut dir_entry = dir_entry;
-        let file_type = platform::mode_file_type(entry.attr.st_mode);
-        dir_entry.type_ = mode_to_dtype(file_type);
-        let looked_up_inode = entry.inode;
 
         match add_entry(dir_entry, entry) {
             Ok(0) => {
-                inode::forget_one(fs, looked_up_inode, 1);
+                if let Some(ino) = looked_up_inode {
+                    inode::forget_one(fs, ino, 1);
+                }
                 break;
             }
-            Ok(_) => emitted_lookup_refs.push(looked_up_inode),
+            Ok(_) => {
+                if let Some(ino) = looked_up_inode {
+                    emitted_lookup_refs.push(ino);
+                }
+            }
             Err(err) => {
-                inode::forget_one(fs, looked_up_inode, 1);
+                if let Some(ino) = looked_up_inode {
+                    inode::forget_one(fs, ino, 1);
+                }
                 for emitted_inode in emitted_lookup_refs {
                     inode::forget_one(fs, emitted_inode, 1);
                 }
@@ -257,6 +268,26 @@ impl SnapshotEntry for PassthroughDirEntry {
 /// Convert a file mode type to a directory entry type.
 fn mode_to_dtype(mode_type: u32) -> u32 {
     platform::dirent_type_from_mode(mode_type)
+}
+
+/// Whether a failed per-entry lookup means the name is truly gone from the directory (deleted or replaced between snapshot and lookup) rather than temporarily unresolvable.
+///
+/// Errors from `do_lookup` are already translated to Linux errno values; `ENOENT` and `ENOTDIR` are numerically identical on Linux and macOS.
+fn lookup_says_gone(err: &io::Error) -> bool {
+    matches!(err.raw_os_error(), Some(libc::ENOENT) | Some(libc::ENOTDIR))
+}
+
+/// Entry for a dirent whose lookup failed for a reason other than the name being gone (fd exhaustion, I/O error, permissions). `inode: 0` tells the guest kernel that no
+/// lookup was performed: the name still appears in the listing and the real error surfaces when the entry is accessed, instead of silently vanishing from the guest's view.
+fn no_lookup_entry() -> Entry {
+    Entry {
+        inode: 0,
+        generation: 0,
+        attr: unsafe { std::mem::zeroed() },
+        attr_flags: 0,
+        attr_timeout: Duration::ZERO,
+        entry_timeout: Duration::ZERO,
+    }
 }
 
 /// Build a point-in-time directory snapshot with stable synthetic offsets.

--- a/crates/filesystem/lib/backends/passthroughfs/unix/file_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/file_ops.rs
@@ -195,7 +195,13 @@ pub(crate) fn do_flush(
 
     let newfd = unsafe { libc::dup(f.as_raw_fd()) };
     if newfd < 0 {
-        return Err(platform::linux_error(io::Error::last_os_error()));
+        let err = io::Error::last_os_error();
+        // The dup+close idiom exists to trigger POSIX lock release on close, but this server never negotiates remote locks, so there is nothing to release. Under fd
+        // exhaustion, failing here would make guest close() fail at exactly the moment it is trying to shed descriptors — report success instead so the guest can recover.
+        if matches!(err.raw_os_error(), Some(libc::EMFILE) | Some(libc::ENFILE)) {
+            return Ok(());
+        }
+        return Err(platform::linux_error(err));
     }
     let ret = unsafe { libc::close(newfd) };
     if ret < 0 {

--- a/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
@@ -566,6 +566,9 @@ fn get_inode_fd_linux(fs: &PassthroughFs, inode: u64) -> io::Result<InodeFd> {
 
     let current_anchor = current_anchor_alias(&data);
     let candidates = candidate_aliases(&data, current_anchor.clone());
+    // Stale-alias failures (ENOENT/ENOTDIR — the path was renamed or removed) mean "try the next alias" and fall through to ENOENT. Any other reopen failure (EMFILE,
+    // EACCES, EIO) is a host-side problem, not a missing file: preserve it so fd exhaustion does not masquerade as phantom "No such file or directory" in the guest.
+    let mut host_err: Option<io::Error> = None;
     for alias in candidates {
         let mut seen = HashSet::new();
         let components = match build_alias_components_locked(&inodes, &alias, &mut seen) {
@@ -574,7 +577,12 @@ fn get_inode_fd_linux(fs: &PassthroughFs, inode: u64) -> io::Result<InodeFd> {
         };
         let fd = match secure_open_path_linux(fs, &components, libc::O_PATH | libc::O_NOFOLLOW) {
             Ok(fd) => fd,
-            Err(_) => continue,
+            Err(err) => {
+                if !matches!(err.raw_os_error(), Some(libc::ENOENT) | Some(libc::ENOTDIR)) {
+                    host_err = Some(err);
+                }
+                continue;
+            }
         };
         if validate_identity_linux(fd, expected).is_ok() {
             drop(inodes);
@@ -586,7 +594,7 @@ fn get_inode_fd_linux(fs: &PassthroughFs, inode: u64) -> io::Result<InodeFd> {
         unsafe { libc::close(fd) };
     }
 
-    Err(platform::enoent())
+    Err(host_err.unwrap_or_else(platform::enoent))
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_corrupt_xattr.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_corrupt_xattr.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::backends::shared::stat_override::OVERRIDE_XATTR_KEY;
 
 /// Write raw bytes to the override xattr on a host file, bypassing the filesystem.
-fn host_set_raw_xattr(path: &std::path::Path, data: &[u8]) {
+pub(super) fn host_set_raw_xattr(path: &std::path::Path, data: &[u8]) {
     let path_cstr = CString::new(path.to_str().unwrap()).unwrap();
     let file = std::fs::OpenOptions::new()
         .read(true)

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_dir_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_dir_ops.rs
@@ -267,3 +267,82 @@ fn test_readdirplus_skips_dot_dotdot() {
         assert_ne!(de.name, b"..");
     }
 }
+
+#[test]
+fn test_readdirplus_degrades_entry_on_lookup_failure() {
+    let sb = TestSandbox::new();
+    sb.fuse_create_root("ok.txt").unwrap();
+    sb.fuse_create_root("broken.txt").unwrap();
+
+    // Corrupt the override xattr so lookups of broken.txt fail with EIO (strict stat virtualization is on by default in TestSandbox).
+    super::test_corrupt_xattr::host_set_raw_xattr(&sb.root.join("broken.txt"), &[0u8; 5]);
+
+    let handle = sb.fuse_opendir(ROOT_INODE).unwrap();
+    let entries = sb
+        .fs
+        .readdirplus(sb.ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
+
+    // The broken entry must still be listed, degraded to inode 0 ("no lookup performed") rather than silently omitted.
+    let broken = entries.iter().find(|(de, _)| de.name == b"broken.txt");
+    let (_, broken_entry) = broken.expect("broken.txt missing from readdirplus listing");
+    assert_eq!(broken_entry.inode, 0, "degraded entry should have inode 0");
+
+    let ok = entries.iter().find(|(de, _)| de.name == b"ok.txt");
+    let (_, ok_entry) = ok.expect("ok.txt missing from readdirplus listing");
+    assert_ne!(ok_entry.inode, 0, "healthy entry should have a real inode");
+}
+
+#[test]
+fn test_readdirplus_for_each_degrades_entry_on_lookup_failure() {
+    let sb = TestSandbox::new();
+    sb.fuse_create_root("ok.txt").unwrap();
+    sb.fuse_create_root("broken.txt").unwrap();
+
+    super::test_corrupt_xattr::host_set_raw_xattr(&sb.root.join("broken.txt"), &[0u8; 5]);
+
+    let handle = sb.fuse_opendir(ROOT_INODE).unwrap();
+    let mut seen: Vec<(Vec<u8>, u64)> = Vec::new();
+    sb.fs
+        .readdirplus_for_each(sb.ctx(), ROOT_INODE, handle, 65536, 0, &mut |de, entry| {
+            seen.push((de.name.to_vec(), entry.inode));
+            Ok(1)
+        })
+        .unwrap();
+
+    let broken = seen.iter().find(|(name, _)| name == b"broken.txt");
+    let (_, broken_inode) = broken.expect("broken.txt missing from streaming listing");
+    assert_eq!(*broken_inode, 0, "degraded entry should have inode 0");
+
+    let ok = seen.iter().find(|(name, _)| name == b"ok.txt");
+    let (_, ok_inode) = ok.expect("ok.txt missing from streaming listing");
+    assert_ne!(*ok_inode, 0, "healthy entry should have a real inode");
+}
+
+#[test]
+fn test_readdirplus_skips_entry_deleted_after_snapshot() {
+    let sb = TestSandbox::new();
+    sb.fuse_create_root("keep.txt").unwrap();
+    sb.fuse_create_root("gone.txt").unwrap();
+
+    // First readdirplus builds the point-in-time snapshot with both files.
+    let handle = sb.fuse_opendir(ROOT_INODE).unwrap();
+    let entries = sb
+        .fs
+        .readdirplus(sb.ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
+    assert!(entries.iter().any(|(de, _)| de.name == b"gone.txt"));
+
+    // Delete the file on the host; the snapshot still lists it, but the per-entry lookup now fails with ENOENT — a genuine race, so the entry is skipped rather than degraded.
+    std::fs::remove_file(sb.root.join("gone.txt")).unwrap();
+
+    let entries = sb
+        .fs
+        .readdirplus(sb.ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
+    assert!(
+        !entries.iter().any(|(de, _)| de.name == b"gone.txt"),
+        "deleted entry should be skipped, not degraded"
+    );
+    assert!(entries.iter().any(|(de, _)| de.name == b"keep.txt"));
+}

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -453,6 +453,12 @@ pub fn enter(config: Config) -> ! {
 }
 
 fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
+    // Raise the fd limit before anything else: every guest-held open file on a virtiofs share pins one fd in this process, so the shell's default soft limit
+    // (1024 on many distros) is nowhere near enough for real workloads. Reference virtiofsd raises its own limit for the same reason. Best-effort: failure is
+    // not fatal, just a smaller fd budget.
+    #[cfg(unix)]
+    raise_nofile_limit();
+
     // Write startup JSON and redirect output FIRST, before any tracing.
     // This ensures all tracing goes to runtime.log, not the terminal.
     let pid = std::process::id();
@@ -1405,6 +1411,65 @@ fn build_vm(
 //--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
+
+/// Raise `RLIMIT_NOFILE` to the hard limit, capped at 1M (the reference virtiofsd default). On macOS the soft limit is additionally clamped to
+/// `kern.maxfilesperproc`, which `setrlimit` enforces even when the hard limit is unlimited.
+#[cfg(unix)]
+fn raise_nofile_limit() {
+    const TARGET: libc::rlim_t = 1_048_576;
+
+    let mut lim = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut lim) } != 0 {
+        tracing::warn!(
+            error = %std::io::Error::last_os_error(),
+            "getrlimit(RLIMIT_NOFILE) failed; keeping inherited fd limit"
+        );
+        return;
+    }
+
+    let want = lim.rlim_max.min(TARGET);
+    #[cfg(target_os = "macos")]
+    let want = macos_maxfilesperproc().map_or(want, |max| want.min(max));
+
+    if want <= lim.rlim_cur {
+        return;
+    }
+
+    let new = libc::rlimit {
+        rlim_cur: want,
+        rlim_max: lim.rlim_max,
+    };
+    if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &new) } != 0 {
+        tracing::warn!(
+            error = %std::io::Error::last_os_error(),
+            soft = lim.rlim_cur,
+            wanted = want,
+            "setrlimit(RLIMIT_NOFILE) failed; keeping inherited fd limit"
+        );
+    } else {
+        tracing::debug!(from = lim.rlim_cur, to = want, "raised RLIMIT_NOFILE");
+    }
+}
+
+/// Read `kern.maxfilesperproc`, the ceiling macOS enforces on the `RLIMIT_NOFILE` soft limit.
+#[cfg(target_os = "macos")]
+fn macos_maxfilesperproc() -> Option<libc::rlim_t> {
+    let mut maxfiles: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>();
+    let ret = unsafe {
+        libc::sysctlbyname(
+            c"kern.maxfilesperproc".as_ptr(),
+            &mut maxfiles as *mut _ as *mut libc::c_void,
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    (ret == 0 && maxfiles > 0).then_some(maxfiles as libc::rlim_t)
+}
 
 /// Build the host-directory rootfs backend used for `RootfsSource::Bind`.
 ///


### PR DESCRIPTION
## TL;DR
Workloads that hold many files open on a virtiofs share (Gradle, JVMs, `rm -r node_modules`) exhaust the host sandbox process's fd limit, which made files silently vanish from guest listings and blocked recovery. This raises the host fd limit at startup and makes the passthrough backend fail honestly and recoverably when the limit is still hit.

Closes #949

## Description
- Every guest-held open file on a virtiofs share pins one fd in the host sandbox process, so a Gradle daemon plus JDK blows past the common 1024 soft limit and every filesystem op starts failing with EMFILE.
- The sandbox process now raises `RLIMIT_NOFILE` to min(hard, 1M) at startup, same approach as reference virtiofsd; on macOS the soft limit is additionally clamped to `kern.maxfilesperproc`. Windows is unaffected and needs no equivalent.
- readdirplus no longer silently drops entries whose per-entry lookup fails, which was the "sandbox does not see *.lock files" desync in #949: only ENOENT/ENOTDIR (entry deleted between snapshot and lookup) is skipped, any other failure emits the dirent with inode 0 ("no lookup performed") so the name stays listed and the real error surfaces on access.
- flush no longer fails on EMFILE/ENFILE from its dup+close idiom; the dup only exists to release POSIX locks and this server never negotiates remote locks, so failing there just made guest `close()` fail exactly when the guest was trying to shed fds.
- Adds unit tests for the degraded entry (both readdirplus paths, via a corrupt stat-override xattr) and for skipping entries deleted after the snapshot.
- Linux only: `get_inode_fd_linux` no longer masks host errors as ENOENT when reopening an inode by alias. Stale aliases (ENOENT/ENOTDIR) still fall through, but real host failures (EMFILE, EACCES, EIO) now propagate, so fd exhaustion stops surfacing as phantom "No such file or directory" - the exact error shape reported in #949.
- Not addressed here: remote lock support (guest-local locking works correctly within a sandbox, verified with fcntl and flock) and the Windows backend, which fails listings loudly rather than silently and has no practical handle limit.

## Test Plan
- [x] `cargo fmt --all -- --check` is clean
- [x] `cargo test -p microsandbox-filesystem --no-default-features` passes (611 tests, includes 3 new)
- [x] `cargo clippy -p microsandbox-filesystem -p microsandbox-runtime --no-default-features` adds no new warnings (4 pre-existing vm.rs warnings unchanged)
- [x] macOS end-to-end: with shell `ulimit -n 512`, a python sandbox holding 600 open files on a mounted share sees no EMFILE, creates lock files, and lists a complete directory (previously wedged at 323)
- [x] macOS end-to-end: with a hard 512 cap, guest `close()` succeeds while exhausted and listings recover fully after fds are shed
- [x] Linux/KVM end-to-end on ci-runner-ubuntu-2404-x64: sandbox process shows `Max open files 1048576` in /proc with a 1024-soft shell; guest holds 1500 open files cleanly at default limits; under a hard 512 cap errors are EMFILE (not FileNotFoundError), listings stay complete, and close/recovery works (0/376 close errors)


