### PR TITLE
chore(release): bump microsandbox to 0.6.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3356,7 +3356,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "base64",
  "chrono",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "base64",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-go"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "base64",
  "cbindgen",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "chrono",
  "libc",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics-collector"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "base64",
  "bytes",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "bytes",
  "chrono",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "chrono",
  "futures",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "bytes",
  "chrono",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "chrono",
  "dprint-plugin-typescript",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "dirs",
  "libc",
@@ -7020,14 +7020,14 @@ dependencies = [
 
 [[package]]
 name = "test-init"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "test-macros"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7036,7 +7036,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.6.6"
+version = "0.6.7"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -65,18 +65,18 @@ panic = "abort"
 # Exact (`=`) pins: these crates share private, unstable APIs across patch
 # releases, so every published version must resolve its siblings to the same
 # version. Caret would let an older release pull newer siblings and break.
-microsandbox = { version = "=0.6.6", path = "sdk/rust", default-features = false }
-microsandbox-agent-client = { version = "=0.6.6", path = "packages/agent-client/rust" }
-microsandbox-db = { version = "=0.6.6", path = "crates/db" }
-microsandbox-filesystem = { version = "=0.6.6", path = "crates/filesystem", default-features = false }
-microsandbox-image = { version = "=0.6.6", path = "crates/image" }
-microsandbox-metrics = { version = "=0.6.6", path = "crates/metrics" }
-microsandbox-types = { version = "=0.6.6", path = "packages/microsandbox-types/rust" }
-microsandbox-migration = { version = "=0.6.6", path = "crates/migration" }
-microsandbox-network = { version = "=0.6.6", path = "crates/network" }
-microsandbox-protocol = { version = "=0.6.6", path = "crates/protocol" }
-microsandbox-runtime = { version = "=0.6.6", path = "crates/runtime", default-features = false }
-microsandbox-utils = { version = "=0.6.6", path = "crates/utils" }
+microsandbox = { version = "=0.6.7", path = "sdk/rust", default-features = false }
+microsandbox-agent-client = { version = "=0.6.7", path = "packages/agent-client/rust" }
+microsandbox-db = { version = "=0.6.7", path = "crates/db" }
+microsandbox-filesystem = { version = "=0.6.7", path = "crates/filesystem", default-features = false }
+microsandbox-image = { version = "=0.6.7", path = "crates/image" }
+microsandbox-metrics = { version = "=0.6.7", path = "crates/metrics" }
+microsandbox-types = { version = "=0.6.7", path = "packages/microsandbox-types/rust" }
+microsandbox-migration = { version = "=0.6.7", path = "crates/migration" }
+microsandbox-network = { version = "=0.6.7", path = "crates/network" }
+microsandbox-protocol = { version = "=0.6.7", path = "crates/protocol" }
+microsandbox-runtime = { version = "=0.6.7", path = "crates/runtime", default-features = false }
+microsandbox-utils = { version = "=0.6.7", path = "crates/utils" }
 msb_krun = "=0.1.25"
 msb_krun_utils = "=0.1.25"
 test-macros = { path = "crates/test-macros" }

--- a/examples/typescript/cloud-backend/package.json
+++ b/examples/typescript/cloud-backend/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/init-handoff/package.json
+++ b/examples/typescript/init-handoff/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/snapshot-fork/package.json
+++ b/examples/typescript/snapshot-fork/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.6"
+    "microsandbox": "0.6.7"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/packages/agent-client/rust/README.md
+++ b/packages/agent-client/rust/README.md
@@ -10,19 +10,19 @@ Use this crate when you already have an agent relay endpoint and want direct pro
 
 ```toml
 [dependencies]
-microsandbox-agent-client = "0.6.4"
-microsandbox-protocol = "0.6.4"
+microsandbox-agent-client = "0.6.7"
+microsandbox-protocol = "0.6.7"
 ```
 
 The crate is transport-agnostic by default. Enable exactly the transport adapter you need:
 
 ```toml
 # Local microsandbox relay sockets.
-microsandbox-agent-client = { version = "0.6.4", features = ["uds"] }
+microsandbox-agent-client = { version = "0.6.7", features = ["uds"] }
 
 # Any caller-owned byte-stream transport (e.g. a pre-authenticated WebSocket
 # adapted to bytes).
-microsandbox-agent-client = { version = "0.6.4", features = ["stream"] }
+microsandbox-agent-client = { version = "0.6.7", features = ["stream"] }
 ```
 
 The high-level `microsandbox` SDK enables `uds` explicitly because local sandboxes are reached through Unix domain sockets.
@@ -99,7 +99,7 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
 Enable the `stream` feature:
 
 ```toml
-microsandbox-agent-client = { version = "0.6.4", features = ["stream"] }
+microsandbox-agent-client = { version = "0.6.7", features = ["stream"] }
 ```
 
 Drive the client over any `AsyncRead + AsyncWrite` — the caller owns the dial and any authentication, then hands over the connected stream:

--- a/packages/agent-client/typescript/package-lock.json
+++ b/packages/agent-client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/agent-client",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "Apache-2.0",
       "dependencies": {
         "cbor-x": "^1.6.0"

--- a/packages/agent-client/typescript/package.json
+++ b/packages/agent-client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "type": "module",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/microsandbox-types/rust/README.md
+++ b/packages/microsandbox-types/rust/README.md
@@ -25,7 +25,7 @@ Backend-private materialized state stays out: registry credentials, local CA pat
 
 ```toml
 [dependencies]
-microsandbox-types = "0.6.4"
+microsandbox-types = "0.6.7"
 ```
 
 ```rust

--- a/packages/microsandbox-types/typescript/package-lock.json
+++ b/packages/microsandbox-types/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/types",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6"

--- a/packages/microsandbox-types/typescript/package.json
+++ b/packages/microsandbox-types/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "type": "module",
   "main": "./dist/cloud.js",
   "types": "./dist/cloud.d.ts",

--- a/sdk/go/setup.go
+++ b/sdk/go/setup.go
@@ -24,7 +24,7 @@ import (
 // embedded FFI library and the downloaded msb+libkrunfw artefacts are
 // both pinned to this version. Bump when cutting a new SDK release so
 // it matches published binaries.
-const sdkVersion = "0.6.6"
+const sdkVersion = "0.6.7"
 
 // libkrunfwABI is the major SONAME version of libkrunfw that msb links
 // against.

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.6.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/npm/win32-arm64-msvc/package.json
+++ b/sdk/node-ts/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-win32-arm64-msvc",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Windows arm64.",
   "os": ["win32"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/win32-x64-msvc/package.json
+++ b/sdk/node-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-win32-x64-msvc",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Windows x64.",
   "os": ["win32"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -22,11 +22,11 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.6.6",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.6",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.6.6",
-        "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.6",
-        "@superradcompany/microsandbox-win32-x64-msvc": "0.6.6"
+        "@superradcompany/microsandbox-darwin-arm64": "0.6.7",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.7",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.6.7",
+        "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.7",
+        "@superradcompany/microsandbox-win32-x64-msvc": "0.6.7"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1851,84 +1851,19 @@
       "license": "MIT"
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.6.6.tgz",
-      "integrity": "sha512-rw7cg0G9mj1c9/14K/K6PMg78H11rGRA5tDzRbx67kAeoKWpAJnFsIYLvOCHcD+6aM0Xdxote90FVVlt1Kknjw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.6.6.tgz",
-      "integrity": "sha512-y4CdSPkSOtCwBNbG8Yhkahxg9yh/jpp4cBMOItCOj0JshU7luE2r4+6ceIrPNAkb8sF0fX7tNTXMDK4fJA8iFA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.6.6.tgz",
-      "integrity": "sha512-9yo6/G454L8ebzZP1qMxjIXRD3zJqQ68w2p9Ust7B7MOj5hr+VyuVZ0kYjSJAc4GSI0fno2xQe5z2tp5ynk78A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-win32-arm64-msvc": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-win32-arm64-msvc/-/microsandbox-win32-arm64-msvc-0.6.6.tgz",
-      "integrity": "sha512-q22t1DVlB8FR90adjBxTf0i//f3yzm7QYsKbsar29zoUAHC/24h6R4LE6YfIDWtPKB8jvTSpCeMehFoyXyLN1Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-win32-x64-msvc": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-win32-x64-msvc/-/microsandbox-win32-x64-msvc-0.6.6.tgz",
-      "integrity": "sha512-m2ir3DNw+Sc7i2DEg1kgY9bFmFHCFt2KamnXzJMUL9qtkE2n11GqIUhQJtKXwcWyM7nH0AxooMmnbx7UDMG8Ww==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -51,11 +51,11 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.6.6",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.6",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.6.6",
-    "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.6",
-    "@superradcompany/microsandbox-win32-x64-msvc": "0.6.6"
+    "@superradcompany/microsandbox-darwin-arm64": "0.6.7",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.7",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.6.7",
+    "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.7",
+    "@superradcompany/microsandbox-win32-x64-msvc": "0.6.7"
   },
   "files": [
     "dist",

--- a/sdk/rust/tests/plain_http_secret.rs
+++ b/sdk/rust/tests/plain_http_secret.rs
@@ -245,11 +245,12 @@ async fn plain_http_invalid_host_blocks_host_bound_secret() {
     );
 
     // Test: no Host header. The exec outcome is irrelevant (the proxy drops the
-    // connection, which can break the guest pipe) — only what the server sees.
+    // connection, which can leave `nc` waiting for a response) — only what the
+    // server sees.
     let _ = sb
         .shell(format!(
-            "printf 'GET / HTTP/1.0\\r\\nAuthorization: Bearer %s\\r\\n\\r\\n' \"$API_KEY\" \
-             | nc host.microsandbox.internal {test_port} || true"
+            "timeout 5 sh -c 'printf \"GET / HTTP/1.0\\r\\nAuthorization: Bearer %s\\r\\n\\r\\n\" \
+             \"$API_KEY\" | nc host.microsandbox.internal {test_port}' || true"
         ))
         .await;
 


### PR DESCRIPTION
## TL;DR
Advance the microsandbox release train and integration references from 0.6.6 to 0.6.7.

## Description
- Bump all Rust crates, shared TypeScript packages, SDK release metadata, native package manifests, and current TypeScript examples to 0.6.7.
- Correct stale 0.6.4 Rust dependency examples so every active release reference matches 0.6.7.
- Refresh publishable npm lock metadata while retaining optional stubs for unpublished Node native packages until the post-publish lock refresh.
- Point the MCP and skills submodules at their pushed 0.6.7 commits ([MCP PR #21](https://github.com/superradcompany/microsandbox-mcp/pull/21), [skills PR #20](https://github.com/superradcompany/skills/pull/20)).
- Release changes since 0.6.6 include snapshot archive and root-disk APIs, image archive support, TTY resize, Go Windows support, richer sandbox status types, filesystem and networking hardening, and SDK compatibility fixes.

## Test Plan
- [x] `cargo fmt --all -- --check && CI=1 MSB_HOME=/tmp/msb-bump-0.6.7-runtime cargo check --workspace`
- [x] `CI=1 MSB_HOME=/tmp/msb-bump-0.6.7-runtime cargo test --workspace && CI=1 MSB_HOME=/tmp/msb-bump-0.6.7-runtime cargo clippy --workspace -- -D warnings`
- [x] `cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate -- --check` and shared TypeScript package build, typecheck, and test commands
- [x] `cd sdk/go && go test -count=1 .`
- [x] Node SDK native build, typecheck, and 102 unit tests
- [x] Python SDK native build, 32 passing tests with 1 skipped, and `uv run ruff check .`
