### PR TITLE
fix(sdk/node): add default export condition for CommonJS consumers

### DIFF
--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./native": {
       "types": "./native/index.d.ts",


### PR DESCRIPTION
## TL;DR
The npm package's exports map only declares `types` and `import`, so any CommonJS consumer fails with ERR_PACKAGE_PATH_NOT_EXPORTED before module loading even starts. Adding a `default` condition makes `require('microsandbox')` resolve, and the ESM dist loads fine under require() on Node 20.19+/22+ (no top-level await).

## Description
- Add `"default": "./dist/index.js"` to the `.` export, matching the style the `./native` entry already uses.
- This was found in the wild: the tsup CJS build of the @computesdk/microsandbox provider could not `require('microsandbox')` at all — resolution failed before Node even looked at the file.
- No dual build needed: the ESM dist has no top-level await, so Node's require(esm) support (20.19+, 22+) loads it synchronously once resolution succeeds. Older Node gets a clear ERR_REQUIRE_ESM instead of the misleading path error.
- ESM consumers are unaffected: the `import` condition still matches first for import resolution.

```js
// before: throws ERR_PACKAGE_PATH_NOT_EXPORTED
// after: works on Node 20.19+/22+ and bun
const { Sandbox } = require("microsandbox");
```

## Test Plan
- [x] fresh consumer with `"microsandbox": "file:..."` installed: `node --input-type=commonjs -e "require('microsandbox')"` loads 108 exports
- [x] same consumer: `node --input-type=module -e "import('microsandbox')"` still loads (no ESM regression)
- [x] `bun -e "require('microsandbox')"` loads
- [ ] republish check: `npm pack` artifact resolves the same way from the registry tarball (verify on next release)