### PR TITLE
fix(sdk): complete go windows setup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -478,6 +478,7 @@ jobs:
             runner: windows-11-arm
             rust_target: aarch64-pc-windows-msvc
             go_arch: arm64
+            go_cc: clang
             kernel_artifact: kernel-c-aarch64
             agentd_artifact: agentd-aarch64-linux-musl
             vs_arch: arm64
@@ -486,6 +487,7 @@ jobs:
             runner: windows-latest
             rust_target: x86_64-pc-windows-msvc
             go_arch: amd64
+            go_cc: clang -fuse-ld=lld
             kernel_artifact: kernel-c-x86_64
             agentd_artifact: agentd-x86_64-linux-musl
             vs_arch: amd64
@@ -588,7 +590,7 @@ jobs:
         shell: pwsh
         working-directory: sdk/go
         env:
-          CC: clang
+          CC: ${{ matrix.go_cc }}
           CGO_ENABLED: "1"
           GOARCH: ${{ matrix.go_arch }}
           GOOS: windows

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -477,6 +477,7 @@ jobs:
           - target: windows-aarch64
             runner: windows-11-arm
             rust_target: aarch64-pc-windows-msvc
+            go_arch: arm64
             kernel_artifact: kernel-c-aarch64
             agentd_artifact: agentd-aarch64-linux-musl
             vs_arch: arm64
@@ -484,6 +485,7 @@ jobs:
           - target: windows-x86_64
             runner: windows-latest
             rust_target: x86_64-pc-windows-msvc
+            go_arch: amd64
             kernel_artifact: kernel-c-x86_64
             agentd_artifact: agentd-x86_64-linux-musl
             vs_arch: amd64
@@ -566,6 +568,36 @@ jobs:
           . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"
           Set-MsvcEnvironment -Architecture ${{ matrix.vs_arch }} -HostArchitecture ${{ matrix.vs_host_arch }}
           cargo +stable build --release --no-default-features --features net,ssh -p microsandbox-cli --target ${{ matrix.rust_target }}
