### PR TITLE
deps: bump hickory to 0.26.1, migrating hickory-client to hickory-net

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,24 +1835,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,48 +2389,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
-name = "hickory-client"
-version = "0.26.0-alpha.1"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b710cd52bde69b58137785a5d2b1ec1b20980a3ca0d5f959eab8c45a72e92d"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "hickory-proto",
- "once_cell",
- "radix_trie",
- "rand 0.9.4",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.26.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62d7684f766b0f96344be88c023f9b6650039aea09d526b4974cce302eb61b1"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
+ "jni 0.22.4",
+ "rand 0.10.2",
  "rustls",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
  "tracing",
  "url",
 ]
@@ -2990,6 +2971,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3598,7 +3609,7 @@ dependencies = [
  "crossbeam-queue",
  "dirs",
  "futures",
- "hickory-client",
+ "hickory-net",
  "hickory-proto",
  "httlib-hpack",
  "httparse",
@@ -4119,15 +4130,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "nix"
@@ -5213,16 +5215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5757,7 +5749,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -6316,6 +6308,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,9 +100,8 @@ flate2 = { version = "1.0", features = ["zlib-rs"] }
 futures = "0.3"
 futures-util = "0.3"
 hex = "0.4"
-hickory-client = "0.26.0-alpha.1"
-hickory-proto = "0.26.0-alpha.1"
-hickory-resolver = "0.26.0-alpha.1"
+hickory-net = "0.26.1"
+hickory-proto = "0.26.1"
 httlib-hpack = "0.1.3"
 indicatif = "0.18"
 ipnetwork = { version = "0.21.0", features = ["serde"] }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -16,11 +16,11 @@ bytes = { workspace = true }
 crossbeam-queue = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
-hickory-client = { workspace = true }
-# tls-ring unlocks `hickory_proto::rustls::tls_client_connect` for the
+# tls-ring unlocks `hickory_net::tls::tls_client_connect` for the
 # upstream DoT client. The workspace already uses rustls with the ring
 # crypto provider, so no new dependency is introduced.
-hickory-proto = { workspace = true, features = ["tls-ring"] }
+hickory-net = { workspace = true, features = ["tls-ring"] }
+hickory-proto = { workspace = true }
 httlib-hpack = { workspace = true }
 httparse = "1"
 ipnetwork = { workspace = true }

--- a/crates/network/lib/dns/client.rs
+++ b/crates/network/lib/dns/client.rs
@@ -15,13 +15,23 @@ use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use hickory_client::client::Client;
-use hickory_client::proto::runtime::TokioRuntimeProvider;
-use hickory_client::proto::tcp::TcpClientStream;
-use hickory_client::proto::udp::UdpClientStream;
+use hickory_net::client::Client as GenericClient;
+use hickory_net::runtime::TokioRuntimeProvider;
+use hickory_net::tcp::TcpClientStream;
+use hickory_net::udp::UdpClientStream;
 use rustls::ClientConfig;
 
 use super::common::transport::Transport;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Upstream DNS client over the Tokio runtime. hickory 0.26 made
+/// [`GenericClient`] generic over the runtime provider; every upstream
+/// client in this crate runs on Tokio, so the concrete type is fixed
+/// here once and the rest of the DNS code keeps using plain `Client`.
+pub(super) type Client = GenericClient<TokioRuntimeProvider>;
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -30,17 +40,13 @@ use super::common::transport::Transport;
 /// Build a hickory UDP client connected to `addr` with the given
 /// per-query timeout. Logs and returns `None` on connect error.
 pub(super) async fn build_udp_client(addr: SocketAddr, timeout: Duration) -> Option<Client> {
-    let stream =
-        UdpClientStream::<TokioRuntimeProvider>::builder(addr, TokioRuntimeProvider::new())
-            .with_timeout(Some(timeout))
-            .build();
-    let (client, bg) = match Client::connect(stream).await {
-        Ok(pair) => pair,
-        Err(e) => {
-            tracing::warn!(upstream = %addr, error = %e, "failed to build UDP DNS client");
-            return None;
-        }
-    };
+    // Since hickory 0.26 the UDP stream is handed to the client as a
+    // request sender; socket errors surface per-query instead of at
+    // build time, so this constructor is infallible.
+    let stream = UdpClientStream::builder(addr, TokioRuntimeProvider::new())
+        .with_timeout(Some(timeout))
+        .build();
+    let (client, bg) = Client::from_sender(stream);
     tokio::spawn(bg);
     Some(client)
 }
@@ -48,18 +54,19 @@ pub(super) async fn build_udp_client(addr: SocketAddr, timeout: Duration) -> Opt
 /// Build a hickory TCP client connected to `addr` with the given
 /// connect+query timeout. Logs and returns `None` on connect error.
 pub(super) async fn build_tcp_client(addr: SocketAddr, timeout: Duration) -> Option<Client> {
-    let (stream, sender) =
+    let (stream_future, sender) =
         TcpClientStream::new(addr, None, Some(timeout), TokioRuntimeProvider::new());
-    // `with_timeout` (not `new`) so the per-query response timeout honors the
-    // configured `query_timeout`; `Client::new` silently falls back to
-    // hickory's 5s default, unlike the UDP/DoT builders above/below.
-    let (client, bg) = match Client::with_timeout(stream, sender, timeout, None).await {
-        Ok(pair) => pair,
+    let stream = match stream_future.await {
+        Ok(stream) => stream,
         Err(e) => {
             tracing::warn!(upstream = %addr, error = %e, "failed to build TCP DNS client");
             return None;
         }
     };
+    // `with_timeout` (not `new`) so the per-query response timeout honors the
+    // configured `query_timeout`; `Client::new` silently falls back to
+    // hickory's 5s default, unlike the UDP/DoT builders above/below.
+    let (client, bg) = Client::with_timeout(stream, sender, timeout);
     tokio::spawn(bg);
     Some(client)
 }
@@ -72,7 +79,7 @@ pub(super) async fn build_dot_client(
     sni: String,
     timeout: Duration,
 ) -> Option<Client> {
-    use hickory_proto::rustls::tls_client_connect;
+    use hickory_net::tls::tls_client_connect;
     use rustls::pki_types::ServerName;
 
     let server_name = match ServerName::try_from(sni.clone()) {
@@ -89,13 +96,14 @@ pub(super) async fn build_dot_client(
         client_config,
         TokioRuntimeProvider::new(),
     );
-    let (client, bg) = match Client::with_timeout(stream_future, sender, timeout, None).await {
-        Ok(pair) => pair,
+    let stream = match stream_future.await {
+        Ok(stream) => stream,
         Err(e) => {
             tracing::warn!(upstream = %addr, error = %e, "failed to build DoT client");
             return None;
         }
     };
+    let (client, bg) = Client::with_timeout(stream, sender, timeout);
     tokio::spawn(bg);
     Some(client)
 }
@@ -170,15 +178,15 @@ fn dot_upstream_client_config() -> Arc<ClientConfig> {
 mod tests {
     use super::*;
     use futures::StreamExt;
-    use hickory_client::proto::op::{Message, MessageType, OpCode, Query};
-    use hickory_client::proto::rr::{Name, RecordType};
-    use hickory_client::proto::xfer::{DnsHandle, DnsRequest};
+    use hickory_net::proto::op::{DnsRequest, Message, MessageType, OpCode, Query};
+    use hickory_net::proto::rr::{Name, RecordType};
+    use hickory_net::xfer::DnsHandle;
     use std::time::Instant;
     use tokio::io::AsyncReadExt;
 
     fn example_query() -> Message {
         let mut msg = Message::new(0x4242, MessageType::Query, OpCode::Query);
-        msg.set_recursion_desired(true);
+        msg.metadata.recursion_desired = true;
         msg.add_query(Query::query(
             Name::from_ascii("example.com.").unwrap(),
             RecordType::A,

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -31,15 +31,14 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures::StreamExt;
-use hickory_client::client::Client;
-use hickory_client::proto::op::{Message, ResponseCode};
-use hickory_client::proto::rr::rdata::{A, AAAA};
-use hickory_client::proto::rr::{RData, Record, RecordType};
-use hickory_client::proto::serialize::binary::{BinDecodable, BinEncodable};
-use hickory_client::proto::xfer::{DnsHandle, DnsRequest};
+use hickory_net::proto::op::{DnsRequest, Message, ResponseCode};
+use hickory_net::proto::rr::rdata::{A, AAAA};
+use hickory_net::proto::rr::{RData, Record, RecordType};
+use hickory_net::proto::serialize::binary::{BinDecodable, BinEncodable};
+use hickory_net::xfer::DnsHandle;
 use tokio::sync::{OnceCell, watch};
 
-use super::client::{build_direct_client, build_tcp_client, build_udp_client};
+use super::client::{Client, build_direct_client, build_tcp_client, build_udp_client};
 use super::common::config::NormalizedDnsConfig;
 use super::common::filter::{is_private_ipv4, is_private_ipv6};
 use super::common::transport::Transport;
@@ -153,9 +152,9 @@ impl DnsForwarder {
         sni: Option<&str>,
     ) -> Option<Bytes> {
         let query_msg = Message::from_bytes(raw_query).ok()?;
-        let guest_id = query_msg.id();
+        let guest_id = query_msg.metadata.id;
 
-        let question = query_msg.queries().first()?;
+        let question = query_msg.queries.first()?;
         let query_type = question.query_type();
         let domain = question.name().to_string();
         let domain = domain.trim_end_matches('.').to_owned();
@@ -210,7 +209,7 @@ impl DnsForwarder {
             }
         };
 
-        // Forward upstream. hickory-client's multiplexer assigns its own
+        // Forward upstream. hickory's multiplexer assigns its own
         // transaction id; we rewrite the response id back to the guest's
         // below.
         let mut send = client.send(DnsRequest::from(query_msg.clone()));
@@ -229,8 +228,8 @@ impl DnsForwarder {
 
         // Rebind protection: reject responses containing private/reserved IPs.
         if self.config.rebind_protection {
-            for record in response_msg.answers() {
-                let is_private = match record.data() {
+            for record in &response_msg.answers {
+                let is_private = match &record.data {
                     RData::A(a) => is_private_ipv4((*a).into()),
                     RData::AAAA(aaaa) => is_private_ipv6((*aaaa).into()),
                     _ => false,
@@ -257,12 +256,8 @@ impl DnsForwarder {
             }
         }
 
-        // Preserve the guest's transaction id. `Message::set_id` is
-        // crate-private in hickory 0.26, so round-trip through `Header`,
-        // which is `Copy`.
-        let mut header = *response_msg.header();
-        header.set_id(guest_id);
-        response_msg.set_header(header);
+        // Preserve the guest's transaction id.
+        response_msg.metadata.id = guest_id;
         let response_bytes = response_msg.to_bytes().ok()?;
 
         // UDP truncation: if the wire response exceeds the buffer the
@@ -501,11 +496,11 @@ fn decide_dns_action(policy: &NetworkPolicy, domain: &str, transport: Transport)
 /// rebind rejection) and SERVFAIL (upstream unreachable). The guest's
 /// transaction id, OPCODE and RD bit are echoed.
 fn build_status_response(query: &Message, rcode: ResponseCode) -> Option<Bytes> {
-    let mut response = Message::response(query.id(), query.op_code());
-    response.set_recursion_desired(query.recursion_desired());
-    response.set_response_code(rcode);
-    response.set_recursion_available(true);
-    if let Some(q) = query.queries().first() {
+    let mut response = Message::response(query.metadata.id, query.metadata.op_code);
+    response.metadata.recursion_desired = query.metadata.recursion_desired;
+    response.metadata.response_code = rcode;
+    response.metadata.recursion_available = true;
+    if let Some(q) = query.queries.first() {
         response.add_query(q.clone());
     }
     response.to_bytes().ok().map(Bytes::from)
@@ -543,15 +538,15 @@ fn extract_addrs_and_ttl(
     let mut addrs = Vec::new();
     let mut ttl: Option<Duration> = None;
 
-    for record in response.answers() {
-        let addr = match (family, record.data()) {
+    for record in &response.answers {
+        let addr = match (family, &record.data) {
             (ResolvedHostnameFamily::Ipv4, RData::A(a)) => IpAddr::V4((*a).into()),
             (ResolvedHostnameFamily::Ipv6, RData::AAAA(aaaa)) => IpAddr::V6((*aaaa).into()),
             _ => continue,
         };
         addrs.push(addr);
         let record_ttl =
-            Duration::from_secs(u64::from(record.ttl().max(RESOLVED_HOSTNAME_MIN_TTL_SECS)));
+            Duration::from_secs(u64::from(record.ttl.max(RESOLVED_HOSTNAME_MIN_TTL_SECS)));
         ttl = Some(ttl.map_or(record_ttl, |current| current.min(record_ttl)));
     }
 
@@ -572,7 +567,7 @@ fn synthesize_host_alias_response(
     gateway: GatewayIps,
     qtype: RecordType,
 ) -> Option<Bytes> {
-    let question = query.queries().first()?;
+    let question = query.queries.first()?;
     let name = question.name().clone();
 
     let rdata = match qtype {
@@ -581,11 +576,11 @@ fn synthesize_host_alias_response(
         _ => return None,
     };
 
-    let mut response = Message::response(query.id(), query.op_code());
-    response.set_recursion_desired(query.recursion_desired());
-    response.set_response_code(ResponseCode::NoError);
-    response.set_recursion_available(true);
-    response.set_authoritative(true);
+    let mut response = Message::response(query.metadata.id, query.metadata.op_code);
+    response.metadata.recursion_desired = query.metadata.recursion_desired;
+    response.metadata.response_code = ResponseCode::NoError;
+    response.metadata.recursion_available = true;
+    response.metadata.authoritative = true;
     response.add_query(question.clone());
     response.add_answer(Record::from_rdata(name, HOST_ALIAS_TTL_SECS, rdata));
 
@@ -596,12 +591,12 @@ fn synthesize_host_alias_response(
 /// servers to set TC when truncating; the guest's stub then retries the
 /// query over TCP per RFC 7766.
 fn build_truncated_response(query: &Message) -> Option<Vec<u8>> {
-    let mut response = Message::response(query.id(), query.op_code());
-    response.set_recursion_desired(query.recursion_desired());
-    response.set_response_code(ResponseCode::NoError);
-    response.set_recursion_available(true);
-    response.set_truncated(true);
-    if let Some(q) = query.queries().first() {
+    let mut response = Message::response(query.metadata.id, query.metadata.op_code);
+    response.metadata.recursion_desired = query.metadata.recursion_desired;
+    response.metadata.response_code = ResponseCode::NoError;
+    response.metadata.recursion_available = true;
+    response.metadata.truncation = true;
+    if let Some(q) = query.queries.first() {
         response.add_query(q.clone());
     }
     response.to_bytes().ok()
@@ -615,12 +610,12 @@ fn build_truncated_response(query: &Message) -> Option<Vec<u8>> {
 mod tests {
     use super::*;
     use crate::policy::Protocol;
-    use hickory_client::proto::op::{Edns, MessageType, OpCode, Query};
-    use hickory_client::proto::rr::{DNSClass, Name, RecordType};
+    use hickory_net::proto::op::{Edns, MessageType, OpCode, Query};
+    use hickory_net::proto::rr::{DNSClass, Name, RecordType};
 
     fn make_query(name: &str, qtype: RecordType) -> Message {
         let mut msg = Message::new(0x4242, MessageType::Query, OpCode::Query);
-        msg.set_recursion_desired(true);
+        msg.metadata.recursion_desired = true;
         let parsed = Name::from_ascii(name).expect("valid dns name");
         let mut q = Query::new();
         q.set_name(parsed);
@@ -635,15 +630,15 @@ mod tests {
         let query = make_query("slack.com.", RecordType::AAAA);
         let bytes = build_status_response(&query, ResponseCode::Refused).expect("built");
         let msg = Message::from_bytes(&bytes).expect("parse response");
-        assert_eq!(msg.id(), 0x4242);
-        assert_eq!(msg.response_code(), ResponseCode::Refused);
-        assert_eq!(msg.message_type(), MessageType::Response);
-        assert_eq!(msg.op_code(), OpCode::Query);
-        assert!(msg.recursion_desired());
-        assert!(msg.recursion_available());
-        assert_eq!(msg.queries().len(), 1);
-        assert_eq!(msg.queries()[0].query_type(), RecordType::AAAA);
-        assert_eq!(msg.answers().len(), 0);
+        assert_eq!(msg.metadata.id, 0x4242);
+        assert_eq!(msg.metadata.response_code, ResponseCode::Refused);
+        assert_eq!(msg.metadata.message_type, MessageType::Response);
+        assert_eq!(msg.metadata.op_code, OpCode::Query);
+        assert!(msg.metadata.recursion_desired);
+        assert!(msg.metadata.recursion_available);
+        assert_eq!(msg.queries.len(), 1);
+        assert_eq!(msg.queries[0].query_type(), RecordType::AAAA);
+        assert_eq!(msg.answers.len(), 0);
     }
 
     #[test]
@@ -651,8 +646,8 @@ mod tests {
         let query = make_query("example.com.", RecordType::A);
         let bytes = build_status_response(&query, ResponseCode::ServFail).expect("built");
         let msg = Message::from_bytes(&bytes).expect("parse response");
-        assert_eq!(msg.response_code(), ResponseCode::ServFail);
-        assert_eq!(msg.answers().len(), 0);
+        assert_eq!(msg.metadata.response_code, ResponseCode::ServFail);
+        assert_eq!(msg.answers.len(), 0);
     }
 
     /// Policy denials synthesize NXDOMAIN (not REFUSED) so stub resolvers
@@ -663,9 +658,9 @@ mod tests {
         let query = make_query("example.com.", RecordType::A);
         let bytes = build_status_response(&query, ResponseCode::NXDomain).expect("built");
         let msg = Message::from_bytes(&bytes).expect("parse response");
-        assert_eq!(msg.response_code(), ResponseCode::NXDomain);
-        assert_eq!(msg.answers().len(), 0);
-        assert_eq!(msg.queries().len(), 1);
+        assert_eq!(msg.metadata.response_code, ResponseCode::NXDomain);
+        assert_eq!(msg.answers.len(), 0);
+        assert_eq!(msg.queries.len(), 1);
     }
 
     #[test]
@@ -673,10 +668,10 @@ mod tests {
         let query = make_query("example.com.", RecordType::AAAA);
         let bytes = build_status_response(&query, ResponseCode::NoError).expect("built");
         let msg = Message::from_bytes(&bytes).expect("parse response");
-        assert_eq!(msg.response_code(), ResponseCode::NoError);
-        assert_eq!(msg.answers().len(), 0);
-        assert_eq!(msg.queries().len(), 1);
-        assert_eq!(msg.queries()[0].query_type(), RecordType::AAAA);
+        assert_eq!(msg.metadata.response_code, ResponseCode::NoError);
+        assert_eq!(msg.answers.len(), 0);
+        assert_eq!(msg.queries.len(), 1);
+        assert_eq!(msg.queries[0].query_type(), RecordType::AAAA);
     }
 
     #[test]
@@ -684,13 +679,13 @@ mod tests {
         let query = make_query("example.com.", RecordType::TXT);
         let bytes = build_truncated_response(&query).expect("built");
         let msg = Message::from_bytes(&bytes).expect("parse response");
-        assert_eq!(msg.id(), 0x4242);
-        assert_eq!(msg.message_type(), MessageType::Response);
-        assert_eq!(msg.response_code(), ResponseCode::NoError);
-        assert!(msg.truncated(), "TC bit should be set");
-        assert_eq!(msg.queries().len(), 1);
-        assert_eq!(msg.queries()[0].query_type(), RecordType::TXT);
-        assert!(msg.answers().is_empty());
+        assert_eq!(msg.metadata.id, 0x4242);
+        assert_eq!(msg.metadata.message_type, MessageType::Response);
+        assert_eq!(msg.metadata.response_code, ResponseCode::NoError);
+        assert!(msg.metadata.truncation, "TC bit should be set");
+        assert_eq!(msg.queries.len(), 1);
+        assert_eq!(msg.queries[0].query_type(), RecordType::TXT);
+        assert!(msg.answers.is_empty());
     }
 
     /// EDNS OPT pass-through (#2): a query parsed back from wire bytes
@@ -703,12 +698,12 @@ mod tests {
         edns.set_max_payload(4096);
         edns.set_dnssec_ok(true);
         edns.set_version(0);
-        *query.extensions_mut() = Some(edns);
+        query.edns = Some(edns);
 
         let bytes = query.to_bytes().expect("serialize");
         let parsed = Message::from_bytes(&bytes).expect("parse");
 
-        let opt = parsed.extensions().as_ref().expect("OPT preserved");
+        let opt = parsed.edns.as_ref().expect("OPT preserved");
         assert_eq!(opt.max_payload(), 4096);
         assert!(opt.flags().dnssec_ok, "DO bit preserved");
         // Message::max_payload returns OPT value (clamped to 512 floor).
@@ -720,7 +715,7 @@ mod tests {
     #[test]
     fn max_payload_defaults_to_512_without_opt() {
         let query = make_query("example.com.", RecordType::A);
-        assert!(query.extensions().is_none());
+        assert!(query.edns.is_none());
         assert_eq!(query.max_payload(), 512);
     }
 


### PR DESCRIPTION
## Summary

Bumps the hickory DNS stack from `0.26.0-alpha.1` (pinned by #690) to the stable `0.26.1` release. The alpha line carries two open RustSec advisories, both DoS-class and both in code paths the in-VM DNS forwarder exercises:

- [RUSTSEC-2026-0118](https://rustsec.org/advisories/RUSTSEC-2026-0118) — NSEC3 closest-encloser proof validation enters an unbounded loop on cross-zone responses (fixed in `0.26.0-beta.1`).
- [RUSTSEC-2026-0119](https://rustsec.org/advisories/RUSTSEC-2026-0119) — CPU exhaustion during message encoding due to O(n²) name compression (fixed in `0.26.1`).

Neither fix was backported to the alpha, so `cargo update` alone cannot resolve this; `cargo audit` flags every build until the requirement moves.

## What changed

Hickory reorganized its crates between `0.26.0-alpha.1` and `0.26.0`: the `hickory-client` crate was discontinued (the alpha is its last published version) and the client, runtime, tcp/udp/tls transports, and `xfer` machinery moved into the new `hickory-net` crate, while `Message`/`Header`/`Record` switched from accessor methods to public fields.

- `Cargo.toml`: `hickory-client 0.26.0-alpha.1` → `hickory-net 0.26.1`, `hickory-proto 0.26.0-alpha.1` → `0.26.1`. Dropped the `hickory-resolver` workspace entry — no crate references it since #578 moved forwarding to the client API (it never appears in `Cargo.lock`).
- `crates/network/Cargo.toml`: the `tls-ring` feature moves to `hickory-net`, where `tls_client_connect` now lives.
- `dns/client.rs`: `Client` is generic over the runtime provider in 0.26, so a `pub(super) type Client = GenericClient<TokioRuntimeProvider>` alias keeps the rest of the DNS code on plain `Client`. Constructors adapted: UDP builds via `Client::from_sender` (socket errors now surface per-query, so the UDP constructor is infallible), TCP/DoT await the connect future and hand the resolved stream to the 3-arg `Client::with_timeout` — same connect-time error surfacing as before, and the per-query `query_timeout` semantics that `tcp_upstream_honors_query_timeout` / `udp_upstream_honors_query_timeout` guard are unchanged.
- `dns/forwarder.rs`: accessor calls become field access (`msg.metadata.id`, `msg.queries`, `record.data`, …). The guest transaction-id rewrite no longer needs the `Header` round-trip workaround, since `metadata.id` is directly assignable now. `DnsRequest` moved to `hickory_proto::op`.

No behavior change intended; DNS policy evaluation, rebind protection, EDNS pass-through, truncation, and host-alias synthesis are untouched.

## Test plan

- `cargo test -p microsandbox-network` — 412 passed, 0 failed (includes the DNS forwarder response-builder tests, EDNS round-trip, and the blackhole-upstream timeout tests for the migrated UDP/TCP client constructors).
- `cargo check --workspace` — clean.
- `cargo clippy -p microsandbox-network --all-targets` — no warnings.
- `cargo fmt --all -- --check` — clean.
- OSV scan of the resulting `Cargo.lock` — both hickory advisories cleared; no new advisories introduced.
