### PR TITLE
feat(logs): shared LogRegistry for followed streams

### DIFF
--- a/sdk/rust/lib/logs/logger.rs
+++ b/sdk/rust/lib/logs/logger.rs
@@ -1,0 +1,132 @@
+//! Sandbox-scoped log handles.
+//!
+//! A [`SandboxLogger`] is a plain, cheap handle to one sandbox's on-disk
+//! log directory, obtained from
+//! [`Sandbox::logger`](crate::sandbox::Sandbox::logger). Used directly,
+//! it behaves exactly like [`Sandbox::log_stream`] /
+//! [`Sandbox::logs`] — each followed stream owns a private watcher.
+//!
+//! Registering it with a
+//! [`LogRegistry`](super::watch::LogRegistry) yields a
+//! [`RegisteredSandboxLogger`], whose followed streams share the
+//! registry's single watcher instead. Everything else — parsing,
+//! cursors, ordering, rotation, the fallback poll — is identical; the
+//! registry only changes where the "files may have new bytes" wake
+//! comes from.
+
+use std::path::{Path, PathBuf};
+
+use super::watch::LogRegistration;
+use super::{LogEntry, LogOptions, LogSnapshot, LogStreamOptions};
+use crate::MicrosandboxResult;
+use crate::backend::sandbox::LogStream;
+
+//--------------------------------------------------------------------------------------------------
+// SandboxLogger
+//--------------------------------------------------------------------------------------------------
+
+/// A handle to one sandbox's log directory. Reads and streams delegate
+/// to the same engine as the backend log methods; followed streams use
+/// a private watcher until the logger is registered with a
+/// [`LogRegistry`](super::watch::LogRegistry).
+pub struct SandboxLogger {
+    name: String,
+    log_dir: PathBuf,
+}
+
+impl SandboxLogger {
+    /// Construct a logger for a named sandbox rooted at `log_dir`.
+    pub(crate) fn new(name: String, log_dir: PathBuf) -> Self {
+        Self { name, log_dir }
+    }
+
+    /// The sandbox name this logger reads.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The on-disk log directory this logger reads.
+    pub fn log_dir(&self) -> &Path {
+        &self.log_dir
+    }
+
+    /// Read a chronologically sorted log snapshot's entries.
+    pub async fn read(&self, opts: &LogOptions) -> MicrosandboxResult<Vec<LogEntry>> {
+        Ok(self.read_snapshot(opts).await?.entries)
+    }
+
+    /// Read a chronologically sorted log snapshot plus its end cursor.
+    pub async fn read_snapshot(&self, opts: &LogOptions) -> MicrosandboxResult<LogSnapshot> {
+        super::read_logs_snapshot_from_dir(&self.name, self.log_dir.clone(), opts).await
+    }
+
+    /// Stream log entries. When `opts.follow` is set, each stream owns a
+    /// private filesystem watcher (the standalone behavior).
+    pub async fn stream(&self, opts: &LogStreamOptions) -> MicrosandboxResult<LogStream> {
+        let stream = super::log_stream_from_dir(&self.name, self.log_dir.clone(), opts).await?;
+        Ok(Box::pin(stream) as LogStream)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// RegisteredSandboxLogger
+//--------------------------------------------------------------------------------------------------
+
+/// A [`SandboxLogger`] registered with a
+/// [`LogRegistry`](super::watch::LogRegistry). Followed
+/// streams share the registry's single watcher; the held
+/// [`LogRegistration`] keeps the directory watched, and each stream
+/// carries its own registration clone so it stays watched even if this
+/// logger is dropped first.
+pub struct RegisteredSandboxLogger {
+    logger: SandboxLogger,
+    registration: LogRegistration,
+}
+
+impl RegisteredSandboxLogger {
+    pub(crate) fn new(logger: SandboxLogger, registration: LogRegistration) -> Self {
+        Self {
+            logger,
+            registration,
+        }
+    }
+
+    /// The sandbox name this logger reads.
+    pub fn name(&self) -> &str {
+        self.logger.name()
+    }
+
+    /// The on-disk log directory this logger reads.
+    pub fn log_dir(&self) -> &Path {
+        self.logger.log_dir()
+    }
+
+    /// Read a chronologically sorted log snapshot's entries.
+    pub async fn read(&self, opts: &LogOptions) -> MicrosandboxResult<Vec<LogEntry>> {
+        self.logger.read(opts).await
+    }
+
+    /// Read a chronologically sorted log snapshot plus its end cursor.
+    pub async fn read_snapshot(&self, opts: &LogOptions) -> MicrosandboxResult<LogSnapshot> {
+        self.logger.read_snapshot(opts).await
+    }
+
+    /// Stream log entries. A followed stream subscribes to the registry's
+    /// shared watch for this directory — no private watcher — and holds a
+    /// registration clone for its lifetime. A non-follow stream needs no
+    /// wake source and takes the plain path.
+    pub async fn stream(&self, opts: &LogStreamOptions) -> MicrosandboxResult<LogStream> {
+        if !opts.follow {
+            return self.logger.stream(opts).await;
+        }
+        let subscription = self.registration.subscribe();
+        let stream = super::log_stream_from_dir_registry(
+            &self.logger.name,
+            self.logger.log_dir.clone(),
+            opts,
+            subscription,
+        )
+        .await?;
+        Ok(Box::pin(stream) as LogStream)
+    }
+}

--- a/sdk/rust/lib/logs/mod.rs
+++ b/sdk/rust/lib/logs/mod.rs
@@ -55,13 +55,17 @@
 //! of the last entry successfully consumed.
 
 mod cursor;
+mod logger;
 mod parser;
 mod stream;
 mod types;
+mod watch;
 
 pub use cursor::{LogCursor, LogCursorParseError};
+pub use logger::{RegisteredSandboxLogger, SandboxLogger};
 pub use stream::{LogStreamOptions, LogStreamStart};
 pub use types::{LogEntry, LogOptions, LogSource};
+pub use watch::{LogRegistration, LogRegistry, RegistryStatsSnapshot};
 
 use std::path::PathBuf;
 
@@ -252,6 +256,33 @@ async fn log_stream_from_dir(
         &opts.start,
         opts.until,
         opts.follow,
+    )
+    .await?;
+    Ok(engine.into_stream())
+}
+
+/// Stream from an explicit directory, waking from a shared
+/// [`LogRegistry`](watch::LogRegistry) subscription rather than
+/// a private watcher. Always follows — a non-follow read has no wake
+/// source and takes [`log_stream_from_dir`] / the snapshot path.
+pub(crate) async fn log_stream_from_dir_registry(
+    name: &str,
+    log_dir: PathBuf,
+    opts: &LogStreamOptions,
+    subscription: watch::LogSubscription,
+) -> MicrosandboxResult<impl Stream<Item = MicrosandboxResult<LogEntry>> + Send + 'static + use<>> {
+    crate::sandbox::validate_sandbox_name(name)?;
+    if !tokio::fs::try_exists(&log_dir).await.unwrap_or(false) {
+        return Err(MicrosandboxError::SandboxNotFound(name.to_string()));
+    }
+    let sources = LogSource::effective(&opts.sources);
+    let engine = LogEngine::new_registry(
+        log_dir,
+        LOG_FILES,
+        sources,
+        &opts.start,
+        opts.until,
+        subscription,
     )
     .await?;
     Ok(engine.into_stream())

--- a/sdk/rust/lib/logs/stream.rs
+++ b/sdk/rust/lib/logs/stream.rs
@@ -7,7 +7,6 @@
 
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -20,6 +19,7 @@ use crate::{MicrosandboxError, MicrosandboxResult};
 use super::cursor::{FilePosition, LogCursor};
 use super::parser::{FileHandle, ParsedChunk, ParserKind};
 use super::types::{LogEntry, LogSource};
+use super::watch::LogSubscription;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -203,23 +203,21 @@ struct PositionedLogEntry {
 pub(crate) struct LogEngine {
     since: Option<DateTime<Utc>>,
     until: Option<DateTime<Utc>>,
-    follow: bool,
 
     readers: Vec<ReaderState>,
     initial_positions: Vec<FilePosition>,
     pending: VecDeque<PositionedLogEntry>,
 
-    _watcher: Option<notify::RecommendedWatcher>,
-    event_rx: Option<tokio::sync::mpsc::UnboundedReceiver<()>>,
+    follow: FollowMode,
 
     finished: bool,
 }
 
 impl LogEngine {
     /// Open one reader per [`LogFileConfig`] whose `produces` set
-    /// intersects `sources`. When `follow` is true, also subscribe
-    /// to filesystem change events on `log_dir` so [`step`] can wake
-    /// promptly on new writes.
+    /// intersects `sources`. When `follow` is true, also build a
+    /// private filesystem watcher on `log_dir` so [`step`] can wake
+    /// promptly on new writes (the standalone behavior).
     pub(crate) async fn new(
         log_dir: PathBuf,
         log_files: &'static [LogFileConfig],
@@ -227,6 +225,46 @@ impl LogEngine {
         start: &LogStreamStart,
         until: Option<DateTime<Utc>>,
         follow: bool,
+    ) -> MicrosandboxResult<Self> {
+        let mode = if follow {
+            FollowMode::standalone(&log_dir)?
+        } else {
+            FollowMode::Off
+        };
+        Self::assemble(log_dir, log_files, sources, start, until, mode).await
+    }
+
+    /// Like [`new`](Self::new) with `follow = true`, but wake from a
+    /// shared [`LogRegistry`](super::watch::LogRegistry)
+    /// subscription rather than a private watcher.
+    pub(crate) async fn new_registry(
+        log_dir: PathBuf,
+        log_files: &'static [LogFileConfig],
+        sources: Vec<LogSource>,
+        start: &LogStreamStart,
+        until: Option<DateTime<Utc>>,
+        subscription: LogSubscription,
+    ) -> MicrosandboxResult<Self> {
+        Self::assemble(
+            log_dir,
+            log_files,
+            sources,
+            start,
+            until,
+            FollowMode::Registry(subscription),
+        )
+        .await
+    }
+
+    /// Build readers and assemble the engine around a prepared follow
+    /// mode. Shared by the standalone and registry-backed constructors.
+    async fn assemble(
+        log_dir: PathBuf,
+        log_files: &'static [LogFileConfig],
+        sources: Vec<LogSource>,
+        start: &LogStreamStart,
+        until: Option<DateTime<Utc>>,
+        follow: FollowMode,
     ) -> MicrosandboxResult<Self> {
         let since = match start {
             LogStreamStart::Since(t) => Some(*t),
@@ -253,22 +291,13 @@ impl LogEngine {
             });
         }
 
-        let (watcher, event_rx) = if follow {
-            let (w, rx) = Self::build_watcher(&log_dir)?;
-            (Some(w), Some(rx))
-        } else {
-            (None, None)
-        };
-
         Ok(Self {
             since,
             until,
-            follow,
             readers,
             initial_positions,
             pending: VecDeque::new(),
-            _watcher: watcher,
-            event_rx,
+            follow,
             finished: false,
         })
     }
@@ -348,50 +377,15 @@ impl LogEngine {
             return StepResult::Continue;
         }
 
-        if !self.follow {
+        if !self.follow.is_following() {
             return StepResult::Terminate;
         }
 
-        let Some(rx) = self.event_rx.as_mut() else {
-            return StepResult::Terminate;
-        };
+        let follow = &mut self.follow;
         tokio::select! {
-            _ = rx.recv() => StepResult::Continue,
+            _ = follow.wait() => StepResult::Continue,
             _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => StepResult::Continue,
         }
-    }
-
-    /// Wire up a non-recursive [`notify`] watcher on `log_dir` and
-    /// return its event receiver. The watcher's callback runs on a
-    /// background thread; we forward only the wake signal so the
-    /// async [`step`] loop can park efficiently between writes.
-    fn build_watcher(
-        log_dir: &Path,
-    ) -> MicrosandboxResult<(
-        notify::RecommendedWatcher,
-        tokio::sync::mpsc::UnboundedReceiver<()>,
-    )> {
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        let tx = Arc::new(tx);
-        let tx_clone = Arc::clone(&tx);
-        let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
-            if let Ok(event) = res {
-                use notify::EventKind;
-                if matches!(
-                    event.kind,
-                    EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
-                ) {
-                    let _ = tx_clone.send(());
-                }
-            }
-        })
-        .map_err(|e| MicrosandboxError::Custom(format!("log watcher init failed: {e}")))?;
-
-        watcher
-            .watch(log_dir, notify::RecursiveMode::NonRecursive)
-            .map_err(|e| MicrosandboxError::Custom(format!("log watcher subscribe failed: {e}")))?;
-
-        Ok((watcher, rx))
     }
 
     /// Consume the engine and yield its entries as a [`futures::Stream`].
@@ -423,6 +417,79 @@ impl LogEngine {
                 }
             }
         })
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// FollowMode
+//--------------------------------------------------------------------------------------------------
+
+/// How a following engine learns the log files may have new bytes. Every
+/// variant is just a wake — "read again" — so the fallback poll still
+/// applies whenever the engine is following.
+enum FollowMode {
+    /// Not following; the stream ends at EOF.
+    Off,
+    /// Following via this stream's own private watcher.
+    Standalone {
+        _watcher: notify::RecommendedWatcher,
+        rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+    },
+    /// Following via a subscription to the shared registry's watcher.
+    Registry(LogSubscription),
+}
+
+impl FollowMode {
+    /// Build this stream's own non-recursive watcher on `log_dir`. The
+    /// callback runs on a background thread and forwards only the wake
+    /// signal so the async [`step`](LogEngine::step) loop can park
+    /// between writes.
+    fn standalone(log_dir: &Path) -> MicrosandboxResult<Self> {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+            if let Ok(event) = res {
+                use notify::EventKind;
+                if matches!(
+                    event.kind,
+                    EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
+                ) {
+                    let _ = tx.send(());
+                }
+            }
+        })
+        .map_err(|e| MicrosandboxError::Custom(format!("log watcher init failed: {e}")))?;
+
+        watcher
+            .watch(log_dir, notify::RecursiveMode::NonRecursive)
+            .map_err(|e| MicrosandboxError::Custom(format!("log watcher subscribe failed: {e}")))?;
+
+        Ok(FollowMode::Standalone {
+            _watcher: watcher,
+            rx,
+        })
+    }
+
+    fn is_following(&self) -> bool {
+        !matches!(self, FollowMode::Off)
+    }
+
+    /// Await the next wake. For a `Registry` subscription a closed sender
+    /// (`changed()` → `Err`) degrades to poll-only rather than
+    /// terminating — the stream's own registration clone keeps the
+    /// sender open, so this only guards a torn-down registry. Never
+    /// resolves for `Off`; callers gate on [`is_following`](Self::is_following).
+    async fn wait(&mut self) {
+        match self {
+            FollowMode::Off => std::future::pending::<()>().await,
+            FollowMode::Standalone { rx, .. } => {
+                let _ = rx.recv().await;
+            }
+            FollowMode::Registry(subscription) => {
+                if subscription.changed().await.is_err() {
+                    std::future::pending::<()>().await
+                }
+            }
+        }
     }
 }
 

