### PR TITLE
feat(types): sandbox status_reason + rename failure-message field

### DIFF
--- a/packages/microsandbox-types/rust/lib/cloud.rs
+++ b/packages/microsandbox-types/rust/lib/cloud.rs
@@ -814,6 +814,10 @@ pub struct CloudCreateSandboxResponse {
     pub slug: String,
     /// Current lifecycle status.
     pub status: CloudSandboxStatus,
+    /// Why the sandbox is not running yet, when known. Only present while
+    /// `status` is `starting`.
+    #[serde(default)]
+    pub status_reason: Option<CloudSandboxStatusReason>,
     /// The sandbox spec the cloud control plane stored for this sandbox.
     pub spec: CloudSandboxSpec,
     /// Whether the sandbox should be removed when its allocation terminates.
@@ -829,9 +833,9 @@ pub struct CloudCreateSandboxResponse {
     #[serde(default)]
     #[cfg_attr(feature = "ts", ts(type = "string | null"))]
     pub stopped_at: Option<DateTime<Utc>>,
-    /// Last failure reason, when any.
+    /// Human-readable message for the most recent failure, when any.
     #[serde(default)]
-    pub last_error: Option<String>,
+    pub last_failure_message: Option<String>,
 }
 
 /// Sandbox lifecycle status returned by the cloud control plane.
@@ -852,6 +856,20 @@ pub enum CloudSandboxStatus {
     Stopped,
     /// Sandbox failed.
     Failed,
+}
+
+/// Reason a sandbox start is still in progress. Only meaningful while
+/// `status` is `starting`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[serde(rename_all = "snake_case")]
+pub enum CloudSandboxStatusReason {
+    /// The start has been accepted and is being scheduled.
+    Scheduling,
+    /// No capacity is currently available; the start proceeds when
+    /// capacity frees up.
+    InsufficientCapacity,
 }
 
 /// Wire shape of paginated list responses.
@@ -1525,12 +1543,13 @@ mod tests {
             name: "agent-1".into(),
             slug: "brave-otter".into(),
             status: CloudSandboxStatus::Created,
+            status_reason: None,
             spec: spec("agent-1"),
             ephemeral: true,
             created_at: "2026-05-17T12:00:00Z".parse().unwrap(),
             started_at: None,
             stopped_at: None,
-            last_error: None,
+            last_failure_message: None,
         };
         let json = serde_json::to_value(&sb).unwrap();
         assert_eq!(json["slug"], "brave-otter");

--- a/packages/microsandbox-types/rust/lib/lib.rs
+++ b/packages/microsandbox-types/rust/lib/lib.rs
@@ -20,8 +20,8 @@ pub use cloud::{
     CloudErrorDetails, CloudHostPattern, CloudMessageResponse, CloudNetworkSpec, CloudPaginated,
     CloudPatch, CloudPullPolicy, CloudRlimit, CloudRlimitResource, CloudRootfsSource,
     CloudSandboxResources, CloudSandboxRuntimeOptions, CloudSandboxSpec, CloudSandboxStatus,
-    CloudSecretEntry, CloudSecretSource, CloudSecretsConfig, CloudViolationAction,
-    CloudVolumeMount,
+    CloudSandboxStatusReason, CloudSecretEntry, CloudSecretSource, CloudSecretsConfig,
+    CloudViolationAction, CloudVolumeMount,
 };
 pub use domain::{
     Action, CertCacheConfig, DEFAULT_METRICS_SAMPLE_INTERVAL_MS, DEFAULT_SANDBOX_CPUS,

--- a/packages/microsandbox-types/rust/lib/typescript.rs
+++ b/packages/microsandbox-types/rust/lib/typescript.rs
@@ -12,11 +12,11 @@ use crate::{
     Action, CloudCreateSandboxResponse, CloudDiskImageFormat, CloudErrorBody, CloudErrorDetails,
     CloudHostPattern, CloudMessageResponse, CloudNetworkSpec, CloudPaginated, CloudPatch,
     CloudPullPolicy, CloudRlimit, CloudRlimitResource, CloudRootfsSource, CloudSandboxResources,
-    CloudSandboxRuntimeOptions, CloudSandboxSpec, CloudSandboxStatus, CloudSecretEntry,
-    CloudSecretSource, CloudSecretsConfig, CloudViolationAction, CloudVolumeMount, Destination,
-    DestinationGroup, Direction, EnvVar, HandoffInit, HostPermissions, MountOptions, NetworkPolicy,
-    PortRange, Protocol, Rule, SandboxLogLevel, SandboxPolicy, SecretInjection, SecurityProfile,
-    StatVirtualization,
+    CloudSandboxRuntimeOptions, CloudSandboxSpec, CloudSandboxStatus, CloudSandboxStatusReason,
+    CloudSecretEntry, CloudSecretSource, CloudSecretsConfig, CloudViolationAction,
+    CloudVolumeMount, Destination, DestinationGroup, Direction, EnvVar, HandoffInit,
+    HostPermissions, MountOptions, NetworkPolicy, PortRange, Protocol, Rule, SandboxLogLevel,
+    SandboxPolicy, SecretInjection, SecurityProfile, StatVirtualization,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -150,6 +150,7 @@ pub fn cloud_declarations() -> Vec<String> {
         CloudViolationAction::decl(&cfg),
         CloudCreateSandboxResponse::decl(&cfg),
         CloudSandboxStatus::decl(&cfg),
+        CloudSandboxStatusReason::decl(&cfg),
         CloudPaginated::<CloudCreateSandboxResponse>::decl(&cfg),
         CloudMessageResponse::decl(&cfg),
         CloudErrorBody::decl(&cfg),
@@ -232,7 +233,7 @@ mod tests {
     #[test]
     fn cloud_bindings_import_domain_and_stay_scoped() {
         assert_eq!(domain_declarations().len(), 17);
-        assert_eq!(cloud_declarations().len(), 22);
+        assert_eq!(cloud_declarations().len(), 23);
 
         let cloud = render_cloud();
         // Cloud twins live here and their domain deps are imported/re-exported.

--- a/packages/microsandbox-types/typescript/src/cloud.ts
+++ b/packages/microsandbox-types/typescript/src/cloud.ts
@@ -507,6 +507,11 @@ export type CloudCreateSandboxResponse = {
    */
   status: CloudSandboxStatus;
   /**
+   * Why the sandbox is not running yet, when known. Only present while
+   * `status` is `starting`.
+   */
+  status_reason: CloudSandboxStatusReason | null;
+  /**
    * The sandbox spec the cloud control plane stored for this sandbox.
    */
   spec: CloudSandboxSpec;
@@ -527,9 +532,9 @@ export type CloudCreateSandboxResponse = {
    */
   stopped_at: string | null;
   /**
-   * Last failure reason, when any.
+   * Human-readable message for the most recent failure, when any.
    */
-  last_error: string | null;
+  last_failure_message: string | null;
 };
 
 export type CloudSandboxStatus =
@@ -539,6 +544,8 @@ export type CloudSandboxStatus =
   | "stopping"
   | "stopped"
   | "failed";
+
+export type CloudSandboxStatusReason = "scheduling" | "insufficient_capacity";
 
 export type CloudPaginated<T> = {
   /**

--- a/sdk/rust/lib/backend/sandbox.rs
+++ b/sdk/rust/lib/backend/sandbox.rs
@@ -119,8 +119,8 @@ pub struct SandboxHandleCloudState {
     pub started_at: Option<DateTime<Utc>>,
     /// Last stop timestamp, when known.
     pub stopped_at: Option<DateTime<Utc>>,
-    /// Last failure reason, when any.
-    pub last_error: Option<String>,
+    /// Human-readable message for the most recent failure, when any.
+    pub last_failure_message: Option<String>,
 }
 
 /// Paginated sandbox list result returned by [`SandboxBackend::list`].
@@ -1429,12 +1429,13 @@ mod tests {
             name: "agent-1".into(),
             slug: "brave-otter".into(),
             status: CloudSandboxStatus::Running,
+            status_reason: None,
             spec: CloudSandboxSpec::from(spec),
             ephemeral: true,
             created_at: chrono::Utc::now(),
             started_at: None,
             stopped_at: None,
-            last_error: None,
+            last_failure_message: None,
         };
 
         let config = sandbox_config_from_cloud(cloud.spec).unwrap();

--- a/sdk/rust/lib/sandbox/handle.rs
+++ b/sdk/rust/lib/sandbox/handle.rs
@@ -102,7 +102,7 @@ impl SandboxHandle {
                 created_at: Some(cloud.created_at),
                 started_at: cloud.started_at,
                 stopped_at: cloud.stopped_at,
-                last_error: cloud.last_error,
+                last_failure_message: cloud.last_failure_message,
             }),
             name,
         })
@@ -159,11 +159,11 @@ impl SandboxHandle {
         }
     }
 
-    /// Snapshot of the cloud `last_error`, if any. Returns `None` for local
-    /// handles (local error reporting flows through the typed error stack).
-    pub fn last_error_snapshot(&self) -> Option<String> {
+    /// Snapshot of the cloud `last_failure_message`, if any. Returns `None`
+    /// for local handles (local errors flow through the typed error stack).
+    pub fn last_failure_message_snapshot(&self) -> Option<String> {
         match &self.inner {
-            SandboxHandleInner::Cloud(s) => s.last_error.clone(),
+            SandboxHandleInner::Cloud(s) => s.last_failure_message.clone(),
             SandboxHandleInner::Local(_) => None,
         }
     }

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -1427,19 +1427,19 @@ impl Sandbox {
         Ok(handle.status_snapshot())
     }
 
-    /// Live last-error string from the backend, when any. Always hits the
+    /// Live failure message from the backend, when any. Always hits the
     /// backend, never reads a cached field.
     ///
     /// Each call is a separate round-trip. If you need this alongside
     /// `status()`, fetch a fresh [`SandboxHandle`] via
     /// [`Sandbox::get`](Self::get) once and read both off the snapshot.
-    pub async fn last_error(&self) -> MicrosandboxResult<Option<String>> {
+    pub async fn last_failure_message(&self) -> MicrosandboxResult<Option<String>> {
         let handle = self
             .backend
             .sandboxes()
             .get(self.backend.clone(), &self.name)
             .await?;
-        Ok(handle.last_error_snapshot())
+        Ok(handle.last_failure_message_snapshot())
     }
 
     /// Read captured output from `exec.log` for this sandbox.


### PR DESCRIPTION
## Summary

Cloud sandbox responses now report why a sandbox is still `starting`: a nullable `status_reason` — `"scheduling"` (the start has been accepted and is being scheduled) or `"insufficient_capacity"` (no capacity is currently available; the start proceeds when capacity frees up). Only present while `status` is `starting`.

The failure text field is renamed `last_error` → `last_failure_message`, keeping the vocabulary consistent: `*_reason` fields are machine-readable enums, `*_message` fields are human-readable prose.

- `CloudSandboxStatusReason` registered in the TypeScript bindings (regenerated; `--check` passes).
- Rust SDK follows the wire: `Sandbox::last_error()` → `last_failure_message()`, `SandboxHandle::last_error_snapshot()` → `last_failure_message_snapshot()`.

## Verification

- `cargo check --workspace --all-targets` clean
- microsandbox-types: 36/36 tests; microsandbox lib: 458 tests
- `cargo run -p microsandbox-types --features ts -- --check` passes