### PR TITLE
fix(sdk/go): forward guest-write quota to bind mounts

### DIFF
--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -1711,7 +1711,13 @@ fn apply_volume(
 
     Ok(builder.volume(guest_path, move |mb| {
         let mut mb = if let Some(ref host) = bind {
-            mb.bind(host)
+            // A caller-provided guest-write quota overrides the protective
+            // default; None keeps it.
+            let mut b = mb.bind(host);
+            if let Some(quota) = quota_mib {
+                b = b.quota(quota);
+            }
+            b
         } else if let Some(ref name) = named {
             if needs_named_create_options {
                 mb.named_with(name, |mut nb| {

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -1082,6 +1082,11 @@ type MountOptions struct {
 	Nodev              bool
 	StatVirtualization StatVirtualization
 	HostPermissions    HostPermissions
+	// QuotaMiB sets a guest-write quota for a bind mount, bounding how much
+	// the guest may add beyond the host directory's existing contents. Zero
+	// keeps the runtime's protective default. Bind mounts only; named volume
+	// quotas go through NamedVolumeOptions.QuotaMiB instead.
+	QuotaMiB uint32
 }
 
 // NamedVolumeOptions tunes sandbox-time named volume provisioning.
@@ -1136,6 +1141,7 @@ func (mountFactory) Bind(hostPath string, opts MountOptions) MountConfig {
 		Nodev:              opts.Nodev,
 		StatVirtualization: opts.StatVirtualization,
 		HostPermissions:    opts.HostPermissions,
+		QuotaMiB:           opts.QuotaMiB,
 	}
 }
 


### PR DESCRIPTION
## TL;DR

The Go SDK drops `quota_mib` for bind mounts in the FFI layer, so Go callers cannot override the protective 4 GiB default from #1020 the way CLI and Rust SDK callers can. Forward it like the CLI does.

## Description

- `sdk/go/native/src/lib.rs`: the `apply_volume` bind branch now forwards `quota_mib` via `MountBuilder::quota`, mirroring the CLI bind path. `None` still applies the protective default, so behavior is unchanged unless a caller sets a quota.
- `sdk/go/options.go`: add `MountOptions.QuotaMiB` and populate it in `Mount.Bind`, giving Go callers a supported way to set a bind quota instead of writing `MountConfig` fields directly.

## Test Plan

- Build the Go FFI cdylib from this branch; load it via the `microsandbox_ffi_path` build tag with `MICROSANDBOX_FFI_PATH` pointing at the built `.so` (loaded identity confirmed through `/proc/<pid>/maps` + md5).
- From a Go host process, create a sandbox with a directory bind mount and `QuotaMiB: 2048`: guest `df` on the mount reports ~2.1G and `dd if=/dev/zero of=<mount>/fill.bin bs=1M count=5120` fails with ENOSPC at `2047+0 records out` (unpatched baseline: 4.1G and `4095+0 records out`).
- Same with `QuotaMiB: 6144`: guest `df` reports ~6.1G.
- With `QuotaMiB` unset: unchanged 4 GiB protective default.
