### PR TITLE
Feat/microsandbox oci runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4175,6 +4175,7 @@ dependencies = [
  "microsandbox-vsock",
  "msb_krun",
  "nix 0.31.3",
+ "oci-spec 0.10.0",
  "rand 0.10.2",
  "rustls",
  "sea-orm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6084,6 +6084,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "runmsb"
+version = "0.6.10"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "libc",
+ "microsandbox",
+ "microsandbox-protocol",
+ "microsandbox-runtime",
+ "nix 0.31.3",
+ "oci-spec 0.10.0",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "russh"
 version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/image",
     "crates/metrics",
     "crates/metrics-collector",
+    "crates/oci-runtime",
     "packages/agent-client/rust",
     "packages/microsandbox-types/rust",
     "sdk/rust",

--- a/crates/agentd/lib/init.rs
+++ b/crates/agentd/lib/init.rs
@@ -204,8 +204,9 @@ mod linux {
             "/dev/pts",
             Some("devpts"),
             noexec_nosuid,
-            None::<&str>,
+            Some("ptmxmode=0666,mode=0620"),
         )?;
+        ensure_dev_ptmx()?;
 
         // /dev/shm — tmpfs
         mkdir_ignore_exists("/dev/shm")?;
@@ -242,6 +243,16 @@ mod linux {
             MsFlags::MS_NODEV | MsFlags::MS_NOEXEC | MsFlags::MS_NOSUID | MsFlags::MS_RELATIME;
         mkdir_ignore_exists("/sys")?;
         mount_ignore_busy(Some("sysfs"), "/sys", Some("sysfs"), flags, None::<&str>)
+    }
+
+    fn ensure_dev_ptmx() -> AgentdResult<()> {
+        let ptmx = Path::new("/dev/ptmx");
+        if fs::symlink_metadata(ptmx).is_ok() {
+            return Ok(());
+        }
+
+        unix_fs::symlink("pts/ptmx", ptmx)
+            .map_err(|e| AgentdError::Init(format!("failed to symlink /dev/ptmx: {e}")))
     }
 
     /// Mounts the virtiofs runtime filesystem at the canonical mount point.

--- a/crates/agentd/lib/process.rs
+++ b/crates/agentd/lib/process.rs
@@ -531,6 +531,8 @@ fn signal_process_group_only(pid: i32, signum: i32) -> AgentdResult<()> {
 fn exit_code(status: i32) -> i32 {
     if libc::WIFEXITED(status) {
         libc::WEXITSTATUS(status)
+    } else if libc::WIFSIGNALED(status) {
+        128 + libc::WTERMSIG(status)
     } else {
         -1
     }
@@ -553,6 +555,13 @@ mod tests {
     const HELPER_ENV: &str = "MSB_AGENTD_PROCESS_MANAGER_HELPER";
     const HELPER_SENTINEL: &str = "process-manager-helper-passed";
     const TEST_NAME: &str = "process::tests::reaping_is_batched_and_tracks_exit_codes";
+
+    #[test]
+    fn maps_normal_and_signal_wait_statuses_to_shell_exit_codes() {
+        assert_eq!(exit_code(42 << 8), 42);
+        assert_eq!(exit_code(libc::SIGTERM), 128 + libc::SIGTERM);
+        assert_eq!(exit_code(libc::SIGKILL), 128 + libc::SIGKILL);
+    }
 
     #[test]
     fn reaping_is_batched_and_tracks_exit_codes() {

--- a/crates/agentd/lib/session.rs
+++ b/crates/agentd/lib/session.rs
@@ -620,9 +620,9 @@ impl ExecSession {
                 if libc::setsid() < 0 {
                     return Err(std::io::Error::last_os_error());
                 }
-                apply_exec_security_profile(security_profile).map_err(agentd_to_io_error)?;
+                apply_exec_security_profile(security_profile).map_err(agentd_to_pre_exec_error)?;
                 if let Some(ref user) = resolved_user {
-                    apply_resolved_user(user).map_err(agentd_to_io_error)?;
+                    apply_resolved_user(user).map_err(agentd_to_pre_exec_error)?;
                 }
                 for (resource, limit) in &parsed_rlimits {
                     if libc::setrlimit(*resource as _, limit) != 0 {
@@ -996,6 +996,9 @@ fn lookup_passwd_by_uid(uid: libc::uid_t) -> AgentdResult<ResolvedUserLookup> {
         )
     };
     if rc != 0 {
+        if passwd_lookup_errno_means_missing(rc) {
+            return Ok(ResolvedUserLookup::Numeric(uid));
+        }
         return Err(AgentdError::ExecSession(format!(
             "failed to resolve guest uid {uid}: {}",
             std::io::Error::from_raw_os_error(rc)
@@ -1054,6 +1057,10 @@ fn lookup_buffer_len() -> usize {
     if size > 0 { size as usize } else { 16 * 1024 }
 }
 
+fn passwd_lookup_errno_means_missing(errno: libc::c_int) -> bool {
+    matches!(errno, libc::ENOENT | libc::ESRCH)
+}
+
 fn apply_resolved_user(user: &ResolvedUser) -> AgentdResult<()> {
     if let Some(ref name) = user.initgroups_user {
         if unsafe { libc::initgroups(name.as_ptr(), user.gid) } != 0 {
@@ -1097,8 +1104,12 @@ fn env_contains_key(env: &[String], key: &str) -> bool {
     })
 }
 
-fn agentd_to_io_error(err: AgentdError) -> std::io::Error {
-    std::io::Error::other(err.to_string())
+fn agentd_to_pre_exec_error(err: AgentdError) -> std::io::Error {
+    match err {
+        AgentdError::Io(err) => err,
+        AgentdError::Nix(err) => std::io::Error::from_raw_os_error(err as i32),
+        _ => std::io::Error::from_raw_os_error(libc::EINVAL),
+    }
 }
 
 /// Writes data to a raw fd using a blocking task, handling short writes.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -27,6 +27,7 @@ net = [
     "dep:ipnetwork",
     "dep:thiserror",
 ]
+oci-runtime = ["microsandbox/oci-runtime", "microsandbox-runtime/oci-runtime"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -55,6 +55,11 @@ pub struct SandboxArgs {
     #[arg(long = "startup-fd", hide = true)]
     pub startup_fd: Option<i32>,
 
+    /// Terminal inherited for the startup workload.
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    #[arg(long = "oci-console-fd", hide = true)]
+    pub oci_console_fd: Option<i32>,
+
     /// Inherited descriptor owning this sandbox's lifecycle lock.
     #[cfg(unix)]
     #[arg(long = "lifecycle-lock-fd", hide = true)]
@@ -136,6 +141,14 @@ pub fn run(args: SandboxArgs) -> ! {
     };
     #[cfg(unix)]
     let startup_fd = match args.startup_fd.map(startup_from_fd).transpose() {
+        Ok(fd) => fd,
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(2);
+        }
+    };
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    let startup_console = match args.oci_console_fd.map(startup_console_from_fd).transpose() {
         Ok(fd) => fd,
         Err(err) => {
             eprintln!("{err}");
@@ -276,6 +289,8 @@ pub fn run(args: SandboxArgs) -> ! {
         startup_command: launch.startup,
         #[cfg(unix)]
         startup_fd,
+        #[cfg(all(unix, feature = "oci-runtime"))]
+        startup_console,
         #[cfg(windows)]
         startup_pipe: args.startup_pipe,
         #[cfg(unix)]
@@ -375,6 +390,21 @@ fn parent_watchdog_from_fd(fd: i32) -> Result<OwnedFd, String> {
 #[cfg(unix)]
 fn startup_from_fd(fd: i32) -> Result<OwnedFd, String> {
     validate_pipe_fd(fd, microsandbox_runtime::vm::STARTUP_FD, "startup-fd")?;
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+#[cfg(all(unix, feature = "oci-runtime"))]
+fn startup_console_from_fd(fd: i32) -> Result<OwnedFd, String> {
+    validate_open_fd(
+        fd,
+        microsandbox_runtime::vm::OCI_CONSOLE_FD,
+        "oci-console-fd",
+    )?;
+    if unsafe { libc::isatty(fd) } != 1 {
+        return Err(format!(
+            "invalid --oci-console-fd {fd}: fd is not a terminal"
+        ));
+    }
     Ok(unsafe { OwnedFd::from_raw_fd(fd) })
 }
 
@@ -648,6 +678,8 @@ mod tests {
             parent_watch_fd: None,
             #[cfg(unix)]
             startup_fd: None,
+            #[cfg(all(unix, feature = "oci-runtime"))]
+            oci_console_fd: None,
             #[cfg(unix)]
             lifecycle_lock_fd: None,
             #[cfg(windows)]

--- a/crates/network/lib/network.rs
+++ b/crates/network/lib/network.rs
@@ -218,8 +218,10 @@ impl SmoltcpNetwork {
         let gateway_mac = derive_gateway_mac(slot);
         let mtu = config.interface.mtu.unwrap_or(1500);
 
+        let ipv4_requested =
+            config.interface.ipv4_address.is_some() || config.interface.ipv4_pool.is_some();
         let guest_ipv4 = config.interface.ipv4_address.or_else(|| {
-            host_has_ipv4.then(|| {
+            (host_has_ipv4 || ipv4_requested).then(|| {
                 derive_guest_ipv4(
                     config
                         .interface
@@ -230,8 +232,10 @@ impl SmoltcpNetwork {
             })
         });
         let gateway_ipv4 = guest_ipv4.map(gateway_from_guest_ipv4);
+        let ipv6_requested =
+            config.interface.ipv6_address.is_some() || config.interface.ipv6_pool.is_some();
         let guest_ipv6 = config.interface.ipv6_address.or_else(|| {
-            host_has_ipv6.then(|| {
+            (host_has_ipv6 || ipv6_requested).then(|| {
                 derive_guest_ipv6(
                     config
                         .interface
@@ -777,6 +781,17 @@ mod tests {
             derive_guest_ipv4(pool, 63),
             Ipv4Addr::new(172, 31, 240, 254)
         );
+    }
+
+    #[test]
+    fn explicit_ipv4_pool_survives_missing_startup_route() {
+        let mut config = NetworkConfig::default();
+        config.interface.ipv4_pool = Some(default_guest_ipv4_pool());
+
+        let network = SmoltcpNetwork::new_with_routes(config, 0, false, false).unwrap();
+
+        assert_eq!(network.guest_ipv4, Some(Ipv4Addr::new(172, 16, 0, 2)));
+        assert_eq!(network.gateway_ipv4, Some(Ipv4Addr::new(172, 16, 0, 1)));
     }
 
     #[test]

--- a/crates/oci-runtime/Cargo.toml
+++ b/crates/oci-runtime/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "runmsb"
+description = "OCI Runtime Specification-compatible runtime binary for Microsandbox."
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "runmsb"
+path = "bin/main.rs"
+required-features = ["runmsb"]
+
+[lib]
+name = "runmsb"
+path = "lib/lib.rs"
+
+[features]
+default = []
+runmsb = [
+    "dep:anyhow",
+    "dep:chrono",
+    "dep:clap",
+    "dep:libc",
+    "dep:microsandbox",
+    "microsandbox/oci-runtime",
+    "dep:microsandbox-protocol",
+    "dep:microsandbox-runtime",
+    "microsandbox-runtime/oci-runtime",
+    "dep:nix",
+    "dep:oci-spec",
+    "dep:serde_json",
+    "dep:tokio",
+    "dep:tracing",
+    "dep:tracing-subscriber",
+]
+
+[dependencies]
+anyhow = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
+libc = { workspace = true, optional = true }
+microsandbox = { workspace = true, features = ["net"], optional = true }
+microsandbox-protocol = { workspace = true, optional = true }
+microsandbox-runtime = { workspace = true, features = ["net"], optional = true }
+nix = { workspace = true, features = ["fs", "signal", "socket", "term", "uio"], optional = true }
+oci-spec = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/oci-runtime/README.md
+++ b/crates/oci-runtime/README.md
@@ -1,0 +1,466 @@
+# Microsandbox OCI Runtime Contribution Report
+
+## Overview
+
+This patch adds an experimental runc-compatible runtime named `runmsb`. It adapts
+Microsandbox's existing libkrun microVM and `agentd` process APIs to the OCI lifecycle expected by
+Docker and containerd.
+
+The patch demonstrates that basic Docker workloads can run through Microsandbox, but it is not yet
+a complete OCI implementation. In particular, pause/resume, hooks, cgroups, security policies, and
+complete Docker networking are still missing. This report describes the implementation, its current
+limits, and the decisions that need maintainer agreement before the runtime becomes supported.
+
+## Changes in this patch
+
+| Area | Files | Reason |
+| --- | --- | --- |
+| OCI model | `crates/runtime/lib/oci/*` | Parse bundles, persist state, and validate lifecycle transitions independently of the CLI. |
+| Runtime executable | `crates/oci-runtime/*` | Provide runc-style commands, console handling, error logging, feature reporting, and VMM-supervised init startup. |
+| Guest PTY/processes | `crates/agentd/lib/init.rs`, `session.rs` | Support `/dev/ptmx`, controlling terminals, bare commands through `PATH`, and numeric OCI users. |
+| Firmware discovery | `sdk/rust/lib/config/mod.rs` | Preserve explicit `libkrunfw` overrides and packaged Microsandbox layouts. |
+| Sandbox startup | `sdk/rust/lib/runtime/spawn.rs` | Preserve detached startup stderr and include it in caller-facing errors. |
+| stdin handling | `sdk/rust/lib/sandbox/exec.rs`, `backend/cloud.rs` | Send EOF for null/fixed stdin so non-interactive processes do not hang. |
+
+The OCI bundle is parsed with `oci-spec`. The patch does not introduce another VM engine;
+Microsandbox remains responsible for launching and managing libkrun-backed microVMs.
+
+## Architecture
+
+The current implementation is a standalone OCI runtime CLI, not a Microsandbox-specific
+containerd shim:
+
+```text
+Docker
+  -> containerd
+  -> containerd-shim-runc-v2
+  -> runmsb
+  -> Microsandbox SDK/runtime
+  -> libkrun VMM on the host
+  -> guest Linux
+  -> agentd
+  -> OCI process
+```
+
+The host runs Docker, containerd, the OCI runtime, `msb`, and libkrun. The guest is the Linux
+environment inside the microVM and contains `agentd` and the OCI processes.
+
+### Responsibilities
+
+| Component | Responsibility |
+| --- | --- |
+| Docker/containerd | Create the OCI bundle, invoke lifecycle commands, attach I/O, and consume exit state. |
+| `runmsb` | Translate OCI commands and configuration into Microsandbox operations. |
+| OCI state store | Preserve state between separate CLI invocations. |
+| Microsandbox/libkrun | Create and own the microVM; the VMM process is the host PID Docker/containerd watches. |
+| `agentd` | Spawn, signal, and observe processes inside the guest. |
+
+`agentd` is inside the VM because host processes cannot directly manage guest PIDs through host
+`/proc`. The host-side process Docker/containerd watches is the persistent Microsandbox VMM process,
+not a separate stand-in monitor.
+
+## Why the implementation is split across two crates
+
+`crates/runtime/lib/oci` contains reusable OCI data and state logic:
+
+```text
+bundle.rs       bundle/config.json loading and validation
+state.rs        OCI state plus Microsandbox extension state
+store.rs        filesystem-backed runtime state
+lifecycle.rs    operation and state-transition validation
+error.rs        typed OCI errors
+```
+
+`crates/oci-runtime` contains the executable integration:
+
+```text
+lib/lib.rs      thin module root and public re-exports
+lib/runtime.rs  OCI-to-Microsandbox lifecycle operations
+lib/sandbox.rs  Microsandbox construction and host PID discovery
+lib/process.rs  guest process execution, signals, and pid files
+lib/console.rs  runtime-side host/guest console bridge
+lib/requests.rs VMM start, signal, session, and exit handoff files
+lib/options.rs  public lifecycle option types
+bin/main.rs     command dispatch
+bin/cli.rs      global options
+bin/commands.rs lifecycle arguments
+bin/console.rs  console socket and PTY handling
+bin/features.rs runtime capability response
+bin/logging.rs  caller-facing error logs
+```
+
+This keeps Clap and Docker/containerd CLI conventions out of the reusable runtime crate. A future
+containerd shim could reuse the bundle, state, and transition types without invoking this CLI.
+
+## OCI mapping
+
+| OCI concept | Current mapping |
+| --- | --- |
+| Bundle | Caller-owned directory containing `config.json` and the referenced rootfs. |
+| Container ID | Maps to a Microsandbox name derived by `sandbox_name_for_container`. |
+| Runtime `--root` | Host directory containing one state directory per container. |
+| Rootfs | Used as the Microsandbox sandbox root filesystem source. |
+| Init/exec process | Guest process started through the Microsandbox protocol and `agentd`. |
+| Host PID | PID of the persistent Microsandbox VMM process recorded for Docker/containerd. |
+| Guest PID | PID reported by `agentd` and stored as extension state. |
+| Console socket | Host socket used to transfer the PTY master to containerd; the slave is inherited directly by the VMM on fixed FD 100. |
+| MicroVM | Currently one microVM per OCI container. |
+
+The runtime must not delete the OCI bundle because Docker/containerd owns it. `delete` removes the
+Microsandbox sandbox and runtime-owned state only.
+
+## Lifecycle implementation
+
+| Command | Current behavior |
+| --- | --- |
+| `create` | Parse the bundle, create durable `created` state, create a detached microVM in OCI startup-gated mode, and write the VMM pid file. |
+| `start` | Publish the VMM start gate, wait for the VMM to create the `agentd` exec session, and mark the state `running`. |
+| `run` | Perform `create` and `start`, wait for the guest init process and VMM to stop, then return the init process exit code. |
+| `exec` | Load `--process` JSON and start an additional guest process; console and non-console paths are supported. |
+| `kill` | Signal the guest init session through `agentd` when it exists; killing a created-but-not-started container stops the VMM instead of queuing stale work. `--all` is unsupported. |
+| `state` | Reconcile and print OCI-compatible persisted state. |
+| `delete` | Stop/remove the sandbox when allowed and remove runtime-owned state. |
+| `pause` / `resume` | Parsed for compatibility but return explicit not-implemented errors. |
+
+The default state root is `/run/runmsb`:
+
+```text
+/run/runmsb/<container-id>/
+  state.json
+  start.request
+  init.session
+  init.session.exit
+```
+
+The expected state flow is:
+
+```text
+absent -> created -> running -> stopped -> absent
+```
+
+## Supporting fixes discovered during Docker integration
+
+### Guest command and PTY execution
+
+OCI images commonly specify bare commands such as `bash` or `sleep`. Guest PTY spawning now uses a
+conventional default `PATH`, preserves OCI environment overrides, creates a controlling terminal,
+and reports normal spawn errors. Guest initialization creates `/dev/ptmx -> pts/ptmx` after mounting
+devpts so interactive applications can allocate terminals.
+
+### Null stdin must produce EOF
+
+`agentd` starts non-TTY processes with a stdin pipe. Previously `StdinMode::Null` sent no protocol
+message, leaving that pipe open. Programs such as `cat` or Python reading from stdin waited forever.
+
+The shared stdin policy is now:
+
+```text
+Null        -> send an empty ExecStdin frame (EOF)
+Pipe        -> send nothing initially and keep stdin open
+Bytes(data) -> send data followed by an empty EOF frame
+```
+
+Both local and cloud backends use the same helper.
+
+### Detached startup errors
+
+Detached startup uses a dedicated pipe on file descriptor 98 for `{"pid": ...}` startup JSON.
+Previously the child's stderr was discarded, so containerd received only a generic failure.
+
+The SDK now writes detached startup stderr to:
+
+```text
+<sandbox>/logs/startup.stderr.log
+```
+
+If startup times out or exits before valid JSON, the final 8 KiB is included in the runtime error
+that containerd reports to Docker.
+
+### libkrunfw discovery
+
+The SDK still resolves `libkrunfw` from explicit Microsandbox-controlled sources:
+
+```text
+MSB_LIBKRUNFW_PATH
+SDK-provided packaged path
+config.paths.libkrunfw
+paths next to the resolved msb binary
+{home}/lib
+```
+
+For Linux layouts next to `msb` or under `{home}/lib`, discovery considers:
+
+```text
+libkrunfw.so.<exact-version>
+libkrunfw.so.<supported-ABI>
+libkrunfw.so
+```
+
+It intentionally does not search global system library directories such as `/usr/lib` or
+`/usr/local/lib`. That keeps this patch from silently binding `runmsb` to a host libkrunfw build
+that was not shipped or selected by Microsandbox. Developers can still set `MSB_LIBKRUNFW_PATH`
+when they need to test a system package explicitly.
+
+### Network namespace isolation
+
+Docker configures networking in the network namespace of the PID returned by the OCI runtime. The
+runtime now returns the VMM PID, so Docker attaches networking to the process that owns the
+Microsandbox userspace virtio-net backend.
+
+When the OCI bundle requests a network namespace, the VMM process calls `unshare(CLONE_NEWNET)`
+before libkrun starts. Docker can then attach its veth to the VMM namespace without conflicting with
+the host route table. The guest still uses the normal Microsandbox-managed userspace virtio-net
+path, but that backend now runs inside the OCI network namespace.
+
+This removes the route conflict and preserves outbound Microsandbox networking, but it is not full
+Docker bridge integration. Docker's veth is not connected to the guest virtio-net backend, so
+published ports, user-defined networks, aliases, static addresses, and container-to-container
+networking remain incomplete.
+
+### Signal ownership and exit status
+
+The VMM owns the startup command lifecycle. After `runmsb start` publishes `start.request`, the VMM
+asks `agentd` to start the OCI init process and writes the accepted session ID to `init.session`.
+Later `runmsb kill` uses that session ID to send the requested signal through `agentd`. The VMM
+sets its own exit code from the startup command result before shutting the guest down, so
+containerd can observe the tracked host PID exit with the workload status.
+
+## Comparison with existing runtimes
+
+| Runtime | Model | Relevance to this patch |
+| --- | --- | --- |
+| runc | Short-lived OCI CLI using host namespaces/cgroups | Defines the command and state behavior being imitated. |
+| crun | C OCI CLI with strong systemd/cgroup support | Demonstrates the compatibility flags and host integration mature runtimes support. |
+| youki | Rust CLI over reusable container libraries | Supports the decision to separate command parsing from reusable OCI state logic. |
+| runsc | runc-compatible CLI backed by a longer-lived sandbox | Shows how an OCI facade can sit in front of a different isolation engine. |
+| Kata | containerd shim plus in-guest `kata-agent`, often one VM per pod | Closest reference for a VM runtime and guest agent, but significantly broader than this patch. |
+
+Microsandbox `agentd` is similar to `kata-agent` only in placement and basic process responsibility.
+It does not currently create multiple independently managed guest containers with separate rootfs,
+mount, and lifecycle state.
+
+## OCI runtime versus containerd shim
+
+A shim is a long-lived host process between containerd and a task implementation. It owns task I/O,
+wait/exit behavior, events, and recovery. It does not run inside the VM and does not replace the
+guest agent.
+
+| Concern | Current implementation | Native Microsandbox shim |
+| --- | --- | --- |
+| Entry point | `containerd-shim-runc-v2` invokes `runmsb` commands | `containerd-shim-microsandbox-v2` implements TaskService directly |
+| Lifetime | Short CLI calls plus one VMM process per container | Long-lived process for a task or sandbox |
+| State | Files plus VMM-owned startup handoff | Shim-owned task state plus recovery metadata |
+| I/O and exits | VMM startup command stream | Shim task streams and events |
+| VM sharing | One VM per OCI container | Could choose one VM per container or pod |
+| Guest control | `agentd` | `agentd` or an expanded guest API is still required |
+
+The existing runc-v2 shim does not understand Microsandbox. It works only because this runtime
+implements the runc-style command surface it expects.
+
+## Current gaps
+
+- OCI hooks are not executed.
+- Cgroups and resource updates are not implemented.
+- Capabilities, seccomp, AppArmor, SELinux, and complete namespace semantics are not applied.
+- `pause`, `resume`, `kill --all`, `update`, and checkpoint/restore are unsupported.
+- Command-style `exec` is incomplete; process-file and detached `exec` are supported.
+- Non-TTY attached stdin (`docker run -i` without `-t`) needs explicit OCI file-descriptor support.
+- Docker bridge networking and published ports are incomplete.
+- State/shim restart recovery has not been tested.
+- OCI runtime-tools and containerd conformance suites have not been added.
+- Start, signal, session, and exit handoff still use polled files; a future VMM control API should
+  replace them with direct requests over the persistent control channel.
+- The OCI-specific VMM supervisor path is enabled only by the `oci-runtime` feature. Normal
+  Microsandbox builds retain the standard detached-startup behavior and do not expose the OCI
+  start, signal, session, exit, console, or network-namespace handoff.
+
+Every accepted OCI field should eventually be implemented or rejected explicitly. Parsing a flag
+without applying its semantics must not be presented as security or OCI compliance.
+
+## Decisions requested from maintainers
+
+1. Should we ship `runmsb` as an official binary now, or keep it experimental while
+   OCI support is still incomplete?
+2. When Docker/containerd pass flags we do not fully support yet, should we accept them for
+   compatibility or fail with a clear error?
+3. Which namespaces, cgroups, hooks, mounts, and security controls are required for the first
+   accepted OCI milestone?
+4. Is the VMM-as-host-PID model acceptable, and should networking continue through the existing
+   userspace virtio-net backend?
+5. Should pause freeze guest processes, suspend the VM, or combine both mechanisms?
+6. Is one OCI container per VM the intended long-term policy?
+7. Is a native containerd shim in scope for this project?
+8. What test threshold is required before the runtime is no longer experimental?
+
+## Kubernetes requires a separate decision
+
+This patch does not add Kubernetes support. It only adds the first OCI/Docker layer. If
+Kubernetes is wanted later, we should choose one of these paths:
+
+### A. Stop at OCI/Docker
+
+Only finish `runmsb` as a Docker/containerd OCI runtime.
+
+This means:
+
+- `docker run` and basic OCI commands are the target.
+- Kubernetes is not promised.
+- We do not need to support CRI, CNI, pod volumes, or Kubernetes conformance in this patch.
+
+### B. Add a one-container-per-VM shim
+
+Build a real `containerd-shim-microsandbox-v2`.
+
+This means containerd would talk directly to a Microsandbox shim instead of using
+`containerd-shim-runc-v2` plus `runmsb`.
+
+The model would still be:
+
+```text
+one container = one Microsandbox VM
+```
+
+This gives better containerd events, wait handling, and recovery. But Kubernetes pods with sidecars
+would become multiple VMs, so we would need to decide if that cost and behavior are acceptable.
+
+### C. Build a Kata-style VM-per-pod runtime
+
+Build something closer to Kata Containers.
+
+The model would be:
+
+```text
+one Kubernetes pod = one Microsandbox VM
+many containers can run inside that VM
+```
+
+This would require much more work. `agentd` would need to manage multiple containers inside the VM,
+not just start processes. It would need container IDs, separate root filesystems, mounts, process
+state, networking, volumes, resources, and recovery.
+
+So this patch should not be described as Kubernetes support. Kubernetes should be a separate
+maintainer decision, with its own design and testing plan.
+
+## Validation completed
+
+```text
+OCI runtime library tests:       17 passed
+OCI runtime binary tests:         3 passed
+Rust SDK library tests:         362 passed
+Snapshot integration tests:      19 passed with writable MSB_HOME
+Focused agentd session tests:     14 passed
+Workspace and agentd formatting: passed
+Affected-crate and agentd Clippy: passed with warnings denied
+Guest agent, msb, and runtime builds: passed
+Runtime version/features probe:  passed
+```
+
+The complete `agentd` run previously passed 102 tests. Two unrelated TCP tests failed in a
+restricted test environment because socket creation returned `EPERM`. Docker tests were completed
+on Linux with KVM, including create/start, attached output, TTY, exec, SIGTERM exit status, removal,
+DNS, and outbound TCP. Reviewers should repeat them on their host configuration.
+
+## Build and install
+
+Prerequisites include Rust, the normal Microsandbox native dependencies, `/dev/kvm`, libkrun,
+a Microsandbox-provided libkrunfw path or `MSB_LIBKRUNFW_PATH`, and Docker Engine.
+
+`runmsb` is feature-gated because it is still experimental. Its `runmsb` feature enables the
+matching `oci-runtime` support in the Rust SDK and runtime crate. The separately installed `msb`
+binary must be built with the same support.
+
+```bash
+just setup
+just build
+
+cargo build -p microsandbox-cli --features oci-runtime --bin msb
+cargo build -p runmsb --features runmsb --bin runmsb
+sudo install -m 0755 target/debug/msb /usr/local/bin/msb
+sudo install -m 0755 target/debug/runmsb /usr/local/bin/runmsb
+```
+
+Add the runtime while preserving the other keys in `/etc/docker/daemon.json`:
+
+```json
+{
+  "runtimes": {
+    "runmsb": {
+      "path": "/usr/local/bin/runmsb"
+    }
+  }
+}
+```
+
+Validate and restart Docker:
+
+```bash
+sudo dockerd --validate --config-file /etc/docker/daemon.json
+sudo systemctl restart docker
+docker info --format '{{json .Runtimes}}'
+```
+
+## Reviewer test commands
+
+Runtime probe:
+
+```bash
+runmsb --version
+runmsb features
+```
+
+Separate `create` and `start`:
+
+```bash
+docker rm -f msb-created 2>/dev/null || true
+docker create --name msb-created --runtime runmsb hello-world:latest
+docker inspect -f '{{.State.Status}}' msb-created
+docker start -a msb-created
+docker inspect -f '{{.State.Status}} {{.State.ExitCode}}' msb-created
+docker rm msb-created
+```
+
+Basic run and null-stdin EOF:
+
+```bash
+docker run --rm --runtime runmsb hello-world:latest
+docker run --rm --runtime runmsb alpine:latest cat
+docker run --rm --runtime runmsb python:3.12
+```
+
+TTY:
+
+```bash
+docker run --rm --runtime runmsb -it ubuntu:latest /bin/bash
+```
+
+Outbound DNS/TCP, which does not prove Docker bridge or published-port support:
+
+```bash
+docker run --rm --runtime runmsb python:3.12 \
+  python -c "import socket; print(socket.getaddrinfo('example.com',80)[0][4][0]); s=socket.create_connection(('1.1.1.1',53),timeout=3); print('tcp_ok'); s.close()"
+```
+
+Detached lifecycle, exec, signal, and delete:
+
+```bash
+docker rm -f msb-sleep 2>/dev/null || true
+docker run -d --name msb-sleep --runtime runmsb ubuntu:latest sleep 300
+docker inspect -f '{{.State.Status}} {{.State.Pid}}' msb-sleep
+docker exec msb-sleep /bin/sh -c 'echo EXEC_OK; id; pwd'
+docker kill --signal TERM msb-sleep
+docker wait msb-sleep
+docker inspect -f '{{.State.Status}} {{.State.ExitCode}}' msb-sleep
+docker rm msb-sleep
+```
+
+The expected wait and inspect exit code after SIGTERM is `143`.
+
+Known unsupported pause behavior:
+
+```bash
+docker run -d --name msb-pause --runtime runmsb ubuntu:latest sleep 300
+docker pause msb-pause
+docker rm -f msb-pause
+```
+
+`docker pause` is currently expected to report that pause is not implemented.

--- a/crates/oci-runtime/bin/cli.rs
+++ b/crates/oci-runtime/bin/cli.rs
@@ -1,0 +1,83 @@
+//! Command-line parsing for the `runmsb` binary.
+
+use std::path::PathBuf;
+
+use clap::{Parser, ValueEnum};
+
+use super::commands::Command;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// OCI Runtime Specification-compatible runtime for Microsandbox.
+#[derive(Debug, Parser)]
+#[command(name = "runmsb", version)]
+pub(crate) struct Cli {
+    /// Root directory for OCI runtime state.
+    #[arg(short = 'r', long, global = true, value_name = "DIR", default_value = default_root())]
+    pub(crate) root: PathBuf,
+
+    /// Enable debug logging.
+    #[arg(long, global = true)]
+    pub(crate) debug: bool,
+
+    /// Log file path used by Docker/containerd for runtime diagnostics.
+    #[arg(short = 'l', long, global = true, value_name = "FILE")]
+    pub(crate) log: Option<PathBuf>,
+
+    /// Log format expected by the caller.
+    #[arg(long, global = true, value_enum, default_value_t = LogFormat::Text)]
+    pub(crate) log_format: LogFormat,
+
+    /// Log level expected by crun-compatible callers.
+    #[arg(long, global = true, value_enum)]
+    pub(crate) log_level: Option<LogLevel>,
+
+    /// Accept crun-compatible cgroup manager selection.
+    #[arg(long, global = true, value_name = "MANAGER")]
+    pub(crate) cgroup_manager: Option<String>,
+
+    /// Accept runc/youki-compatible systemd cgroup flag.
+    #[arg(short = 's', long, global = true)]
+    pub(crate) systemd_cgroup: bool,
+
+    /// Accept runc-compatible rootless mode flag.
+    #[arg(long, global = true, value_name = "MODE")]
+    pub(crate) rootless: Option<String>,
+
+    /// OCI lifecycle command.
+    #[command(subcommand)]
+    pub(crate) command: Command,
+}
+
+/// Runtime log format.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum LogFormat {
+    /// Human-readable text logs.
+    Text,
+
+    /// JSON log records.
+    Json,
+}
+
+/// Runtime log level.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum LogLevel {
+    /// Error-level diagnostics only.
+    Error,
+
+    /// Warning-level diagnostics.
+    Warning,
+
+    /// Debug-level diagnostics.
+    Debug,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn default_root() -> &'static str {
+    "/run/runmsb"
+}

--- a/crates/oci-runtime/bin/commands.rs
+++ b/crates/oci-runtime/bin/commands.rs
@@ -1,0 +1,232 @@
+//! OCI lifecycle command definitions.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// OCI lifecycle commands.
+#[derive(Debug, Subcommand)]
+pub(crate) enum Command {
+    /// Create a container environment from an OCI bundle.
+    Create(CreateCommand),
+
+    /// Start the configured OCI init process.
+    Start(ContainerIdCommand),
+
+    /// Create and start a container in one command.
+    Run(RunCommand),
+
+    /// Execute an additional process in a running container.
+    Exec(Box<ExecCommand>),
+
+    /// Send a signal to a container.
+    Kill(KillCommand),
+
+    /// Delete container state.
+    Delete(DeleteCommand),
+
+    /// Print OCI state JSON.
+    State(ContainerIdCommand),
+
+    /// Pause a running container.
+    Pause(ContainerIdCommand),
+
+    /// Resume a paused container.
+    Resume(ContainerIdCommand),
+
+    /// Print runtime feature metadata.
+    Features,
+
+    /// Run the host-side proxy for one detached OCI exec process.
+    #[command(name = "__exec-supervisor", hide = true)]
+    ExecSupervisor(ExecSupervisorCommand),
+}
+
+/// Arguments for `create`.
+#[derive(Debug, Args)]
+pub(crate) struct CreateCommand {
+    /// Options shared by `create` and `run`.
+    #[command(flatten)]
+    pub(crate) options: CreateRunOptions,
+
+    /// OCI container ID.
+    pub(crate) id: String,
+}
+
+/// Arguments for `run`.
+#[derive(Debug, Args)]
+pub(crate) struct RunCommand {
+    /// Options shared by `create` and `run`.
+    #[command(flatten)]
+    pub(crate) options: CreateRunOptions,
+
+    /// OCI container ID.
+    pub(crate) id: String,
+}
+
+/// Options shared by `create` and `run`.
+#[derive(Debug, Args)]
+pub(crate) struct CreateRunOptions {
+    /// Path to the OCI bundle directory.
+    #[arg(short = 'b', long, value_name = "DIR", default_value = ".")]
+    pub(crate) bundle: PathBuf,
+
+    /// Write the Microsandbox VMM host PID to this file.
+    #[arg(long, value_name = "FILE")]
+    pub(crate) pid_file: Option<PathBuf>,
+
+    /// Console socket path supplied by Docker/containerd for TTY containers.
+    #[arg(long, value_name = "SOCKET")]
+    pub(crate) console_socket: Option<PathBuf>,
+
+    /// Pidfd socket path supplied by newer runc callers.
+    #[arg(long, value_name = "SOCKET")]
+    pub(crate) pidfd_socket: Option<PathBuf>,
+
+    /// Accept runc-compatible no-pivot flag.
+    #[arg(long)]
+    pub(crate) no_pivot: bool,
+
+    /// Accept runc-compatible no-new-keyring flag.
+    #[arg(long)]
+    pub(crate) no_new_keyring: bool,
+
+    /// Accept runc-compatible preserved file descriptor count.
+    #[arg(long, value_name = "N", default_value_t = 0)]
+    pub(crate) preserve_fds: u32,
+}
+
+/// Arguments for `exec`.
+#[derive(Debug, Args)]
+pub(crate) struct ExecCommand {
+    /// Path to an OCI process JSON file.
+    #[arg(short = 'p', long, value_name = "FILE")]
+    pub(crate) process: Option<PathBuf>,
+
+    /// Console socket path supplied by Docker/containerd for TTY exec.
+    #[arg(long, value_name = "SOCKET")]
+    pub(crate) console_socket: Option<PathBuf>,
+
+    /// Pidfd socket path supplied by newer runc callers.
+    #[arg(long, value_name = "SOCKET")]
+    pub(crate) pidfd_socket: Option<PathBuf>,
+
+    /// Working directory for command-style exec.
+    #[arg(long, value_name = "DIR")]
+    pub(crate) cwd: Option<PathBuf>,
+
+    /// Environment entry for command-style exec.
+    #[arg(short = 'e', long, value_name = "KEY=VALUE")]
+    pub(crate) env: Vec<String>,
+
+    /// Allocate a pseudo-TTY.
+    #[arg(short = 't', long)]
+    pub(crate) tty: bool,
+
+    /// User for command-style exec.
+    #[arg(short = 'u', long, value_name = "UID[:GID]")]
+    pub(crate) user: Option<String>,
+
+    /// Additional group IDs.
+    #[arg(short = 'g', long, value_name = "GID")]
+    pub(crate) additional_gids: Vec<String>,
+
+    /// Detach from the exec process.
+    #[arg(short = 'd', long)]
+    pub(crate) detach: bool,
+
+    /// Write the exec process PID to this file.
+    #[arg(long, value_name = "FILE")]
+    pub(crate) pid_file: Option<PathBuf>,
+
+    /// SELinux process label.
+    #[arg(long, value_name = "LABEL")]
+    pub(crate) process_label: Option<String>,
+
+    /// AppArmor profile.
+    #[arg(long, value_name = "PROFILE")]
+    pub(crate) apparmor: Option<String>,
+
+    /// Set no-new-privileges for the exec process.
+    #[arg(long)]
+    pub(crate) no_new_privs: bool,
+
+    /// Add a capability to the exec process.
+    #[arg(short = 'c', long, value_name = "CAP")]
+    pub(crate) cap: Vec<String>,
+
+    /// Accept runc-compatible preserved file descriptor count.
+    #[arg(long, value_name = "N", default_value_t = 0)]
+    pub(crate) preserve_fds: u32,
+
+    /// Run the process in a sub-cgroup.
+    #[arg(long, value_name = "CGROUP")]
+    pub(crate) cgroup: Option<String>,
+
+    /// Allow exec in a paused container.
+    #[arg(long)]
+    pub(crate) ignore_paused: bool,
+
+    /// OCI container ID.
+    pub(crate) id: String,
+
+    /// Command-style exec arguments.
+    #[arg(trailing_var_arg = true)]
+    pub(crate) command: Vec<String>,
+}
+
+/// Internal arguments used by the detached OCI exec supervisor.
+#[derive(Debug, Args)]
+pub(crate) struct ExecSupervisorCommand {
+    /// Path to the OCI process JSON supplied by containerd.
+    #[arg(long, value_name = "FILE")]
+    pub(crate) process: PathBuf,
+
+    /// Host PTY slave used to bridge a terminal exec session.
+    #[arg(long, value_name = "PATH")]
+    pub(crate) console: Option<PathBuf>,
+
+    /// File where the supervisor publishes its host PID after guest startup.
+    #[arg(long, value_name = "FILE")]
+    pub(crate) pid_file: PathBuf,
+
+    /// OCI container ID.
+    pub(crate) id: String,
+}
+
+/// Arguments for commands that only need a container ID.
+#[derive(Debug, Args)]
+pub(crate) struct ContainerIdCommand {
+    /// OCI container ID.
+    pub(crate) id: String,
+}
+
+/// Arguments for `kill`.
+#[derive(Debug, Args)]
+pub(crate) struct KillCommand {
+    /// Signal all processes in the container.
+    #[arg(long)]
+    pub(crate) all: bool,
+
+    /// OCI container ID.
+    pub(crate) id: String,
+
+    /// Signal number or name.
+    #[arg(default_value = "TERM")]
+    pub(crate) signal: String,
+}
+
+/// Arguments for `delete`.
+#[derive(Debug, Args)]
+pub(crate) struct DeleteCommand {
+    /// Force deletion by first killing the Microsandbox VM.
+    #[arg(short = 'f', long)]
+    pub(crate) force: bool,
+
+    /// OCI container ID.
+    pub(crate) id: String,
+}

--- a/crates/oci-runtime/bin/console.rs
+++ b/crates/oci-runtime/bin/console.rs
@@ -1,0 +1,197 @@
+//! OCI console socket and PTY handling.
+
+use std::io::IoSlice;
+use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use nix::fcntl::OFlag;
+use nix::pty::{PtyMaster, grantpt, posix_openpt, ptsname_r, unlockpt};
+use nix::sys::socket::{ControlMessage, MsgFlags, sendmsg};
+use nix::sys::termios::{self, SetArg};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const PTY_MASTER_NAME: &[u8] = b"/dev/ptmx";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub(crate) struct OciConsole {
+    master: PtyMaster,
+    slave: OwnedFd,
+    slave_path: PathBuf,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl OciConsole {
+    pub(crate) fn slave_path(&self) -> &PathBuf {
+        &self.slave_path
+    }
+
+    pub(crate) fn into_slave(self) -> OwnedFd {
+        self.slave
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) fn setup_oci_console(console_socket: Option<&PathBuf>) -> Result<Option<OciConsole>> {
+    let Some(console_socket) = console_socket else {
+        return Ok(None);
+    };
+
+    let console = open_oci_console_pty().context("open OCI console PTY")?;
+    send_console_fd(console_socket, console.master.as_raw_fd(), PTY_MASTER_NAME)
+        .with_context(|| format!("send OCI console fd to `{}`", console_socket.display()))?;
+    Ok(Some(console))
+}
+
+fn open_oci_console_pty() -> Result<OciConsole> {
+    let master = posix_openpt(OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_CLOEXEC)?;
+    grantpt(&master)?;
+    unlockpt(&master)?;
+    let slave_path = PathBuf::from(ptsname_r(&master)?);
+    let slave = configure_console_slave(&slave_path).context("configure OCI console slave")?;
+    Ok(OciConsole {
+        master,
+        slave,
+        slave_path,
+    })
+}
+
+fn configure_console_slave(path: &PathBuf) -> Result<OwnedFd> {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .with_context(|| format!("open OCI console slave `{}`", path.display()))?;
+    let fd: OwnedFd = file.into();
+    let mut attrs = termios::tcgetattr(&fd).context("read OCI console termios")?;
+    termios::cfmakeraw(&mut attrs);
+    attrs
+        .output_flags
+        .remove(termios::OutputFlags::OPOST | termios::OutputFlags::ONLCR);
+    termios::tcsetattr(&fd, SetArg::TCSANOW, &attrs).context("set OCI console termios")?;
+    Ok(fd)
+}
+
+fn send_console_fd(console_socket: &PathBuf, fd: i32, name: &[u8]) -> Result<()> {
+    let stream = UnixStream::connect(console_socket)
+        .with_context(|| format!("connect OCI console socket `{}`", console_socket.display()))?;
+    send_console_fd_to_stream(&stream, fd, name)
+}
+
+fn send_console_fd_to_stream(stream: &UnixStream, fd: i32, name: &[u8]) -> Result<()> {
+    let iov = [IoSlice::new(name)];
+    let fds = [fd];
+    let cmsg = [ControlMessage::ScmRights(&fds)];
+    sendmsg::<()>(stream.as_raw_fd(), &iov, &cmsg, MsgFlags::empty(), None)?;
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::io::IoSliceMut;
+    use std::os::fd::FromRawFd;
+
+    use nix::sys::socket::{ControlMessageOwned, MsgFlags, recvmsg};
+    use nix::sys::termios::{LocalFlags, OutputFlags};
+
+    use super::*;
+
+    #[test]
+    fn open_oci_console_pty_returns_existing_slave() {
+        let console = open_oci_console_pty().expect("open console pty");
+
+        assert!(console.slave_path.starts_with("/dev/pts/"));
+        assert!(console.slave_path.exists());
+    }
+
+    #[test]
+    fn open_oci_console_pty_keeps_host_slave_fully_raw() {
+        let console = open_oci_console_pty().expect("open console pty");
+        let attrs = termios::tcgetattr(&console.slave).expect("read console termios");
+
+        assert!(!attrs.local_flags.contains(LocalFlags::ECHO));
+        assert!(!attrs.local_flags.contains(LocalFlags::ICANON));
+        assert!(!attrs.output_flags.contains(OutputFlags::OPOST));
+        assert!(!attrs.output_flags.contains(OutputFlags::ONLCR));
+    }
+
+    #[test]
+    fn host_console_does_not_translate_guest_newlines_again() {
+        let console = open_oci_console_pty().expect("open console pty");
+        let newline = b"\n";
+        let written = unsafe {
+            libc::write(
+                console.slave.as_raw_fd(),
+                newline.as_ptr().cast(),
+                newline.len(),
+            )
+        };
+        assert_eq!(written, newline.len() as isize);
+
+        let mut output = [0u8; 4];
+        let read = unsafe {
+            libc::read(
+                console.master.as_raw_fd(),
+                output.as_mut_ptr().cast(),
+                output.len(),
+            )
+        };
+
+        assert_eq!(&output[..read as usize], b"\n");
+    }
+
+    #[test]
+    fn setup_oci_console_sends_named_pty_master() {
+        let console = open_oci_console_pty().expect("open console PTY");
+        let (sender, receiver) = UnixStream::pair().expect("create console socket pair");
+        send_console_fd_to_stream(&sender, console.master.as_raw_fd(), PTY_MASTER_NAME)
+            .expect("send console descriptor");
+
+        let mut name = [0u8; 64];
+        let mut iov = [IoSliceMut::new(&mut name)];
+        let mut cmsg_buffer = nix::cmsg_space!([i32; 1]);
+        let (name_len, descriptor) = {
+            let message = recvmsg::<()>(
+                receiver.as_raw_fd(),
+                &mut iov,
+                Some(&mut cmsg_buffer),
+                MsgFlags::empty(),
+            )
+            .expect("receive console descriptor");
+            let descriptor = message
+                .cmsgs()
+                .expect("parse console control messages")
+                .find_map(|message| match message {
+                    ControlMessageOwned::ScmRights(mut descriptors) => descriptors.pop(),
+                    _ => None,
+                })
+                .expect("receive PTY master descriptor");
+            (message.bytes, descriptor)
+        };
+        let descriptor = unsafe { OwnedFd::from_raw_fd(descriptor) };
+
+        let name = name[..name_len].to_vec();
+        let is_terminal = termios::tcgetattr(&descriptor).is_ok();
+
+        assert_eq!(name, PTY_MASTER_NAME);
+        assert!(is_terminal);
+    }
+}

--- a/crates/oci-runtime/bin/features.rs
+++ b/crates/oci-runtime/bin/features.rs
@@ -1,0 +1,75 @@
+//! OCI runtime feature reporting.
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) fn oci_features_json() -> serde_json::Value {
+    serde_json::json!({
+        "ociVersionMin": "1.0.0",
+        "ociVersionMax": "1.2.0",
+        "hooks": [],
+        "mountOptions": [
+            "bind",
+            "rbind",
+            "ro",
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec"
+        ],
+        "linux": {
+            "namespaces": [],
+            "capabilities": [],
+            "cgroup": {
+                "v1": false,
+                "v2": false,
+                "systemd": false,
+                "systemdUser": false,
+                "rdma": false
+            },
+            "seccomp": {
+                "enabled": false
+            },
+            "apparmor": {
+                "enabled": false
+            },
+            "selinux": {
+                "enabled": false
+            }
+        },
+        "annotations": {
+            "org.opencontainers.runmsb.version": env!("CARGO_PKG_VERSION")
+        },
+        "potentiallyUnsafeConfigAnnotations": []
+    })
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn features_reports_required_oci_probe_fields() {
+        let features = oci_features_json();
+
+        assert_eq!(features["ociVersionMin"], "1.0.0");
+        assert_eq!(features["ociVersionMax"], "1.2.0");
+        assert!(features["hooks"].is_array());
+        assert!(
+            features["mountOptions"]
+                .as_array()
+                .unwrap()
+                .contains(&serde_json::Value::String("rbind".to_string()))
+        );
+        assert_eq!(features["linux"]["seccomp"]["enabled"], false);
+        assert_eq!(
+            features["annotations"]["org.opencontainers.runmsb.version"],
+            env!("CARGO_PKG_VERSION")
+        );
+    }
+}

--- a/crates/oci-runtime/bin/linux.rs
+++ b/crates/oci-runtime/bin/linux.rs
@@ -1,0 +1,271 @@
+//! Linux entry point implementation for the `runmsb` OCI runtime binary.
+
+#[path = "cli.rs"]
+mod cli;
+#[path = "commands.rs"]
+mod commands;
+#[path = "console.rs"]
+mod console;
+#[path = "features.rs"]
+mod features;
+#[path = "logging.rs"]
+mod logging;
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command as ProcessCommand, Stdio};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use runmsb::{CreateOptions, DeleteOptions, ExecOptions, KillOptions, MicrosandboxOciRuntime};
+
+use self::cli::Cli;
+use self::commands::{
+    Command, ContainerIdCommand, CreateCommand, CreateRunOptions, DeleteCommand, ExecCommand,
+    ExecSupervisorCommand, KillCommand, RunCommand,
+};
+use self::console::setup_oci_console;
+use self::features::oci_features_json;
+use self::logging::{init_tracing, write_runtime_error_log};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+#[tokio::main]
+pub(crate) async fn main() {
+    let cli = Cli::parse();
+    init_tracing(cli.debug, cli.log_level);
+    let log = cli.log.clone();
+    let log_format = cli.log_format;
+
+    let code = match run(cli).await {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("runmsb: {error:#}");
+            write_runtime_error_log(log.as_ref(), log_format, &format!("{error:#}"));
+            1
+        }
+    };
+
+    std::process::exit(code);
+}
+
+async fn run(cli: Cli) -> Result<i32> {
+    let root = cli.root.clone();
+    let runtime = MicrosandboxOciRuntime::new(root.clone());
+    match cli.command {
+        Command::Create(CreateCommand {
+            options:
+                CreateRunOptions {
+                    bundle,
+                    pid_file,
+                    console_socket,
+                    ..
+                },
+            id,
+        }) => {
+            let console = setup_oci_console(console_socket.as_ref())?;
+            runtime
+                .create(CreateOptions {
+                    id: id.clone(),
+                    bundle,
+                    console: console.map(|console| console.into_slave()),
+                })
+                .await?;
+            let state = runtime.state(&id).await?;
+            let pid = state
+                .pid
+                .ok_or_else(|| anyhow::anyhow!("container `{id}` has no VMM host PID"))?;
+            write_pid_file(pid_file.as_deref(), pid)?;
+            Ok(0)
+        }
+        Command::Start(ContainerIdCommand { id }) => {
+            runtime.start(&id).await?;
+            Ok(0)
+        }
+        Command::Run(RunCommand {
+            options:
+                CreateRunOptions {
+                    bundle,
+                    pid_file,
+                    console_socket,
+                    ..
+                },
+            id,
+        }) => {
+            let console = setup_oci_console(console_socket.as_ref())?;
+            runtime
+                .create(CreateOptions {
+                    id: id.clone(),
+                    bundle,
+                    console: console.map(|console| console.into_slave()),
+                })
+                .await?;
+            let state = runtime.state(&id).await?;
+            let pid = state
+                .pid
+                .ok_or_else(|| anyhow::anyhow!("container `{id}` has no VMM host PID"))?;
+            write_pid_file(pid_file.as_deref(), pid)?;
+            runtime.start(&id).await?;
+            runtime.wait(&id).await
+        }
+        Command::Exec(command) => {
+            let ExecCommand {
+                process,
+                console_socket,
+                detach,
+                pid_file,
+                id,
+                ..
+            } = *command;
+            let process = process.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "command-style exec is not implemented; pass --process process.json"
+                )
+            })?;
+            let console = setup_oci_console(console_socket.as_ref())?;
+            let console_slave = console
+                .as_ref()
+                .map(|console| console.slave_path().to_path_buf());
+            if detach {
+                let pid_file =
+                    pid_file.ok_or_else(|| anyhow::anyhow!("exec --detach requires --pid-file"))?;
+                spawn_exec_supervisor(&root, &id, &process, console_slave.as_deref(), &pid_file)
+                    .await?;
+                return Ok(0);
+            }
+            write_pid_file(pid_file.as_deref(), std::process::id() as i32)?;
+            let options = ExecOptions {
+                id,
+                process,
+                pid_file: None,
+            };
+            let code = if let Some(console_slave) = console_slave {
+                runtime.exec_console(options, console_slave).await?
+            } else {
+                runtime.exec(options).await?
+            };
+            Ok(code)
+        }
+        Command::ExecSupervisor(ExecSupervisorCommand {
+            process,
+            console,
+            pid_file,
+            id,
+        }) => {
+            let options = ExecOptions {
+                id,
+                process,
+                pid_file: Some(pid_file),
+            };
+            let code = if let Some(console) = console {
+                runtime.exec_console(options, console).await?
+            } else {
+                runtime.exec(options).await?
+            };
+            Ok(code)
+        }
+        Command::Kill(KillCommand { all, id, signal }) => {
+            runtime.kill(KillOptions { id, signal, all }).await?;
+            Ok(0)
+        }
+        Command::Delete(DeleteCommand { force, id }) => {
+            runtime.delete(DeleteOptions { id, force }).await?;
+            Ok(0)
+        }
+        Command::State(ContainerIdCommand { id }) => {
+            let state = runtime.state(&id).await?;
+            println!("{}", serde_json::to_string_pretty(&state)?);
+            Ok(0)
+        }
+        Command::Pause(ContainerIdCommand { id }) => {
+            runtime.pause(&id).await?;
+            Ok(0)
+        }
+        Command::Resume(ContainerIdCommand { id }) => {
+            runtime.resume(&id).await?;
+            Ok(0)
+        }
+        Command::Features => {
+            println!("{}", serde_json::to_string_pretty(&oci_features_json())?);
+            Ok(0)
+        }
+    }
+}
+
+fn write_pid_file(path: Option<&Path>, pid: i32) -> Result<()> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create pid-file directory `{}`", parent.display()))?;
+    }
+
+    fs::write(path, pid.to_string()).with_context(|| format!("write pid-file `{}`", path.display()))
+}
+
+async fn spawn_exec_supervisor(
+    root: &Path,
+    id: &str,
+    process: &Path,
+    console: Option<&Path>,
+    pid_file: &Path,
+) -> Result<()> {
+    if let Some(parent) = pid_file.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create exec pid-file directory `{}`", parent.display()))?;
+    }
+    match fs::remove_file(pid_file) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("remove stale exec pid file `{}`", pid_file.display()));
+        }
+    }
+
+    let executable = std::env::current_exe().context("resolve runmsb executable")?;
+    let mut command = ProcessCommand::new(executable);
+    command
+        .arg("--root")
+        .arg(root)
+        .arg("__exec-supervisor")
+        .arg("--process")
+        .arg(process)
+        .arg("--pid-file")
+        .arg(pid_file);
+    if let Some(console) = console {
+        command.arg("--console").arg(console);
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+    }
+    command.arg(id);
+
+    let mut child = command.spawn().context("spawn OCI exec supervisor")?;
+    let expected_pid = child.id() as i32;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Ok(contents) = fs::read_to_string(pid_file)
+            && contents.trim().parse::<i32>().ok() == Some(expected_pid)
+        {
+            return Ok(());
+        }
+        if let Some(status) = child
+            .try_wait()
+            .context("poll OCI exec supervisor startup")?
+        {
+            anyhow::bail!("OCI exec supervisor exited before guest startup: {status}");
+        }
+        if tokio::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            anyhow::bail!("timed out waiting for OCI exec supervisor to start guest process");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}

--- a/crates/oci-runtime/bin/logging.rs
+++ b/crates/oci-runtime/bin/logging.rs
@@ -1,0 +1,53 @@
+//! Logging setup and OCI runtime error log writing.
+
+use std::fs;
+use std::path::PathBuf;
+
+use chrono::Utc;
+
+use super::cli::{LogFormat, LogLevel};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) fn init_tracing(debug: bool, log_level: Option<LogLevel>) {
+    let default = match log_level {
+        Some(LogLevel::Error) => "error",
+        Some(LogLevel::Warning) => "warn",
+        Some(LogLevel::Debug) => "debug",
+        None if debug => "debug",
+        None => "error",
+    };
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .or_else(|_| tracing_subscriber::EnvFilter::try_new(default))
+        .expect("valid tracing filter");
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .init();
+}
+
+pub(crate) fn write_runtime_error_log(path: Option<&PathBuf>, format: LogFormat, message: &str) {
+    let Some(path) = path else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    let line = match format {
+        LogFormat::Json => serde_json::json!({
+            "time": Utc::now().to_rfc3339(),
+            "level": "error",
+            "msg": message,
+        })
+        .to_string(),
+        LogFormat::Text => format!(
+            "time=\"{}\" level=error msg={:?}",
+            Utc::now().to_rfc3339(),
+            message
+        ),
+    };
+    let _ = fs::write(path, format!("{line}\n"));
+}

--- a/crates/oci-runtime/bin/main.rs
+++ b/crates/oci-runtime/bin/main.rs
@@ -1,0 +1,19 @@
+//! Entry point for the `runmsb` OCI runtime binary.
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("runmsb is only supported on Linux hosts");
+    std::process::exit(1);
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    linux::main();
+}

--- a/crates/oci-runtime/lib/console.rs
+++ b/crates/oci-runtime/lib/console.rs
@@ -1,0 +1,270 @@
+//! OCI console bridging between containerd's host PTY and the guest process.
+
+use std::io::ErrorKind;
+use std::os::fd::{AsRawFd, OwnedFd};
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use microsandbox::sandbox::exec::{ExecControl, ExecEvent, ExecHandle};
+use microsandbox_runtime::oci::OciProcess;
+use tokio::io::unix::AsyncFd;
+
+use crate::process::{HostSignalForwarder, forward_host_signal};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const CONSOLE_RESIZE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PtySize {
+    pub(crate) rows: u16,
+    pub(crate) cols: u16,
+}
+
+pub(crate) struct ConsoleBridge {
+    fd: AsyncFd<OwnedFd>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) async fn wait_for_console_process_exit(
+    id: &str,
+    handle: &mut ExecHandle,
+    console: &ConsoleBridge,
+    host_signals: &mut HostSignalForwarder,
+) -> Result<i32> {
+    let stdin = handle
+        .take_stdin()
+        .ok_or_else(|| anyhow!("container `{id}` requested an OCI console without piped stdin"))?;
+    let control = handle.control();
+    let mut last_size = None;
+    sync_console_size(&control, console, &mut last_size).await?;
+    let mut resize_poll = tokio::time::interval(CONSOLE_RESIZE_POLL_INTERVAL);
+    let mut input = [0u8; 4096];
+
+    loop {
+        tokio::select! {
+            signal = host_signals.recv() => {
+                forward_host_signal(&control, signal).await?;
+            }
+            _ = resize_poll.tick() => {
+                sync_console_size(&control, console, &mut last_size).await?;
+            }
+            read = read_console_input(console, &mut input) => {
+                match read.context("read OCI console input")? {
+                    0 => {
+                        let _ = stdin.close().await;
+                    }
+                    n => {
+                        stdin.write(&input[..n]).await.context("write OCI console input to guest")?;
+                    }
+                }
+            }
+            event = handle.recv() => {
+                match event {
+                    Some(ExecEvent::Exited { code }) => return Ok(code),
+                    Some(ExecEvent::Failed(payload)) => {
+                        return Err(microsandbox::MicrosandboxError::ExecFailed(payload).into());
+                    }
+                    Some(ExecEvent::Stdout(data)) | Some(ExecEvent::Stderr(data)) => {
+                        write_console_output(console, &data).await.context("write OCI console output")?;
+                    }
+                    Some(ExecEvent::Started { .. }) | Some(ExecEvent::StdinError(_)) => {}
+                    None => bail!("OCI init process stream ended before exit event for `{id}`"),
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn open_console_bridge(path: &Path) -> Result<ConsoleBridge> {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .with_context(|| format!("open OCI console slave `{}`", path.display()))?;
+    let fd: OwnedFd = file.into();
+    set_nonblocking(fd.as_raw_fd()).context("set OCI console slave nonblocking")?;
+    let fd = AsyncFd::new(fd).context("register OCI console slave with tokio")?;
+    Ok(ConsoleBridge { fd })
+}
+
+pub(crate) fn process_console_size(process: &OciProcess) -> Option<PtySize> {
+    let size = process.console_size()?;
+    pty_size_from_rows_cols(size.height(), size.width())
+}
+
+async fn sync_console_size(
+    control: &ExecControl,
+    console: &ConsoleBridge,
+    last_size: &mut Option<PtySize>,
+) -> Result<()> {
+    let Some(size) = console_size_from_fd(console.fd.get_ref().as_raw_fd()) else {
+        return Ok(());
+    };
+    if Some(size) == *last_size {
+        return Ok(());
+    }
+
+    control
+        .resize(size.rows, size.cols)
+        .await
+        .context("resize OCI console PTY in guest")?;
+    *last_size = Some(size);
+    Ok(())
+}
+
+fn console_size_from_fd(fd: i32) -> Option<PtySize> {
+    let mut size = std::mem::MaybeUninit::<libc::winsize>::zeroed();
+    if unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, size.as_mut_ptr()) } < 0 {
+        return None;
+    }
+    let size = unsafe { size.assume_init() };
+    pty_size_from_rows_cols(u64::from(size.ws_row), u64::from(size.ws_col))
+}
+
+fn pty_size_from_rows_cols(rows: u64, cols: u64) -> Option<PtySize> {
+    if rows == 0 || cols == 0 {
+        return None;
+    }
+    Some(PtySize {
+        rows: rows.min(u64::from(u16::MAX)) as u16,
+        cols: cols.min(u64::from(u16::MAX)) as u16,
+    })
+}
+
+async fn read_console_input(console: &ConsoleBridge, buf: &mut [u8]) -> std::io::Result<usize> {
+    loop {
+        let mut guard = console.fd.readable().await?;
+        match guard.try_io(|inner| read_fd(inner.get_ref().as_raw_fd(), buf)) {
+            Ok(result) => return result,
+            Err(_) => continue,
+        }
+    }
+}
+
+async fn write_console_output(console: &ConsoleBridge, mut data: &[u8]) -> std::io::Result<()> {
+    while !data.is_empty() {
+        let mut guard = console.fd.writable().await?;
+        match guard.try_io(|inner| write_fd(inner.get_ref().as_raw_fd(), data)) {
+            Ok(Ok(0)) => {
+                return Err(std::io::Error::new(
+                    ErrorKind::WriteZero,
+                    "console write returned zero",
+                ));
+            }
+            Ok(Ok(n)) => data = &data[n..],
+            Ok(Err(error)) if error.kind() == ErrorKind::Interrupted => continue,
+            Ok(Err(error)) => return Err(error),
+            Err(_) => continue,
+        }
+    }
+    Ok(())
+}
+
+fn read_fd(fd: i32, buf: &mut [u8]) -> std::io::Result<usize> {
+    loop {
+        let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+        if n >= 0 {
+            return Ok(n as usize);
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() == ErrorKind::Interrupted {
+            continue;
+        }
+        return Err(error);
+    }
+}
+
+fn write_fd(fd: i32, buf: &[u8]) -> std::io::Result<usize> {
+    loop {
+        let n = unsafe { libc::write(fd, buf.as_ptr().cast(), buf.len()) };
+        if n >= 0 {
+            return Ok(n as usize);
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() == ErrorKind::Interrupted {
+            continue;
+        }
+        return Err(error);
+    }
+}
+
+fn set_nonblocking(fd: i32) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::{AsRawFd, OwnedFd};
+
+    use nix::fcntl::OFlag;
+    use nix::pty::{grantpt, posix_openpt, ptsname_r, unlockpt};
+
+    use super::*;
+
+    #[test]
+    fn console_size_from_fd_reads_pty_window_size() {
+        let master = posix_openpt(OFlag::O_RDWR | OFlag::O_NOCTTY).expect("open pty master");
+        grantpt(&master).expect("grant pty");
+        unlockpt(&master).expect("unlock pty");
+        let slave_path = ptsname_r(&master).expect("pty slave path");
+        let slave = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(slave_path)
+            .expect("open pty slave");
+        let fd: OwnedFd = slave.into();
+        let size = libc::winsize {
+            ws_row: 42,
+            ws_col: 132,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+
+        assert_eq!(
+            unsafe { libc::ioctl(fd.as_raw_fd(), libc::TIOCSWINSZ, &size) },
+            0
+        );
+        assert_eq!(
+            console_size_from_fd(fd.as_raw_fd()),
+            Some(PtySize {
+                rows: 42,
+                cols: 132
+            })
+        );
+    }
+
+    #[test]
+    fn pty_size_ignores_zero_and_clamps_large_values() {
+        assert_eq!(pty_size_from_rows_cols(0, 80), None);
+        assert_eq!(pty_size_from_rows_cols(24, 0), None);
+        assert_eq!(
+            pty_size_from_rows_cols(u64::MAX, u64::MAX),
+            Some(PtySize {
+                rows: u16::MAX,
+                cols: u16::MAX,
+            })
+        );
+    }
+}

--- a/crates/oci-runtime/lib/lib.rs
+++ b/crates/oci-runtime/lib/lib.rs
@@ -1,0 +1,16 @@
+//! Standalone OCI runtime binary integration for Microsandbox.
+#![cfg(all(target_os = "linux", feature = "runmsb"))]
+
+mod console;
+mod options;
+mod process;
+mod requests;
+mod runtime;
+mod sandbox;
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use options::{CreateOptions, DeleteOptions, ExecOptions, KillOptions};
+pub use runtime::MicrosandboxOciRuntime;

--- a/crates/oci-runtime/lib/options.rs
+++ b/crates/oci-runtime/lib/options.rs
@@ -1,0 +1,57 @@
+//! Options accepted by OCI lifecycle operations.
+
+use std::os::fd::OwnedFd;
+use std::path::PathBuf;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Options for `create`.
+#[derive(Debug)]
+pub struct CreateOptions {
+    /// OCI container ID.
+    pub id: String,
+
+    /// OCI bundle directory.
+    pub bundle: PathBuf,
+
+    /// Optional host PTY slave inherited by the Microsandbox VMM process.
+    pub console: Option<OwnedFd>,
+}
+
+/// Options for `exec`.
+#[derive(Debug, Clone)]
+pub struct ExecOptions {
+    /// OCI container ID.
+    pub id: String,
+
+    /// OCI process descriptor path.
+    pub process: PathBuf,
+
+    /// Optional pid-file path requested by Docker/containerd.
+    pub pid_file: Option<PathBuf>,
+}
+
+/// Options for `kill`.
+#[derive(Debug, Clone)]
+pub struct KillOptions {
+    /// OCI container ID.
+    pub id: String,
+
+    /// Signal number or name.
+    pub signal: String,
+
+    /// Whether to signal all processes.
+    pub all: bool,
+}
+
+/// Options for `delete`.
+#[derive(Debug, Clone)]
+pub struct DeleteOptions {
+    /// OCI container ID.
+    pub id: String,
+
+    /// Force removal even if OCI state is not stopped.
+    pub force: bool,
+}

--- a/crates/oci-runtime/lib/process.rs
+++ b/crates/oci-runtime/lib/process.rs
@@ -1,0 +1,466 @@
+//! OCI guest-process execution, command resolution, signals, and pid files.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use anyhow::{Context, Result, anyhow, bail};
+use microsandbox::sandbox::exec::{ExecControl, ExecEvent, ExecHandle};
+use microsandbox::sandbox::{ExecOptionsBuilder, Sandbox, SandboxStatus};
+use microsandbox_runtime::oci::{OciProcess, sandbox_name_for_container, validate_process};
+use nix::sys::signal::Signal;
+
+use crate::console::{ConsoleBridge, process_console_size, wait_for_console_process_exit};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const DEFAULT_EXEC_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StartedProcess {
+    guest_pid: Option<u32>,
+}
+
+pub(crate) struct HostSignalForwarder {
+    terminate: tokio::signal::unix::Signal,
+    interrupt: tokio::signal::unix::Signal,
+    hangup: tokio::signal::unix::Signal,
+    quit: tokio::signal::unix::Signal,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl HostSignalForwarder {
+    pub(crate) fn new() -> Result<Self> {
+        Ok(Self {
+            terminate: tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .context("install OCI signal forwarder SIGTERM handler")?,
+            interrupt: tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+                .context("install OCI signal forwarder SIGINT handler")?,
+            hangup: tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
+                .context("install OCI signal forwarder SIGHUP handler")?,
+            quit: tokio::signal::unix::signal(tokio::signal::unix::SignalKind::quit())
+                .context("install OCI signal forwarder SIGQUIT handler")?,
+        })
+    }
+
+    pub(crate) async fn recv(&mut self) -> i32 {
+        tokio::select! {
+            _ = self.terminate.recv() => libc::SIGTERM,
+            _ = self.interrupt.recv() => libc::SIGINT,
+            _ = self.hangup.recv() => libc::SIGHUP,
+            _ = self.quit.recv() => libc::SIGQUIT,
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) async fn connect_sandbox(id: &str) -> Result<Sandbox> {
+    let handle = Sandbox::get(&sandbox_name_for_container(id)).await?;
+    match handle.status_snapshot() {
+        SandboxStatus::Running | SandboxStatus::Draining => {
+            handle.connect().await.map_err(Into::into)
+        }
+        SandboxStatus::Stopped | SandboxStatus::Crashed => {
+            handle.start_detached().await.map_err(Into::into)
+        }
+        status => bail!("cannot connect to sandbox for container `{id}` while it is {status:?}"),
+    }
+}
+
+pub(crate) async fn start_process_stream(
+    sandbox: &Sandbox,
+    process: &OciProcess,
+    rootfs: &Path,
+) -> Result<(StartedProcess, ExecHandle)> {
+    let command = resolve_process_command(process, rootfs)?;
+    let mut handle = sandbox
+        .exec_stream_with(command, |exec| configure_exec(exec, process))
+        .await?;
+    let _session_id = handle
+        .id()
+        .parse::<u32>()
+        .context("parse Microsandbox exec session ID")?;
+
+    while let Some(event) = handle.recv().await {
+        match event {
+            ExecEvent::Started { pid } => {
+                if let Some(size) = process_console_size(process) {
+                    handle
+                        .resize(size.rows, size.cols)
+                        .await
+                        .context("resize OCI init PTY from process.consoleSize")?;
+                }
+                return Ok((
+                    StartedProcess {
+                        guest_pid: Some(pid),
+                    },
+                    handle,
+                ));
+            }
+            ExecEvent::Failed(payload) => {
+                return Err(microsandbox::MicrosandboxError::ExecFailed(payload).into());
+            }
+            ExecEvent::Exited { code } => {
+                bail!("OCI init process exited before start completed with code {code}")
+            }
+            ExecEvent::Stdout(_) | ExecEvent::Stderr(_) | ExecEvent::StdinError(_) => {}
+        }
+    }
+
+    bail!("OCI init process stream ended before start completed")
+}
+
+pub(crate) async fn wait_for_process_exit(
+    id: &str,
+    handle: &mut ExecHandle,
+    console: Option<&ConsoleBridge>,
+    host_signals: &mut HostSignalForwarder,
+) -> Result<i32> {
+    if let Some(console) = console {
+        return wait_for_console_process_exit(id, handle, console, host_signals).await;
+    }
+
+    let control = handle.control();
+    loop {
+        tokio::select! {
+            signal = host_signals.recv() => {
+                forward_host_signal(&control, signal).await?;
+            }
+            event = handle.recv() => {
+                match event {
+                    Some(ExecEvent::Exited { code }) => return Ok(code),
+                    Some(ExecEvent::Failed(payload)) => {
+                        return Err(microsandbox::MicrosandboxError::ExecFailed(payload).into());
+                    }
+                    Some(ExecEvent::Stdout(data)) => {
+                        let mut stdout = std::io::stdout().lock();
+                        stdout.write_all(&data).context("write OCI init stdout")?;
+                        stdout.flush().context("flush OCI init stdout")?;
+                    }
+                    Some(ExecEvent::Stderr(data)) => {
+                        let mut stderr = std::io::stderr().lock();
+                        stderr.write_all(&data).context("write OCI init stderr")?;
+                        stderr.flush().context("flush OCI init stderr")?;
+                    }
+                    Some(ExecEvent::Started { .. }) | Some(ExecEvent::StdinError(_)) => {}
+                    None => bail!("OCI init process stream ended before exit event for `{id}`"),
+                }
+            }
+        }
+    }
+}
+
+pub(crate) async fn forward_host_signal(control: &ExecControl, signal: i32) -> Result<()> {
+    control
+        .signal(signal)
+        .await
+        .with_context(|| format!("forward host signal {signal} to OCI process"))
+}
+
+pub(crate) fn load_process(path: &Path) -> Result<OciProcess> {
+    let data = std::fs::read_to_string(path)
+        .with_context(|| format!("read OCI process JSON `{}`", path.display()))?;
+    let process: OciProcess = serde_json::from_str(&data)
+        .with_context(|| format!("parse OCI process JSON `{}`", path.display()))?;
+    validate_process(&process, path.parent().unwrap_or_else(|| Path::new(".")))
+        .map_err(Into::into)
+        .map(|()| process)
+}
+
+pub(crate) fn process_args(process: &OciProcess) -> Result<&[String]> {
+    let args = process.args().as_deref().unwrap_or_default();
+    if args.is_empty() {
+        bail!("OCI process args must contain at least one entry");
+    }
+    Ok(args)
+}
+
+pub(crate) fn write_exec_pid_file(path: Option<&Path>, started: &StartedProcess) -> Result<()> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+    let _guest_pid = started
+        .guest_pid
+        .ok_or_else(|| anyhow!("exec process started without a guest PID for pid-file"))?;
+    write_pid_file(path, std::process::id() as i32)
+}
+
+pub(crate) fn env_pairs(env: &[String]) -> Result<Vec<(String, String)>> {
+    env.iter()
+        .map(|entry| {
+            entry
+                .split_once('=')
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .ok_or_else(|| anyhow!("OCI environment entry must be KEY=VALUE: `{entry}`"))
+        })
+        .collect()
+}
+
+pub(crate) fn parse_signal(signal: &str) -> Result<i32> {
+    if let Ok(number) = signal.parse::<i32>() {
+        return Ok(number);
+    }
+
+    let normalized = signal.trim_start_matches('-').to_ascii_uppercase();
+    let name = if normalized.starts_with("SIG") {
+        normalized
+    } else {
+        format!("SIG{normalized}")
+    };
+    Signal::from_str(&name)
+        .map(|signal| signal as i32)
+        .map_err(|_| anyhow!("unsupported signal `{signal}`"))
+}
+
+fn resolve_process_command(process: &OciProcess, rootfs: &Path) -> Result<String> {
+    let args = process_args(process)?;
+    let command = &args[0];
+    if command.contains('/') {
+        return Ok(command.clone());
+    }
+
+    for entry in process_path_entries(process) {
+        let guest_path = if entry.is_empty() || entry == "." {
+            PathBuf::from(command)
+        } else {
+            Path::new(&entry).join(command)
+        };
+        let host_path = if guest_path.is_absolute() {
+            rootfs.join(guest_path.strip_prefix("/").unwrap_or(&guest_path))
+        } else {
+            rootfs.join(&guest_path)
+        };
+        if host_path.is_file() {
+            return Ok(guest_path_for_exec(&guest_path));
+        }
+    }
+
+    Ok(command.clone())
+}
+
+fn process_path_entries(process: &OciProcess) -> Vec<String> {
+    process
+        .env()
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .find_map(|entry| entry.strip_prefix("PATH="))
+        .unwrap_or(DEFAULT_EXEC_PATH)
+        .split(':')
+        .map(str::to_string)
+        .collect()
+}
+
+fn guest_path_for_exec(path: &Path) -> String {
+    if path.is_absolute() {
+        path.display().to_string()
+    } else {
+        format!("/{}", path.display())
+    }
+}
+
+fn configure_exec(mut exec: ExecOptionsBuilder, process: &OciProcess) -> ExecOptionsBuilder {
+    let args = process.args().as_deref().unwrap_or_default();
+    let terminal = process.terminal().unwrap_or(false);
+    exec = exec
+        .args(args.iter().skip(1).cloned())
+        .cwd(process.cwd().display().to_string())
+        .tty(terminal);
+    if terminal {
+        exec = exec.stdin_pipe();
+    }
+    let user = process.user();
+    if user.uid() != 0 || user.gid() != 0 {
+        exec = exec.user(format!("{}:{}", user.uid(), user.gid()));
+    }
+    for (key, value) in env_pairs_lossy(process.env().as_deref().unwrap_or_default()) {
+        exec = exec.env(key, value);
+    }
+    exec
+}
+
+fn write_pid_file(path: &Path, pid: i32) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create pid-file directory `{}`", parent.display()))?;
+    }
+    std::fs::write(path, pid.to_string())
+        .with_context(|| format!("write pid-file `{}`", path.display()))
+}
+
+fn env_pairs_lossy(env: &[String]) -> Vec<(String, String)> {
+    env.iter()
+        .filter_map(|entry| {
+            entry
+                .split_once('=')
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use microsandbox_runtime::oci::OciBundle;
+
+    use super::*;
+
+    #[test]
+    fn parses_signal_names_and_numbers() {
+        assert_eq!(parse_signal("0").expect("zero"), 0);
+        assert_eq!(parse_signal("9").expect("number"), libc::SIGKILL);
+        assert_eq!(parse_signal("SIGTERM").expect("sigterm"), libc::SIGTERM);
+        assert_eq!(parse_signal("TERM").expect("term"), libc::SIGTERM);
+        assert_eq!(parse_signal("sigusr1").expect("sigusr1"), libc::SIGUSR1);
+        assert_eq!(parse_signal("USR2").expect("usr2"), libc::SIGUSR2);
+        assert_eq!(parse_signal("WINCH").expect("winch"), libc::SIGWINCH);
+        assert_eq!(parse_signal("-CONT").expect("cont"), libc::SIGCONT);
+        assert!(parse_signal("SIGBOGUS").is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_env_entries() {
+        assert!(env_pairs(&["PATH=/bin".to_string()]).is_ok());
+        assert!(env_pairs(&["PATH".to_string()]).is_err());
+    }
+
+    #[test]
+    fn write_pid_file_creates_parent_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("nested").join("init.pid");
+
+        write_pid_file(&path, 1234).expect("write pid file");
+
+        let content = std::fs::read_to_string(path).expect("read pid file");
+        assert_eq!(content, "1234");
+    }
+
+    #[test]
+    fn write_exec_pid_file_uses_host_supervisor_pid() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("exec.pid");
+        let started = StartedProcess {
+            guest_pid: Some(4321),
+        };
+
+        write_exec_pid_file(Some(&path), &started).expect("write exec pid file");
+
+        let content = std::fs::read_to_string(path).expect("read exec pid file");
+        assert_eq!(content, std::process::id().to_string());
+    }
+
+    #[test]
+    fn write_exec_pid_file_rejects_missing_guest_pid() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("exec.pid");
+        let started = StartedProcess { guest_pid: None };
+
+        let error = write_exec_pid_file(Some(&path), &started).expect_err("missing guest pid");
+
+        assert!(error.to_string().contains("without a guest PID"));
+    }
+
+    #[test]
+    fn terminal_process_uses_tty_and_piped_stdin() {
+        let (_temp, bundle) = process_bundle("/bin/sh", true);
+        let process = bundle.process().expect("process");
+        let options = configure_exec(ExecOptionsBuilder::default(), process)
+            .build()
+            .expect("exec options");
+
+        assert!(options.tty);
+        assert!(matches!(
+            options.stdin,
+            microsandbox::sandbox::exec::StdinMode::Pipe
+        ));
+    }
+
+    #[test]
+    fn resolves_bare_process_command_from_rootfs_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bash = temp.path().join("rootfs/usr/bin/bash");
+        std::fs::create_dir_all(bash.parent().expect("parent")).expect("bin dir");
+        std::fs::write(&bash, b"").expect("bash");
+        write_bundle_config(temp.path(), "bash", false);
+        let bundle = OciBundle::load(temp.path()).expect("load bundle");
+
+        let command =
+            resolve_process_command(bundle.process().expect("process"), &bundle.rootfs_path())
+                .expect("resolve command");
+
+        assert_eq!(command, "/usr/bin/bash");
+    }
+
+    #[test]
+    fn leaves_explicit_process_command_unchanged() {
+        let (_temp, bundle) = process_bundle("/custom/bash", false);
+
+        let command =
+            resolve_process_command(bundle.process().expect("process"), &bundle.rootfs_path())
+                .expect("resolve command");
+
+        assert_eq!(command, "/custom/bash");
+    }
+
+    #[test]
+    fn reads_process_console_size_from_oci_config() {
+        let (temp, _) = process_bundle("/bin/sh", true);
+        let config = std::fs::read_to_string(temp.path().join("config.json")).expect("config");
+        let config = config.replace(
+            "\"terminal\": true,",
+            "\"terminal\": true, \"consoleSize\": { \"height\": 45, \"width\": 160 },",
+        );
+        std::fs::write(temp.path().join("config.json"), config).expect("rewrite config");
+        let bundle = OciBundle::load(temp.path()).expect("reload bundle");
+
+        assert_eq!(
+            process_console_size(bundle.process().expect("process")),
+            Some(crate::console::PtySize {
+                rows: 45,
+                cols: 160,
+            })
+        );
+    }
+
+    fn process_bundle(command: &str, terminal: bool) -> (tempfile::TempDir, OciBundle) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(temp.path().join("rootfs")).expect("rootfs");
+        write_bundle_config(temp.path(), command, terminal);
+        let bundle = OciBundle::load(temp.path()).expect("load bundle");
+        (temp, bundle)
+    }
+
+    fn write_bundle_config(path: &Path, command: &str, terminal: bool) {
+        std::fs::write(
+            path.join("config.json"),
+            format!(
+                r#"{{
+                    "ociVersion": "1.2.0",
+                    "root": {{ "path": "rootfs" }},
+                    "process": {{
+                        "terminal": {terminal},
+                        "user": {{ "uid": 0, "gid": 0 }},
+                        "cwd": "/",
+                        "args": ["{command}"]
+                    }}
+                }}"#
+            ),
+        )
+        .expect("config");
+    }
+}

--- a/crates/oci-runtime/lib/requests.rs
+++ b/crates/oci-runtime/lib/requests.rs
@@ -1,0 +1,289 @@
+//! Host-side start and signal requests consumed by the persistent VMM process.
+
+use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use microsandbox::sandbox::{Sandbox, SandboxStatus};
+use microsandbox_protocol::exec::ExecSignal;
+use microsandbox_protocol::message::MessageType;
+use microsandbox_runtime::oci::{OciState, OciStateStore, sandbox_name_for_container};
+use nix::errno::Errno;
+use nix::sys::signal::kill;
+use nix::unistd::Pid;
+
+use crate::process::connect_sandbox;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) const OCI_START_REQUEST: &str = "start.request";
+pub(crate) const OCI_INIT_SESSION: &str = "init.session";
+pub(crate) const OCI_SIGNAL_REQUEST: &str = "init.signal";
+
+const OCI_INIT_SESSION_ERROR: &str = "init.session.error";
+const OCI_INIT_SESSION_EXIT: &str = "init.session.exit";
+const OCI_START_TIMEOUT: Duration = Duration::from_secs(30);
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) async fn signal_init_process(id: &str, state: &OciState, signal: i32) -> Result<()> {
+    let session_id = state
+        .microsandbox
+        .as_ref()
+        .and_then(|msb| msb.init_exec_session_id)
+        .ok_or_else(|| anyhow!("container `{id}` has no OCI init exec session to signal"))?;
+    let sandbox = connect_sandbox(id).await?;
+    let payload = ExecSignal { signal };
+
+    sandbox
+        .client_arc()
+        .send(session_id, MessageType::ExecSignal, &payload)
+        .await
+        .with_context(|| {
+            format!("send signal {signal} to OCI init exec session {session_id} for `{id}`")
+        })?;
+    sandbox.detach().await;
+    Ok(())
+}
+
+pub(crate) async fn signal_init_process_if_known(
+    id: &str,
+    state: &OciState,
+    signal: i32,
+) -> Result<()> {
+    if state
+        .microsandbox
+        .as_ref()
+        .and_then(|msb| msb.init_exec_session_id)
+        .is_none()
+    {
+        return Ok(());
+    }
+
+    if let Err(error) = signal_init_process(id, state, signal).await {
+        tracing::warn!(
+            container_id = id,
+            signal,
+            error = %error,
+            "failed to signal OCI init process during force delete; continuing with sandbox cleanup"
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn publish_start_request(path: &Path) -> Result<()> {
+    fs::write(path, b"start").with_context(|| {
+        format!(
+            "publish OCI start request for VMM supervisor `{}`",
+            path.display()
+        )
+    })
+}
+
+pub(crate) fn publish_signal_request(path: &Path, signal: i32) -> Result<()> {
+    let temporary = path.with_extension(format!("signal.{}", std::process::id()));
+    fs::write(&temporary, signal.to_string())
+        .with_context(|| format!("write OCI init signal request `{}`", temporary.display()))?;
+    fs::rename(&temporary, path)
+        .with_context(|| format!("publish OCI init signal request `{}`", path.display()))
+}
+
+pub(crate) async fn wait_for_init_session_id(
+    store: &OciStateStore,
+    id: &str,
+    host_pid: i32,
+) -> Result<u32> {
+    let deadline = tokio::time::Instant::now() + OCI_START_TIMEOUT;
+    loop {
+        if let Some(error) = read_init_session_error(store, id)? {
+            bail!("VMM supervisor failed to start OCI init for `{id}`: {error}");
+        }
+        match read_init_session_id(store, id) {
+            Ok(session_id) => return Ok(session_id),
+            Err(error) if tokio::time::Instant::now() >= deadline => {
+                let state_dir = store.container_dir(id)?;
+                let entries = state_dir_entries(&state_dir);
+                return Err(error)
+                    .with_context(|| {
+                        format!("timed out waiting for VMM supervisor to start OCI init for `{id}`")
+                    })
+                    .with_context(|| {
+                        format!(
+                            "OCI state directory `{}` contains: {entries}",
+                            state_dir.display()
+                        )
+                    });
+            }
+            Err(_) => {
+                ensure_vmm_process_alive(id, host_pid)?;
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
+    }
+}
+
+pub(crate) fn ensure_vmm_process_alive(id: &str, host_pid: i32) -> Result<()> {
+    if host_pid <= 0 {
+        bail!("container `{id}` has invalid Microsandbox VMM host PID {host_pid}");
+    }
+
+    match kill(Pid::from_raw(host_pid), None) {
+        Ok(()) | Err(Errno::EPERM) => Ok(()),
+        Err(Errno::ESRCH) => {
+            bail!("Microsandbox VMM process {host_pid} for `{id}` exited before OCI init started")
+        }
+        Err(error) => Err(error).with_context(|| {
+            format!("check Microsandbox VMM process {host_pid} for `{id}` during OCI start")
+        }),
+    }
+}
+
+pub(crate) fn read_init_session_id(store: &OciStateStore, id: &str) -> Result<u32> {
+    let path = store.container_dir(id)?.join(OCI_INIT_SESSION);
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("read OCI init session id `{}`", path.display()))?;
+    raw.trim()
+        .parse::<u32>()
+        .with_context(|| format!("parse OCI init session id `{}`", path.display()))
+}
+
+pub(crate) async fn wait_for_init_exit(store: &OciStateStore, id: &str) -> Result<i32> {
+    let path = store.container_dir(id)?.join(OCI_INIT_SESSION_EXIT);
+    loop {
+        match fs::read_to_string(&path) {
+            Ok(raw) => {
+                return raw
+                    .trim()
+                    .parse::<i32>()
+                    .with_context(|| format!("parse OCI init exit status `{}`", path.display()));
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("read OCI init exit status `{}`", path.display()));
+            }
+        }
+
+        if let Ok(handle) = Sandbox::get(&sandbox_name_for_container(id)).await {
+            let refreshed = handle.refresh().await.unwrap_or(handle);
+            if matches!(
+                refreshed.status_snapshot(),
+                SandboxStatus::Stopped | SandboxStatus::Crashed
+            ) {
+                bail!(
+                    "Microsandbox VMM for `{id}` stopped without publishing OCI init exit status"
+                );
+            }
+        }
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+pub(crate) async fn stop_sandbox_for_delete(id: &str) -> Result<()> {
+    let name = sandbox_name_for_container(id);
+    let Ok(handle) = Sandbox::get(&name).await else {
+        return Ok(());
+    };
+    let refreshed = handle.refresh().await.unwrap_or(handle);
+    if matches!(
+        refreshed.status_snapshot(),
+        SandboxStatus::Stopped | SandboxStatus::Crashed
+    ) {
+        return Ok(());
+    }
+
+    refreshed
+        .stop()
+        .await
+        .with_context(|| format!("stop Microsandbox sandbox `{name}` during force delete"))
+}
+
+fn read_init_session_error(store: &OciStateStore, id: &str) -> Result<Option<String>> {
+    let path = store.container_dir(id)?.join(OCI_INIT_SESSION_ERROR);
+    match fs::read_to_string(&path) {
+        Ok(raw) => Ok(Some(raw.trim().to_string())),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => {
+            Err(error).with_context(|| format!("read OCI init startup error `{}`", path.display()))
+        }
+    }
+}
+
+fn state_dir_entries(path: &Path) -> String {
+    let Ok(entries) = fs::read_dir(path) else {
+        return "<unreadable>".into();
+    };
+
+    let mut names = entries
+        .filter_map(|entry| {
+            entry
+                .ok()
+                .and_then(|entry| entry.file_name().into_string().ok())
+        })
+        .collect::<Vec<_>>();
+    names.sort();
+
+    if names.is_empty() {
+        "<empty>".into()
+    } else {
+        names.join(", ")
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vmm_liveness_accepts_current_process_and_rejects_missing_process() {
+        ensure_vmm_process_alive("container", std::process::id() as i32)
+            .expect("current process is alive");
+
+        let error = ensure_vmm_process_alive("container", i32::MAX)
+            .expect_err("maximum PID should not exist");
+        assert!(error.to_string().contains("exited before OCI init started"));
+    }
+
+    #[tokio::test]
+    async fn wait_for_init_session_fails_immediately_when_vmm_exits() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = OciStateStore::new(temp.path());
+        let state_dir = store.container_dir("container").expect("state dir");
+        std::fs::create_dir_all(&state_dir).expect("create state dir");
+
+        let started = tokio::time::Instant::now();
+        let error = wait_for_init_session_id(&store, "container", i32::MAX)
+            .await
+            .expect_err("dead VMM should fail startup");
+
+        assert!(error.to_string().contains("exited before OCI init started"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn wait_for_init_exit_returns_published_status() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = OciStateStore::new(temp.path());
+        let state_dir = store.container_dir("container").expect("state dir");
+        std::fs::create_dir_all(&state_dir).expect("create state dir");
+        std::fs::write(state_dir.join(OCI_INIT_SESSION_EXIT), "143\n").expect("write exit status");
+
+        assert_eq!(
+            wait_for_init_exit(&store, "container")
+                .await
+                .expect("wait for exit"),
+            143
+        );
+    }
+}

--- a/crates/oci-runtime/lib/runtime.rs
+++ b/crates/oci-runtime/lib/runtime.rs
@@ -1,0 +1,272 @@
+//! OCI lifecycle orchestration backed by Microsandbox.
+
+use std::path::PathBuf;
+
+use anyhow::{Result, anyhow, bail};
+use chrono::Utc;
+use microsandbox::sandbox::{Sandbox, SandboxStatus};
+use microsandbox_runtime::oci::{
+    OciBundle, OciOperation, OciState, OciStateStore, next_status, sandbox_name_for_container,
+};
+
+use crate::console::open_console_bridge;
+use crate::options::{CreateOptions, DeleteOptions, ExecOptions, KillOptions};
+use crate::process::{
+    HostSignalForwarder, load_process, parse_signal, start_process_stream, wait_for_process_exit,
+    write_exec_pid_file,
+};
+use crate::requests::{
+    OCI_SIGNAL_REQUEST, OCI_START_REQUEST, ensure_vmm_process_alive, publish_signal_request,
+    publish_start_request, read_init_session_id, signal_init_process_if_known,
+    stop_sandbox_for_delete, wait_for_init_exit, wait_for_init_session_id,
+};
+use crate::sandbox::{
+    create_sandbox_for_bundle, requires_fresh_network_namespace, resolve_created_sandbox_host_pid,
+    sandbox_host_pid_from_handle,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Host-side OCI runtime implementation backed by Microsandbox.
+#[derive(Debug, Clone)]
+pub struct MicrosandboxOciRuntime {
+    store: OciStateStore,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl MicrosandboxOciRuntime {
+    /// Create an OCI runtime wrapper using the supplied `--root` directory.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            store: OciStateStore::new(root),
+        }
+    }
+
+    /// Create the Microsandbox-backed OCI container environment.
+    pub async fn create(&self, options: CreateOptions) -> Result<()> {
+        let bundle = OciBundle::load(&options.bundle)?;
+        let mut state = self.store.create_created(&options.id, &bundle)?;
+
+        let state_dir = self.store.container_dir(&options.id)?;
+        let sandbox =
+            create_sandbox_for_bundle(&options.id, &bundle, &state_dir, options.console).await?;
+        if let Some(pid) = resolve_created_sandbox_host_pid(&options.id, &sandbox).await {
+            state.pid = Some(pid);
+        }
+        self.store.save(&state)?;
+
+        sandbox.detach().await;
+        Ok(())
+    }
+
+    /// Record the host process PID Docker/containerd should track for the OCI container.
+    pub fn record_host_pid(&self, id: &str, pid: i32) -> Result<()> {
+        let mut state = self.store.load(id)?;
+        state.pid = Some(pid);
+        self.store.save(&state)?;
+        Ok(())
+    }
+
+    /// Return whether the OCI bundle asks for a fresh network namespace.
+    pub fn requires_fresh_network_namespace(&self, id: &str) -> Result<bool> {
+        let state = self.store.load(id)?;
+        let bundle = OciBundle::load(&state.bundle)?;
+        Ok(requires_fresh_network_namespace(&bundle))
+    }
+
+    /// Start the configured OCI init process.
+    pub async fn start(&self, id: &str) -> Result<()> {
+        let mut state = self.store.load(id)?;
+        OciOperation::Start.validate(&state)?;
+
+        let host_pid = state
+            .pid
+            .or(sandbox_host_pid_from_handle(id).await)
+            .ok_or_else(|| anyhow!("container `{id}` has no Microsandbox host PID"))?;
+        ensure_vmm_process_alive(id, host_pid)?;
+
+        let start_request = self.store.container_dir(id)?.join(OCI_START_REQUEST);
+        publish_start_request(&start_request)?;
+        let session_id = match wait_for_init_session_id(&self.store, id, host_pid).await {
+            Ok(session_id) => session_id,
+            Err(error) => {
+                let _ = std::fs::remove_file(start_request);
+                return Err(error);
+            }
+        };
+
+        state.mark_running(host_pid, None, Some(session_id), Utc::now());
+        self.store.save(&state)?;
+        Ok(())
+    }
+
+    /// Wait for the OCI init process and its VMM to exit, returning the init exit code.
+    pub async fn wait(&self, id: &str) -> Result<i32> {
+        let state = self.store.load(id)?;
+        if state.status != microsandbox_runtime::oci::OciStatus::Running {
+            bail!(
+                "cannot wait for container `{id}` while it is {:?}",
+                state.status
+            );
+        }
+
+        let exit_code = wait_for_init_exit(&self.store, id).await?;
+        if let Ok(handle) = Sandbox::get(&sandbox_name_for_container(id)).await {
+            handle.wait_until_stopped().await?;
+        }
+
+        let mut state = self.store.load(id)?;
+        state.mark_stopped(Some(exit_code), Utc::now());
+        self.store.save(&state)?;
+        Ok(exit_code)
+    }
+
+    /// Run an additional OCI process in a running container.
+    pub async fn exec(&self, options: ExecOptions) -> Result<i32> {
+        self.exec_with_console(options, None).await
+    }
+
+    /// Run an additional OCI process attached to an OCI console socket bridge.
+    pub async fn exec_console(&self, options: ExecOptions, console_slave: PathBuf) -> Result<i32> {
+        self.exec_with_console(options, Some(console_slave)).await
+    }
+
+    /// Send a signal to the OCI init process inside the guest.
+    pub async fn kill(&self, options: KillOptions) -> Result<()> {
+        let state = self.store.load(&options.id)?;
+        OciOperation::Kill.validate(&state)?;
+
+        let signal = parse_signal(&options.signal)?;
+        let mut state = state;
+        if state
+            .microsandbox
+            .as_ref()
+            .and_then(|msb| msb.init_exec_session_id)
+            .is_none()
+            && let Ok(session_id) = read_init_session_id(&self.store, &options.id)
+            && let Some(msb) = state.microsandbox.as_mut()
+        {
+            msb.init_exec_session_id = Some(session_id);
+        }
+        if state
+            .microsandbox
+            .as_ref()
+            .and_then(|msb| msb.init_exec_session_id)
+            .is_none()
+        {
+            stop_sandbox_for_delete(&options.id).await?;
+            state.mark_stopped(Some(128 + signal), Utc::now());
+            self.store.save(&state)?;
+            return Ok(());
+        }
+        publish_signal_request(
+            &self
+                .store
+                .container_dir(&options.id)?
+                .join(OCI_SIGNAL_REQUEST),
+            signal,
+        )?;
+        Ok(())
+    }
+
+    /// Delete OCI and Microsandbox state.
+    pub async fn delete(&self, options: DeleteOptions) -> Result<()> {
+        let mut state = self.store.load(&options.id)?;
+        if options.force && !state.status.is_terminal() {
+            signal_init_process_if_known(&options.id, &state, libc::SIGKILL).await?;
+            stop_sandbox_for_delete(&options.id).await?;
+            state.mark_stopped(None, Utc::now());
+            self.store.save(&state)?;
+        } else {
+            OciOperation::Delete.validate(&state)?;
+        }
+
+        if let Ok(handle) = Sandbox::get(&sandbox_name_for_container(&options.id)).await {
+            let refreshed = handle.refresh().await.unwrap_or(handle);
+            if !matches!(
+                refreshed.status_snapshot(),
+                SandboxStatus::Stopped | SandboxStatus::Crashed
+            ) {
+                bail!(
+                    "cannot delete running Microsandbox sandbox `{}`",
+                    refreshed.name()
+                );
+            }
+            refreshed.remove().await?;
+        }
+
+        self.store.delete(&options.id)?;
+        Ok(())
+    }
+
+    /// Return OCI state, refreshing terminal status from Microsandbox when possible.
+    pub async fn state(&self, id: &str) -> Result<OciState> {
+        let mut state = self.store.load(id)?;
+        if let Ok(handle) = Sandbox::get(&sandbox_name_for_container(id)).await {
+            if let Some(local) = handle.local()
+                && state.pid.is_none()
+            {
+                state.pid = local.pid;
+            }
+            if matches!(
+                handle.status_snapshot(),
+                SandboxStatus::Stopped | SandboxStatus::Crashed
+            ) && !state.status.is_terminal()
+            {
+                state.mark_stopped(None, Utc::now());
+                self.store.save(&state)?;
+            }
+        }
+        Ok(state)
+    }
+
+    /// Pause the OCI container if Microsandbox has a matching backend state.
+    pub async fn pause(&self, id: &str) -> Result<()> {
+        let state = self.store.load(id)?;
+        let _ = next_status(OciOperation::Pause, &state)?;
+        bail!("pause is not implemented by runmsb yet")
+    }
+
+    /// Resume the OCI container if Microsandbox has a matching backend state.
+    pub async fn resume(&self, id: &str) -> Result<()> {
+        let state = self.store.load(id)?;
+        let _ = next_status(OciOperation::Resume, &state)?;
+        bail!("resume is not implemented by runmsb yet")
+    }
+
+    async fn exec_with_console(
+        &self,
+        options: ExecOptions,
+        console_slave: Option<PathBuf>,
+    ) -> Result<i32> {
+        let state = self.store.load(&options.id)?;
+        OciOperation::Exec.validate(&state)?;
+        let mut host_signals = HostSignalForwarder::new()?;
+
+        let process = load_process(&options.process)?;
+        let bundle = OciBundle::load(&state.bundle)?;
+        let sandbox = crate::process::connect_sandbox(&options.id).await?;
+        let (started, mut handle) =
+            start_process_stream(&sandbox, &process, &bundle.rootfs_path()).await?;
+        write_exec_pid_file(options.pid_file.as_deref(), &started)?;
+
+        let console = console_slave
+            .as_deref()
+            .map(open_console_bridge)
+            .transpose()?;
+        let exit_code = wait_for_process_exit(
+            &options.id,
+            &mut handle,
+            console.as_ref(),
+            &mut host_signals,
+        )
+        .await?;
+        sandbox.detach().await;
+        Ok(exit_code)
+    }
+}

--- a/crates/oci-runtime/lib/sandbox.rs
+++ b/crates/oci-runtime/lib/sandbox.rs
@@ -1,0 +1,266 @@
+//! Microsandbox construction and host-process discovery for OCI containers.
+
+use std::os::fd::OwnedFd;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::Result;
+use microsandbox::sandbox::Sandbox;
+use microsandbox_runtime::oci::{OciBundle, sandbox_name_for_container};
+
+use crate::console::process_console_size;
+use crate::process::{env_pairs, process_args};
+use crate::requests::{OCI_INIT_SESSION, OCI_SIGNAL_REQUEST, OCI_START_REQUEST};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const OCI_FORWARD_STDIO_LABEL: &str = "oci.microsandbox.forward_stdio";
+const OCI_CONSOLE_ROWS_LABEL: &str = "oci.microsandbox.console_rows";
+const OCI_CONSOLE_COLS_LABEL: &str = "oci.microsandbox.console_cols";
+const OCI_INIT_SESSION_PATH_LABEL: &str = "oci.microsandbox.init_session_path";
+const OCI_ISOLATE_NETWORK_NAMESPACE_LABEL: &str = "oci.microsandbox.isolate_network_namespace";
+const OCI_SIGNAL_PATH_LABEL: &str = "oci.microsandbox.signal_path";
+const OCI_STARTUP_CWD_LABEL: &str = "oci.microsandbox.startup_cwd";
+const OCI_START_SIGNAL_PATH_LABEL: &str = "oci.microsandbox.start_signal_path";
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) async fn create_sandbox_for_bundle(
+    id: &str,
+    bundle: &OciBundle,
+    state_dir: &Path,
+    console: Option<OwnedFd>,
+) -> Result<Sandbox> {
+    let process = bundle.process();
+    let mut builder = Sandbox::builder(sandbox_name_for_container(id))
+        .image(bundle.rootfs_path())
+        .detached(true)
+        .label("oci.container.id", id)
+        .label("oci.bundle", bundle.path.display().to_string())
+        .label(OCI_FORWARD_STDIO_LABEL, "true")
+        .label(
+            OCI_START_SIGNAL_PATH_LABEL,
+            state_dir.join(OCI_START_REQUEST).display().to_string(),
+        )
+        .label(
+            OCI_INIT_SESSION_PATH_LABEL,
+            state_dir.join(OCI_INIT_SESSION).display().to_string(),
+        )
+        .label(
+            OCI_SIGNAL_PATH_LABEL,
+            state_dir.join(OCI_SIGNAL_REQUEST).display().to_string(),
+        );
+
+    if let Some(console) = console {
+        builder = builder.inherited_startup_console(console);
+        if let Some(size) = process.and_then(process_console_size) {
+            builder = builder
+                .label(OCI_CONSOLE_ROWS_LABEL, size.rows.to_string())
+                .label(OCI_CONSOLE_COLS_LABEL, size.cols.to_string());
+        }
+    }
+
+    if requires_fresh_network_namespace(bundle) {
+        builder = builder.label(OCI_ISOLATE_NETWORK_NAMESPACE_LABEL, "true");
+        builder = builder.network(|network| {
+            network.ipv4_pool("172.16.0.0/12".parse().expect("valid OCI IPv4 pool"))
+        });
+    }
+
+    if let Some(process) = process {
+        builder = builder.background_command(process_args(process)?.iter().cloned());
+        let cwd = process.cwd().display().to_string();
+        builder = builder.label(OCI_STARTUP_CWD_LABEL, cwd.clone());
+        if cwd != "/" {
+            builder = builder.workdir(cwd);
+        }
+        let user = process.user();
+        if user.uid() != 0 || user.gid() != 0 {
+            builder = builder.user(format!("{}:{}", user.uid(), user.gid()));
+        }
+        for (key, value) in env_pairs(process.env().as_deref().unwrap_or_default())? {
+            builder = builder.env(key, value);
+        }
+    }
+
+    for mount in bundle.mounts() {
+        if is_runtime_managed_mount(mount.destination()) {
+            continue;
+        }
+
+        match mount.typ().as_deref() {
+            Some("bind") => {
+                let Some(source) = mount.source().as_ref() else {
+                    continue;
+                };
+                let destination = mount.destination().display().to_string();
+                let source = absolutize_mount_source(&bundle.path, source);
+                let readonly = mount
+                    .options()
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .any(|opt| opt == "ro");
+                builder = builder.volume(destination, |mount| {
+                    let mount = mount.bind(source);
+                    if readonly { mount.readonly() } else { mount }
+                });
+            }
+            Some("tmpfs") => {
+                let destination = mount.destination().display().to_string();
+                builder = builder.volume(destination, |mount| mount.tmpfs());
+            }
+            _ => {}
+        }
+    }
+
+    builder.create_detached().await.map_err(Into::into)
+}
+
+pub(crate) async fn resolve_created_sandbox_host_pid(id: &str, sandbox: &Sandbox) -> Option<i32> {
+    const PID_WAIT_ATTEMPTS: usize = 50;
+    const PID_WAIT_INTERVAL: Duration = Duration::from_millis(20);
+
+    if let Some(pid) = sandbox_host_pid(sandbox).await {
+        return Some(pid);
+    }
+
+    for _ in 0..PID_WAIT_ATTEMPTS {
+        if let Some(pid) = sandbox_host_pid_from_handle(id).await {
+            return Some(pid);
+        }
+        tokio::time::sleep(PID_WAIT_INTERVAL).await;
+    }
+
+    None
+}
+
+pub(crate) async fn sandbox_host_pid_from_handle(id: &str) -> Option<i32> {
+    let handle = Sandbox::get(&sandbox_name_for_container(id)).await.ok()?;
+    handle.local().and_then(|local| local.pid)
+}
+
+pub(crate) fn requires_fresh_network_namespace(bundle: &OciBundle) -> bool {
+    bundle
+        .spec
+        .linux()
+        .as_ref()
+        .and_then(|linux| linux.namespaces().as_ref())
+        .is_some_and(|namespaces| {
+            namespaces.iter().any(|namespace| {
+                namespace.typ() == oci_spec::runtime::LinuxNamespaceType::Network
+                    && namespace.path().is_none()
+            })
+        })
+}
+
+async fn sandbox_host_pid(sandbox: &Sandbox) -> Option<i32> {
+    let local = sandbox.local()?;
+    let handle = local.handle.as_ref()?;
+    Some(handle.lock().await.pid() as i32)
+}
+
+fn is_runtime_managed_mount(destination: &Path) -> bool {
+    matches!(
+        normalize_guest_path(destination).as_str(),
+        "/dev" | "/dev/pts" | "/dev/ptmx" | "/dev/console" | "/proc" | "/sys" | "/sys/fs/cgroup"
+    )
+}
+
+fn normalize_guest_path(path: &Path) -> String {
+    let mut normalized = path.display().to_string();
+    if normalized.is_empty() {
+        return "/".to_string();
+    }
+    if !normalized.starts_with('/') {
+        normalized.insert(0, '/');
+    }
+    while normalized.len() > 1 && normalized.ends_with('/') {
+        normalized.pop();
+    }
+    normalized
+}
+
+fn absolutize_mount_source(bundle: &Path, source: &Path) -> PathBuf {
+    if source.is_absolute() {
+        source.to_path_buf()
+    } else {
+        bundle.join(source)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_relative_mount_source_against_bundle() {
+        assert_eq!(
+            absolutize_mount_source(Path::new("/bundle"), Path::new("data")),
+            PathBuf::from("/bundle/data")
+        );
+        assert_eq!(
+            absolutize_mount_source(Path::new("/bundle"), Path::new("/host/data")),
+            PathBuf::from("/host/data")
+        );
+    }
+
+    #[test]
+    fn detects_fresh_oci_network_namespace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(temp.path().join("rootfs")).expect("rootfs");
+        std::fs::write(
+            temp.path().join("config.json"),
+            r#"{
+                "ociVersion": "1.2.0",
+                "root": { "path": "rootfs" },
+                "process": {
+                    "user": { "uid": 0, "gid": 0 },
+                    "cwd": "/",
+                    "args": ["/bin/sh"]
+                },
+                "linux": {
+                    "namespaces": [{ "type": "network" }]
+                }
+            }"#,
+        )
+        .expect("config");
+        let bundle = OciBundle::load(temp.path()).expect("load bundle");
+
+        assert!(requires_fresh_network_namespace(&bundle));
+    }
+
+    #[test]
+    fn skips_runtime_managed_oci_mounts() {
+        for destination in [
+            "/dev",
+            "/dev/",
+            "/dev/pts",
+            "/dev/ptmx",
+            "/dev/console",
+            "/proc",
+            "/sys",
+            "/sys/fs/cgroup",
+        ] {
+            assert!(
+                is_runtime_managed_mount(Path::new(destination)),
+                "{destination} should be runtime-managed"
+            );
+        }
+
+        for destination in ["/dev/shm", "/etc/hosts", "/etc/resolv.conf", "/tmp"] {
+            assert!(
+                !is_runtime_managed_mount(Path::new(destination)),
+                "{destination} should be forwarded from the OCI bundle"
+            );
+        }
+    }
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -15,6 +15,7 @@ path = "lib/lib.rs"
 default = ["prebuilt", "net"]
 prebuilt = ["microsandbox-filesystem/prebuilt"]
 net = ["dep:microsandbox-network", "msb_krun/net"]
+oci-runtime = []
 
 [dependencies]
 bytes = { workspace = true }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -33,6 +33,7 @@ microsandbox-utils.workspace = true
 microsandbox-vsock.workspace = true
 msb_krun = { workspace = true, features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
+oci-spec.workspace = true
 rand.workspace = true
 rustls = { workspace = true }
 sea-orm.workspace = true

--- a/crates/runtime/lib/lib.rs
+++ b/crates/runtime/lib/lib.rs
@@ -24,6 +24,7 @@ pub mod launch;
 pub mod logging;
 pub mod maintenance;
 pub mod metrics;
+pub mod oci;
 pub mod policy;
 pub mod relay;
 mod startup;

--- a/crates/runtime/lib/lib.rs
+++ b/crates/runtime/lib/lib.rs
@@ -27,6 +27,10 @@ pub mod metrics;
 pub mod oci;
 pub mod policy;
 pub mod relay;
+#[cfg(feature = "oci-runtime")]
+mod startup;
+#[cfg(not(feature = "oci-runtime"))]
+#[path = "startup_standard.rs"]
 mod startup;
 pub mod vm;
 pub(crate) mod writeback;

--- a/crates/runtime/lib/oci/bundle.rs
+++ b/crates/runtime/lib/oci/bundle.rs
@@ -1,0 +1,220 @@
+//! OCI bundle parsing used by Microsandbox runtime integration.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use oci_spec::runtime::{Mount, Process, Spec};
+
+use super::{OciResult, OciRuntimeError, io_error};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const CONFIG_JSON: &str = "config.json";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// OCI bundle loaded from a host directory.
+#[derive(Debug, Clone)]
+pub struct OciBundle {
+    /// Absolute path to the bundle directory.
+    pub path: PathBuf,
+
+    /// Parsed OCI `config.json`.
+    pub spec: OciSpec,
+}
+
+/// OCI runtime specification parsed from `config.json`.
+pub type OciSpec = Spec;
+
+/// OCI process descriptor parsed from `config.json` or `process.json`.
+pub type OciProcess = Process;
+
+/// OCI mount descriptor parsed from `config.json`.
+pub type OciMount = Mount;
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl OciBundle {
+    /// Load and validate an OCI bundle from a directory.
+    pub fn load(path: impl AsRef<Path>) -> OciResult<Self> {
+        let path = absolutize_existing(path.as_ref())?;
+        let config_path = path.join(CONFIG_JSON);
+        let spec = OciSpec::load(&config_path).map_err(|e| OciRuntimeError::InvalidBundle {
+            bundle: path.clone(),
+            reason: format!(
+                "failed to load `{}` with oci-spec: {e}",
+                config_path.display()
+            ),
+        })?;
+
+        let bundle = Self { path, spec };
+        bundle.validate()?;
+        Ok(bundle)
+    }
+
+    /// Resolve the OCI rootfs path to an absolute host path.
+    pub fn rootfs_path(&self) -> PathBuf {
+        let root = self
+            .spec
+            .root()
+            .as_ref()
+            .expect("validated OCI bundle must have a root filesystem");
+        if root.path().is_absolute() {
+            root.path().clone()
+        } else {
+            self.path.join(root.path())
+        }
+    }
+
+    /// Return the OCI process configured for `start`, if present.
+    pub fn process(&self) -> Option<&OciProcess> {
+        self.spec.process().as_ref()
+    }
+
+    /// Return additional OCI mounts.
+    pub fn mounts(&self) -> &[OciMount] {
+        self.spec.mounts().as_deref().unwrap_or_default()
+    }
+
+    /// Return annotations as the deterministic map used by persisted OCI state.
+    pub fn annotations(&self) -> BTreeMap<String, String> {
+        self.spec
+            .annotations()
+            .as_ref()
+            .map(|annotations| {
+                annotations
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Validate the bundle shape needed by Microsandbox's OCI layer.
+    pub fn validate(&self) -> OciResult<()> {
+        if self.spec.version().trim().is_empty() {
+            return Err(OciRuntimeError::InvalidBundle {
+                bundle: self.path.clone(),
+                reason: "ociVersion must not be empty".to_string(),
+            });
+        }
+        if self.spec.root().is_none() {
+            return Err(OciRuntimeError::InvalidBundle {
+                bundle: self.path.clone(),
+                reason: "root must be present".to_string(),
+            });
+        }
+        if let Some(process) = self.process() {
+            validate_process(process, &self.path)?;
+        }
+        let rootfs = self.rootfs_path();
+        if !rootfs.is_dir() {
+            return Err(OciRuntimeError::InvalidBundle {
+                bundle: self.path.clone(),
+                reason: format!("rootfs `{}` is not a directory", rootfs.display()),
+            });
+        }
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Validate process fields needed by Microsandbox's OCI execution layer.
+pub fn validate_process(process: &OciProcess, bundle: &Path) -> OciResult<()> {
+    if !process.cwd().is_absolute() {
+        return Err(OciRuntimeError::InvalidBundle {
+            bundle: bundle.to_path_buf(),
+            reason: format!("process.cwd must be absolute: {}", process.cwd().display()),
+        });
+    }
+    if process.args().as_deref().unwrap_or_default().is_empty() {
+        return Err(OciRuntimeError::InvalidBundle {
+            bundle: bundle.to_path_buf(),
+            reason: "process.args must contain at least one entry".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn absolutize_existing(path: &Path) -> OciResult<PathBuf> {
+    std::fs::canonicalize(path).map_err(|e| io_error("canonicalize", path, e))
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn load_resolves_relative_rootfs_against_bundle() {
+        let temp = TempDir::new().expect("tempdir");
+        let rootfs = temp.path().join("rootfs");
+        fs::create_dir(&rootfs).expect("rootfs");
+        fs::write(
+            temp.path().join(CONFIG_JSON),
+            r#"{
+                "ociVersion": "1.2.0",
+                "root": { "path": "rootfs" },
+                "process": {
+                    "user": { "uid": 0, "gid": 0 },
+                    "cwd": "/",
+                    "args": ["/bin/sh"],
+                    "env": ["PATH=/bin"]
+                },
+                "annotations": {
+                    "io.containerd.runtime.v2.task": "default/demo"
+                }
+            }"#,
+        )
+        .expect("config");
+
+        let bundle = OciBundle::load(temp.path()).expect("load bundle");
+        let rootfs = fs::canonicalize(rootfs).expect("canonical rootfs");
+
+        assert_eq!(bundle.rootfs_path(), rootfs);
+        assert_eq!(bundle.spec.version(), "1.2.0");
+        assert_eq!(
+            bundle.annotations()["io.containerd.runtime.v2.task"],
+            "default/demo"
+        );
+    }
+
+    #[test]
+    fn load_rejects_relative_process_cwd() {
+        let temp = TempDir::new().expect("tempdir");
+        fs::create_dir(temp.path().join("rootfs")).expect("rootfs");
+        fs::write(
+            temp.path().join(CONFIG_JSON),
+            r#"{
+                "ociVersion": "1.2.0",
+                "root": { "path": "rootfs" },
+                "process": {
+                    "user": { "uid": 0, "gid": 0 },
+                    "cwd": "app",
+                    "args": ["/bin/sh"]
+                }
+            }"#,
+        )
+        .expect("config");
+
+        let err = OciBundle::load(temp.path()).expect_err("invalid cwd");
+
+        assert!(err.to_string().contains("process.cwd must be absolute"));
+    }
+}

--- a/crates/runtime/lib/oci/error.rs
+++ b/crates/runtime/lib/oci/error.rs
@@ -1,0 +1,121 @@
+//! Error types for OCI runtime compatibility.
+
+use std::path::PathBuf;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Result type used by OCI compatibility components.
+pub type OciResult<T> = Result<T, OciRuntimeError>;
+
+/// Errors returned by OCI compatibility components.
+#[derive(Debug, thiserror::Error)]
+pub enum OciRuntimeError {
+    /// The supplied container ID is empty or contains path separators.
+    #[error("invalid container ID `{id}`")]
+    InvalidContainerId {
+        /// Invalid container ID.
+        id: String,
+    },
+
+    /// The OCI bundle does not contain a valid `config.json`.
+    #[error("invalid OCI bundle `{bundle}`: {reason}")]
+    InvalidBundle {
+        /// Bundle path.
+        bundle: PathBuf,
+
+        /// Human-readable validation failure.
+        reason: String,
+    },
+
+    /// The requested container state was not found.
+    #[error("container `{id}` does not exist")]
+    NotFound {
+        /// Container ID.
+        id: String,
+    },
+
+    /// The requested container ID is already in use.
+    #[error("container `{id}` already exists")]
+    AlreadyExists {
+        /// Container ID.
+        id: String,
+    },
+
+    /// The requested operation is not valid for the current OCI status.
+    #[error("cannot {operation} container `{id}` while it is {status}")]
+    InvalidTransition {
+        /// Container ID.
+        id: String,
+
+        /// Requested operation.
+        operation: &'static str,
+
+        /// Current status.
+        status: String,
+    },
+
+    /// A required OCI process was not provided.
+    #[error("container `{id}` has no OCI process to start")]
+    MissingProcess {
+        /// Container ID.
+        id: String,
+    },
+
+    /// A filesystem operation failed.
+    #[error("{operation} `{path}`: {source}")]
+    Io {
+        /// Operation that failed.
+        operation: &'static str,
+
+        /// Path involved in the failure.
+        path: PathBuf,
+
+        /// Source I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// JSON serialization or parsing failed.
+    #[error("{operation} JSON `{path}`: {source}")]
+    Json {
+        /// Operation that failed.
+        operation: &'static str,
+
+        /// Path involved in the failure.
+        path: PathBuf,
+
+        /// Source JSON error.
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) fn io_error(
+    operation: &'static str,
+    path: impl Into<PathBuf>,
+    source: std::io::Error,
+) -> OciRuntimeError {
+    OciRuntimeError::Io {
+        operation,
+        path: path.into(),
+        source,
+    }
+}
+
+pub(crate) fn json_error(
+    operation: &'static str,
+    path: impl Into<PathBuf>,
+    source: serde_json::Error,
+) -> OciRuntimeError {
+    OciRuntimeError::Json {
+        operation,
+        path: path.into(),
+        source,
+    }
+}

--- a/crates/runtime/lib/oci/lifecycle.rs
+++ b/crates/runtime/lib/oci/lifecycle.rs
@@ -1,0 +1,194 @@
+//! OCI lifecycle command validation.
+
+use super::{OciResult, OciRuntimeError, OciState, OciStatus};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// OCI lifecycle operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OciOperation {
+    /// Create the container environment.
+    Create,
+
+    /// Start the configured init process.
+    Start,
+
+    /// Execute an additional process in the running container.
+    Exec,
+
+    /// Send a signal to the container init process.
+    Kill,
+
+    /// Delete resources created by `create`.
+    Delete,
+
+    /// Return current container state.
+    State,
+
+    /// Suspend the container.
+    Pause,
+
+    /// Resume the container.
+    Resume,
+}
+
+/// State transition requested by an OCI operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OciTransition {
+    /// Operation being performed.
+    pub operation: OciOperation,
+
+    /// Status before the operation.
+    pub from: OciStatus,
+
+    /// Status after the operation.
+    pub to: OciStatus,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl OciOperation {
+    /// Operation name used in diagnostics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Create => "create",
+            Self::Start => "start",
+            Self::Exec => "exec",
+            Self::Kill => "kill",
+            Self::Delete => "delete",
+            Self::State => "state",
+            Self::Pause => "pause",
+            Self::Resume => "resume",
+        }
+    }
+
+    /// Validate that this operation can run against the supplied state.
+    pub fn validate(self, state: &OciState) -> OciResult<()> {
+        let valid = match self {
+            Self::Create => false,
+            Self::Start => matches!(state.status, OciStatus::Created),
+            Self::Exec => matches!(state.status, OciStatus::Running),
+            Self::Kill => state.status.can_receive_signal(),
+            Self::Delete => matches!(state.status, OciStatus::Stopped),
+            Self::State => true,
+            Self::Pause => matches!(state.status, OciStatus::Running),
+            Self::Resume => matches!(state.status, OciStatus::Paused),
+        };
+
+        if valid {
+            Ok(())
+        } else {
+            Err(OciRuntimeError::InvalidTransition {
+                id: state.id.clone(),
+                operation: self.as_str(),
+                status: state.status.as_str().to_string(),
+            })
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Validate and compute the next state for an OCI operation that has a direct status transition.
+pub fn next_status(operation: OciOperation, state: &OciState) -> OciResult<OciStatus> {
+    operation.validate(state)?;
+    let next = match operation {
+        OciOperation::Start => OciStatus::Running,
+        OciOperation::Kill => state.status,
+        OciOperation::Pause => OciStatus::Paused,
+        OciOperation::Resume => OciStatus::Running,
+        OciOperation::State | OciOperation::Exec => state.status,
+        OciOperation::Delete => state.status,
+        OciOperation::Create => OciStatus::Created,
+    };
+    Ok(next)
+}
+
+/// Validate and return a transition descriptor for a direct status-changing operation.
+pub fn transition(operation: OciOperation, state: &OciState) -> OciResult<OciTransition> {
+    Ok(OciTransition {
+        operation,
+        from: state.status,
+        to: next_status(operation, state)?,
+    })
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use chrono::Utc;
+
+    use super::super::MicrosandboxState;
+    use super::*;
+
+    fn state(status: OciStatus) -> OciState {
+        let mut state = OciState::created(
+            "demo",
+            "1.2.0",
+            "/bundle",
+            BTreeMap::new(),
+            MicrosandboxState::new("oci-demo", "/state/demo", "/bundle/rootfs", Utc::now()),
+        );
+        state.status = status;
+        state
+    }
+
+    #[test]
+    fn start_only_accepts_created() {
+        assert_eq!(
+            next_status(OciOperation::Start, &state(OciStatus::Created)).expect("start"),
+            OciStatus::Running
+        );
+        assert!(next_status(OciOperation::Start, &state(OciStatus::Running)).is_err());
+        assert!(next_status(OciOperation::Start, &state(OciStatus::Stopped)).is_err());
+    }
+
+    #[test]
+    fn docker_exec_requires_running_container() {
+        assert_eq!(
+            next_status(OciOperation::Exec, &state(OciStatus::Running)).expect("exec"),
+            OciStatus::Running
+        );
+        assert!(next_status(OciOperation::Exec, &state(OciStatus::Created)).is_err());
+        assert!(next_status(OciOperation::Exec, &state(OciStatus::Paused)).is_err());
+    }
+
+    #[test]
+    fn pause_resume_cycle_matches_de_facto_runtime_behavior() {
+        assert_eq!(
+            next_status(OciOperation::Pause, &state(OciStatus::Running)).expect("pause"),
+            OciStatus::Paused
+        );
+        assert_eq!(
+            next_status(OciOperation::Resume, &state(OciStatus::Paused)).expect("resume"),
+            OciStatus::Running
+        );
+        assert!(next_status(OciOperation::Pause, &state(OciStatus::Created)).is_err());
+    }
+
+    #[test]
+    fn delete_only_accepts_stopped() {
+        assert!(next_status(OciOperation::Delete, &state(OciStatus::Stopped)).is_ok());
+        assert!(next_status(OciOperation::Delete, &state(OciStatus::Running)).is_err());
+    }
+
+    #[test]
+    fn kill_validates_signalable_state_without_stopping_container() {
+        assert_eq!(
+            next_status(OciOperation::Kill, &state(OciStatus::Running)).expect("kill"),
+            OciStatus::Running
+        );
+        assert!(next_status(OciOperation::Kill, &state(OciStatus::Stopped)).is_err());
+    }
+}

--- a/crates/runtime/lib/oci/mod.rs
+++ b/crates/runtime/lib/oci/mod.rs
@@ -1,0 +1,23 @@
+//! OCI Runtime Specification compatibility primitives.
+//!
+//! This module contains the host-side contracts that a future
+//! `runmsb` OCI binary and a containerd shim can share. It does
+//! not launch VMs directly; instead it defines the durable state model,
+//! bundle parsing, and lifecycle validation used to map OCI commands onto
+//! Microsandbox's existing microVM runtime.
+
+mod bundle;
+mod error;
+mod lifecycle;
+mod state;
+mod store;
+
+//--------------------------------------------------------------------------------------------------
+// Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use bundle::*;
+pub use error::*;
+pub use lifecycle::*;
+pub use state::*;
+pub use store::*;

--- a/crates/runtime/lib/oci/state.rs
+++ b/crates/runtime/lib/oci/state.rs
@@ -1,0 +1,275 @@
+//! OCI state model persisted by the runtime layer.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// OCI runtime lifecycle status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OciStatus {
+    /// The runtime is creating the container environment.
+    Creating,
+
+    /// The container environment exists, but the configured process has not run.
+    Created,
+
+    /// The configured process has started and has not exited.
+    Running,
+
+    /// The container process has exited.
+    Stopped,
+
+    /// The VM or container process group is suspended.
+    ///
+    /// `paused` is a de-facto runtime status used by Docker/runc-style CLIs,
+    /// although the core OCI spec only standardizes creating/created/running/stopped.
+    Paused,
+}
+
+/// OCI state returned by the `state` command.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OciState {
+    /// OCI Runtime Specification version represented by this state.
+    pub oci_version: String,
+
+    /// Host-unique container ID supplied by Docker/containerd.
+    pub id: String,
+
+    /// Current OCI lifecycle status.
+    pub status: OciStatus,
+
+    /// Host PID of the Microsandbox VMM/sandbox process.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<i32>,
+
+    /// Absolute path to the OCI bundle.
+    pub bundle: PathBuf,
+
+    /// OCI annotations copied from `config.json`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub annotations: BTreeMap<String, String>,
+
+    /// Microsandbox-specific state extensions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub microsandbox: Option<MicrosandboxState>,
+}
+
+/// Microsandbox-specific extension fields persisted beside OCI state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MicrosandboxState {
+    /// Durable Microsandbox sandbox name derived from the OCI container ID.
+    pub sandbox_name: String,
+
+    /// Path to this container's private OCI state directory.
+    pub state_dir: PathBuf,
+
+    /// Rootfs path resolved from the OCI bundle.
+    pub rootfs: PathBuf,
+
+    /// Guest PID reported for the OCI init process, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guest_pid: Option<u32>,
+
+    /// Agent protocol exec session ID for the OCI init process, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub init_exec_session_id: Option<u32>,
+
+    /// Exit code reported for the OCI init process, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+
+    /// Time at which create started.
+    pub created_at: DateTime<Utc>,
+
+    /// Time at which the init process started.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<DateTime<Utc>>,
+
+    /// Time at which the init process exited or the VM stopped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stopped_at: Option<DateTime<Utc>>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl OciStatus {
+    /// Return the status string used by OCI JSON and diagnostics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Creating => "creating",
+            Self::Created => "created",
+            Self::Running => "running",
+            Self::Stopped => "stopped",
+            Self::Paused => "paused",
+        }
+    }
+
+    /// Whether OCI permits signals to be sent in this state.
+    pub fn can_receive_signal(self) -> bool {
+        matches!(self, Self::Created | Self::Running | Self::Paused)
+    }
+
+    /// Whether the state is terminal from Docker/containerd's perspective.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Stopped)
+    }
+}
+
+impl OciState {
+    /// Construct new persisted state for a just-created OCI environment.
+    pub fn created(
+        id: impl Into<String>,
+        oci_version: impl Into<String>,
+        bundle: impl Into<PathBuf>,
+        annotations: BTreeMap<String, String>,
+        microsandbox: MicrosandboxState,
+    ) -> Self {
+        Self {
+            oci_version: oci_version.into(),
+            id: id.into(),
+            status: OciStatus::Created,
+            pid: None,
+            bundle: bundle.into(),
+            annotations,
+            microsandbox: Some(microsandbox),
+        }
+    }
+
+    /// Mark the container init process as running.
+    pub fn mark_running(
+        &mut self,
+        host_pid: i32,
+        guest_pid: Option<u32>,
+        init_exec_session_id: Option<u32>,
+        now: DateTime<Utc>,
+    ) {
+        self.status = OciStatus::Running;
+        self.pid = Some(host_pid);
+        if let Some(msb) = self.microsandbox.as_mut() {
+            msb.guest_pid = guest_pid;
+            msb.init_exec_session_id = init_exec_session_id;
+            msb.started_at = Some(now);
+        }
+    }
+
+    /// Mark the container as stopped.
+    pub fn mark_stopped(&mut self, exit_code: Option<i32>, now: DateTime<Utc>) {
+        self.status = OciStatus::Stopped;
+        if let Some(msb) = self.microsandbox.as_mut() {
+            msb.exit_code = exit_code;
+            msb.stopped_at = Some(now);
+        }
+    }
+}
+
+impl MicrosandboxState {
+    /// Construct Microsandbox extension state for a newly created OCI container.
+    pub fn new(
+        sandbox_name: impl Into<String>,
+        state_dir: impl Into<PathBuf>,
+        rootfs: impl Into<PathBuf>,
+        now: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            sandbox_name: sandbox_name.into(),
+            state_dir: state_dir.into(),
+            rootfs: rootfs.into(),
+            guest_pid: None,
+            init_exec_session_id: None,
+            exit_code: None,
+            created_at: now,
+            started_at: None,
+            stopped_at: None,
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use chrono::TimeZone;
+
+    use super::*;
+
+    #[test]
+    fn serializes_oci_state_with_camel_case_fields() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 6, 25, 12, 0, 0)
+            .single()
+            .expect("valid test time");
+        let state = OciState::created(
+            "abc",
+            "1.2.0",
+            "/bundle",
+            BTreeMap::from([("com.example".to_string(), "yes".to_string())]),
+            MicrosandboxState::new("oci-abc", "/state/abc", "/bundle/rootfs", now),
+        );
+
+        let json = serde_json::to_value(&state).expect("serialize state");
+
+        assert_eq!(json["ociVersion"], "1.2.0");
+        assert_eq!(json["id"], "abc");
+        assert_eq!(json["status"], "created");
+        assert_eq!(json["bundle"], "/bundle");
+        assert_eq!(json["annotations"]["com.example"], "yes");
+        assert_eq!(json["microsandbox"]["sandboxName"], "oci-abc");
+        assert_eq!(json["microsandbox"]["stateDir"], "/state/abc");
+        assert_eq!(json["microsandbox"]["rootfs"], "/bundle/rootfs");
+    }
+
+    #[test]
+    fn mark_running_and_stopped_updates_runtime_fields() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 6, 25, 12, 0, 0)
+            .single()
+            .expect("valid test time");
+        let mut state = OciState::created(
+            "abc",
+            "1.2.0",
+            PathBuf::from("/bundle"),
+            BTreeMap::new(),
+            MicrosandboxState::new("oci-abc", "/state/abc", "/bundle/rootfs", now),
+        );
+
+        state.mark_running(42, Some(7), Some(99), now);
+        assert_eq!(state.status, OciStatus::Running);
+        assert_eq!(state.pid, Some(42));
+        assert_eq!(
+            state.microsandbox.as_ref().and_then(|msb| msb.guest_pid),
+            Some(7)
+        );
+        assert_eq!(
+            state
+                .microsandbox
+                .as_ref()
+                .and_then(|msb| msb.init_exec_session_id),
+            Some(99)
+        );
+        let json = serde_json::to_value(&state).expect("state JSON");
+        assert_eq!(json["microsandbox"]["initExecSessionId"], 99);
+
+        state.mark_stopped(Some(0), now);
+        assert_eq!(state.status, OciStatus::Stopped);
+        assert_eq!(
+            state.microsandbox.as_ref().and_then(|msb| msb.exit_code),
+            Some(0)
+        );
+    }
+}

--- a/crates/runtime/lib/oci/store.rs
+++ b/crates/runtime/lib/oci/store.rs
@@ -1,0 +1,340 @@
+//! Durable OCI state storage.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::Utc;
+
+use super::{
+    MicrosandboxState, OciBundle, OciResult, OciRuntimeError, OciState, io_error, json_error,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const STATE_JSON: &str = "state.json";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Filesystem-backed OCI state store.
+///
+/// The root directory is normally supplied by the OCI runtime CLI's `--root`
+/// option. Each container ID owns one subdirectory containing `state.json`
+/// and Microsandbox runtime metadata.
+#[derive(Debug, Clone)]
+pub struct OciStateStore {
+    root: PathBuf,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl OciStateStore {
+    /// Create a state store rooted at the supplied directory.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Return the state store root.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Return the private state directory for a container ID.
+    pub fn container_dir(&self, id: &str) -> OciResult<PathBuf> {
+        validate_container_id(id)?;
+        Ok(self.root.join(id))
+    }
+
+    /// Return the `state.json` path for a container ID.
+    pub fn state_path(&self, id: &str) -> OciResult<PathBuf> {
+        Ok(self.container_dir(id)?.join(STATE_JSON))
+    }
+
+    /// Create initial `created` state for a container.
+    pub fn create_created(&self, id: &str, bundle: &OciBundle) -> OciResult<OciState> {
+        let state_dir = self.container_dir(id)?;
+        fs::create_dir_all(&self.root).map_err(|e| io_error("create directory", &self.root, e))?;
+        match fs::create_dir(&state_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                return Err(OciRuntimeError::AlreadyExists { id: id.to_string() });
+            }
+            Err(error) => return Err(io_error("create directory", &state_dir, error)),
+        }
+
+        let microsandbox = MicrosandboxState::new(
+            sandbox_name_for_container(id),
+            &state_dir,
+            bundle.rootfs_path(),
+            Utc::now(),
+        );
+        let state = OciState::created(
+            id,
+            bundle.spec.version().clone(),
+            bundle.path.clone(),
+            bundle.annotations(),
+            microsandbox,
+        );
+        self.save(&state)?;
+        Ok(state)
+    }
+
+    /// Load the current state for a container.
+    pub fn load(&self, id: &str) -> OciResult<OciState> {
+        let path = self.state_path(id)?;
+        if !path.exists() {
+            return Err(OciRuntimeError::NotFound { id: id.to_string() });
+        }
+        let data = fs::read_to_string(&path).map_err(|e| io_error("read", &path, e))?;
+        serde_json::from_str(&data).map_err(|e| json_error("parse", &path, e))
+    }
+
+    /// Atomically save state for a container.
+    pub fn save(&self, state: &OciState) -> OciResult<()> {
+        validate_container_id(&state.id)?;
+        let dir = self.container_dir(&state.id)?;
+        if !dir.is_dir() {
+            return Err(OciRuntimeError::NotFound {
+                id: state.id.clone(),
+            });
+        }
+
+        let path = dir.join(STATE_JSON);
+        let json =
+            serde_json::to_vec_pretty(state).map_err(|e| json_error("serialize", &path, e))?;
+        let (mut tmp_file, tmp_path) = create_state_temp_file(&dir)?;
+        tmp_file
+            .write_all(&json)
+            .map_err(|e| io_error("write", &tmp_path, e))?;
+        tmp_file
+            .sync_all()
+            .map_err(|e| io_error("sync", &tmp_path, e))?;
+        drop(tmp_file);
+
+        if let Err(error) = fs::rename(&tmp_path, &path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(io_error("rename", &path, error));
+        }
+        sync_directory(&dir)?;
+        Ok(())
+    }
+
+    /// Delete all state for a stopped container.
+    pub fn delete(&self, id: &str) -> OciResult<()> {
+        let dir = self.container_dir(id)?;
+        if !dir.exists() {
+            return Err(OciRuntimeError::NotFound { id: id.to_string() });
+        }
+        fs::remove_dir_all(&dir).map_err(|e| io_error("remove directory", &dir, e))
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Validate a container ID for safe use as a state-directory name.
+pub fn validate_container_id(id: &str) -> OciResult<()> {
+    let valid = !id.is_empty()
+        && id != "."
+        && id != ".."
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'+' | b'-'));
+
+    if valid {
+        Ok(())
+    } else {
+        Err(OciRuntimeError::InvalidContainerId { id: id.to_string() })
+    }
+}
+
+/// Return the Microsandbox sandbox name derived from an OCI container ID.
+pub fn sandbox_name_for_container(id: &str) -> String {
+    format!("oci-{id}")
+}
+
+fn create_state_temp_file(dir: &Path) -> OciResult<(File, PathBuf)> {
+    for attempt in 0..128 {
+        let tmp_path = dir.join(format!(
+            ".{STATE_JSON}.{}.{}.tmp",
+            std::process::id(),
+            unique_temp_suffix(attempt)
+        ));
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+        {
+            Ok(file) => return Ok((file, tmp_path)),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(io_error("create", &tmp_path, error)),
+        }
+    }
+
+    let path = dir.join(format!(".{STATE_JSON}.tmp"));
+    Err(io_error(
+        "create",
+        &path,
+        std::io::Error::new(
+            ErrorKind::AlreadyExists,
+            "could not allocate unique state temp file",
+        ),
+    ))
+}
+
+fn unique_temp_suffix(attempt: u32) -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default()
+        .saturating_add(attempt as u128)
+}
+
+#[cfg(unix)]
+fn sync_directory(dir: &Path) -> OciResult<()> {
+    let directory = File::open(dir).map_err(|e| io_error("open", dir, e))?;
+    directory.sync_all().map_err(|e| io_error("sync", dir, e))
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_dir: &Path) -> OciResult<()> {
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::super::OciStatus;
+    use super::*;
+
+    fn bundle() -> (TempDir, OciBundle) {
+        let temp = TempDir::new().expect("tempdir");
+        fs::create_dir(temp.path().join("rootfs")).expect("rootfs");
+        fs::write(
+            temp.path().join("config.json"),
+            r#"{
+                "ociVersion": "1.2.0",
+                "root": { "path": "rootfs" },
+                "process": {
+                    "user": { "uid": 0, "gid": 0 },
+                    "cwd": "/",
+                    "args": ["/bin/sh"]
+                }
+            }"#,
+        )
+        .expect("config");
+
+        let bundle = OciBundle::load(temp.path()).expect("bundle");
+        (temp, bundle)
+    }
+
+    #[test]
+    fn create_created_persists_loadable_state() {
+        let (_bundle_dir, bundle) = bundle();
+        let state_root = TempDir::new().expect("state root");
+        let store = OciStateStore::new(state_root.path());
+
+        let state = store
+            .create_created("abc123", &bundle)
+            .expect("create state");
+        let loaded = store.load("abc123").expect("load state");
+
+        assert_eq!(loaded, state);
+        assert_eq!(loaded.status, OciStatus::Created);
+        assert_eq!(
+            loaded
+                .microsandbox
+                .as_ref()
+                .map(|msb| msb.sandbox_name.as_str()),
+            Some("oci-abc123")
+        );
+    }
+
+    #[test]
+    fn create_created_rejects_duplicate_ids() {
+        let (_bundle_dir, bundle) = bundle();
+        let state_root = TempDir::new().expect("state root");
+        let store = OciStateStore::new(state_root.path());
+
+        store
+            .create_created("abc123", &bundle)
+            .expect("first create");
+        let err = store
+            .create_created("abc123", &bundle)
+            .expect_err("duplicate should fail");
+
+        assert!(matches!(err, OciRuntimeError::AlreadyExists { .. }));
+    }
+
+    #[test]
+    fn container_id_must_not_escape_state_root() {
+        assert!(validate_container_id("abc123").is_ok());
+        assert!(validate_container_id("abc_123-DEF.456+ghi").is_ok());
+        assert!(validate_container_id("../abc").is_err());
+        assert!(validate_container_id("a/b").is_err());
+        assert!(validate_container_id("a\nb").is_err());
+        assert!(validate_container_id("a b").is_err());
+        assert!(validate_container_id("").is_err());
+    }
+
+    #[test]
+    fn delete_removes_container_state_directory() {
+        let (_bundle_dir, bundle) = bundle();
+        let state_root = TempDir::new().expect("state root");
+        let store = OciStateStore::new(state_root.path());
+        store.create_created("abc123", &bundle).expect("create");
+
+        store.delete("abc123").expect("delete");
+
+        assert!(!state_root.path().join("abc123").exists());
+    }
+
+    #[test]
+    fn save_does_not_recreate_deleted_container_directory() {
+        let (_bundle_dir, bundle) = bundle();
+        let state_root = TempDir::new().expect("state root");
+        let store = OciStateStore::new(state_root.path());
+        let state = store.create_created("abc123", &bundle).expect("create");
+        fs::remove_dir_all(state_root.path().join("abc123")).expect("remove container dir");
+
+        let err = store
+            .save(&state)
+            .expect_err("save should not recreate dir");
+
+        assert!(matches!(err, OciRuntimeError::NotFound { .. }));
+        assert!(!state_root.path().join("abc123").exists());
+    }
+
+    #[test]
+    fn save_uses_unique_temp_files_without_leaving_shared_tmp() {
+        let (_bundle_dir, bundle) = bundle();
+        let state_root = TempDir::new().expect("state root");
+        let store = OciStateStore::new(state_root.path());
+        let state = store.create_created("abc123", &bundle).expect("create");
+
+        store.save(&state).expect("save");
+
+        assert!(
+            !state_root
+                .path()
+                .join("abc123")
+                .join("state.json.tmp")
+                .exists()
+        );
+    }
+}

--- a/crates/runtime/lib/startup.rs
+++ b/crates/runtime/lib/startup.rs
@@ -1,12 +1,20 @@
 //! Startup workload execution for detached `msb run -- CMD`.
 
+use std::io::{ErrorKind, Write};
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, OwnedFd};
 use std::path::Path;
 
 use microsandbox_agent_client::AgentClient;
 use microsandbox_protocol::{
-    exec::{ExecExited, ExecFailed, ExecRequest},
+    exec::{
+        ExecExited, ExecFailed, ExecRequest, ExecResize, ExecSignal, ExecStderr, ExecStdin,
+        ExecStdout,
+    },
     message::MessageType,
 };
+#[cfg(unix)]
+use tokio::io::unix::AsyncFd;
 
 use crate::vm::StartupCommand;
 use crate::{RuntimeError, RuntimeResult};
@@ -24,6 +32,35 @@ pub(crate) enum StartupCommandExit {
     Failed(ExecFailed),
 }
 
+/// Optional host stdio handles used for OCI startup command forwarding.
+pub(crate) struct StartupStdio {
+    /// Original host stdout captured before runtime log redirection.
+    pub(crate) stdout: std::fs::File,
+
+    /// Original host stderr captured before runtime log redirection.
+    pub(crate) stderr: std::fs::File,
+}
+
+#[cfg(unix)]
+pub(crate) type StartupConsole = OwnedFd;
+
+#[cfg(not(unix))]
+pub(crate) struct StartupConsole;
+
+#[cfg(unix)]
+struct StartupConsoleBridge {
+    fd: AsyncFd<OwnedFd>,
+}
+
+#[cfg(not(unix))]
+struct StartupConsoleBridge;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PtySize {
+    rows: u16,
+    cols: u16,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
@@ -31,7 +68,60 @@ pub(crate) enum StartupCommandExit {
 pub(crate) async fn run_startup_command(
     agent_sock_path: &Path,
     command: StartupCommand,
+    mut stdio: Option<StartupStdio>,
+    console: Option<StartupConsole>,
 ) -> RuntimeResult<StartupCommandExit> {
+    let error_path = command.session_id_path.as_deref().map(startup_error_path);
+    let exit_path = command.session_id_path.as_deref().map(startup_exit_path);
+    let result = run_startup_command_inner(agent_sock_path, command, &mut stdio, console).await;
+
+    match &result {
+        Err(error) => {
+            if let Some(path) = error_path.as_deref() {
+                let _ = write_startup_error(path, &error.to_string());
+            }
+            if let Some(path) = exit_path.as_deref() {
+                let _ = write_startup_exit(path, 1);
+            }
+        }
+        Ok(StartupCommandExit::Failed(failed)) => {
+            if let Some(path) = error_path.as_deref() {
+                let _ = write_startup_error(path, &failed.message);
+            }
+            if let Some(path) = exit_path.as_deref() {
+                let _ = write_startup_exit(path, 127);
+            }
+        }
+        Ok(StartupCommandExit::Exited(code)) => {
+            if let Some(path) = exit_path.as_deref() {
+                write_startup_exit(path, *code)?;
+            }
+        }
+    }
+
+    result
+}
+
+async fn run_startup_command_inner(
+    agent_sock_path: &Path,
+    command: StartupCommand,
+    stdio: &mut Option<StartupStdio>,
+    console: Option<StartupConsole>,
+) -> RuntimeResult<StartupCommandExit> {
+    let mut session_id_path = command.session_id_path;
+    let signal_path = command.signal_path.clone();
+    let uses_console = console.is_some();
+    // Keep the inherited PTY slave open during OCI `create`. containerd owns
+    // the master and waits for a live slave before it invokes OCI `start`.
+    let mut console = open_startup_console(console)?;
+    if let Some(start_signal_path) = command.start_signal_path.as_ref() {
+        wait_for_start_signal(start_signal_path).await?;
+    }
+    let mut console_input_closed = console.is_none();
+    let tty = command.tty || console.is_some();
+    let rows = nonzero_tty_size(command.rows, 24);
+    let cols = nonzero_tty_size(command.cols, 80);
+
     let client = AgentClient::connect(agent_sock_path)
         .await
         .map_err(|err| RuntimeError::Custom(format!("startup command connect: {err}")))?;
@@ -42,36 +132,464 @@ pub(crate) async fn run_startup_command(
         env: command.env,
         cwd: command.cwd,
         user: command.user,
-        tty: false,
-        rows: 24,
-        cols: 80,
+        tty,
+        rows,
+        cols,
         rlimits: Vec::new(),
     };
 
-    let (_id, mut rx) = client
+    let (id, mut rx) = client
         .stream(MessageType::ExecRequest, &request)
         .await
         .map_err(|err| RuntimeError::Custom(format!("startup command dispatch: {err}")))?;
+    let mut initial_stdin = initial_startup_stdin(uses_console);
+    let mut resize_poll = tokio::time::interval(std::time::Duration::from_millis(250));
+    let mut signal_poll = tokio::time::interval(std::time::Duration::from_millis(20));
+    let mut input = [0u8; 4096];
 
-    while let Some(message) = rx.recv().await {
-        match message.t {
-            MessageType::ExecExited => {
-                let exited = message
-                    .payload::<ExecExited>()
-                    .map_err(|err| RuntimeError::Custom(format!("startup command exit: {err}")))?;
-                return Ok(StartupCommandExit::Exited(exited.code));
+    loop {
+        tokio::select! {
+            _ = signal_poll.tick(), if signal_path.is_some() => {
+                if let Some(signal) = take_signal_request(signal_path.as_deref().unwrap())? {
+                    let payload = ExecSignal { signal };
+                    client
+                        .send(id, MessageType::ExecSignal, &payload)
+                        .await
+                        .map_err(|err| RuntimeError::Custom(format!(
+                            "startup command signal {signal}: {err}"
+                        )))?;
+                }
             }
-            MessageType::ExecFailed => {
-                let failed = message.payload::<ExecFailed>().map_err(|err| {
-                    RuntimeError::Custom(format!("startup command failure: {err}"))
-                })?;
-                return Ok(StartupCommandExit::Failed(failed));
+            _ = resize_poll.tick(), if console.is_some() => {
+                if let Some(size) = startup_console_size(console.as_ref()) {
+                    let payload = ExecResize { rows: size.rows, cols: size.cols };
+                    let _ = client.send(id, MessageType::ExecResize, &payload).await;
+                }
             }
-            _ => {}
+            read = read_optional_startup_console_input(console.as_ref(), &mut input),
+                if console.is_some() && !console_input_closed =>
+            {
+                match read {
+                    Ok(0) => {
+                        console_input_closed = true;
+                        let payload = ExecStdin { data: Vec::new() };
+                        let _ = client.send(id, MessageType::ExecStdin, &payload).await;
+                    }
+                    Ok(n) => {
+                        let payload = ExecStdin { data: input[..n].to_vec() };
+                        if client.send(id, MessageType::ExecStdin, &payload).await.is_err() {
+                            console_input_closed = true;
+                        }
+                    }
+                    Err(error) if is_console_disconnect(&error) => {
+                        console_input_closed = true;
+                        console = None;
+                        let payload = ExecStdin { data: Vec::new() };
+                        let _ = client.send(id, MessageType::ExecStdin, &payload).await;
+                    }
+                    Err(error) => {
+                        return Err(RuntimeError::Custom(format!(
+                            "startup command console input: {error}"
+                        )));
+                    }
+                }
+            }
+            message = rx.recv() => {
+                let Some(message) = message else {
+                    return Err(RuntimeError::Custom(
+                        "startup command stream ended before terminal event".into(),
+                    ));
+                };
+                match message.t {
+                    MessageType::ExecStarted => {
+                        if let Some(path) = session_id_path.take() {
+                            write_session_id(&path, id)?;
+                        }
+                        if let Some(payload) = initial_stdin.take() {
+                            client
+                                .send(id, MessageType::ExecStdin, &payload)
+                                .await
+                                .map_err(|err| RuntimeError::Custom(format!(
+                                    "startup command close stdin: {err}"
+                                )))?;
+                        }
+                    }
+                    MessageType::ExecStdout => {
+                        let stdout = message.payload::<ExecStdout>().map_err(|err| {
+                            RuntimeError::Custom(format!("startup command stdout: {err}"))
+                        })?;
+                        write_startup_output(
+                            console.as_ref(),
+                            if uses_console { None } else { stdio.as_mut() },
+                            true,
+                            &stdout.data,
+                        )
+                        .await?;
+                    }
+                    MessageType::ExecStderr => {
+                        let stderr = message.payload::<ExecStderr>().map_err(|err| {
+                            RuntimeError::Custom(format!("startup command stderr: {err}"))
+                        })?;
+                        write_startup_output(
+                            console.as_ref(),
+                            if uses_console { None } else { stdio.as_mut() },
+                            false,
+                            &stderr.data,
+                        )
+                        .await?;
+                    }
+                    MessageType::ExecExited => {
+                        let exited = message.payload::<ExecExited>().map_err(|err| {
+                            RuntimeError::Custom(format!("startup command exit: {err}"))
+                        })?;
+                        return Ok(StartupCommandExit::Exited(exited.code));
+                    }
+                    MessageType::ExecFailed => {
+                        let failed = message.payload::<ExecFailed>().map_err(|err| {
+                            RuntimeError::Custom(format!("startup command failure: {err}"))
+                        })?;
+                        return Ok(StartupCommandExit::Failed(failed));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn initial_startup_stdin(uses_console: bool) -> Option<ExecStdin> {
+    (!uses_console).then(|| ExecStdin { data: Vec::new() })
+}
+
+#[cfg(unix)]
+fn open_startup_console(
+    console: Option<StartupConsole>,
+) -> RuntimeResult<Option<StartupConsoleBridge>> {
+    let Some(fd) = console else {
+        return Ok(None);
+    };
+    set_nonblocking(fd.as_raw_fd())?;
+    let fd = AsyncFd::new(fd)?;
+    Ok(Some(StartupConsoleBridge { fd }))
+}
+
+#[cfg(not(unix))]
+fn open_startup_console(
+    _console: Option<StartupConsole>,
+) -> RuntimeResult<Option<StartupConsoleBridge>> {
+    Ok(None)
+}
+
+fn nonzero_tty_size(size: u16, default: u16) -> u16 {
+    if size == 0 { default } else { size }
+}
+
+async fn write_startup_output(
+    console: Option<&StartupConsoleBridge>,
+    stdio: Option<&mut StartupStdio>,
+    stdout: bool,
+    data: &[u8],
+) -> RuntimeResult<()> {
+    if let Some(console) = console {
+        match write_startup_console_output(console, data).await {
+            Ok(()) => return Ok(()),
+            Err(error) if is_console_disconnect(&error) => return Ok(()),
+            Err(error) => return Err(error.into()),
         }
     }
 
-    Err(RuntimeError::Custom(
-        "startup command stream ended before terminal event".into(),
-    ))
+    let Some(stdio) = stdio else {
+        return Ok(());
+    };
+    if stdout {
+        stdio.stdout.write_all(data)?;
+        stdio.stdout.flush()?;
+    } else {
+        stdio.stderr.write_all(data)?;
+        stdio.stderr.flush()?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn read_startup_console_input(
+    console: &StartupConsoleBridge,
+    buf: &mut [u8],
+) -> std::io::Result<usize> {
+    loop {
+        let mut guard = console.fd.readable().await?;
+        match guard.try_io(|inner| read_fd(inner.get_ref().as_raw_fd(), buf)) {
+            Ok(result) => return result,
+            Err(_) => continue,
+        }
+    }
+}
+
+async fn read_optional_startup_console_input(
+    console: Option<&StartupConsoleBridge>,
+    buf: &mut [u8],
+) -> std::io::Result<usize> {
+    match console {
+        Some(console) => read_startup_console_input(console, buf).await,
+        None => std::future::pending().await,
+    }
+}
+
+#[cfg(not(unix))]
+async fn read_startup_console_input(
+    _console: &StartupConsoleBridge,
+    _buf: &mut [u8],
+) -> std::io::Result<usize> {
+    std::future::pending().await
+}
+
+#[cfg(unix)]
+async fn write_startup_console_output(
+    console: &StartupConsoleBridge,
+    mut data: &[u8],
+) -> std::io::Result<()> {
+    while !data.is_empty() {
+        let mut guard = console.fd.writable().await?;
+        match guard.try_io(|inner| write_fd(inner.get_ref().as_raw_fd(), data)) {
+            Ok(Ok(0)) => {
+                return Err(std::io::Error::new(
+                    ErrorKind::WriteZero,
+                    "console write returned zero",
+                ));
+            }
+            Ok(Ok(n)) => data = &data[n..],
+            Ok(Err(error)) if error.kind() == ErrorKind::Interrupted => continue,
+            Ok(Err(error)) => return Err(error),
+            Err(_) => continue,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn write_startup_console_output(
+    _console: &StartupConsoleBridge,
+    _data: &[u8],
+) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn startup_console_size(console: Option<&StartupConsoleBridge>) -> Option<PtySize> {
+    console.and_then(|console| console_size_from_fd(console.fd.get_ref().as_raw_fd()))
+}
+
+#[cfg(not(unix))]
+fn startup_console_size(_console: Option<&StartupConsoleBridge>) -> Option<PtySize> {
+    None
+}
+
+fn is_console_disconnect(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        ErrorKind::BrokenPipe | ErrorKind::ConnectionReset | ErrorKind::UnexpectedEof
+    ) || error.raw_os_error() == Some(libc::EIO)
+}
+
+#[cfg(unix)]
+fn console_size_from_fd(fd: i32) -> Option<PtySize> {
+    let mut size = std::mem::MaybeUninit::<libc::winsize>::zeroed();
+    if unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, size.as_mut_ptr()) } < 0 {
+        return None;
+    }
+    let size = unsafe { size.assume_init() };
+    pty_size_from_rows_cols(u64::from(size.ws_row), u64::from(size.ws_col))
+}
+
+fn pty_size_from_rows_cols(rows: u64, cols: u64) -> Option<PtySize> {
+    if rows == 0 || cols == 0 {
+        return None;
+    }
+    Some(PtySize {
+        rows: rows.min(u64::from(u16::MAX)) as u16,
+        cols: cols.min(u64::from(u16::MAX)) as u16,
+    })
+}
+
+#[cfg(unix)]
+fn read_fd(fd: i32, buf: &mut [u8]) -> std::io::Result<usize> {
+    loop {
+        let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+        if n >= 0 {
+            return Ok(n as usize);
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() == ErrorKind::Interrupted {
+            continue;
+        }
+        return Err(error);
+    }
+}
+
+#[cfg(unix)]
+fn write_fd(fd: i32, buf: &[u8]) -> std::io::Result<usize> {
+    loop {
+        let n = unsafe { libc::write(fd, buf.as_ptr().cast(), buf.len()) };
+        if n >= 0 {
+            return Ok(n as usize);
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() == ErrorKind::Interrupted {
+            continue;
+        }
+        return Err(error);
+    }
+}
+
+#[cfg(unix)]
+fn set_nonblocking(fd: i32) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn write_session_id(path: &Path, id: u32) -> RuntimeResult<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp_path = path.with_extension("tmp");
+    std::fs::write(&tmp_path, id.to_string())?;
+    std::fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+fn startup_error_path(session_id_path: &Path) -> std::path::PathBuf {
+    let file_name = session_id_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("startup");
+    session_id_path.with_file_name(format!("{file_name}.error"))
+}
+
+fn startup_exit_path(session_id_path: &Path) -> std::path::PathBuf {
+    let file_name = session_id_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("startup");
+    session_id_path.with_file_name(format!("{file_name}.exit"))
+}
+
+fn write_startup_exit(path: &Path, code: i32) -> RuntimeResult<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp_path = path.with_extension("exit.tmp");
+    std::fs::write(&tmp_path, code.to_string())?;
+    std::fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+fn write_startup_error(path: &Path, message: &str) -> RuntimeResult<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp_path = path.with_extension("error.tmp");
+    std::fs::write(&tmp_path, message)?;
+    std::fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+async fn wait_for_start_signal(path: &Path) -> RuntimeResult<()> {
+    let mut interval = tokio::time::interval(std::time::Duration::from_millis(20));
+    loop {
+        interval.tick().await;
+        match tokio::fs::try_exists(path).await {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(err) => {
+                return Err(RuntimeError::Custom(format!(
+                    "startup command start signal {}: {err}",
+                    path.display()
+                )));
+            }
+        }
+    }
+}
+
+fn take_signal_request(path: &Path) -> RuntimeResult<Option<i32>> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    std::fs::remove_file(path)?;
+    let signal = raw.trim().parse::<i32>().map_err(|error| {
+        RuntimeError::Custom(format!(
+            "startup command signal request {}: {error}",
+            path.display()
+        ))
+    })?;
+    Ok(Some(signal))
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    #[test]
+    fn takes_signal_request_once() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("init.signal");
+        std::fs::write(&path, "15").expect("write signal request");
+
+        assert_eq!(
+            super::take_signal_request(&path).expect("take request"),
+            Some(15)
+        );
+        assert_eq!(
+            super::take_signal_request(&path).expect("request consumed"),
+            None
+        );
+    }
+
+    #[test]
+    fn derives_and_writes_startup_exit_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session = temp.path().join("init.session");
+        let exit = super::startup_exit_path(&session);
+
+        assert_eq!(exit, temp.path().join("init.session.exit"));
+        super::write_startup_exit(&exit, 143).expect("write exit status");
+        assert_eq!(
+            std::fs::read_to_string(exit).expect("read exit status"),
+            "143"
+        );
+        assert_eq!(
+            super::startup_exit_path(Path::new("session")),
+            Path::new("session.exit")
+        );
+    }
+
+    #[test]
+    fn non_console_startup_closes_stdin_but_console_keeps_it_open() {
+        let stdin = super::initial_startup_stdin(false).expect("non-console EOF");
+        assert!(stdin.data.is_empty());
+        assert!(super::initial_startup_stdin(true).is_none());
+    }
+
+    #[tokio::test]
+    async fn optional_console_input_waits_when_console_is_absent() {
+        let mut buf = [0u8; 1];
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(10),
+            super::read_optional_startup_console_input(None, &mut buf),
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
 }

--- a/crates/runtime/lib/startup_standard.rs
+++ b/crates/runtime/lib/startup_standard.rs
@@ -1,0 +1,77 @@
+//! Startup workload execution for detached `msb run -- CMD`.
+
+use std::path::Path;
+
+use microsandbox_agent_client::AgentClient;
+use microsandbox_protocol::{
+    exec::{ExecExited, ExecFailed, ExecRequest},
+    message::MessageType,
+};
+
+use crate::vm::StartupCommand;
+use crate::{RuntimeError, RuntimeResult};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Terminal status for the startup workload exec session.
+pub(crate) enum StartupCommandExit {
+    /// The command ran and exited with the contained status code.
+    Exited(i32),
+
+    /// agentd could not spawn the command.
+    Failed(ExecFailed),
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) async fn run_startup_command(
+    agent_sock_path: &Path,
+    command: StartupCommand,
+) -> RuntimeResult<StartupCommandExit> {
+    let client = AgentClient::connect(agent_sock_path)
+        .await
+        .map_err(|err| RuntimeError::Custom(format!("startup command connect: {err}")))?;
+
+    let request = ExecRequest {
+        cmd: command.cmd,
+        args: command.args,
+        env: command.env,
+        cwd: command.cwd,
+        user: command.user,
+        tty: false,
+        rows: 24,
+        cols: 80,
+        rlimits: Vec::new(),
+    };
+
+    let (_id, mut rx) = client
+        .stream(MessageType::ExecRequest, &request)
+        .await
+        .map_err(|err| RuntimeError::Custom(format!("startup command dispatch: {err}")))?;
+
+    while let Some(message) = rx.recv().await {
+        match message.t {
+            MessageType::ExecExited => {
+                let exited = message
+                    .payload::<ExecExited>()
+                    .map_err(|err| RuntimeError::Custom(format!("startup command exit: {err}")))?;
+                return Ok(StartupCommandExit::Exited(exited.code));
+            }
+            MessageType::ExecFailed => {
+                let failed = message.payload::<ExecFailed>().map_err(|err| {
+                    RuntimeError::Custom(format!("startup command failure: {err}"))
+                })?;
+                return Ok(StartupCommandExit::Failed(failed));
+            }
+            _ => {}
+        }
+    }
+
+    Err(RuntimeError::Custom(
+        "startup command stream ended before terminal event".into(),
+    ))
+}

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -83,6 +83,10 @@ pub const STARTUP_FD: i32 = 98;
 #[cfg(unix)]
 pub const LIFECYCLE_LOCK_FD: i32 = 99;
 
+/// Fixed fd holding an inherited terminal for the sandbox startup workload.
+#[cfg(all(unix, feature = "oci-runtime"))]
+pub const OCI_CONSOLE_FD: i32 = 100;
+
 /// Control byte sent by the owner to stop parent-watch monitoring without stopping the sandbox.
 pub const PARENT_WATCH_DETACH: u8 = 1;
 
@@ -151,6 +155,10 @@ pub struct Config {
     #[cfg(unix)]
     pub startup_fd: Option<OwnedFd>,
 
+    /// Terminal inherited for the startup workload.
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    pub startup_console: Option<OwnedFd>,
+
     /// Dedicated Windows startup JSON pipe.
     ///
     /// When present, startup info is written here instead of stdout so
@@ -213,6 +221,55 @@ pub struct StartupCommand {
 
     /// Guest user override for the command.
     pub user: Option<String>,
+
+    /// Whether the startup command should run under a guest PTY.
+    #[cfg(feature = "oci-runtime")]
+    #[serde(default)]
+    pub tty: bool,
+
+    /// Initial terminal row count for PTY-backed startup commands.
+    #[cfg(feature = "oci-runtime")]
+    #[serde(default)]
+    pub rows: u16,
+
+    /// Initial terminal column count for PTY-backed startup commands.
+    #[cfg(feature = "oci-runtime")]
+    #[serde(default)]
+    pub cols: u16,
+
+    /// Optional host path that must exist before the command is started.
+    ///
+    /// OCI runtimes use this to preserve the `create`/`start` split: the VMM
+    /// process boots at `create`, then waits for `start` to publish this file
+    /// before it asks `agentd` to spawn the workload.
+    #[cfg(feature = "oci-runtime")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_signal_path: Option<PathBuf>,
+
+    /// Optional host path where the VMM writes the agent exec session ID for
+    /// the startup command after `agentd` accepts it.
+    #[cfg(feature = "oci-runtime")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id_path: Option<PathBuf>,
+
+    /// Optional host path used to deliver signals to the startup command.
+    ///
+    /// The VMM owns the agent connection that created the command, so OCI
+    /// runtimes publish signal requests here instead of trying to control the
+    /// session from a different relay client.
+    #[cfg(feature = "oci-runtime")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal_path: Option<PathBuf>,
+
+    /// Whether stdout/stderr from this command should be forwarded to the VMM
+    /// process's original stdout/stderr handles.
+    ///
+    /// Normal detached Microsandbox sandboxes keep workload output in logs.
+    /// OCI runtimes set this so Docker/containerd receive attached output from
+    /// the host PID they are tracking.
+    #[cfg(feature = "oci-runtime")]
+    #[serde(default)]
+    pub forward_stdio: bool,
 }
 
 #[cfg(unix)]
@@ -514,7 +571,9 @@ pub fn enter(config: Config) -> ! {
     }
 }
 
-fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
+fn run(
+    #[cfg_attr(not(feature = "oci-runtime"), allow(unused_mut))] mut config: Config,
+) -> RuntimeResult<std::convert::Infallible> {
     // Raise the fd limit before anything else: every guest-held open file on a virtiofs share pins one fd in this process, so the shell's default soft limit
     // (1024 on many distros) is nowhere near enough for real workloads. Reference virtiofsd raises its own limit for the same reason. Best-effort: failure is
     // not fatal, just a smaller fd budget.
@@ -532,6 +591,12 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     write_startup_info(config.startup_fd.as_ref(), &startup_json)?;
     #[cfg(windows)]
     write_startup_info(config.startup_pipe.as_deref(), &startup_json)?;
+    #[cfg(feature = "oci-runtime")]
+    let startup_stdio = startup_stdio(&config)?;
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    let startup_console = config.startup_console.take();
+    #[cfg(all(not(unix), feature = "oci-runtime"))]
+    let startup_console = None;
     setup_log_capture(&config.log_dir, config.forward_output)?;
 
     tracing::info!(sandbox = %config.sandbox_name, "sandbox starting");
@@ -917,6 +982,8 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     }
     let krun_metrics_handle = vm.metrics_handle();
     let exit_handle = vm.exit_handle();
+    #[cfg(feature = "oci-runtime")]
+    let vm_exit_code = vm.exit_code();
     let upper_host_path = oci_upper_host_path(&config.vm);
 
     // Serve host-side live control when this VM booted with reserved resize
@@ -1078,6 +1145,14 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     // so it runs on a background thread, not blocking the main thread.
     let relay_exit_handle = exit_handle.clone();
     let relay_exit_reason = Arc::clone(&exit_reason);
+    let startup_command = config.startup_command.clone();
+    let startup_agent_sock_path = config.agent_sock_path.clone();
+    let startup_shared = Arc::clone(&shared);
+    let startup_exit_handle = exit_handle.clone();
+    let startup_reason = Arc::clone(&exit_reason);
+    let startup_shutdown_flush_timeout = shutdown_flush_timeout;
+    #[cfg(feature = "oci-runtime")]
+    let startup_vm_exit_code = Arc::clone(&vm_exit_code);
     tokio_rt.spawn(async move {
         let ready_result =
             tokio::task::spawn_blocking(move || relay.wait_ready().map(|()| relay)).await;
@@ -1108,8 +1183,97 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                         upper_host_path,
                     }));
                 }
-                if let Err(e) = relay.run(relay_shutdown_rx, relay_drain_tx).await {
-                    tracing::error!("agent relay error: {e}");
+                let relay_task = tokio::spawn(async move {
+                    if let Err(e) = relay.run(relay_shutdown_rx, relay_drain_tx).await {
+                        tracing::error!("agent relay error: {e}");
+                    }
+                });
+                tokio::task::yield_now().await;
+
+                // Startup workload: detached `msb run -- CMD` makes the sandbox process
+                // own the command lifecycle. Run it only after agentd has reported ready
+                // and after the relay accept loop has been scheduled, otherwise the startup
+                // exec can race the relay and fail before OCI `start`.
+                if let Some(startup_command) = startup_command {
+                    tokio::spawn(async move {
+                        tracing::info!(
+                            cmd = %startup_command.cmd,
+                            args = ?startup_command.args,
+                            "starting startup command"
+                        );
+
+                        #[cfg(feature = "oci-runtime")]
+                        let startup_result = crate::startup::run_startup_command(
+                            &startup_agent_sock_path,
+                            startup_command,
+                            startup_stdio,
+                            startup_console,
+                        )
+                        .await;
+                        #[cfg(not(feature = "oci-runtime"))]
+                        let startup_result = crate::startup::run_startup_command(
+                            &startup_agent_sock_path,
+                            startup_command,
+                        )
+                        .await;
+
+                        match startup_result {
+                            Ok(crate::startup::StartupCommandExit::Exited(0)) => {
+                                #[cfg(feature = "oci-runtime")]
+                                startup_vm_exit_code.store(0, std::sync::atomic::Ordering::SeqCst);
+                                tracing::info!("startup command exited successfully");
+                            }
+                            Ok(crate::startup::StartupCommandExit::Exited(code)) => {
+                                #[cfg(feature = "oci-runtime")]
+                                startup_vm_exit_code
+                                    .store(code, std::sync::atomic::Ordering::SeqCst);
+                                startup_reason.store(
+                                    EXIT_REASON_STARTUP_COMMAND_FAILED,
+                                    std::sync::atomic::Ordering::SeqCst,
+                                );
+                                tracing::warn!(code, "startup command exited with non-zero status");
+                            }
+                            Ok(crate::startup::StartupCommandExit::Failed(failed)) => {
+                                #[cfg(feature = "oci-runtime")]
+                                startup_vm_exit_code
+                                    .store(127, std::sync::atomic::Ordering::SeqCst);
+                                startup_reason.store(
+                                    EXIT_REASON_STARTUP_COMMAND_FAILED,
+                                    std::sync::atomic::Ordering::SeqCst,
+                                );
+                                tracing::warn!(
+                                    error = %failed.message,
+                                    "startup command failed to spawn"
+                                );
+                            }
+                            Err(err) => {
+                                #[cfg(feature = "oci-runtime")]
+                                startup_vm_exit_code.store(1, std::sync::atomic::Ordering::SeqCst);
+                                startup_reason.store(
+                                    EXIT_REASON_STARTUP_COMMAND_FAILED,
+                                    std::sync::atomic::Ordering::SeqCst,
+                                );
+                                tracing::warn!(error = %err, "startup command failed");
+                            }
+                        }
+
+                        match request_guest_shutdown(&startup_shared) {
+                            Ok(()) => {
+                                tokio::time::sleep(startup_shutdown_flush_timeout).await;
+                                tracing::info!("startup command shutdown flush window elapsed");
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    error = %err,
+                                    "startup command shutdown request failed, triggering host exit"
+                                );
+                            }
+                        }
+                        startup_exit_handle.trigger();
+                    });
+                }
+                if let Err(e) = relay_task.await {
+                    tracing::error!("agent relay task panicked: {e}");
                 }
             }
             Ok(Err(e)) => {
@@ -1156,67 +1320,6 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                 tracing::info!("flush window elapsed, triggering host exit");
                 shutdown_exit_handle.trigger();
             }
-        });
-    }
-
-    // Startup workload: detached `msb run -- CMD` makes the sandbox process
-    // own the command lifecycle. Once the command terminates, stop the VM so
-    // named sandboxes become stopped and ephemeral sandboxes can self-clean.
-    if let Some(startup_command) = config.startup_command.clone() {
-        let startup_agent_sock_path = config.agent_sock_path.clone();
-        let startup_shared = Arc::clone(&shared);
-        let startup_exit_handle = exit_handle.clone();
-        let startup_reason = Arc::clone(&exit_reason);
-        let startup_shutdown_flush_timeout = shutdown_flush_timeout;
-        tokio_rt.spawn(async move {
-            tracing::info!(
-                cmd = %startup_command.cmd,
-                args = ?startup_command.args,
-                "starting startup command"
-            );
-
-            match crate::startup::run_startup_command(&startup_agent_sock_path, startup_command)
-                .await
-            {
-                Ok(crate::startup::StartupCommandExit::Exited(0)) => {
-                    tracing::info!("startup command exited successfully");
-                }
-                Ok(crate::startup::StartupCommandExit::Exited(code)) => {
-                    startup_reason.store(
-                        EXIT_REASON_STARTUP_COMMAND_FAILED,
-                        std::sync::atomic::Ordering::SeqCst,
-                    );
-                    tracing::warn!(code, "startup command exited with non-zero status");
-                }
-                Ok(crate::startup::StartupCommandExit::Failed(failed)) => {
-                    startup_reason.store(
-                        EXIT_REASON_STARTUP_COMMAND_FAILED,
-                        std::sync::atomic::Ordering::SeqCst,
-                    );
-                    tracing::warn!(error = %failed.message, "startup command failed to spawn");
-                }
-                Err(err) => {
-                    startup_reason.store(
-                        EXIT_REASON_STARTUP_COMMAND_FAILED,
-                        std::sync::atomic::Ordering::SeqCst,
-                    );
-                    tracing::warn!(error = %err, "startup command failed");
-                }
-            }
-
-            match request_guest_shutdown(&startup_shared) {
-                Ok(()) => {
-                    tokio::time::sleep(startup_shutdown_flush_timeout).await;
-                    tracing::info!("startup command shutdown flush window elapsed");
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        error = %err,
-                        "startup command shutdown request failed, triggering host exit"
-                    );
-                }
-            }
-            startup_exit_handle.trigger();
         });
     }
 
@@ -2075,6 +2178,37 @@ fn release_reserved_metrics_slot(handoff: Option<&MetricsSlotHandoff>) {
     if let Ok(reg) = MetricsRegistry::open(&handoff.shm_name) {
         let _ = reg.release_reserved(handoff.slot, handoff.generation);
     }
+}
+
+#[cfg(all(unix, feature = "oci-runtime"))]
+fn startup_stdio(config: &Config) -> RuntimeResult<Option<crate::startup::StartupStdio>> {
+    if !config
+        .startup_command
+        .as_ref()
+        .is_some_and(|command| command.forward_stdio)
+    {
+        return Ok(None);
+    }
+
+    let stdout = unsafe { libc::dup(libc::STDOUT_FILENO) };
+    if stdout < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let stderr = unsafe { libc::dup(libc::STDERR_FILENO) };
+    if stderr < 0 {
+        let _ = unsafe { libc::close(stdout) };
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    Ok(Some(crate::startup::StartupStdio {
+        stdout: unsafe { std::fs::File::from_raw_fd(stdout) },
+        stderr: unsafe { std::fs::File::from_raw_fd(stderr) },
+    }))
+}
+
+#[cfg(all(windows, feature = "oci-runtime"))]
+fn startup_stdio(_config: &Config) -> RuntimeResult<Option<crate::startup::StartupStdio>> {
+    Ok(None)
 }
 
 #[cfg(unix)]

--- a/docs/changelog/2026-08-14.mdx
+++ b/docs/changelog/2026-08-14.mdx
@@ -1,0 +1,13 @@
+---
+title: "Week of August 14, 2026"
+description: "Reliable non-interactive stdin handling and conventional OCI signal exit codes."
+icon: "bolt"
+---
+
+## Behavior changes
+
+- **Null stdin now closes immediately.** Rust SDK executions configured with `StdinMode::Null`
+  send EOF to the guest process instead of leaving its stdin pipe open. Programs such as `cat` and
+  interpreters reading from standard input now finish instead of waiting indefinitely.
+- **OCI signal exits use conventional status codes.** `runmsb` propagates signal termination through
+  the VMM using `128 + signal`, so Docker reports `143` for `SIGTERM` and `137` for `SIGKILL`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -390,6 +390,7 @@
                 "group": "August 2026",
                 "expanded": true,
                 "pages": [
+                  "changelog/2026-08-14",
                   "changelog/2026-08-07"
                 ]
               },

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -27,6 +27,7 @@ prebuilt = [
     "microsandbox-utils/http-client",
 ]
 net = ["dep:microsandbox-network", "microsandbox-runtime/net"]
+oci-runtime = ["microsandbox-runtime/oci-runtime"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }

--- a/sdk/rust/lib/backend/cloud/sandbox.rs
+++ b/sdk/rust/lib/backend/cloud/sandbox.rs
@@ -380,6 +380,11 @@ fn reject_dropped_cloud_create_fields(config: &SandboxConfig) -> MicrosandboxRes
         )
     };
 
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    if config.inherited_startup_console().is_some() {
+        return Err(unsupported("inherited_startup_console"));
+    }
+
     if config.spec.resources.max_cpus != config.spec.resources.cpus {
         return Err(unsupported("max_cpus"));
     }

--- a/sdk/rust/lib/backend/local/sandbox/create.rs
+++ b/sdk/rust/lib/backend/local/sandbox/create.rs
@@ -475,6 +475,12 @@ impl LocalBackend {
     ) -> MicrosandboxResult<(crate::backend::SandboxLocalState, SandboxConfig)> {
         let (mut handle, agent_sock_path) =
             spawn_sandbox(self, &config, sandbox_id, mode, lifecycle_guard).await?;
+        #[cfg(all(unix, feature = "oci-runtime"))]
+        let config = {
+            let mut config = config;
+            config.clear_inherited_startup_console();
+            config
+        };
         let log_dir = self.sandboxes_dir().join(&config.spec.name).join("logs");
 
         // Wait for the relay socket to become available.

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -8,6 +8,8 @@
 #[cfg(windows)]
 use std::fmt::Write as _;
 #[cfg(unix)]
+use std::fs::OpenOptions;
+#[cfg(unix)]
 use std::os::fd::AsRawFd;
 #[cfg(unix)]
 use std::os::fd::{FromRawFd, OwnedFd};
@@ -22,7 +24,7 @@ use std::os::windows::io::AsRawHandle;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     ffi::{OsStr, OsString},
-    fs::File,
+    fs::{self, File},
     io::{Seek, SeekFrom, Write as IoWrite},
     path::{Path, PathBuf},
     process::Stdio,
@@ -588,12 +590,24 @@ pub async fn spawn_sandbox(
         }
     }
 
+    let startup_stderr_path = startup_pipe
+        .is_some()
+        .then(|| log_dir.join("startup.stderr.log"));
+
     // Capture stdout for attached startup JSON. Detached mode uses a
-    // dedicated startup fd so stdio can be severed from the launcher.
+    // dedicated startup fd so stdout can be severed from the launcher; stderr
+    // is written to a small startup log so callers like Docker can surface
+    // pre-handoff failures.
     #[cfg(unix)]
     if startup_pipe.is_some() {
         cmd.stdout(Stdio::null());
-        cmd.stderr(Stdio::null());
+        let stderr_path = startup_stderr_path.as_ref().expect("path set above");
+        let stderr = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(stderr_path)?;
+        cmd.stderr(Stdio::from(stderr));
     } else {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::inherit());
@@ -670,9 +684,14 @@ pub async fn spawn_sandbox(
         Err(_) => {
             terminate_startup_process(&mut child).await;
             release_metrics_reservation(config, metrics_reservation.as_ref());
-            return Err(crate::MicrosandboxError::Runtime(
-                "sandbox startup timeout: no JSON received within 30 seconds".into(),
-            ));
+            let stderr = startup_stderr_excerpt(startup_stderr_path.as_deref());
+            let message = match stderr {
+                Some(stderr) => format!(
+                    "sandbox startup timeout: no JSON received within 30 seconds; stderr: {stderr}"
+                ),
+                None => "sandbox startup timeout: no JSON received within 30 seconds".into(),
+            };
+            return Err(crate::MicrosandboxError::Runtime(message));
         }
     };
 
@@ -686,10 +705,18 @@ pub async fn spawn_sandbox(
                 exit_status = ?status,
                 "spawn_sandbox: failed to parse startup JSON"
             );
-            return Err(crate::MicrosandboxError::Runtime(format!(
-                "sandbox process exited ({status:?}) before sending startup info \
-                 (line: {line:?}, check stderr above for details)"
-            )));
+            let stderr = startup_stderr_excerpt(startup_stderr_path.as_deref());
+            let message = match stderr {
+                Some(stderr) => format!(
+                    "sandbox process exited ({status:?}) before sending startup info \
+                     (line: {line:?}); stderr: {stderr}"
+                ),
+                None => format!(
+                    "sandbox process exited ({status:?}) before sending startup info \
+                     (line: {line:?}, check stderr above for details)"
+                ),
+            };
+            return Err(crate::MicrosandboxError::Runtime(message));
         }
     };
     if startup.pid != _pid {
@@ -2114,6 +2141,20 @@ async fn terminate_startup_process(
     child.wait().await.ok()
 }
 
+fn startup_stderr_excerpt(path: Option<&Path>) -> Option<String> {
+    const MAX_STARTUP_STDERR_BYTES: usize = 8 * 1024;
+
+    let path = path?;
+    let bytes = fs::read(path).ok()?;
+    let bytes = if bytes.len() > MAX_STARTUP_STDERR_BYTES {
+        &bytes[bytes.len() - MAX_STARTUP_STDERR_BYTES..]
+    } else {
+        &bytes
+    };
+    let stderr = String::from_utf8_lossy(bytes).trim().to_string();
+    (!stderr.is_empty()).then_some(stderr)
+}
+
 /// Scan `config.spec.mounts` for file bind mounts and stage each file in its own
 /// isolated directory inside an ephemeral [`TempDir`].
 ///
@@ -2839,6 +2880,7 @@ fn sandbox_log_level_cli_flag(level: SandboxLogLevel) -> &'static str {
 mod tests {
     use std::collections::HashMap;
     use std::ffi::{OsStr, OsString};
+    use std::fs;
     #[cfg(target_os = "linux")]
     use std::num::NonZero;
     use std::path::{Path, PathBuf};
@@ -2924,6 +2966,20 @@ mod tests {
                 "SIGCHLD handler should run on the alternate signal stack"
             );
         }
+    }
+
+    #[test]
+    fn test_startup_stderr_excerpt_returns_trimmed_tail() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("startup.stderr.log");
+        let prefix = "x".repeat(9 * 1024);
+        fs::write(&path, format!("{prefix}real startup error\n")).unwrap();
+
+        let excerpt = super::startup_stderr_excerpt(Some(&path)).unwrap();
+
+        assert!(excerpt.len() <= 8 * 1024 + "real startup error".len());
+        assert!(excerpt.ends_with("real startup error"));
+        assert!(!excerpt.ends_with('\n'));
     }
 
     //----------------------------------------------------------------------------------------------

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -109,6 +109,22 @@ const AUTO_BLOCK_WRITEBACK_LIMIT_BYTES: u64 = 1536 * 1024 * 1024;
 const AUTO_BLOCK_WRITEBACK_POOL_DIVISOR: u64 = 10;
 #[cfg(target_os = "linux")]
 const MIN_BLOCK_WRITEBACK_LIMIT_BYTES: u64 = 128 * 1024 * 1024;
+#[cfg(feature = "oci-runtime")]
+const OCI_FORWARD_STDIO_LABEL: &str = "oci.microsandbox.forward_stdio";
+#[cfg(feature = "oci-runtime")]
+const OCI_CONSOLE_ROWS_LABEL: &str = "oci.microsandbox.console_rows";
+#[cfg(feature = "oci-runtime")]
+const OCI_CONSOLE_COLS_LABEL: &str = "oci.microsandbox.console_cols";
+#[cfg(feature = "oci-runtime")]
+const OCI_INIT_SESSION_PATH_LABEL: &str = "oci.microsandbox.init_session_path";
+#[cfg(feature = "oci-runtime")]
+const OCI_ISOLATE_NETWORK_NAMESPACE_LABEL: &str = "oci.microsandbox.isolate_network_namespace";
+#[cfg(feature = "oci-runtime")]
+const OCI_SIGNAL_PATH_LABEL: &str = "oci.microsandbox.signal_path";
+#[cfg(feature = "oci-runtime")]
+const OCI_STARTUP_CWD_LABEL: &str = "oci.microsandbox.startup_cwd";
+#[cfg(feature = "oci-runtime")]
+const OCI_START_SIGNAL_PATH_LABEL: &str = "oci.microsandbox.start_signal_path";
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -523,6 +539,12 @@ pub async fn spawn_sandbox(
         }
     };
 
+    let isolate_network_namespace = should_isolate_network_namespace(config);
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    let inherited_console_fd = config
+        .inherited_startup_console()
+        .map(|console| console.as_raw_fd());
+
     // Build the command.
     let mut cmd = Command::new(&msb_path);
     #[cfg(windows)]
@@ -546,6 +568,10 @@ pub async fn spawn_sandbox(
         let lifecycle_lock_fd = lifecycle_guard.as_raw_fd();
         unsafe {
             cmd.pre_exec(move || {
+                if isolate_network_namespace && libc::unshare(libc::CLONE_NEWNET) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+
                 if startup_write_fd.is_some() {
                     detach_from_launcher_session()?;
                 }
@@ -557,6 +583,10 @@ pub async fn spawn_sandbox(
                 });
                 let mut startup_mapping = startup_write_fd
                     .map(|fd| InheritedFdMapping::new(fd, microsandbox_runtime::vm::STARTUP_FD));
+                #[cfg(feature = "oci-runtime")]
+                let mut console_mapping = inherited_console_fd.map(|fd| {
+                    InheritedFdMapping::new(fd, microsandbox_runtime::vm::OCI_CONSOLE_FD)
+                });
                 let mut lifecycle_mapping = InheritedFdMapping::new(
                     lifecycle_lock_fd,
                     microsandbox_runtime::vm::LIFECYCLE_LOCK_FD,
@@ -566,12 +596,19 @@ pub async fn spawn_sandbox(
                 // open files that pipe/tempfile allocation lands on one of the
                 // fixed inherited fd numbers. Move those sources away before
                 // any dup2 call can overwrite a later source fd.
+                #[cfg(feature = "oci-runtime")]
+                let mut next_spare_fd = microsandbox_runtime::vm::OCI_CONSOLE_FD + 1;
+                #[cfg(not(feature = "oci-runtime"))]
                 let mut next_spare_fd = microsandbox_runtime::vm::LIFECYCLE_LOCK_FD + 1;
                 move_reserved_source_fd(&mut config_mapping, &mut next_spare_fd)?;
                 if let Some(mapping) = parent_watch_mapping.as_mut() {
                     move_reserved_source_fd(mapping, &mut next_spare_fd)?;
                 }
                 if let Some(mapping) = startup_mapping.as_mut() {
+                    move_reserved_source_fd(mapping, &mut next_spare_fd)?;
+                }
+                #[cfg(feature = "oci-runtime")]
+                if let Some(mapping) = console_mapping.as_mut() {
                     move_reserved_source_fd(mapping, &mut next_spare_fd)?;
                 }
                 move_reserved_source_fd(&mut lifecycle_mapping, &mut next_spare_fd)?;
@@ -581,6 +618,10 @@ pub async fn spawn_sandbox(
                     dup_inherited_fd(mapping.src, mapping.dst)?;
                 }
                 if let Some(mapping) = startup_mapping {
+                    dup_inherited_fd(mapping.src, mapping.dst)?;
+                }
+                #[cfg(feature = "oci-runtime")]
+                if let Some(mapping) = console_mapping {
                     dup_inherited_fd(mapping.src, mapping.dst)?;
                 }
                 dup_inherited_fd(lifecycle_mapping.src, lifecycle_mapping.dst)?;
@@ -600,14 +641,29 @@ pub async fn spawn_sandbox(
     // pre-handoff failures.
     #[cfg(unix)]
     if startup_pipe.is_some() {
-        cmd.stdout(Stdio::null());
+        if should_inherit_detached_stdio(config) {
+            cmd.stdout(Stdio::inherit());
+        } else {
+            cmd.stdout(Stdio::null());
+        }
         let stderr_path = startup_stderr_path.as_ref().expect("path set above");
-        let stderr = OpenOptions::new()
+        let stderr = match OpenOptions::new()
             .create(true)
             .truncate(true)
             .write(true)
-            .open(stderr_path)?;
-        cmd.stderr(Stdio::from(stderr));
+            .open(stderr_path)
+        {
+            Ok(stderr) => stderr,
+            Err(err) => {
+                release_metrics_reservation(config, metrics_reservation.as_ref());
+                return Err(err.into());
+            }
+        };
+        if should_inherit_detached_stdio(config) {
+            cmd.stderr(Stdio::inherit());
+        } else {
+            cmd.stderr(Stdio::from(stderr));
+        }
     } else {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::inherit());
@@ -1209,14 +1265,16 @@ fn move_reserved_source_fd(
 
 #[cfg(unix)]
 fn inherited_fd_source_needs_spare(src: i32, dst: i32) -> bool {
-    src != dst
-        && matches!(
-            src,
-            microsandbox_runtime::vm::CONFIG_FD
-                | microsandbox_runtime::vm::PARENT_WATCH_FD
-                | microsandbox_runtime::vm::STARTUP_FD
-                | microsandbox_runtime::vm::LIFECYCLE_LOCK_FD
-        )
+    let reserved = matches!(
+        src,
+        microsandbox_runtime::vm::CONFIG_FD
+            | microsandbox_runtime::vm::PARENT_WATCH_FD
+            | microsandbox_runtime::vm::STARTUP_FD
+            | microsandbox_runtime::vm::LIFECYCLE_LOCK_FD
+    );
+    #[cfg(feature = "oci-runtime")]
+    let reserved = reserved || src == microsandbox_runtime::vm::OCI_CONSOLE_FD;
+    src != dst && reserved
 }
 
 #[cfg(unix)]
@@ -2481,6 +2539,13 @@ fn sandbox_cli_args(
         visible.push(OsString::from("--startup-pipe"));
         visible.push(pipe.to_os_string());
     }
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    if config.inherited_startup_console().is_some() {
+        visible.push(OsString::from("--oci-console-fd"));
+        visible.push(OsString::from(
+            microsandbox_runtime::vm::OCI_CONSOLE_FD.to_string(),
+        ));
+    }
     visible.push(OsString::from("--vcpus"));
     visible.push(OsString::from(config.spec.resources.cpus.to_string()));
     visible.push(OsString::from("--memory-mib"));
@@ -2838,13 +2903,121 @@ fn startup_command(config: &SandboxConfig) -> Option<StartupCommand> {
             .iter()
             .map(|var| format!("{}={}", var.key, var.value))
             .collect(),
-        cwd: config.spec.runtime.workdir.clone(),
+        cwd: startup_command_cwd(config),
         user: config.spec.runtime.user.clone(),
+        #[cfg(feature = "oci-runtime")]
+        tty: has_inherited_startup_console(config),
+        #[cfg(feature = "oci-runtime")]
+        rows: oci_console_size(config, OCI_CONSOLE_ROWS_LABEL).unwrap_or(24),
+        #[cfg(feature = "oci-runtime")]
+        cols: oci_console_size(config, OCI_CONSOLE_COLS_LABEL).unwrap_or(80),
+        #[cfg(feature = "oci-runtime")]
+        start_signal_path: oci_start_signal_path(config),
+        #[cfg(feature = "oci-runtime")]
+        session_id_path: oci_init_session_path(config),
+        #[cfg(feature = "oci-runtime")]
+        signal_path: oci_signal_path(config),
+        #[cfg(feature = "oci-runtime")]
+        forward_stdio: should_forward_oci_stdio(config),
     })
 }
 
+#[cfg(feature = "oci-runtime")]
+fn has_inherited_startup_console(config: &SandboxConfig) -> bool {
+    #[cfg(unix)]
+    {
+        config.inherited_startup_console().is_some()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = config;
+        false
+    }
+}
+
+#[cfg(feature = "oci-runtime")]
+fn oci_console_size(config: &SandboxConfig, label: &str) -> Option<u16> {
+    config.spec.labels.get(label)?.parse().ok()
+}
+
+fn startup_command_cwd(config: &SandboxConfig) -> Option<String> {
+    #[cfg(feature = "oci-runtime")]
+    if let Some(cwd) = config.spec.labels.get(OCI_STARTUP_CWD_LABEL) {
+        return Some(cwd.clone());
+    }
+    config.spec.runtime.workdir.clone()
+}
+
+#[cfg(feature = "oci-runtime")]
+fn oci_start_signal_path(config: &SandboxConfig) -> Option<PathBuf> {
+    config
+        .spec
+        .labels
+        .get(OCI_START_SIGNAL_PATH_LABEL)
+        .map(PathBuf::from)
+}
+
+#[cfg(feature = "oci-runtime")]
+fn oci_init_session_path(config: &SandboxConfig) -> Option<PathBuf> {
+    config
+        .spec
+        .labels
+        .get(OCI_INIT_SESSION_PATH_LABEL)
+        .map(PathBuf::from)
+}
+
+#[cfg(feature = "oci-runtime")]
+fn oci_signal_path(config: &SandboxConfig) -> Option<PathBuf> {
+    config
+        .spec
+        .labels
+        .get(OCI_SIGNAL_PATH_LABEL)
+        .map(PathBuf::from)
+}
+
+#[cfg(feature = "oci-runtime")]
+fn should_forward_oci_stdio(config: &SandboxConfig) -> bool {
+    config
+        .spec
+        .labels
+        .get(OCI_FORWARD_STDIO_LABEL)
+        .is_some_and(|value| value == "true")
+}
+
+fn should_inherit_detached_stdio(config: &SandboxConfig) -> bool {
+    #[cfg(feature = "oci-runtime")]
+    {
+        should_forward_oci_stdio(config) && !has_inherited_startup_console(config)
+    }
+    #[cfg(not(feature = "oci-runtime"))]
+    {
+        let _ = config;
+        false
+    }
+}
+
+fn should_isolate_network_namespace(config: &SandboxConfig) -> bool {
+    #[cfg(feature = "oci-runtime")]
+    {
+        config
+            .spec
+            .labels
+            .get(OCI_ISOLATE_NETWORK_NAMESPACE_LABEL)
+            .is_some_and(|value| value == "true")
+    }
+    #[cfg(not(feature = "oci-runtime"))]
+    {
+        let _ = config;
+        false
+    }
+}
+
 fn resolve_startup_command(config: &SandboxConfig) -> Option<(String, Vec<String>)> {
-    if !config.should_launch_background_command() {
+    #[cfg(feature = "oci-runtime")]
+    let has_oci_start_signal = oci_start_signal_path(config).is_some();
+    #[cfg(not(feature = "oci-runtime"))]
+    let has_oci_start_signal = false;
+    if !config.should_launch_background_command() && !has_oci_start_signal {
         return None;
     }
 
@@ -2883,6 +3056,8 @@ mod tests {
     use std::fs;
     #[cfg(target_os = "linux")]
     use std::num::NonZero;
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    use std::os::fd::OwnedFd;
     use std::path::{Path, PathBuf};
 
     use microsandbox_protocol::{
@@ -2922,6 +3097,11 @@ mod tests {
         assert!(super::inherited_fd_source_needs_spare(
             microsandbox_runtime::vm::PARENT_WATCH_FD,
             microsandbox_runtime::vm::STARTUP_FD,
+        ));
+        #[cfg(feature = "oci-runtime")]
+        assert!(super::inherited_fd_source_needs_spare(
+            microsandbox_runtime::vm::LIFECYCLE_LOCK_FD,
+            microsandbox_runtime::vm::OCI_CONSOLE_FD,
         ));
     }
 
@@ -3503,6 +3683,69 @@ mod tests {
 
         assert!(rendered.contains(&"--startup-cmd=/entrypoint".to_string()));
         assert!(rendered.contains(&"--startup-arg=bash".to_string()));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "oci-runtime")]
+    async fn test_sandbox_cli_args_include_oci_startup_after_launch_intent_is_cleared() {
+        let mut config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .background_command(["/hello"])
+            .label(super::OCI_START_SIGNAL_PATH_LABEL, "/tmp/start.request")
+            .label(super::OCI_INIT_SESSION_PATH_LABEL, "/tmp/init.session")
+            .build()
+            .await
+            .unwrap();
+        config.clear_launch_intent();
+
+        let startup = super::startup_command(&config).expect("OCI startup command");
+
+        assert_eq!(startup.cmd, "/hello");
+        assert_eq!(
+            startup.start_signal_path.as_deref(),
+            Some(Path::new("/tmp/start.request"))
+        );
+        assert_eq!(
+            startup.session_id_path.as_deref(),
+            Some(Path::new("/tmp/init.session"))
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    async fn test_oci_console_does_not_inherit_detached_launcher_stdio() {
+        let console: OwnedFd = std::fs::File::open("/dev/null").expect("open fd").into();
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .background_command(["/bin/bash"])
+            .label(super::OCI_FORWARD_STDIO_LABEL, "true")
+            .inherited_startup_console(console)
+            .build()
+            .await
+            .unwrap();
+
+        assert!(super::should_forward_oci_stdio(&config));
+        assert!(!super::should_inherit_detached_stdio(&config));
+        let startup = super::startup_command(&config).expect("startup command");
+        assert!(startup.tty);
+        assert!(render_args(&config).contains(&format!(
+            "--oci-console-fd={}",
+            microsandbox_runtime::vm::OCI_CONSOLE_FD
+        )));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "oci-runtime")]
+    async fn test_non_console_oci_inherits_detached_launcher_stdio() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .background_command(["/hello"])
+            .label(super::OCI_FORWARD_STDIO_LABEL, "true")
+            .build()
+            .await
+            .unwrap();
+
+        assert!(super::should_inherit_detached_stdio(&config));
     }
 
     #[tokio::test]

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -3,6 +3,8 @@
 use std::collections::{BTreeMap, HashSet};
 #[cfg(feature = "net")]
 use std::net::{IpAddr, Ipv4Addr};
+#[cfg(all(unix, feature = "oci-runtime"))]
+use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -953,6 +955,16 @@ impl SandboxBuilder {
         for (k, v) in labels {
             self.config.spec.labels.insert(k.into(), v.into());
         }
+        self
+    }
+
+    /// Transfer a host terminal descriptor to the sandbox startup workload.
+    ///
+    /// This is an internal runtime handoff and is not persisted with the sandbox configuration.
+    #[doc(hidden)]
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    pub fn inherited_startup_console(mut self, console: OwnedFd) -> Self {
+        self.config.inherited_startup_console = Some(std::sync::Arc::new(console));
         self
     }
 

--- a/sdk/rust/lib/sandbox/config.rs
+++ b/sdk/rust/lib/sandbox/config.rs
@@ -2,7 +2,11 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZero;
+#[cfg(all(unix, feature = "oci-runtime"))]
+use std::os::fd::OwnedFd;
 use std::path::PathBuf;
+#[cfg(all(unix, feature = "oci-runtime"))]
+use std::sync::Arc;
 
 use microsandbox_runtime::logging::LogLevel;
 use microsandbox_types::{
@@ -182,6 +186,11 @@ pub struct SandboxConfig {
     /// Number of transient workload arguments appended to the init specification.
     #[serde(skip)]
     pub(crate) init_workload_arg_count: usize,
+
+    /// Host PTY slave transferred to the sandbox process for its startup workload.
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    #[serde(skip)]
+    pub(crate) inherited_startup_console: Option<Arc<OwnedFd>>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -209,6 +218,10 @@ impl SandboxConfig {
         let mut config = self.clone();
         config.launch_intent = LaunchIntent::None;
         config.init_owns_workload = false;
+        #[cfg(all(unix, feature = "oci-runtime"))]
+        {
+            config.inherited_startup_console = None;
+        }
         if config.init_workload_arg_count > 0 {
             if let Some(init) = config.spec.init.as_mut() {
                 let durable_len = init
@@ -254,6 +267,16 @@ impl SandboxConfig {
     /// Clear process-launch intent after another mechanism takes ownership of the command.
     pub(crate) fn clear_launch_intent(&mut self) {
         self.launch_intent = LaunchIntent::None;
+    }
+
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    pub(crate) fn inherited_startup_console(&self) -> Option<&OwnedFd> {
+        self.inherited_startup_console.as_deref()
+    }
+
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    pub(crate) fn clear_inherited_startup_console(&mut self) {
+        self.inherited_startup_console = None;
     }
 
     /// Return whether inherited image init routing owns this create operation's boot workload.
@@ -707,6 +730,8 @@ impl Default for SandboxConfig {
             launch_intent: LaunchIntent::None,
             init_owns_workload: false,
             init_workload_arg_count: 0,
+            #[cfg(all(unix, feature = "oci-runtime"))]
+            inherited_startup_console: None,
         }
     }
 }
@@ -717,6 +742,9 @@ impl Default for SandboxConfig {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    use std::os::fd::OwnedFd;
+
     use super::{SandboxConfig, merge_env};
     use crate::sandbox::{
         HandoffInit, MountOptions, NamedVolumeMode, RootDisk, RootfsSource, StatVirtualization,
@@ -1858,5 +1886,18 @@ mod tests {
             }
             mount => panic!("expected tmpfs mount, got {mount:?}"),
         }
+    }
+
+    #[test]
+    #[cfg(all(unix, feature = "oci-runtime"))]
+    fn test_clone_for_persistence_drops_inherited_startup_console() {
+        let console: OwnedFd = std::fs::File::open("/dev/null").expect("open fd").into();
+        let mut config = SandboxConfig::default();
+        config.inherited_startup_console = Some(std::sync::Arc::new(console));
+
+        let persisted = config.clone_for_persistence();
+
+        assert!(config.inherited_startup_console().is_some());
+        assert!(persisted.inherited_startup_console().is_none());
     }
 }

--- a/sdk/rust/lib/sandbox/exec.rs
+++ b/sdk/rust/lib/sandbox/exec.rs
@@ -505,6 +505,20 @@ impl ExecSink {
     }
 }
 
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) fn initial_stdin_messages(stdin_mode: &StdinMode) -> Vec<ExecStdin> {
+    match stdin_mode {
+        StdinMode::Null => vec![ExecStdin { data: Vec::new() }],
+        StdinMode::Pipe => Vec::new(),
+        StdinMode::Bytes(data) => vec![
+            ExecStdin { data: data.clone() },
+            ExecStdin { data: Vec::new() },
+        ],
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Module: agent (backend-agnostic ops driven over an agent connection)
 //--------------------------------------------------------------------------------------------------
@@ -518,7 +532,7 @@ pub(crate) mod agent {
 
     use bytes::Bytes;
     use microsandbox_protocol::{
-        exec::{ExecExited, ExecStarted, ExecStderr, ExecStdin, ExecStdout},
+        exec::{ExecExited, ExecStarted, ExecStderr, ExecStdout},
         message::{Message, MessageType},
     };
     use tokio::sync::mpsc;
@@ -528,7 +542,10 @@ pub(crate) mod agent {
         sandbox::{SandboxConfig, build_exec_request},
     };
 
-    use super::{ExecEvent, ExecHandle, ExecOptions, ExecOutput, ExecSink, ExitStatus, StdinMode};
+    use super::{
+        ExecEvent, ExecHandle, ExecOptions, ExecOutput, ExecSink, ExitStatus, StdinMode,
+        initial_stdin_messages,
+    };
 
     pub(crate) async fn exec_stream(
         backend: &dyn crate::backend::Backend,
@@ -580,14 +597,13 @@ pub(crate) mod agent {
             _ => None,
         };
 
-        if let StdinMode::Bytes(ref data) = stdin_mode {
-            let data = data.clone();
+        let initial_stdin = initial_stdin_messages(&stdin_mode);
+        if !initial_stdin.is_empty() {
             let bridge = Arc::clone(&client);
             tokio::spawn(async move {
-                let payload = ExecStdin { data };
-                let _ = bridge.send(id, MessageType::ExecStdin, &payload).await;
-                let close = ExecStdin { data: Vec::new() };
-                let _ = bridge.send(id, MessageType::ExecStdin, &close).await;
+                for payload in initial_stdin {
+                    let _ = bridge.send(id, MessageType::ExecStdin, &payload).await;
+                }
             });
         }
 
@@ -674,6 +690,37 @@ pub(crate) mod agent {
             code,
             success: code == 0,
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn null_stdin_sends_eof() {
+        let messages = initial_stdin_messages(&StdinMode::Null);
+
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].data.is_empty());
+    }
+
+    #[test]
+    fn pipe_stdin_leaves_stdin_open_for_caller() {
+        assert!(initial_stdin_messages(&StdinMode::Pipe).is_empty());
+    }
+
+    #[test]
+    fn byte_stdin_sends_data_then_eof() {
+        let messages = initial_stdin_messages(&StdinMode::Bytes(b"hello".to_vec()));
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].data, b"hello");
+        assert!(messages[1].data.is_empty());
     }
 }
 

--- a/sdk/rust/tests/stdin.rs
+++ b/sdk/rust/tests/stdin.rs
@@ -106,6 +106,38 @@ async fn stdin_bytes_waits_for_slow_reader() {
     assert_eq!(actual_sha, expected_sha);
 }
 
+/// Regression test for null stdin: `cat` should receive EOF immediately and
+/// exit instead of waiting forever for more input.
+#[msb_test]
+async fn stdin_null_lets_cat_finish() {
+    let name = "stdin-null-cat";
+
+    let sandbox = Sandbox::builder(name)
+        .image("mirror.gcr.io/library/alpine")
+        .cpus(1)
+        .memory(512)
+        .replace()
+        .create()
+        .await
+        .expect("create sandbox");
+
+    let output = sandbox
+        .exec_with("cat", |exec| exec.stdin_null())
+        .await
+        .expect("run cat with null stdin");
+
+    stop_and_remove(name).await;
+
+    assert!(
+        output.status().success,
+        "cat failed: stdout=`{}` stderr=`{}`",
+        output.stdout().unwrap_or_default(),
+        output.stderr().unwrap_or_default()
+    );
+    assert_eq!(output.stdout().unwrap_or_default(), "");
+    assert_eq!(output.stderr().unwrap_or_default(), "");
+}
+
 /// Streaming test: multiple sequential `ExecSink::write` calls, each
 /// exceeding typical pipe capacity. Verifies that repeated invocations
 /// of `write_stdin` (rather than a single bytes payload) all reach the


### PR DESCRIPTION
## TL;DR

Add the Linux-only `runmsb` OCI runtime so Docker and the stock
`containerd-shim-runc-v2` can run one OCI container inside one Microsandbox
microVM. The persistent VMM is the host PID watched by containerd, while
`agentd` starts and manages the workload inside the guest.

Fixes https://github.com/superradcompany/microsandbox/issues/279

## Description

- Add reusable OCI bundle parsing, lifecycle validation, state types, and an
  atomic filesystem state store under `crates/runtime/lib/oci`.
- Add the feature-gated `runmsb` crate with `create`, `start`, `run`, `exec`,
  `kill`, `delete`, `state`, `features`, `pause`, and `resume` command
  handling. Unsupported operations return explicit errors.
- Keep `runmsb` Linux-only with a non-Linux stub so macOS and Windows
  workspace builds remain valid.
- Use the persistent Microsandbox VMM as the OCI host PID instead of creating
  a separate stand-in monitor process.
- Boot the VM during `create`, hold the guest init workload until `start`,
  detect VMM death during startup, and return the guest init exit status from
  `run`.
- Use `agentd` to start guest processes, apply users and resource limits,
  provide PTYs, forward signals, and report workload exit status.
- Mount `devpts` with standard PTY permissions and keep `/dev/ptmx` available
  as a defensive fallback.
- Transfer the OCI PTY master to containerd and inherit the slave directly
  into the VMM on fixed descriptor 100. Keep the host PTY raw so newline
  translation is not applied twice.
- Send EOF for null and fixed stdin so non-interactive commands do not remain
  blocked waiting for input.
- Preserve detached startup stderr and include a bounded excerpt in startup
  failures reported through Docker and containerd.
- Enter a fresh host network namespace before starting the VMM when the OCI
  bundle requests a new network namespace.
- Support process-file and detached `exec`, named and numeric signals,
  conventional signal exit codes, and forced deletion.
- Keep the bundled Microsandbox `libkrunfw` policy; no system-library fallback
  is introduced.
- Document the one-container-per-VM architecture, OCI mapping, installation,
  Docker tests, unsupported features, and the difference between an OCI
  runtime and a native containerd shim.

## Current Boundaries

- `pause`, `resume`, `kill --all`, hooks, cgroup and security-policy
  translation, checkpoint/restore, recovery, and full OCI conformance remain
  unsupported.
- Non-TTY attached stdin and complete Docker bridge and published-port
  behavior need additional integration work.
- Start, signal, session, and exit handoff still use files polled by the VMM.
  A future VMM control API should replace them with direct requests over the
  persistent control channel.
- The `runmsb` crate and binary are feature-gated. Shared VMM startup
  primitives remain enabled in normal Microsandbox builds until maintainers
  decide whether a broader feature boundary is needed.
- This patch does not claim Kubernetes support. A native containerd shim,
  CRI/CNI behavior, pod volumes, and VM-per-pod support require a separate
  design decision.

## Test Plan

```bash
cargo +nightly fmt --all -- --check
cargo +nightly clippy -j 2 \
  -p runmsb --features runmsb --all-targets \
  -- -D warnings
cargo +nightly clippy -j 2 \
  -p microsandbox-runtime \
  -p microsandbox-agentd \
  -p microsandbox \
  -- -D warnings

cargo +nightly test -j 2 -p runmsb --features runmsb
cargo +nightly test -j 2 -p microsandbox-runtime --lib
cargo +nightly test -j 2 -p microsandbox-agentd --lib
cargo +nightly test -j 2 \
  -p microsandbox --lib inherited_startup_console
cargo +nightly test -j 2 \
  -p microsandbox --test stdin stdin_null_lets_cat_finish
```

Build and install on a Linux KVM host:

```bash
cargo +nightly build -j 2 -p microsandbox-cli --bin msb
cargo +nightly build -j 2 -p runmsb --features runmsb --bin runmsb
sudo install -m 0755 target/debug/msb /usr/local/bin/msb
sudo install -m 0755 target/debug/runmsb /usr/local/bin/runmsb
sudo systemctl restart docker
```

Run the Docker lifecycle checks:

```bash
docker run --rm --runtime runmsb hello-world:latest
docker run --rm --runtime runmsb alpine:latest cat
docker run --rm --runtime runmsb -it ubuntu:latest /bin/bash

docker rm -f msb-sleep 2>/dev/null || true
docker run -d --name msb-sleep \
  --runtime runmsb ubuntu:latest sleep 300
docker exec msb-sleep /bin/sh -c 'echo EXEC_OK; id; pwd'
docker kill --signal TERM msb-sleep
docker wait msb-sleep
docker inspect -f \
  'status={{.State.Status}} exit={{.State.ExitCode}}' msb-sleep
docker rm msb-sleep
```

The expected exit status after `SIGTERM` is `143`; `SIGKILL` produces `137`.
`docker pause` and `docker unpause` should return explicit unsupported errors.

<details>
<summary>Sequence diagram</summary>

```mermaid
sequenceDiagram
    participant D as Docker/containerd
    participant R as runmsb
    participant S as OCI state store
    participant V as Microsandbox VMM
    participant A as agentd
    participant P as OCI process
    D->>R: create(bundle, id, console socket)
    R->>S: persist created state
    R->>V: create detached microVM
    R->>V: inherit PTY slave on FD 100
    R-->>D: VMM host PID and PTY master
    D->>R: start(id)
    R->>S: publish start.request
    V->>A: ExecRequest
    A->>P: spawn init process
    A-->>V: session ID and exit status
    V->>S: publish session and exit files
    R-->>D: lifecycle state and exit code
```

</details>