+
+      - name: Build Go FFI cdylib
+        shell: pwsh
+        env:
+          RUSTFLAGS: -C target-feature=+crt-static
+        run: |
+          $ErrorActionPreference = "Stop"
+          . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"
+          Set-MsvcEnvironment -Architecture ${{ matrix.vs_arch }} -HostArchitecture ${{ matrix.vs_host_arch }}
+          cargo +stable build --release -p microsandbox-go --target ${{ matrix.rust_target }}
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: stable
+          cache: false
+
+      - name: Build and test Go SDK
+        shell: pwsh
+        working-directory: sdk/go
+        env:
+          CC: clang
+          CGO_ENABLED: "1"
+          GOARCH: ${{ matrix.go_arch }}
+          GOOS: windows
+        run: |
+          $ErrorActionPreference = "Stop"
+          . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"
+          Set-MsvcEnvironment -Architecture ${{ matrix.vs_arch }} -HostArchitecture ${{ matrix.vs_host_arch }}
+          go build ./...
+          go test -count=1 .
 
   # ---------------------------------------------------------------------------
   # CLI smoke tests (requires KVM)

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -342,7 +342,7 @@ if err := m.EnsureInstalled(ctx); err != nil {
 
 </Accordion>
 
-Ensure `msb` + `libkrunfw` are present under `~/.microsandbox/`, downloading them from the matching GitHub release if needed. Call this at process startup when the program will create local sandboxes so runtime download/setup failures surface before the first sandbox operation. The Go FFI library is embedded in the Go binary and loads automatically on first use; `EnsureInstalled` only governs the `msb` + `libkrunfw` runtime install. Idempotent; options apply only to the first call.
+Ensure `msb` + `libkrunfw` are present under `~/.microsandbox/` (`%USERPROFILE%\.microsandbox` on Windows), downloading them from the matching GitHub release if needed. Call this at process startup when the program will create local sandboxes so runtime download/setup failures surface before the first sandbox operation. The Go FFI library is embedded in the Go binary and loads automatically on first use; `EnsureInstalled` only governs the `msb` + `libkrunfw` runtime install. Idempotent; options apply only to the first call.
 
 <p className="msb-label">Parameters</p>
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -27,8 +27,7 @@ For the full API reference and longer guides, use Go docs and the microsandbox d
 
 - Go 1.22+
 - CGO enabled and a C compiler/toolchain available
-- Linux with KVM or macOS with Apple Silicon
-- The broader microsandbox runtime has Windows preview support, but the Go SDK currently bundles FFI libraries only for macOS ARM64, Linux x86_64, and Linux ARM64.
+- Linux with KVM, macOS with Apple Silicon, or Windows 10/11 with Windows Hypervisor Platform enabled
 
 ## Supported Platforms
 
@@ -37,9 +36,9 @@ For the full API reference and longer guides, use Go docs and the microsandbox d
 | macOS | ARM64 / Apple Silicon | Embedded FFI library |
 | Linux | x86_64 | Embedded FFI library |
 | Linux | ARM64 | Embedded FFI library |
-| Windows | x86_64, ARM64 | Runtime preview exists, but no bundled Go FFI library in this SDK yet |
+| Windows | x86_64, ARM64 | Embedded FFI library; runtime support is in preview |
 
-The Go binary embeds the SDK FFI library and extracts it on first use. The `msb` runtime and `libkrunfw` are installed separately into `~/.microsandbox/` by `EnsureInstalled`.
+The Go binary embeds the SDK FFI library and extracts it on first use. The `msb` runtime and `libkrunfw` are installed separately into `~/.microsandbox/` by `EnsureInstalled` (`%USERPROFILE%\.microsandbox` on Windows).
 
 ## Installation
 

--- a/sdk/go/internal/bundle/bundle.go
+++ b/sdk/go/internal/bundle/bundle.go
@@ -11,7 +11,7 @@
 //
 // Build modes selected at compile time:
 //
-//	default                       — //go:embed of the matching platform .so
+//	default                       — //go:embed of the matching shared library
 //	-tags microsandbox_ffi_path   — reads from $MICROSANDBOX_FFI_PATH
 //	                                (no embed; used by integration/smoke
 //	                                tests and SDK contributors iterating
@@ -22,7 +22,7 @@ package bundle
 
 // FFIPathEnv is the env var consulted by builds tagged with
 // `microsandbox_ffi_path`. It must point at a locally-built
-// libmicrosandbox_go_ffi.{so,dylib}. The variable is undocumented in
+// libmicrosandbox_go_ffi.{so,dylib,dll}. The variable is undocumented in
 // user-facing docs because it has no effect on default builds.
 const FFIPathEnv = "MICROSANDBOX_FFI_PATH"
 

--- a/sdk/go/internal/bundle/bundle_path.go
+++ b/sdk/go/internal/bundle/bundle_path.go
@@ -11,7 +11,7 @@ import (
 // Bytes reads the FFI library bytes from $MICROSANDBOX_FFI_PATH.
 // Builds tagged with `microsandbox_ffi_path` use this variant in place
 // of the embedded library — intended for SDK contributors testing a
-// locally-built libmicrosandbox_go_ffi.{so,dylib} without rebuilding
+// locally-built libmicrosandbox_go_ffi.{so,dylib,dll} without rebuilding
 // the embed.
 func Bytes() ([]byte, error) {
 	path := os.Getenv(FFIPathEnv)
@@ -39,8 +39,12 @@ func Bytes() ([]byte, error) {
 // current platform, so callers can write the bytes to disk under the
 // expected name.
 func Filename() string {
-	if runtime.GOOS == "darwin" {
+	switch runtime.GOOS {
+	case "darwin":
 		return "libmicrosandbox_go_ffi.dylib"
+	case "windows":
+		return "libmicrosandbox_go_ffi.dll"
+	default:
+		return "libmicrosandbox_go_ffi.so"
 	}
-	return "libmicrosandbox_go_ffi.so"
 }

--- a/sdk/go/setup.go
+++ b/sdk/go/setup.go
@@ -97,7 +97,7 @@ func autoLoadFFI() error {
 			return
 		}
 		// Pin the resolver's SDK-tier msb path to our install dir.
-		ffi.SetSdkMsbPath(filepath.Join(dir, "bin", "msb"))
+		ffi.SetSdkMsbPath(filepath.Join(dir, "bin", msbFilename()))
 	})
 	return autoLoadErr
 }
@@ -247,7 +247,7 @@ func wrapDlopenErr(err error, path string) error {
 // msbAndKrunfwInstalled reports whether msb is present at the expected
 // version and libkrunfw is present.
 func msbAndKrunfwInstalled(installDir string) bool {
-	msbBin := filepath.Join(installDir, "bin", "msb")
+	msbBin := filepath.Join(installDir, "bin", msbFilename())
 	if _, err := os.Stat(msbBin); err != nil {
 		return false
 	}
@@ -271,27 +271,54 @@ func installedMsbVersion(msbPath string) string {
 	return strings.TrimPrefix(s, "msb ")
 }
 
+// msbFilename returns the platform-specific runtime executable name.
+func msbFilename() string {
+	return msbFilenameFor(runtime.GOOS)
+}
+
+func msbFilenameFor(goos string) string {
+	if goos == "windows" {
+		return "msb.exe"
+	}
+	return "msb"
+}
+
 // libkrunfwFilename returns the exact filename of the prebuilt libkrunfw
 // for the current platform.
 func libkrunfwFilename() string {
-	if runtime.GOOS == "darwin" {
-		return fmt.Sprintf("libkrunfw.%s.dylib", libkrunfwABI)
-	}
-	return fmt.Sprintf("libkrunfw.so.%s", libkrunfwVersion)
+	return libkrunfwFilenameFor(runtime.GOOS)
 }
 
-// libkrunfwSymlinks returns (linkName, target) pairs for the libkrunfw
-// SONAME layout. Without these symlinks the dynamic linker cannot resolve
-// the libkrunfw SONAME that msb was built against.
-func libkrunfwSymlinks() [][2]string {
-	full := libkrunfwFilename()
-	if runtime.GOOS == "darwin" {
-		return [][2]string{{"libkrunfw.dylib", full}}
+func libkrunfwFilenameFor(goos string) string {
+	switch goos {
+	case "darwin":
+		return fmt.Sprintf("libkrunfw.%s.dylib", libkrunfwABI)
+	case "windows":
+		return "libkrunfw.dll"
+	default:
+		return fmt.Sprintf("libkrunfw.so.%s", libkrunfwVersion)
 	}
-	soname := fmt.Sprintf("libkrunfw.so.%s", libkrunfwABI)
-	return [][2]string{
-		{soname, full},
-		{"libkrunfw.so", soname},
+}
+
+// libkrunfwSymlinks returns (linkName, target) pairs for the Unix libkrunfw
+// SONAME layout. Windows resolves the DLL directly and needs no links.
+func libkrunfwSymlinks() [][2]string {
+	return libkrunfwSymlinksFor(runtime.GOOS)
+}
+
+func libkrunfwSymlinksFor(goos string) [][2]string {
+	full := libkrunfwFilenameFor(goos)
+	switch goos {
+	case "darwin":
+		return [][2]string{{"libkrunfw.dylib", full}}
+	case "windows":
+		return nil
+	default:
+		soname := fmt.Sprintf("libkrunfw.so.%s", libkrunfwABI)
+		return [][2]string{
+			{soname, full},
+			{"libkrunfw.so", soname},
+		}
 	}
 }
 
@@ -310,11 +337,15 @@ func archString() (string, error) {
 
 // osString converts Go's runtime.GOOS into the tag used in release assets.
 func osString() (string, error) {
-	switch runtime.GOOS {
-	case "darwin", "linux":
-		return runtime.GOOS, nil
+	return osStringFor(runtime.GOOS)
+}
+
+func osStringFor(goos string) (string, error) {
+	switch goos {
+	case "darwin", "linux", "windows":
+		return goos, nil
 	default:
-		return "", fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+		return "", fmt.Errorf("unsupported platform: %s", goos)
 	}
 }
 
@@ -387,7 +418,7 @@ func downloadMsbAndKrunfw(ctx context.Context, installDir string) error {
 	}
 
 	// Sanity check.
-	if _, err := os.Stat(filepath.Join(binDir, "msb")); err != nil {
+	if _, err := os.Stat(filepath.Join(binDir, msbFilename())); err != nil {
 		return fmt.Errorf("msb not found after extraction: %w", err)
 	}
 	if _, err := os.Stat(filepath.Join(libDir, libkrunfwFilename())); err != nil {

--- a/sdk/go/setup_test.go
+++ b/sdk/go/setup_test.go
@@ -1,0 +1,152 @@
+package microsandbox
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestPlatformRuntimeFiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		goos      string
+		msb       string
+		libkrunfw string
+		symlinks  [][2]string
+	}{
+		{
+			name:      "darwin",
+			goos:      "darwin",
+			msb:       "msb",
+			libkrunfw: "libkrunfw.5.dylib",
+			symlinks:  [][2]string{{"libkrunfw.dylib", "libkrunfw.5.dylib"}},
+		},
+		{
+			name:      "linux",
+			goos:      "linux",
+			msb:       "msb",
+			libkrunfw: "libkrunfw.so.5.6.0",
+			symlinks: [][2]string{
+				{"libkrunfw.so.5", "libkrunfw.so.5.6.0"},
+				{"libkrunfw.so", "libkrunfw.so.5"},
+			},
+		},
+		{
+			name:      "windows",
+			goos:      "windows",
+			msb:       "msb.exe",
+			libkrunfw: "libkrunfw.dll",
+			symlinks:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := msbFilenameFor(tt.goos); got != tt.msb {
+				t.Errorf("msbFilenameFor(%q) = %q, want %q", tt.goos, got, tt.msb)
+			}
+			if got := libkrunfwFilenameFor(tt.goos); got != tt.libkrunfw {
+				t.Errorf("libkrunfwFilenameFor(%q) = %q, want %q", tt.goos, got, tt.libkrunfw)
+			}
+			if got := libkrunfwSymlinksFor(tt.goos); !reflect.DeepEqual(got, tt.symlinks) {
+				t.Errorf("libkrunfwSymlinksFor(%q) = %#v, want %#v", tt.goos, got, tt.symlinks)
+			}
+		})
+	}
+}
+
+func TestOSStringFor(t *testing.T) {
+	t.Parallel()
+
+	for _, goos := range []string{"darwin", "linux", "windows"} {
+		goos := goos
+		t.Run(goos, func(t *testing.T) {
+			t.Parallel()
+			got, err := osStringFor(goos)
+			if err != nil {
+				t.Fatalf("osStringFor(%q): %v", goos, err)
+			}
+			if got != goos {
+				t.Errorf("osStringFor(%q) = %q, want %q", goos, got, goos)
+			}
+		})
+	}
+
+	if _, err := osStringFor("freebsd"); err == nil {
+		t.Fatal("osStringFor(\"freebsd\") succeeded, want unsupported-platform error")
+	}
+}
+
+func TestExtractMsbAndKrunfwWindowsBundle(t *testing.T) {
+	t.Parallel()
+
+	var archive bytes.Buffer
+	gz := gzip.NewWriter(&archive)
+	tw := tar.NewWriter(gz)
+	files := []struct {
+		name string
+		data string
+	}{
+		{name: "msb.exe", data: "msb"},
+		{name: "libkrunfw.dll", data: "krunfw"},
+		{name: "libmicrosandbox_go_ffi.dll", data: "ffi"},
+	}
+	for _, file := range files {
+		hdr := &tar.Header{
+			Name: file.name,
+			Mode: 0o755,
+			Size: int64(len(file.data)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write tar header: %v", err)
+		}
+		if _, err := tw.Write([]byte(file.data)); err != nil {
+			t.Fatalf("write tar data: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	libDir := filepath.Join(root, "lib")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("create lib dir: %v", err)
+	}
+	if err := extractMsbAndKrunfw(bytes.NewReader(archive.Bytes()), binDir, libDir); err != nil {
+		t.Fatalf("extract Windows bundle: %v", err)
+	}
+
+	assertFileContents(t, filepath.Join(binDir, "msb.exe"), "msb")
+	assertFileContents(t, filepath.Join(libDir, "libkrunfw.dll"), "krunfw")
+	if _, err := os.Stat(filepath.Join(libDir, "libmicrosandbox_go_ffi.dll")); !os.IsNotExist(err) {
+		t.Fatalf("embedded FFI library should not be extracted, stat error = %v", err)
+	}
+}
+
+func assertFileContents(t *testing.T, path, want string) {
+	t.Helper()
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Errorf("%s contents = %q, want %q", path, got, want)
+	}
+}

--- a/sdk/go/smoke_test.go
+++ b/sdk/go/smoke_test.go
@@ -5,7 +5,7 @@
 //
 // Run with:
 //
-//	MICROSANDBOX_FFI_PATH=/path/to/libmicrosandbox_go_ffi.{so,dylib} \
+//	MICROSANDBOX_FFI_PATH=/path/to/libmicrosandbox_go_ffi.{so,dylib,dll} \
 //	    go test -tags "smoke microsandbox_ffi_path" -count=1 ./...
 //
 // The microsandbox_ffi_path build tag swaps the embedded FFI for a

--- a/sdk/go/volume_test.go
+++ b/sdk/go/volume_test.go
@@ -20,6 +20,7 @@ func TestVolumeName(t *testing.T) {
 func TestVolumeFsPathEscape(t *testing.T) {
 	root := t.TempDir()
 	fs := &VolumeFs{root: root}
+	volumeRoot := filepath.VolumeName(root) + string(filepath.Separator)
 
 	cases := []struct {
 		name string
@@ -27,7 +28,7 @@ func TestVolumeFsPathEscape(t *testing.T) {
 	}{
 		{"parent traversal", "../escape"},
 		{"deep traversal", "a/b/../../../escape"},
-		{"absolute path", "/etc/passwd"},
+		{"absolute path", filepath.Join(volumeRoot, "etc", "passwd")},
 		{"absolute under root", filepath.Join(root, "..", "escape")},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## TL;DR

complete the Windows Go SDK setup introduced in #1187 by making runtime installation platform-aware and exercising the Windows Go paths in pull request CI.

## Description

- use `msb.exe` and `libkrunfw.dll` throughout `EnsureInstalled` on Windows
- download the existing Windows release archives and skip Unix-only library symlinks
- preserve the `.dll` filename for `microsandbox_ffi_path` development builds
- add focused tests for platform filenames and Windows archive extraction
- build the Go FFI cdylib and Go SDK in both Windows CI jobs
- update the Go support matrix and installation documentation

## Test Plan

- `go test -count=1 .`
- `go vet ./...`
- `go build ./...`
- `gofmt -l setup.go setup_test.go internal/bundle/bundle.go internal/bundle/bundle_path.go smoke_test.go`
- `actionlint -shellcheck= -ignore 'label "self-hosted-ubuntu-2404-x64" is unknown' .github/workflows/check.yml`
- `npx mint@latest validate`
- `npx mint@latest broken-links`
