### PR TITLE
feat(network)!: add composable network profiles

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -257,6 +257,23 @@ pub struct SandboxOpts {
     )]
     pub no_net: bool,
 
+    /// High-level network profile. Repeatable and comma-separated. Profiles
+    /// (`public`, `private`, `host`) compose and automatically enable gateway
+    /// DNS. `all` and `none` are terminal policies and cannot be combined with
+    /// profiles. Explicit `--net-rule` entries take precedence.
+    #[cfg(feature = "net")]
+    #[arg(
+        long = "net",
+        value_name = "PROFILE",
+        conflicts_with_all = [
+            "no_net",
+            "net_default",
+            "net_default_egress",
+            "net_default_ingress"
+        ]
+    )]
+    pub net: Vec<String>,
+
     /// Allow DNS responses pointing to private/internal IP addresses.
     #[cfg(feature = "net")]
     #[arg(long)]
@@ -290,7 +307,8 @@ pub struct SandboxOpts {
     ///
     /// Target kinds: IPs/CIDRs, domains (`example.com`), domain suffixes
     /// (`*.example.com` shorthand or `suffix=example.com`), and groups
-    /// (`public`, `private`, `multicast`, ...). Suffixes must be at
+    /// (`public`, `private`, `multicast`, ...), plus the semantic `dns`
+    /// target for gateway UDP/TCP port 53. Suffixes must be at
     /// least two labels (e.g. `*.example.com`, not `*.com`).
     ///
     /// Examples: --net-rule "allow@public"
@@ -500,6 +518,7 @@ impl SandboxOpts {
         #[cfg(feature = "net")]
         let net = !self.port.is_empty()
             || self.no_net
+            || !self.net.is_empty()
             || self.no_dns_rebind_protection
             || !self.dns_nameserver.is_empty()
             || self.dns_query_timeout_ms.is_some()
@@ -1513,6 +1532,7 @@ fn apply_network_opts(
         || !opts.dns_nameserver.is_empty()
         || opts.dns_query_timeout_ms.is_some()
         || !opts.net_rule.is_empty()
+        || !opts.net.is_empty()
         || opts.no_net
         || opts.net_default.is_some()
         || opts.net_default_egress.is_some()
@@ -1541,6 +1561,7 @@ fn apply_network_opts(
             .collect::<anyhow::Result<Vec<_>>>()?;
         let dns_query_timeout_ms = opts.dns_query_timeout_ms;
         let network_policy = build_network_policy(
+            &opts.net,
             &opts.net_rule,
             opts.no_net,
             opts.net_default.as_deref(),
@@ -1707,26 +1728,28 @@ pub fn parse_duration(s: &str) -> anyhow::Result<std::time::Duration> {
     }
 }
 
-/// Assemble a [`NetworkPolicy`] from `--net-rule`, `--net-default*`,
-/// and `--no-net`. Returns `None` when no flag is set. Multiple
-/// `--net-rule` invocations concatenate in argv order.
+/// Assemble a [`NetworkPolicy`] from `--net`, `--net-rule`,
+/// `--net-default*`, and `--no-net`. Returns `None` when no flag is set.
+/// Multiple profile and rule invocations concatenate in argv order.
 ///
 /// `--no-net` desugars to `--net-default deny`; clap rejects combining
 /// it with the explicit defaults, so the four default-source params are
 /// mutually exclusive on the caller side.
 #[cfg(feature = "net")]
 fn build_network_policy(
+    profile_args: &[String],
     rule_args: &[String],
     no_net: bool,
     default_both: Option<&str>,
     default_egress: Option<&str>,
     default_ingress: Option<&str>,
 ) -> anyhow::Result<Option<microsandbox_network::policy::NetworkPolicy>> {
-    use microsandbox_network::policy::{Action, NetworkPolicy};
+    use microsandbox_network::policy::{Action, NetworkPolicy, NetworkProfile};
 
     use crate::net_rule::parse_rule_list;
 
-    let no_flags = rule_args.is_empty()
+    let no_flags = profile_args.is_empty()
+        && rule_args.is_empty()
         && !no_net
         && default_both.is_none()
         && default_egress.is_none()
@@ -1739,6 +1762,52 @@ fn build_network_policy(
     for arg in rule_args {
         let parsed = parse_rule_list(arg).map_err(anyhow::Error::from)?;
         rules.extend(parsed);
+    }
+
+    if !profile_args.is_empty() {
+        let mut profiles = Vec::new();
+        let mut terminal = None;
+        for raw in profile_args
+            .iter()
+            .flat_map(|arg| arg.split(','))
+            .map(str::trim)
+        {
+            if raw.is_empty() {
+                anyhow::bail!("empty --net profile; expected public, private, host, all, or none");
+            }
+            match raw {
+                "public" => profiles.push(NetworkProfile::Public),
+                "private" => profiles.push(NetworkProfile::Private),
+                "host" => profiles.push(NetworkProfile::Host),
+                "all" | "none" => {
+                    if terminal.replace(raw).is_some() {
+                        anyhow::bail!("--net `{raw}` may only be specified once");
+                    }
+                }
+                other => anyhow::bail!(
+                    "unknown --net profile {other:?}; expected public, private, host, all, or none"
+                ),
+            }
+        }
+        if let Some(terminal) = terminal {
+            if !profiles.is_empty() {
+                anyhow::bail!(
+                    "--net `{terminal}` cannot be combined with public, private, or host"
+                );
+            }
+            let mut policy = match terminal {
+                "all" => NetworkPolicy::allow_all(),
+                "none" => NetworkPolicy::none(),
+                _ => unreachable!("validated terminal profile"),
+            };
+            policy.rules = rules;
+            return Ok(Some(policy));
+        }
+
+        let mut policy = NetworkPolicy::from_profiles(profiles);
+        rules.append(&mut policy.rules);
+        policy.rules = rules;
+        return Ok(Some(policy));
     }
 
     let parse_action = |label: &str, raw: &str| -> anyhow::Result<Action> {
@@ -1762,18 +1831,18 @@ fn build_network_policy(
     };
 
     // When the user sets no defaults explicitly, fall through to
-    // NetworkPolicy::public_only's defaults so behaviour stays in sync
-    // with the preset.
-    let preset = NetworkPolicy::public_only();
+    // the default public-profile policy's direction defaults so low-level
+    // rule-only behavior remains deny-egress / allow-ingress.
+    let baseline = NetworkPolicy::default();
     let default_egress = match (symmetric, default_egress) {
         (_, Some(raw)) => parse_action("--net-default-egress", raw)?,
         (Some(action), None) => action,
-        (None, None) => preset.default_egress,
+        (None, None) => baseline.default_egress,
     };
     let default_ingress = match (symmetric, default_ingress) {
         (_, Some(raw)) => parse_action("--net-default-ingress", raw)?,
         (Some(action), None) => action,
-        (None, None) => preset.default_ingress,
+        (None, None) => baseline.default_ingress,
     };
 
     Ok(Some(NetworkPolicy {
@@ -3553,14 +3622,14 @@ mod tests {
     #[cfg(feature = "net")]
     #[test]
     fn build_policy_no_flags_returns_none() {
-        let p = build_network_policy(&[], false, None, None, None).unwrap();
+        let p = build_network_policy(&[], &[], false, None, None, None).unwrap();
         assert!(p.is_none());
     }
 
     #[cfg(feature = "net")]
     #[test]
     fn build_policy_net_default_deny_sets_both_directions() {
-        let p = build_network_policy(&[], false, Some("deny"), None, None)
+        let p = build_network_policy(&[], &[], false, Some("deny"), None, None)
             .unwrap()
             .expect("policy");
         assert_eq!(p.default_egress, Action::Deny);
@@ -3571,7 +3640,7 @@ mod tests {
     #[cfg(feature = "net")]
     #[test]
     fn build_policy_net_default_allow_sets_both_directions() {
-        let p = build_network_policy(&[], false, Some("allow"), None, None)
+        let p = build_network_policy(&[], &[], false, Some("allow"), None, None)
             .unwrap()
             .expect("policy");
         assert_eq!(p.default_egress, Action::Allow);
@@ -3581,7 +3650,7 @@ mod tests {
     #[cfg(feature = "net")]
     #[test]
     fn build_policy_no_net_desugars_to_deny_both() {
-        let p = build_network_policy(&[], true, None, None, None)
+        let p = build_network_policy(&[], &[], true, None, None, None)
             .unwrap()
             .expect("policy");
         assert_eq!(p.default_egress, Action::Deny);
@@ -3592,7 +3661,7 @@ mod tests {
     #[test]
     fn build_policy_no_net_with_allow_rule_yields_allowlist() {
         let rules = vec!["allow@example.com".to_string()];
-        let p = build_network_policy(&rules, true, None, None, None)
+        let p = build_network_policy(&[], &rules, true, None, None, None)
             .unwrap()
             .expect("policy");
         assert_eq!(p.default_egress, Action::Deny);
@@ -3604,7 +3673,7 @@ mod tests {
     #[cfg(feature = "net")]
     #[test]
     fn build_policy_net_default_rejects_unknown_action() {
-        let err = build_network_policy(&[], false, Some("maybe"), None, None).unwrap_err();
+        let err = build_network_policy(&[], &[], false, Some("maybe"), None, None).unwrap_err();
         assert!(
             err.to_string().contains("--net-default"),
             "expected --net-default in error, got: {err}"
@@ -3613,17 +3682,64 @@ mod tests {
 
     #[cfg(feature = "net")]
     #[test]
-    fn build_policy_rule_only_uses_preset_defaults() {
+    fn build_policy_rule_only_uses_default_direction_actions() {
         // Without any --net-default* flag, rules apply on top of the
-        // public_only preset (deny egress, allow ingress). Verifies the
-        // "rules alone keep the preset's defaults" path now that the
+        // public profile (deny egress, allow ingress). Verifies the
+        // "rules alone keep the default direction actions" path now that the
         // --deny-domain* flip-to-allow exception is gone.
         let rules = vec!["allow@example.com".to_string()];
-        let p = build_network_policy(&rules, false, None, None, None)
+        let p = build_network_policy(&[], &rules, false, None, None, None)
             .unwrap()
             .expect("policy");
-        let preset = microsandbox_network::policy::NetworkPolicy::public_only();
-        assert_eq!(p.default_egress, preset.default_egress);
-        assert_eq!(p.default_ingress, preset.default_ingress);
+        let baseline = microsandbox_network::policy::NetworkPolicy::default();
+        assert_eq!(p.default_egress, baseline.default_egress);
+        assert_eq!(p.default_ingress, baseline.default_ingress);
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn build_policy_composes_profiles_canonically_and_deduplicates_dns() {
+        use microsandbox_network::policy::{Destination, DestinationGroup, Protocol};
+
+        let profiles = vec!["host,private".to_string(), "public,private".to_string()];
+        let p = build_network_policy(&profiles, &[], false, None, None, None)
+            .unwrap()
+            .expect("policy");
+        assert_eq!(p.rules.len(), 4);
+        assert_eq!(p.rules[0].protocols, [Protocol::Udp, Protocol::Tcp]);
+        for (rule, expected) in p.rules[1..].iter().zip([
+            DestinationGroup::Public,
+            DestinationGroup::Private,
+            DestinationGroup::Host,
+        ]) {
+            assert!(matches!(rule.destination, Destination::Group(group) if group == expected));
+        }
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn build_policy_places_explicit_rules_before_profile_rules() {
+        let profiles = vec!["public".to_string()];
+        let rules = vec!["deny@dns".to_string()];
+        let p = build_network_policy(&profiles, &rules, false, None, None, None)
+            .unwrap()
+            .expect("policy");
+        assert_eq!(p.rules[0].action, Action::Deny);
+        assert_eq!(p.rules[1].action, Action::Allow);
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn build_policy_terminal_all_and_none_reject_composition() {
+        let rules = vec!["deny@private".to_string()];
+        let all = build_network_policy(&["all".to_string()], &rules, false, None, None, None)
+            .unwrap()
+            .expect("policy");
+        assert_eq!(all.default_egress, Action::Allow);
+        assert_eq!(all.rules.len(), 1);
+
+        let err = build_network_policy(&["none,public".to_string()], &[], false, None, None, None)
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot be combined"));
     }
 }

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -1780,9 +1780,15 @@ fn build_network_policy(
                 "private" => profiles.push(NetworkProfile::Private),
                 "host" => profiles.push(NetworkProfile::Host),
                 "all" | "none" => {
-                    if terminal.replace(raw).is_some() {
-                        anyhow::bail!("--net `{raw}` may only be specified once");
+                    if let Some(previous) = terminal {
+                        if previous == raw {
+                            anyhow::bail!("--net `{raw}` may only be specified once");
+                        }
+                        anyhow::bail!(
+                            "--net terminal profiles `all` and `none` cannot be combined"
+                        );
                     }
+                    terminal = Some(raw);
                 }
                 other => anyhow::bail!(
                     "unknown --net profile {other:?}; expected public, private, host, all, or none"
@@ -3741,5 +3747,27 @@ mod tests {
         let err = build_network_policy(&["none,public".to_string()], &[], false, None, None, None)
             .unwrap_err();
         assert!(err.to_string().contains("cannot be combined"));
+
+        for profiles in [
+            vec!["all".to_string(), "none".to_string()],
+            vec!["none,all".to_string()],
+        ] {
+            let err = build_network_policy(&profiles, &[], false, None, None, None).unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "--net terminal profiles `all` and `none` cannot be combined"
+            );
+        }
+
+        let err = build_network_policy(
+            &["all".to_string(), "all".to_string()],
+            &[],
+            false,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err.to_string(), "--net `all` may only be specified once");
     }
 }

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -419,6 +419,27 @@ mod tests {
         assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     }
 
+    #[cfg(feature = "net")]
+    #[test]
+    fn net_profiles_are_repeatable_and_preserve_comma_groups() {
+        let args = parse_run_args(&["--net", "public,private", "--net", "host", "alpine"]);
+        assert_eq!(args.sandbox.net, ["public,private", "host"]);
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn net_profile_conflicts_with_low_level_default_baselines() {
+        for conflicting in ["--no-net", "--net-default"] {
+            let mut argv = vec!["msb", "--net", "public", conflicting];
+            if conflicting == "--net-default" {
+                argv.push("deny");
+            }
+            argv.push("alpine");
+            let err = TestCli::try_parse_from(argv).unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+        }
+    }
+
     #[test]
     fn existing_reuse_does_not_warn_for_required_image() {
         let args = parse_run_args(&["--name", "box", "alpine", "--", "echo", "hello"]);

--- a/crates/cli/lib/net_rule.rs
+++ b/crates/cli/lib/net_rule.rs
@@ -9,7 +9,7 @@
 //! <TOKEN>     := <action>[:<direction>]@<target>[:<proto>[:<ports>]]
 //! <action>    := allow | deny
 //! <direction> := egress | ingress | any                    (default: egress)
-//! <target>    := any | <group> | <ipv4> | [<ipv6>] | <cidr> | [<ipv6-cidr>]
+//! <target>    := any | dns | <group> | <ipv4> | [<ipv6>] | <cidr> | [<ipv6-cidr>]
 //!              | <fqdn> | domain=<name> | suffix=<domain>
 //! <group>     := public | private | loopback | link-local | meta | multicast | host
 //! <proto>     := any | tcp | udp | icmpv4 | icmpv6
@@ -74,7 +74,7 @@ pub enum RuleParseError {
     /// The target field is empty or doesn't match any recognized form.
     #[error(
         "`{raw}` is not a valid target. \
-         Expected: any, a group name (public, private, loopback, link-local, meta, multicast, host), \
+         Expected: any, dns, a group name (public, private, loopback, link-local, meta, multicast, host), \
          an IP, a CIDR, a domain (with dot), domain=<name>, or suffix=<domain>{suggestion}"
     )]
     InvalidTarget {
@@ -169,6 +169,18 @@ pub enum RuleParseError {
          port numbers don't belong in the target"
     )]
     PortInProtocolSlot { target: String, value: String },
+
+    /// The `dns` macro only describes gateway-bound egress.
+    #[error("the `dns` target only supports egress rules; omit the direction or use `:egress`")]
+    DnsMustBeEgress,
+
+    /// The `dns` macro only covers UDP and TCP DNS.
+    #[error("the `dns` target supports `tcp`, `udp`, or `any`, not `{raw}`")]
+    InvalidDnsProtocol { raw: String },
+
+    /// The `dns` macro is fixed to port 53.
+    #[error("the `dns` target is fixed to port 53; omit the port or use `53`/`any`")]
+    InvalidDnsPort,
 }
 
 /// Renders an optional Levenshtein-2 suggestion as `". Did you mean
@@ -204,6 +216,10 @@ pub fn parse_rule_token(token: &str) -> Result<Rule, RuleParseError> {
 
     let (action, direction) = parse_action_and_direction(left)?;
 
+    if right == "dns" || right.starts_with("dns:") {
+        return parse_dns_rule(right, action, direction, token);
+    }
+
     let (destination, proto_raw, ports_raw) = match right.strip_prefix('[') {
         Some(after_open) => parse_bracketed_right(after_open, token)?,
         None => parse_unbracketed_right(right, token)?,
@@ -231,6 +247,50 @@ pub fn parse_rule_token(token: &str) -> Result<Rule, RuleParseError> {
         destination,
         protocols,
         ports,
+        action,
+    })
+}
+
+/// Expand the semantic `dns` target into the gateway TCP/UDP port-53 rule.
+fn parse_dns_rule(
+    right: &str,
+    action: Action,
+    direction: Direction,
+    token: &str,
+) -> Result<Rule, RuleParseError> {
+    if direction != Direction::Egress {
+        return Err(RuleParseError::DnsMustBeEgress);
+    }
+
+    let mut parts = right.splitn(4, ':');
+    debug_assert_eq!(parts.next(), Some("dns"));
+    let proto_raw = parts.next();
+    let ports_raw = parts.next();
+    if parts.next().is_some() {
+        return Err(RuleParseError::TrailingJunk {
+            token: token.to_string(),
+        });
+    }
+
+    let protocols = match proto_raw {
+        None | Some("") | Some("any") => vec![Protocol::Udp, Protocol::Tcp],
+        Some("udp") => vec![Protocol::Udp],
+        Some("tcp") => vec![Protocol::Tcp],
+        Some(raw) => {
+            return Err(RuleParseError::InvalidDnsProtocol {
+                raw: raw.to_string(),
+            });
+        }
+    };
+    if !matches!(ports_raw, None | Some("") | Some("any") | Some("53")) {
+        return Err(RuleParseError::InvalidDnsPort);
+    }
+
+    Ok(Rule {
+        direction,
+        destination: Destination::Group(DestinationGroup::Host),
+        protocols,
+        ports: vec![PortRange::single(53)],
         action,
     })
 }
@@ -313,7 +373,8 @@ pub fn parse_rule_list(comma_separated: &str) -> Result<Vec<Rule>, RuleParseErro
 
 const ACTION_KEYWORDS: &[&str] = &["allow", "deny"];
 const DIRECTION_KEYWORDS: &[&str] = &["egress", "ingress", "any"];
-const GROUP_KEYWORDS: &[&str] = &[
+const TARGET_KEYWORDS: &[&str] = &[
+    "dns",
     "public",
     "private",
     "loopback",
@@ -428,7 +489,7 @@ fn parse_target(raw: &str) -> Result<Destination, RuleParseError> {
     }
 
     // 8. Bare single-label is ambiguous — could be a typoed group.
-    let suggestion = suggest(raw, GROUP_KEYWORDS);
+    let suggestion = suggest(raw, TARGET_KEYWORDS);
     Err(RuleParseError::AmbiguousBareToken {
         raw: raw.to_string(),
         suggestion: SuggestionDisplay(suggestion),
@@ -612,6 +673,42 @@ mod tests {
         ));
         assert!(r.protocols.is_empty());
         assert!(r.ports.is_empty());
+    }
+
+    #[test]
+    fn dns_target_expands_to_gateway_udp_and_tcp_port_53() {
+        let rule = parse_rule_token("allow@dns").unwrap();
+        assert_eq!(rule.direction, Direction::Egress);
+        assert_eq!(rule.protocols, [Protocol::Udp, Protocol::Tcp]);
+        assert_eq!(rule.ports, [PortRange::single(53)]);
+        assert!(matches!(
+            rule.destination,
+            Destination::Group(DestinationGroup::Host)
+        ));
+    }
+
+    #[test]
+    fn deny_dns_and_protocol_qualifier_are_supported() {
+        let rule = parse_rule_token("deny@dns:tcp").unwrap();
+        assert_eq!(rule.action, Action::Deny);
+        assert_eq!(rule.protocols, [Protocol::Tcp]);
+        assert_eq!(rule.ports, [PortRange::single(53)]);
+    }
+
+    #[test]
+    fn dns_target_rejects_ingress_icmp_and_non_dns_ports() {
+        assert!(matches!(
+            parse_rule_token("allow:ingress@dns"),
+            Err(RuleParseError::DnsMustBeEgress)
+        ));
+        assert!(matches!(
+            parse_rule_token("allow@dns:icmpv4"),
+            Err(RuleParseError::InvalidDnsProtocol { .. })
+        ));
+        assert!(matches!(
+            parse_rule_token("allow@dns:udp:5353"),
+            Err(RuleParseError::InvalidDnsPort)
+        ));
     }
 
     #[test]

--- a/crates/cli/lib/net_rule.rs
+++ b/crates/cli/lib/net_rule.rs
@@ -171,7 +171,10 @@ pub enum RuleParseError {
     PortInProtocolSlot { target: String, value: String },
 
     /// The `dns` macro only describes gateway-bound egress.
-    #[error("the `dns` target only supports egress rules; omit the direction or use `:egress`")]
+    #[error(
+        "the `dns` target only supports egress rules; omit the direction or use \
+         `allow:egress@dns`/`deny:egress@dns`"
+    )]
     DnsMustBeEgress,
 
     /// The `dns` macro only covers UDP and TCP DNS.
@@ -697,10 +700,13 @@ mod tests {
 
     #[test]
     fn dns_target_rejects_ingress_icmp_and_non_dns_ports() {
-        assert!(matches!(
-            parse_rule_token("allow:ingress@dns"),
-            Err(RuleParseError::DnsMustBeEgress)
-        ));
+        let direction_error = parse_rule_token("allow:ingress@dns").unwrap_err();
+        assert!(matches!(&direction_error, RuleParseError::DnsMustBeEgress));
+        assert_eq!(
+            direction_error.to_string(),
+            "the `dns` target only supports egress rules; omit the direction or use \
+             `allow:egress@dns`/`deny:egress@dns`"
+        );
         assert!(matches!(
             parse_rule_token("allow@dns:icmpv4"),
             Err(RuleParseError::InvalidDnsProtocol { .. })

--- a/crates/network/lib/config.rs
+++ b/crates/network/lib/config.rs
@@ -216,7 +216,7 @@ mod tests {
         // Exercise the tricky leaves: a domain rule (validated `DomainName`), a
         // CIDR rule (`IpNetwork`), group rules, parsed nameservers, and the
         // interface IP/MAC/pool.
-        let mut policy = NetworkPolicy::public_only()
+        let mut policy = NetworkPolicy::default()
             .allow_domain("example.com")
             .expect("valid domain")
             .allow_domain_suffix("staging.example.com")

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -673,6 +673,18 @@ mod tests {
     }
 
     #[test]
+    fn rebind_filter_rejects_unspecified_answers_for_public_profile() {
+        let policy = NetworkPolicy::from_profiles([NetworkProfile::Public]);
+        let shared = SharedState::new(4);
+        for addr in ["0.0.0.0", "::"] {
+            assert!(
+                !policy_allows_rebind_address(&policy, &shared, addr.parse().unwrap()),
+                "expected {addr} to remain blocked by rebind protection"
+            );
+        }
+    }
+
+    #[test]
     fn rebind_filter_remains_enabled_for_allow_all_default() {
         let policy = NetworkPolicy::allow_all();
         let shared = SharedState::new(4);

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -229,12 +229,20 @@ impl DnsForwarder {
         // Rebind protection: reject responses containing private/reserved IPs.
         if self.config.rebind_protection {
             for record in &response_msg.answers {
-                let is_private = match &record.data {
-                    RData::A(a) => is_private_ipv4((*a).into()),
-                    RData::AAAA(aaaa) => is_private_ipv6((*aaaa).into()),
-                    _ => false,
+                let private_addr = match &record.data {
+                    RData::A(a) => {
+                        let addr = IpAddr::V4((*a).into());
+                        is_private_ipv4((*a).into()).then_some(addr)
+                    }
+                    RData::AAAA(aaaa) => {
+                        let addr = IpAddr::V6((*aaaa).into());
+                        is_private_ipv6((*aaaa).into()).then_some(addr)
+                    }
+                    _ => None,
                 };
-                if is_private {
+                if private_addr.is_some_and(|addr| {
+                    !policy_allows_rebind_address(&self.network_policy, &self.shared, addr)
+                }) {
                     tracing::debug!(
                         domain = %domain,
                         "DNS rebind protection: response contains private IP"
@@ -437,6 +445,23 @@ impl DnsForwarder {
     }
 }
 
+/// Return whether a private/reserved DNS answer was explicitly made reachable.
+///
+/// Rebind protection remains fail-closed unless an address-only TCP or UDP
+/// policy evaluation allows the answer. Port-scoped rules do not qualify here;
+/// they cannot be evaluated safely before the guest chooses a connection port.
+fn policy_allows_rebind_address(
+    policy: &NetworkPolicy,
+    shared: &SharedState,
+    addr: IpAddr,
+) -> bool {
+    [crate::policy::Protocol::Tcp, crate::policy::Protocol::Udp]
+        .into_iter()
+        .any(|protocol| {
+            policy.evaluate_explicit_egress_ip(addr, protocol, shared) == Some(Action::Allow)
+        })
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
@@ -609,7 +634,7 @@ fn build_truncated_response(query: &Message) -> Option<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::policy::Protocol;
+    use crate::policy::{Action, Destination, NetworkProfile, Protocol, Rule};
     use hickory_net::proto::op::{Edns, MessageType, OpCode, Query};
     use hickory_net::proto::rr::{DNSClass, Name, RecordType};
 
@@ -623,6 +648,75 @@ mod tests {
         q.set_query_class(DNSClass::IN);
         msg.add_query(q);
         msg
+    }
+
+    #[test]
+    fn rebind_filter_allows_private_answers_for_private_profile() {
+        let policy = NetworkPolicy::from_profiles([NetworkProfile::Private]);
+        let shared = SharedState::new(4);
+        assert!(policy_allows_rebind_address(
+            &policy,
+            &shared,
+            "10.20.30.40".parse().unwrap()
+        ));
+    }
+
+    #[test]
+    fn rebind_filter_rejects_private_answers_for_public_profile() {
+        let policy = NetworkPolicy::from_profiles([NetworkProfile::Public]);
+        let shared = SharedState::new(4);
+        assert!(!policy_allows_rebind_address(
+            &policy,
+            &shared,
+            "10.20.30.40".parse().unwrap()
+        ));
+    }
+
+    #[test]
+    fn rebind_filter_remains_enabled_for_allow_all_default() {
+        let policy = NetworkPolicy::allow_all();
+        let shared = SharedState::new(4);
+        assert!(!policy_allows_rebind_address(
+            &policy,
+            &shared,
+            "10.20.30.40".parse().unwrap()
+        ));
+    }
+
+    #[test]
+    fn rebind_filter_does_not_treat_explicit_any_as_private_intent() {
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::allow_egress(Destination::Any)],
+        };
+        let shared = SharedState::new(4);
+        assert!(!policy_allows_rebind_address(
+            &policy,
+            &shared,
+            "10.20.30.40".parse().unwrap()
+        ));
+    }
+
+    #[test]
+    fn rebind_filter_honors_ordered_deny_before_private_allow() {
+        let mut policy = NetworkPolicy::from_profiles([NetworkProfile::Private]);
+        policy.rules.insert(
+            0,
+            Rule {
+                direction: crate::policy::Direction::Egress,
+                destination: Destination::Cidr("10.20.30.40/32".parse().unwrap()),
+                protocols: Vec::new(),
+                ports: Vec::new(),
+                action: Action::Deny,
+            },
+        );
+        let shared = SharedState::new(4);
+        assert!(!policy_allows_rebind_address(
+            &policy,
+            &shared,
+            "10.20.30.40".parse().unwrap()
+        ));
     }
 
     #[test]
@@ -816,13 +910,13 @@ mod tests {
 
     #[test]
     fn decide_upstream_policy_denied_when_policy_denies_resolver() {
-        // public_only policy denies private addresses — guest aiming at
+        // The public profile denies private addresses — guest aiming at
         // a private resolver should be routed to the denial path (a
         // synthesized NXDOMAIN) rather than silently hitting the configured
         // upstream instead.
         let gw = gateway_set();
         let shared = SharedState::new(4);
-        let policy = NetworkPolicy::public_only();
+        let policy = NetworkPolicy::default();
         let dst = Some(IpAddr::V4(std::net::Ipv4Addr::new(192, 168, 1, 53)));
         assert_eq!(
             decide_upstream(&gw, &policy, &shared, dst, Transport::Udp),

--- a/crates/network/lib/policy/destination.rs
+++ b/crates/network/lib/policy/destination.rs
@@ -18,41 +18,44 @@ use crate::shared::SharedState;
 /// Built on a single private classifier (`addr_classify`) so adding a
 /// new `DestinationGroup` variant forces an exhaustive-match update
 /// in the classifier and a corresponding witness in the test suite.
-/// `Public` is the fallback when no other classification matches —
-/// there's no list of excluded groups to keep in sync.
+/// `Public` is the fallback for classified addresses that match no other
+/// group. Unspecified addresses intentionally belong to no group.
 ///
-/// Groups are disjoint: each IP belongs to exactly one. `Metadata`
-/// takes precedence over `LinkLocal` for `169.254.169.254`, and `Host`
-/// takes precedence over `Private` when the gateway IPs sit inside
+/// Groups are disjoint: each non-unspecified IP belongs to exactly one.
+/// `Metadata` takes precedence over `LinkLocal` for `169.254.169.254`, and
+/// `Host` takes precedence over `Private` when the gateway IPs sit inside
 /// CGNAT or ULA ranges (which they currently do).
 pub fn matches_group(group: DestinationGroup, addr: IpAddr, shared: &SharedState) -> bool {
-    addr_classify(addr, shared) == group
+    addr_classify(addr, shared) == Some(group)
 }
 
-/// Classify an IP into exactly one destination group.
+/// Classify an IP into at most one destination group.
 ///
 /// Order matters: more specific tests first. `Host` first because
 /// today's gateway IPs land in CGNAT (`100.64.0.0/10`) and ULA
 /// (`fc00::/7`) ranges that `is_private` would otherwise claim.
 /// `Metadata` before `LinkLocal` because `169.254.169.254` is in the
-/// link-local CIDR.
-fn addr_classify(addr: IpAddr, shared: &SharedState) -> DestinationGroup {
+/// link-local CIDR. Unspecified addresses are deliberately unclassified so
+/// a public profile cannot make `0.0.0.0` or `::` reachable.
+fn addr_classify(addr: IpAddr, shared: &SharedState) -> Option<DestinationGroup> {
     let addr = normalize_ip_addr(addr);
 
-    if matches_host(addr, shared) {
-        DestinationGroup::Host
+    if addr.is_unspecified() {
+        None
+    } else if matches_host(addr, shared) {
+        Some(DestinationGroup::Host)
     } else if is_metadata(addr) {
-        DestinationGroup::Metadata
+        Some(DestinationGroup::Metadata)
     } else if is_loopback(addr) {
-        DestinationGroup::Loopback
+        Some(DestinationGroup::Loopback)
     } else if is_private(addr) {
-        DestinationGroup::Private
+        Some(DestinationGroup::Private)
     } else if is_link_local(addr) {
-        DestinationGroup::LinkLocal
+        Some(DestinationGroup::LinkLocal)
     } else if is_multicast(addr) {
-        DestinationGroup::Multicast
+        Some(DestinationGroup::Multicast)
     } else {
-        DestinationGroup::Public
+        Some(DestinationGroup::Public)
     }
 }
 
@@ -362,12 +365,14 @@ mod tests {
     fn public_excludes_other_categories() {
         let s = no_host();
         let not_public = [
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             IpAddr::V4(Ipv4Addr::LOCALHOST),
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
             IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1)),
             IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254)),
             IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)),
+            IpAddr::V6(Ipv6Addr::UNSPECIFIED),
             IpAddr::V6(Ipv6Addr::LOCALHOST),
             IpAddr::V6("fd42:6d73:62:2a::1".parse().unwrap()),
             IpAddr::V6("fe80::1".parse().unwrap()),
@@ -452,7 +457,7 @@ mod tests {
         for (ip, expected) in cases {
             assert_eq!(
                 addr_classify(*ip, &s),
-                *expected,
+                Some(*expected),
                 "expected {ip:?} to classify as {expected:?}"
             );
         }

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -49,7 +49,7 @@ pub struct NetworkPolicy {
 
     /// Default action for ingress traffic not matching any rule. The
     /// per-field serde default is `Deny` so partially-specified JSON
-    /// fails closed; permissive presets like [`NetworkPolicy::public_only`]
+    /// fails closed; profile policies built by [`NetworkPolicy::from_profiles`]
     /// flip this back to `Allow` explicitly.
     #[serde(default = "Action::deny")]
     pub default_ingress: Action,
@@ -57,6 +57,24 @@ pub struct NetworkPolicy {
     /// Ordered list of rules, evaluated first-match-wins per direction.
     #[serde(default)]
     pub rules: Vec<Rule>,
+}
+
+/// A composable high-level network access profile.
+///
+/// Profiles expand into ordinary first-match-wins policy rules. Every non-empty
+/// profile set includes exactly one narrow DNS rule for the sandbox gateway;
+/// the requested destination groups then follow in canonical order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkProfile {
+    /// Public internet addresses.
+    Public,
+
+    /// Private/LAN address ranges (RFC 1918, RFC 4193 ULA, and CGN).
+    Private,
+
+    /// The sandbox host via its gateway addresses.
+    Host,
 }
 
 /// Action to take on matched traffic.
@@ -267,32 +285,47 @@ impl NetworkPolicy {
         }
     }
 
-    /// Public internet only — allow egress to public IPs, deny private,
-    /// loopback, link-local, and metadata. Ingress defaults to allow
-    /// (preserves today's unfiltered published-port behavior).
-    pub fn public_only() -> Self {
-        Self {
-            default_egress: Action::Deny,
-            default_ingress: Action::Allow,
-            rules: vec![
-                Rule::allow_dns(),
-                Rule::allow_egress(Destination::Group(DestinationGroup::Public)),
-            ],
-        }
-    }
+    /// Build a deny-by-default policy from composable profiles.
+    ///
+    /// Duplicate profiles are ignored and input order does not affect the
+    /// resulting rule order. An empty profile set permits no egress and does
+    /// not add DNS; ingress remains allowed to preserve published-port
+    /// behavior.
+    pub fn from_profiles<I>(profiles: I) -> Self
+    where
+        I: IntoIterator<Item = NetworkProfile>,
+    {
+        let mut public = false;
+        let mut private = false;
+        let mut host = false;
 
-    /// Non-local network access — allow public internet and private/LAN
-    /// egress; deny loopback, link-local, and metadata. Ingress defaults
-    /// to allow.
-    pub fn non_local() -> Self {
+        for profile in profiles {
+            match profile {
+                NetworkProfile::Public => public = true,
+                NetworkProfile::Private => private = true,
+                NetworkProfile::Host => host = true,
+            }
+        }
+
+        let mut rules =
+            Vec::with_capacity(1 + usize::from(public) + usize::from(private) + usize::from(host));
+        if public || private || host {
+            rules.push(Rule::allow_dns());
+        }
+        for (enabled, group) in [
+            (public, DestinationGroup::Public),
+            (private, DestinationGroup::Private),
+            (host, DestinationGroup::Host),
+        ] {
+            if enabled {
+                rules.push(Rule::allow_egress(Destination::Group(group)));
+            }
+        }
+
         Self {
             default_egress: Action::Deny,
             default_ingress: Action::Allow,
-            rules: vec![
-                Rule::allow_dns(),
-                Rule::allow_egress(Destination::Group(DestinationGroup::Public)),
-                Rule::allow_egress(Destination::Group(DestinationGroup::Private)),
-            ],
+            rules,
         }
     }
 
@@ -328,6 +361,34 @@ impl NetworkPolicy {
     ) -> Action {
         self.egress_walk(dst, None, protocol, shared, HostnameSource::CacheOnly)
             .into()
+    }
+
+    /// Evaluate only explicit, address-only egress rules and ignore the
+    /// policy default. DNS rebinding protection uses this distinction so an
+    /// explicit private profile can admit internal answers without making an
+    /// `allow_all` default disable rebinding protection implicitly.
+    pub(crate) fn evaluate_explicit_egress_ip(
+        &self,
+        addr: IpAddr,
+        protocol: Protocol,
+        shared: &SharedState,
+    ) -> Option<Action> {
+        for rule in &self.rules {
+            if !matches!(rule.direction, Direction::Egress | Direction::Any)
+                || !matches!(
+                    rule.destination,
+                    Destination::Cidr(_) | Destination::Group(_)
+                )
+                || !rule.ports.is_empty()
+                || (!rule.protocols.is_empty() && !rule.protocols.contains(&protocol))
+            {
+                continue;
+            }
+            if matches_destination(&rule.destination, addr, shared) {
+                return Some(rule.action);
+            }
+        }
+        None
     }
 
     /// Evaluate an outbound connection with an explicit
@@ -610,7 +671,7 @@ impl From<EgressEvaluation> for Action {
 
 impl Default for NetworkPolicy {
     fn default() -> Self {
-        Self::public_only()
+        Self::from_profiles([NetworkProfile::Public])
     }
 }
 
@@ -681,6 +742,17 @@ impl Rule {
             protocols: vec![Protocol::Udp, Protocol::Tcp],
             ports: vec![PortRange::single(53)],
             action: Action::Allow,
+        }
+    }
+
+    /// Deny plain DNS (UDP/53 and TCP/53) to the sandbox gateway.
+    ///
+    /// This is the deny counterpart to [`Self::allow_dns`] and is useful as
+    /// an override placed before profile-generated rules.
+    pub fn deny_dns() -> Self {
+        Self {
+            action: Action::Deny,
+            ..Self::allow_dns()
         }
     }
 }
@@ -917,6 +989,73 @@ mod tests {
             default_ingress: Action::Allow,
             rules: vec![Rule::allow_egress(dest)],
         }
+    }
+
+    #[test]
+    fn profiles_are_deduplicated_and_expanded_in_canonical_order() {
+        let policy = NetworkPolicy::from_profiles([
+            NetworkProfile::Host,
+            NetworkProfile::Private,
+            NetworkProfile::Public,
+            NetworkProfile::Private,
+        ]);
+
+        assert_eq!(policy.default_egress, Action::Deny);
+        assert_eq!(policy.default_ingress, Action::Allow);
+        assert_eq!(policy.rules.len(), 4);
+        assert_eq!(policy.rules[0].protocols, [Protocol::Udp, Protocol::Tcp]);
+        assert_eq!(policy.rules[0].ports, [PortRange::single(53)]);
+        for (rule, expected) in policy.rules[1..].iter().zip([
+            DestinationGroup::Public,
+            DestinationGroup::Private,
+            DestinationGroup::Host,
+        ]) {
+            assert!(matches!(rule.destination, Destination::Group(group) if group == expected));
+        }
+    }
+
+    #[test]
+    fn empty_profile_set_has_no_implicit_dns_or_egress() {
+        let policy = NetworkPolicy::from_profiles([]);
+        assert_eq!(policy.default_egress, Action::Deny);
+        assert_eq!(policy.default_ingress, Action::Allow);
+        assert!(policy.rules.is_empty());
+    }
+
+    #[test]
+    fn default_policy_is_the_public_profile() {
+        let policy = NetworkPolicy::default();
+        assert_eq!(policy.rules.len(), 2);
+        assert!(matches!(
+            policy.rules[1].destination,
+            Destination::Group(DestinationGroup::Public)
+        ));
+    }
+
+    #[test]
+    fn profile_wire_names_are_stable() {
+        assert_eq!(
+            serde_json::to_string(&NetworkProfile::Public).unwrap(),
+            "\"public\""
+        );
+        assert_eq!(
+            serde_json::from_str::<NetworkProfile>("\"private\"").unwrap(),
+            NetworkProfile::Private
+        );
+    }
+
+    #[test]
+    fn deny_dns_is_the_exact_action_inverse_of_allow_dns() {
+        let allow = Rule::allow_dns();
+        let deny = Rule::deny_dns();
+        assert_eq!(deny.action, Action::Deny);
+        assert_eq!(deny.direction, allow.direction);
+        assert_eq!(deny.protocols, allow.protocols);
+        assert_eq!(deny.ports, allow.ports);
+        assert!(matches!(
+            deny.destination,
+            Destination::Group(DestinationGroup::Host)
+        ));
     }
 
     /// Outbound TCP/443 allow rule pinned to a specific hostname,
@@ -1191,9 +1330,9 @@ mod tests {
     }
 
     #[test]
-    fn public_only_preset_denies_host_gateway() {
+    fn public_profile_denies_host_gateway() {
         let (shared, gw4, gw6) = shared_with_gateway();
-        let policy = NetworkPolicy::public_only();
+        let policy = NetworkPolicy::from_profiles([NetworkProfile::Public]);
 
         let v4 = SocketAddr::new(IpAddr::V4(gw4), 80);
         assert_eq!(
@@ -1211,7 +1350,7 @@ mod tests {
     }
 
     #[test]
-    fn allow_all_preset_permits_host_gateway() {
+    fn allow_all_policy_permits_host_gateway() {
         let (shared, gw4, _) = shared_with_gateway();
         let policy = NetworkPolicy::allow_all();
         let v4 = SocketAddr::new(IpAddr::V4(gw4), 80);
@@ -1224,7 +1363,7 @@ mod tests {
     #[test]
     fn group_host_allow_overrides_private_deny_when_ordered_first() {
         let (shared, gw4, _) = shared_with_gateway();
-        let mut policy = NetworkPolicy::public_only();
+        let mut policy = NetworkPolicy::from_profiles([NetworkProfile::Public]);
         policy.rules.insert(
             0,
             Rule::allow_egress(Destination::Group(DestinationGroup::Host)),

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -1594,6 +1594,9 @@ mod tests {
         assert!(egress_tcp(&policy, "127.0.0.1", &shared).is_deny());
         // Metadata is not in Public.
         assert!(egress_tcp(&policy, "169.254.169.254", &shared).is_deny());
+        // Unspecified addresses are reserved and do not belong to Public.
+        assert!(egress_tcp(&policy, "0.0.0.0", &shared).is_deny());
+        assert!(egress_tcp(&policy, "::", &shared).is_deny());
     }
 
     //----------------------------------------------------------------------------------------------

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -53,6 +53,7 @@ Common flags:
 | `--no-tty` | Disable PTY allocation and run non-interactively |
 | `--replace` | Replace an existing sandbox with the same name |
 | `--no-net` | Disable network access |
+| `--net` | Add a high-level network profile (`public`, `private`, `host`, `all`, or `none`) |
 | `--net-rule` | Add a network policy rule |
 | `--secret` | Inject a host-held secret for an allowed destination |
 | `--tmpfs` | Mount an in-memory filesystem |
@@ -61,6 +62,19 @@ Common flags:
 Use `msb run --help` for the full flag list.
 
 Published ports bind to `127.0.0.1` by default. Use an explicit bind address only when the sandbox service should be reachable beyond localhost. On Windows, opening a published port can trigger a Windows Defender Firewall prompt for `msb.exe`; keep the bind on `127.0.0.1` for local-only development, and allow private/public network access only when you intentionally bind beyond loopback.
+
+### Network profiles
+
+`--net` is repeatable and accepts comma-separated profiles. `public`, `private`, and `host` compose; DNS through the sandbox gateway is enabled automatically and only once. `all` and `none` are terminal policies and cannot be mixed with the three positive profiles.
+
+```bash
+msb run alpine --net public
+msb run alpine --net "public,private"
+msb run alpine --net public --net private
+msb run alpine --net host --net-rule "deny@host:tcp:22"
+```
+
+Explicit `--net-rule` entries are evaluated before profile-generated rules, so they can narrow or deny part of a profile. `--net` conflicts with `--no-net` and the `--net-default*` flags because those select a different policy baseline.
 
 ### Network rule syntax
 
@@ -84,8 +98,9 @@ Published ports bind to `127.0.0.1` by default. Use an explicit bind address onl
 | ---- | ------- | ----- |
 | IP / CIDR | `198.51.100.5`, `10.0.0.0/8`, `[2001:db8::]/32` | IPv6 must be bracketed |
 | Domain (exact) | `example.com` | Use `domain=public` to disambiguate from the `public` group |
+| DNS | `dns` | Semantic gateway DNS target: UDP/53 + TCP/53. May be qualified with `tcp`, `udp`, or `any` |
 | Domain suffix | `*.example.com`, `suffix=example.com` | Matches the apex and any subdomain at any depth. Suffixes must be at least two labels: `*.com` and `suffix=local` are rejected to prevent accidental blast radius |
-| Group | `public`, `private`, `multicast`, `loopback`, `link_local`, `metadata`, `any` | Pre-defined IP groups |
+| Group | `public`, `private`, `loopback`, `link-local`, `meta`, `multicast`, `host`, `any` | Pre-defined destination groups (`any` is the catch-all target) |
 
 Wildcard quoting: the rule grammar uses `@`, `:`, and `,` which are shell-significant, so always quote `--net-rule` values. The `*.` in suffix shorthand mirrors the syntax already used by `--tls-bypass` and `--secret`.
 
@@ -103,6 +118,9 @@ msb run alpine --no-net
 
 # Airgapped except one host (allowlist with --no-net sugar)
 msb run alpine --no-net --net-rule "allow@api.internal.corp"
+
+# Public profile with DNS disabled by a higher-priority explicit rule
+msb run alpine --net public --net-rule "deny@dns"
 ```
 
 ## msb create

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -96,7 +96,7 @@ Explicit `--net-rule` entries are evaluated before profile-generated rules, so t
 
 | Form | Example | Notes |
 | ---- | ------- | ----- |
-| IP / CIDR | `198.51.100.5`, `10.0.0.0/8`, `[2001:db8::]/32` | IPv6 must be bracketed |
+| IP / CIDR | `198.51.100.5`, `10.0.0.0/8`, `[2001:db8::/32]` | IPv6 must be bracketed |
 | Domain (exact) | `example.com` | Use `domain=public` to disambiguate from the `public` group |
 | DNS | `dns` | Semantic gateway DNS target: UDP/53 + TCP/53. May be qualified with `tcp`, `udp`, or `any` |
 | Domain suffix | `*.example.com`, `suffix=example.com` | Matches the apex and any subdomain at any depth. Suffixes must be at least two labels: `*.com` and `suffix=local` are rejected to prevent accidental blast radius |

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -21,9 +21,11 @@ A DNS query is itself an egress action that the policy evaluates before the forw
 - **`Any` rules** match the DNS transport's actual protocol and port. An `Any udp/53 allow` is the standard way to grant plain DNS broadly.
 - **IP-based rules** mostly can't match (a query has no resolved IP yet), with one exception: `Group::Host` matches because it names the gateway forwarder the query is delivered to. A `Group::Host udp/53 + tcp/53 allow` rule is the narrow way to open DNS while still denying the guest from aiming queries at arbitrary resolver IPs.
 
-Under a deny-by-default policy whose rules are all IP-based (`Cidr` / non-`Host` `Group`), nothing matches at DNS-decision time and every query is denied. The default `public_only` and `non_local` presets ship with an explicit `Group::Host udp/53 + tcp/53 allow` rule (`Rule::allow_dns()` in Rust, `Rule.allowDns()` in TypeScript, `Rule.allow_dns()` in Python) so DNS works under those policies; custom deny-by-default policies need an equivalent allow.
+Under a deny-by-default policy whose rules are all IP-based (`Cidr` / non-`Host` `Group`), nothing matches at DNS-decision time and every query is denied. Policies built from the `public`, `private`, or `host` profiles include an explicit `Group::Host udp/53 + tcp/53 allow` rule (`Rule::allow_dns()` in Rust, `Rule.allowDns()` in TypeScript, `Rule.allow_dns()` in Python) so DNS works automatically; custom deny-by-default policies need an equivalent allow. In the CLI, `allow@dns` and `deny@dns` are semantic shortcuts for that gateway DNS rule.
 
 DoT (TCP/853) is a separate port; `allow_dns()` does not include it. Pair an `Any tcp/853 allow` (or `Group::Host tcp/853 allow`) with [TLS interception](/networking/tls) if you need DoT.
+
+DNS rebinding protection remains enabled independently of DNS query access. Private/reserved answers are rejected unless an explicit address-only egress rule, such as the generated `private` profile rule, permits the returned address. Ordered denies still win, port-scoped rules do not qualify before a connection port is known, and an `allow_all` default alone does not silently disable rebinding protection. Use the explicit rebind-protection setting only when you intend to disable that check globally.
 
 ## Blocking domains
 

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -10,7 +10,7 @@ All sandbox traffic flows through a host-controlled networking stack. From insid
 
 By default, sandboxes can reach the public internet but cannot reach private networks, loopback, link-local addresses, or cloud metadata endpoints. Only published ports accept inbound traffic.
 
-To turn networking off entirely:
+To block network access:
 
 <CodeGroup>
 ```rust Rust
@@ -46,6 +46,8 @@ msb create python --name isolated --no-net
 ```
 </CodeGroup>
 
+The Rust and TypeScript examples disable the network device. Python `Network.none()`, Go `NetworkPolicy.None()`, and CLI `--no-net` retain the device but deny traffic in both directions through policy.
+
 ## High-level profiles
 
 For common access shapes, compose high-level profiles. Every non-empty profile set automatically adds narrow DNS access through the sandbox gateway.
@@ -79,15 +81,6 @@ msb run alpine --net "public,private"
 </CodeGroup>
 
 The composable profiles are `public`, `private`, and `host`. `none` and `all` remain terminal whole-policy choices rather than profiles. Duplicate profiles are ignored, generated rules use a stable order, and explicit low-level rules can be placed before generated profile rules to override them.
-
-The legacy public/non-local presets are removed in favor of explicit composition; terminal constructors remain:
-
-| Legacy/common shape | Replacement |
-|--------------|-------------|
-| `public_only` / `publicOnly` / `PublicOnly` | `public` profile |
-| `non_local` / `nonLocal` / `NonLocal` | `public` + `private` profiles |
-| `none` | Terminal `none` policy (`--net none`, or the SDK's `none`/`None` constructor) |
-| `allow_all` / `allowAll` / `AllowAll` | Terminal `all` policy (`--net all`, or the SDK's `allow_all`/`allowAll`/`AllowAll` constructor) |
 
 ## Low-level custom policies
 
@@ -154,7 +147,7 @@ sb, err := m.CreateSandbox(ctx, "restricted-worker",
         DefaultEgress: m.PolicyActionDeny,
         Rules: []m.PolicyRule{
             {Action: m.PolicyActionAllow, Direction: m.PolicyDirectionEgress, Destination: "public", Protocol: m.PolicyProtocolTCP, Port: "443"},
-            {Action: m.PolicyActionAllow, Direction: m.PolicyDirectionEgress, Destination: "host", Protocol: m.PolicyProtocolUDP, Port: "53"},
+            m.Rule.AllowDNS(),
         },
     }),
 )

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -46,7 +46,50 @@ msb create python --name isolated --no-net
 ```
 </CodeGroup>
 
-## Custom policies
+## High-level profiles
+
+For common access shapes, compose high-level profiles. Every non-empty profile set automatically adds narrow DNS access through the sandbox gateway.
+
+<CodeGroup>
+```rust Rust
+let policy = NetworkPolicy::from_profiles([
+    NetworkProfile::Public,
+    NetworkProfile::Private,
+]);
+```
+
+```typescript TypeScript
+const policy = NetworkPolicy.fromProfiles(["public", "private"]);
+```
+
+```python Python
+network = Network.from_profiles(NetworkProfile.PUBLIC, NetworkProfile.PRIVATE)
+```
+
+```go Go
+network := m.NetworkPolicy.FromProfiles(
+    m.NetworkProfilePublic,
+    m.NetworkProfilePrivate,
+)
+```
+
+```bash CLI
+msb run alpine --net "public,private"
+```
+</CodeGroup>
+
+The composable profiles are `public`, `private`, and `host`. `none` and `all` remain terminal whole-policy choices rather than profiles. Duplicate profiles are ignored, generated rules use a stable order, and explicit low-level rules can be placed before generated profile rules to override them.
+
+The legacy public/non-local presets are removed in favor of explicit composition; terminal constructors remain:
+
+| Legacy/common shape | Replacement |
+|--------------|-------------|
+| `public_only` / `publicOnly` / `PublicOnly` | `public` profile |
+| `non_local` / `nonLocal` / `NonLocal` | `public` + `private` profiles |
+| `none` | Terminal `none` policy (`--net none`, or the SDK's `none`/`None` constructor) |
+| `allow_all` / `allowAll` / `AllowAll` | Terminal `all` policy (`--net all`, or the SDK's `allow_all`/`allowAll`/`AllowAll` constructor) |
+
+## Low-level custom policies
 
 A policy has two defaults and an ordered list of rules. The first matching rule wins.
 
@@ -89,20 +132,18 @@ await using sb = await Sandbox.builder("restricted-worker")
 ```
 
 ```python Python
-from microsandbox import Network, Sandbox
+from microsandbox import Action, DestGroup, Destination, Network, NetworkPolicy, Protocol, Rule, Sandbox
 
 sb = await Sandbox.create(
     "restricted-worker",
     image="alpine",
-    network={
-        "policy": {
-            "default_egress": "deny",
-            "rules": [
-                {"action": "allow", "direction": "egress", "destination": "public", "protocol": "tcp", "port": "443"},
-                {"action": "allow", "direction": "egress", "destination": "host", "protocol": "udp", "port": "53"},
-            ],
-        },
-    },
+    network=Network(policy=NetworkPolicy(
+        default_egress=Action.DENY,
+        rules=(
+            Rule.allow(destination=Destination.group(DestGroup.PUBLIC), protocol=Protocol.TCP, port=443),
+            *Rule.allow_dns(),
+        ),
+    )),
 )
 ```
 
@@ -122,7 +163,7 @@ sb, err := m.CreateSandbox(ctx, "restricted-worker",
 ```bash CLI
 msb create alpine --name restricted-worker \
   --net-default-egress deny \
-  --net-rule "allow@public:tcp:443,allow@host:udp:53"
+  --net-rule "allow@public:tcp:443,allow@dns"
 ```
 </CodeGroup>
 
@@ -175,8 +216,7 @@ On Windows, the first published port may trigger a Windows Defender Firewall pro
 From inside the sandbox, `host.microsandbox.internal` resolves to the host machine. The default policy denies host access, so allow the `host` group when a sandbox needs to call a dev server, database, or other local service.
 
 ```bash
-msb create python --name devbox \
-  --net-rule "allow@public,allow@host"
+msb create python --name devbox --net "public,host"
 ```
 
 `loopback` means the sandbox's own `127.0.0.1`, not your laptop's localhost. Use `host` for `host.microsandbox.internal`.

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -224,6 +224,36 @@ Build a deny-by-default policy from `NetworkProfilePublic`, `NetworkProfilePriva
   </div>
 </div>
 
+When profile names come from JSON, configuration, environment variables, or other runtime input, use the checked variant instead:
+
+```go
+network, err := m.NetworkPolicy.FromProfilesChecked(profiles...)
+if err != nil {
+    return err
+}
+```
+
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">FromProfilesChecked()</span>
+
+```go
+func (networkPolicyFactory) FromProfilesChecked(profiles ...NetworkProfile) (*NetworkConfig, error)
+```
+
+Builds the same canonical deny-by-default policy as `FromProfiles`, but returns an error instead of panicking when a profile is unknown. Use this method for values derived from runtime input.
+
+<p className="msb-label">Returns</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><a className="msb-type" href="#networkconfig">*NetworkConfig</a></div>
+    <div className="msb-param-desc">Config containing canonical profile and DNS rules.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><span className="msb-type">error</span></div>
+    <div className="msb-param-desc">Non-nil when any requested profile is unknown.</div>
+  </div>
+</div>
+
 #### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">None()</span>
 
 ```go

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -213,6 +213,8 @@ m.WithNetwork(m.NetworkPolicy.FromProfiles(
 
 Build a deny-by-default policy from `NetworkProfilePublic`, `NetworkProfilePrivate`, and `NetworkProfileHost`. Duplicate profiles are ignored, rules use canonical order, and each non-empty set receives one gateway DNS rule. An empty profile set permits no egress and adds no DNS; ingress defaults to allow.
 
+`FromProfiles` panics if passed a value other than the three package-defined `NetworkProfile` constants.
+
 <p className="msb-label">Returns</p>
 
 <div className="msb-params">

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -12,10 +12,10 @@ The Go SDK exposes networking as a single [`NetworkConfig`](#networkconfig) stru
 ```go
 import m "github.com/superradcompany/microsandbox/sdk/go"
 
-// Preset: public internet only
+// Public internet profile
 sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("alpine"),
-    m.WithNetwork(m.NetworkPolicy.PublicOnly()),
+    m.WithNetwork(m.NetworkPolicy.FromProfiles(m.NetworkProfilePublic)),
 )
 
 // Or a custom first-match-wins firewall
@@ -50,13 +50,13 @@ func WithNetwork(net *NetworkConfig) SandboxOption
 ```go
 sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("alpine"),
-    m.WithNetwork(m.NetworkPolicy.PublicOnly()),
+    m.WithNetwork(m.NetworkPolicy.FromProfiles(m.NetworkProfilePublic)),
 )
 ```
 
 </Accordion>
 
-Set the network configuration for the sandbox. Pass a preset from the [`NetworkPolicy`](#networkpolicy) factory, or a custom [`NetworkConfig`](#networkconfig) value with your own rules, DNS, TLS, and port settings.
+Set the network configuration for the sandbox. Pass a profile policy from the [`NetworkPolicy`](#networkpolicy) factory, or a custom [`NetworkConfig`](#networkconfig) value with your own rules, DNS, TLS, and port settings.
 
 <p className="msb-label">Parameters</p>
 
@@ -192,30 +192,33 @@ Make services running in the sandbox reachable on explicit host addresses and po
 
 ## NetworkPolicy
 
-Factory namespace returning common preset [`*NetworkConfig`](#networkconfig) values. Access through the package-level `NetworkPolicy` value, for example `m.NetworkPolicy.PublicOnly()`.
+Factory namespace returning high-level [`*NetworkConfig`](#networkconfig) values. Access through the package-level `NetworkPolicy` value.
 
-#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">PublicOnly()</span>
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">FromProfiles()</span>
 
 ```go
-func (networkPolicyFactory) PublicOnly() *NetworkConfig
+func (networkPolicyFactory) FromProfiles(profiles ...NetworkProfile) *NetworkConfig
 ```
 
 <Accordion title="Example">
 
 ```go
-m.WithNetwork(m.NetworkPolicy.PublicOnly())
+m.WithNetwork(m.NetworkPolicy.FromProfiles(
+    m.NetworkProfilePublic,
+    m.NetworkProfilePrivate,
+))
 ```
 
 </Accordion>
 
-Allow only public internet traffic; RFC-1918 private ranges are blocked. This is the **default** when no network configuration is supplied.
+Build a deny-by-default policy from `NetworkProfilePublic`, `NetworkProfilePrivate`, and `NetworkProfileHost`. Duplicate profiles are ignored, rules use canonical order, and each non-empty set receives one gateway DNS rule. An empty profile set permits no egress and adds no DNS; ingress defaults to allow.
 
 <p className="msb-label">Returns</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><a className="msb-type" href="#networkconfig">*NetworkConfig</a></div>
-    <div className="msb-param-desc">Preset config with <code>Policy: "public-only"</code>.</div>
+    <div className="msb-param-desc">Config containing canonical profile and DNS rules.</div>
   </div>
 </div>
 
@@ -233,14 +236,14 @@ m.WithNetwork(m.NetworkPolicy.None())
 
 </Accordion>
 
-Block all network access. No network interface is created; the guest is fully offline. `Exec` and `FS` still work, since they use the host-guest channel rather than the network.
+Block all network traffic in both directions. The network interface remains present; `Exec` and `FS` still work because they use the host-guest channel.
 
 <p className="msb-label">Returns</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><a className="msb-type" href="#networkconfig">*NetworkConfig</a></div>
-    <div className="msb-param-desc">Preset config with <code>Policy: "none"</code>.</div>
+    <div className="msb-param-desc">Config with deny defaults in both directions.</div>
   </div>
 </div>
 
@@ -265,34 +268,19 @@ Permit all network traffic, including private addresses and the host machine.
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><a className="msb-type" href="#networkconfig">*NetworkConfig</a></div>
-    <div className="msb-param-desc">Preset config with <code>Policy: "allow-all"</code>.</div>
+    <div className="msb-param-desc">Config with allow defaults in both directions.</div>
   </div>
 </div>
 
-#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">NonLocal()</span>
+## Rule
+
+The package-level `Rule` factory provides semantic low-level rules. `Rule.AllowDNS()` returns a [`PolicyRule`](#policyrule) allowing gateway UDP/53 and TCP/53; `Rule.DenyDNS()` returns its deny counterpart. Put `Rule.DenyDNS()` before profile-generated rules when you need to override automatic DNS access.
 
 ```go
-func (networkPolicyFactory) NonLocal() *NetworkConfig
+network := m.NetworkPolicy.FromProfiles(m.NetworkProfilePublic)
+network.Rules = append([]m.PolicyRule{m.Rule.DenyDNS()}, network.Rules...)
 ```
 
-<Accordion title="Example">
-
-```go
-m.WithNetwork(m.NetworkPolicy.NonLocal())
-```
-
-</Accordion>
-
-Allow public internet plus private/LAN egress; block loopback, link-local, and metadata.
-
-<p className="msb-label">Returns</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><a className="msb-type" href="#networkconfig">*NetworkConfig</a></div>
-    <div className="msb-param-desc">Preset config with <code>Policy: "non-local"</code>.</div>
-  </div>
-</div>
 
 ## Custom rules
 
@@ -329,7 +317,6 @@ The full network stack configuration passed via [`WithNetwork`](#m-withnetwork).
 
 | Field | Type | Description |
 |-------|------|-------------|
-| Policy | [`NetworkPolicyPreset`](#networkpolicypreset) | Preset name. Mutually exclusive with custom rules for canned configs; set via [`NetworkPolicy`](#networkpolicy). When set alongside `Rules`, preset rules come first and custom rules follow |
 | Rules | `[]`[`PolicyRule`](#policyrule) | Ordered custom rules (first match wins) |
 | DefaultEgress | [`PolicyAction`](#policyaction) | Fall-through action for outbound when no rule matches. Defaults to `"deny"` |
 | DefaultIngress | [`PolicyAction`](#policyaction) | Fall-through action for inbound when no rule matches. Defaults to `"allow"` |
@@ -486,18 +473,15 @@ The protocol half of a [`PolicyRule`](#policyrule).
 | `PolicyProtocolICMPv4` | `"icmpv4"` | ICMPv4 traffic (egress only) |
 | `PolicyProtocolICMPv6` | `"icmpv6"` | ICMPv6 traffic (egress only) |
 
-### NetworkPolicyPreset
+### NetworkProfile
 
-<p className="msb-backref">Used by <a href="#networkconfig">NetworkConfig.Policy</a></p>
-
-Preset names accepted by [`NetworkConfig.Policy`](#networkconfig). Prefer the [`NetworkPolicy`](#networkpolicy) factory, which returns a preconfigured `*NetworkConfig`.
+Composable profile names accepted by [`NetworkPolicy.FromProfiles()`](#networkpolicyfromprofiles).
 
 | Constant | Value | Description |
 |----------|-------|-------------|
-| `NetworkPolicyPresetNone` | `"none"` | Fully airgapped |
-| `NetworkPolicyPresetPublicOnly` | `"public-only"` | Block private + metadata; allow everything else |
-| `NetworkPolicyPresetAllowAll` | `"allow-all"` | Unrestricted |
-| `NetworkPolicyPresetNonLocal` | `"non-local"` | Public + private/LAN egress; block loopback / link-local / metadata |
+| `NetworkProfilePublic` | `"public"` | Public internet addresses |
+| `NetworkProfilePrivate` | `"private"` | Private/LAN ranges |
+| `NetworkProfileHost` | `"host"` | Sandbox host gateway addresses |
 
 ### Destination groups
 

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -1522,13 +1522,13 @@ func WithNetwork(net *NetworkConfig) SandboxOption
 ```go
 sb, err := m.CreateSandbox(ctx, "api",
     m.WithImage("python"),
-    m.WithNetwork(m.NetworkPolicy.PublicOnly()),
+    m.WithNetwork(m.NetworkPolicy.FromProfiles(m.NetworkProfilePublic)),
 )
 ```
 
 </Accordion>
 
-Configure the network stack: preset, custom rules, DNS, and TLS interception. Build via the [`NetworkPolicy`](/sdk/go/networking) factory or a [`*NetworkConfig`](/sdk/go/networking#networkconfig) literal. See [Networking](/sdk/go/networking).
+Configure the network stack: profiles, custom rules, DNS, and TLS interception. Build via the [`NetworkPolicy`](/sdk/go/networking) factory or a [`*NetworkConfig`](/sdk/go/networking#networkconfig) literal. See [Networking](/sdk/go/networking).
 
 <p className="msb-label">Parameters</p>
 

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -14,6 +14,7 @@ from microsandbox import (
     Destination,
     Network,
     NetworkPolicy,
+    NetworkProfile,
     PortBinding,
     Protocol,
     Rule,
@@ -84,6 +85,8 @@ def from_profiles(*profiles: NetworkProfile | str) -> Network
 Build a deny-by-default network configuration from `PUBLIC`, `PRIVATE`, and `HOST` profiles. Duplicate profiles are ignored, generated rules use canonical order, and gateway DNS is added automatically for every non-empty profile set.
 
 ```python
+from microsandbox import Network, NetworkProfile
+
 network = Network.from_profiles(NetworkProfile.PUBLIC, NetworkProfile.PRIVATE)
 ```
 

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -46,7 +46,7 @@ The default policy denies egress except for an implicit allow-public rule, and a
 
 ## Network factory
 
-[`Network`](#network) is a frozen dataclass. The presets below return a `Network` for the common policy shapes; construct one directly for custom policies, ports, DNS, or TLS.
+[`Network`](#network) is a frozen dataclass. The profile and terminal-policy helpers below return a `Network` for common shapes; construct one directly for custom policies, ports, DNS, or TLS.
 
 #### <span className="msb-recv">Network.</span><span className="msb-hn">none()</span>
 
@@ -63,32 +63,36 @@ sb = await Sandbox.create("offline", image="python", network=Network.none())
 
 </Accordion>
 
-Deny all traffic. No network interface is created; the guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+Deny all traffic in both directions. The network interface remains present; `exec` and `fs` still work since they use the host-guest channel, not the network.
 
 <p className="msb-label">Returns</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><a className="msb-type" href="#network">Network</a></div>
-    <div className="msb-param-desc">Fully airgapped network configuration.</div>
+    <div className="msb-param-desc">Network configuration with deny defaults in both directions.</div>
   </div>
 </div>
 
-#### <span className="msb-recv">Network.</span><span className="msb-hn">public_only()</span>
+#### <span className="msb-recv">Network.</span><span className="msb-hn">from_profiles()</span>
 
 ```python
 @classmethod
-def public_only() -> Network
+def from_profiles(*profiles: NetworkProfile | str) -> Network
 ```
 
-Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+Build a deny-by-default network configuration from `PUBLIC`, `PRIVATE`, and `HOST` profiles. Duplicate profiles are ignored, generated rules use canonical order, and gateway DNS is added automatically for every non-empty profile set.
+
+```python
+network = Network.from_profiles(NetworkProfile.PUBLIC, NetworkProfile.PRIVATE)
+```
 
 <p className="msb-label">Returns</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><a className="msb-type" href="#network">Network</a></div>
-    <div className="msb-param-desc">Public-only network configuration.</div>
+    <div className="msb-param-desc">Network configuration containing the composed profiles.</div>
   </div>
 </div>
 
@@ -274,6 +278,15 @@ policy = NetworkPolicy(
 Allow plain DNS (UDP/53 and TCP/53) to the sandbox gateway, i.e. the in-process DNS forwarder. The standard one-liner for opening DNS under a deny-by-default policy. See [DNS as egress](/networking/dns#dns-as-egress) for the underlying semantics.
 
 Returns the pair `(udp_rule, tcp_rule)` since this SDK's [`Rule`](#rule) shape carries a single protocol; splat into `NetworkPolicy.rules`. DoT (TCP/853) is intentionally not included; add an explicit `Rule.allow(destination=Destination.group(DestGroup.HOST), protocol=Protocol.TCP, port=853)` if needed (and pair with TLS interception).
+
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">deny_dns()</span>
+
+```python
+@classmethod
+def deny_dns() -> tuple[Rule, Rule]
+```
+
+Deny gateway UDP/53 and TCP/53. Place these rules before profile-generated rules to override their automatic DNS access.
 
 <p className="msb-label">Returns</p>
 
@@ -487,7 +500,7 @@ Publish a UDP port from the sandbox to the host.
 
 <p className="msb-backref">Used by <a href="/sdk/python/sandbox#sandbox-create">Sandbox.create(network=...)</a></p>
 
-Frozen dataclass for sandbox network configuration. Use a [class-method preset](#network-factory) for the common cases, or construct directly with custom options.
+Frozen dataclass for sandbox network configuration. Use the [profile and terminal-policy helpers](#network-factory) for common cases, or construct directly with custom options.
 
 ```python
 Network(
@@ -506,7 +519,7 @@ Network(
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| policy | `str \| `[`NetworkPolicy`](#networkpolicy)` \| None` | `None` | Preset name (`"none"`, `"public_only"`, `"allow_all"`) or a custom [`NetworkPolicy`](#networkpolicy) |
+| policy | [`NetworkPolicy`](#networkpolicy)` \| None` | `None` | Concrete network policy |
 | ports | `Mapping[int, int] \| Sequence[`[`PortBinding`](#portbinding)`]` | `{}` | Port mappings from host to guest. Mapping form binds TCP to `127.0.0.1`; [`PortBinding`](#portbinding) can set an explicit bind address or UDP |
 | deny_domains | `tuple[str, ...]` | `()` | Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (NXDOMAIN), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy so it takes precedence over later allow rules |
 | deny_domain_suffixes | `tuple[str, ...]` | `()` | Deny egress to all subdomains of these suffixes. Adds `deny DomainSuffix("...")` rules; same enforcement layers as `deny_domains` |
@@ -519,15 +532,15 @@ Network(
 
 | Class method | Returns | Description |
 |--------------|---------|-------------|
-| [none()](#network-none) | [`Network`](#network) | Deny all traffic, no interface |
-| [public_only()](#network-public_only) | [`Network`](#network) | Public destinations only (default) |
+| [none()](#network-none) | [`Network`](#network) | Deny traffic in both directions |
+| [from_profiles()](#network-from_profiles) | [`Network`](#network) | Compose `PUBLIC`, `PRIVATE`, and `HOST` access with automatic DNS |
 | [allow_all()](#network-allow_all) | [`Network`](#network) | Unrestricted access |
 
 ### NetworkPolicy
 
 <p className="msb-backref">Used by <a href="#network">Network(policy=...)</a></p>
 
-Frozen dataclass: an ordered list of [`Rule`](#rule) values plus two per-direction defaults, evaluated first-match-wins. The defaults are asymmetric to preserve today's behavior: egress falls through to deny (public_only reachability when paired with the implicit allow-public rule); ingress falls through to allow (unfiltered published-port behavior).
+Frozen dataclass: an ordered list of [`Rule`](#rule) values plus two per-direction defaults, evaluated first-match-wins. The defaults are asymmetric: egress falls through to deny; ingress falls through to allow. Use `NetworkPolicy.from_profiles(...)` to add canonical profile and DNS rules.
 
 ```python
 NetworkPolicy(
@@ -542,6 +555,16 @@ NetworkPolicy(
 | default_egress | [`Action`](#action) | `DENY` | Action when no egress-applicable rule matches |
 | default_ingress | [`Action`](#action) | `ALLOW` | Action when no ingress-applicable rule matches |
 | rules | `tuple[`[`Rule`](#rule)`, ...]` | `()` | Rules evaluated first-match-wins per direction |
+
+Class methods `none()` and `allow_all()` construct terminal whole policies. `from_profiles(profiles)` composes [`NetworkProfile`](#networkprofile) values with canonical ordering and automatic gateway DNS.
+
+### NetworkProfile
+
+| Member | Value | Access |
+|--------|-------|--------|
+| `NetworkProfile.PUBLIC` | `"public"` | Public internet addresses |
+| `NetworkProfile.PRIVATE` | `"private"` | Private/LAN ranges |
+| `NetworkProfile.HOST` | `"host"` | Sandbox host gateway addresses |
 
 ### Rule
 
@@ -574,6 +597,7 @@ Ingress rules carrying ICMP protocols are rejected at sandbox creation; the host
 | [allow(...)](#rule-allow) | [`Rule`](#rule) | Permit matching traffic |
 | [deny(...)](#rule-deny) | [`Rule`](#rule) | Block matching traffic |
 | [allow_dns()](#rule-allow_dns) | `tuple[`[`Rule`](#rule)`, `[`Rule`](#rule)`]` | Open plain DNS to the gateway |
+| [deny_dns()](#rule-deny_dns) | `tuple[`[`Rule`](#rule)`, `[`Rule`](#rule)`]` | Block plain DNS to the gateway |
 
 ### Destination
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -1162,7 +1162,7 @@ The keyword arguments accepted by [`create()`](#sandbox-create) and [`create_wit
 | volumes | `dict[str, `[`MountConfig`](/sdk/python/volumes)`]` | `{}` | Volume mounts. See [Volumes](/sdk/python/volumes) |
 | patches | `list[`[`PatchConfig`](#patchconfig)`]` | `[]` | Rootfs modifications applied before boot |
 | ports | `dict[int, int] \| Sequence[`[`PortBinding`](/sdk/python/networking#portbinding)`]` | `{}` | Port mappings. Dict form is TCP and binds to `127.0.0.1`; use `PortBinding` for explicit bind addresses or UDP |
-| network | [`Network`](/sdk/python/networking#network) | `public_only` | Network policy and configuration |
+| network | [`Network`](/sdk/python/networking#network) | public profile | Network policy and configuration |
 | secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | `[]` | Secret injection |
 | detached | `bool` | `False` | If `True`, spawn the sandbox in detached mode; call [`detach()`](#sb-detach) before dropping the returned handle when it should keep running |
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -30,7 +30,7 @@ The default policy denies egress except for an implicit allow-public rule (plus 
 
 ## NetworkPolicy static methods
 
-A [`NetworkPolicy`](#networkpolicy) is an ordered rule list plus two per-direction defaults, evaluated first-match-wins. The presets below construct common shapes directly; for anything custom, start from [`builder()`](#networkpolicybuilder).
+A [`NetworkPolicy`](#networkpolicy) is an ordered rule list plus two per-direction defaults, evaluated first-match-wins. Compose common access shapes with [`from_profiles()`](#networkpolicyfrom_profiles); for anything custom, start from [`builder()`](#networkpolicybuilder).
 
 #### <span className="msb-recv">NetworkPolicy::</span><span className="msb-hn">builder()</span>
 
@@ -78,25 +78,28 @@ fn allow_all() -> NetworkPolicy
 
 Unrestricted network access: allow everything in both directions, no rules.
 
-#### <span className="msb-recv">NetworkPolicy::</span><span className="msb-hn">public_only()</span>
+#### <span className="msb-recv">NetworkPolicy::</span><span className="msb-hn">from_profiles()</span>
 
 ```rust
-fn public_only() -> NetworkPolicy
+fn from_profiles<I: IntoIterator<Item = NetworkProfile>>(profiles: I) -> NetworkPolicy
 ```
 
-Public internet only, and the [`Default`](#networkpolicy) policy. Egress defaults to deny but allows DNS to the gateway forwarder and any [`Public`](#destinationgroup) destination; private, loopback, link-local, and metadata are denied. Ingress defaults to allow, preserving unfiltered published-port behavior.
+Build a deny-by-default policy from composable [`NetworkProfile`](#networkprofile) values. Duplicate profiles are ignored, the generated rules use canonical `Public`, `Private`, `Host` order, and every non-empty profile set receives exactly one narrow gateway DNS rule. An empty profile set permits no egress and adds no DNS. Ingress defaults to allow, preserving published-port behavior.
 
-#### <span className="msb-recv">NetworkPolicy::</span><span className="msb-hn">non_local()</span>
+<Accordion title="Example">
 
 ```rust
-fn non_local() -> NetworkPolicy
+let policy = NetworkPolicy::from_profiles([
+    NetworkProfile::Public,
+    NetworkProfile::Private,
+]);
 ```
 
-Non-local access: like [`public_only()`](#networkpolicypublic_only) but also allows egress to [`Private`](#destinationgroup) / LAN ranges. Loopback, link-local, and metadata stay denied; ingress defaults to allow.
+</Accordion>
 
 ## NetworkPolicy instance methods
 
-These methods consume `self` and return a modified policy, so they chain off a preset or a built policy. Each **prepends** its rules, so a later deny outranks a catch-all allow like `allow public` under first-match-wins. All return [`Result<NetworkPolicy, DomainNameError>`](#domainname) because the names are parsed eagerly.
+These methods consume `self` and return a modified policy, so they chain off a profile or a built policy. Each **prepends** its rules, so a later deny outranks a catch-all allow like `allow public` under first-match-wins. All return [`Result<NetworkPolicy, DomainNameError>`](#domainname) because the names are parsed eagerly.
 
 #### <span className="msb-recv">policy.</span><span className="msb-hn">allow_domain()</span>
 
@@ -107,7 +110,7 @@ fn allow_domain<S: AsRef<str>>(self, name: S) -> Result<NetworkPolicy, DomainNam
 <Accordion title="Example">
 
 ```rust
-let policy = NetworkPolicy::public_only().allow_domain("api.openai.com")?;
+let policy = NetworkPolicy::default().allow_domain("api.openai.com")?;
 ```
 
 </Accordion>
@@ -718,7 +721,7 @@ fn policy(self, policy: NetworkPolicy) -> Self
 
 </Accordion>
 
-Set the network access policy. Pass a preset or a builder-constructed [`NetworkPolicy`](#networkpolicy).
+Set the network access policy. Pass a profile-composed or builder-constructed [`NetworkPolicy`](#networkpolicy).
 
 <p className="msb-label">Parameters</p>
 
@@ -1149,13 +1152,23 @@ Allow **any** host to receive placeholders unchanged. Takes effect only when `i_
 
 <p className="msb-backref">Built by <a href="#networkpolicybuilder">NetworkPolicy::builder()</a> · used by <a href="#policy">policy()</a></p>
 
-An ordered rule list plus two per-direction defaults, evaluated first-match-wins. Egress evaluation considers rules where `direction ∈ {Egress, Any}`; ingress considers `{Ingress, Any}`. If no rule matches, the direction-specific default applies. `Default` is [`public_only()`](#networkpolicypublic_only).
+An ordered rule list plus two per-direction defaults, evaluated first-match-wins. Egress evaluation considers rules where `direction ∈ {Egress, Any}`; ingress considers `{Ingress, Any}`. If no rule matches, the direction-specific default applies. `Default` is [`from_profiles([NetworkProfile::Public])`](#networkpolicyfrom_profiles).
 
 | Field | Type | Description |
 |-------|------|-------------|
 | default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
 | default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
 | rules | `Vec<`[`Rule`](#rule)`>` | Ordered rules; first match wins per direction |
+
+### NetworkProfile
+
+Composable high-level access category accepted by [`NetworkPolicy::from_profiles()`](#networkpolicyfrom_profiles).
+
+| Variant | Access |
+|---------|--------|
+| `Public` | Public internet addresses |
+| `Private` | Private/LAN ranges (RFC 1918, RFC 4193 ULA, and CGN) |
+| `Host` | The sandbox host via its gateway addresses |
 
 ### Rule
 
@@ -1182,6 +1195,7 @@ Convenience constructors build any-protocol, any-port rules:
 | `Rule::allow_any(destination)` | Allow rule, direction `Any` |
 | `Rule::deny_any(destination)` | Deny rule, direction `Any` |
 | `Rule::allow_dns()` | Allow plain DNS (UDP/53 + TCP/53) to the gateway forwarder (`Group::Host`); the one-liner for opening DNS under deny-by-default. See [DNS as egress](/networking/dns#dns-as-egress) |
+| `Rule::deny_dns()` | Deny plain DNS (UDP/53 + TCP/53) to the gateway forwarder; place before profile-generated rules to override automatic DNS |
 
 ### Action
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -89,6 +89,8 @@ Build a deny-by-default policy from composable [`NetworkProfile`](#networkprofil
 <Accordion title="Example">
 
 ```rust
+use microsandbox::{NetworkPolicy, NetworkProfile};
+
 let policy = NetworkPolicy::from_profiles([
     NetworkProfile::Public,
     NetworkProfile::Private,

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -31,7 +31,7 @@ The default policy denies egress except for an implicit allow-public rule (plus 
 
 ## NetworkPolicy
 
-A [`NetworkPolicy`](#networkpolicy-2) is an ordered rule list plus two per-direction defaults, evaluated first-match-wins. The presets below construct common shapes directly; for anything custom, start from [`builder()`](#networkpolicybuilder) or write a literal and pass it to [`NetworkBuilder.policy()`](#policy).
+A [`NetworkPolicy`](#networkpolicy-2) is an ordered rule list plus two per-direction defaults, evaluated first-match-wins. Compose common access shapes with [`fromProfiles()`](#networkpolicyfromprofiles); for anything custom, start from [`builder()`](#networkpolicybuilder) or write a literal and pass it to [`NetworkBuilder.policy()`](#policy).
 
 ```typescript
 import { NetworkPolicy, Rule, Destination } from "microsandbox";
@@ -126,21 +126,21 @@ allowAll(): NetworkPolicy
 
 Unrestricted network access: allow everything in both directions, no rules. Includes private addresses and the host machine.
 
-#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">publicOnly()</span>
+#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">fromProfiles()</span>
 
 ```typescript
-publicOnly(): NetworkPolicy
+fromProfiles(profiles: Iterable<NetworkProfile>): NetworkPolicy
 ```
 
-Egress allowed only to public destinations (plus DNS to the gateway); ingress allowed by default. Blocks private address ranges and cloud metadata endpoints. This is the **default** policy.
+Build a deny-by-default policy from `"public"`, `"private"`, and `"host"` profiles. Duplicate profiles are ignored, rules use canonical order, and every non-empty profile set receives one narrow gateway DNS rule. An empty set permits no egress and adds no DNS; ingress defaults to allow.
 
-#### <span className="msb-recv">NetworkPolicy.</span><span className="msb-hn">nonLocal()</span>
+<Accordion title="Example">
 
 ```typescript
-nonLocal(): NetworkPolicy
+const policy = NetworkPolicy.fromProfiles(["public", "private"]);
 ```
 
-Egress allowed to public + private (LAN) destinations (plus DNS); ingress allowed by default. Local groups (loopback, link-local, host, metadata) stay denied.
+</Accordion>
 
 ## Rule, Destination, PortRange
 
@@ -282,6 +282,14 @@ Allow plain DNS (UDP/53 and TCP/53) to the sandbox gateway, i.e. the in-process 
 
 DoT (TCP/853) is intentionally not included; add an explicit `Destination.group("host")` tcp/853 allow rule if needed (and pair with TLS interception).
 
+#### <span className="msb-recv">Rule.</span><span className="msb-hn">denyDns()</span>
+
+```typescript
+denyDns(): Rule
+```
+
+Deny plain gateway DNS (UDP/53 and TCP/53). Place this rule before profile-generated rules to override their automatic DNS access.
+
 #### <span className="msb-recv">Destination.</span><span className="msb-hn">any()</span>
 
 ```typescript
@@ -413,7 +421,7 @@ import { NetworkPolicy, Sandbox } from "microsandbox";
 
 const sb = await Sandbox.builder("api")
   .image("python")
-  .network((n) => n.policy(NetworkPolicy.publicOnly()))
+  .network((n) => n.policy(NetworkPolicy.fromProfiles(["public"])))
   .create();
 ```
 
@@ -1818,6 +1826,14 @@ interface NetworkPolicy {
   readonly defaultIngress: Action;
   readonly rules: readonly Rule[];
 }
+```
+
+### NetworkProfile
+
+Composable high-level access category accepted by [`NetworkPolicy.fromProfiles()`](#networkpolicyfromprofiles).
+
+```typescript
+type NetworkProfile = "public" | "private" | "host";
 ```
 
 ### Rule

--- a/docs/security/network.mdx
+++ b/docs/security/network.mdx
@@ -63,7 +63,7 @@ NetworkPolicy::builder()
 
 An attacker who controls a domain can make it resolve to a public IP during the allowlist check, then flip to a private IP on a later lookup. The guest ends up making a request that *looked* bound for `evil.example.com` but actually lands on `192.168.1.10`.
 
-Rebind protection catches this at the response level: when the DNS interceptor sees an answer resolving a name to a private, loopback, or link-local address, it rewrites the response to `NXDOMAIN` and the connection is never made. It's on by default. You can disable it when you genuinely need names to resolve to internal hosts, such as local development or split-horizon DNS. See [DNS](/networking/dns).
+Rebind protection catches this at the response level. A private, loopback, or link-local answer is rewritten to `NXDOMAIN` unless the first matching explicit, address-only egress rule permits the returned address. For example, the `private` profile allows private DNS answers while retaining protection against loopback, link-local, metadata, and unspecified addresses. Ordered address-specific denies still win; policy defaults, `Any` rules, and port-scoped rules do not disable the check. Disable rebind protection globally only when policy-aware exceptions cannot represent the intended access. See [DNS](/networking/dns).
 
 ## DNS-to-IP binding (TOCTOU)
 

--- a/sdk/go/enums.go
+++ b/sdk/go/enums.go
@@ -55,16 +55,13 @@ const (
 	PolicyProtocolICMPv6 PolicyProtocol = "icmpv6"
 )
 
-// NetworkPolicyPreset is the preset name accepted by NetworkConfig.Policy.
-// Prefer the NetworkPolicy factory (NetworkPolicy.None / PublicOnly / AllowAll
-// / NonLocal) which returns a preconfigured *NetworkConfig.
-type NetworkPolicyPreset string
+// NetworkProfile is a composable high-level network access profile.
+type NetworkProfile string
 
 const (
-	NetworkPolicyPresetNone       NetworkPolicyPreset = "none"
-	NetworkPolicyPresetPublicOnly NetworkPolicyPreset = "public-only"
-	NetworkPolicyPresetAllowAll   NetworkPolicyPreset = "allow-all"
-	NetworkPolicyPresetNonLocal   NetworkPolicyPreset = "non-local"
+	NetworkProfilePublic  NetworkProfile = "public"
+	NetworkProfilePrivate NetworkProfile = "private"
+	NetworkProfileHost    NetworkProfile = "host"
 )
 
 // PatchKind is the discriminator for PatchConfig.Kind. Prefer the Patch

--- a/sdk/go/examples/network/main.go
+++ b/sdk/go/examples/network/main.go
@@ -1,6 +1,6 @@
 // Network policy example for the microsandbox Go SDK.
 //
-// Demonstrates each of the four built-in presets and a custom rule list
+// Demonstrates high-level profiles, terminal policies, and a custom rule list
 // with a port range and asymmetric egress / ingress defaults. Each
 // configuration boots a sandbox, runs a single representative shell
 // command, and prints the result.
@@ -36,8 +36,8 @@ func main() {
 
 	scenarios := []scenario{
 		{
-			name:   "public-only (default)",
-			config: microsandbox.NetworkPolicy.PublicOnly(),
+			name:   "public profile (default)",
+			config: microsandbox.NetworkPolicy.FromProfiles(microsandbox.NetworkProfilePublic),
 			probe:  "ping -c 1 -W 5 1.1.1.1 >/dev/null && echo public-OK || echo public-FAIL",
 		},
 		{
@@ -51,9 +51,12 @@ func main() {
 			probe:  "ping -c 1 -W 5 1.1.1.1 >/dev/null && echo public-OK || echo public-FAIL",
 		},
 		{
-			name:   "non-local (public + LAN)",
-			config: microsandbox.NetworkPolicy.NonLocal(),
-			probe:  "ping -c 1 -W 5 1.1.1.1 >/dev/null && echo public-OK || echo public-FAIL",
+			name: "public + private profiles",
+			config: microsandbox.NetworkPolicy.FromProfiles(
+				microsandbox.NetworkProfilePublic,
+				microsandbox.NetworkProfilePrivate,
+			),
+			probe: "ping -c 1 -W 5 1.1.1.1 >/dev/null && echo public-OK || echo public-FAIL",
 		},
 		{
 			name: "custom: deny-egress except 1.1.1.1:443 (allow public ingress)",

--- a/sdk/go/examples/tls/main.go
+++ b/sdk/go/examples/tls/main.go
@@ -39,18 +39,17 @@ func main() {
 
 	name := fmt.Sprintf("go-sdk-tls-%d", time.Now().Unix())
 	log.Printf("creating sandbox %q with TLS interception enabled", name)
+	network := microsandbox.NetworkPolicy.AllowAll()
+	network.TLS = &microsandbox.TLSConfig{
+		Bypass:           []string{"*.google.com"},
+		VerifyUpstream:   &verifyUpstream,
+		InterceptedPorts: []uint16{443},
+		BlockQUIC:        &blockQUIC,
+	}
 
 	sb, err := microsandbox.CreateSandbox(ctx, name,
 		microsandbox.WithImage("alpine:3.19"),
-		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
-			Policy: microsandbox.NetworkPolicyPresetAllowAll,
-			TLS: &microsandbox.TLSConfig{
-				Bypass:           []string{"*.google.com"},
-				VerifyUpstream:   &verifyUpstream,
-				InterceptedPorts: []uint16{443},
-				BlockQUIC:        &blockQUIC,
-			},
-		}),
+		microsandbox.WithNetwork(network),
 	)
 	if err != nil {
 		log.Fatalf("CreateSandbox: %v", err)

--- a/sdk/go/integration/network_test.go
+++ b/sdk/go/integration/network_test.go
@@ -11,16 +11,19 @@ import (
 	microsandbox "github.com/superradcompany/microsandbox/sdk/go"
 )
 
-// TestNetworkPolicyNonLocal verifies the new NonLocal preset accepts
+// TestNetworkPolicyProfiles verifies composed public + private profiles accept
 // public + private/LAN egress and blocks loopback/link-local/metadata.
 // We can only assert on a public reach here (LAN is environment-specific).
-func TestNetworkPolicyNonLocal(t *testing.T) {
+func TestNetworkPolicyProfiles(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-nonlocal-" + t.Name()
 
 	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
-		microsandbox.WithNetwork(microsandbox.NetworkPolicy.NonLocal()),
+		microsandbox.WithNetwork(microsandbox.NetworkPolicy.FromProfiles(
+			microsandbox.NetworkProfilePublic,
+			microsandbox.NetworkProfilePrivate,
+		)),
 	)
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)
@@ -41,7 +44,7 @@ func TestNetworkPolicyNonLocal(t *testing.T) {
 		t.Fatalf("Shell: %v", err)
 	}
 	if !out.Success() {
-		t.Errorf("expected NonLocal preset to permit public TCP; stdout=%q stderr=%q",
+		t.Errorf("expected composed profiles to permit public TCP; stdout=%q stderr=%q",
 			out.Stdout(), out.Stderr())
 	}
 }
@@ -279,16 +282,15 @@ func TestDNSConfigCreates(t *testing.T) {
 
 	rebind := true
 	timeoutMs := uint64(5000)
+	network := microsandbox.NetworkPolicy.AllowAll()
+	network.DNS = &microsandbox.DNSConfig{
+		RebindProtection: &rebind,
+		Nameservers:      []string{"1.1.1.1:53"},
+		QueryTimeoutMs:   &timeoutMs,
+	}
 	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
-		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
-			Policy: microsandbox.NetworkPolicyPresetAllowAll,
-			DNS: &microsandbox.DNSConfig{
-				RebindProtection: &rebind,
-				Nameservers:      []string{"1.1.1.1:53"},
-				QueryTimeoutMs:   &timeoutMs,
-			},
-		}),
+		microsandbox.WithNetwork(network),
 	)
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)
@@ -315,13 +317,12 @@ func TestDNSConfigCreates(t *testing.T) {
 func TestNetworkOnSecretViolationCreates(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-onviolation-" + t.Name()
+	network := microsandbox.NetworkPolicy.FromProfiles(microsandbox.NetworkProfilePublic)
+	network.OnSecretViolation = microsandbox.ViolationActionBlockAndLog
 
 	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
-		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
-			Policy:            microsandbox.NetworkPolicyPresetPublicOnly,
-			OnSecretViolation: microsandbox.ViolationActionBlockAndLog,
-		}),
+		microsandbox.WithNetwork(network),
 	)
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)
@@ -377,16 +378,12 @@ func TestSecretWithOnViolation(t *testing.T) {
 func TestTLSConfigUpstreamCACertsCreates(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-upstreamcas-" + t.Name()
+	network := microsandbox.NetworkPolicy.AllowAll()
+	network.TLS = &microsandbox.TLSConfig{UpstreamCACerts: []string{}}
 
 	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
-		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
-			Policy: microsandbox.NetworkPolicyPresetAllowAll,
-			TLS: &microsandbox.TLSConfig{
-				// Don't set actual paths — the runtime accepts an empty slice.
-				UpstreamCACerts: []string{},
-			},
-		}),
+		microsandbox.WithNetwork(network),
 	)
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)
@@ -405,12 +402,11 @@ func TestNetworkMaxConnectionsCreates(t *testing.T) {
 	name := "go-sdk-maxconn-" + t.Name()
 
 	max := uint(64)
+	network := microsandbox.NetworkPolicy.AllowAll()
+	network.MaxConnections = &max
 	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
-		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
-			Policy:         microsandbox.NetworkPolicyPresetAllowAll,
-			MaxConnections: &max,
-		}),
+		microsandbox.WithNetwork(network),
 	)
 	if err != nil {
 		t.Fatalf("CreateSandbox: %v", err)

--- a/sdk/go/integration/sandbox_test.go
+++ b/sdk/go/integration/sandbox_test.go
@@ -577,7 +577,7 @@ func TestNetworkPolicyNone(t *testing.T) {
 
 	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
-		microsandbox.WithNetwork(&microsandbox.NetworkConfig{Policy: "none"}),
+		microsandbox.WithNetwork(microsandbox.NetworkPolicy.None()),
 	)
 	if err != nil {
 		t.Fatalf("CreateSandbox with network none: %v", err)
@@ -590,7 +590,7 @@ func TestNetworkPolicyNone(t *testing.T) {
 	})
 
 	// TCP egress check (wget) rather than ICMP — see comment in
-	// TestNetworkPolicyNonLocal. Should fail under policy=none regardless.
+	// TestNetworkPolicyProfiles. Should fail under policy=none regardless.
 	out, err := sb.Shell(ctx, "wget -q -O - --timeout=3 http://1.1.1.1/",
 		microsandbox.WithExecTimeout(10*time.Second))
 	if err != nil {
@@ -611,7 +611,7 @@ func TestNetworkPolicyAllowAll(t *testing.T) {
 
 	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
-		microsandbox.WithNetwork(&microsandbox.NetworkConfig{Policy: "allow-all"}),
+		microsandbox.WithNetwork(microsandbox.NetworkPolicy.AllowAll()),
 	)
 	if err != nil {
 		t.Fatalf("CreateSandbox allow-all: %v", err)
@@ -642,13 +642,12 @@ func TestNetworkPolicyAllowAll(t *testing.T) {
 func TestDNSBlockDomain(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-dns-" + t.Name()
+	network := microsandbox.NetworkPolicy.AllowAll()
+	network.DenyDomains = []string{"blocked-domain-test.example.com"}
 
 	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
-		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
-			Policy:      microsandbox.NetworkPolicyPresetAllowAll,
-			DenyDomains: []string{"blocked-domain-test.example.com"},
-		}),
+		microsandbox.WithNetwork(network),
 	)
 	if err != nil {
 		t.Fatalf("CreateSandbox with block_domains: %v", err)
@@ -679,13 +678,12 @@ func TestDNSBlockDomain(t *testing.T) {
 func TestDNSBlockDomainSuffix(t *testing.T) {
 	ctx := integrationCtx(t)
 	name := "go-sdk-dnssuffix-" + t.Name()
+	network := microsandbox.NetworkPolicy.AllowAll()
+	network.DenyDomainSuffixes = []string{".blocked-suffix-test.invalid"}
 
 	sb, err := createSandbox(t, ctx, name,
 		microsandbox.WithImage(goIntegrationImage),
-		microsandbox.WithNetwork(&microsandbox.NetworkConfig{
-			Policy:             microsandbox.NetworkPolicyPresetAllowAll,
-			DenyDomainSuffixes: []string{".blocked-suffix-test.invalid"},
-		}),
+		microsandbox.WithNetwork(network),
 	)
 	if err != nil {
 		t.Fatalf("CreateSandbox with block_domain_suffixes: %v", err)

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -1559,7 +1559,6 @@ type MountSpec struct {
 
 // NetworkOptions is the JSON representation of the network config block.
 type NetworkOptions struct {
-	Policy              string               `json:"policy,omitempty"`
 	CustomPolicy        *CustomNetworkPolicy `json:"custom_policy,omitempty"`
 	DNS                 *DNSOptions          `json:"dns,omitempty"`
 	DNSRebindProtection *bool                `json:"dns_rebind_protection,omitempty"`

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -806,7 +806,7 @@ fn default_port_protocol() -> String {
 
 /// Custom policy. Parity-aligned with Node/Python: `default_egress` and
 /// `default_ingress` are the asymmetric default actions. Empty defaults to
-/// deny egress / allow ingress (matching upstream `public_only`).
+/// deny egress / allow ingress (matching the default public profile).
 #[derive(serde::Deserialize, Default)]
 struct CustomNetworkPolicy {
     default_egress: Option<String>,
@@ -857,7 +857,10 @@ struct DnsOpts {
 
 #[derive(serde::Deserialize, Default)]
 struct NetworkOpts {
-    policy: Option<String>,
+    /// Removed preset field retained only to return migration guidance instead
+    /// of silently accepting JSON from an older Go SDK.
+    #[serde(rename = "policy")]
+    removed_policy: Option<String>,
     custom_policy: Option<CustomNetworkPolicy>,
     /// DNS configuration. Replaces the legacy flat `dns_rebind_protection`.
     dns: Option<DnsOpts>,
@@ -1153,24 +1156,10 @@ fn apply_network(
 
     let mut policy_set = false;
 
-    // Preset policy string.
-    if let Some(ref preset) = net.policy {
-        let mut policy = match preset.as_str() {
-            "none" => NetworkPolicy::none(),
-            "public_only" | "public-only" => NetworkPolicy::public_only(),
-            "allow_all" | "allow-all" => NetworkPolicy::allow_all(),
-            "non_local" | "non-local" => NetworkPolicy::non_local(),
-            other => {
-                return Err(FfiError::invalid_argument(format!(
-                    "unknown network policy preset: {other}"
-                )));
-            }
-        };
-        let mut combined = bulk_deny.clone();
-        combined.extend(policy.rules);
-        policy.rules = combined;
-        builder = builder.network(|n| n.policy(policy));
-        policy_set = true;
+    if net.removed_policy.is_some() {
+        return Err(FfiError::invalid_argument(
+            "string network policy presets were removed; use NetworkPolicy.FromProfiles, NetworkPolicy.None, or NetworkPolicy.AllowAll",
+        ));
     }
 
     // Custom policy.
@@ -1218,7 +1207,7 @@ fn apply_network(
         policy_set = true;
     }
 
-    // No preset / custom policy was specified, but legacy DNS deny entries
+    // No custom policy was specified, but legacy DNS deny entries
     // were. Use permissive defaults so the rest of the network keeps
     // working — preserves the legacy "full network minus blocked domains"
     // semantics.

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -990,20 +990,33 @@ func (networkPolicyFactory) AllowAll() *NetworkConfig {
 // FromProfiles returns a canonical deny-by-default policy. Duplicate profiles
 // are ignored, gateway DNS is added once, and group rules use fixed order.
 // It panics if a profile is not one of the package-defined NetworkProfile
-// constants.
+// constants. Use FromProfilesChecked when profiles come from runtime input.
 func (networkPolicyFactory) FromProfiles(profiles ...NetworkProfile) *NetworkConfig {
+	config, err := NetworkPolicy.FromProfilesChecked(profiles...)
+	if err != nil {
+		panic(err)
+	}
+	return config
+}
+
+// FromProfilesChecked returns a canonical deny-by-default policy. Duplicate
+// profiles are ignored, gateway DNS is added once, and group rules use fixed
+// order. It returns an error for an unknown profile instead of panicking,
+// making it suitable for profiles parsed from JSON, configuration, or the
+// environment.
+func (networkPolicyFactory) FromProfilesChecked(profiles ...NetworkProfile) (*NetworkConfig, error) {
 	requested := make(map[NetworkProfile]bool, len(profiles))
 	for _, profile := range profiles {
 		switch profile {
 		case NetworkProfilePublic, NetworkProfilePrivate, NetworkProfileHost:
 		default:
-			panic(fmt.Sprintf("microsandbox: unknown network profile %q", profile))
+			return nil, fmt.Errorf("microsandbox: unknown network profile %q", profile)
 		}
 		requested[profile] = true
 	}
 	config := &NetworkConfig{DefaultEgress: PolicyActionDeny, DefaultIngress: PolicyActionAllow}
 	if len(requested) == 0 {
-		return config
+		return config, nil
 	}
 	config.Rules = append(config.Rules, Rule.AllowDNS())
 	for _, profile := range []NetworkProfile{
@@ -1019,7 +1032,7 @@ func (networkPolicyFactory) FromProfiles(profiles ...NetworkProfile) *NetworkCon
 			})
 		}
 	}
-	return config
+	return config, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -989,6 +989,8 @@ func (networkPolicyFactory) AllowAll() *NetworkConfig {
 
 // FromProfiles returns a canonical deny-by-default policy. Duplicate profiles
 // are ignored, gateway DNS is added once, and group rules use fixed order.
+// It panics if a profile is not one of the package-defined NetworkProfile
+// constants.
 func (networkPolicyFactory) FromProfiles(profiles ...NetworkProfile) *NetworkConfig {
 	requested := make(map[NetworkProfile]bool, len(profiles))
 	for _, profile := range profiles {

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -806,13 +806,8 @@ type RegistryAuth struct {
 
 // NetworkConfig configures the sandbox network stack.
 type NetworkConfig struct {
-	// Policy is a preset name: "none", "public-only", "allow-all", "non-local".
-	// Mutually exclusive with custom rules.
-	Policy NetworkPolicyPreset
-
-	// Rules are custom ordered allow/deny rules (first match wins). When
-	// set, Policy is still honoured: preset rules come first, custom rules
-	// follow. Use DefaultEgress / DefaultIngress to set fall-through behaviour.
+	// Rules are custom ordered allow/deny rules (first match wins). Use
+	// DefaultEgress / DefaultIngress to set fall-through behaviour.
 	Rules []PolicyRule
 
 	// DefaultEgress is "allow" or "deny"; falls through here when no rule
@@ -895,6 +890,31 @@ type PolicyRule struct {
 	Ports []string
 }
 
+// networkRuleFactory constructs semantic low-level rules shared with the
+// other SDKs.
+type networkRuleFactory struct{}
+
+// Rule is the factory namespace for semantic low-level policy rules.
+var Rule networkRuleFactory
+
+// AllowDNS permits gateway UDP/53 and TCP/53.
+func (networkRuleFactory) AllowDNS() PolicyRule {
+	return PolicyRule{
+		Action:      PolicyActionAllow,
+		Direction:   PolicyDirectionEgress,
+		Destination: "host",
+		Protocols:   []PolicyProtocol{PolicyProtocolUDP, PolicyProtocolTCP},
+		Port:        "53",
+	}
+}
+
+// DenyDNS blocks gateway UDP/53 and TCP/53.
+func (networkRuleFactory) DenyDNS() PolicyRule {
+	rule := Rule.AllowDNS()
+	rule.Action = PolicyActionDeny
+	return rule
+}
+
 // ScopedUpstreamCACert configures an upstream CA bundle for a host pattern.
 type ScopedUpstreamCACert struct {
 	// Pattern is an exact host or "*.suffix" wildcard.
@@ -946,37 +966,58 @@ type TLSConfig struct {
 	ScopedVerifyUpstream []ScopedVerifyUpstream
 }
 
-// networkPolicyFactory is the static-method surface matching the Node
-// NetworkPolicy class and the Python Network classmethods. Invoke through
-// the package-level NetworkPolicy value, e.g. `microsandbox.NetworkPolicy.PublicOnly()`.
+// networkPolicyFactory is the static-method surface shared with the other SDKs.
 type networkPolicyFactory struct{}
 
-// NetworkPolicy is the factory namespace for common network presets.
+// NetworkPolicy is the factory namespace for high-level network policies.
 //
-//	microsandbox.WithNetwork(microsandbox.NetworkPolicy.PublicOnly())
+//	microsandbox.WithNetwork(microsandbox.NetworkPolicy.FromProfiles(
+//		microsandbox.NetworkProfilePublic,
+//		microsandbox.NetworkProfilePrivate,
+//	))
 var NetworkPolicy networkPolicyFactory
 
 // None returns a NetworkConfig that blocks all network access.
 func (networkPolicyFactory) None() *NetworkConfig {
-	return &NetworkConfig{Policy: NetworkPolicyPresetNone}
-}
-
-// PublicOnly returns a NetworkConfig that allows only public internet traffic
-// (RFC-1918 private ranges are blocked). This is the default when no network
-// configuration is supplied.
-func (networkPolicyFactory) PublicOnly() *NetworkConfig {
-	return &NetworkConfig{Policy: NetworkPolicyPresetPublicOnly}
+	return &NetworkConfig{DefaultEgress: PolicyActionDeny, DefaultIngress: PolicyActionDeny}
 }
 
 // AllowAll returns a NetworkConfig that permits all network traffic.
 func (networkPolicyFactory) AllowAll() *NetworkConfig {
-	return &NetworkConfig{Policy: NetworkPolicyPresetAllowAll}
+	return &NetworkConfig{DefaultEgress: PolicyActionAllow, DefaultIngress: PolicyActionAllow}
 }
 
-// NonLocal returns a NetworkConfig that allows public internet plus
-// private/LAN egress; blocks loopback, link-local, and metadata.
-func (networkPolicyFactory) NonLocal() *NetworkConfig {
-	return &NetworkConfig{Policy: NetworkPolicyPresetNonLocal}
+// FromProfiles returns a canonical deny-by-default policy. Duplicate profiles
+// are ignored, gateway DNS is added once, and group rules use fixed order.
+func (networkPolicyFactory) FromProfiles(profiles ...NetworkProfile) *NetworkConfig {
+	requested := make(map[NetworkProfile]bool, len(profiles))
+	for _, profile := range profiles {
+		switch profile {
+		case NetworkProfilePublic, NetworkProfilePrivate, NetworkProfileHost:
+		default:
+			panic(fmt.Sprintf("microsandbox: unknown network profile %q", profile))
+		}
+		requested[profile] = true
+	}
+	config := &NetworkConfig{DefaultEgress: PolicyActionDeny, DefaultIngress: PolicyActionAllow}
+	if len(requested) == 0 {
+		return config
+	}
+	config.Rules = append(config.Rules, Rule.AllowDNS())
+	for _, profile := range []NetworkProfile{
+		NetworkProfilePublic,
+		NetworkProfilePrivate,
+		NetworkProfileHost,
+	} {
+		if requested[profile] {
+			config.Rules = append(config.Rules, PolicyRule{
+				Action:      PolicyActionAllow,
+				Direction:   PolicyDirectionEgress,
+				Destination: string(profile),
+			})
+		}
+	}
+	return config
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/go/options_test.go
+++ b/sdk/go/options_test.go
@@ -291,7 +291,7 @@ func TestWithPortBindings(t *testing.T) {
 
 func TestWithNetwork(t *testing.T) {
 	o := SandboxConfig{}
-	net := &NetworkConfig{Policy: NetworkPolicyPresetPublicOnly}
+	net := NetworkPolicy.FromProfiles(NetworkProfilePublic)
 	WithNetwork(net)(&o)
 	if o.Network != net {
 		t.Error("WithNetwork should set the Network pointer")
@@ -299,7 +299,7 @@ func TestWithNetwork(t *testing.T) {
 }
 
 func TestWithNetworkNilClearsPolicy(t *testing.T) {
-	o := SandboxConfig{Network: &NetworkConfig{Policy: NetworkPolicyPresetAllowAll}}
+	o := SandboxConfig{Network: NetworkPolicy.AllowAll()}
 	WithNetwork(nil)(&o)
 	if o.Network != nil {
 		t.Error("WithNetwork(nil) should clear Network")
@@ -307,20 +307,45 @@ func TestWithNetworkNilClearsPolicy(t *testing.T) {
 }
 
 func TestNetworkPolicyFactory(t *testing.T) {
-	cases := []struct {
-		got  *NetworkConfig
-		want NetworkPolicyPreset
-	}{
-		{NetworkPolicy.None(), NetworkPolicyPresetNone},
-		{NetworkPolicy.PublicOnly(), NetworkPolicyPresetPublicOnly},
-		{NetworkPolicy.AllowAll(), NetworkPolicyPresetAllowAll},
-		{NetworkPolicy.NonLocal(), NetworkPolicyPresetNonLocal},
+	if got := NetworkPolicy.None(); got.DefaultEgress != PolicyActionDeny || got.DefaultIngress != PolicyActionDeny {
+		t.Fatalf("None defaults = %q/%q", got.DefaultEgress, got.DefaultIngress)
 	}
-	for _, c := range cases {
-		if c.got.Policy != c.want {
-			t.Errorf("Policy: got %q, want %q", c.got.Policy, c.want)
+	if got := NetworkPolicy.AllowAll(); got.DefaultEgress != PolicyActionAllow || got.DefaultIngress != PolicyActionAllow {
+		t.Fatalf("AllowAll defaults = %q/%q", got.DefaultEgress, got.DefaultIngress)
+	}
+	got := NetworkPolicy.FromProfiles(NetworkProfileHost, NetworkProfilePrivate, NetworkProfilePublic, NetworkProfilePrivate)
+	if len(got.Rules) != 4 {
+		t.Fatalf("FromProfiles rules = %d, want 4", len(got.Rules))
+	}
+	want := []string{"host", "public", "private", "host"}
+	for i, destination := range want {
+		if got.Rules[i].Destination != destination {
+			t.Errorf("rule %d destination = %q, want %q", i, got.Rules[i].Destination, destination)
 		}
 	}
+}
+
+func TestDNSRuleFactory(t *testing.T) {
+	allow := Rule.AllowDNS()
+	deny := Rule.DenyDNS()
+	if allow.Action != PolicyActionAllow || deny.Action != PolicyActionDeny {
+		t.Fatalf("DNS actions = %q/%q", allow.Action, deny.Action)
+	}
+	if allow.Destination != "host" || allow.Port != "53" {
+		t.Fatalf("AllowDNS = %#v", allow)
+	}
+	if len(allow.Protocols) != 2 || allow.Protocols[0] != PolicyProtocolUDP || allow.Protocols[1] != PolicyProtocolTCP {
+		t.Fatalf("AllowDNS protocols = %#v", allow.Protocols)
+	}
+}
+
+func TestNetworkPolicyProfilesRejectUnknownValue(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("FromProfiles should panic for an unknown typed value")
+		}
+	}()
+	NetworkPolicy.FromProfiles(NetworkProfile("bogus"))
 }
 
 func TestWithSecrets(t *testing.T) {
@@ -448,19 +473,12 @@ func TestPatchCopyFileFields(t *testing.T) {
 	}
 }
 
-func TestNetworkConfigPreset(t *testing.T) {
-	for _, preset := range []NetworkPolicyPreset{
-		NetworkPolicyPresetNone,
-		NetworkPolicyPresetPublicOnly,
-		NetworkPolicyPresetAllowAll,
-		NetworkPolicyPresetNonLocal,
-	} {
-		n := &NetworkConfig{Policy: preset}
-		o := SandboxConfig{}
-		WithNetwork(n)(&o)
-		if o.Network.Policy != preset {
-			t.Errorf("Policy: got %q, want %q", o.Network.Policy, preset)
-		}
+func TestNetworkConfigProfiles(t *testing.T) {
+	n := NetworkPolicy.FromProfiles(NetworkProfilePublic, NetworkProfilePrivate)
+	o := SandboxConfig{}
+	WithNetwork(n)(&o)
+	if len(o.Network.Rules) != 3 {
+		t.Fatalf("Rules len = %d, want DNS + two profiles", len(o.Network.Rules))
 	}
 }
 

--- a/sdk/go/options_test.go
+++ b/sdk/go/options_test.go
@@ -317,10 +317,18 @@ func TestNetworkPolicyFactory(t *testing.T) {
 	if len(got.Rules) != 4 {
 		t.Fatalf("FromProfiles rules = %d, want 4", len(got.Rules))
 	}
-	want := []string{"host", "public", "private", "host"}
-	for i, destination := range want {
-		if got.Rules[i].Destination != destination {
-			t.Errorf("rule %d destination = %q, want %q", i, got.Rules[i].Destination, destination)
+	dns := got.Rules[0]
+	if dns.Destination != "host" || dns.Port != "53" || len(dns.Protocols) != 2 || dns.Protocols[0] != PolicyProtocolUDP || dns.Protocols[1] != PolicyProtocolTCP {
+		t.Errorf("DNS rule = %#v, want host UDP+TCP/53", dns)
+	}
+	wantProfiles := []string{"public", "private", "host"}
+	for i, destination := range wantProfiles {
+		rule := got.Rules[i+1]
+		if rule.Destination != destination {
+			t.Errorf("profile rule %d destination = %q, want %q", i, rule.Destination, destination)
+		}
+		if rule.Port != "" || len(rule.Protocols) != 0 {
+			t.Errorf("profile rule %d has unexpected transport filters: %#v", i, rule)
 		}
 	}
 }
@@ -346,6 +354,30 @@ func TestNetworkPolicyProfilesRejectUnknownValue(t *testing.T) {
 		}
 	}()
 	NetworkPolicy.FromProfiles(NetworkProfile("bogus"))
+}
+
+func TestNetworkPolicyProfilesCheckedRejectsUnknownValue(t *testing.T) {
+	config, err := NetworkPolicy.FromProfilesChecked(NetworkProfilePublic, NetworkProfile("bogus"))
+	if err == nil {
+		t.Fatal("FromProfilesChecked should return an error for an unknown typed value")
+	}
+	if config != nil {
+		t.Fatalf("FromProfilesChecked config = %#v, want nil", config)
+	}
+	if got, want := err.Error(), `microsandbox: unknown network profile "bogus"`; got != want {
+		t.Fatalf("FromProfilesChecked error = %q, want %q", got, want)
+	}
+}
+
+func TestNetworkPolicyProfilesCheckedMatchesFromProfiles(t *testing.T) {
+	got, err := NetworkPolicy.FromProfilesChecked(NetworkProfileHost, NetworkProfilePublic, NetworkProfileHost)
+	if err != nil {
+		t.Fatalf("FromProfilesChecked returned an unexpected error: %v", err)
+	}
+	want := NetworkPolicy.FromProfiles(NetworkProfileHost, NetworkProfilePublic, NetworkProfileHost)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("FromProfilesChecked = %#v, want %#v", got, want)
+	}
 }
 
 func TestWithSecrets(t *testing.T) {

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -255,7 +255,6 @@ func sandboxTouchResultFromFFI(result *ffi.SandboxTouchResult) *SandboxTouchResu
 // buildFFINetwork converts a public NetworkConfig into its ffi counterpart.
 func buildFFINetwork(n *NetworkConfig) *ffi.NetworkOptions {
 	out := &ffi.NetworkOptions{
-		Policy:              string(n.Policy),
 		DNSRebindProtection: n.DNSRebindProtection,
 		DenyDomains:         n.DenyDomains,
 		DenyDomainSuffixes:  n.DenyDomainSuffixes,

--- a/sdk/go/sandbox_options_test.go
+++ b/sdk/go/sandbox_options_test.go
@@ -550,14 +550,16 @@ func TestFFIWireShape_Secrets(t *testing.T) {
 	}
 }
 
-func TestFFIWireShape_NetworkPreset(t *testing.T) {
+func TestFFIWireShape_NetworkProfile(t *testing.T) {
 	got := marshalCreateOptions(t,
 		WithImage("alpine"),
-		WithNetwork(NetworkPolicy.PublicOnly()),
+		WithNetwork(NetworkPolicy.FromProfiles(NetworkProfilePublic)),
 	)
 	net := mustField(t, got, "network").(map[string]any)
-	if net["policy"] != "public-only" {
-		t.Fatalf("network.policy = %v", net["policy"])
+	policy := mustField(t, net, "custom_policy").(map[string]any)
+	rules := mustField(t, policy, "rules").([]any)
+	if len(rules) != 2 {
+		t.Fatalf("network.custom_policy.rules len = %d, want 2", len(rules))
 	}
 }
 

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -461,8 +461,8 @@ export declare class NetworkBuilder {
   /** Publish a UDP port on a specific host bind address. */
   portUdpBind(bind: string, hostPort: number, guestPort: number): this
   /**
-   * Set a policy. Construct via the JS-side `NetworkPolicy.publicOnly()`
-   * / `.allowAll()` / `.none()` / `.nonLocal()` factories or build a
+   * Set a policy. Construct via the JS-side `NetworkPolicy.fromProfiles()`
+   * / `.allowAll()` / `.none()` factories or build a
    * custom one and pass it through `JSON.stringify`-friendly JSON. Here
    * we accept the canonical serialized form (a JSON string) to avoid
    * re-modeling the rule schema across the FFI; Phase 7 reconciles.

--- a/sdk/node-ts/native/network_builder.rs
+++ b/sdk/node-ts/native/network_builder.rs
@@ -100,8 +100,8 @@ impl JsNetworkBuilder {
         Ok(self)
     }
 
-    /// Set a policy. Construct via the JS-side `NetworkPolicy.publicOnly()`
-    /// / `.allowAll()` / `.none()` / `.nonLocal()` factories or build a
+    /// Set a policy. Construct via the JS-side `NetworkPolicy.fromProfiles()`
+    /// / `.allowAll()` / `.none()` factories or build a
     /// custom one and pass it through `JSON.stringify`-friendly JSON. Here
     /// we accept the canonical serialized form (a JSON string) to avoid
     /// re-modeling the rule schema across the FFI; Phase 7 reconciles.

--- a/sdk/node-ts/src/index.ts
+++ b/sdk/node-ts/src/index.ts
@@ -141,8 +141,8 @@ export { MetricsStream } from "./metrics-stream.js";
 
 // Attach a JS-side `policy(NetworkPolicy)` method to the native
 // `NetworkBuilder.prototype` so callers can pass the plain
-// `NetworkPolicy` object produced by `NetworkPolicy.publicOnly()` /
-// `.allowAll()` / `.none()` / `.nonLocal()` and the custom-rule
+// `NetworkPolicy` object produced by `NetworkPolicy.fromProfiles()` /
+// `.allowAll()` / `.none()` and the custom-rule
 // factories. Native exposes `policyJson(string)`; this shim
 // serializes once.
 // Wrap a class's prototype method so any thrown error gets remapped
@@ -522,10 +522,11 @@ export type {
   Action,
   DestinationGroup,
   Direction,
+  NetworkProfile,
   Protocol,
 } from "./policy/types.js";
 
-// `Destination`, `NetworkPolicy`, `PortRange`, `Rule` each merge an
+// `Destination`, `NetworkPolicy`, `PortRange`, and `Rule` each merge an
 // interface (the value shape) with a factory namespace (the constructors)
 // under one name.
 import * as _Factories from "./policy/factories.js";

--- a/sdk/node-ts/src/policy/factories.ts
+++ b/sdk/node-ts/src/policy/factories.ts
@@ -64,6 +64,11 @@ const allowDnsRule = (): Types.Rule => ({
   action: "allow",
 });
 
+const denyDnsRule = (): Types.Rule => ({
+  ...allowDnsRule(),
+  action: "deny",
+});
+
 export const Rule = {
   allowEgress: allowEgressRule,
   denyEgress: denyEgressRule,
@@ -72,6 +77,7 @@ export const Rule = {
   allowAny: allowAnyRule,
   denyAny: denyAnyRule,
   allowDns: allowDnsRule,
+  denyDns: denyDnsRule,
 };
 
 export const Destination = {
@@ -108,24 +114,30 @@ export const NetworkPolicy = {
     rules: [],
   }),
 
-  /** Egress allowed only to public destinations; ingress allowed by default. */
-  publicOnly: (): Types.NetworkPolicy => ({
-    defaultEgress: "deny",
-    defaultIngress: "allow",
-    rules: [
-      allowDnsRule(),
-      allowEgressRule({ kind: "group", group: "public" }),
-    ],
-  }),
-
-  /** Egress allowed to public + private (LAN); ingress allowed by default. */
-  nonLocal: (): Types.NetworkPolicy => ({
-    defaultEgress: "deny",
-    defaultIngress: "allow",
-    rules: [
-      allowDnsRule(),
-      allowEgressRule({ kind: "group", group: "public" }),
-      allowEgressRule({ kind: "group", group: "private" }),
-    ],
-  }),
+  /** Build a canonical deny-by-default policy from composable profiles. */
+  fromProfiles: (
+    profiles: Iterable<Types.NetworkProfile>,
+  ): Types.NetworkPolicy => {
+    const requested = new Set(profiles);
+    const canonical: readonly Types.NetworkProfile[] = [
+      "public",
+      "private",
+      "host",
+    ];
+    for (const profile of requested) {
+      if (!canonical.includes(profile)) {
+        throw new RangeError(`unknown network profile: ${String(profile)}`);
+      }
+    }
+    return {
+      defaultEgress: "deny",
+      defaultIngress: "allow",
+      rules: [
+        ...(requested.size > 0 ? [allowDnsRule()] : []),
+        ...canonical
+          .filter((profile) => requested.has(profile))
+          .map((group) => allowEgressRule({ kind: "group", group })),
+      ],
+    };
+  },
 };

--- a/sdk/node-ts/src/policy/types.ts
+++ b/sdk/node-ts/src/policy/types.ts
@@ -16,6 +16,9 @@ export type DestinationGroup =
   | "multicast"
   | "host";
 
+/** Composable high-level network access profile. */
+export type NetworkProfile = "public" | "private" | "host";
+
 export const DestinationGroups: readonly DestinationGroup[] = [
   "public",
   "loopback",

--- a/sdk/node-ts/tests/unit/policy.test.ts
+++ b/sdk/node-ts/tests/unit/policy.test.ts
@@ -7,7 +7,7 @@ import {
   Rule,
 } from "../../dist/index.js";
 
-describe("NetworkPolicy presets", () => {
+describe("NetworkPolicy profiles", () => {
   it("none denies in both directions", () => {
     expect(NetworkPolicy.none()).toEqual({
       defaultEgress: "deny",
@@ -24,8 +24,8 @@ describe("NetworkPolicy presets", () => {
     });
   });
 
-  it("publicOnly denies egress by default and adds DNS + allow-public rules", () => {
-    const p = NetworkPolicy.publicOnly();
+  it("public profile denies egress by default and adds DNS + allow-public rules", () => {
+    const p = NetworkPolicy.fromProfiles(["public"]);
     expect(p.defaultEgress).toBe("deny");
     expect(p.defaultIngress).toBe("allow");
     expect(p.rules).toHaveLength(2);
@@ -43,12 +43,32 @@ describe("NetworkPolicy presets", () => {
     });
   });
 
-  it("nonLocal allows DNS + public + private egress", () => {
-    const p = NetworkPolicy.nonLocal();
-    expect(p.rules).toHaveLength(3);
+  it("deduplicates and canonically orders composed profiles", () => {
+    const p = NetworkPolicy.fromProfiles([
+      "host",
+      "private",
+      "public",
+      "private",
+    ]);
+    expect(p.rules).toHaveLength(4);
     expect(p.rules[0].destination).toMatchObject({ kind: "group", group: "host" });
     expect(p.rules[1].destination).toMatchObject({ kind: "group", group: "public" });
     expect(p.rules[2].destination).toMatchObject({ kind: "group", group: "private" });
+    expect(p.rules[3].destination).toMatchObject({ kind: "group", group: "host" });
+  });
+
+  it("does not add DNS for an empty profile set", () => {
+    expect(NetworkPolicy.fromProfiles([])).toEqual({
+      defaultEgress: "deny",
+      defaultIngress: "allow",
+      rules: [],
+    });
+  });
+
+  it("rejects unknown profiles at the runtime boundary", () => {
+    expect(() =>
+      NetworkPolicy.fromProfiles(["bogus" as never]),
+    ).toThrowError("unknown network profile: bogus");
   });
 });
 
@@ -76,6 +96,13 @@ describe("Rule factory", () => {
       protocols: ["udp", "tcp"],
       ports: [{ start: 53, end: 53 }],
       action: "allow",
+    });
+  });
+
+  it("denyDns is the action inverse of allowDns", () => {
+    expect(Rule.denyDns()).toEqual({
+      ...Rule.allowDns(),
+      action: "deny",
     });
   });
 });

--- a/sdk/node-ts/tests/unit/policy.test.ts
+++ b/sdk/node-ts/tests/unit/policy.test.ts
@@ -51,10 +51,26 @@ describe("NetworkPolicy profiles", () => {
       "private",
     ]);
     expect(p.rules).toHaveLength(4);
-    expect(p.rules[0].destination).toMatchObject({ kind: "group", group: "host" });
-    expect(p.rules[1].destination).toMatchObject({ kind: "group", group: "public" });
-    expect(p.rules[2].destination).toMatchObject({ kind: "group", group: "private" });
-    expect(p.rules[3].destination).toMatchObject({ kind: "group", group: "host" });
+    expect(p.rules[0]).toMatchObject({
+      destination: { kind: "group", group: "host" },
+      protocols: ["udp", "tcp"],
+      ports: [{ start: 53, end: 53 }],
+    });
+    expect(p.rules[1]).toMatchObject({
+      destination: { kind: "group", group: "public" },
+      protocols: [],
+      ports: [],
+    });
+    expect(p.rules[2]).toMatchObject({
+      destination: { kind: "group", group: "private" },
+      protocols: [],
+      ports: [],
+    });
+    expect(p.rules[3]).toMatchObject({
+      destination: { kind: "group", group: "host" },
+      protocols: [],
+      ports: [],
+    });
   });
 
   it("does not add DNS for an empty profile set", () => {

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -172,7 +172,7 @@ web = await Sandbox.create(
     "python-readme-web",
     image="python",
     ports={8080: 80},
-    network=Network.public_only(),
+    network=Network.from_profiles("public"),
     replace=True,
 )
 ```

--- a/sdk/python/microsandbox/__init__.py
+++ b/sdk/python/microsandbox/__init__.py
@@ -122,6 +122,7 @@ from microsandbox.types import (
     Network,
     NetworkDestination,
     NetworkPolicy,
+    NetworkProfile,
     Patch,
     PatchConfig,
     PortBinding,
@@ -226,6 +227,7 @@ __all__ = [
     # Network
     "Network",
     "NetworkPolicy",
+    "NetworkProfile",
     "Rule",
     "Destination",
     "NetworkDestination",

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import enum
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Literal, TypeAlias
 
@@ -87,6 +87,12 @@ class DestGroup(StrEnum):
     LINK_LOCAL = "link-local"
     METADATA = "metadata"
     MULTICAST = "multicast"
+    HOST = "host"
+
+class NetworkProfile(StrEnum):
+    """Composable high-level network access profile."""
+    PUBLIC = "public"
+    PRIVATE = "private"
     HOST = "host"
 
 class ViolationAction(StrEnum):
@@ -772,19 +778,56 @@ class Rule:
             ),
         )
 
+    @classmethod
+    def deny_dns(cls) -> tuple[Rule, Rule]:
+        """Deny gateway UDP/53 and TCP/53, for overriding profile DNS."""
+        udp, tcp = cls.allow_dns()
+        return (
+            cls(Action.DENY, udp.direction, udp.destination, udp.protocol, udp.port),
+            cls(Action.DENY, tcp.direction, tcp.destination, tcp.protocol, tcp.port),
+        )
+
 @dataclass(frozen=True, slots=True)
 class NetworkPolicy:
     """Custom network policy with rules.
 
     Mirrors Rust's `NetworkPolicy { default_egress, default_ingress, rules }`.
     The defaults are asymmetric to preserve today's behavior:
-    egress falls through to deny (today's `public_only` reachability when
-    paired with the implicit allow-public rule); ingress falls through
+    egress falls through to deny (the default public-profile reachability when
+    paired with an allow-public rule); ingress falls through
     to allow (today's unfiltered published-port behavior).
     """
     default_egress: Action = Action.DENY
     default_ingress: Action = Action.ALLOW
     rules: tuple[Rule, ...] = ()
+
+    @classmethod
+    def none(cls) -> NetworkPolicy:
+        """Deny traffic in both directions."""
+        return cls(default_egress=Action.DENY, default_ingress=Action.DENY)
+
+    @classmethod
+    def allow_all(cls) -> NetworkPolicy:
+        """Allow traffic in both directions."""
+        return cls(default_egress=Action.ALLOW, default_ingress=Action.ALLOW)
+
+    @classmethod
+    def from_profiles(
+        cls, profiles: Iterable[NetworkProfile | str]
+    ) -> NetworkPolicy:
+        """Build a canonical deny-by-default policy from profiles."""
+        requested = {NetworkProfile(profile) for profile in profiles}
+        rules: list[Rule] = []
+        if requested:
+            rules.extend(Rule.allow_dns())
+        for profile in (
+            NetworkProfile.PUBLIC,
+            NetworkProfile.PRIVATE,
+            NetworkProfile.HOST,
+        ):
+            if profile in requested:
+                rules.append(Rule.allow(destination=Destination.group(profile.value)))
+        return cls(rules=tuple(rules))
 
     def _to_dict(self) -> dict:
         def destination_fields(destination: NetworkDestinationLike) -> dict:
@@ -921,7 +964,7 @@ class PortBinding:
 @dataclass(frozen=True, slots=True)
 class Network:
     """Network configuration for a sandbox."""
-    policy: str | NetworkPolicy | None = None
+    policy: NetworkPolicy | None = None
     ports: Mapping[int, int] | Sequence[PortBinding] = field(default_factory=dict)
     deny_domains: tuple[str, ...] = ()
     """Deny egress to these exact domains. Each entry adds a
@@ -945,23 +988,26 @@ class Network:
 
     @classmethod
     def none(cls) -> Network:
-        return cls(policy="none")
+        return cls(policy=NetworkPolicy.none())
 
     @classmethod
-    def public_only(cls) -> Network:
-        return cls(policy="public_only")
+    def from_profiles(cls, *profiles: NetworkProfile | str) -> Network:
+        return cls(policy=NetworkPolicy.from_profiles(profiles))
 
     @classmethod
     def allow_all(cls) -> Network:
-        return cls(policy="allow_all")
+        return cls(policy=NetworkPolicy.allow_all())
 
 
     def _to_dict(self) -> dict:
         d: dict = {}
-        if isinstance(self.policy, str):
-            d["policy"] = self.policy
-        elif isinstance(self.policy, NetworkPolicy):
+        if isinstance(self.policy, NetworkPolicy):
             d["custom_policy"] = self.policy._to_dict()
+        elif self.policy is not None:
+            raise TypeError(
+                "Network.policy must be a NetworkPolicy; use "
+                "Network.from_profiles(...), Network.none(), or Network.allow_all()"
+            )
         if self.ports:
             if isinstance(self.ports, Mapping):
                 d["ports"] = dict(self.ports)

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -903,23 +903,12 @@ fn apply_network(
     }
     let mut policy_set = false;
 
-    // Check for preset policy string.
-    if let Some(policy_str) = extract_opt::<String>(net, "policy")? {
-        let mut policy = match policy_str.as_str() {
-            "none" => NetworkPolicy::none(),
-            "public_only" | "public-only" => NetworkPolicy::public_only(),
-            "allow_all" | "allow-all" => NetworkPolicy::allow_all(),
-            _ => {
-                return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                    "unknown network policy preset: {policy_str}"
-                )));
-            }
-        };
-        let mut combined = bulk_deny_rules.clone();
-        combined.extend(policy.rules);
-        policy.rules = combined;
-        builder = builder.network(|n| n.policy(policy));
-        policy_set = true;
+    if let Some(legacy) = net.get_item("policy")?
+        && !legacy.is_none()
+    {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "string network policy presets were removed; use Network.from_profiles(...), Network.none(), or Network.allow_all()",
+        ));
     }
 
     // Check for custom policy object.
@@ -941,7 +930,7 @@ fn apply_network(
             }
         };
         // Asymmetric defaults match the rest of the stack: egress falls
-        // through to Deny (preserves today's `public_only` reachability
+        // through to Deny (preserves the default public-profile reachability
         // when paired with an implicit allow-public rule); ingress falls
         // through to Allow (preserves today's unfiltered published-port
         // behavior).
@@ -1033,7 +1022,7 @@ fn apply_network(
         policy_set = true;
     }
 
-    // No preset / custom policy was specified, but legacy DNS block
+    // No custom policy was specified, but legacy DNS block
     // entries were. Use permissive defaults so the rest of the network
     // keeps working — preserves the legacy "full network minus blocked
     // domains" semantics.

--- a/sdk/python/tests/test_network_destinations.py
+++ b/sdk/python/tests/test_network_destinations.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from microsandbox import DestGroup, Destination, NetworkPolicy, Protocol, Rule
+from microsandbox import (
+    Action,
+    DestGroup,
+    Destination,
+    Network,
+    NetworkPolicy,
+    NetworkProfile,
+    Protocol,
+    Rule,
+)
 
 
 def test_typed_ip_destination_serializes_with_kind() -> None:
@@ -63,3 +72,61 @@ def test_string_destination_remains_compatibility_shorthand() -> None:
             "port": "443",
         }
     ]
+
+
+def test_profiles_are_deduplicated_and_canonically_ordered() -> None:
+    policy = NetworkPolicy.from_profiles(
+        [
+            NetworkProfile.HOST,
+            NetworkProfile.PRIVATE,
+            NetworkProfile.PUBLIC,
+            NetworkProfile.PRIVATE,
+        ]
+    )
+
+    assert policy.default_egress is Action.DENY
+    assert policy.default_ingress is Action.ALLOW
+    assert [rule.destination for rule in policy.rules[2:]] == [
+        Destination.group(DestGroup.PUBLIC),
+        Destination.group(DestGroup.PRIVATE),
+        Destination.group(DestGroup.HOST),
+    ]
+    assert policy.rules[:2] == Rule.allow_dns()
+
+
+def test_empty_profiles_do_not_add_dns() -> None:
+    assert NetworkPolicy.from_profiles([]).rules == ()
+
+
+def test_terminal_policy_constructors_set_both_defaults() -> None:
+    assert NetworkPolicy.none() == NetworkPolicy(Action.DENY, Action.DENY)
+    assert NetworkPolicy.allow_all() == NetworkPolicy(Action.ALLOW, Action.ALLOW)
+
+
+def test_unknown_profile_is_rejected() -> None:
+    try:
+        NetworkPolicy.from_profiles(["bogus"])
+    except ValueError as error:
+        assert "bogus" in str(error)
+    else:
+        raise AssertionError("unknown profile should be rejected")
+
+
+def test_network_profile_convenience_serializes_as_custom_policy() -> None:
+    network = Network.from_profiles(NetworkProfile.PUBLIC, NetworkProfile.PRIVATE)
+    assert "custom_policy" in network._to_dict()
+    assert "policy" not in network._to_dict()
+
+
+def test_removed_string_presets_fail_with_migration_guidance() -> None:
+    try:
+        Network(policy="public_only")._to_dict()  # type: ignore[arg-type]
+    except TypeError as error:
+        assert "Network.from_profiles" in str(error)
+    else:
+        raise AssertionError("removed string preset should be rejected")
+
+
+def test_deny_dns_is_action_inverse_of_allow_dns() -> None:
+    assert all(rule.action is Action.DENY for rule in Rule.deny_dns())
+    assert [rule.protocol for rule in Rule.deny_dns()] == [Protocol.UDP, Protocol.TCP]

--- a/sdk/rust/lib/backend/sandbox.rs
+++ b/sdk/rust/lib/backend/sandbox.rs
@@ -1163,7 +1163,7 @@ pub(super) fn cloud_create_request_from_config(
     #[cfg(feature = "net")]
     {
         // Only flag user-set opt-in fields. The default `NetworkConfig`
-        // ships with a baseline policy (`public_only`) and built-in DNS
+        // ships with a baseline public profile and built-in DNS
         // settings, so comparing those would always trigger; instead we
         // catch the explicit-add fields (ports, secrets, custom DNS
         // resolvers, host-CA trust).

--- a/sdk/rust/lib/lib.rs
+++ b/sdk/rust/lib/lib.rs
@@ -45,8 +45,6 @@ pub use microsandbox_image::{ImageArchiveFormat, RegistryAuth};
 pub use microsandbox_protocol as protocol;
 pub use microsandbox_runtime::logging::LogLevel;
 pub use microsandbox_utils::size;
-#[cfg(feature = "net")]
-pub use sandbox::NetworkPolicy;
 pub use sandbox::exec::{ExecControl, ExecEvent, ExecHandle};
 #[cfg(feature = "ssh")]
 pub use sandbox::ssh::{
@@ -65,6 +63,8 @@ pub use sandbox::{
     all_sandbox_metrics_local, all_sandbox_metrics_reports_local, sandbox_metrics_report_local,
     validate_sandbox_name,
 };
+#[cfg(feature = "net")]
+pub use sandbox::{NetworkPolicy, NetworkProfile};
 pub use snapshot::{
     SaveOpts, Snapshot, SnapshotBuilder, SnapshotConfig, SnapshotFormat, SnapshotHandle,
     SnapshotScope, SnapshotSpec, SnapshotVerifyReport, UpperIntegrity, UpperVerifyStatus,

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -508,7 +508,7 @@ impl SandboxBuilder {
     /// ```ignore
     /// .network(|n| n
     ///     .port(8080, 80)
-    ///     .policy(NetworkPolicy::public_only())
+    ///     .policy(NetworkPolicy::default())
     ///     .tls(|t| t.bypass("*.internal.com"))
     /// )
     /// ```

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -141,7 +141,7 @@ pub use microsandbox_network::builder::SecretBuilder;
 #[cfg(feature = "net")]
 pub use microsandbox_network::config::NetworkConfig;
 #[cfg(feature = "net")]
-pub use microsandbox_network::policy::NetworkPolicy;
+pub use microsandbox_network::policy::{NetworkPolicy, NetworkProfile};
 pub use microsandbox_runtime::logging::LogLevel;
 pub use microsandbox_types::PullPolicy;
 pub use microsandbox_types::{

--- a/sdk/rust/tests/host_access.rs
+++ b/sdk/rust/tests/host_access.rs
@@ -271,7 +271,7 @@ async fn host_alias_denied_by_gateway_cidr_policy() {
     teardown(sb, name).await;
 }
 
-/// Default `public_only` must block host access; users opt in explicitly.
+/// The default public profile must block host access; users opt in explicitly.
 #[msb_test]
 async fn host_alias_denied_by_default_policy() {
     let server = HostHttp::start("should not see")
@@ -291,7 +291,7 @@ async fn host_alias_denied_by_default_policy() {
     let stdout = out.stdout().unwrap();
     assert!(
         stdout.contains("status=") && !stdout.trim_end().ends_with("status=0"),
-        "expected wget to fail under default public_only policy; got: {stdout:?} (stderr: {})",
+        "expected wget to fail under default public profile; got: {stdout:?} (stderr: {})",
         out.stderr().unwrap_or_default()
     );
     assert!(


### PR DESCRIPTION
## TL;DR

Fixes #1192 by adding composable `public`, `private`, and `host` network profiles with automatic gateway DNS across the CLI and every SDK, while keeping low-level rules available for precise overrides.

## Description

- add canonical, deduplicated profile expansion and replace legacy `public_only` / `non_local` APIs
- add repeatable and comma-separated `--net`, terminal `all` / `none`, and `allow@dns` / `deny@dns`
- preserve explicit rule precedence and make private DNS answers policy-aware without broadly disabling rebinding protection
- keep IPv4 and IPv6 unspecified addresses outside the `public` group so protected DNS answers remain fail-closed
- update Rust, Python, TypeScript, and Go APIs, tests, examples, and documentation
- update the bundled microsandbox skill through superradcompany/skills#19

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p microsandbox-network`
- [x] `cargo test -p microsandbox-cli`
- [x] `cargo test -p microsandbox --lib`
- [x] `cargo clippy -p microsandbox-network -p microsandbox-cli -p microsandbox -- -D warnings`
- [x] `cargo clippy --manifest-path sdk/go/native/Cargo.toml -- -D warnings`
- [x] `cargo clippy --manifest-path sdk/python/Cargo.toml -- -D warnings`
- [x] `cd sdk/python && uv run maturin develop --release && uv run pytest && uv run ruff check .`
- [x] `cd sdk/node-ts && npm run build && npm test && npm run typecheck`
- [x] `cd sdk/go && go test -count=1 ./...`
- [x] `quick_validate.py skills/microsandbox` in superradcompany/skills#19

### Live end-to-end validation (macOS ARM64 / libkrun)

- [x] `just build-msb` rebuilt and codesigned the current-branch CLI
- [x] `MSB_PATH=$PWD/build/msb cargo test -p microsandbox --test host_access -- --ignored --test-threads=1` — 7 VM-backed tests passed
- [x] live CLI matrix for `public`, `private`, `host`, every profile subset, repeated/comma syntax, default policy, terminal `all`/`none`, DNS-only access, explicit host/private denies, and `deny@dns`
- [x] live public/private/host probes used real public HTTP, host HTTP, and DNS plus TCP to a host LAN server through `192.168.1.80.nip.io`
- [x] live Rust, Python, TypeScript, and Go SDK sandboxes verified composed profiles, public isolation, terminal `none`, terminal `allow_all`, and DNS-deny overrides
- [x] published-port ingress reached a guest service under the public profile; terminal `none` reset the same connection, confirming deny-ingress behavior
- [x] controlled DNS E2E: the default public profile rewrote an upstream `0.0.0.0` answer to guest-visible `NXDOMAIN`; disabling rebind protection or explicitly allowing `0.0.0.0/32` returned the answer
- [x] unit coverage verifies both `0.0.0.0` and `::` are excluded from `public` and rejected by public-profile rebind evaluation
- [x] all E2E sandboxes and temporary host servers were removed after the run
