### PR TITLE
refactor(db): drop remote field; dispatch transaction on inner variant

### DIFF
--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -569,7 +569,7 @@ mod tests {
         use std::io::Write;
 
         let launch = LaunchConfig {
-            db_path: PathBuf::from("/tmp/x.db"),
+            db_path: "/tmp/x.db".to_string(),
             env: vec!["TOKEN=secret".to_string()],
             ..Default::default()
         };
@@ -580,7 +580,7 @@ mod tests {
         let args = args_with(None, Some(file.path().to_path_buf()));
         let loaded = load_launch_config(&args).unwrap();
 
-        assert_eq!(loaded.db_path, PathBuf::from("/tmp/x.db"));
+        assert_eq!(loaded.db_path, "/tmp/x.db");
         assert_eq!(loaded.env, vec!["TOKEN=secret".to_string()]);
     }
 

--- a/crates/db/lib/connection.rs
+++ b/crates/db/lib/connection.rs
@@ -221,7 +221,6 @@ impl DbWriteConnection {
             inner,
             pool: Some(pool),
             stats: DbStats::new(),
-            remote: None,
         })
     }
 

--- a/crates/db/lib/connection.rs
+++ b/crates/db/lib/connection.rs
@@ -19,7 +19,7 @@ use sea_orm::{
 };
 use sqlx::SqlitePool;
 
-use crate::{pool, retry, retry::IsSqliteBusy, stats::DbStats};
+use crate::{DbTarget, pool, retry, retry::IsSqliteBusy, stats::DbStats, target::TargetKind};
 
 /// Read pool. Multi-connection; concurrent reads enabled by WAL mode.
 ///
@@ -103,16 +103,37 @@ impl DbReadConnection {
         }
     }
 
-    /// Open a stand-alone read pool at `db_path` with shared PRAGMAs.
+    /// Open a stand-alone read pool for a database target — a SQLite file
+    /// path (bare or `sqlite://`), or a `libsql://` server URL.
     ///
