### PR TITLE
fix(network): allow duplicate secret placeholders

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -391,10 +391,11 @@ pub struct SandboxOpts {
     pub tls_no_verify_upstream_for: Vec<String>,
 
     // --- Secrets ---
-    /// Inject a secret that is only sent to an allowed host (ENV@HOST). The
-    /// value is read from the host environment variable ENV at start time and
-    /// stored only as a source reference, never inlined in the sandbox config.
-    /// Inline `ENV=VALUE@HOST` is rejected; export the value and use `ENV@HOST`.
+    /// Inject a secret that is only sent to allowed hosts (ENV@HOST[,HOST...]).
+    /// The value is read from the host environment variable ENV at start time
+    /// and stored only as a source reference, never inlined in the sandbox
+    /// config. Inline `ENV=VALUE@HOST` is rejected; export the value and use
+    /// `ENV@HOST[,HOST...]`.
     #[cfg(feature = "net")]
     #[arg(long)]
     pub secret: Vec<String>,
@@ -1483,12 +1484,28 @@ fn apply_network_opts(
     // Secrets. `create` persists a host-side source reference, not the raw
     // value: the plaintext is read from the host environment at spawn time so
     // the durable config never stores secret material at rest.
+    let mut secret_specs: Vec<(String, Vec<String>)> = Vec::new();
     for secret_str in &opts.secret {
-        let (env_var, host) = parse_secret(secret_str, "create")?;
+        let (env_var, hosts) = parse_secret(secret_str, "create")?;
+        match secret_specs
+            .iter_mut()
+            .find(|(existing, _)| *existing == env_var)
+        {
+            Some((_, existing_hosts)) => existing_hosts.extend(hosts),
+            None => secret_specs.push((env_var, hosts)),
+        }
+    }
+    for (env_var, hosts) in secret_specs {
         let source = microsandbox::sandbox::SecretSource::Env {
             var: env_var.clone(),
         };
-        builder = builder.secret(|s| s.env(&env_var).source(source).allow_host(host));
+        builder = builder.secret(|mut s| {
+            s = s.env(&env_var).source(source);
+            for host in hosts {
+                s = allow_secret_host(s, &host);
+            }
+            s
+        });
     }
 
     // DNS, TLS, and other network configuration.
@@ -1826,8 +1843,8 @@ fn parse_port_mapping(spec: &str) -> anyhow::Result<(std::net::IpAddr, u16, u16,
     Ok((bind, host, guest, udp))
 }
 
-/// Parse a `--secret ENV@HOST` spec into `(env_var, host)` for `command`
-/// (`create` or `modify`).
+/// Parse a `--secret ENV@HOST[,HOST...]` spec into `(env_var, hosts)` for
+/// `command` (`create` or `modify`).
 ///
 /// The value is NOT read here: the CLI records a host-side source reference
 /// (`{kind: env, var: ENV}`) that is resolved from the host environment when
@@ -1836,8 +1853,8 @@ fn parse_port_mapping(spec: &str) -> anyhow::Result<(std::net::IpAddr, u16, u16,
 ///
 /// The inline `ENV=VALUE@HOST` form is rejected loudly: the shell would leak
 /// the value regardless, so the value path is SDK-only. Users are pointed at
-/// the `ENV@HOST` env-var form instead.
-pub(crate) fn parse_secret(spec: &str, command: &str) -> anyhow::Result<(String, String)> {
+/// the `ENV@HOST[,HOST...]` env-var form instead.
+pub(crate) fn parse_secret(spec: &str, command: &str) -> anyhow::Result<(String, Vec<String>)> {
     if let Some(eq_pos) = spec.find('=') {
         let env_var = &spec[..eq_pos];
         anyhow::bail!(
@@ -1850,15 +1867,36 @@ pub(crate) fn parse_secret(spec: &str, command: &str) -> anyhow::Result<(String,
 
     let at_pos = spec
         .rfind('@')
-        .ok_or_else(|| anyhow::anyhow!("secret must be in format ENV@HOST"))?;
+        .ok_or_else(|| anyhow::anyhow!("secret must be in format ENV@HOST[,HOST...]"))?;
     let env_var = spec[..at_pos].to_string();
-    let host = spec[at_pos + 1..].to_string();
+    let hosts: Vec<String> = spec[at_pos + 1..]
+        .split(',')
+        .map(str::trim)
+        .filter(|host| !host.is_empty())
+        .map(ToString::to_string)
+        .collect();
 
-    if env_var.is_empty() || host.is_empty() {
-        anyhow::bail!("secret must be in format ENV@HOST (all parts required)");
+    if env_var.is_empty() || hosts.is_empty() {
+        anyhow::bail!("secret must be in format ENV@HOST[,HOST...] (all parts required)");
     }
 
-    Ok((env_var, host))
+    Ok((env_var, hosts))
+}
+
+#[cfg(feature = "net")]
+fn allow_secret_host(
+    builder: microsandbox::sandbox::SecretBuilder,
+    host: &str,
+) -> microsandbox::sandbox::SecretBuilder {
+    match microsandbox_network::secrets::config::HostPattern::parse(host) {
+        microsandbox_network::secrets::config::HostPattern::Exact(host) => builder.allow_host(host),
+        microsandbox_network::secrets::config::HostPattern::Wildcard(host) => {
+            builder.allow_host_pattern(host)
+        }
+        microsandbox_network::secrets::config::HostPattern::Any => {
+            builder.allow_any_host_dangerous(true)
+        }
+    }
 }
 
 /// Parse a scoped upstream CA spec: `PATTERN=PATH`.
@@ -2312,11 +2350,23 @@ mod tests {
     fn parse_secret_returns_env_and_host_reference() {
         // The value is NOT read here: `create` persists a source reference and
         // the spawn resolver reads the host env at start time.
-        let (env_var, host) =
+        let (env_var, hosts) =
             parse_secret("MSB_PARSE_SECRET_TOKEN@api.example.com", "create").unwrap();
 
         assert_eq!(env_var, "MSB_PARSE_SECRET_TOKEN");
-        assert_eq!(host, "api.example.com");
+        assert_eq!(hosts, vec!["api.example.com"]);
+    }
+
+    #[test]
+    fn parse_secret_accepts_multiple_hosts() {
+        let (env_var, hosts) = parse_secret(
+            "MSB_PARSE_SECRET_TOKEN@api.example.com, *.example.org, *",
+            "create",
+        )
+        .unwrap();
+
+        assert_eq!(env_var, "MSB_PARSE_SECRET_TOKEN");
+        assert_eq!(hosts, vec!["api.example.com", "*.example.org", "*"]);
     }
 
     #[test]
@@ -2343,6 +2393,43 @@ mod tests {
         assert!(parse_secret("API_KEY", "create").is_err());
         assert!(parse_secret("@api.example.com", "create").is_err());
         assert!(parse_secret("API_KEY@", "create").is_err());
+    }
+
+    #[cfg(feature = "net")]
+    #[tokio::test]
+    async fn apply_sandbox_opts_groups_secret_hosts_and_parses_patterns() {
+        use microsandbox_network::secrets::config::HostPattern;
+
+        let opts = SandboxOpts {
+            secret: vec![
+                "API_KEY@api.example.com,*.example.org".into(),
+                "API_KEY@*".into(),
+            ],
+            ..Default::default()
+        };
+
+        let config = apply_sandbox_opts(SandboxBuilder::new("test").image("alpine"), &opts)
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        let secrets = config
+            .spec
+            .network
+            .secrets
+            .expect("network secrets")
+            .secrets;
+
+        assert_eq!(secrets.len(), 1);
+        assert_eq!(secrets[0].env_var, "API_KEY");
+        assert_eq!(
+            secrets[0].allowed_hosts,
+            vec![
+                HostPattern::Exact("api.example.com".into()),
+                HostPattern::Wildcard("*.example.org".into()),
+                HostPattern::Any,
+            ]
+        );
     }
 
     #[cfg(feature = "net")]

--- a/crates/cli/lib/commands/modify.rs
+++ b/crates/cli/lib/commands/modify.rs
@@ -72,8 +72,9 @@ pub struct ModifyArgs {
     #[arg(long, value_name = "PATH")]
     pub workdir: Option<String>,
 
-    /// Add or rotate a secret from a host environment variable (`NAME@HOST`).
-    #[arg(long = "secret", value_name = "NAME@HOST")]
+    /// Add or rotate a secret from a host environment variable
+    /// (`NAME@HOST[,HOST...]`).
+    #[arg(long = "secret", value_name = "NAME@HOST[,HOST...]")]
     pub secrets: Vec<String>,
 
     /// Remove a secret by name.
@@ -193,14 +194,14 @@ fn apply_secret_args(
     mut builder: SandboxModificationBuilder,
     args: &ModifyArgs,
 ) -> anyhow::Result<SandboxModificationBuilder> {
-    // Group hosts by secret name so repeated `--secret NAME@HOST` flags
-    // accumulate into one declarative spec per name.
+    // Group hosts by secret name so repeated `--secret NAME@HOST[,HOST...]`
+    // flags accumulate into one declarative spec per name.
     let mut specs: Vec<(String, Vec<String>)> = Vec::new();
     for secret in &args.secrets {
-        let (name, host) = common::parse_secret(secret, "modify")?;
+        let (name, hosts) = common::parse_secret(secret, "modify")?;
         match specs.iter_mut().find(|(existing, _)| *existing == name) {
-            Some((_, hosts)) => hosts.push(host),
-            None => specs.push((name, vec![host])),
+            Some((_, existing_hosts)) => existing_hosts.extend(hosts),
+            None => specs.push((name, hosts)),
         }
     }
     for (name, hosts) in specs {
@@ -600,7 +601,7 @@ fn replayed_args(args: &ModifyArgs) -> String {
     }
     for secret in &args.secrets {
         let sanitized = common::parse_secret(secret, "modify")
-            .map(|(name, host)| format!("{name}@{host}"))
+            .map(|(name, hosts)| format!("{name}@{}", hosts.join(",")))
             .unwrap_or_else(|_| "<secret>".to_string());
         rendered.push(format!("--secret {sanitized}"));
     }

--- a/crates/network/lib/secrets/handler.rs
+++ b/crates/network/lib/secrets/handler.rs
@@ -612,6 +612,14 @@ impl SecretsHandler {
             });
         }
 
+        // Do not block a placeholder that another rule allows for this host.
+        let eligible_placeholders: HashSet<&str> = eligible_for_substitution
+            .iter()
+            .map(|secret| secret.placeholder.as_str())
+            .collect();
+        ineligible_for_substitution
+            .retain(|secret| !eligible_placeholders.contains(secret.placeholder.as_str()));
+
         Self {
             eligible_for_substitution,
             ineligible_for_substitution,
@@ -3277,6 +3285,24 @@ mod tests {
         assert_eq!(
             String::from_utf8(output.into_owned()).unwrap(),
             "GET / HTTP/1.1\r\nAuthorization: Bearer allowed-secret\r\n\r\n"
+        );
+    }
+
+    #[test]
+    fn same_placeholder_substitutes_when_duplicate_secret_is_ineligible() {
+        let allowed = make_secret("$KEY", "real-secret", "api.github.com");
+        let mut duplicate_host = make_secret("$KEY", "real-secret", "unused.example.com");
+        duplicate_host.allowed_hosts =
+            vec![HostPattern::Wildcard("*.githubusercontent.com".into())];
+        let config = make_config(vec![allowed, duplicate_host]);
+        let mut handler = SecretsHandler::new(&config, "api.github.com", true);
+
+        let input = b"GET /user HTTP/1.1\r\nAuthorization: Bearer $KEY\r\n\r\n";
+        let output = handler.substitute(input).unwrap();
+
+        assert_eq!(
+            String::from_utf8(output.into_owned()).unwrap(),
+            "GET /user HTTP/1.1\r\nAuthorization: Bearer real-secret\r\n\r\n"
         );
     }
 

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -230,7 +230,7 @@ Live resize is not necessarily instant. When an accepted resize has not fully se
 
 Env and workdir changes on a running sandbox apply to future execs only — running processes keep their current environment. The plan reports this as a warning.
 
-`--secret NAME@HOST` adds or rotates a secret from the same-named host environment variable, recording a source reference — the value itself never rides in the command. The inline `NAME=VALUE@HOST` form is rejected, same as on `msb create`: shell history and process listings would leak the value, so providing a raw value is SDK-only.
+`--secret NAME@HOST[,HOST...]` adds or rotates a secret from the same-named host environment variable, recording a source reference — the value itself never rides in the command. The inline `NAME=VALUE@HOST` form is rejected, same as on `msb create`: shell history and process listings would leak the value, so providing a raw value is SDK-only.
 
 | Flag | Description |
 |------|-------------|
@@ -241,7 +241,7 @@ Env and workdir changes on a running sandbox apply to future execs only — runn
 | `--env`, `--env-rm` | Set (`KEY=VALUE`) or remove an environment variable for future execs |
 | `--label`, `--label-rm` | Set (`KEY=VALUE`) or remove a label |
 | `--workdir` | Working directory for future execs |
-| `--secret`, `--secret-rm` | Add or rotate a secret from a host environment variable (`NAME@HOST`), or remove one |
+| `--secret`, `--secret-rm` | Add or rotate a secret from a host environment variable (`NAME@HOST[,HOST...]`), or remove one |
 | `--dry-run` | Show the plan without applying anything |
 | `--next-start` | Save changes for the next start without mutating a running VM |
 | `--restart` | Restart if needed so restart-required changes become active now |

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -86,13 +86,13 @@ sb, err := m.CreateSandbox(ctx, "worker",
 
 ```bash CLI
 msb create python --name worker \
-  --secret "GITHUB_TOKEN@api.github.com" \
+  --secret "GITHUB_TOKEN@api.github.com,*.githubusercontent.com" \
   --secret "SERVICE_API_KEY@api.example.com"
 ```
 
 </CodeGroup>
 
-In the CLI form, `ENV@HOST` records a host-side source reference: the real value is read from the same-named host environment variable when the sandbox starts, and never lands in the durable config. The inline `ENV=VALUE@HOST` form is rejected on both `msb create` and `msb modify` — shell history and process listings would leak the value regardless — so providing a raw value is SDK-only.
+In the CLI form, `ENV@HOST[,HOST...]` records a host-side source reference: the real value is read from the same-named host environment variable when the sandbox starts, and never lands in the durable config. The inline `ENV=VALUE@HOST` form is rejected on both `msb create` and `msb modify` — shell history and process listings would leak the value regardless — so providing a raw value is SDK-only.
 
 <Warning>
   **Raw values persist at rest.** SDK paths that take a raw value — `.value(..)` in the secret closure, `secret_env()`, and modify's value-based rotate — store the value verbatim in the durable sandbox config. It stays there until a later modify rotates the secret to a source reference. Downstream behavior is identical to the reference path (placeholder-only guest, proxy injection, zeroized memory copies); only the at-rest property differs. A future host-side secret store will make these same calls import the value and store a reference, with no signature change. Prefer source references when the value can be referenced.

--- a/sdk/rust/lib/sandbox/modify.rs
+++ b/sdk/rust/lib/sandbox/modify.rs
@@ -1053,8 +1053,9 @@ fn live_secret_updates(
                     name: spec.name.clone(),
                     value: SecretValue(value),
                 });
-                // A rotate request may carry new hosts (e.g. `--secret NAME@HOST`
-                // on an existing secret); apply them in the same batch.
+                // A rotate request may carry new hosts (for example
+                // `--secret NAME@HOST[,HOST...]` on an existing secret);
+                // apply them in the same batch.
                 if !spec.allowed_hosts.is_empty() {
                     updates.push(SecretLiveChange::SetAllowedHosts {
                         name: spec.name.clone(),


### PR DESCRIPTION
Fixes #1170.

Repeated `--secret ENV@HOST` rules share the same placeholder. If one rule matched and another did not, the non-matching rule could block the request before substitution.

This filters duplicate ineligible placeholders when the same placeholder is allowed for the current host. It also supports `--secret 'ENV@host1,host2'` so one CLI secret can carry multiple allowed hosts.