--- a/sdk/rust/lib/logs/watch.rs
+++ b/sdk/rust/lib/logs/watch.rs
@@ -1,0 +1,668 @@
+//! Host-scoped shared filesystem watching for followed log streams.
+//!
+//! A [`LogRegistry`] owns a single [`notify::RecommendedWatcher`]
+//! (one inotify instance + one thread on Linux) and multiplexes it
+//! across every followed sandbox log stream on the host. Each sandbox
+//! log directory is watched once regardless of how many streams tail
+//! it; a filesystem event bumps a per-directory coalescing signal that
+//! wakes exactly the engines reading that directory.
+//!
+//! This exists because the standalone path builds one watcher per
+//! followed stream (see `super::stream::FollowMode::Standalone`), which
+//! exhausts `fs.inotify.max_user_instances` once a host holds enough
+//! sandboxes. Host orchestrators managing many sandboxes opt in by
+//! constructing one registry and registering each sandbox's logger.
+//!
+//! The registry is a wake signal only: log files remain the source of
+//! truth, so over-waking is merely a wasted parse and a missed event is
+//! caught by the engine's fallback poll.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
+
+use notify::Watcher;
+use tokio::sync::{oneshot, watch};
+
+use super::logger::{RegisteredSandboxLogger, SandboxLogger};
+use crate::{MicrosandboxError, MicrosandboxResult};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Host-scoped registry sharing one filesystem watcher across many
+/// followed log streams. Cheap to clone — every clone points at the
+/// same underlying watcher and routing table.
+#[derive(Clone)]
+pub struct LogRegistry {
+    inner: Arc<RegistryInner>,
+}
+
+struct RegistryInner {
+    /// Serializes registrations so only the first registrant of a new
+    /// directory issues a `watch`. A tokio mutex because `register` holds
+    /// it across the admin-thread round-trip await; NEVER taken by the
+    /// event callback or by Drop, so it gates neither routing nor
+    /// teardown.
+    admin: tokio::sync::Mutex<()>,
+    /// Commands to the watcher-admin thread that owns the single watcher.
+    /// `watch`/`unwatch` run there in FIFO order, off every runtime
+    /// thread.
+    admin_tx: mpsc::Sender<AdminCommand>,
+    /// Routing table. A plain `Mutex` suffices: its only users are
+    /// notify's single callback thread — which delivers events serially,
+    /// so events never contend event-vs-event — and the rare cold-path
+    /// register/Drop mutators. The callback locks it just to look up and
+    /// clone the signal `Arc`(s); every wake happens after the lock is
+    /// released.
+    dirs: Arc<Mutex<HashMap<PathBuf, DirEntry>>>,
+    /// `dirs.len()` mirrored so [`stats`](LogRegistry::stats) never
+    /// locks the map.
+    registered_dirs: Arc<AtomicUsize>,
+    stats: Arc<RegistryStats>,
+}
+
+/// A watch-lifecycle request for the watcher-admin thread. `Watch`
+/// carries a reply channel so `register` learns the outcome; `Unwatch` is
+/// fire-and-forget because Drop cannot await. FIFO delivery keeps a later
+/// re-`watch` of a path ordered after its `unwatch`.
+enum AdminCommand {
+    Watch {
+        dir: PathBuf,
+        reply: oneshot::Sender<notify::Result<()>>,
+    },
+    Unwatch {
+        dir: PathBuf,
+    },
+}
+
+/// One watched directory: a coalescing wake signal plus the refcount of
+/// live loggers and streams keeping it registered.
+struct DirEntry {
+    /// Bumped counter; subscribers await `changed()`. `Arc` so the
+    /// callback can wake outside the map lock.
+    signal: Arc<watch::Sender<u64>>,
+    /// Live loggers + live streams for this directory. The watch is torn
+    /// down when this reaches zero.
+    registrations: usize,
+}
+
+#[derive(Default)]
+struct RegistryStats {
+    total_registrations: AtomicUsize,
+    wake_all_events: AtomicU64,
+    route_misses: AtomicU64,
+    watch_failures: AtomicU64,
+}
+
+/// Point-in-time counters for host-side instrumentation. All fields are
+/// cumulative except `registered_dirs` and `total_registrations`, which
+/// are current gauges.
+#[derive(Debug, Clone, Copy)]
+pub struct RegistryStatsSnapshot {
+    /// Directories currently watched (== inotify watch descriptors).
+    pub registered_dirs: usize,
+    /// Sum of refcounts across all directories (live loggers + streams).
+    pub total_registrations: usize,
+    /// Overflow/error recoveries that woke every subscriber to rescan.
+    pub wake_all_events: u64,
+    /// Filesystem events that matched no registered directory.
+    pub route_misses: u64,
+    /// `watcher.watch()` failures during registration.
+    pub watch_failures: u64,
+}
+
+/// RAII token keeping a sandbox log directory registered. Cloning bumps
+/// the directory's refcount; dropping the last outstanding token removes
+/// the watch. Held inside a [`RegisteredSandboxLogger`] and inside every
+/// `LogSubscription` a stream carries.
+pub struct LogRegistration {
+    inner: Arc<RegistryInner>,
+    dir: PathBuf,
+}
+
+/// A followed stream's handle on the shared watcher: the wake receiver
+/// plus a registration clone that keeps the directory watched for as
+/// long as the stream lives.
+pub(crate) struct LogSubscription {
+    rx: watch::Receiver<u64>,
+    _registration: LogRegistration,
+}
+
+//--------------------------------------------------------------------------------------------------
+// LogRegistry
+//--------------------------------------------------------------------------------------------------
+
+impl LogRegistry {
+    /// Build a registry with one shared watcher and its watcher-admin
+    /// thread. Fails if the platform watcher cannot be created or the
+    /// thread cannot be spawned.
+    pub fn new() -> MicrosandboxResult<Self> {
+        let dirs: Arc<Mutex<HashMap<PathBuf, DirEntry>>> = Arc::new(Mutex::new(HashMap::new()));
+        let stats = Arc::new(RegistryStats::default());
+
+        let cb_dirs = Arc::clone(&dirs);
+        let cb_stats = Arc::clone(&stats);
+        let watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+            route_event(&cb_dirs, &cb_stats, res);
+        })
+        .map_err(|e| MicrosandboxError::Custom(format!("log watch registry init failed: {e}")))?;
+
+        // A dedicated thread owns the watcher so watch/unwatch never run on
+        // a runtime thread and stay serialized. It exits once the last
+        // command sender (held via RegistryInner) drops.
+        let (admin_tx, admin_rx) = mpsc::channel();
+        std::thread::Builder::new()
+            .name("log-watch-admin".into())
+            .spawn(move || admin_loop(watcher, admin_rx))
+            .map_err(|e| {
+                MicrosandboxError::Custom(format!("log watch admin thread spawn failed: {e}"))
+            })?;
+
+        Ok(Self {
+            inner: Arc::new(RegistryInner {
+                admin: tokio::sync::Mutex::new(()),
+                admin_tx,
+                dirs,
+                registered_dirs: Arc::new(AtomicUsize::new(0)),
+                stats,
+            }),
+        })
+    }
+
+    /// Register `logger` with the shared watcher and return a
+    /// registry-backed logger whose followed streams share one watch
+    /// descriptor. Returns [`MicrosandboxError::SandboxNotFound`] if the
+    /// log directory does not exist.
+    ///
+    /// Async and non-blocking: the blocking `watch()` runs on the
+    /// watcher-admin thread and `register` only awaits its reply, so a
+    /// caller on the tokio runtime never stalls a worker.
+    pub async fn register(
+        &self,
+        logger: SandboxLogger,
+    ) -> MicrosandboxResult<RegisteredSandboxLogger> {
+        // Canonicalize so different spellings of one directory share a
+        // single watch, and use the lookup as the existence check.
+        let dir = tokio::fs::canonicalize(logger.log_dir())
+            .await
+            .map_err(|_| MicrosandboxError::SandboxNotFound(logger.name().to_string()))?;
+
+        let inner = &self.inner;
+        let _admin = inner.admin.lock().await;
+
+        // Fast path: directory already watched — just bump the refcount.
+        {
+            let mut map = lock(&inner.dirs);
+            if let Some(entry) = map.get_mut(&dir) {
+                entry.registrations += 1;
+                inner
+                    .stats
+                    .total_registrations
+                    .fetch_add(1, Ordering::Relaxed);
+                return Ok(RegisteredSandboxLogger::new(
+                    logger,
+                    LogRegistration {
+                        inner: Arc::clone(inner),
+                        dir,
+                    },
+                ));
+            }
+        }
+
+        // New directory: hand the blocking `watch` to the admin thread and
+        // await its result. `admin` (held) guarantees no other registrant
+        // observes this directory until the watch succeeds and the entry
+        // is inserted, so a failed watch needs no rollback.
+        let (reply_tx, reply_rx) = oneshot::channel();
+        inner
+            .admin_tx
+            .send(AdminCommand::Watch {
+                dir: dir.clone(),
+                reply: reply_tx,
+            })
+            .map_err(|_| MicrosandboxError::Custom("log watch admin thread stopped".into()))?;
+        reply_rx
+            .await
+            .map_err(|_| MicrosandboxError::Custom("log watch admin thread dropped reply".into()))?
+            .map_err(|e| {
+                inner.stats.watch_failures.fetch_add(1, Ordering::Relaxed);
+                MicrosandboxError::Custom(format!(
+                    "log watch subscribe failed for {}: {e}",
+                    dir.display()
+                ))
+            })?;
+
+        {
+            let (tx, _rx) = watch::channel(0u64);
+            lock(&inner.dirs).insert(
+                dir.clone(),
+                DirEntry {
+                    signal: Arc::new(tx),
+                    registrations: 1,
+                },
+            );
+        }
+        inner.registered_dirs.fetch_add(1, Ordering::Relaxed);
+        inner
+            .stats
+            .total_registrations
+            .fetch_add(1, Ordering::Relaxed);
+
+        Ok(RegisteredSandboxLogger::new(
+            logger,
+            LogRegistration {
+                inner: Arc::clone(inner),
+                dir,
+            },
+        ))
+    }
+
+    /// Snapshot the instrumentation counters.
+    pub fn stats(&self) -> RegistryStatsSnapshot {
+        let s = &self.inner.stats;
+        RegistryStatsSnapshot {
+            registered_dirs: self.inner.registered_dirs.load(Ordering::Relaxed),
+            total_registrations: s.total_registrations.load(Ordering::Relaxed),
+            wake_all_events: s.wake_all_events.load(Ordering::Relaxed),
+            route_misses: s.route_misses.load(Ordering::Relaxed),
+            watch_failures: s.watch_failures.load(Ordering::Relaxed),
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// LogRegistration
+//--------------------------------------------------------------------------------------------------
+
+impl LogRegistration {
+    /// Subscribe a new followed stream to this directory's wake signal.
+    /// The returned subscription carries a registration clone, so the
+    /// directory stays watched until the stream drops.
+    pub(crate) fn subscribe(&self) -> LogSubscription {
+        // The source registration keeps the entry alive, so this lookup
+        // always hits.
+        let rx = lock(&self.inner.dirs)
+            .get(&self.dir)
+            .map(|entry| entry.signal.subscribe())
+            .expect("registration keeps its dir entry alive");
+        LogSubscription {
+            rx,
+            _registration: self.clone(),
+        }
+    }
+}
+
+impl Clone for LogRegistration {
+    fn clone(&self) -> Self {
+        // Brief map lock, no `admin`, no syscall: the source handle keeps
+        // this directory's refcount >= 1, so no concurrent drop can
+        // remove the entry mid-clone.
+        {
+            let mut map = lock(&self.inner.dirs);
+            if let Some(entry) = map.get_mut(&self.dir) {
+                entry.registrations += 1;
+                self.inner
+                    .stats
+                    .total_registrations
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        Self {
+            inner: Arc::clone(&self.inner),
+            dir: self.dir.clone(),
+        }
+    }
+}
+
+impl Drop for LogRegistration {
+    fn drop(&mut self) {
+        // Decrement under the map lock; on the last drop remove the entry
+        // and enqueue the unwatch under the SAME lock, so the command's
+        // FIFO order matches the map-state order — a later re-watch of this
+        // path is guaranteed to enqueue after this unwatch. Non-blocking:
+        // the watcher round-trip happens on the admin thread.
+        let mut map = lock(&self.inner.dirs);
+        let Some(entry) = map.get_mut(&self.dir) else {
+            return;
+        };
+        entry.registrations -= 1;
+        self.inner
+            .stats
+            .total_registrations
+            .fetch_sub(1, Ordering::Relaxed);
+        if entry.registrations > 0 {
+            return;
+        }
+
+        map.remove(&self.dir);
+        self.inner.registered_dirs.fetch_sub(1, Ordering::Relaxed);
+        let _ = self.inner.admin_tx.send(AdminCommand::Unwatch {
+            dir: self.dir.clone(),
+        });
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// LogSubscription
+//--------------------------------------------------------------------------------------------------
+
+impl LogSubscription {
+    /// Await the next wake for this directory. Returns `Err` only if the
+    /// sender has closed, which the held registration clone prevents
+    /// while the stream lives.
+    pub(crate) async fn changed(&mut self) -> Result<(), watch::error::RecvError> {
+        self.rx.changed().await
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Own the single watcher and serve watch/unwatch requests in FIFO
+/// order. Runs on a dedicated thread so these (possibly slow) calls never
+/// touch a runtime thread. Exits when every [`RegistryInner`] — and thus
+/// every command sender — has dropped.
+fn admin_loop(mut watcher: notify::RecommendedWatcher, rx: mpsc::Receiver<AdminCommand>) {
+    while let Ok(command) = rx.recv() {
+        match command {
+            AdminCommand::Watch { dir, reply } => {
+                let result = watcher.watch(&dir, notify::RecursiveMode::NonRecursive);
+                let _ = reply.send(result);
+            }
+            AdminCommand::Unwatch { dir } => {
+                let _ = watcher.unwatch(&dir);
+            }
+        }
+    }
+}
+
+/// Route one watcher callback. Runs on notify's single callback thread,
+/// so events are handled serially — one at a time. Fans out to every
+/// subscriber on overflow/error, otherwise wakes only the directories the
+/// event touched. Signals are cloned under the map lock and woken after it
+/// is released, so routing never holds the map across a wake.
+fn route_event(
+    dirs: &Mutex<HashMap<PathBuf, DirEntry>>,
+    stats: &RegistryStats,
+    res: notify::Result<notify::Event>,
+) {
+    let event = match res {
+        Ok(event) => {
+            if event.need_rescan() {
+                wake_all(dirs, stats);
+                return;
+            }
+            event
+        }
+        // A watcher-level error may mean dropped events; rescan all.
+        Err(_) => {
+            wake_all(dirs, stats);
+            return;
+        }
+    };
+
+    use notify::EventKind;
+    if !matches!(
+        event.kind,
+        EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
+    ) {
+        return;
+    }
+
+    let signals = collect_signals(dirs, stats, &event.paths);
+    for signal in signals {
+        signal.send_modify(|v| *v = v.wrapping_add(1));
+    }
+}
+
+/// Resolve each event path to its owning directory (the path itself, or
+/// its parent for a child entry) and collect the matching wake signals.
+fn collect_signals(
+    dirs: &Mutex<HashMap<PathBuf, DirEntry>>,
+    stats: &RegistryStats,
+    paths: &[PathBuf],
+) -> Vec<Arc<watch::Sender<u64>>> {
+    let map = lock(dirs);
+    let mut signals = Vec::new();
+    for path in paths {
+        let entry = map
+            .get(path.as_path())
+            .or_else(|| path.parent().and_then(|parent| map.get(parent)));
+        match entry {
+            Some(entry) => signals.push(Arc::clone(&entry.signal)),
+            None => {
+                stats.route_misses.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+    signals
+}
+
+/// Snapshot every signal under one brief lock, then wake them all — used
+/// for inotify overflow and watcher errors so readers rescan their files.
+fn wake_all(dirs: &Mutex<HashMap<PathBuf, DirEntry>>, stats: &RegistryStats) {
+    let signals: Vec<Arc<watch::Sender<u64>>> =
+        { lock(dirs).values().map(|e| Arc::clone(&e.signal)).collect() };
+    for signal in &signals {
+        signal.send_modify(|v| *v = v.wrapping_add(1));
+    }
+    stats.wake_all_events.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Lock a mutex, recovering the guard through a poisoned lock. Registry
+/// critical sections never unwind, so poisoning only means a prior panic
+/// elsewhere left the guard — the data itself stays consistent.
+fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `dirs` map with the given directories, each with a fresh
+    /// signal and refcount 1, plus a retained receiver per dir so the
+    /// senders observe changes.
+    fn map_with(
+        dirs: &[&std::path::Path],
+    ) -> (
+        Arc<Mutex<HashMap<PathBuf, DirEntry>>>,
+        Vec<watch::Receiver<u64>>,
+    ) {
+        let map = Arc::new(Mutex::new(HashMap::new()));
+        let mut receivers = Vec::new();
+        {
+            let mut guard = map.lock().unwrap();
+            for dir in dirs {
+                let (tx, rx) = watch::channel(0u64);
+                receivers.push(rx);
+                guard.insert(
+                    dir.to_path_buf(),
+                    DirEntry {
+                        signal: Arc::new(tx),
+                        registrations: 1,
+                    },
+                );
+            }
+        }
+        (map, receivers)
+    }
+
+    fn synthetic_event(kind: notify::EventKind, paths: Vec<PathBuf>) -> notify::Event {
+        notify::Event {
+            kind,
+            paths,
+            attrs: Default::default(),
+        }
+    }
+
+    #[test]
+    fn routes_child_event_to_only_its_directory() {
+        let a = PathBuf::from("/tmp/msb-a/logs");
+        let b = PathBuf::from("/tmp/msb-b/logs");
+        let (map, receivers) = map_with(&[&a, &b]);
+        let stats = RegistryStats::default();
+
+        let event = synthetic_event(
+            notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Content,
+            )),
+            vec![a.join("exec.log")],
+        );
+        route_event(&map, &stats, Ok(event));
+
+        assert_eq!(*receivers[0].borrow(), 1, "dir a woke");
+        assert_eq!(*receivers[1].borrow(), 0, "dir b untouched");
+        assert_eq!(stats.route_misses.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn unmatched_path_counts_a_route_miss() {
+        let a = PathBuf::from("/tmp/msb-a/logs");
+        let (map, _receivers) = map_with(&[&a]);
+        let stats = RegistryStats::default();
+
+        let event = synthetic_event(
+            notify::EventKind::Create(notify::event::CreateKind::File),
+            vec![PathBuf::from("/tmp/msb-other/logs/exec.log")],
+        );
+        route_event(&map, &stats, Ok(event));
+
+        assert_eq!(stats.route_misses.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn error_wakes_all_directories() {
+        let a = PathBuf::from("/tmp/msb-a/logs");
+        let b = PathBuf::from("/tmp/msb-b/logs");
+        let (map, receivers) = map_with(&[&a, &b]);
+        let stats = RegistryStats::default();
+
+        route_event(&map, &stats, Err(notify::Error::generic("dropped events")));
+
+        assert_eq!(*receivers[0].borrow(), 1);
+        assert_eq!(*receivers[1].borrow(), 1);
+        assert_eq!(stats.wake_all_events.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn ignored_event_kinds_do_not_wake() {
+        let a = PathBuf::from("/tmp/msb-a/logs");
+        let (map, receivers) = map_with(&[&a]);
+        let stats = RegistryStats::default();
+
+        let event = synthetic_event(
+            notify::EventKind::Access(notify::event::AccessKind::Read),
+            vec![a.join("exec.log")],
+        );
+        route_event(&map, &stats, Ok(event));
+
+        assert_eq!(*receivers[0].borrow(), 0);
+    }
+
+    #[tokio::test]
+    async fn register_missing_dir_is_sandbox_not_found() {
+        let registry = LogRegistry::new().unwrap();
+        let logger = SandboxLogger::new(
+            "sbx".to_string(),
+            PathBuf::from("/tmp/msb-nonexistent-xyz/logs"),
+        );
+        match registry.register(logger).await {
+            Err(MicrosandboxError::SandboxNotFound(_)) => {}
+            Err(other) => panic!("expected SandboxNotFound, got {other:?}"),
+            Ok(_) => panic!("expected SandboxNotFound, got Ok"),
+        }
+        assert_eq!(registry.stats().registered_dirs, 0);
+    }
+
+    // Exercises a real OS watch via `register`. On Linux (the production
+    // target) `inotify_add_watch` is instant; on macOS `notify`'s FSEvents
+    // `watch()` can take tens of seconds on some hosts (security agents
+    // hooking stream creation), so it is skipped there by default — run
+    // with `--ignored` to include it.
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "FSEvents watch() latency; runs on Linux CI"
+    )]
+    #[tokio::test]
+    async fn one_directory_two_registrations_share_one_descriptor() {
+        let registry = LogRegistry::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+
+        let first = registry
+            .register(SandboxLogger::new("sbx".into(), dir.path().to_path_buf()))
+            .await
+            .unwrap();
+        let second = registry
+            .register(SandboxLogger::new("sbx".into(), dir.path().to_path_buf()))
+            .await
+            .unwrap();
+
+        // Same directory → one watch descriptor, two registrations.
+        assert_eq!(registry.stats().registered_dirs, 1);
+        assert_eq!(registry.stats().total_registrations, 2);
+
+        // Last registration standing keeps the watch.
+        drop(first);
+        assert_eq!(registry.stats().registered_dirs, 1);
+        assert_eq!(registry.stats().total_registrations, 1);
+
+        // Final drop removes it; the directory can be re-registered.
+        drop(second);
+        assert_eq!(registry.stats().registered_dirs, 0);
+        let third = registry
+            .register(SandboxLogger::new("sbx".into(), dir.path().to_path_buf()))
+            .await
+            .unwrap();
+        assert_eq!(registry.stats().registered_dirs, 1);
+        drop(third);
+        assert_eq!(registry.stats().registered_dirs, 0);
+    }
+
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "FSEvents watch() latency; runs on Linux CI"
+    )]
+    #[tokio::test]
+    async fn stream_keeps_directory_registered_after_logger_drops() {
+        use crate::logs::LogStreamOptions;
+
+        let registry = LogRegistry::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let logger = registry
+            .register(SandboxLogger::new("sbx".into(), dir.path().to_path_buf()))
+            .await
+            .unwrap();
+
+        let stream = logger
+            .stream(&LogStreamOptions {
+                follow: true,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        // Logger + stream both hold the directory.
+        assert_eq!(registry.stats().registered_dirs, 1);
+        assert_eq!(registry.stats().total_registrations, 2);
+
+        // Dropping the logger must NOT tear down the watch — the live
+        // stream's registration clone keeps it.
+        drop(logger);
+        assert_eq!(registry.stats().registered_dirs, 1);
+        assert_eq!(registry.stats().total_registrations, 1);
+
+        // Dropping the last stream removes the watch.
+        drop(stream);
+        assert_eq!(registry.stats().registered_dirs, 0);
+        assert_eq!(registry.stats().total_registrations, 0);
+    }
+}

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -1470,6 +1470,28 @@ impl Sandbox {
             .await
     }
 
+    /// A [`SandboxLogger`](crate::logs::SandboxLogger) over this
+    /// sandbox's on-disk logs.
+    ///
+    /// **Local backend only** — cloud sandboxes stream logs via SSE and
+    /// have no host log directory. Used directly it behaves like
+    /// [`log_stream`](Self::log_stream) (a private watcher per followed
+    /// stream); registered with a
+    /// [`LogRegistry`](crate::logs::LogRegistry) its followed
+    /// streams share one host-wide watcher instead.
+    pub fn logger(&self) -> MicrosandboxResult<crate::logs::SandboxLogger> {
+        self.require_local("logger")?;
+        let local =
+            self.backend
+                .as_local()
+                .ok_or_else(|| crate::MicrosandboxError::Unsupported {
+                    feature: "Sandbox::logger".into(),
+                    available_when: "with a LocalBackend".into(),
+                })?;
+        let log_dir = crate::logs::log_dir_for_local(local, &self.name);
+        Ok(crate::logs::SandboxLogger::new(self.name.clone(), log_dir))
+    }
+
     /// Check whether agentd is reachable without refreshing the sandbox idle timer.
     ///
     /// Local backend only. The request uses `core.ping` and returns the SDK-measured

--- a/sdk/rust/tests/log_registry_e2e.rs
+++ b/sdk/rust/tests/log_registry_e2e.rs
@@ -1,0 +1,203 @@
+//! End-to-end tests for the shared [`LogRegistry`] against real
+//! microVMs.
+//!
+//! These boot alpine sandboxes, register their loggers with a single
+//! host-scoped registry, and validate the registry-backed pipeline:
+//! `sandbox.logger()` → `registry.register()` → `RegisteredSandboxLogger`
+//! read/stream carries the sandbox's real output through to a consumer,
+//! and multiple sandboxes coexist on one registry.
+//!
+//! Scope: these prove the registry *wiring* end to end. The fine-grained
+//! routing, refcount, and ordering guarantees are covered deterministically
+//! by the `logs::watch` unit tests; a followed stream also has a fallback
+//! poll, so a live-delivery test here can't isolate the watcher from it.
+//!
+//! These tests require KVM (or libkrun on macOS). The `#[msb_test]`
+//! attribute marks them `#[ignore]`, so plain `cargo test --workspace`
+//! skips them. Run them via:
+//!
+//!     cargo nextest run -p microsandbox --test log_registry_e2e --run-ignored=only
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use microsandbox::Sandbox;
+use microsandbox::logs::{
+    LogEntry, LogOptions, LogRegistry, LogSource, LogStreamOptions, LogStreamStart,
+};
+use test_utils::msb_test;
+
+const ALPINE: &str = "mirror.gcr.io/library/alpine";
+
+async fn start_alpine(name: &str) -> Sandbox {
+    Sandbox::builder(name)
+        .image(ALPINE)
+        .cpus(1)
+        .memory(512)
+        .replace()
+        .create()
+        .await
+        .expect("create sandbox")
+}
+
+async fn stop_and_remove(name: &str) {
+    let handle = Sandbox::get(name).await.expect("get");
+    handle.stop().await.expect("stop");
+    Sandbox::remove(name).await.expect("remove");
+}
+
+fn contains(entry: &LogEntry, needle: &str) -> bool {
+    std::str::from_utf8(&entry.data)
+        .map(|s| s.contains(needle))
+        .unwrap_or(false)
+}
+
+/// Snapshot path through the registry: register a running sandbox's
+/// logger, exec a command, and `read` back its stdout. The registry
+/// should report exactly one watched directory.
+#[msb_test]
+async fn registry_reads_sandbox_logs() {
+    let name = "log-watch-registry-e2e-read";
+    let marker = "registry-read-marker-4c1a";
+
+    let registry = LogRegistry::new().expect("registry");
+    let sandbox = start_alpine(name).await;
+
+    let logger = sandbox.logger().expect("logger");
+    let registered = registry.register(logger).await.expect("register");
+    assert_eq!(registry.stats().registered_dirs, 1);
+
+    sandbox
+        .exec("sh", ["-c", &format!("echo {marker}")])
+        .await
+        .expect("exec");
+
+    let entries = registered
+        .read(&LogOptions::default())
+        .await
+        .expect("read logs");
+
+    stop_and_remove(name).await;
+
+    let matched: Vec<_> = entries.iter().filter(|e| contains(e, marker)).collect();
+    assert!(
+        !matched.is_empty(),
+        "expected marker {marker:?} via registered logger; saw {} entries",
+        entries.len(),
+    );
+    assert_eq!(matched[0].source, LogSource::Stdout);
+}
+
+/// Follow path through the registry: open a followed stream on the
+/// registered logger, then exec. The shared-watcher pipeline must deliver
+/// the new write to the subscriber within a short timeout.
+#[msb_test]
+async fn registry_follow_catches_live_writes() {
+    let name = "log-watch-registry-e2e-follow";
+    let marker = "registry-follow-marker-9d2f";
+
+    let registry = LogRegistry::new().expect("registry");
+    let sandbox = start_alpine(name).await;
+
+    let logger = sandbox.logger().expect("logger");
+    let registered = registry.register(logger).await.expect("register");
+
+    // Start at "now" so boot-lifecycle entries are skipped and the only
+    // match is the exec below.
+    let cutoff = chrono::Utc::now();
+    let mut stream = registered
+        .stream(&LogStreamOptions {
+            sources: Vec::new(),
+            start: LogStreamStart::Since(cutoff),
+            until: None,
+            follow: true,
+        })
+        .await
+        .expect("open registry stream");
+
+    sandbox
+        .exec("sh", ["-c", &format!("echo {marker}")])
+        .await
+        .expect("exec");
+
+    let found = tokio::time::timeout(Duration::from_secs(8), async {
+        while let Some(item) = stream.next().await {
+            let entry = item.expect("stream item");
+            if contains(&entry, marker) {
+                return entry;
+            }
+        }
+        panic!("stream ended without ever seeing marker {marker:?}");
+    })
+    .await
+    .expect("marker arrived within timeout");
+
+    stop_and_remove(name).await;
+
+    assert_eq!(found.source, LogSource::Stdout);
+}
+
+/// One registry, two sandboxes: register both, confirm the registry
+/// tracks two watched directories, and confirm each registered logger
+/// reads back its own sandbox's output and not the other's.
+#[msb_test]
+async fn registry_serves_two_sandboxes() {
+    let name_a = "log-watch-registry-e2e-multi-a";
+    let name_b = "log-watch-registry-e2e-multi-b";
+    let marker_a = "registry-multi-marker-A-6b3c";
+    let marker_b = "registry-multi-marker-B-1e8d";
+
+    let registry = LogRegistry::new().expect("registry");
+    let sandbox_a = start_alpine(name_a).await;
+    let sandbox_b = start_alpine(name_b).await;
+
+    let registered_a = registry
+        .register(sandbox_a.logger().expect("logger a"))
+        .await
+        .expect("register a");
+    let registered_b = registry
+        .register(sandbox_b.logger().expect("logger b"))
+        .await
+        .expect("register b");
+
+    // Two distinct directories on the one registry.
+    assert_eq!(registry.stats().registered_dirs, 2);
+
+    sandbox_a
+        .exec("sh", ["-c", &format!("echo {marker_a}")])
+        .await
+        .expect("exec a");
+    sandbox_b
+        .exec("sh", ["-c", &format!("echo {marker_b}")])
+        .await
+        .expect("exec b");
+
+    let entries_a = registered_a
+        .read(&LogOptions::default())
+        .await
+        .expect("read a");
+    let entries_b = registered_b
+        .read(&LogOptions::default())
+        .await
+        .expect("read b");
+
+    stop_and_remove(name_a).await;
+    stop_and_remove(name_b).await;
+
+    assert!(
+        entries_a.iter().any(|e| contains(e, marker_a)),
+        "sandbox A logs missing its own marker",
+    );
+    assert!(
+        !entries_a.iter().any(|e| contains(e, marker_b)),
+        "sandbox A logs leaked sandbox B's marker",
+    );
+    assert!(
+        entries_b.iter().any(|e| contains(e, marker_b)),
+        "sandbox B logs missing its own marker",
+    );
+    assert!(
+        !entries_b.iter().any(|e| contains(e, marker_a)),
+        "sandbox B logs leaked sandbox A's marker",
+    );
+}


### PR DESCRIPTION
## Problem

A process that keeps a followed log stream open per sandbox (to tail many sandboxes at once) hits a scaling wall. Every followed `Sandbox::log_stream(follow = true)` builds its own `notify::RecommendedWatcher`, and on Linux each watcher is a separate inotify instance + thread. Past `fs.inotify.max_user_instances` (default 128) watcher creation fails, and affected streams silently stop receiving updates. `LimitNOFILE` doesn't help — it's a distinct per-user kernel quota.

## What this does

Adds an opt-in `LogRegistry` that shares **one** watcher across every followed stream in the process. Standalone SDK/CLI use is unchanged (still a private watcher per stream).

```rust
let registry = LogRegistry::new()?;
let logger = registry.register(sandbox.logger()?).await?;  // RAII-registered
let stream = logger.stream(&opts).await?;                  // shares one watch descriptor
```

- **One watcher per registry, one watch descriptor per sandbox dir**, regardless of stream count. A per-directory coalescing `watch::Sender<u64>` signal wakes only the engines reading that dir; inotify overflow / watcher errors wake all (rescan).
- **RAII refcount** = live loggers + live streams. A stream that outlives its parent logger keeps the dir watched; the watch drops when the last holder does.
- **Dedicated watcher-admin thread** owns the watcher and serves `watch`/`unwatch` over a channel in FIFO order, so those (potentially slow) calls never run on a runtime thread. `register()` is async and non-blocking (awaits a reply); `Drop` is a non-blocking, lock-ordered `unwatch` enqueue — a later re-watch of a path is guaranteed to land after its unwatch.
- **Engine wake source** refactored into a private `FollowMode { Off, Standalone, Registry }`; cursors, parsing, rotation, and the fallback poll are untouched — the registry only changes where the "read again" nudge comes from.
- New `Sandbox::logger()` (local-only) returns a `SandboxLogger` you can use directly or register.

## Tests

- **Unit** (`logs::watch`): event routing, route-miss accounting, overflow wake-all, refcount lifecycle (share one descriptor, last-drop cleanup, re-register), and the stream-outlives-logger guarantee. The real-`watch()` ones are skipped on macOS (FSEvents `watch()` latency on some hosts) and run on Linux.
- **Real-VM e2e** (`tests/log_registry_e2e.rs`, `#[msb_test]`): register a running sandbox's logger and read its stdout; a followed registry stream catches live writes; one registry serves two sandboxes with per-sandbox isolation. Run with `cargo nextest run -p microsandbox --test log_registry_e2e --run-ignored=only` — all three pass against real alpine microVMs.

## Notes

`registry.stats()` exposes registered dirs, total registrations, wake-all recoveries, route misses, and watch failures for host-side scraping.
