### PR TITLE
ci(python): add a 3.10 lower-bound test job for the python sdk

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -984,6 +984,11 @@ jobs:
           name: msb-linux-x86_64
           path: build/
 
+      # microsandbox-runtime links against libcap-ng; GitHub-hosted
+      # runners don't ship the dev package.
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
+
       - name: Sync Python dev environment
         working-directory: sdk/python
         run: uv sync --group dev

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -953,7 +953,7 @@ jobs:
   # ---------------------------------------------------------------------------
   python-sdk-lower-bound:
     name: Python SDK (3.10 lower bound)
-    needs: changes
+    needs: [check, changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -971,6 +971,18 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "sdk/python/uv.lock"
           python-version: "3.10"
+
+      # The sdk/rust build script provisions msb + libkrunfw during the
+      # maturin build. Between a libkrunfw version bump and the next
+      # release its fallback (downloading the released PREBUILT_VERSION
+      # bundle) ships the older libkrunfw and fails on Linux, so feed
+      # its CI escape hatch the locally built bundle from `check`, like
+      # the other SDK jobs do.
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: msb-linux-x86_64
+          path: build/
 
       - name: Sync Python dev environment
         working-directory: sdk/python

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -943,6 +943,57 @@ jobs:
         run: scripts/ci/clean-runner-disk.sh
 
   # ---------------------------------------------------------------------------
+  # Python SDK lower-bound check (Python 3.10)
+  #
+  # Every other Python job runs uv unpinned, so it always resolves a modern
+  # interpreter and never exercises the declared floor in pyproject.toml
+  # (requires-python = ">=3.10"). That let 3.11-only code ship unimportable
+  # on 3.10 (#1153). This job pins uv to 3.10 and runs the unit tests, so
+  # the support claim stays tested until the floor is raised.
+  # ---------------------------------------------------------------------------
+  python-sdk-lower-bound:
+    name: Python SDK (3.10 lower bound)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-bin: false
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "sdk/python/uv.lock"
+          python-version: "3.10"
+
+      - name: Sync Python dev environment
+        working-directory: sdk/python
+        run: uv sync --group dev
+
+      # Guard against the pin silently not applying — an unpinned resolve
+      # is exactly the failure mode this job exists to prevent.
+      - name: Verify interpreter is 3.10
+        working-directory: sdk/python
+        run: uv run python -c "import sys; assert sys.version_info[:2] == (3, 10), sys.version"
+
+      - name: Build Python SDK (editable)
+        working-directory: sdk/python
+        run: uv run maturin develop --release
+
+      # No runtime bundle is staged here; test_runtime_binary skips without
+      # it. Bundle-dependent behavior is covered by `check` on a modern
+      # interpreter — this job only guards the interpreter floor.
+      - name: Test Python SDK
+        working-directory: sdk/python
+        run: uv run pytest
+
+  # ---------------------------------------------------------------------------
   # Go SDK integration tests (requires KVM)
   #
   # Downloads the pre-built msb + libkrunfw + libmicrosandbox_go_ffi.so from
@@ -1058,6 +1109,7 @@ jobs:
       - integration-test
       - node-sdk-test
       - python-sdk-test
+      - python-sdk-lower-bound
       - go-sdk-test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## TL;DR
CI runs uv unpinned everywhere, so the Python SDK is never tested on Python 3.10 even though it declares `requires-python = ">=3.10"`. That gap is how #1153 shipped. This adds a job that pins uv to 3.10 and runs the SDK unit tests so the declared floor stays tested.

## Description
- Add a `python-sdk-lower-bound` job on `ubuntu-latest` that pins the interpreter through setup-uv's `python-version` input, which sets `UV_PYTHON` for every uv call in the job.
- The job mirrors the existing unit-test steps in `check`: `uv sync --group dev`, `uv run maturin develop --release`, `uv run pytest`.
- A small guard step asserts the synced venv really is 3.10, since a silently unapplied pin is the exact failure mode this job exists to catch.
- No runtime bundle is staged. `test_runtime_binary` skips without it, pytest's `testpaths = ["tests"]` keeps integration tests out, and bundle-dependent behavior stays covered by `check` on a modern interpreter. A comment in the job records this so the omission does not look accidental.
- The job downloads the `msb-linux-x86_64` bundle from `check` so the sdk/rust build script's CI escape hatch installs the freshly built msb and libkrunfw. Without it the script falls back to the released bundle, which between a libkrunfw bump and the next release ships the older library and panics on Linux (this is what failed the job's first run here).
- Wired into the `summary` job's needs list so a 3.10 failure fails the aggregate check.

## Test Plan
- [x] `.github/workflows/check.yml` parses as YAML and the new job plus `summary` wiring are present
- [x] actionlint reports no issues in the new job (the only findings are pre-existing `self-hosted-ubuntu-2404-x64` runner-label warnings on existing jobs)
- [x] the job's exact command sequence passes locally on Python 3.10.14: `uv sync --group dev`, interpreter guard, `uv run maturin develop --release`, `uv run pytest` in `sdk/python` (32 passed, 1 skipped)
- [x] the `python-sdk-lower-bound` job appears and passes on this PR (green in 13m28s, 32 passed / 1 skipped on Python 3.10)

