### PR TITLE
ci(release): gate winget publishing until package approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -746,27 +746,27 @@ jobs:
   #   - WINGET_RELEASE_ENABLED: set this repository variable to `true` only
   #     after the first package version is accepted into winget-pkgs.
   #
-  # The submit step is a no-op unless publishing is enabled and WINGET_TOKEN is
-  # set, so releases never fail before the initial package is accepted or for
-  # forks that have not configured winget publishing. Prerelease tags
-  # (rc/alpha/beta/dev) are skipped to match the assemble job's --prerelease
-  # detection.
+  # The job is skipped unless publishing is enabled, and the submit step is a
+  # no-op when WINGET_TOKEN is unset. This keeps releases from failing before
+  # the initial package is accepted or for forks that have not configured
+  # winget publishing. Prerelease tags (rc/alpha/beta/dev) are skipped to match
+  # the assemble job's --prerelease detection.
   # ---------------------------------------------------------------------------
   update-winget:
     name: Update winget package
     needs: assemble
+    if: >-
+      vars.WINGET_RELEASE_ENABLED == 'true'
+      && !contains(github.ref_name, '-rc')
+      && !contains(github.ref_name, '-alpha')
+      && !contains(github.ref_name, '-beta')
+      && !contains(github.ref_name, '-dev')
     runs-on: ubuntu-latest
     env:
       WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
     steps:
       - name: Submit to winget-pkgs
-        if: >-
-          vars.WINGET_RELEASE_ENABLED == 'true'
-          && env.WINGET_TOKEN != ''
-          && !contains(github.ref_name, '-rc')
-          && !contains(github.ref_name, '-alpha')
-          && !contains(github.ref_name, '-beta')
-          && !contains(github.ref_name, '-dev')
+        if: env.WINGET_TOKEN != ''
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: SuperRadCompany.Microsandbox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -743,9 +743,12 @@ jobs:
   #     fork of microsoft/winget-pkgs. Set the WINGET_FORK_USER repository
   #     variable if that fork lives under a different account than this repo's
   #     owner.
+  #   - WINGET_RELEASE_ENABLED: set this repository variable to `true` only
+  #     after the first package version is accepted into winget-pkgs.
   #
-  # The submit step is a no-op when WINGET_TOKEN is unset, so releases never
-  # fail for forks that have not configured winget publishing. Prerelease tags
+  # The submit step is a no-op unless publishing is enabled and WINGET_TOKEN is
+  # set, so releases never fail before the initial package is accepted or for
+  # forks that have not configured winget publishing. Prerelease tags
   # (rc/alpha/beta/dev) are skipped to match the assemble job's --prerelease
   # detection.
   # ---------------------------------------------------------------------------
@@ -758,7 +761,8 @@ jobs:
     steps:
       - name: Submit to winget-pkgs
         if: >-
-          env.WINGET_TOKEN != ''
+          vars.WINGET_RELEASE_ENABLED == 'true'
+          && env.WINGET_TOKEN != ''
           && !contains(github.ref_name, '-rc')
           && !contains(github.ref_name, '-alpha')
           && !contains(github.ref_name, '-beta')

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -24,7 +24,7 @@ After that first version lands, set the `WINGET_RELEASE_ENABLED` repository vari
 
 One-time setup for the automation:
 
-- After the first version is accepted into `microsoft/winget-pkgs`, set the `WINGET_RELEASE_ENABLED` repository variable to `true`. Keep it unset before then so release workflows skip the submission step.
+- After the first version is accepted into `microsoft/winget-pkgs`, set the `WINGET_RELEASE_ENABLED` repository variable to `true`. Keep it unset before then so release workflows skip the `update-winget` job.
 - Add a `WINGET_TOKEN` repository secret: a classic PAT with `public_repo` scope whose owner has a fork of `microsoft/winget-pkgs`. The submit step is skipped when this secret is absent.
 - If that fork lives under an account other than `superradcompany`, set a `WINGET_FORK_USER` repository variable to the fork owner's username.
 

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -20,10 +20,11 @@ The package uses winget's zip + portable installer shape because the microsandbo
 
 The **first** version must be submitted to `microsoft/winget-pkgs` by hand using the staged `0.6.0` manifests (see [Submit 0.6.0](#submit-060) below). Komac, which the release automation uses, refuses to open a PR for a package that does not yet exist in the community repository.
 
-After that first version lands, **subsequent releases are automated**. The `update-winget` job in [`.github/workflows/release.yml`](../../.github/workflows/release.yml) runs on every `v*` tag: it invokes [`winget-releaser`](https://github.com/vedantmgoyal9/winget-releaser) (Komac), which copies the previously published manifests, bumps the version, rewrites the installer URLs and SHA256 hashes from the release's `microsandbox-windows-*.zip` assets, and opens a PR against `microsoft/winget-pkgs`.
+After that first version lands, set the `WINGET_RELEASE_ENABLED` repository variable to `true` to automate subsequent releases. The `update-winget` job in [`.github/workflows/release.yml`](../../.github/workflows/release.yml) then runs on every `v*` tag: it invokes [`winget-releaser`](https://github.com/vedantmgoyal9/winget-releaser) (Komac), which copies the previously published manifests, bumps the version, rewrites the installer URLs and SHA256 hashes from the release's `microsandbox-windows-*.zip` assets, and opens a PR against `microsoft/winget-pkgs`.
 
 One-time setup for the automation:
 
+- After the first version is accepted into `microsoft/winget-pkgs`, set the `WINGET_RELEASE_ENABLED` repository variable to `true`. Keep it unset before then so release workflows skip the submission step.
 - Add a `WINGET_TOKEN` repository secret: a classic PAT with `public_repo` scope whose owner has a fork of `microsoft/winget-pkgs`. The submit step is skipped when this secret is absent.
 - If that fork lives under an account other than `superradcompany`, set a `WINGET_FORK_USER` repository variable to the fork owner's username.
 


### PR DESCRIPTION
## TL;DR
Keep Winget publishing disabled until the initial package is accepted into `microsoft/winget-pkgs`. Set `WINGET_RELEASE_ENABLED` to `true` afterward to resume automated submissions.

## Description
- Skip the entire `update-winget` job unless `WINGET_RELEASE_ENABLED` equals `true` and the release tag is stable, avoiding unnecessary runner allocation.
- Preserve the existing token guard on the submission step when Winget publishing is enabled.
- Document when and how to enable automated Winget submissions after the bootstrap manifest is accepted.

## Test Plan
- [x] `git diff --check -- .github/workflows/release.yml packaging/winget/README.md` passes.
- [x] Ruby parses `.github/workflows/release.yml` and confirms the enable and prerelease guards are job-level while the token guard remains step-level.
- [x] The repository pre-commit `check yaml` hook passes.
- [x] `gh variable list -R superradcompany/microsandbox` confirms `WINGET_RELEASE_ENABLED` is unset.
- [ ] Confirm the Winget submission step is skipped on the next release tag. (post-merge)