### PR TITLE
fix(image): use byte offsets in split VMDK extents

### DIFF
--- a/crates/image/lib/stitch/vmdk.rs
+++ b/crates/image/lib/stitch/vmdk.rs
@@ -44,13 +44,13 @@ pub fn write_vmdk_descriptor(output: &Path, extents: &[&Path]) -> io::Result<()>
         let abs_path = std::fs::canonicalize(path)?;
         let abs_str = abs_path.to_string_lossy();
 
-        // Split into <= 2 GiB extent lines.
-        let mut offset: u64 = 0;
+        // Split into <= 2 GiB extent lines. libkrun interprets FLAT offsets as bytes.
+        let mut offset_bytes: u64 = 0;
         let mut remaining = sectors;
         while remaining > 0 {
             let chunk = remaining.min(MAX_EXTENT_SECTORS);
-            extent_lines.push(format!("RW {chunk} FLAT \"{abs_str}\" {offset}"));
-            offset += chunk;
+            extent_lines.push(format!("RW {chunk} FLAT \"{abs_str}\" {offset_bytes}"));
+            offset_bytes += chunk * 512;
             remaining -= chunk;
         }
 
@@ -122,6 +122,40 @@ mod tests {
         assert!(content.contains("RW 8 FLAT"));
         assert_eq!(content.matches("RW 8 FLAT").count(), 3);
         assert!(content.contains("ddb.virtualHWVersion = \"4\""));
+    }
+
+    #[test]
+    fn test_vmdk_split_offsets_are_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("large.bin");
+        std::fs::File::create(&p)
+            .unwrap()
+            .set_len(MAX_EXTENT_SECTORS * 512 + 4096)
+            .unwrap();
+
+        let vmdk_path = dir.path().join("test.vmdk");
+        write_vmdk_descriptor(&vmdk_path, &[p.as_path()]).unwrap();
+
+        let mut content = String::new();
+        std::fs::File::open(&vmdk_path)
+            .unwrap()
+            .read_to_string(&mut content)
+            .unwrap();
+
+        // `RW {sectors} FLAT "{path}" {offset}` — assert exact count, order,
+        // sector counts, and byte offsets so a regression cannot hide behind a
+        // loose substring match.
+        let rw_lines: Vec<&str> = content.lines().filter(|l| l.starts_with("RW ")).collect();
+        assert_eq!(rw_lines.len(), 2, "expected exactly two extent lines");
+
+        let parse = |line: &str| -> (u64, u64) {
+            let sectors: u64 = line.split_whitespace().nth(1).unwrap().parse().unwrap();
+            let offset: u64 = line.rsplit('"').next().unwrap().trim().parse().unwrap();
+            (sectors, offset)
+        };
+
+        assert_eq!(parse(rw_lines[0]), (MAX_EXTENT_SECTORS, 0));
+        assert_eq!(parse(rw_lines[1]), (8, MAX_EXTENT_SECTORS * 512));
     }
 
     #[test]


### PR DESCRIPTION


## TL;DR
Split VMDK FLAT extent offsets were advanced in sectors, but libkrun interprets them as bytes — so data after the first 2 GiB extent pointed at the wrong position.

## Description
- `write_vmdk_descriptor` advanced split-extent offsets in sectors (`offset += chunk`). libkrun treats FLAT extent offsets as byte offsets, so every extent past the first 2 GiB resolved to the wrong position in the backing file.
- Advance offsets in bytes (`offset_bytes += chunk * 512`). The offset resets per extent file, since each FLAT extent line references a position within its own backing file.
- Add `test_vmdk_split_offsets_are_bytes` covering the descriptor output for a file just over 2 GiB: first extent at offset `0`, second at `2147483648`.

## Test Plan
```bash
cargo test -p microsandbox-image vmdk
cargo clippy -p microsandbox-image -- -D warnings
cargo fmt -p microsandbox-image -- --check
```
All pass locally (4 tests, 0 clippy warnings, fmt clean).

---

This PR was generated with an AI agent (pi + glm-5.2).