### PR TITLE
feat(db): attribute pool exhaustion by pool and count retries

### DIFF
--- a/crates/db/lib/connection.rs
+++ b/crates/db/lib/connection.rs
@@ -17,8 +17,9 @@ use sea_orm::{
     ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, DbErr, ExecResult,
     QueryResult, Statement, TransactionTrait,
 };
+use sqlx::SqlitePool;
 
-use crate::{pool, retry, retry::IsSqliteBusy};
+use crate::{pool, retry, retry::IsSqliteBusy, stats::DbStats};
 
 /// Read pool. Multi-connection; concurrent reads enabled by WAL mode.
 ///
@@ -30,7 +31,11 @@ use crate::{pool, retry, retry::IsSqliteBusy};
 /// `Clone` is cheap: the inner `DatabaseConnection` holds an `Arc` over
 /// the underlying sqlx pool, so clones share connection state.
 #[derive(Debug, Clone)]
-pub struct DbReadConnection(DatabaseConnection);
+pub struct DbReadConnection {
+    inner: DatabaseConnection,
+    pool: Option<SqlitePool>,
+    stats: DbStats,
+}
 
 /// Write pool. Single connection; serialises in-process writes so the
 /// SQLite writer lock is never contested from within one process.
@@ -42,12 +47,54 @@ pub struct DbReadConnection(DatabaseConnection);
 /// `Clone` is cheap: the inner `DatabaseConnection` holds an `Arc` over
 /// the underlying sqlx pool, so clones share the same single connection.
 #[derive(Debug, Clone)]
-pub struct DbWriteConnection(DatabaseConnection);
+pub struct DbWriteConnection {
+    inner: DatabaseConnection,
+    pool: Option<SqlitePool>,
+    stats: DbStats,
+}
+
+/// When `err` is a pool-acquisition timeout: count it, log the pool's live
+/// occupancy, and rewrite the message to name the pool that was exhausted.
+/// Every other error (including `SQLITE_BUSY`) passes through untouched so
+/// busy classification keeps working.
+fn note_pool_timeout(
+    err: DbErr,
+    kind: &'static str,
+    pool: Option<&SqlitePool>,
+    stats: &DbStats,
+) -> DbErr {
+    if !retry::is_pool_timeout(&err) {
+        return err;
+    }
+    stats.record_pool_timeout();
+    match pool {
+        Some(pool) => {
+            let (size, idle) = (pool.size(), pool.num_idle());
+            tracing::warn!(
+                pool = kind,
+                connections = size,
+                idle,
+                "catalog pool acquisition timed out"
+            );
+            DbErr::Custom(format!(
+                "{kind} pool exhausted ({size} connections, {idle} idle): {err}"
+            ))
+        }
+        None => {
+            tracing::warn!(pool = kind, "catalog pool acquisition timed out");
+            DbErr::Custom(format!("{kind} pool exhausted: {err}"))
+        }
+    }
+}
 
 impl DbReadConnection {
     /// Wrap a sea-orm connection as a read pool.
     pub fn new(inner: DatabaseConnection) -> Self {
-        Self(inner)
+        Self {
+            inner,
+            pool: None,
+            stats: DbStats::new(),
+        }
     }
 
     /// Open a stand-alone read pool at `db_path` with shared PRAGMAs.
@@ -60,7 +107,7 @@ impl DbReadConnection {
         connect_timeout: Duration,
         busy_timeout: Duration,
     ) -> Result<Self, sqlx::Error> {
-        let conn = pool::build_pool(
+        let (inner, pool) = pool::build_pool(
             db_path,
             max_connections,
             connect_timeout,
@@ -68,19 +115,32 @@ impl DbReadConnection {
             false,
         )
         .await?;
-        Ok(Self(conn))
+        Ok(Self {
+            inner,
+            pool: Some(pool),
+            stats: DbStats::new(),
+        })
     }
 
     /// Borrow the underlying sea-orm connection.
     pub fn inner(&self) -> &DatabaseConnection {
-        &self.0
+        &self.inner
+    }
+
+    /// Counters recorded by this connection (shared across clones).
+    pub fn stats(&self) -> &DbStats {
+        &self.stats
     }
 }
 
 impl DbWriteConnection {
     /// Wrap a sea-orm connection as a write pool.
     pub fn new(inner: DatabaseConnection) -> Self {
-        Self(inner)
+        Self {
+            inner,
+            pool: None,
+            stats: DbStats::new(),
+        }
     }
 
     /// Open a stand-alone single-connection write pool at `db_path`.
@@ -92,13 +152,23 @@ impl DbWriteConnection {
         connect_timeout: Duration,
         busy_timeout: Duration,
     ) -> Result<Self, sqlx::Error> {
-        let conn = pool::build_pool(db_path, 1, connect_timeout, busy_timeout, true).await?;
-        Ok(Self(conn))
+        let (inner, pool) =
+            pool::build_pool(db_path, 1, connect_timeout, busy_timeout, true).await?;
+        Ok(Self {
+            inner,
+            pool: Some(pool),
+            stats: DbStats::new(),
+        })
     }
 
     /// Borrow the underlying sea-orm connection.
     pub fn inner(&self) -> &DatabaseConnection {
-        &self.0
+        &self.inner
+    }
+
+    /// Counters recorded by this connection (shared across clones).
+    pub fn stats(&self) -> &DbStats {
+        &self.stats
     }
 
     /// Run a multi-statement atomic write inside a transaction with
@@ -123,12 +193,15 @@ impl DbWriteConnection {
         T: Send,
         E: From<DbErr> + IsSqliteBusy,
     {
-        retry::retry_on_busy(|| async {
-            let txn = self.0.begin().await?;
-            let (txn, value) = f(txn).await?;
-            txn.commit().await?;
-            Ok(value)
-        })
+        retry::retry_on_busy_with_stats(
+            || async {
+                let txn = self.inner.begin().await?;
+                let (txn, value) = f(txn).await?;
+                txn.commit().await?;
+                Ok(value)
+            },
+            Some(&self.stats),
+        )
         .await
     }
 }
@@ -136,31 +209,43 @@ impl DbWriteConnection {
 #[async_trait::async_trait]
 impl ConnectionTrait for DbReadConnection {
     fn get_database_backend(&self) -> DbBackend {
-        self.0.get_database_backend()
+        self.inner.get_database_backend()
     }
 
     async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
-        self.0.execute(stmt).await
+        self.inner
+            .execute(stmt)
+            .await
+            .map_err(|e| note_pool_timeout(e, "read", self.pool.as_ref(), &self.stats))
     }
 
     async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
-        self.0.execute_unprepared(sql).await
+        self.inner
+            .execute_unprepared(sql)
+            .await
+            .map_err(|e| note_pool_timeout(e, "read", self.pool.as_ref(), &self.stats))
     }
 
     async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
-        self.0.query_one(stmt).await
+        self.inner
+            .query_one(stmt)
+            .await
+            .map_err(|e| note_pool_timeout(e, "read", self.pool.as_ref(), &self.stats))
     }
 
     async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
-        self.0.query_all(stmt).await
+        self.inner
+            .query_all(stmt)
+            .await
+            .map_err(|e| note_pool_timeout(e, "read", self.pool.as_ref(), &self.stats))
     }
 
     fn support_returning(&self) -> bool {
-        self.0.support_returning()
+        self.inner.support_returning()
     }
 
     fn is_mock_connection(&self) -> bool {
-        self.0.is_mock_connection()
+        self.inner.is_mock_connection()
     }
 }
 
