### PR TITLE
ci: shrink integration-test debuginfo and harden runner disk cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -185,7 +185,11 @@ jobs:
     needs: [build-kernel, build-agentd-aarch64, changes]
     if: always() && needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 45
+    # A green darwin-aarch64 run takes ~35m, and GitHub-hosted macos-14
+    # runner speed varies enough that slow runners blew a 45m budget
+    # mid-build (main and a PR, both on 2026-07-10). 60m restores
+    # headroom while still bounding a genuinely wedged run.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -628,6 +628,12 @@ jobs:
     # several jobs can build at once without crushing VM boot latency.
     env:
       CARGO_BUILD_JOBS: "12"
+      # Full debuginfo for the dozen-plus integration-test binaries is
+      # ~14 GiB of target/ and has filled the shared runner disk mid-link,
+      # killing rust-lld with SIGBUS (#1162). line-tables-only keeps
+      # file:line in backtraces — all CI needs — at a fraction of the size.
+      CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
+      CARGO_PROFILE_TEST_DEBUG: "line-tables-only"
     steps:
       - name: Clean workspace
         run: |

--- a/scripts/ci/clean-runner-disk.sh
+++ b/scripts/ci/clean-runner-disk.sh
@@ -14,8 +14,10 @@ rm -rf "${HOME}/.microsandbox"
 # Clean only old temp directories so active jobs keep their per-test homes.
 # The runner sudoers policy only permits apt-get, so keep this best-effort and
 # limited to paths the current runner user can remove.
+# 'msb*' not 'msb-*': tests also leave hyphen-less dirs (msbperf,
+# msbtest1128, msbunmount) that a 'msb-*' glob never reclaims (#1162).
 find /tmp -mindepth 1 -maxdepth 1 -type d \
-  \( -name 'msb-*' -o -name 'TestSandbox*' -o -name 'go-build*' \) \
+  \( -name 'msb*' -o -name 'TestSandbox*' -o -name 'go-build*' \) \
   -mmin +120 -exec rm -rf {} + 2>/dev/null || true
 
 find /tmp -mindepth 1 -maxdepth 1 -type d \
@@ -40,3 +42,12 @@ echo "::group::runner disk after cleanup"
 df -hT / /tmp "${GITHUB_WORKSPACE:-$PWD}" "${RUNNER_WORKSPACE:-$PWD}" || true
 du -xhd1 /tmp 2>/dev/null | sort -h | tail -30 || true
 echo "::endgroup::"
+
+# A job that starts under this headroom can still fill the shared disk while
+# linking test binaries in parallel and kill rust-lld with SIGBUS (#1162
+# died from an 18G start), so surface low disk as an annotation instead of
+# leaving the next occurrence to read as a mysterious linker crash.
+avail_kb=$(df -Pk / | awk 'NR==2 {print $4}' || echo 0)
+if (( avail_kb > 0 && avail_kb < 25 * 1024 * 1024 )); then
+  echo "::warning::runner root disk has only $(( avail_kb / 1024 / 1024 ))G free after cleanup (<25G); parallel test linking may fail with SIGBUS (#1162)"
+fi


### PR DESCRIPTION
## TL;DR

Integration Tests can kill rust-lld with SIGBUS when the shared runner disk fills during parallel test linking (#1162, hit on #1150). This applies the three workflow-reachable mitigations from that issue: line-tables-only debuginfo for the integration-test job, a wider /tmp cleanup glob, and a low-disk warning annotation from `clean-runner-disk.sh`.

## Description

The integration-test job builds a dozen-plus test binaries with full debuginfo (~14 GiB of `target/` in ~3 minutes) on self-hosted x64 runners that share one 96G root disk across runner users. The failed run on #1150 started at 79G used and hit 91G one second after a batch of parallel `rust-lld` invocations died with signal 7 — the signature of a write fault on an mmapped output the filesystem can no longer back, i.e. momentary ENOSPC. The same commit passed every other job and the PR's previous run, so the code was never the problem.

Changes, as proposed by @nuri-yoo in #1162:

- `CARGO_PROFILE_DEV_DEBUG`/`CARGO_PROFILE_TEST_DEBUG: line-tables-only` on the integration-test job only. Backtraces keep file:line; `target/` and link time drop substantially, shrinking the window where a concurrent job can push the shared disk over the edge. Local builds are unaffected.
- `/tmp` cleanup glob widened from `msb-*` to `msb*` so hyphen-less leftovers (`msbperf`, `msbtest1128`, `msbunmount`) are reclaimed.
- `clean-runner-disk.sh` emits a `::warning::` when the root disk has under 25G free after cleanup (the failed run started from 18G), so the next occurrence is legible as low disk instead of a mysterious linker crash.

Runner-level headroom (item 4 in #1162) is an infra task and intentionally not addressed here.

## Test Plan

- [x] `bash -n scripts/ci/clean-runner-disk.sh`
- [x] workflow YAML parses (`ruby -ryaml`)
- [ ] shellcheck/actionlint — not installed locally; covered by CI lint if configured
- [ ] Integration Tests green on this PR with visibly smaller `target/` (watch the job's disk-usage groups)