### PR TITLE
fix(cli): run image defaults in detached mode

### DIFF
--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -37,9 +37,9 @@ pub struct RunArgs {
     )]
     pub from_snapshot: Option<String>,
 
-    /// Start the sandbox in the background and print its name.
+    /// Run the resolved image command in the background and print the sandbox name.
     ///
-    /// Use `msb exec` to run commands in a detached sandbox.
+    /// Use `msb create` to boot an idle sandbox without starting the image command.
     #[arg(short, long)]
     pub detach: bool,
 
@@ -63,7 +63,9 @@ pub struct RunArgs {
     #[arg(long)]
     pub detach_keys: Option<String>,
 
-    /// Command to run inside the sandbox in attached mode (after --).
+    /// Command to run inside the sandbox (after --).
+    ///
+    /// Replaces the image CMD while preserving its effective entrypoint.
     #[arg(last = true)]
     pub command: Vec<String>,
 
@@ -190,9 +192,9 @@ async fn run_new(
         builder = builder.ephemeral(true);
     }
     if args.detach {
-        builder = builder.persistent_initial_command(args.command.clone());
+        builder = builder.background_command(args.command.clone());
     } else {
-        builder = builder.initial_command(args.command.clone());
+        builder = builder.foreground_command(args.command.clone());
     }
 
     // Create sandbox with pull progress — select attached vs detached mode.
@@ -417,6 +419,31 @@ mod tests {
             TestCli::try_parse_from(["msb", "--tty", "--no-tty", "python:3-alpine"]).unwrap_err();
 
         assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn detached_entrypoint_can_use_image_cmd() {
+        let args = parse_run_args(&[
+            "--detach",
+            "--entrypoint",
+            "start-desktop",
+            "debian:bookworm-slim",
+        ]);
+
+        assert!(args.detach);
+        assert_eq!(args.sandbox.entrypoint.as_deref(), Some("start-desktop"));
+        assert!(args.command.is_empty());
+    }
+
+    #[test]
+    fn detach_help_points_idle_workloads_to_create() {
+        let mut help = Vec::new();
+        <TestCli as clap::CommandFactory>::command()
+            .write_long_help(&mut help)
+            .unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(help.contains("Use `msb create` to boot an idle sandbox"));
     }
 
     #[cfg(feature = "net")]

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -7,7 +7,7 @@ icon: "cube"
 
 ## msb run
 
-Create a sandbox and optionally run a command. Without `--name`, the sandbox is ephemeral and removed when the command finishes. With `--name`, it persists for later use.
+Create a sandbox and run its resolved OCI command. A command after `--` replaces the image CMD while preserving its entrypoint; without one, microsandbox runs the image's default `ENTRYPOINT + CMD`. Without `--name`, the sandbox is ephemeral and removed when the command finishes. With `--name`, it persists for later use.
 
 ```bash
 # Ephemeral: runs and cleans up
@@ -26,9 +26,13 @@ msb run --name api \
   -w /app \
   python
 
-# Detached (boots in background; run work later with exec)
-msb run -d --name worker python
-msb exec worker -- python worker.py
+# Detached: run the resolved command in the background
+msb run -d --name worker python -- python worker.py
+msb logs -f worker
+
+# Boot an idle sandbox for later exec calls
+msb create --name devbox python
+msb exec devbox -- python -c "print('hello')"
 
 # Publish on all IPv4 host interfaces instead of the default 127.0.0.1
 msb run --name public-api -p 0.0.0.0:8000:8000 python
@@ -49,7 +53,7 @@ Common flags:
 | `-e`, `--env` | Set an environment variable |
 | `--label` | Attach a label for metric attribution (`KEY=VALUE`, or bare `KEY`). Repeatable |
 | `-w`, `--workdir` | Set the working directory |
-| `-d`, `--detach` | Boot in the background. Run work later with `msb exec` |
+| `-d`, `--detach` | Run the resolved image command in the background and print the sandbox name |
 | `--no-tty` | Disable PTY allocation and run non-interactively |
 | `--replace` | Replace an existing sandbox with the same name |
 | `--no-net` | Disable network access |

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -2576,7 +2576,7 @@ fn startup_command(config: &SandboxConfig) -> Option<StartupCommand> {
 }
 
 fn resolve_startup_command(config: &SandboxConfig) -> Option<(String, Vec<String>)> {
-    if !config.startup_command_requested {
+    if !config.should_launch_background_command() {
         return None;
     }
 
@@ -3054,7 +3054,7 @@ mod tests {
             .env("APP_ENV", "test")
             .workdir("/workspace")
             .user("nobody")
-            .persistent_initial_command(["/bin/sh", "-lc", "echo detached"])
+            .background_command(["/bin/sh", "-lc", "echo detached"])
             .build()
             .await
             .unwrap();
@@ -3068,6 +3068,23 @@ mod tests {
         assert!(rendered.contains(&"--startup-env=APP_ENV=test".to_string()));
         assert!(rendered.contains(&"--startup-cwd=/workspace".to_string()));
         assert!(rendered.contains(&"--startup-user=nobody".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_cli_args_include_detached_image_default_command() {
+        let mut config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .entrypoint(["/entrypoint"])
+            .build()
+            .await
+            .unwrap();
+        config.spec.runtime.cmd = Some(vec!["bash".to_string()]);
+        config.set_background_command(Vec::new());
+
+        let rendered = render_args(&config);
+
+        assert!(rendered.contains(&"--startup-cmd=/entrypoint".to_string()));
+        assert!(rendered.contains(&"--startup-arg=bash".to_string()));
     }
 
     #[tokio::test]
@@ -3108,7 +3125,7 @@ mod tests {
         let mut config = SandboxBuilder::new("test")
             .image("/tmp/rootfs")
             .workdir("/opt/hermes")
-            .persistent_initial_command(["gateway", "run"])
+            .background_command(["gateway", "run"])
             .build()
             .await
             .unwrap();
@@ -3121,7 +3138,7 @@ mod tests {
             ],
             env: Vec::new(),
         });
-        config.startup_command_requested = false;
+        config.clear_launch_intent();
 
         let rendered = render_args(&config);
 

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -379,22 +379,28 @@ impl SandboxBuilder {
         self
     }
 
-    /// Clear detached startup intent for attached CLI `run`.
+    /// Select the foreground command for attached CLI `run`.
     #[doc(hidden)]
-    pub fn initial_command(mut self, command: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        self.config
-            .set_initial_command(command.into_iter().map(Into::into).collect());
-        self
-    }
-
-    /// Set the persisted startup command for detached CLI `run`.
-    #[doc(hidden)]
-    pub fn persistent_initial_command(
+    pub fn foreground_command(
         mut self,
         command: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
         self.config
-            .set_persistent_initial_command(command.into_iter().map(Into::into).collect());
+            .set_foreground_command(command.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Select the background command for detached CLI `run`.
+    ///
+    /// An empty command uses the image's default CMD. A non-empty command replaces CMD while
+    /// preserving the effective OCI entrypoint.
+    #[doc(hidden)]
+    pub fn background_command(
+        mut self,
+        command: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.config
+            .set_background_command(command.into_iter().map(Into::into).collect());
         self
     }
 

--- a/sdk/rust/lib/sandbox/config.rs
+++ b/sdk/rust/lib/sandbox/config.rs
@@ -75,6 +75,27 @@ fn default_disable_metrics_sample() -> bool {
 // Types
 //--------------------------------------------------------------------------------------------------
 
+/// Transient intent for the initial process requested by a CLI operation.
+///
+/// Foreground commands remain separate from the durable OCI command because an attached
+/// `msb run` is one-shot. Background commands use `runtime.cmd` so the resolved startup shape is
+/// visible through inspect and preserved with the sandbox configuration.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) enum LaunchIntent {
+    /// Boot the sandbox without starting an initial workload.
+    #[default]
+    None,
+
+    /// Run the resolved OCI command through the foreground attach/exec path.
+    Foreground {
+        /// Optional one-shot CMD override supplied after `--`.
+        command: Option<Vec<String>>,
+    },
+
+    /// Run the resolved OCI command in the background after the guest agent is ready.
+    Background,
+}
+
 /// Configuration for a sandbox.
 ///
 /// The durable task description lives in [`SandboxSpec`]. This type keeps
@@ -139,13 +160,9 @@ pub struct SandboxConfig {
     #[serde(skip)]
     pub(crate) snapshot_upper_source: Option<PathBuf>,
 
-    /// Whether `runtime.cmd` should be launched by the sandbox process after boot.
+    /// Transient process-launch intent for the current create operation.
     #[serde(skip)]
-    pub(crate) startup_command_requested: bool,
-
-    /// One-shot foreground command requested by attached `msb run`.
-    #[serde(skip)]
-    pub(crate) initial_command: Option<Vec<String>>,
+    pub(crate) launch_intent: LaunchIntent,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -172,8 +189,7 @@ impl SandboxConfig {
     /// image-declared init entrypoints, passed to the init handoff as the container startup argv.
     pub(crate) fn clone_for_persistence(&self) -> Self {
         let mut config = self.clone();
-        config.startup_command_requested = false;
-        config.initial_command = None;
+        config.launch_intent = LaunchIntent::None;
         for mount in &mut config.spec.mounts {
             if let VolumeMount::Named { create, .. } = mount {
                 *create = None;
@@ -182,21 +198,33 @@ impl SandboxConfig {
         config
     }
 
-    /// Clear detached startup intent for attached `msb run`.
-    pub(crate) fn set_initial_command(&mut self, command: Vec<String>) {
-        self.initial_command = (!command.is_empty()).then_some(command);
-        self.startup_command_requested = false;
+    /// Select the foreground launch path for attached `msb run`.
+    pub(crate) fn set_foreground_command(&mut self, command: Vec<String>) {
+        self.launch_intent = LaunchIntent::Foreground {
+            command: (!command.is_empty()).then_some(command),
+        };
     }
 
-    /// Set startup initial command intent for detached `msb run -d`.
-    pub(crate) fn set_persistent_initial_command(&mut self, command: Vec<String>) {
+    /// Select the background launch path for detached `msb run -d`.
+    ///
+    /// A non-empty command replaces the image CMD while preserving the effective entrypoint. An
+    /// empty command intentionally keeps the image CMD so detached and attached runs resolve the
+    /// same OCI process.
+    pub(crate) fn set_background_command(&mut self, command: Vec<String>) {
         if !command.is_empty() {
-            self.spec.runtime.cmd = Some(command.clone());
-            self.startup_command_requested = true;
-        } else {
-            self.startup_command_requested = false;
+            self.spec.runtime.cmd = Some(command);
         }
-        self.initial_command = None;
+        self.launch_intent = LaunchIntent::Background;
+    }
+
+    /// Return whether this create operation should launch the resolved command in the background.
+    pub(crate) fn should_launch_background_command(&self) -> bool {
+        self.launch_intent == LaunchIntent::Background
+    }
+
+    /// Clear process-launch intent after another mechanism takes ownership of the command.
+    pub(crate) fn clear_launch_intent(&mut self) {
+        self.launch_intent = LaunchIntent::None;
     }
 
     /// Apply OCI image config as defaults. User-provided values take precedence.
@@ -286,10 +314,11 @@ impl SandboxConfig {
         {
             entrypoint.remove(0);
         }
-        let runtime_cmd = self
-            .initial_command
-            .as_deref()
-            .or(self.spec.runtime.cmd.as_deref());
+        let foreground_command = match &self.launch_intent {
+            LaunchIntent::Foreground { command } => command.as_deref(),
+            LaunchIntent::None | LaunchIntent::Background => None,
+        };
+        let runtime_cmd = foreground_command.or(self.spec.runtime.cmd.as_deref());
         let init_args = resolved_container_argv(&entrypoint, runtime_cmd);
 
         let init = self
@@ -303,8 +332,8 @@ impl SandboxConfig {
 
         // The startup command is now part of the PID 1 argv. Running it again through agentd would
         // both duplicate execution and bypass any state the image init establishes before execing.
-        if self.startup_command_requested {
-            self.startup_command_requested = false;
+        if self.should_launch_background_command() {
+            self.clear_launch_intent();
         }
         self.spec.runtime.entrypoint = (!entrypoint.is_empty()).then_some(entrypoint);
     }
@@ -605,8 +634,7 @@ impl Default for SandboxConfig {
             replace_with_timeout: DEFAULT_REPLACE_TIMEOUT,
             manifest_digest: None,
             snapshot_upper_source: None,
-            startup_command_requested: false,
-            initial_command: None,
+            launch_intent: LaunchIntent::None,
         }
     }
 }
@@ -792,7 +820,7 @@ mod tests {
             },
             ..Default::default()
         };
-        config.set_initial_command(vec!["gateway".to_string(), "run".to_string()]);
+        config.set_foreground_command(vec!["gateway".to_string(), "run".to_string()]);
         config.merge_image_defaults(&image);
 
         let init = config
@@ -848,7 +876,7 @@ mod tests {
             },
             ..Default::default()
         };
-        config.set_initial_command(vec!["gateway".to_string(), "run".to_string()]);
+        config.set_foreground_command(vec!["gateway".to_string(), "run".to_string()]);
         config.merge_image_defaults(&image);
 
         let init = config
@@ -889,7 +917,7 @@ mod tests {
             },
             ..Default::default()
         };
-        config.set_persistent_initial_command(vec!["gateway".to_string(), "run".to_string()]);
+        config.set_background_command(vec!["gateway".to_string(), "run".to_string()]);
         config.merge_image_defaults(&image);
 
         let init = config.spec.init.as_ref().expect("runtime init");
@@ -910,14 +938,14 @@ mod tests {
             config.spec.runtime.cmd,
             Some(vec!["gateway".to_string(), "run".to_string()])
         );
-        assert!(!config.startup_command_requested);
+        assert!(!config.should_launch_background_command());
     }
 
     #[test]
-    fn test_persistent_initial_command_sets_runtime_cmd() {
+    fn test_background_command_sets_runtime_cmd() {
         let mut config = SandboxConfig::default();
 
-        config.set_persistent_initial_command(vec![
+        config.set_background_command(vec![
             "/bin/sh".to_string(),
             "-lc".to_string(),
             "echo detached".to_string(),
@@ -931,10 +959,11 @@ mod tests {
                 "echo detached".to_string(),
             ])
         );
+        assert!(config.should_launch_background_command());
     }
 
     #[test]
-    fn test_empty_persistent_initial_command_keeps_runtime_cmd() {
+    fn test_empty_background_command_keeps_runtime_cmd() {
         let mut config = SandboxConfig {
             spec: SandboxSpec {
                 runtime: SandboxRuntimeOptions {
@@ -946,9 +975,38 @@ mod tests {
             ..Default::default()
         };
 
-        config.set_persistent_initial_command(Vec::new());
+        config.set_background_command(Vec::new());
 
         assert_eq!(config.spec.runtime.cmd, Some(vec!["python3".to_string()]));
+        assert!(config.should_launch_background_command());
+    }
+
+    #[test]
+    fn test_empty_background_command_uses_merged_image_cmd() {
+        let image = ImageConfig {
+            cmd: Some(vec!["bash".to_string()]),
+            ..Default::default()
+        };
+        let mut config = SandboxConfig {
+            spec: SandboxSpec {
+                runtime: SandboxRuntimeOptions {
+                    entrypoint: Some(vec!["start-desktop".to_string()]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        config.set_background_command(Vec::new());
+        config.merge_image_defaults(&image);
+
+        assert_eq!(
+            config.spec.runtime.entrypoint,
+            Some(vec!["start-desktop".to_string()])
+        );
+        assert_eq!(config.spec.runtime.cmd, Some(vec!["bash".to_string()]));
+        assert!(config.should_launch_background_command());
     }
 
     #[test]
@@ -1029,7 +1087,7 @@ mod tests {
             },
             ..Default::default()
         };
-        config.set_initial_command(Vec::new());
+        config.set_foreground_command(Vec::new());
         config.merge_image_defaults(&image);
 
         let init = config
@@ -1067,7 +1125,7 @@ mod tests {
             },
             ..Default::default()
         };
-        config.set_initial_command(vec!["bash".to_string()]);
+        config.set_foreground_command(vec!["bash".to_string()]);
         config.merge_image_defaults(&image);
 
         let init = config
@@ -1105,7 +1163,7 @@ mod tests {
             },
             ..Default::default()
         };
-        config.set_initial_command(vec!["gateway".to_string(), "run".to_string()]);
+        config.set_foreground_command(vec!["gateway".to_string(), "run".to_string()]);
         config.merge_image_defaults(&image);
 
         let init = config


### PR DESCRIPTION
## TL;DR
Make detached `msb run` launch the same resolved OCI command as attached runs. Keep `msb create` as the explicit way to boot an idle sandbox.

## Description
- Track foreground, background, and idle launch intent explicitly so command execution no longer depends on whether the CLI is attached.
- Preserve OCI command rules: an omitted command uses the image CMD, while a command after `--` replaces CMD and keeps the effective entrypoint.
- Keep image init handoff ownership intact so supervised entrypoints are not started twice.
- Update `msb run -d` help and CLI docs to direct idle workflows to `msb create`.
- Cover image, overridden, and script entrypoints with default and explicit commands in unit and end-to-end tests.

```bash
msb run -d --script start='exec dockerd' --entrypoint start docker:dind

msb create --name devbox python
msb exec devbox -- python -c "print('hello')"
```

## Test Plan
- [x] `cargo fmt --all -- --check` exits 0
- [x] `cargo test -p microsandbox -p microsandbox-cli` passes
- [x] `cargo build --no-default-features --features net,ssh -p microsandbox-cli` succeeds and the resulting `msb` binary passes `codesign --verify`
- [x] Repository pre-commit hooks pass, including workspace Clippy, agentd Clippy, docs, and CLI build checks
- [x] A 15-case attached, detached, and idle runtime matrix passes with image, overridden, and script entrypoints