@@ -178,31 +263,51 @@ impl ConnectionTrait for DbReadConnection {
 #[async_trait::async_trait]
 impl ConnectionTrait for DbWriteConnection {
     fn get_database_backend(&self) -> DbBackend {
-        self.0.get_database_backend()
+        self.inner.get_database_backend()
     }
 
     async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
-        retry::retry_on_busy(|| async { self.0.execute(stmt.clone()).await }).await
+        retry::retry_on_busy_with_stats(
+            || async { self.inner.execute(stmt.clone()).await },
+            Some(&self.stats),
+        )
+        .await
+        .map_err(|e| note_pool_timeout(e, "write", self.pool.as_ref(), &self.stats))
     }
 
     async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
-        retry::retry_on_busy(|| async { self.0.execute_unprepared(sql).await }).await
+        retry::retry_on_busy_with_stats(
+            || async { self.inner.execute_unprepared(sql).await },
+            Some(&self.stats),
+        )
+        .await
+        .map_err(|e| note_pool_timeout(e, "write", self.pool.as_ref(), &self.stats))
     }
 
     async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
-        retry::retry_on_busy(|| async { self.0.query_one(stmt.clone()).await }).await
+        retry::retry_on_busy_with_stats(
+            || async { self.inner.query_one(stmt.clone()).await },
+            Some(&self.stats),
+        )
+        .await
+        .map_err(|e| note_pool_timeout(e, "write", self.pool.as_ref(), &self.stats))
     }
 
     async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
