### PR TITLE
chore(lint): fix clippy 1.97 lints in cli and python sdk

### DIFF
--- a/crates/cli/lib/commands/logs.rs
+++ b/crates/cli/lib/commands/logs.rs
@@ -177,7 +177,7 @@ pub async fn run(args: LogsArgs) -> anyhow::Result<()> {
     if !log_dir.exists() {
         return Err(anyhow!(
             "no logs directory for sandbox {:?} (sandbox not found?)",
-            &args.name
+            args.name
         ));
     }
 

--- a/sdk/python/src/sandbox.rs
+++ b/sdk/python/src/sandbox.rs
@@ -1356,7 +1356,7 @@ fn parse_stdin(stdin: Option<&Bound<'_, PyAny>>) -> PyResult<(Option<String>, Op
     let data = stdin
         .getattr("_data")
         .ok()
-        .and_then(|v| if v.is_none() { None } else { Some(v) })
+        .filter(|v| !v.is_none())
         .map(|v| v.extract::<Vec<u8>>())
         .transpose()?;
     normalize_stdin(mode, data)


### PR DESCRIPTION
## TL;DR
Stable clippy moved to 1.97 on 2026-07-07 and the CI `-D warnings` gate now rejects two pre-existing patterns, so every PR fails the Linux Check jobs until these land. Two one-line fixes, no behavior change.

## Description
- Remove a redundant `&` on `args.name` in an `anyhow!` format argument in the logs command (`useless_borrows_in_formatting`).
- Replace a hand-rolled `.and_then(...)` with `.filter(|v| !v.is_none())` in the python sdk stdin handling (`manual_filter`).
- Both were surfaced by CI's `cargo +stable clippy --workspace -- -D warnings` after the 1.97 release; a full workspace sweep under 1.97 confirms these are the only two new lints.

## Test Plan
- [x] `cargo +1.97.0 clippy --workspace --exclude microsandbox-agentd -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Linux Check jobs pass on this PR (runs in CI)