-    /// Read-only: opening a non-existent DB fails rather than creating it, so a
-    /// read consumer never authors or pre-empts the database owned by `msb`.
+    /// The file backend is read-only: opening a non-existent DB fails rather
+    /// than creating it, so a read consumer never authors or pre-empts the
+    /// database owned by `msb`. On a server target, `max_connections` bounds
+    /// concurrent in-flight reads and `connect_timeout` bounds admission.
     pub async fn open(
+        target: impl Into<DbTarget>,
+        max_connections: u32,
+        connect_timeout: Duration,
+        busy_timeout: Duration,
+    ) -> Result<Self, DbErr> {
+        match target.into().kind() {
+            TargetKind::File(path) => {
+                Self::open_file(path, max_connections, connect_timeout, busy_timeout).await
+            }
+            TargetKind::Remote(url) => {
+                Self::open_remote(url, max_connections, connect_timeout, busy_timeout).await
+            }
+            TargetKind::Unsupported(raw) => Err(crate::unsupported_target(raw)),
+        }
+    }
+
+    /// Open the read side of the file backend at `db_path`.
+    async fn open_file(
         db_path: &Path,
         max_connections: u32,
         connect_timeout: Duration,
         busy_timeout: Duration,
-    ) -> Result<Self, sqlx::Error> {
+    ) -> Result<Self, DbErr> {
         let (inner, pool) = pool::build_pool(
             db_path,
             max_connections,
@@ -120,7 +141,8 @@ impl DbReadConnection {
             busy_timeout,
             false,
         )
-        .await?;
+        .await
+        .map_err(|e| DbErr::Conn(sea_orm::RuntimeErr::SqlxError(e)))?;
         Ok(Self {
             inner,
             pool: Some(pool),
@@ -128,11 +150,8 @@ impl DbReadConnection {
         })
     }
 
-    /// Open a read proxy to a remote database server (`sqld`) at `url`.
-    ///
-    /// `max_connections` bounds concurrent in-flight reads exactly like the
-    /// file backend's pool size; `connect_timeout` bounds admission waits.
-    pub async fn open_url(
+    /// Open the read side of the remote backend at the normalized `url`.
+    async fn open_remote(
         url: &str,
         max_connections: u32,
         connect_timeout: Duration,
@@ -170,11 +189,44 @@ impl DbWriteConnection {
         }
     }
 
-    /// Open a write proxy to a remote database server (`sqld`) at `url`.
+    /// Open a stand-alone single-connection write pool for a database target —
+    /// a SQLite file path (bare or `sqlite://`), or a `libsql://` server URL.
     ///
-    /// Single-connection like the file backend; `connect_timeout` bounds
-    /// admission waits and `busy_timeout` derives the per-request bound.
-    pub async fn open_url(
+    /// Used by callers that don't need a paired read pool (e.g. the in-VM
+    /// runtime, which only writes run records). Single-connection on both
+    /// backends; on a server target `connect_timeout` bounds admission waits
+    /// and `busy_timeout` derives the per-request bound.
+    pub async fn open(
+        target: impl Into<DbTarget>,
+        connect_timeout: Duration,
+        busy_timeout: Duration,
+    ) -> Result<Self, DbErr> {
+        match target.into().kind() {
+            TargetKind::File(path) => Self::open_file(path, connect_timeout, busy_timeout).await,
+            TargetKind::Remote(url) => Self::open_remote(url, connect_timeout, busy_timeout).await,
+            TargetKind::Unsupported(raw) => Err(crate::unsupported_target(raw)),
+        }
+    }
+
+    /// Open the write side of the file backend at `db_path`.
+    async fn open_file(
+        db_path: &Path,
+        connect_timeout: Duration,
+        busy_timeout: Duration,
+    ) -> Result<Self, DbErr> {
+        let (inner, pool) = pool::build_pool(db_path, 1, connect_timeout, busy_timeout, true)
+            .await
+            .map_err(|e| DbErr::Conn(sea_orm::RuntimeErr::SqlxError(e)))?;
+        Ok(Self {
+            inner,
+            pool: Some(pool),
+            stats: DbStats::new(),
+            remote: None,
+        })
+    }
+
+    /// Open the write side of the remote backend at the normalized `url`.
+    async fn open_remote(
         url: &str,
         connect_timeout: Duration,
         busy_timeout: Duration,
@@ -184,24 +236,6 @@ impl DbWriteConnection {
         Ok(Self {
             inner,
             pool: None,
-            stats: DbStats::new(),
-        })
-    }
-
-    /// Open a stand-alone single-connection write pool at `db_path`.
-    ///
-    /// Used by callers that don't need a paired read pool (e.g. the in-VM
-    /// runtime, which only writes run records).
-    pub async fn open(
-        db_path: &Path,
-        connect_timeout: Duration,
-        busy_timeout: Duration,
-    ) -> Result<Self, sqlx::Error> {
-        let (inner, pool) =
-            pool::build_pool(db_path, 1, connect_timeout, busy_timeout, true).await?;
-        Ok(Self {
-            inner,
-            pool: Some(pool),
             stats: DbStats::new(),
         })
     }
@@ -416,10 +450,67 @@ mod tests {
     const TIMEOUT: Duration = Duration::from_secs(5);
 
     #[tokio::test]
+    async fn write_open_accepts_bare_string_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("msb.db");
+
+        let target = db_path.to_string_lossy().into_owned();
+        DbWriteConnection::open(&target, TIMEOUT, TIMEOUT)
+            .await
+            .unwrap();
+        assert!(db_path.exists());
+    }
+
+    #[tokio::test]
+    async fn write_open_accepts_sqlite_scheme_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("msb.db");
+
+        let target = format!("sqlite://{}", db_path.display());
+        DbWriteConnection::open(&target, TIMEOUT, TIMEOUT)
+            .await
+            .unwrap();
+        assert!(db_path.exists());
+    }
+
+    #[tokio::test]
+    async fn open_unknown_scheme_is_a_clear_error() {
+        let err = DbWriteConnection::open("postgres://127.0.0.1:5432/db", TIMEOUT, TIMEOUT)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("not a supported database target"),
+            "got: {err}"
+        );
+    }
+
+    // A remote target must reach the connect path (and fail there when
+    // nothing listens), not die in parsing.
+    #[tokio::test]
+    async fn open_libsql_url_dispatches_to_the_remote_backend() {
+        let err = DbWriteConnection::open(
+            "libsql://127.0.0.1:9",
+            Duration::from_millis(300),
+            Duration::from_millis(300),
+        )
+        .await
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            !message.contains("not a supported database target"),
+            "libsql target must not be rejected as unsupported: {message}"
+        );
+        assert!(
+            !message.contains("`libsql` feature"),
+            "libsql target must not hit the missing-feature error: {message}"
+        );
+    }
+
+    #[tokio::test]
     async fn read_open_does_not_create_db() {
         // Existing directory, missing DB file.
         let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("catalog.db");
+        let db_path = dir.path().join("msb.db");
 
         let result = DbReadConnection::open(&db_path, 1, TIMEOUT, TIMEOUT).await;
 
@@ -433,7 +524,7 @@ mod tests {
     #[tokio::test]
     async fn write_open_creates_db() {
         let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("catalog.db");
+        let db_path = dir.path().join("msb.db");
 
         let conn = DbWriteConnection::open(&db_path, TIMEOUT, TIMEOUT).await;
 
@@ -447,7 +538,7 @@ mod tests {
     #[tokio::test]
     async fn pool_timeout_is_attributed_and_counted() {
         let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("catalog.db");
+        let db_path = dir.path().join("msb.db");
 
         // Single-connection write pool with a short acquire timeout.
         let conn = DbWriteConnection::open(&db_path, Duration::from_millis(100), TIMEOUT)
@@ -475,7 +566,7 @@ mod tests {
     #[tokio::test]
     async fn sqlite_busy_passes_through_unchanged() {
         let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("catalog.db");
+        let db_path = dir.path().join("msb.db");
 
         let a = DbWriteConnection::open(&db_path, TIMEOUT, Duration::from_millis(10))
             .await

--- a/crates/db/lib/lib.rs
+++ b/crates/db/lib/lib.rs
@@ -18,6 +18,16 @@ pub mod pool;
 mod remote;
 pub mod retry;
 pub mod stats;
+pub mod target;
 
 pub use connection::{DbReadConnection, DbWriteConnection};
 pub use stats::{DbStats, DbStatsSnapshot};
+pub use target::DbTarget;
+
+/// The error returned for a database target whose scheme this crate does not
+/// recognize.
+pub(crate) fn unsupported_target(target: &str) -> sea_orm::DbErr {
+    sea_orm::DbErr::Custom(format!(
+        "'{target}' is not a supported database target: use a file path, sqlite://, or libsql://"
+    ))
+}

--- a/crates/db/lib/pool.rs
+++ b/crates/db/lib/pool.rs
@@ -11,7 +11,10 @@ use sea_orm::{DatabaseConnection, SqlxSqliteConnector};
 use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 
-use crate::connection::{DbReadConnection, DbWriteConnection};
+use crate::{
+    DbTarget,
+    connection::{DbReadConnection, DbWriteConnection},
+};
 
 /// Default `busy_timeout` PRAGMA value used when a caller has no
 /// user-facing knob to plumb (e.g. the in-VM runtime, where the host
@@ -33,55 +36,25 @@ pub struct DbPools {
 }
 
 impl DbPools {
-    /// Open both pools for the SQLite file at `db_path` with shared PRAGMAs.
+    /// Open both pools for a database target — a SQLite file path (bare or
+    /// `sqlite://`), or a `libsql://` server URL.
     ///
     /// The write pool connects first so WAL mode (persisted in the database
     /// header) is set before the read pool opens. `max_read_connections`
     /// sizes only the read pool; the write pool is always single-connection
-    /// by design.
+    /// by design. On a server target, `connect_timeout` doubles as the
+    /// admission timeout and `busy_timeout` derives the per-request bound.
     pub async fn open(
-        db_path: &Path,
-        max_read_connections: u32,
-        connect_timeout: Duration,
-        busy_timeout: Duration,
-    ) -> Result<Self, sqlx::Error> {
-        let write = DbWriteConnection::open(db_path, connect_timeout, busy_timeout).await?;
-        let read =
-            DbReadConnection::open(db_path, max_read_connections, connect_timeout, busy_timeout)
-                .await?;
-        Ok(Self { read, write })
-    }
-
-    /// Open both pools for a database target: a SQLite file path, or a remote
-    /// server URL (`http://`, `https://`, `libsql://`).
-    ///
-    /// The remote backend reuses `connect_timeout` as its admission timeout
-    /// and derives a per-request bound from `busy_timeout` (see
-    /// `DbWriteConnection::open_url`).
-    pub async fn open_target(
-        target: &str,
+        target: impl Into<DbTarget>,
         max_read_connections: u32,
         connect_timeout: Duration,
         busy_timeout: Duration,
     ) -> Result<Self, sea_orm::DbErr> {
-        let is_url = target.starts_with("http://")
-            || target.starts_with("https://")
-            || target.starts_with("libsql://");
+        let target = target.into();
 
-        if !is_url {
-            return Self::open(
-                Path::new(target),
-                max_read_connections,
-                connect_timeout,
-                busy_timeout,
-            )
-            .await
-            .map_err(|e| sea_orm::DbErr::Conn(sea_orm::RuntimeErr::SqlxError(e)));
-        }
-
-        let write = DbWriteConnection::open_url(target, connect_timeout, busy_timeout).await?;
+        let write = DbWriteConnection::open(target.clone(), connect_timeout, busy_timeout).await?;
         let read =
-            DbReadConnection::open_url(target, max_read_connections, connect_timeout, busy_timeout)
+            DbReadConnection::open(target, max_read_connections, connect_timeout, busy_timeout)
                 .await?;
         Ok(Self { read, write })
     }

--- a/crates/db/lib/target.rs
+++ b/crates/db/lib/target.rs
@@ -1,0 +1,191 @@
+//! One connection string for every database backend.
+//!
+//! A database target is a bare filesystem path or `sqlite://` URL for the
+//! local SQLite file, or a `libsql://` URL for a self-hosted libSQL server
+//! (`sqld`). The connection openers accept either form through the same
+//! entry points and dispatch on the scheme.
+
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const SQLITE_SCHEME: &str = "sqlite://";
+const LIBSQL_SCHEME: &str = "libsql://";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Where the database lives: a local SQLite file or a self-hosted libSQL
+/// server.
+///
+/// Built infallibly from paths and strings so existing path-based callers
+/// keep working; an unrecognized scheme is rejected with a clear error when
+/// the target is opened, not while it is carried around.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DbTarget {
+    kind: TargetKind,
+}
+
+/// Parsed backend selection for a [`DbTarget`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TargetKind {
+    /// Local SQLite file.
+    File(PathBuf),
+    /// Remote server endpoint, normalized to the `http(s)://` URL the
+    /// libsql client connects to.
+    Remote(String),
+    /// A `scheme://` string this crate does not recognize.
+    Unsupported(String),
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl DbTarget {
+    /// Whether this target names a remote database server rather than a
+    /// local file. Unrecognized schemes count as remote-shaped: they are
+    /// URLs, and the open path reports them with their own error.
+    pub fn is_remote(&self) -> bool {
+        !matches!(self.kind, TargetKind::File(_))
+    }
+
+    pub(crate) fn kind(&self) -> &TargetKind {
+        &self.kind
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl From<&str> for DbTarget {
+    fn from(target: &str) -> Self {
+        // Self-hosted sqld speaks plain hrana-over-HTTP; on loopback there
+        // is no TLS to negotiate, so `libsql://host:port` normalizes to
+        // `http://host:port`. Explicit `http(s)://` passes through for
+        // callers that want to be literal about the transport.
+        let kind = if let Some(rest) = target.strip_prefix(SQLITE_SCHEME) {
+            TargetKind::File(PathBuf::from(rest))
+        } else if let Some(rest) = target.strip_prefix(LIBSQL_SCHEME) {
+            TargetKind::Remote(format!("http://{rest}"))
+        } else if target.starts_with("http://") || target.starts_with("https://") {
+            TargetKind::Remote(target.to_owned())
+        } else if target.contains("://") {
+            TargetKind::Unsupported(target.to_owned())
+        } else {
+            TargetKind::File(PathBuf::from(target))
+        };
+        Self { kind }
+    }
+}
+
+impl From<String> for DbTarget {
+    fn from(target: String) -> Self {
+        Self::from(target.as_str())
+    }
+}
+
+impl From<&String> for DbTarget {
+    fn from(target: &String) -> Self {
+        Self::from(target.as_str())
+    }
+}
+
+impl From<&Path> for DbTarget {
+    fn from(path: &Path) -> Self {
+        Self {
+            kind: TargetKind::File(path.to_path_buf()),
+        }
+    }
+}
+
+impl From<&PathBuf> for DbTarget {
+    fn from(path: &PathBuf) -> Self {
+        Self::from(path.as_path())
+    }
+}
+
+impl From<PathBuf> for DbTarget {
+    fn from(path: PathBuf) -> Self {
+        Self {
+            kind: TargetKind::File(path),
+        }
+    }
+}
+
+impl fmt::Display for DbTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            TargetKind::File(path) => write!(f, "{}", path.display()),
+            TargetKind::Remote(url) => write!(f, "{url}"),
+            TargetKind::Unsupported(raw) => write!(f, "{raw}"),
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_path_is_a_file_target() {
+        let target = DbTarget::from("/abs/path/msb.db");
+        assert_eq!(
+            target.kind(),
+            &TargetKind::File(PathBuf::from("/abs/path/msb.db"))
+        );
+        assert!(!target.is_remote());
+    }
+
+    #[test]
+    fn sqlite_scheme_is_a_file_target() {
+        let target = DbTarget::from("sqlite:///abs/path/msb.db");
+        assert_eq!(
+            target.kind(),
+            &TargetKind::File(PathBuf::from("/abs/path/msb.db"))
+        );
+    }
+
+    #[test]
+    fn libsql_scheme_normalizes_to_http() {
+        let target = DbTarget::from("libsql://127.0.0.1:8890");
+        assert_eq!(
+            target.kind(),
+            &TargetKind::Remote("http://127.0.0.1:8890".to_owned())
+        );
+        assert!(target.is_remote());
+    }
+
+    #[test]
+    fn http_urls_pass_through() {
+        let target = DbTarget::from("https://db.example:8890");
+        assert_eq!(
+            target.kind(),
+            &TargetKind::Remote("https://db.example:8890".to_owned())
+        );
+    }
+
+    #[test]
+    fn unknown_scheme_is_unsupported() {
+        let target = DbTarget::from("postgres://127.0.0.1:5432/db");
+        assert!(matches!(target.kind(), TargetKind::Unsupported(_)));
+    }
+
+    #[test]
+    fn paths_never_parse_as_urls() {
+        let path = PathBuf::from("libsql:%2F%2Fodd dir/msb.db");
+        let target = DbTarget::from(&path);
+        assert_eq!(target.kind(), &TargetKind::File(path));
+    }
+}

--- a/crates/db/tests/remote_libsql.rs
+++ b/crates/db/tests/remote_libsql.rs
@@ -82,10 +82,9 @@ mod tests {
             })
             .await;
 
-        let read =
-            DbReadConnection::open(&url, READ_CONNECTIONS, ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
-                .await
-                .expect("open read proxy");
+        let read = DbReadConnection::open(&url, READ_CONNECTIONS, ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
+            .await
+            .expect("open read proxy");
 
         (read, write)
     }

--- a/crates/db/tests/remote_libsql.rs
+++ b/crates/db/tests/remote_libsql.rs
@@ -5,7 +5,7 @@
 //!
 //! ```text
 //! sqld --db-path /tmp/msb-libsql-test --http-listen-addr 127.0.0.1:8890
-//! MSB_TEST_LIBSQL_URL=http://127.0.0.1:8890 cargo test -p microsandbox-db --test remote_libsql -- --ignored
+//! MSB_TEST_LIBSQL_URL=libsql://127.0.0.1:8890 cargo test -p microsandbox-db --test remote_libsql -- --ignored
 //! ```
 
 mod tests {
@@ -69,7 +69,7 @@ mod tests {
     async fn setup() -> (DbReadConnection, DbWriteConnection) {
         let url = server_url();
 
-        let write = DbWriteConnection::open_url(&url, ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
+        let write = DbWriteConnection::open(&url, ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
             .await
             .expect("open write proxy");
 
@@ -83,7 +83,7 @@ mod tests {
             .await;
 
         let read =
-            DbReadConnection::open_url(&url, READ_CONNECTIONS, ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
+            DbReadConnection::open(&url, READ_CONNECTIONS, ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
                 .await
                 .expect("open read proxy");
 
@@ -276,7 +276,7 @@ mod tests {
         }
 
         fn url(&self) -> String {
-            format!("http://127.0.0.1:{}", self.port)
+            format!("libsql://127.0.0.1:{}", self.port)
         }
 
         /// SIGKILL the server, then bring it back on the same database.
@@ -292,7 +292,7 @@ mod tests {
         async fn wait_ready(&self) {
             let deadline = std::time::Instant::now() + Duration::from_secs(30);
             loop {
-                let probe = DbWriteConnection::open_url(
+                let probe = DbWriteConnection::open(
                     &self.url(),
                     Duration::from_secs(1),
                     Duration::from_secs(1),
@@ -326,7 +326,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let mut server = TestServer::spawn(dir.path().to_owned(), 18901).await;
 
-        let write = DbWriteConnection::open_url(&server.url(), ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
+        let write = DbWriteConnection::open(&server.url(), ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
             .await
             .expect("open write proxy");
         write
@@ -340,7 +340,7 @@ mod tests {
             .await
             .expect("insert before restart");
 
-        let read = DbReadConnection::open_url(&server.url(), 2, ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
+        let read = DbReadConnection::open(&server.url(), 2, ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
             .await
             .expect("open read proxy");
 
@@ -377,7 +377,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let server = TestServer::spawn(dir.path().to_owned(), 18902).await;
 
-        let write = DbWriteConnection::open_url(&server.url(), ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
+        let write = DbWriteConnection::open(&server.url(), ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
             .await
             .expect("open write proxy");
         write
@@ -447,7 +447,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let server = TestServer::spawn(dir.path().to_owned(), 18903).await;
 
-        let write = DbWriteConnection::open_url(&server.url(), ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
+        let write = DbWriteConnection::open(&server.url(), ACQUIRE_TIMEOUT, BUSY_TIMEOUT)
             .await
             .expect("open write proxy");
         write

--- a/crates/metrics-collector/bin/main.rs
+++ b/crates/metrics-collector/bin/main.rs
@@ -19,7 +19,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use microsandbox_metrics_collector::exporters::{
     OtelExporter, OtlpCompression, OtlpProtocol, StdoutExporter,
 };
-use microsandbox_metrics_collector::{CatalogLabelSource, MetricsCollector};
+use microsandbox_metrics_collector::{DbLabelSource, MetricsCollector};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
@@ -368,9 +368,9 @@ fn resolve_registry_name(msb_home: Option<&std::path::Path>) -> anyhow::Result<S
     ))
 }
 
-/// Path to the catalog DB (`$MSB_HOME/db/msb.db`) used for label lookups. The
-/// connection is opened lazily (and retried) by [`CatalogLabelSource`], so a
-/// catalog that does not exist yet is fine: enrichment switches on once it
+/// Path to the database (`$MSB_HOME/db/msb.db`) used for label lookups. The
+/// connection is opened lazily (and retried) by [`DbLabelSource`], so a
+/// database that does not exist yet is fine: enrichment switches on once it
 /// appears.
 fn label_db_path(msb_home: Option<&std::path::Path>) -> anyhow::Result<PathBuf> {
     Ok(resolve_msb_home(msb_home)?
@@ -378,14 +378,22 @@ fn label_db_path(msb_home: Option<&std::path::Path>) -> anyhow::Result<PathBuf> 
         .join(microsandbox_utils::DB_FILENAME))
 }
 
-/// Build the catalog label source for `opts`, or `None` when `--no-labels`
+/// Build the database label source for `opts`, or `None` when `--no-labels`
 /// disables enrichment entirely. Applies the `--exclude-label-keys` denylist.
-fn label_source(opts: &CollectorOpts) -> anyhow::Result<Option<CatalogLabelSource>> {
+fn label_source(opts: &CollectorOpts) -> anyhow::Result<Option<DbLabelSource>> {
     if opts.no_labels {
         return Ok(None);
     }
-    let db_path = label_db_path(opts.msb_home.as_deref())?;
-    Ok(Some(CatalogLabelSource::new(db_path).with_excluded_keys(
+
+    // MSB_DATABASE_URL points this host's processes at a database target
+    // (`libsql://` server or an alternate file) — same override the msb CLI
+    // honours.
+    let source = match std::env::var("MSB_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => DbLabelSource::new(url),
+        _ => DbLabelSource::new(label_db_path(opts.msb_home.as_deref())?),
+    };
+
+    Ok(Some(source.with_excluded_keys(
         opts.exclude_label_keys.iter().cloned(),
     )))
 }

--- a/crates/metrics-collector/lib/core/builder.rs
+++ b/crates/metrics-collector/lib/core/builder.rs
@@ -153,7 +153,7 @@ impl MetricsCollectorBuilder {
     }
 
     /// Enrich each collection with per-sandbox labels from a [`LabelSource`]
-    /// (e.g. [`CatalogLabelSource`](super::CatalogLabelSource)). Labels are
+    /// (e.g. [`DbLabelSource`](super::DbLabelSource)). Labels are
     /// attached as attributes by label-aware exporters (e.g. OTel). Without
     /// this, collections carry no labels.
     pub fn enrich_labels(mut self, source: Arc<dyn LabelSource>) -> Self {

--- a/crates/metrics-collector/lib/core/label_source.rs
+++ b/crates/metrics-collector/lib/core/label_source.rs
@@ -2,17 +2,16 @@
 //!
 //! [`LabelSource`] abstracts *where* labels come from, so the collect loop and
 //! the builder depend on a trait rather than a database connection. The
-//! production implementation ([`CatalogLabelSource`]) reads the sqlite catalog
+//! production implementation ([`DbLabelSource`]) reads the sqlite database
 //! and caches per sandbox; tests can inject an in-memory map instead.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use microsandbox_db::DbReadConnection;
 use microsandbox_db::pool::DEFAULT_BUSY_TIMEOUT_SECS;
+use microsandbox_db::{DbReadConnection, DbTarget};
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
@@ -25,10 +24,10 @@ use super::types::SandboxLabels;
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-/// Read connections opened against the catalog for label lookups.
+/// Read connections opened against the database for label lookups.
 const READ_CONNECTIONS: u32 = 2;
 
-/// How long to wait for a catalog connection before giving up for this tick
+/// How long to wait for a database connection before giving up for this tick
 /// (retried on the next one).
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -52,17 +51,19 @@ pub trait LabelSource: Send + Sync {
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// A [`LabelSource`] backed by the sqlite catalog.
+/// A [`LabelSource`] backed by the sqlite database.
 ///
-/// Connects lazily and retries: if the catalog DB is not yet present (e.g.
+/// Connects lazily and retries: if the database is not yet present (e.g.
 /// msb-metrics started before msb initialized `$MSB_HOME`), each tick emits no
 /// labels and tries again, so enrichment switches on automatically once the
-/// catalog appears. Reads go through an internal cache (one sqlite read per
+/// database appears. Reads go through an internal cache (one sqlite read per
 /// newly-seen sandbox, presence-based eviction).
-pub struct CatalogLabelSource {
-    db_path: PathBuf,
+pub struct DbLabelSource {
+    /// Database target: the sqlite file path, or a `libsql://` server URL
+    /// when `MSB_DATABASE_URL` points this host at a database server.
+    target: DbTarget,
 
-    /// Label keys dropped from emitted metrics. The labels stay in the catalog
+    /// Label keys dropped from emitted metrics. The labels stay in the database
     /// (still visible to `msb inspect`); they are only withheld from metric
     /// attributes so an operator can cap series cardinality on noisy keys.
     exclude_keys: HashSet<String>,
@@ -73,23 +74,24 @@ pub struct CatalogLabelSource {
 /// Mutable state guarded by a single lock; the collect loop is sequential, so
 /// there is never contention.
 struct State {
-    /// The catalog connection, opened on first successful use.
+    /// The database connection, opened on first successful use.
     db: Option<DbReadConnection>,
 
     /// Per-sandbox label cache.
     cache: LabelCache,
 
-    /// True while emitting without labels because the catalog is unavailable.
+    /// True while emitting without labels because the database is unavailable.
     /// Gates logging so a persistent outage warns once, not every tick.
     degraded: bool,
 }
 
-impl CatalogLabelSource {
-    /// Build a catalog-backed source over the catalog DB at `db_path`. The
-    /// connection is opened lazily on first use.
-    pub fn new(db_path: PathBuf) -> Self {
+impl DbLabelSource {
+    /// Build a database-backed source over a database target: the sqlite file
+    /// path, or a `libsql://` server URL. The connection is opened lazily on
+    /// first use.
+    pub fn new(target: impl Into<DbTarget>) -> Self {
         Self {
-            db_path,
+            target: target.into(),
             exclude_keys: HashSet::new(),
             state: Mutex::new(State {
                 db: None,
@@ -108,7 +110,7 @@ impl CatalogLabelSource {
 }
 
 #[async_trait]
-impl LabelSource for CatalogLabelSource {
+impl LabelSource for DbLabelSource {
     async fn labels_for(&self, sandbox_ids: HashSet<i32>) -> MetricsCollectorResult<SandboxLabels> {
         let mut state = self.state.lock().await;
 
@@ -117,7 +119,7 @@ impl LabelSource for CatalogLabelSource {
         // rather than disabling enrichment for the process lifetime.
         if state.db.is_none() {
             match DbReadConnection::open(
-                &self.db_path,
+                self.target.clone(),
                 READ_CONNECTIONS,
                 CONNECT_TIMEOUT,
                 Duration::from_secs(DEFAULT_BUSY_TIMEOUT_SECS),
@@ -129,8 +131,8 @@ impl LabelSource for CatalogLabelSource {
                     if !state.degraded {
                         warn!(
                             %error,
-                            db = %self.db_path.display(),
-                            "catalog unavailable; emitting metrics without labels (will retry)"
+                            db = %self.target,
+                            "database unavailable; emitting metrics without labels (will retry)"
                         );
                         state.degraded = true;
                     }
@@ -150,7 +152,7 @@ impl LabelSource for CatalogLabelSource {
         match resolved {
             Ok(labels) => {
                 if state.degraded {
-                    info!("catalog available again; resuming label enrichment");
+                    info!("database available again; resuming label enrichment");
                     state.degraded = false;
                 }
                 Ok(labels)
@@ -160,7 +162,7 @@ impl LabelSource for CatalogLabelSource {
                 // non-fatal: emit without labels and retry. The connection is
                 // kept; it will see the table once msb migrates the same file.
                 if !state.degraded {
-                    warn!(%error, "catalog query failed; emitting metrics without labels (will retry)");
+                    warn!(%error, "database query failed; emitting metrics without labels (will retry)");
                     state.degraded = true;
                 }
                 Ok(SandboxLabels::new())
@@ -223,7 +225,7 @@ mod tests {
 
     use super::*;
 
-    /// Create the catalog at `db_path` with one labelled sandbox.
+    /// Create the database at `db_path` with one labelled sandbox.
     async fn seed_catalog(db_path: &std::path::Path) {
         std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
         let write = DbWriteConnection::open(
@@ -310,7 +312,7 @@ mod tests {
         .await
         .unwrap();
 
-        let source = CatalogLabelSource::new(db_path)
+        let source = DbLabelSource::new(db_path)
             .with_excluded_keys(["org.opencontainers.image.revision".to_string()]);
 
         let labels = source.labels_for(HashSet::from([1])).await.unwrap();
@@ -321,17 +323,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn emits_no_labels_until_catalog_appears_then_recovers() {
+    async fn emits_no_labels_until_db_appears_then_recovers() {
         let dir = tempfile::tempdir().unwrap();
-        // Parent `db/` dir does not exist yet → the catalog is absent.
+        // Parent `db/` dir does not exist yet → the database is absent.
         let db_path = dir.path().join("db").join("msb.db");
-        let source = CatalogLabelSource::new(db_path.clone());
+        let source = DbLabelSource::new(db_path.clone());
 
-        // Absent catalog: no labels, but no error (the tick still ships metrics).
+        // Absent database: no labels, but no error (the tick still ships metrics).
         let labels = source.labels_for(HashSet::from([1])).await.unwrap();
         assert!(labels.is_empty());
 
-        // The catalog comes up with a labelled sandbox.
+        // The database comes up with a labelled sandbox.
         seed_catalog(&db_path).await;
 
         // The next tick picks it up without a restart.

--- a/crates/metrics-collector/lib/core/mod.rs
+++ b/crates/metrics-collector/lib/core/mod.rs
@@ -25,7 +25,7 @@ pub use builder::{
     DEFAULT_MAX_BUFFERED_COLLECTIONS, MetricsCollectorBuilder, MetricsExporterConfig,
 };
 pub use driver::{MetricsCollector, MetricsErrorPolicy, RunningCollector};
-pub use label_source::{CatalogLabelSource, LabelSource};
+pub use label_source::{DbLabelSource, LabelSource};
 pub use types::{
     MetricsCollection, MetricsExportBatch, MetricsExporter, SandboxLabels, SandboxMetricSnapshot,
 };

--- a/crates/metrics-collector/lib/lib.rs
+++ b/crates/metrics-collector/lib/lib.rs
@@ -70,10 +70,10 @@ pub mod exporters;
 //--------------------------------------------------------------------------------------------------
 
 pub use core::{
-    CatalogLabelSource, DEFAULT_COLLECT_INTERVAL, DEFAULT_EXPORT_TIMEOUT, DEFAULT_FLUSH_INTERVAL,
-    DEFAULT_MAX_BUFFERED_COLLECTIONS, LabelSource, MetricsCollection, MetricsCollector,
-    MetricsCollectorBuilder, MetricsErrorPolicy, MetricsExportBatch, MetricsExporter,
-    MetricsExporterConfig, RunningCollector, SandboxLabels, SandboxMetricSnapshot,
+    DEFAULT_COLLECT_INTERVAL, DEFAULT_EXPORT_TIMEOUT, DEFAULT_FLUSH_INTERVAL,
+    DEFAULT_MAX_BUFFERED_COLLECTIONS, DbLabelSource, LabelSource, MetricsCollection,
+    MetricsCollector, MetricsCollectorBuilder, MetricsErrorPolicy, MetricsExportBatch,
+    MetricsExporter, MetricsExporterConfig, RunningCollector, SandboxLabels, SandboxMetricSnapshot,
 };
 pub use error::{MetricsCollectorError, MetricsCollectorResult};
 pub use microsandbox_metrics::SandboxMetrics;

--- a/crates/runtime/lib/launch.rs
+++ b/crates/runtime/lib/launch.rs
@@ -24,8 +24,10 @@ use crate::vm::{MetricsSlotHandoff, StartupCommand};
 /// The bulk `msb sandbox` configuration delivered over the config fd.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct LaunchConfig {
-    /// Path to the sandbox database file.
-    pub db_path: PathBuf,
+    /// Database target: the sandbox database file path, or a `libsql://`
+    /// server URL. Serialized as `db_path` — a plain path, the original
+    /// form of the field, is still valid.
+    pub db_path: String,
 
     /// Timeout when acquiring a sandbox database connection from the pool.
     pub db_connect_timeout_secs: u64,
@@ -140,4 +142,26 @@ pub struct RootfsConfig {
     /// root disks so the runner attaches with the right format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upper_format: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launch_config_db_path_accepts_plain_paths_and_urls() {
+        let mut serialized = serde_json::to_value(LaunchConfig::default()).unwrap();
+
+        serialized["db_path"] = "/home/user/.microsandbox/db/msb.db".into();
+        let launch: LaunchConfig = serde_json::from_value(serialized.clone()).unwrap();
+        assert_eq!(launch.db_path, "/home/user/.microsandbox/db/msb.db");
+
+        serialized["db_path"] = "libsql://127.0.0.1:8890".into();
+        let launch: LaunchConfig = serde_json::from_value(serialized).unwrap();
+        assert_eq!(launch.db_path, "libsql://127.0.0.1:8890");
+    }
 }

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -92,8 +92,9 @@ pub struct Config {
     /// Selected tracing verbosity.
     pub log_level: Option<LogLevel>,
 
-    /// Path to the sandbox database file.
-    pub sandbox_db_path: PathBuf,
+    /// Database target: the sandbox database file path, or a `libsql://`
+    /// server URL.
+    pub sandbox_db_path: String,
 
     /// Timeout when acquiring a sandbox database connection from the pool.
     pub sandbox_db_connect_timeout_secs: u64,
@@ -1652,17 +1653,13 @@ fn write_startup_info(startup_pipe: Option<&str>, json: &str) -> RuntimeResult<(
 /// Busy timeout uses [`microsandbox_db::pool::DEFAULT_BUSY_TIMEOUT_SECS`]:
 /// the in-VM runtime is not user-configurable, so DB tuning policy lives
 /// with the host (which honours `~/.microsandbox/config.json`).
-async fn connect_db(
-    db_path: &std::path::Path,
-    connect_timeout_secs: u64,
-) -> RuntimeResult<DbWriteConnection> {
-    DbWriteConnection::open(
-        db_path,
-        Duration::from_secs(connect_timeout_secs),
-        Duration::from_secs(microsandbox_db::pool::DEFAULT_BUSY_TIMEOUT_SECS),
-    )
-    .await
-    .map_err(|e| RuntimeError::Custom(format!("database connect: {e}")))
+async fn connect_db(target: &str, connect_timeout_secs: u64) -> RuntimeResult<DbWriteConnection> {
+    let connect_timeout = Duration::from_secs(connect_timeout_secs);
+    let busy_timeout = Duration::from_secs(microsandbox_db::pool::DEFAULT_BUSY_TIMEOUT_SECS);
+
+    DbWriteConnection::open(target, connect_timeout, busy_timeout)
+        .await
+        .map_err(|e| RuntimeError::Custom(format!("database connect: {e}")))
 }
 
 /// Insert a run record into the database.

--- a/sdk/rust/lib/backend/local.rs
+++ b/sdk/rust/lib/backend/local.rs
@@ -494,28 +494,46 @@ impl Drop for MigrationLock {
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
-/// Open both pools for `db_dir/msb.db` and run migrations on the writer.
+/// Open both pools and run migrations on the writer.
 ///
-/// The write pool connects first so WAL mode (persisted in the database
-/// header) is set before the read pool opens.
+/// For a file target (`sqlite://` or bare path), the write pool connects first
+/// so WAL mode (persisted in the header) is set before the read pool opens,
+/// and a cross-process file lock serializes concurrent migrators. For a remote
+/// `libsql://` target the server serializes migrations itself and the file
+/// lock is skipped.
 async fn connect_and_migrate(
     db_dir: &Path,
     database: &DatabaseConfig,
     snapshots_dir: &Path,
 ) -> MicrosandboxResult<DbPools> {
     tokio::fs::create_dir_all(db_dir).await?;
-    let _migration_lock = acquire_migration_lock(db_dir).await?;
-    refuse_incomplete_self_downgrade(db_dir)?;
 
-    let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
+    // One connection string covers both backends: a `libsql://` target goes
+    // to the shared database server; a `sqlite://` or bare-path override (or
+    // the default file) stays on the file backend.
+    let db_target = database.effective_url().unwrap_or_else(|| {
+        db_dir
+            .join(microsandbox_utils::DB_FILENAME)
+            .display()
+            .to_string()
+    });
+    let is_remote = microsandbox_db::DbTarget::from(db_target.as_str()).is_remote();
+
+    let _migration_lock = if is_remote {
+        None
+    } else {
+        refuse_incomplete_self_downgrade(db_dir)?;
+        Some(acquire_migration_lock(db_dir).await?)
+    };
+
     let pools = DbPools::open(
-        &db_path,
+        &db_target,
         database.max_connections,
         Duration::from_secs(database.connect_timeout_secs),
         Duration::from_secs(database.busy_timeout_secs),
     )
     .await
-    .map_err(|e| MicrosandboxError::Custom(format!("connect to {}: {e}", db_path.display())))?;
+    .map_err(|e| MicrosandboxError::Custom(format!("connect to {db_target}: {e}")))?;
 
     microsandbox_runtime::maintenance::refuse_if_install_exclusive_held(pools.write())
         .await
@@ -523,15 +541,26 @@ async fn connect_and_migrate(
     refuse_schema_ahead(pools.write().inner()).await?;
     Migrator::up(pools.write().inner(), None).await?;
 
-    // Descriptor translation mutates the same installation state as schema
-    // migration. Keep both gates held until every discovered artifact is
-    // either canonical or durably journaled as blocked.
+    reconcile_snapshots_with_lease(&pools, snapshots_dir).await?;
+
+    Ok(pools)
+}
+
+/// Reconcile snapshot descriptors under the install-exclusive lease.
+///
+/// Descriptor translation mutates the same installation state as schema
+/// migration. Keep both gates held until every discovered artifact is
+/// either canonical or durably journaled as blocked.
+async fn reconcile_snapshots_with_lease(
+    pools: &DbPools,
+    snapshots_dir: &Path,
+) -> MicrosandboxResult<()> {
     let install_lease =
         microsandbox_runtime::maintenance::acquire_install_exclusive_lease(pools.write())
             .await
             .map_err(|err| MicrosandboxError::Runtime(err.to_string()))?;
     let reconcile_result =
-        crate::snapshot::migration::reconcile_managed(&pools, snapshots_dir).await;
+        crate::snapshot::migration::reconcile_managed(pools, snapshots_dir).await;
     let clear_result = microsandbox_runtime::maintenance::clear_install_exclusive_lease(
         pools.write(),
         &install_lease,
@@ -541,7 +570,7 @@ async fn connect_and_migrate(
     reconcile_result?;
     clear_result?;
 
-    Ok(pools)
+    Ok(())
 }
 
 /// Refuse normal startup while a durable self-downgrade operation owns local

--- a/sdk/rust/lib/config/mod.rs
+++ b/sdk/rust/lib/config/mod.rs
@@ -35,6 +35,10 @@ pub(crate) const DEFAULT_CPUS: u8 = 1;
 /// Default guest memory in MiB.
 pub(crate) const DEFAULT_MEMORY_MIB: u32 = 512;
 
+/// Environment variable overriding the database target (`libsql://` server
+/// URL, or `sqlite://`/bare file path).
+pub const DATABASE_URL_ENV: &str = "MSB_DATABASE_URL";
+
 /// Default database max connections.
 pub(crate) const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 
@@ -149,7 +153,9 @@ pub struct MetricsConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct DatabaseConfig {
-    /// Database connection URL. `None` uses the default SQLite path.
+    /// Database target: a `libsql://host:port` server URL, or a `sqlite://`
+    /// (or bare) file path. `None` uses the default SQLite file. Overridden
+    /// by `MSB_DATABASE_URL`; see [`DatabaseConfig::effective_url`].
     pub url: Option<String>,
 
     /// Maximum connection pool size.
@@ -568,6 +574,25 @@ impl LocalConfig {
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
+
+impl DatabaseConfig {
+    /// The effective database target override, if any.
+    ///
+    /// Precedence: the `MSB_DATABASE_URL` environment variable, then the
+    /// persisted `database.url` config field. `None` means the default
+    /// SQLite file path. The value is one connection string: `libsql://`
+    /// selects the server backend, `sqlite://` or a bare path the file
+    /// backend.
+    pub fn effective_url(&self) -> Option<String> {
+        if let Ok(url) = std::env::var(DATABASE_URL_ENV)
+            && !url.trim().is_empty()
+        {
+            return Some(url);
+        }
+
+        self.url.clone()
+    }
+}
 
 impl Default for DatabaseConfig {
     fn default() -> Self {
@@ -1147,6 +1172,29 @@ fn keyring_unavailable_message(hostname: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn database_effective_url_prefers_env_over_config() {
+        // No other test reads MSB_DATABASE_URL, so mutating it here is safe.
+        let config = DatabaseConfig {
+            url: Some("http://config.example:8890".into()),
+            ..DatabaseConfig::default()
+        };
+
+        unsafe { std::env::remove_var(DATABASE_URL_ENV) };
+        assert_eq!(
+            config.effective_url().as_deref(),
+            Some("http://config.example:8890")
+        );
+
+        unsafe { std::env::set_var(DATABASE_URL_ENV, "http://env.example:8890") };
+        assert_eq!(
+            config.effective_url().as_deref(),
+            Some("http://env.example:8890")
+        );
+
+        unsafe { std::env::remove_var(DATABASE_URL_ENV) };
+    }
 
     use std::collections::VecDeque;
 

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -2230,8 +2230,17 @@ fn sandbox_cli_args(
         ));
     }
 
+    // The database target: the configured override (env or config), or this
+    // host's database file. Spawned supervisors use the same database as
+    // the host that spawned them.
+    let db_target = local
+        .config()
+        .database
+        .effective_url()
+        .unwrap_or_else(|| db_path.to_string_lossy().into_owned());
+
     let mut launch = LaunchConfig {
-        db_path: db_path.to_path_buf(),
+        db_path: db_target,
         db_connect_timeout_secs,
         log_dir: log_dir.to_path_buf(),
         runtime_dir: runtime_dir.to_path_buf(),
@@ -2719,7 +2728,7 @@ mod tests {
         }
 
         let mut out: Vec<String> = Vec::new();
-        pair(&mut out, "--db-path", path(&launch.db_path));
+        pair(&mut out, "--db-path", launch.db_path.clone());
         pair(
             &mut out,
             "--db-connect-timeout-secs",


### PR DESCRIPTION
Drops the `remote: Option<WriteControl>` field from `DbWriteConnection` now that the proxy (in `microsandbox-libsql`, #1210) owns its own admission permit and releases it cancellation-safely via `start_rollback`. Each connection wrapper holds only `inner` (+ a sqlite pool handle for the file backend + stats).

`transaction()` discriminates the backend by matching `sea_orm::DatabaseConnection::ProxyDatabaseConnection(_)` on `inner` instead of an `is_remote` flag, and the remote path issues `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` as ordinary durable statements under the busy-retry wrapper. All invariants preserved — bounded admission, durable commit, reconnect-after-restart, whole-transaction retry — and a new `cancelled_transaction_releases_write_permit` test proves a mid-flight cancellation no longer leaks the single writer. Live-sqld suite: 9/9.

Stacked on #1210.