-        retry::retry_on_busy(|| async { self.0.query_all(stmt.clone()).await }).await
+        retry::retry_on_busy_with_stats(
+            || async { self.inner.query_all(stmt.clone()).await },
+            Some(&self.stats),
+        )
+        .await
+        .map_err(|e| note_pool_timeout(e, "write", self.pool.as_ref(), &self.stats))
     }
 
     fn support_returning(&self) -> bool {
-        self.0.support_returning()
+        self.inner.support_returning()
     }
 
     fn is_mock_connection(&self) -> bool {
-        self.0.is_mock_connection()
+        self.inner.is_mock_connection()
     }
 }
 
@@ -242,6 +347,69 @@ mod tests {
         assert!(
             db_path.exists(),
             "write open should create the catalog db file"
+        );
+    }
+
+    #[tokio::test]
+    async fn pool_timeout_is_attributed_and_counted() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("catalog.db");
+
+        // Single-connection write pool with a short acquire timeout.
+        let conn = DbWriteConnection::open(&db_path, Duration::from_millis(100), TIMEOUT)
+            .await
+            .unwrap();
+
+        // Hold the only connection so the next operation must time out
+        // acquiring from the pool.
+        let _txn = conn.inner().begin().await.unwrap();
+
+        let err = conn.execute_unprepared("SELECT 1").await.unwrap_err();
+
+        assert!(
+            err.to_string().contains("write pool exhausted"),
+            "error should name the exhausted pool, got: {err}"
+        );
+        assert!(
+            !retry::is_sqlite_busy(&err),
+            "an attributed pool timeout must not classify as SQLITE_BUSY"
+        );
+        assert_eq!(conn.stats().snapshot().pool_timeouts, 1);
+        assert_eq!(conn.stats().snapshot().busy_retries, 0);
+    }
+
+    #[tokio::test]
+    async fn sqlite_busy_passes_through_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("catalog.db");
+
+        let a = DbWriteConnection::open(&db_path, TIMEOUT, Duration::from_millis(10))
+            .await
+            .unwrap();
+        let b = DbWriteConnection::open(&db_path, TIMEOUT, Duration::from_millis(10))
+            .await
+            .unwrap();
+
+        // Hold the SQLite writer lock from `a` via an open transaction.
+        let txn = a.inner().begin().await.unwrap();
+        txn.execute_unprepared("CREATE TABLE held (x INTEGER)")
+            .await
+            .unwrap();
+
+        // Bypass the retry wrapper so we see the raw error `b` gets.
+        let err = b
+            .inner()
+            .execute_unprepared("CREATE TABLE blocked (x INTEGER)")
+            .await
+            .unwrap_err();
+
+        assert!(
+            retry::is_sqlite_busy(&err),
+            "contended write should classify as SQLITE_BUSY, got: {err}"
+        );
+        assert!(
+            !retry::is_pool_timeout(&err),
+            "SQLITE_BUSY must not classify as a pool timeout"
         );
     }
 }

--- a/crates/db/lib/lib.rs
+++ b/crates/db/lib/lib.rs
@@ -16,5 +16,7 @@ pub mod connection;
 pub mod entity;
 pub mod pool;
 pub mod retry;
+pub mod stats;
 
 pub use connection::{DbReadConnection, DbWriteConnection};
+pub use stats::{DbStats, DbStatsSnapshot};

--- a/crates/db/lib/pool.rs
+++ b/crates/db/lib/pool.rs
@@ -8,6 +8,7 @@
 use std::{path::Path, time::Duration};
 
 use sea_orm::{DatabaseConnection, SqlxSqliteConnector};
+use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 
 use crate::connection::{DbReadConnection, DbWriteConnection};
@@ -75,13 +76,17 @@ impl DbPools {
 /// `create_if_missing` controls whether opening a non-existent DB file creates
 /// it. The write side (owned by `msb`) creates the catalog; read-only consumers
 /// (e.g. `msb-metrics`) pass `false` so they never author or pre-empt it.
+///
+/// Returns the sea-orm connection plus the underlying sqlx pool handle, so
+/// the connection wrappers can report live pool occupancy when acquisition
+/// times out.
 pub(crate) async fn build_pool(
     db_path: &Path,
     max_connections: u32,
     connect_timeout: Duration,
     busy_timeout: Duration,
     create_if_missing: bool,
-) -> Result<DatabaseConnection, sqlx::Error> {
+) -> Result<(DatabaseConnection, SqlitePool), sqlx::Error> {
     let connect_options = SqliteConnectOptions::new()
         .filename(db_path)
         .create_if_missing(create_if_missing)
@@ -96,5 +101,8 @@ pub(crate) async fn build_pool(
         .connect_with(connect_options)
         .await?;
 
-    Ok(SqlxSqliteConnector::from_sqlx_sqlite_pool(pool))
+    Ok((
+        SqlxSqliteConnector::from_sqlx_sqlite_pool(pool.clone()),
+        pool,
+    ))
 }

--- a/crates/db/lib/retry.rs
+++ b/crates/db/lib/retry.rs
@@ -6,7 +6,9 @@
 
 use std::{future::Future, time::Duration};
 
-use sea_orm::{DbErr, RuntimeErr};
+use sea_orm::{ConnAcquireErr, DbErr, RuntimeErr};
+
+use crate::stats::DbStats;
 
 /// SQLite extended error codes for "another writer holds the lock".
 ///
@@ -34,6 +36,25 @@ pub fn is_sqlite_busy(err: &DbErr) -> bool {
         db_err.code().as_deref(),
         Some(SQLITE_BUSY) | Some(SQLITE_BUSY_SNAPSHOT)
     )
+}
+
+/// Returns `true` if `err` is a pool-acquisition timeout — the pool had no
+/// free connection within `acquire_timeout`.
+///
+/// sea-orm surfaces this as `DbErr::ConnectionAcquire(Timeout)`; sqlx
+/// errors reaching us through other variants appear as `PoolTimedOut`.
+///
+/// Distinct from [`is_sqlite_busy`]: a busy error comes from SQLite's lock
+/// after a connection was acquired, a pool timeout means acquisition itself
+/// failed. The two never overlap, so busy classification is unaffected.
+pub fn is_pool_timeout(err: &DbErr) -> bool {
+    match err {
+        DbErr::ConnectionAcquire(ConnAcquireErr::Timeout) => true,
+        DbErr::Conn(e) | DbErr::Exec(e) | DbErr::Query(e) => {
+            matches!(e, RuntimeErr::SqlxError(sqlx::Error::PoolTimedOut))
+        }
+        _ => false,
+    }
 }
 
 /// Trait for application error types so the retry layer can recognise
@@ -67,7 +88,21 @@ impl IsSqliteBusy for DbErr {
 /// should wrap the call in a `tracing::info_span!` or apply `#[instrument]`
 /// to the calling function — the warnings emitted here pick up the current
 /// span automatically.
-pub async fn retry_on_busy<F, Fut, T, E>(mut f: F) -> Result<T, E>
+pub async fn retry_on_busy<F, Fut, T, E>(f: F) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: IsSqliteBusy,
+{
+    retry_on_busy_with_stats(f, None).await
+}
+
+/// [`retry_on_busy`] variant that also records each busy retry (and retry
+/// exhaustion) into `stats`, when provided.
+pub async fn retry_on_busy_with_stats<F, Fut, T, E>(
+    mut f: F,
+    stats: Option<&DbStats>,
+) -> Result<T, E>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, E>>,
@@ -83,6 +118,9 @@ where
                 return Ok(value);
             }
             Err(err) if err.is_sqlite_busy() && attempt < MAX_BUSY_RETRY_ATTEMPTS => {
+                if let Some(stats) = stats {
+                    stats.record_busy_retry();
+                }
                 tracing::warn!(
                     attempt,
                     delay_ms = delay.as_millis() as u64,
@@ -92,6 +130,9 @@ where
                 delay = (delay * 2).min(MAX_DELAY);
             }
             Err(err) if err.is_sqlite_busy() => {
+                if let Some(stats) = stats {
+                    stats.record_retries_exhausted();
+                }
                 tracing::error!(
                     attempts = attempt,
                     "SQLITE_BUSY exhausted retries, giving up"
@@ -102,4 +143,75 @@ where
         }
     }
     unreachable!("loop returns or errors before exhausting attempts")
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestErr {
+        busy: bool,
+    }
+
+    impl IsSqliteBusy for TestErr {
+        fn is_sqlite_busy(&self) -> bool {
+            self.busy
+        }
+    }
+
+    #[test]
+    fn pool_timeout_classifies_distinctly_from_busy() {
+        let acquire = DbErr::ConnectionAcquire(ConnAcquireErr::Timeout);
+        let sqlx_level = DbErr::Conn(RuntimeErr::SqlxError(sqlx::Error::PoolTimedOut));
+
+        assert!(is_pool_timeout(&acquire));
+        assert!(is_pool_timeout(&sqlx_level));
+        assert!(!is_sqlite_busy(&acquire));
+        assert!(!is_sqlite_busy(&sqlx_level));
+    }
+
+    #[tokio::test]
+    async fn busy_retries_are_counted() {
+        let stats = DbStats::new();
+        let attempts = AtomicU32::new(0);
+
+        let result = retry_on_busy_with_stats(
+            || async {
+                if attempts.fetch_add(1, Ordering::SeqCst) < 2 {
+                    Err(TestErr { busy: true })
+                } else {
+                    Ok(())
+                }
+            },
+            Some(&stats),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(stats.snapshot().busy_retries, 2);
+        assert_eq!(stats.snapshot().retries_exhausted, 0);
+    }
+
+    #[tokio::test]
+    async fn exhausted_retries_are_counted() {
+        let stats = DbStats::new();
+
+        let result: Result<(), TestErr> =
+            retry_on_busy_with_stats(|| async { Err(TestErr { busy: true }) }, Some(&stats)).await;
+
+        assert!(result.is_err());
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.retries_exhausted, 1);
+        assert_eq!(
+            snapshot.busy_retries,
+            u64::from(MAX_BUSY_RETRY_ATTEMPTS) - 1
+        );
+    }
 }

--- a/crates/db/lib/stats.rs
+++ b/crates/db/lib/stats.rs
@@ -1,0 +1,87 @@
+//! Lightweight counters for catalog database health.
+//!
+//! Hosts running many sandboxes can exhaust the catalog connection pools;
+//! these counters let host processes export how often pool acquisition
+//! timed out or writes had to retry on `SQLITE_BUSY`, without pulling a
+//! metrics framework into this crate.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+/// Shared counters recorded by the connection wrappers and retry loop.
+///
+/// `Clone` is cheap: clones share the same `Arc`-backed counters, so a
+/// snapshot taken from any clone reflects the whole connection's history.
+#[derive(Debug, Clone, Default)]
+pub struct DbStats(Arc<Counters>);
+
+#[derive(Debug, Default)]
+struct Counters {
+    pool_timeouts: AtomicU64,
+    busy_retries: AtomicU64,
+    retries_exhausted: AtomicU64,
+}
+
+/// Point-in-time copy of [`DbStats`] counters, for export by host processes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DbStatsSnapshot {
+    /// Operations that failed because pool acquisition timed out.
+    pub pool_timeouts: u64,
+    /// Individual retries performed after `SQLITE_BUSY` / `BUSY_SNAPSHOT`.
+    pub busy_retries: u64,
+    /// Operations that gave up after exhausting all busy retries.
+    pub retries_exhausted: u64,
+}
+
+impl DbStats {
+    /// Create a fresh set of zeroed counters.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Copy the current counter values.
+    pub fn snapshot(&self) -> DbStatsSnapshot {
+        DbStatsSnapshot {
+            pool_timeouts: self.0.pool_timeouts.load(Ordering::Relaxed),
+            busy_retries: self.0.busy_retries.load(Ordering::Relaxed),
+            retries_exhausted: self.0.retries_exhausted.load(Ordering::Relaxed),
+        }
+    }
+
+    pub(crate) fn record_pool_timeout(&self) {
+        self.0.pool_timeouts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_busy_retry(&self) {
+        self.0.busy_retries.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_retries_exhausted(&self) {
+        self.0.retries_exhausted.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clones_share_counters() {
+        let stats = DbStats::new();
+        let clone = stats.clone();
+
+        stats.record_pool_timeout();
+        clone.record_busy_retry();
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.pool_timeouts, 1);
+        assert_eq!(snapshot.busy_retries, 1);
+        assert_eq!(snapshot.retries_exhausted, 0);
+    }
+}


### PR DESCRIPTION
On hosts running many sandboxes concurrently, catalog operations can exhaust the sqlite connection pools, and the resulting error (`Failed to acquire connection from pool: Connection pool timed out`) doesn't say which pool was exhausted or how contended it was.

This PR:
- classifies pool-acquisition timeouts distinctly from `SQLITE_BUSY` (`is_pool_timeout`, covering both sea-orm's `ConnectionAcquire(Timeout)` and raw sqlx `PoolTimedOut`);
- rewrites the error to name the pool with its live occupancy, e.g. `read pool exhausted (5 connections, 0 idle): …`;
- adds a `DbStats` counter set (pool timeouts, busy retries, retry exhaustion) exposed from `DbReadConnection`/`DbWriteConnection` so host processes can export them.

No public API changes: existing constructors and `retry_on_busy` keep their signatures, and busy classification is untouched (covered by tests). `cargo test -p microsandbox-db` 8/8; `cargo check` clean for microsandbox, runtime, metrics-collector, and cli.