### PR TITLE
refactor(db): one DbConnection handle, engine-enforced rw split

### DIFF
--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -247,7 +247,7 @@ enum DowngradeRunOutcome {
 }
 
 struct DowngradeRunContext<'a> {
-    db: &'a microsandbox_db::connection::DbWriteConnection,
+    db: &'a microsandbox_db::DbConnection,
     base_dir: &'a Path,
     db_path: &'a Path,
     backup_path: Option<&'a Path>,
@@ -828,11 +828,11 @@ async fn run_downgrade_local(args: SelfDowngradeArgs) -> anyhow::Result<()> {
         };
 
     let db = open_downgrade_db(&db_path).await?;
-    let applied_migrations = applied_migrations(db.inner()).await?;
+    let applied_migrations = applied_migrations(db.inner()?).await?;
     let rollback_plan = build_rollback_plan(&target_baseline, &applied_migrations)?;
     refuse_irreversible_rollback(&rollback_plan)?;
     let user_data_warnings = if rollback_plan.affects_user_data {
-        user_data_warnings(db.inner()).await?
+        user_data_warnings(db.inner()?).await?
     } else {
         Vec::new()
     };
@@ -863,7 +863,7 @@ async fn run_downgrade_local(args: SelfDowngradeArgs) -> anyhow::Result<()> {
     }
 
     let mut install_lease = if maintenance_lease_available(&applied_migrations) {
-        Some(microsandbox_runtime::maintenance::acquire_install_exclusive_lease(&db).await?)
+        Some(microsandbox_runtime::maintenance::acquire_install_exclusive_lease(db.inner()?).await?)
     } else {
         None
     };
@@ -883,8 +883,11 @@ async fn run_downgrade_local(args: SelfDowngradeArgs) -> anyhow::Result<()> {
         install_lease.as_ref(),
     ) {
         if let Some(lease) = install_lease.as_ref() {
-            let _ =
-                microsandbox_runtime::maintenance::clear_install_exclusive_lease(&db, lease).await;
+            let _ = microsandbox_runtime::maintenance::clear_install_exclusive_lease(
+                db.inner()?,
+                lease,
+            )
+            .await;
         }
         return Err(error);
     }
@@ -921,7 +924,8 @@ async fn run_downgrade_local(args: SelfDowngradeArgs) -> anyhow::Result<()> {
         .unwrap_or(true);
     if clear_lease_in_parent && let Some(lease) = install_lease.as_ref() {
         let clear_result =
-            microsandbox_runtime::maintenance::clear_install_exclusive_lease(&db, lease).await;
+            microsandbox_runtime::maintenance::clear_install_exclusive_lease(db.inner()?, lease)
+                .await;
         if let Err(err) = clear_result {
             ui::warn(&format!("failed to clear downgrade lease: {err}"));
         }
@@ -940,14 +944,14 @@ async fn run_downgrade_with_db(
 
     {
         let _migration_lock = acquire_migration_lock(db_dir)?;
-        let fresh_applied = applied_migrations(ctx.db.inner()).await?;
+        let fresh_applied = applied_migrations(ctx.db.inner()?).await?;
         let fresh_plan = build_rollback_plan(ctx.target_baseline, &fresh_applied)?;
         refuse_irreversible_rollback(&fresh_plan)?;
         if ctx.operation.phase() < DowngradePhase::DatabaseReverted {
             ensure_applied_unchanged(ctx.planned_applied_migrations, &fresh_applied)?;
             ensure_plan_unchanged(ctx.rollback_plan, &fresh_plan)?;
         }
-        renew_install_lease_if_present(ctx.db, &mut ctx.install_lease).await?;
+        renew_install_lease_if_present(ctx.db.inner()?, &mut ctx.install_lease).await?;
         refresh_windows_downgrade_recovery(&ctx)?;
 
         if !maintenance_lease_available(&fresh_applied) && fresh_plan.steps() > 0 {
@@ -959,7 +963,7 @@ async fn run_downgrade_with_db(
         }
 
         if fresh_plan.steps() > 0 || (cfg!(windows) && !fresh_applied.is_empty()) {
-            refuse_if_active_sandboxes(ctx.db.inner()).await?;
+            refuse_if_active_sandboxes(ctx.db.inner()?).await?;
         }
 
         if ctx.operation.phase() < DowngradePhase::DatabaseReverted {
@@ -971,7 +975,7 @@ async fn run_downgrade_with_db(
             {
                 let spinner = ui::Spinner::start("Checking", "retained snapshot graph");
                 let result = microsandbox::snapshot::downgrade::preflight_managed_v066(
-                    ctx.db.inner(),
+                    ctx.db.inner()?,
                     ctx.snapshots_dir,
                 )
                 .await;
@@ -993,7 +997,7 @@ async fn run_downgrade_with_db(
                     let spinner = ui::Spinner::start("Checking", "database rollback");
                     let preflight_path = ctx.operation.recovery_dir().join("schema-preflight.db");
                     match preflight_schema_rollback(
-                        ctx.db.inner(),
+                        ctx.db.inner()?,
                         &preflight_path,
                         fresh_plan.steps(),
                     )
@@ -1017,9 +1021,9 @@ async fn run_downgrade_with_db(
                         verify_sqlite_backup(path).await
                     } else {
                         run_with_install_lease_renewal(
-                            ctx.db,
+                            ctx.db.inner()?,
                             &mut ctx.install_lease,
-                            vacuum_into(ctx.db.inner(), path),
+                            vacuum_into(ctx.db.inner()?, path),
                         )
                         .await
                     };
@@ -1030,7 +1034,7 @@ async fn run_downgrade_with_db(
                             return Err(err);
                         }
                     }
-                    renew_install_lease_if_present(ctx.db, &mut ctx.install_lease).await?;
+                    renew_install_lease_if_present(ctx.db.inner()?, &mut ctx.install_lease).await?;
                     refresh_windows_downgrade_recovery(&ctx)?;
                 }
                 ctx.operation.set_phase(DowngradePhase::BackupComplete)?;
@@ -1042,7 +1046,7 @@ async fn run_downgrade_with_db(
                 if let Some(plan) = snapshot_plan {
                     let spinner = ui::Spinner::start("Reverting", "snapshot artifacts");
                     match microsandbox::snapshot::downgrade::execute_managed_v066(
-                        ctx.db.inner(),
+                        ctx.db.inner()?,
                         ctx.operation.recovery_dir(),
                         plan,
                     )
@@ -1062,9 +1066,11 @@ async fn run_downgrade_with_db(
 
             if fresh_plan.steps() > 0 {
                 let spinner = ui::Spinner::start("Rolling back", "local database changes");
-                match run_with_install_lease_renewal(ctx.db, &mut ctx.install_lease, async {
-                    rollback_schema(ctx.db.inner(), fresh_plan.steps()).await
-                })
+                match run_with_install_lease_renewal(
+                    ctx.db.inner()?,
+                    &mut ctx.install_lease,
+                    async { rollback_schema(ctx.db.inner()?, fresh_plan.steps()).await },
+                )
                 .await
                 {
                     Ok(()) => spinner.finish_success("Rolled back"),
@@ -1073,7 +1079,7 @@ async fn run_downgrade_with_db(
                         return Err(err);
                     }
                 }
-                renew_install_lease_if_present(ctx.db, &mut ctx.install_lease).await?;
+                renew_install_lease_if_present(ctx.db.inner()?, &mut ctx.install_lease).await?;
                 refresh_windows_downgrade_recovery(&ctx)?;
             }
             ctx.operation.set_phase(DowngradePhase::DatabaseReverted)?;
@@ -1083,7 +1089,7 @@ async fn run_downgrade_with_db(
     if ctx.rollback_plan.affects_cache && !ctx.args.keep_cache {
         let spinner = ui::Spinner::start("Purging", "cache");
         let base_dir = ctx.base_dir.to_path_buf();
-        match run_with_install_lease_renewal(ctx.db, &mut ctx.install_lease, async move {
+        match run_with_install_lease_renewal(ctx.db.inner()?, &mut ctx.install_lease, async move {
             tokio::task::spawn_blocking(move || purge_cache(&base_dir)).await?
         })
         .await
@@ -1095,7 +1101,7 @@ async fn run_downgrade_with_db(
             }
         }
     }
-    renew_install_lease_if_present(ctx.db, &mut ctx.install_lease).await?;
+    renew_install_lease_if_present(ctx.db.inner()?, &mut ctx.install_lease).await?;
     refresh_windows_downgrade_recovery(&ctx)?;
 
     install_target_release(&mut ctx).await
@@ -1108,10 +1114,12 @@ async fn install_target_release(
     let spinner = ui::Spinner::start("Installing", &format!("msb v{}", ctx.target_version));
     let staged_dir = ctx.operation.target_dir().to_path_buf();
     let base_dir = ctx.base_dir.to_path_buf();
-    let result = run_with_install_lease_renewal(ctx.db, &mut ctx.install_lease, async move {
-        tokio::task::spawn_blocking(move || activate_staged_release(&staged_dir, &base_dir)).await?
-    })
-    .await;
+    let result =
+        run_with_install_lease_renewal(ctx.db.inner()?, &mut ctx.install_lease, async move {
+            tokio::task::spawn_blocking(move || activate_staged_release(&staged_dir, &base_dir))
+                .await?
+        })
+        .await;
     match result {
         Ok(()) => spinner.finish_success("Installed"),
         Err(err) => {
@@ -1534,8 +1542,11 @@ async fn clear_windows_downgrade_lease(
         .join(microsandbox_utils::DB_SUBDIR)
         .join(microsandbox_utils::DB_FILENAME);
     let db = open_downgrade_db(&db_path).await?;
-    microsandbox_runtime::maintenance::clear_install_exclusive_lease_idempotent(&db, &lease)
-        .await?;
+    microsandbox_runtime::maintenance::clear_install_exclusive_lease_idempotent(
+        db.inner()?,
+        &lease,
+    )
+    .await?;
 
     writeln!(log, "cleared install-exclusive lease")?;
     Ok(())
@@ -2161,16 +2172,15 @@ fn floor_0_6_0_baseline() -> SchemaBaseline {
     }
 }
 
-async fn open_downgrade_db(
-    db_path: &Path,
-) -> anyhow::Result<microsandbox_db::connection::DbWriteConnection> {
+async fn open_downgrade_db(db_path: &Path) -> anyhow::Result<microsandbox_db::DbConnection> {
     if let Some(parent) = db_path.parent() {
         fs::create_dir_all(parent)?;
     }
 
     let config = microsandbox::config::load_persisted_config_or_default()?;
-    let db = microsandbox_db::connection::DbWriteConnection::open(
+    let db = microsandbox_db::DbConnection::open(
         db_path,
+        config.database.max_connections,
         std::time::Duration::from_secs(config.database.connect_timeout_secs),
         std::time::Duration::from_secs(config.database.busy_timeout_secs),
     )
@@ -2413,9 +2423,8 @@ fn warn_downgrade_plan(
 }
 
 async fn refuse_if_active_sandboxes(db: &DatabaseConnection) -> anyhow::Result<()> {
-    let write = microsandbox_db::connection::DbWriteConnection::new(db.clone());
     let active =
-        microsandbox_runtime::maintenance::active_sandboxes_for_schema_rollback(&write).await?;
+        microsandbox_runtime::maintenance::active_sandboxes_for_schema_rollback(db).await?;
 
     if active.is_empty() {
         return Ok(());
@@ -2475,6 +2484,7 @@ async fn preflight_schema_rollback(
     // `down()` methods, including config projections, can be exercised before
     // any live artifact or schema mutation.
     match preflight
+        .inner()?
         .execute_unprepared("UPDATE snapshot_index SET migration_state = 'reverse_complete'")
         .await
     {
@@ -2482,7 +2492,7 @@ async fn preflight_schema_rollback(
         Err(error) if is_missing_table_or_column(&error) => {}
         Err(error) => return Err(error.into()),
     }
-    rollback_schema(preflight.inner(), steps).await?;
+    rollback_schema(preflight.inner()?, steps).await?;
     drop(preflight);
     verify_sqlite_backup(preflight_path).await
 }
@@ -2624,7 +2634,7 @@ fn sync_directory(path: &Path) -> anyhow::Result<()> {
 }
 
 async fn renew_install_lease_if_present(
-    db: &microsandbox_db::connection::DbWriteConnection,
+    db: &DatabaseConnection,
     install_lease: &mut Option<&mut microsandbox_runtime::maintenance::InstallExclusiveLease>,
 ) -> anyhow::Result<()> {
     if let Some(lease) = install_lease.as_deref_mut() {
@@ -2635,7 +2645,7 @@ async fn renew_install_lease_if_present(
 }
 
 async fn run_with_install_lease_renewal<F, T>(
-    db: &microsandbox_db::connection::DbWriteConnection,
+    db: &DatabaseConnection,
     install_lease: &mut Option<&mut microsandbox_runtime::maintenance::InstallExclusiveLease>,
     operation: F,
 ) -> anyhow::Result<T>
@@ -3135,13 +3145,15 @@ mod tests {
     async fn vacuum_into_writes_backup_file() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("msb.db");
-        let db = microsandbox_db::connection::DbWriteConnection::open(
+        let db = microsandbox_db::DbConnection::open(
             &db_path,
+            1,
             std::time::Duration::from_secs(5),
             std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
+        let db = db.inner().unwrap();
         db.execute_unprepared("CREATE TABLE sample (id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
             .await
             .unwrap();
@@ -3150,12 +3162,13 @@ mod tests {
             .unwrap();
 
         let backup_path = dir.path().join("backup").join("msb.db.bak");
-        vacuum_into(db.inner(), &backup_path).await.unwrap();
+        vacuum_into(db, &backup_path).await.unwrap();
 
         assert!(backup_path.exists());
 
-        let backup_db = microsandbox_db::connection::DbWriteConnection::open(
+        let backup_db = microsandbox_db::DbConnection::open(
             &backup_path,
+            1,
             std::time::Duration::from_secs(5),
             std::time::Duration::from_secs(5),
         )
@@ -3177,18 +3190,20 @@ mod tests {
     async fn rollback_schema_rolls_back_latest_migration() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("msb.db");
-        let db = microsandbox_db::connection::DbWriteConnection::open(
+        let db = microsandbox_db::DbConnection::open(
             &db_path,
+            1,
             std::time::Duration::from_secs(5),
             std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
-        Migrator::up(db.inner(), None).await.unwrap();
+        let db = db.inner().unwrap();
+        Migrator::up(db, None).await.unwrap();
 
         // The snapshot artifact transition is latest; one step must restore
         // the preceding file-only index while everything older stays intact.
-        rollback_schema(db.inner(), 1).await.unwrap();
+        rollback_schema(db, 1).await.unwrap();
 
         let columns = db
             .query_all(Statement::from_string(
@@ -3220,13 +3235,15 @@ mod tests {
     async fn user_data_warnings_list_snapshots_and_disk_volumes() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("msb.db");
-        let db = microsandbox_db::connection::DbWriteConnection::open(
+        let db = microsandbox_db::DbConnection::open(
             &db_path,
+            1,
             std::time::Duration::from_secs(5),
             std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
+        let db = db.inner().unwrap();
         db.execute_unprepared("CREATE TABLE snapshot_index (digest TEXT PRIMARY KEY)")
             .await
             .unwrap();
@@ -3244,7 +3261,7 @@ mod tests {
         .await
         .unwrap();
 
-        let warnings = user_data_warnings(db.inner()).await.unwrap();
+        let warnings = user_data_warnings(db).await.unwrap();
 
         assert_eq!(warnings.len(), 2);
         assert!(warnings[0].contains("snapshots to project"));

--- a/crates/db/lib/connection.rs
+++ b/crates/db/lib/connection.rs
@@ -1,15 +1,22 @@
-//! Typed wrappers around `sea_orm::DatabaseConnection`.
+//! Single database handle with engine-enforced read/write separation.
 //!
-//! Splits a connection into [`DbReadConnection`] and [`DbWriteConnection`]
-//! so the type system enforces which pool a given operation hits. SQLite is
-//! single-writer system-wide; routing every write through a dedicated
-//! single-connection write pool turns intra-process contention into an
-//! in-process queue rather than `SQLITE_BUSY` retries.
+//! [`DbConnection`] wraps two lanes over the same SQLite file:
 //!
-//! Both types implement [`sea_orm::ConnectionTrait`], so existing query
-//! builders (`Entity::find().all(db)`, `Entity::insert(...).exec(db)`, etc.)
-//! work without source changes — callers just pick the right type for the
-//! operation.
+//! - a multi-connection **read pool** opened with `SQLITE_OPEN_READONLY`, so
+//!   the engine itself rejects any write that slips onto the read lane;
+//! - a **single write connection** (a 1-connection sqlx pool), so all writes
+//!   from one process serialize at pool checkout instead of contending for
+//!   SQLite's writer lock.
+//!
+//! `DbConnection` implements [`sea_orm::ConnectionTrait`] over the read lane only, so
+//! existing query builders (`Entity::find().all(&db)` etc.) keep working for
+//! reads. Writes run directly on the write connection via [`DbConnection::inner`]
+//! (`stmt.exec(db.inner()?)`), and multi-statement atomic work goes through
+//! [`DbConnection::transaction`].
+//!
+//! Cross-process contention with other writers (e.g. the in-VM runtime)
+//! still exists and is absorbed by the `busy_timeout` PRAGMA plus the
+//! retry-on-busy helpers in [`crate::retry`].
 
 use std::{future::Future, path::Path, time::Duration};
 
@@ -20,92 +27,92 @@ use sea_orm::{
 
 use crate::{pool, retry, retry::IsSqliteBusy};
 
-/// Read pool. Multi-connection; concurrent reads enabled by WAL mode.
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// One handle to the database: a read-only pool for queries plus an
+/// optional single write connection.
 ///
-/// `ConnectionTrait` is implemented so SELECTs work transparently. Writes
-/// also technically execute (sea-orm has no read-only enforcement at the
-/// trait level), but doing so via this type defeats the purpose — write
-/// paths must take a [`DbWriteConnection`] argument.
+/// Open with [`DbConnection::open`] (full read/write handle; creates the file) or
+/// [`DbConnection::open_observer`] (read-only pool only; [`DbConnection::inner`] and
+/// [`DbConnection::transaction`] fail with a clear error).
 ///
-/// `Clone` is cheap: the inner `DatabaseConnection` holds an `Arc` over
-/// the underlying sqlx pool, so clones share connection state.
+/// `Clone` is cheap: connections hold `Arc`s over the underlying sqlx pools,
+/// so cloned handles share the same connections.
 #[derive(Debug, Clone)]
-pub struct DbReadConnection(DatabaseConnection);
+pub struct DbConnection {
+    /// Multi-connection pool opened read-only; the engine rejects writes here.
+    read: DatabaseConnection,
 
-/// Write pool. Single connection; serialises in-process writes so the
-/// SQLite writer lock is never contested from within one process.
-///
-/// Cross-process contention with other writers (e.g. the in-VM runtime)
-/// still exists and is absorbed by the `busy_timeout` PRAGMA + the
-/// retry-on-busy transaction helpers (added in a follow-up step).
-///
-/// `Clone` is cheap: the inner `DatabaseConnection` holds an `Arc` over
-/// the underlying sqlx pool, so clones share the same single connection.
-#[derive(Debug, Clone)]
-pub struct DbWriteConnection(DatabaseConnection);
-
-impl DbReadConnection {
-    /// Wrap a sea-orm connection as a read pool.
-    pub fn new(inner: DatabaseConnection) -> Self {
-        Self(inner)
-    }
-
-    /// Open a stand-alone read pool at `db_path` with shared PRAGMAs.
-    ///
-    /// Read-only: opening a non-existent DB fails rather than creating it, so a
-    /// read consumer never authors or pre-empts the catalog owned by `msb`.
-    pub async fn open(
-        db_path: &Path,
-        max_connections: u32,
-        connect_timeout: Duration,
-        busy_timeout: Duration,
-    ) -> Result<Self, sqlx::Error> {
-        let conn = pool::build_pool(
-            db_path,
-            max_connections,
-            connect_timeout,
-            busy_timeout,
-            false,
-        )
-        .await?;
-        Ok(Self(conn))
-    }
-
-    /// Borrow the underlying sea-orm connection.
-    pub fn inner(&self) -> &DatabaseConnection {
-        &self.0
-    }
+    /// Single-connection write pool (`None` for observer handles); concurrent
+    /// statements and transactions serialize at pool checkout.
+    write: Option<DatabaseConnection>,
 }
 
-impl DbWriteConnection {
-    /// Wrap a sea-orm connection as a write pool.
-    pub fn new(inner: DatabaseConnection) -> Self {
-        Self(inner)
-    }
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
 
-    /// Open a stand-alone single-connection write pool at `db_path`.
+impl DbConnection {
+    /// Open a full read/write handle for the SQLite file at `db_path`.
     ///
-    /// Used by callers that don't need a paired read pool (e.g. the in-VM
-    /// runtime, which only writes run records).
+    /// The write connection opens first (creating the file and establishing
+    /// WAL mode, which persists in the database header) so the read-only pool
+    /// always opens an existing WAL database. `max_read_connections` sizes
+    /// only the read pool; the write side is always a single connection.
+    ///
+    /// Does not run migrations — callers own schema management (via
+    /// [`DbConnection::inner`]).
     pub async fn open(
         db_path: &Path,
+        max_read_connections: u32,
         connect_timeout: Duration,
         busy_timeout: Duration,
     ) -> Result<Self, sqlx::Error> {
-        let conn = pool::build_pool(db_path, 1, connect_timeout, busy_timeout, true).await?;
-        Ok(Self(conn))
+        let write = pool::build_write_pool(db_path, connect_timeout, busy_timeout).await?;
+        let read =
+            pool::build_read_pool(db_path, max_read_connections, connect_timeout, busy_timeout)
+                .await?;
+
+        Ok(Self {
+            read,
+            write: Some(write),
+        })
     }
 
-    /// Borrow the underlying sea-orm connection.
-    pub fn inner(&self) -> &DatabaseConnection {
-        &self.0
+    /// Open a read-only observer handle: a read pool and no write connection.
+    ///
+    /// Fails if the database file does not exist (a read-only open never
+    /// creates or pre-empts the database owned by `msb`); callers that expect
+    /// the file to appear later retry lazily. [`DbConnection::inner`] and
+    /// [`DbConnection::transaction`] on an observer return a clear [`DbErr`] instead of
+    /// touching the database.
+    pub async fn open_observer(
+        db_path: &Path,
+        max_read_connections: u32,
+        connect_timeout: Duration,
+        busy_timeout: Duration,
+    ) -> Result<Self, sqlx::Error> {
+        let read =
+            pool::build_read_pool(db_path, max_read_connections, connect_timeout, busy_timeout)
+                .await?;
+
+        Ok(Self { read, write: None })
     }
 
-    /// Run a multi-statement atomic write inside a transaction with
-    /// automatic retry on `SQLITE_BUSY` / `SQLITE_BUSY_SNAPSHOT`. Use this
-    /// when you need several writes to commit (or roll back) as a unit.
-    /// Single-statement writes don't need this — auto-commit `.exec(db)`
-    /// already retries via the `ConnectionTrait` impl below.
+    /// Borrow the raw single write connection, or fail with a clear error on
+    /// observer handles.
+    pub fn inner(&self) -> Result<&DatabaseConnection, DbErr> {
+        self.write.as_ref().ok_or_else(|| {
+            DbErr::Custom("read-only database handle: opened as observer".to_string())
+        })
+    }
+
+    /// Run a multi-statement atomic write inside a transaction on the write
+    /// connection with automatic retry on `SQLITE_BUSY` /
+    /// `SQLITE_BUSY_SNAPSHOT`. Use this when you need several writes to
+    /// commit (or roll back) as a unit.
     ///
     /// `f` is invoked once per attempt with a freshly opened transaction.
     /// Return `Ok((txn, value))` to commit, or any `Err` to roll back (the
@@ -123,86 +130,65 @@ impl DbWriteConnection {
         T: Send,
         E: From<DbErr> + IsSqliteBusy,
     {
+        let write = self.inner().map_err(E::from)?;
+
         retry::retry_on_busy(|| async {
-            let txn = self.0.begin().await?;
+            let txn = write.begin().await?;
             let (txn, value) = f(txn).await?;
             txn.commit().await?;
             Ok(value)
         })
         .await
     }
-}
 
-#[async_trait::async_trait]
-impl ConnectionTrait for DbReadConnection {
-    fn get_database_backend(&self) -> DbBackend {
-        self.0.get_database_backend()
-    }
-
-    async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
-        self.0.execute(stmt).await
-    }
-
-    async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
-        self.0.execute_unprepared(sql).await
-    }
-
-    async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
-        self.0.query_one(stmt).await
-    }
-
-    async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
-        self.0.query_all(stmt).await
-    }
-
-    fn support_returning(&self) -> bool {
-        self.0.support_returning()
-    }
-
-    fn is_mock_connection(&self) -> bool {
-        self.0.is_mock_connection()
+    /// Close both lanes, waiting for the underlying pools to shut down.
+    ///
+    /// Useful when a caller must observe SQLite's on-close behavior
+    /// deterministically (e.g. WAL sidecar removal) instead of relying on
+    /// drop-time cleanup.
+    pub async fn close(self) -> Result<(), DbErr> {
+        if let Some(write) = self.write {
+            write.close().await?;
+        }
+        self.read.close().await
     }
 }
 
-// Auto-retry every auto-commit operation on the writer pool. Sea-orm
-// callers (`Entity::insert(...).exec(db)` etc.) ultimately funnel through
-// these `ConnectionTrait` methods, so wrapping them in `retry_on_busy`
-// gives every single-statement write inter-process retry semantics
-// without per-call-site code.
-//
-// `Statement` is `Clone`, so the closure can produce a fresh future on
-// each retry. Multi-statement atomic work still uses `transaction()`
-// above (which retries the whole closure body); statements *inside* a
-// transaction call `ConnectionTrait` methods on `DatabaseTransaction`,
-// not on this type, so no double-retry occurs.
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+// The `ConnectionTrait` impl delegates to the read lane ONLY. The read pool
+// is opened with `SQLITE_OPEN_READONLY`, so a write routed through this impl
+// fails in the engine rather than silently landing on the wrong lane.
 #[async_trait::async_trait]
-impl ConnectionTrait for DbWriteConnection {
+impl ConnectionTrait for DbConnection {
     fn get_database_backend(&self) -> DbBackend {
-        self.0.get_database_backend()
+        self.read.get_database_backend()
     }
 
     async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
-        retry::retry_on_busy(|| async { self.0.execute(stmt.clone()).await }).await
+        self.read.execute(stmt).await
     }
 
     async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
-        retry::retry_on_busy(|| async { self.0.execute_unprepared(sql).await }).await
+        self.read.execute_unprepared(sql).await
     }
 
     async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
-        retry::retry_on_busy(|| async { self.0.query_one(stmt.clone()).await }).await
+        self.read.query_one(stmt).await
     }
 
     async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
-        retry::retry_on_busy(|| async { self.0.query_all(stmt.clone()).await }).await
+        self.read.query_all(stmt).await
     }
 
     fn support_returning(&self) -> bool {
-        self.0.support_returning()
+        self.read.support_returning()
     }
 
     fn is_mock_connection(&self) -> bool {
-        self.0.is_mock_connection()
+        self.read.is_mock_connection()
     }
 }
 
@@ -212,36 +198,231 @@ impl ConnectionTrait for DbWriteConnection {
 
 #[cfg(test)]
 mod tests {
+    use sea_orm::DatabaseBackend;
+
     use super::*;
 
     const TIMEOUT: Duration = Duration::from_secs(5);
+
+    async fn open_db(db_path: &Path) -> DbConnection {
+        DbConnection::open(db_path, 2, TIMEOUT, TIMEOUT)
+            .await
+            .unwrap()
+    }
+
+    fn select_count() -> Statement {
+        Statement::from_string(DatabaseBackend::Sqlite, "SELECT COUNT(*) FROM t")
+    }
+
+    async fn count_rows(db: &DbConnection) -> i64 {
+        db.query_one(select_count())
+            .await
+            .unwrap()
+            .unwrap()
+            .try_get_by_index::<i64>(0)
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn read_open_does_not_create_db() {
         // Existing directory, missing DB file.
         let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("catalog.db");
+        let db_path = dir.path().join("msb.db");
 
-        let result = DbReadConnection::open(&db_path, 1, TIMEOUT, TIMEOUT).await;
+        let result = DbConnection::open_observer(&db_path, 1, TIMEOUT, TIMEOUT).await;
 
-        assert!(result.is_err(), "read open should fail on a missing db");
+        assert!(result.is_err(), "observer open should fail on a missing db");
         assert!(
             !db_path.exists(),
-            "read open must not create the catalog db file"
+            "observer open must not create the db file"
         );
     }
 
     #[tokio::test]
     async fn write_open_creates_db() {
         let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("catalog.db");
+        let db_path = dir.path().join("msb.db");
 
-        let conn = DbWriteConnection::open(&db_path, TIMEOUT, TIMEOUT).await;
+        let db = DbConnection::open(&db_path, 1, TIMEOUT, TIMEOUT).await;
 
-        assert!(conn.is_ok(), "write open should succeed");
+        assert!(db.is_ok(), "open should succeed");
+        assert!(db_path.exists(), "open should create the db file");
+    }
+
+    #[tokio::test]
+    async fn read_lane_rejects_writes_in_the_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_db(&dir.path().join("msb.db")).await;
+        db.inner()
+            .unwrap()
+            .execute_unprepared("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .await
+            .unwrap();
+
+        // An INSERT routed through the ConnectionTrait impl hits the
+        // read-only pool and must be rejected by SQLite itself.
+        let err = ConnectionTrait::execute(
+            &db,
+            Statement::from_string(DatabaseBackend::Sqlite, "INSERT INTO t (v) VALUES ('x')"),
+        )
+        .await
+        .unwrap_err();
+
         assert!(
-            db_path.exists(),
-            "write open should create the catalog db file"
+            err.to_string().contains("readonly"),
+            "expected a SQLITE_READONLY error, got: {err}"
         );
+        assert_eq!(count_rows(&db).await, 0, "the write must not land");
+    }
+
+    #[tokio::test]
+    async fn observer_reads_work_and_write_paths_fail_clearly() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("msb.db");
+        let owner = open_db(&db_path).await;
+        let owner_conn = owner.inner().unwrap();
+        owner_conn
+            .execute_unprepared("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .await
+            .unwrap();
+        owner_conn
+            .execute_unprepared("INSERT INTO t (v) VALUES ('seeded')")
+            .await
+            .unwrap();
+
+        let observer = DbConnection::open_observer(&db_path, 1, TIMEOUT, TIMEOUT)
+            .await
+            .unwrap();
+        assert_eq!(count_rows(&observer).await, 1, "observer reads must work");
+
+        let inner_err = observer.inner().unwrap_err();
+        let txn_err = observer
+            .transaction::<_, _, (), DbErr>(|txn| async move { Ok((txn, ())) })
+            .await
+            .unwrap_err();
+
+        for err in [inner_err, txn_err] {
+            assert!(
+                err.to_string().contains("opened as observer"),
+                "expected the observer capability error, got: {err}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn write_waits_for_in_flight_transaction() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_db(&dir.path().join("msb.db")).await;
+        db.inner()
+            .unwrap()
+            .execute_unprepared("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .await
+            .unwrap();
+
+        // Channels let the test hold a transaction open at a known point.
+        // They live in Option cells because the transaction closure is `Fn`
+        // (retriable); the single successful attempt takes them out.
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let entered_tx = std::sync::Mutex::new(Some(entered_tx));
+        let release_rx = std::sync::Mutex::new(Some(release_rx));
+
+        let txn_db = db.clone();
+        let txn_task = tokio::spawn(async move {
+            txn_db
+                .transaction::<_, _, (), DbErr>(|txn| {
+                    let entered_tx = entered_tx.lock().unwrap().take().unwrap();
+                    let release_rx = release_rx.lock().unwrap().take().unwrap();
+                    async move {
+                        txn.execute_unprepared("INSERT INTO t (v) VALUES ('txn')")
+                            .await?;
+                        entered_tx.send(()).unwrap();
+                        release_rx.await.unwrap();
+                        Ok((txn, ()))
+                    }
+                })
+                .await
+        });
+
+        // Wait until the transaction is provably in flight, then race a
+        // single-statement write against it.
+        entered_rx.await.unwrap();
+        let write_db = db.clone();
+        let mut write_task = tokio::spawn(async move {
+            write_db
+                .inner()?
+                .execute(Statement::from_string(
+                    DatabaseBackend::Sqlite,
+                    "INSERT INTO t (v) VALUES ('write')",
+                ))
+                .await
+        });
+
+        // The transaction owns the single pooled write connection, so the
+        // statement must park at pool checkout until the transaction commits.
+        let parked = tokio::time::timeout(Duration::from_millis(200), &mut write_task).await;
+        assert!(
+            parked.is_err(),
+            "the write must wait for the in-flight transaction, not interleave"
+        );
+
+        release_tx.send(()).unwrap();
+        txn_task.await.unwrap().unwrap();
+        write_task.await.unwrap().unwrap();
+        assert_eq!(count_rows(&db).await, 2, "both writes must land in order");
+    }
+
+    #[tokio::test]
+    async fn observer_reads_while_owner_holds_the_file_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("msb.db");
+        let owner = open_db(&db_path).await;
+        let owner_conn = owner.inner().unwrap();
+        owner_conn
+            .execute_unprepared("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .await
+            .unwrap();
+        owner_conn
+            .execute_unprepared("INSERT INTO t (v) VALUES ('live')")
+            .await
+            .unwrap();
+
+        // WAL sidecars exist while the owner is open; a read-only open must
+        // still attach and see committed data.
+        let observer = DbConnection::open_observer(&db_path, 1, TIMEOUT, TIMEOUT)
+            .await
+            .unwrap();
+        assert_eq!(count_rows(&observer).await, 1);
+    }
+
+    #[tokio::test]
+    async fn observer_reopens_after_wal_sidecars_are_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("msb.db");
+        let owner = open_db(&db_path).await;
+        let owner_conn = owner.inner().unwrap();
+        owner_conn
+            .execute_unprepared("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .await
+            .unwrap();
+        owner_conn
+            .execute_unprepared("INSERT INTO t (v) VALUES ('persisted')")
+            .await
+            .unwrap();
+
+        // Closing the last connection makes SQLite checkpoint and delete the
+        // `-wal` / `-shm` sidecars.
+        owner.close().await.unwrap();
+        assert!(
+            !db_path.with_extension("db-wal").exists(),
+            "closing the owner should remove the WAL sidecar"
+        );
+
+        // A read-only reopen in a writable directory recreates the sidecars
+        // and reads the checkpointed data.
+        let observer = DbConnection::open_observer(&db_path, 1, TIMEOUT, TIMEOUT)
+            .await
+            .unwrap();
+        assert_eq!(count_rows(&observer).await, 1);
     }
 }

--- a/crates/db/lib/lib.rs
+++ b/crates/db/lib/lib.rs
@@ -17,4 +17,4 @@ pub mod entity;
 pub mod pool;
 pub mod retry;
 
-pub use connection::{DbReadConnection, DbWriteConnection};
+pub use connection::DbConnection;

--- a/crates/db/lib/pool.rs
+++ b/crates/db/lib/pool.rs
@@ -1,95 +1,91 @@
-//! Canonical SQLite connection builder shared by every microsandbox process.
+//! Canonical SQLite pool builders shared by every microsandbox process.
 //!
 //! Both the host CLI and the in-VM runtime open the same SQLite file and
-//! must apply identical PRAGMAs (WAL, busy timeout, foreign keys,
-//! synchronous=NORMAL). Centralising the builder keeps that contract in
-//! one place — when a new PRAGMA is needed, this is the only file to edit.
+//! must apply identical PRAGMAs. Centralising the builders keeps that
+//! contract in one place — when a new PRAGMA is needed, this is the only
+//! file to edit.
+//!
+//! The write side carries the writer-establishment PRAGMAs (WAL journal
+//! mode, `synchronous=NORMAL`) and may create the file. The read side opens
+//! with `SQLITE_OPEN_READONLY`, so the engine rejects writes on that lane;
+//! WAL mode persists in the database header, so read connections never need
+//! to (and must not) issue journal-mode or synchronous PRAGMAs themselves.
 
 use std::{path::Path, time::Duration};
 
 use sea_orm::{DatabaseConnection, SqlxSqliteConnector};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 
-use crate::connection::{DbReadConnection, DbWriteConnection};
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
 
 /// Default `busy_timeout` PRAGMA value used when a caller has no
 /// user-facing knob to plumb (e.g. the in-VM runtime, where the host
 /// owns DB-tuning policy and the runtime is not user-configurable).
 pub const DEFAULT_BUSY_TIMEOUT_SECS: u64 = 5;
 
-/// Read pool + dedicated single-connection write pool for the same SQLite
-/// file. SQLite is single-writer system-wide, so a multi-connection pool
-/// fighting for the writer lock just generates `SQLITE_BUSY` and (under
-/// deferred transactions) `SQLITE_BUSY_SNAPSHOT`. Funnelling all writes
-/// from one process through a single connection turns within-process
-/// contention into an in-process queue (deterministic) instead of
-/// SQLite-level lock contention (probabilistic, retry-required). Reads
-/// keep the wider pool — WAL mode lets readers run concurrently.
-#[derive(Debug)]
-pub struct DbPools {
-    read: DbReadConnection,
-    write: DbWriteConnection,
-}
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
 
-impl DbPools {
-    /// Open both pools for the SQLite file at `db_path` with shared PRAGMAs.
-    ///
-    /// The write pool connects first so WAL mode (persisted in the database
-    /// header) is set before the read pool opens. `max_read_connections`
-    /// sizes only the read pool; the write pool is always single-connection
-    /// by design.
-    pub async fn open(
-        db_path: &Path,
-        max_read_connections: u32,
-        connect_timeout: Duration,
-        busy_timeout: Duration,
-    ) -> Result<Self, sqlx::Error> {
-        let write = DbWriteConnection::open(db_path, connect_timeout, busy_timeout).await?;
-        let read =
-            DbReadConnection::open(db_path, max_read_connections, connect_timeout, busy_timeout)
-                .await?;
-        Ok(Self { read, write })
-    }
-
-    /// Borrow the read pool (multi-connection).
-    pub fn read(&self) -> &DbReadConnection {
-        &self.read
-    }
-
-    /// Borrow the write pool (single-connection, retries handled inside).
-    pub fn write(&self) -> &DbWriteConnection {
-        &self.write
-    }
-}
-
-/// Open a sqlx-backed SQLite pool wrapped as a sea-orm `DatabaseConnection`.
+/// Open the single-connection write pool for the SQLite file at `db_path`.
 ///
-/// PRAGMAs are applied to every connection in the pool via
-/// `SqliteConnectOptions`, so callers don't need to issue any setup SQL.
-///
-/// `busy_timeout` is how long SQLite will spin internally on a contended
-/// lock before returning `SQLITE_BUSY`. It interacts with the
-/// application-level retry policy: a longer busy timeout reduces retry
-/// volume at the cost of higher tail latency on contention.
-///
-/// `create_if_missing` controls whether opening a non-existent DB file creates
-/// it. The write side (owned by `msb`) creates the catalog; read-only consumers
-/// (e.g. `msb-metrics`) pass `false` so they never author or pre-empt it.
-pub(crate) async fn build_pool(
+/// Creates the file if missing and establishes WAL mode (persisted in the
+/// database header) plus `synchronous=NORMAL`. `busy_timeout` is how long
+/// SQLite spins internally on a contended lock before returning
+/// `SQLITE_BUSY`; it interacts with the application-level retry policy — a
+/// longer busy timeout reduces retry volume at the cost of higher tail
+/// latency under contention.
+pub(crate) async fn build_write_pool(
     db_path: &Path,
-    max_connections: u32,
     connect_timeout: Duration,
     busy_timeout: Duration,
-    create_if_missing: bool,
 ) -> Result<DatabaseConnection, sqlx::Error> {
     let connect_options = SqliteConnectOptions::new()
         .filename(db_path)
-        .create_if_missing(create_if_missing)
+        .create_if_missing(true)
         .journal_mode(SqliteJournalMode::Wal)
         .busy_timeout(busy_timeout)
         .foreign_keys(true)
         .synchronous(SqliteSynchronous::Normal);
 
+    connect(connect_options, 1, connect_timeout).await
+}
+
+/// Open the read-only pool for the SQLite file at `db_path`.
+///
+/// `SQLITE_OPEN_READONLY` makes the engine reject writes on this lane, and a
+/// missing file is an error rather than being created. Deliberately no
+/// journal-mode or synchronous PRAGMAs: those are writer-establishment
+/// settings, and WAL is already persistent in the file.
+pub(crate) async fn build_read_pool(
+    db_path: &Path,
+    max_connections: u32,
+    connect_timeout: Duration,
+    busy_timeout: Duration,
+) -> Result<DatabaseConnection, sqlx::Error> {
+    let connect_options = SqliteConnectOptions::new()
+        .filename(db_path)
+        .read_only(true)
+        .busy_timeout(busy_timeout)
+        .foreign_keys(true);
+
+    connect(connect_options, max_connections, connect_timeout).await
+}
+
+/// Open a sqlx-backed SQLite pool wrapped as a sea-orm `DatabaseConnection`.
+///
+/// PRAGMAs are applied to every connection in the pool via
+/// `SqliteConnectOptions`, so callers don't need to issue any setup SQL. The
+/// pool eagerly establishes one connection, so open errors (missing file for
+/// read-only opens, unwritable directory) surface here rather than on first
+/// use.
+async fn connect(
+    connect_options: SqliteConnectOptions,
+    max_connections: u32,
+    connect_timeout: Duration,
+) -> Result<DatabaseConnection, sqlx::Error> {
     let pool = SqlitePoolOptions::new()
         .max_connections(max_connections)
         .acquire_timeout(connect_timeout)

--- a/crates/metrics-collector/lib/core/label_source.rs
+++ b/crates/metrics-collector/lib/core/label_source.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use microsandbox_db::DbReadConnection;
+use microsandbox_db::DbConnection;
 use microsandbox_db::pool::DEFAULT_BUSY_TIMEOUT_SECS;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
@@ -73,8 +73,9 @@ pub struct CatalogLabelSource {
 /// Mutable state guarded by a single lock; the collect loop is sequential, so
 /// there is never contention.
 struct State {
-    /// The catalog connection, opened on first successful use.
-    db: Option<DbReadConnection>,
+    /// The catalog handle (observer: read-only, no write lane), opened on
+    /// first successful use.
+    db: Option<DbConnection>,
 
     /// Per-sandbox label cache.
     cache: LabelCache,
@@ -116,7 +117,7 @@ impl LabelSource for CatalogLabelSource {
         // initialized `$MSB_HOME`; emit no labels and retry on the next tick
         // rather than disabling enrichment for the process lifetime.
         if state.db.is_none() {
-            match DbReadConnection::open(
+            match DbConnection::open_observer(
                 &self.db_path,
                 READ_CONNECTIONS,
                 CONNECT_TIMEOUT,
@@ -175,7 +176,7 @@ impl LabelSource for CatalogLabelSource {
 
 /// Sync the cache to the active snapshot, then resolve each sandbox's labels.
 async fn resolve_labels(
-    db: &DbReadConnection,
+    db: &DbConnection,
     cache: &mut LabelCache,
     sandbox_ids: &HashSet<i32>,
     exclude_keys: &HashSet<String>,
@@ -216,7 +217,6 @@ fn apply_exclusions(set: Arc<LabelSet>, exclude_keys: &HashSet<String>) -> Arc<L
 
 #[cfg(test)]
 mod tests {
-    use microsandbox_db::DbWriteConnection;
     use microsandbox_db::entity::{sandbox, sandbox_label};
     use microsandbox_migration::{Migrator, MigratorTrait};
     use sea_orm::{ActiveModelTrait, Set};
@@ -226,14 +226,15 @@ mod tests {
     /// Create the catalog at `db_path` with one labelled sandbox.
     async fn seed_catalog(db_path: &std::path::Path) {
         std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
-        let write = DbWriteConnection::open(
+        let write = DbConnection::open(
             db_path,
+            1,
             CONNECT_TIMEOUT,
             Duration::from_secs(DEFAULT_BUSY_TIMEOUT_SECS),
         )
         .await
         .unwrap();
-        Migrator::up(write.inner(), None).await.unwrap();
+        Migrator::up(write.inner().unwrap(), None).await.unwrap();
         sandbox::ActiveModel {
             id: Set(1),
             name: Set("s1".to_string()),
@@ -244,7 +245,7 @@ mod tests {
             created_at: Set(None),
             updated_at: Set(None),
         }
-        .insert(write.inner())
+        .insert(write.inner().unwrap())
         .await
         .unwrap();
         sandbox_label::ActiveModel {
@@ -252,7 +253,7 @@ mod tests {
             key: Set("user.id".to_string()),
             value: Set("alice".to_string()),
         }
-        .insert(write.inner())
+        .insert(write.inner().unwrap())
         .await
         .unwrap();
     }
@@ -294,8 +295,9 @@ mod tests {
         seed_catalog(&db_path).await;
 
         // Add a second, noisy label to the same sandbox.
-        let write = DbWriteConnection::open(
+        let write = DbConnection::open(
             &db_path,
+            1,
             CONNECT_TIMEOUT,
             Duration::from_secs(DEFAULT_BUSY_TIMEOUT_SECS),
         )
@@ -306,7 +308,7 @@ mod tests {
             key: Set("org.opencontainers.image.revision".to_string()),
             value: Set("abc123".to_string()),
         }
-        .insert(write.inner())
+        .insert(write.inner().unwrap())
         .await
         .unwrap();
 

--- a/crates/runtime/lib/maintenance.rs
+++ b/crates/runtime/lib/maintenance.rs
@@ -21,13 +21,13 @@
 use std::path::Path;
 use std::time::Instant;
 
-use microsandbox_db::DbWriteConnection;
 use microsandbox_db::entity::{
     maintenance_lease as lease_entity, run as run_entity, sandbox as sandbox_entity,
 };
 use sea_orm::sea_query::{Expr, OnConflict};
 use sea_orm::{
-    ColumnTrait, Condition, DbErr, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set,
+    ColumnTrait, Condition, DatabaseConnection, DbErr, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect, Set,
 };
 
 use crate::{RuntimeError, RuntimeResult};
@@ -156,7 +156,7 @@ impl Default for MaintenanceLimits {
 /// Best-effort: this must never abort the sandbox boot path, so all errors are
 /// logged and swallowed. When the lease is not won, returns immediately after a
 /// single indexed read.
-pub async fn run_startup_maintenance(db: &DbWriteConnection, sandboxes_dir: &Path) {
+pub async fn run_startup_maintenance(db: &DatabaseConnection, sandboxes_dir: &Path) {
     match try_acquire_lease(db).await {
         Ok(true) => {}
         Ok(false) => {
@@ -195,7 +195,7 @@ pub async fn run_startup_maintenance(db: &DbWriteConnection, sandboxes_dir: &Pat
 /// clean terminal ephemeral sandboxes. Per-row errors are counted, not
 /// propagated, so one bad row cannot abort the rest.
 pub async fn run_sandbox_lifecycle_maintenance(
-    db: &DbWriteConnection,
+    db: &DatabaseConnection,
     sandboxes_dir: &Path,
     limits: MaintenanceLimits,
 ) -> RuntimeResult<MaintenanceReport> {
@@ -269,7 +269,7 @@ pub async fn run_sandbox_lifecycle_maintenance(
 /// row with no PID is still state owned by a runtime transition and should not
 /// be mutated out from under it.
 pub async fn active_sandboxes_for_schema_rollback(
-    db: &DbWriteConnection,
+    db: &DatabaseConnection,
 ) -> RuntimeResult<Vec<ActiveSandbox>> {
     let sandboxes = sandbox_entity::Entity::find()
         .filter(sandbox_entity::Column::Status.is_in([
@@ -309,7 +309,7 @@ pub async fn active_sandboxes_for_schema_rollback(
 /// Usable both from the runtime exit observer (self-clean) and the startup
 /// sweep.
 pub async fn cleanup_terminal_ephemeral_sandbox(
-    db: &DbWriteConnection,
+    db: &DatabaseConnection,
     sandboxes_dir: &Path,
     sandbox_id: i32,
 ) -> RuntimeResult<CleanupOutcome> {
@@ -376,7 +376,7 @@ pub async fn cleanup_terminal_ephemeral_sandbox(
 /// Read-gates first: a cheap SELECT skips the write entirely when the lease is
 /// currently held or a sweep completed within the last interval. Only a
 /// genuinely stale lease triggers the conditional acquire write.
-async fn try_acquire_lease(db: &DbWriteConnection) -> RuntimeResult<bool> {
+async fn try_acquire_lease(db: &DatabaseConnection) -> RuntimeResult<bool> {
     let now = chrono::Utc::now().naive_utc();
     let recent_cutoff = now - chrono::Duration::seconds(MIN_SWEEP_INTERVAL_SECS);
 
@@ -443,7 +443,7 @@ async fn try_acquire_lease(db: &DbWriteConnection) -> RuntimeResult<bool> {
 
 /// Record successful sweep completion so the read-gate suppresses redundant
 /// sweeps for the next interval.
-async fn record_completion(db: &DbWriteConnection) -> RuntimeResult<()> {
+async fn record_completion(db: &DatabaseConnection) -> RuntimeResult<()> {
     let now = chrono::Utc::now().naive_utc();
     lease_entity::Entity::update_many()
         .col_expr(lease_entity::Column::LastCompletedAt, Expr::value(now))
@@ -456,7 +456,7 @@ async fn record_completion(db: &DbWriteConnection) -> RuntimeResult<()> {
 
 /// Acquire the install-exclusive lease if it is currently free or expired.
 pub async fn acquire_install_exclusive_lease(
-    db: &DbWriteConnection,
+    db: &DatabaseConnection,
 ) -> RuntimeResult<InstallExclusiveLease> {
     let now = chrono::Utc::now().naive_utc();
     let holder_pid = std::process::id() as i32;
@@ -503,7 +503,7 @@ pub async fn acquire_install_exclusive_lease(
 
 /// Renew an install-exclusive lease if this process still owns the exact row.
 pub async fn renew_install_exclusive_lease(
-    db: &DbWriteConnection,
+    db: &DatabaseConnection,
     lease: &mut InstallExclusiveLease,
 ) -> RuntimeResult<()> {
     let now = chrono::Utc::now().naive_utc();
@@ -536,7 +536,7 @@ pub async fn renew_install_exclusive_lease(
 
 /// Clear the install-exclusive lease after an install-mutating command exits.
 pub async fn clear_install_exclusive_lease(
-    db: &DbWriteConnection,
+    db: &DatabaseConnection,
     lease: &InstallExclusiveLease,
 ) -> RuntimeResult<()> {
     let now = chrono::Utc::now().naive_utc();
@@ -562,7 +562,7 @@ pub async fn clear_install_exclusive_lease(
 /// Clear an install-exclusive lease, accepting an already released or expired
 /// row as success so a crash-restarted installer can repeat its cleanup.
 pub async fn clear_install_exclusive_lease_idempotent(
-    db: &DbWriteConnection,
+    db: &DatabaseConnection,
     lease: &InstallExclusiveLease,
 ) -> RuntimeResult<()> {
     match clear_install_exclusive_lease(db, lease).await {
@@ -589,7 +589,7 @@ pub async fn clear_install_exclusive_lease_idempotent(
 /// migration yet. In that case startup continues so normal migrations can
 /// create it. Once the table exists, the install-exclusive row becomes a hard
 /// refusal while unexpired.
-pub async fn refuse_if_install_exclusive_held(db: &DbWriteConnection) -> RuntimeResult<()> {
+pub async fn refuse_if_install_exclusive_held(db: &DatabaseConnection) -> RuntimeResult<()> {
     let now = chrono::Utc::now().naive_utc();
     let lease = match lease_entity::Entity::find_by_id(lease_entity::INSTALL_EXCLUSIVE)
         .one(db)
@@ -617,7 +617,7 @@ pub async fn refuse_if_install_exclusive_held(db: &DbWriteConnection) -> Runtime
 //--------------------------------------------------------------------------------------------------
 
 async fn seed_install_exclusive_lease(
-    db: &DbWriteConnection,
+    db: &DatabaseConnection,
     now: chrono::NaiveDateTime,
 ) -> RuntimeResult<()> {
     let seed = lease_entity::ActiveModel {
@@ -644,7 +644,7 @@ async fn seed_install_exclusive_lease(
 /// Reconcile one active sandbox whose owning runtime may have died. Returns
 /// `true` when the sandbox was marked terminal.
 async fn reconcile_stale_active(
-    db: &DbWriteConnection,
+    db: &DatabaseConnection,
     sandbox: &sandbox_entity::Model,
 ) -> RuntimeResult<bool> {
     let run = run_entity::Entity::find()
@@ -744,7 +744,7 @@ fn stale_runtime_terminal_state(
 }
 
 /// Whether the sandbox has any run that is still Running with a live PID.
-async fn has_live_active_run(db: &DbWriteConnection, sandbox_id: i32) -> RuntimeResult<bool> {
+async fn has_live_active_run(db: &DatabaseConnection, sandbox_id: i32) -> RuntimeResult<bool> {
     let runs = run_entity::Entity::find()
         .filter(run_entity::Column::SandboxId.eq(sandbox_id))
         .filter(run_entity::Column::Status.eq(run_entity::RunStatus::Running))
@@ -798,21 +798,26 @@ mod tests {
     /// A PID that is essentially certain not to map to a live process.
     const DEAD_PID: i32 = 2_000_000_000;
 
-    async fn test_db() -> (TempDir, DbWriteConnection) {
+    async fn test_db() -> (TempDir, DatabaseConnection) {
         let dir = tempfile::tempdir().unwrap();
-        let db = DbWriteConnection::open(
+        let db = microsandbox_db::DbConnection::open(
             &dir.path().join("test.db"),
+            1,
             Duration::from_secs(5),
             Duration::from_secs(5),
         )
         .await
         .unwrap();
-        Migrator::up(db.inner(), None).await.unwrap();
+
+        // The tests exercise the write paths, so they run on the raw write
+        // connection; the read lane is not needed here.
+        let db = db.inner().unwrap().clone();
+        Migrator::up(&db, None).await.unwrap();
         (dir, db)
     }
 
     async fn insert_sandbox(
-        db: &DbWriteConnection,
+        db: &DatabaseConnection,
         name: &str,
         status: sandbox_entity::SandboxStatus,
         ephemeral: bool,
@@ -834,7 +839,7 @@ mod tests {
     }
 
     async fn insert_run(
-        db: &DbWriteConnection,
+        db: &DatabaseConnection,
         sandbox_id: i32,
         pid: Option<i32>,
         status: run_entity::RunStatus,
@@ -851,7 +856,7 @@ mod tests {
         .unwrap();
     }
 
-    async fn status_of(db: &DbWriteConnection, id: i32) -> Option<sandbox_entity::SandboxStatus> {
+    async fn status_of(db: &DatabaseConnection, id: i32) -> Option<sandbox_entity::SandboxStatus> {
         sandbox_entity::Entity::find_by_id(id)
             .one(db)
             .await

--- a/crates/runtime/lib/metrics.rs
+++ b/crates/runtime/lib/metrics.rs
@@ -3,7 +3,7 @@
 //! Samples come from `msb_krun` VMM/device counters plus the runtime network
 //! boundary counters. They are written into the process's reserved slot in the
 //! shared-memory registry. The catalog database is not touched on the
-//! per-sample path; lifecycle rows still flow through `DbWriteConnection`.
+//! per-sample path; lifecycle rows still flow through the `DbConnection` write lane.
 
 use std::num::NonZero;
 #[cfg(unix)]

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use microsandbox_db::DbWriteConnection;
 use microsandbox_db::entity::run as run_entity;
 #[cfg(unix)]
 use microsandbox_filesystem::{BindIdentityMapHandle, DynFileSystem};
@@ -28,7 +27,7 @@ use microsandbox_protocol::{
     message::{Message, MessageType},
 };
 use msb_krun::VmBuilder;
-use sea_orm::{ColumnTrait, EntityTrait, Set};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, Set};
 use serde::{Deserialize, Serialize};
 
 #[cfg(windows)]
@@ -1652,21 +1651,28 @@ fn write_startup_info(startup_pipe: Option<&str>, json: &str) -> RuntimeResult<(
 /// Busy timeout uses [`microsandbox_db::pool::DEFAULT_BUSY_TIMEOUT_SECS`]:
 /// the in-VM runtime is not user-configurable, so DB tuning policy lives
 /// with the host (which honours `~/.microsandbox/config.json`).
+///
+/// Returns the raw single write connection: the runtime only writes
+/// lifecycle rows and runs maintenance sweeps, so it keeps just the write
+/// lane of the handle.
 async fn connect_db(
     db_path: &std::path::Path,
     connect_timeout_secs: u64,
-) -> RuntimeResult<DbWriteConnection> {
-    DbWriteConnection::open(
+) -> RuntimeResult<DatabaseConnection> {
+    let db = microsandbox_db::DbConnection::open(
         db_path,
+        1,
         Duration::from_secs(connect_timeout_secs),
         Duration::from_secs(microsandbox_db::pool::DEFAULT_BUSY_TIMEOUT_SECS),
     )
     .await
-    .map_err(|e| RuntimeError::Custom(format!("database connect: {e}")))
+    .map_err(|e| RuntimeError::Custom(format!("database connect: {e}")))?;
+
+    Ok(db.inner()?.clone())
 }
 
 /// Insert a run record into the database.
-async fn insert_run(db: &DbWriteConnection, sandbox_id: i32, pid: u32) -> RuntimeResult<i32> {
+async fn insert_run(db: &DatabaseConnection, sandbox_id: i32, pid: u32) -> RuntimeResult<i32> {
     let now = chrono::Utc::now().naive_utc();
     let record = run_entity::ActiveModel {
         sandbox_id: Set(sandbox_id),
@@ -1683,7 +1689,7 @@ async fn insert_run(db: &DbWriteConnection, sandbox_id: i32, pid: u32) -> Runtim
 }
 
 /// Mark a run record as failed (Terminated + InternalError) on startup error.
-async fn mark_run_failed(db: &DbWriteConnection, run_id: i32) -> RuntimeResult<()> {
+async fn mark_run_failed(db: &DatabaseConnection, run_id: i32) -> RuntimeResult<()> {
     use sea_orm::QueryFilter;
     use sea_orm::sea_query::Expr;
 

--- a/sdk/rust/lib/backend/local.rs
+++ b/sdk/rust/lib/backend/local.rs
@@ -28,7 +28,7 @@ use std::{
     os::fd::AsRawFd,
 };
 
-use microsandbox_db::pool::DbPools;
+use microsandbox_db::DbConnection;
 use microsandbox_migration::{Migrator, MigratorTrait, schema_metadata};
 use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, DbErr, Statement};
 use tokio::sync::OnceCell;
@@ -44,12 +44,12 @@ use crate::{MicrosandboxError, MicrosandboxResult};
 /// Local-runtime backend: spawns microVMs via libkrun on the calling host.
 ///
 /// Owns the persisted [`LocalConfig`] (paths, sandbox defaults, registry
-/// settings, database tuning) and the SQLite [`DbPools`] for this instance.
+/// settings, database tuning) and the SQLite [`DbConnection`] handle for this instance.
 /// Built via either [`LocalBackend::lazy`] (no-explicit-setup ambient
 /// default, lazily initialised) or [`LocalBackend::builder`] (programmatic).
 pub struct LocalBackend {
     config: Arc<LocalConfig>,
-    db: OnceCell<DbPools>,
+    db: OnceCell<DbConnection>,
 }
 
 /// Fluent builder for [`LocalBackend`]. Construct via [`LocalBackend::builder`].
@@ -128,9 +128,9 @@ impl LocalBackend {
         LocalBackendBuilder::default()
     }
 
-    /// Access the open DB pool, initialising it (and applying migrations) on
-    /// first call.
-    pub async fn db(&self) -> MicrosandboxResult<&DbPools> {
+    /// Access the open DB handle, initialising it (and applying migrations)
+    /// on first call.
+    pub async fn db(&self) -> MicrosandboxResult<&DbConnection> {
         self.db
             .get_or_try_init(|| async {
                 let db_dir = self.config.home().join(microsandbox_utils::DB_SUBDIR);
@@ -494,21 +494,21 @@ impl Drop for MigrationLock {
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
-/// Open both pools for `db_dir/msb.db` and run migrations on the writer.
+/// Open the DB handle for `db_dir/msb.db` and run migrations on the writer.
 ///
-/// The write pool connects first so WAL mode (persisted in the database
-/// header) is set before the read pool opens.
+/// The write connection opens first (inside [`DbConnection::open`]) so WAL mode
+/// (persisted in the database header) is set before the read-only pool opens.
 async fn connect_and_migrate(
     db_dir: &Path,
     database: &DatabaseConfig,
     snapshots_dir: &Path,
-) -> MicrosandboxResult<DbPools> {
+) -> MicrosandboxResult<DbConnection> {
     tokio::fs::create_dir_all(db_dir).await?;
     let _migration_lock = acquire_migration_lock(db_dir).await?;
     refuse_incomplete_self_downgrade(db_dir)?;
 
     let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
-    let pools = DbPools::open(
+    let db = DbConnection::open(
         &db_path,
         database.max_connections,
         Duration::from_secs(database.connect_timeout_secs),
@@ -517,23 +517,22 @@ async fn connect_and_migrate(
     .await
     .map_err(|e| MicrosandboxError::Custom(format!("connect to {}: {e}", db_path.display())))?;
 
-    microsandbox_runtime::maintenance::refuse_if_install_exclusive_held(pools.write())
+    microsandbox_runtime::maintenance::refuse_if_install_exclusive_held(db.inner()?)
         .await
         .map_err(|err| MicrosandboxError::Runtime(err.to_string()))?;
-    refuse_schema_ahead(pools.write().inner()).await?;
-    Migrator::up(pools.write().inner(), None).await?;
+    refuse_schema_ahead(db.inner()?).await?;
+    Migrator::up(db.inner()?, None).await?;
 
     // Descriptor translation mutates the same installation state as schema
     // migration. Keep both gates held until every discovered artifact is
     // either canonical or durably journaled as blocked.
     let install_lease =
-        microsandbox_runtime::maintenance::acquire_install_exclusive_lease(pools.write())
+        microsandbox_runtime::maintenance::acquire_install_exclusive_lease(db.inner()?)
             .await
             .map_err(|err| MicrosandboxError::Runtime(err.to_string()))?;
-    let reconcile_result =
-        crate::snapshot::migration::reconcile_managed(&pools, snapshots_dir).await;
+    let reconcile_result = crate::snapshot::migration::reconcile_managed(&db, snapshots_dir).await;
     let clear_result = microsandbox_runtime::maintenance::clear_install_exclusive_lease(
-        pools.write(),
+        db.inner()?,
         &install_lease,
     )
     .await
@@ -541,7 +540,7 @@ async fn connect_and_migrate(
     reconcile_result?;
     clear_result?;
 
-    Ok(pools)
+    Ok(db)
 }
 
 /// Refuse normal startup while a durable self-downgrade operation owns local
@@ -655,10 +654,10 @@ mod tests {
         let db_dir = tmp.path().join("db");
         let database = DatabaseConfig::default();
 
-        let pools = connect_and_migrate(&db_dir, &database, &tmp.path().join("snapshots"))
+        let db = connect_and_migrate(&db_dir, &database, &tmp.path().join("snapshots"))
             .await
             .unwrap();
-        let conn = pools.read();
+        let conn = &db;
 
         // DB file should exist on disk.
         assert!(db_dir.join(microsandbox_utils::DB_FILENAME).exists());
@@ -703,12 +702,12 @@ mod tests {
         let db_dir = tmp.path().join("db");
         let database = DatabaseConfig::default();
 
-        let pools = connect_and_migrate(&db_dir, &database, &tmp.path().join("snapshots"))
+        let db = connect_and_migrate(&db_dir, &database, &tmp.path().join("snapshots"))
             .await
             .unwrap();
 
         // Running migrations again on the same DB should succeed.
-        Migrator::up(pools.write().inner(), None).await.unwrap();
+        Migrator::up(db.inner().unwrap(), None).await.unwrap();
     }
 
     #[tokio::test]
@@ -731,7 +730,7 @@ mod tests {
         std::fs::write(root_dir.join("manifest.json"), root).unwrap();
         std::fs::write(child_dir.join("manifest.json"), child).unwrap();
 
-        let pools = connect_and_migrate(&db_dir, &DatabaseConfig::default(), &snapshots_dir)
+        let db = connect_and_migrate(&db_dir, &DatabaseConfig::default(), &snapshots_dir)
             .await
             .unwrap();
 
@@ -749,8 +748,7 @@ mod tests {
         assert!(root_dir.join(".manifest.json.legacy").exists());
         assert!(child_dir.join(".manifest.json.legacy").exists());
 
-        let count = pools
-            .read()
+        let count = db
             .query_one(Statement::from_string(
                 DatabaseBackend::Sqlite,
                 "SELECT COUNT(*) FROM snapshot_index",
@@ -769,13 +767,12 @@ mod tests {
         let db_dir = tmp.path().join("db");
         let database = DatabaseConfig::default();
 
-        let pools = connect_and_migrate(&db_dir, &database, &tmp.path().join("snapshots"))
+        let db = connect_and_migrate(&db_dir, &database, &tmp.path().join("snapshots"))
             .await
             .unwrap();
         let future = chrono::Utc::now().naive_utc() + chrono::Duration::minutes(10);
-        pools
-            .write()
-            .inner()
+        db.inner()
+            .unwrap()
             .execute(Statement::from_sql_and_values(
                 DatabaseBackend::Sqlite,
                 "INSERT OR REPLACE INTO maintenance_lease (name, holder_pid, lease_expires_at, last_completed_at) VALUES (?, ?, ?, NULL)",
@@ -787,7 +784,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        drop(pools);
+        drop(db);
 
         let err = connect_and_migrate(&db_dir, &database, &tmp.path().join("snapshots"))
             .await
@@ -801,12 +798,11 @@ mod tests {
         let db_dir = tmp.path().join("db");
         let database = DatabaseConfig::default();
 
-        let pools = connect_and_migrate(&db_dir, &database, &tmp.path().join("snapshots"))
+        let db = connect_and_migrate(&db_dir, &database, &tmp.path().join("snapshots"))
             .await
             .unwrap();
-        pools
-            .write()
-            .inner()
+        db.inner()
+            .unwrap()
             .execute(Statement::from_sql_and_values(
                 DatabaseBackend::Sqlite,
                 "INSERT INTO seaql_migrations (version, applied_at) VALUES (?, ?)",
@@ -814,7 +810,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        drop(pools);
+        drop(db);
 
         let err = connect_and_migrate(&db_dir, &database, &tmp.path().join("snapshots"))
             .await
@@ -911,7 +907,6 @@ mod tests {
             .unwrap();
 
         let migration_row_count = recovered
-            .read()
             .query_one(Statement::from_string(
                 DatabaseBackend::Sqlite,
                 "SELECT COUNT(*) FROM seaql_migrations WHERE version = 'm20260305_000003_create_storage_tables'",

--- a/sdk/rust/lib/db/mod.rs
+++ b/sdk/rust/lib/db/mod.rs
@@ -1,11 +1,9 @@
-//! Database entity + pool type re-exports.
+//! Database entity + handle re-exports.
 //!
-//! The actual `DbPools` instance is owned by [`LocalBackend`](crate::backend::LocalBackend)
-//! per D6.7. This module just re-exports the entity types and pool aliases so
-//! the rest of the crate has one place to import them from.
+//! The actual [`DbConnection`] instance is owned by [`LocalBackend`](crate::backend::LocalBackend)
+//! per D6.7. This module just re-exports the entity types and the database
+//! handle so the rest of the crate has one place to import them from.
 
+#[allow(unused_imports)]
+pub use microsandbox_db::DbConnection;
 pub use microsandbox_db::entity;
-#[allow(unused_imports)]
-pub use microsandbox_db::pool::DbPools;
-#[allow(unused_imports)]
-pub use microsandbox_db::{DbReadConnection, DbWriteConnection};

--- a/sdk/rust/lib/image/mod.rs
+++ b/sdk/rust/lib/image/mod.rs
@@ -192,8 +192,7 @@ impl Image {
         reference: &str,
         metadata: CachedImageMetadata,
     ) -> MicrosandboxResult<i32> {
-        let pools = local.db().await?;
-        let db = pools.write();
+        let db = local.db().await?;
         let reference = reference.to_string();
 
         if let Some(image_ref_id) = try_persist_fast_path(db, &reference, &metadata).await? {
@@ -328,7 +327,7 @@ impl Image {
         local: &LocalBackend,
         reference: &str,
     ) -> MicrosandboxResult<ImageHandle> {
-        let db = local.db().await?.read();
+        let db = local.db().await?;
 
         let (image_ref_model, manifest) = image_ref_entity::Entity::find()
             .filter(image_ref_entity::Column::Reference.eq(reference))
@@ -346,7 +345,7 @@ impl Image {
 
     /// List all cached images from an explicit local backend, ordered by creation time.
     pub async fn list_local(local: &LocalBackend) -> MicrosandboxResult<Vec<ImageHandle>> {
-        let db = local.db().await?.read();
+        let db = local.db().await?;
 
         let models = image_ref_entity::Entity::find()
             .order_by_desc(image_ref_entity::Column::CreatedAt)
@@ -366,7 +365,7 @@ impl Image {
         local: &LocalBackend,
         reference: &str,
     ) -> MicrosandboxResult<ImageDetail> {
-        let db = local.db().await?.read();
+        let db = local.db().await?;
 
         let image_ref_model = image_ref_entity::Entity::find()
             .filter(image_ref_entity::Column::Reference.eq(reference))
@@ -464,12 +463,11 @@ impl Image {
         reference: &str,
         force: bool,
     ) -> MicrosandboxResult<()> {
-        let pools = local.db().await?;
-        let db = pools.write();
+        let db = local.db().await?;
 
         let image_ref_model = image_ref_entity::Entity::find()
             .filter(image_ref_entity::Column::Reference.eq(reference))
-            .one(pools.read())
+            .one(db)
             .await?
             .ok_or_else(|| MicrosandboxError::ImageNotFound(reference.into()))?;
 
@@ -588,8 +586,7 @@ impl Image {
     /// that become unreachable. Images used by existing sandboxes or snapshots
     /// are preserved.
     pub async fn prune_local(local: &LocalBackend) -> MicrosandboxResult<ImagePruneReport> {
-        let pools = local.db().await?;
-        let db = pools.write();
+        let db = local.db().await?;
 
         let (mut report, cleanup) = db
             .transaction(|txn| async move {
@@ -1028,7 +1025,7 @@ async fn upsert_layer_record<C: ConnectionTrait>(
 /// Returns `None` when the caller must fall through to the full transactional
 /// upsert (fresh DB, manifest digest changed, partially persisted state).
 async fn try_persist_fast_path(
-    db: &microsandbox_db::DbWriteConnection,
+    db: &microsandbox_db::DbConnection,
     reference: &str,
     metadata: &CachedImageMetadata,
 ) -> MicrosandboxResult<Option<i32>> {
@@ -1067,7 +1064,7 @@ async fn try_persist_fast_path(
         layer_entity::Entity::update_many()
             .col_expr(layer_entity::Column::LastUsedAt, Expr::value(now))
             .filter(layer_entity::Column::DiffId.is_in(diff_ids))
-            .exec(db)
+            .exec(db.inner()?)
             .await?;
     }
 
@@ -1075,7 +1072,7 @@ async fn try_persist_fast_path(
     image_ref_entity::Entity::update_many()
         .col_expr(image_ref_entity::Column::UpdatedAt, Expr::value(now))
         .filter(image_ref_entity::Column::Id.eq(image_ref_model.id))
-        .exec(db)
+        .exec(db.inner()?)
         .await?;
 
     Ok(Some(image_ref_model.id))

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -1084,10 +1084,10 @@ async fn ensure_named_volumes_inner(
         };
 
         validate_volume_name(create.name())?;
-        let pools = local.db().await?;
+        let db = local.db().await?;
         let existing = volume_entity::Entity::find()
             .filter(volume_entity::Column::Name.eq(create.name()))
-            .one(pools.read())
+            .one(db)
             .await?;
 
         if let Some(existing) = existing {
@@ -1141,14 +1141,14 @@ async fn ensure_named_volumes_inner(
             ..Default::default()
         };
         let inserted = volume_entity::Entity::insert(model)
-            .exec(pools.write())
+            .exec(db.inner()?)
             .await?;
         let volume_id = inserted.last_insert_id;
 
         let path = local.volume_path(&volume_config.name);
         if let Err(err) = materialize_volume_path(&volume_config, &path).await {
             let _ = volume_entity::Entity::delete_by_id(volume_id)
-                .exec(pools.write())
+                .exec(db.inner()?)
                 .await;
             let _ = tokio::fs::remove_dir_all(&path).await;
             return Err(err);
@@ -1182,10 +1182,12 @@ async fn rollback_created_named_volume_records(
     }
 
     let ids = volumes.iter().map(|volume| volume.id).collect::<Vec<_>>();
-    if let Ok(pools) = local.db().await {
+    if let Ok(db) = local.db().await
+        && let Ok(conn) = db.inner()
+    {
         let _ = volume_entity::Entity::delete_many()
             .filter(volume_entity::Column::Id.is_in(ids))
-            .exec(pools.write())
+            .exec(conn)
             .await;
     }
 }
@@ -1233,10 +1235,10 @@ async fn resolve_named_volumes(
             continue;
         }
 
-        let pools = local.db().await?;
+        let db = local.db().await?;
         let model = volume_entity::Entity::find()
             .filter(volume_entity::Column::Name.eq(name))
-            .one(pools.read())
+            .one(db)
             .await?
             .ok_or_else(|| MicrosandboxError::VolumeNotFound(name.clone()))?;
 
@@ -3953,10 +3955,10 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("already exists"), "got: {err}");
-        let pools = local.db().await.unwrap();
+        let db = local.db().await.unwrap();
         let existing = super::volume_entity::Entity::find()
             .filter(super::volume_entity::Column::Name.eq("broken"))
-            .one(pools.read())
+            .one(db)
             .await
             .unwrap();
         assert!(
@@ -3997,10 +3999,10 @@ mod tests {
             "got: {err}"
         );
         assert!(!local.volume_path("first-created").exists());
-        let pools = local.db().await.unwrap();
+        let db = local.db().await.unwrap();
         let existing = super::volume_entity::Entity::find()
             .filter(super::volume_entity::Column::Name.eq("first-created"))
-            .one(pools.read())
+            .one(db)
             .await
             .unwrap();
         assert!(
@@ -4017,7 +4019,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let pools = local.db().await.unwrap();
+        let db = local.db().await.unwrap();
         super::volume_entity::ActiveModel {
             name: Set("mydata".to_string()),
             kind: Set(VolumeKind::Disk.as_str().to_string()),
@@ -4027,7 +4029,7 @@ mod tests {
             updated_at: Set(Some(chrono::Utc::now().naive_utc())),
             ..Default::default()
         }
-        .insert(pools.write())
+        .insert(db.inner().unwrap())
         .await
         .unwrap();
 
@@ -4062,7 +4064,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let pools = local.db().await.unwrap();
+        let db = local.db().await.unwrap();
         super::volume_entity::ActiveModel {
             name: Set("docker-data".to_string()),
             kind: Set(VolumeKind::Disk.as_str().to_string()),
@@ -4073,7 +4075,7 @@ mod tests {
             updated_at: Set(Some(chrono::Utc::now().naive_utc())),
             ..Default::default()
         }
-        .insert(pools.write())
+        .insert(db.inner().unwrap())
         .await
         .unwrap();
 

--- a/sdk/rust/lib/sandbox/handle.rs
+++ b/sdk/rust/lib/sandbox/handle.rs
@@ -326,7 +326,7 @@ impl SandboxHandle {
                     feature: "SandboxHandle::metrics on cloud".into(),
                     available_when: "when cloud metrics land".into(),
                 })?;
-        let db = local_backend.db().await?.read();
+        let db = local_backend.db().await?;
         super::metrics::metrics_for_sandbox(db, local_backend, local.db_id, &config).await
     }
 
@@ -631,11 +631,11 @@ impl SandboxHandle {
                 #[cfg(windows)]
                 super::reap_leaked_runtime_process(local_backend, local.db_id, &self.name).await?;
 
-                let pools = local_backend.db().await?;
+                let db = local_backend.db().await?;
 
                 super::remove_dir_if_exists(&local_backend.sandboxes_dir().join(&self.name))?;
                 sandbox_entity::Entity::delete_by_id(local.db_id)
-                    .exec(pools.write())
+                    .exec(db.inner()?)
                     .await?;
 
                 Ok(())

--- a/sdk/rust/lib/sandbox/metrics.rs
+++ b/sdk/rust/lib/sandbox/metrics.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 use futures::stream;
-use microsandbox_db::DbReadConnection;
+use microsandbox_db::DbConnection;
 use microsandbox_metrics::{LiveMetric, LiveMetricState, MetricsRegistry};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
@@ -141,16 +141,16 @@ pub(crate) async fn local_metrics(
     if config.effective_metrics_interval().is_none() {
         return Err(MicrosandboxError::MetricsDisabled(name.to_string()));
     }
-    let pools = local.db().await?;
+    let db = local.db().await?;
     let model = sandbox_entity::Entity::find()
         .filter(sandbox_entity::Column::Name.eq(name))
-        .one(pools.read())
+        .one(db)
         .await?
         .ok_or_else(|| MicrosandboxError::SandboxNotFound(name.to_string()))?;
     // Prefer the catalog's active config over the caller-supplied one so
     // limits reflect accepted live resizes, not the boot-time spec.
     let effective = model_effective_config(&model).unwrap_or_else(|| config.clone());
-    metrics_for_sandbox(pools.read(), local, model.id, &effective).await
+    metrics_for_sandbox(db, local, model.id, &effective).await
 }
 
 /// Local-backend streaming metrics. Called from the
@@ -180,15 +180,15 @@ pub(crate) fn local_metrics_stream(
             ticker.tick().await;
             let item = match backend.as_local() {
                 Some(local) => match local.db().await {
-                    Ok(pools) => match sandbox_entity::Entity::find()
+                    Ok(db) => match sandbox_entity::Entity::find()
                         .filter(sandbox_entity::Column::Name.eq(&name))
-                        .one(pools.read())
+                        .one(db)
                         .await
                     {
                         Ok(Some(model)) => {
                             let effective =
                                 model_effective_config(&model).unwrap_or_else(|| config.clone());
-                            metrics_for_sandbox(pools.read(), local, model.id, &effective).await
+                            metrics_for_sandbox(db, local, model.id, &effective).await
                         }
                         Ok(None) => Err(MicrosandboxError::SandboxNotFound(name.clone())),
                         Err(e) => Err(e.into()),
@@ -281,10 +281,10 @@ pub async fn all_sandbox_metrics_reports_local(
     if ids.is_empty() {
         return Ok(Vec::new());
     }
-    let pools = local.db().await?;
+    let db = local.db().await?;
     let models = sandbox_entity::Entity::find()
         .filter(sandbox_entity::Column::Id.is_in(ids))
-        .all(pools.read())
+        .all(db)
         .await?;
     // Require the slot's inline name to match the catalog row: ids are
     // recycled after removal, so a ghost slot from a deleted sandbox can
@@ -319,10 +319,10 @@ pub async fn sandbox_metrics_report_local(
     local: &LocalBackend,
     name: &str,
 ) -> MicrosandboxResult<Option<SandboxMetricsReport>> {
-    let pools = local.db().await?;
+    let db = local.db().await?;
     let model = sandbox_entity::Entity::find()
         .filter(sandbox_entity::Column::Name.eq(name))
-        .one(pools.read())
+        .one(db)
         .await?
         .ok_or_else(|| MicrosandboxError::SandboxNotFound(name.to_string()))?;
 
@@ -342,7 +342,7 @@ pub async fn sandbox_metrics_report_local(
 }
 
 pub(super) async fn metrics_for_sandbox(
-    db: &DbReadConnection,
+    db: &DbConnection,
     local: &LocalBackend,
     sandbox_id: i32,
     config: &SandboxConfig,

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -27,8 +27,7 @@ use std::{
     sync::Arc,
 };
 
-use microsandbox_db::pool::DbPools;
-use microsandbox_db::{DbReadConnection, DbWriteConnection};
+use microsandbox_db::DbConnection;
 use microsandbox_image::Registry;
 use microsandbox_protocol::{
     core::{CoreError, Ping, Pong, Touch, Touched},
@@ -692,7 +691,7 @@ pub(crate) async fn create_local(
     let created_named_volumes = ensure_named_volumes(local_backend, &config).await?;
 
     // Insert the sandbox record and keep its stable database ID.
-    let write_db = db.write();
+    let write_db = db;
     let persisted_config = config.clone_for_persistence();
     let sandbox_id = match insert_sandbox_record(write_db, &persisted_config).await {
         Ok(sandbox_id) => sandbox_id,
@@ -799,9 +798,9 @@ pub(crate) async fn start_local(
                 feature: "start_local".into(),
                 available_when: "with a LocalBackend".into(),
             })?;
-    let pools = local_backend.db().await?;
-    let write_db = pools.write();
-    let model = load_sandbox_record_reconciled(pools, name).await?;
+    let db = local_backend.db().await?;
+    let write_db = db;
+    let model = load_sandbox_record_reconciled(db, name).await?;
     tracing::debug!(sandbox = name, status = ?model.status, "start_local: current status");
 
     if model.status == SandboxStatus::Running || model.status == SandboxStatus::Draining {
@@ -899,14 +898,14 @@ pub(crate) async fn get_local_handle_state(
     local_backend: &crate::backend::LocalBackend,
     name: &str,
 ) -> MicrosandboxResult<(sandbox_entity::Model, Option<i32>)> {
-    let pools = local_backend.db().await?;
+    let db = local_backend.db().await?;
     let model = sandbox_entity::Entity::find()
         .filter(sandbox_entity::Column::Name.eq(name))
-        .one(pools.read())
+        .one(db)
         .await?
         .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(name.into()))?;
-    let model = reconcile_sandbox_runtime_state(pools, model).await?;
-    let run = load_active_run(pools.read(), model.id).await?;
+    let model = reconcile_sandbox_runtime_state(db, model).await?;
+    let run = load_active_run(db, model.id).await?;
     let pid = pid_from_run(run.as_ref());
     Ok((model, pid))
 }
@@ -916,20 +915,20 @@ pub(crate) async fn get_local_handle_state(
 pub(crate) async fn list_local_handle_state(
     local_backend: &crate::backend::LocalBackend,
 ) -> MicrosandboxResult<Vec<(sandbox_entity::Model, Option<i32>)>> {
-    let pools = local_backend.db().await?;
+    let db = local_backend.db().await?;
     let sandboxes = sandbox_entity::Entity::find()
         .order_by_desc(sandbox_entity::Column::CreatedAt)
-        .all(pools.read())
+        .all(db)
         .await?;
 
     let mut reconciled = Vec::with_capacity(sandboxes.len());
     for sandbox in sandboxes {
-        let model = reconcile_sandbox_runtime_state(pools, sandbox).await?;
+        let model = reconcile_sandbox_runtime_state(db, sandbox).await?;
         reconciled.push(model);
     }
 
     let sandbox_ids: Vec<i32> = reconciled.iter().map(|sandbox| sandbox.id).collect();
-    let active_pids = load_active_pids(pools.read(), &sandbox_ids).await?;
+    let active_pids = load_active_pids(db, &sandbox_ids).await?;
     let mut out = Vec::with_capacity(reconciled.len());
     for sandbox in reconciled {
         let pid = active_pids.get(&sandbox.id).copied();
@@ -986,7 +985,7 @@ pub(crate) async fn stop_local(
     }
 
     if model.status == SandboxStatus::Running {
-        mark_sandbox_draining_if_running(local_backend.db().await?.write(), model.id).await?;
+        mark_sandbox_draining_if_running(local_backend.db().await?, model.id).await?;
     }
 
     match request_agent_shutdown(local_backend, name).await {
@@ -1070,7 +1069,7 @@ pub(crate) async fn kill_local(
                 )));
             }
         }
-        let db = local_backend.db().await?.write();
+        let db = local_backend.db().await?;
         if let Err(e) = update_sandbox_status(db, model.id, SandboxStatus::Stopped).await {
             tracing::warn!(sandbox = %name, error = %e, "failed to update sandbox status after kill");
         }
@@ -1099,7 +1098,7 @@ pub(crate) async fn kill_local(
 
         let all_dead = pids.is_empty() || pids.iter().all(|pid| pid_is_dead_or_reaped(*pid));
         if all_dead {
-            let db = local_backend.db().await?.write();
+            let db = local_backend.db().await?;
             if let Err(e) = update_sandbox_status(db, model.id, SandboxStatus::Stopped).await {
                 tracing::warn!(sandbox = %name, error = %e, "failed to update sandbox status after kill");
             }
@@ -1131,7 +1130,7 @@ pub(crate) async fn drain_local(
     }
 
     if model.status == SandboxStatus::Running {
-        mark_sandbox_draining_if_running(local_backend.db().await?.write(), model.id).await?;
+        mark_sandbox_draining_if_running(local_backend.db().await?, model.id).await?;
     }
 
     #[cfg(windows)]
@@ -1193,11 +1192,11 @@ pub(crate) async fn reap_leaked_runtime_process(
 ) -> MicrosandboxResult<LeakedReapVerdict> {
     use crate::runtime::reap;
 
-    let pools = local_backend.db().await?;
+    let db = local_backend.db().await?;
     let run = run_entity::Entity::find()
         .filter(run_entity::Column::SandboxId.eq(sandbox_id))
         .order_by_desc(run_entity::Column::Id)
-        .one(pools.read())
+        .one(db)
         .await?;
     let Some(run) = run else {
         return Ok(LeakedReapVerdict::NoProcess);
@@ -1336,11 +1335,11 @@ impl Sandbox {
                     feature: "Sandbox::remove_persisted on cloud".into(),
                     available_when: "never — cloud sandboxes are removed via the API".into(),
                 })?;
-        let pools = local_backend.db().await?;
+        let db = local_backend.db().await?;
 
         remove_dir_if_exists(&local_backend.sandboxes_dir().join(&self.name))?;
         sandbox_entity::Entity::delete_by_id(local.db_id)
-            .exec(pools.write())
+            .exec(db.inner()?)
             .await?;
 
         Ok(())
@@ -2312,7 +2311,7 @@ pub(super) fn sandbox_not_found_for_name(error: &crate::MicrosandboxError, name:
 
 /// Update the sandbox status in the database.
 pub(super) async fn update_sandbox_status(
-    db: &DbWriteConnection,
+    db: &DbConnection,
     sandbox_id: i32,
     status: SandboxStatus,
 ) -> MicrosandboxResult<()> {
@@ -2339,7 +2338,7 @@ pub(super) async fn update_sandbox_status(
 }
 
 pub(super) async fn update_sandbox_active_config(
-    db: &DbWriteConnection,
+    db: &DbConnection,
     sandbox_id: i32,
     config: &SandboxConfig,
 ) -> MicrosandboxResult<()> {
@@ -2354,7 +2353,7 @@ pub(super) async fn update_sandbox_active_config(
             Expr::value(chrono::Utc::now().naive_utc()),
         )
         .filter(sandbox_entity::Column::Id.eq(sandbox_id))
-        .exec(db)
+        .exec(db.inner()?)
         .await?;
 
     Ok(())
@@ -2368,7 +2367,7 @@ fn sandbox_status_clears_active_config(status: SandboxStatus) -> bool {
 }
 
 async fn mark_sandbox_draining_if_running(
-    db: &DbWriteConnection,
+    db: &DbConnection,
     sandbox_id: i32,
 ) -> MicrosandboxResult<()> {
     sandbox_entity::Entity::update_many()
@@ -2382,7 +2381,7 @@ async fn mark_sandbox_draining_if_running(
         )
         .filter(sandbox_entity::Column::Id.eq(sandbox_id))
         .filter(sandbox_entity::Column::Status.eq(SandboxStatus::Running))
-        .exec(db)
+        .exec(db.inner()?)
         .await?;
 
     Ok(())
@@ -2400,15 +2399,15 @@ async fn mark_sandbox_draining_if_running(
 //--------------------------------------------------------------------------------------------------
 
 pub(super) async fn load_sandbox_record_reconciled(
-    pools: &DbPools,
+    db: &DbConnection,
     name: &str,
 ) -> MicrosandboxResult<sandbox_entity::Model> {
-    let sandbox = load_sandbox_record(pools.read(), name).await?;
-    reconcile_sandbox_runtime_state(pools, sandbox).await
+    let sandbox = load_sandbox_record(db, name).await?;
+    reconcile_sandbox_runtime_state(db, sandbox).await
 }
 
 pub(super) async fn reconcile_sandbox_runtime_state(
-    pools: &DbPools,
+    db: &DbConnection,
     sandbox: sandbox_entity::Model,
 ) -> MicrosandboxResult<sandbox_entity::Model> {
     if !matches!(
@@ -2418,7 +2417,7 @@ pub(super) async fn reconcile_sandbox_runtime_state(
         return Ok(sandbox);
     }
 
-    let run = load_active_run(pools.read(), sandbox.id).await?;
+    let run = load_active_run(db, sandbox.id).await?;
 
     // No run record yet while Running means the sandbox is still starting up
     // (the child process has not inserted its PID). A Draining row with no
@@ -2427,11 +2426,10 @@ pub(super) async fn reconcile_sandbox_runtime_state(
     let Some(run) = run else {
         if sandbox.status == SandboxStatus::Draining {
             let (terminal_status, reason) = stale_runtime_terminal_state(sandbox.status);
-            mark_sandbox_runtime_stale(pools.write(), sandbox.id, None, terminal_status, reason)
-                .await?;
+            mark_sandbox_runtime_stale(db, sandbox.id, None, terminal_status, reason).await?;
 
             return sandbox_entity::Entity::find_by_id(sandbox.id)
-                .one(pools.read())
+                .one(db)
                 .await?
                 .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(sandbox.name));
         }
@@ -2444,23 +2442,16 @@ pub(super) async fn reconcile_sandbox_runtime_state(
     }
 
     let (terminal_status, reason) = stale_runtime_terminal_state(sandbox.status);
-    mark_sandbox_runtime_stale(
-        pools.write(),
-        sandbox.id,
-        Some(run.id),
-        terminal_status,
-        reason,
-    )
-    .await?;
+    mark_sandbox_runtime_stale(db, sandbox.id, Some(run.id), terminal_status, reason).await?;
 
     sandbox_entity::Entity::find_by_id(sandbox.id)
-        .one(pools.read())
+        .one(db)
         .await?
         .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(sandbox.name))
 }
 
 pub(super) async fn load_active_run(
-    db: &DbReadConnection,
+    db: &DbConnection,
     sandbox_id: i32,
 ) -> MicrosandboxResult<Option<run_entity::Model>> {
     run_entity::Entity::find()
@@ -2473,7 +2464,7 @@ pub(super) async fn load_active_run(
 }
 
 async fn load_active_pids(
-    db: &DbReadConnection,
+    db: &DbConnection,
     sandbox_ids: &[i32],
 ) -> MicrosandboxResult<HashMap<i32, i32>> {
     if sandbox_ids.is_empty() {
@@ -2524,7 +2515,7 @@ fn stale_runtime_terminal_state(
 }
 
 async fn mark_sandbox_runtime_stale(
-    db: &DbWriteConnection,
+    db: &DbConnection,
     sandbox_id: i32,
     run_id: Option<i32>,
     terminal_status: SandboxStatus,
@@ -2966,7 +2957,7 @@ pub(super) fn remove_dir_if_exists(path: &Path) -> MicrosandboxResult<()> {
 
 /// Load a sandbox row by name.
 pub(super) async fn load_sandbox_record(
-    db: &DbReadConnection,
+    db: &DbConnection,
     name: &str,
 ) -> MicrosandboxResult<sandbox_entity::Model> {
     sandbox_entity::Entity::find()
@@ -2977,13 +2968,13 @@ pub(super) async fn load_sandbox_record(
 }
 
 async fn prepare_create_target(
-    pools: &DbPools,
+    db: &DbConnection,
     config: &SandboxConfig,
     sandbox_dir: &Path,
 ) -> MicrosandboxResult<()> {
     let existing = sandbox_entity::Entity::find()
         .filter(sandbox_entity::Column::Name.eq(&config.spec.name))
-        .one(pools.read())
+        .one(db)
         .await?;
 
     let dir_exists = sandbox_dir.exists();
@@ -2999,17 +2990,17 @@ async fn prepare_create_target(
     }
 
     if let Some(model) = existing {
-        let model = reconcile_sandbox_runtime_state(pools, model).await?;
+        let model = reconcile_sandbox_runtime_state(db, model).await?;
         let active = matches!(
             model.status,
             SandboxStatus::Running | SandboxStatus::Draining | SandboxStatus::Paused
         );
         if active {
-            stop_sandbox_for_replacement(pools, &model, config.replace_with_timeout).await?;
+            stop_sandbox_for_replacement(db, &model, config.replace_with_timeout).await?;
         }
 
         sandbox_entity::Entity::delete_by_id(model.id)
-            .exec(pools.write())
+            .exec(db.inner()?)
             .await?;
     }
 
@@ -3029,11 +3020,11 @@ async fn prepare_create_target(
 /// the full timeout when libkrun's SIGTERM handler did a slow
 /// graceful shutdown.
 async fn stop_sandbox_for_replacement(
-    pools: &DbPools,
+    db: &DbConnection,
     sandbox: &sandbox_entity::Model,
     grace: std::time::Duration,
 ) -> MicrosandboxResult<()> {
-    let run = load_active_run(pools.read(), sandbox.id).await?;
+    let run = load_active_run(db, sandbox.id).await?;
     let pids: Vec<i32> = run
         .as_ref()
         .and_then(|model| model.pid)
@@ -3063,16 +3054,11 @@ async fn stop_sandbox_for_replacement(
         }
     }
 
-    mark_sandbox_stopped_for_replacement(
-        pools.write(),
-        sandbox.id,
-        run.as_ref().map(|model| model.id),
-    )
-    .await
+    mark_sandbox_stopped_for_replacement(db, sandbox.id, run.as_ref().map(|model| model.id)).await
 }
 
 async fn mark_sandbox_stopped_for_replacement(
-    db: &DbWriteConnection,
+    db: &DbConnection,
     sandbox_id: i32,
     run_id: Option<i32>,
 ) -> MicrosandboxResult<()> {
@@ -3163,7 +3149,7 @@ fn validate_start_state(
 
 /// Insert the sandbox record in the database and return its ID.
 async fn insert_sandbox_record(
-    db: &DbWriteConnection,
+    db: &DbConnection,
     config: &SandboxConfig,
 ) -> MicrosandboxResult<i32> {
     let config_json = serde_json::to_string(config)?;
@@ -3188,15 +3174,15 @@ async fn insert_sandbox_record(
     .await
 }
 
-async fn delete_sandbox_record(db: &DbWriteConnection, sandbox_id: i32) -> MicrosandboxResult<()> {
+async fn delete_sandbox_record(db: &DbConnection, sandbox_id: i32) -> MicrosandboxResult<()> {
     sandbox_entity::Entity::delete_by_id(sandbox_id)
-        .exec(db)
+        .exec(db.inner()?)
         .await?;
     Ok(())
 }
 
 async fn persist_oci_manifest_pin(
-    db: &DbWriteConnection,
+    db: &DbConnection,
     sandbox_id: i32,
     manifest_digest: &str,
 ) -> MicrosandboxResult<()> {
@@ -3309,8 +3295,8 @@ mod tests {
         process::Command,
     };
 
+    use microsandbox_db::DbConnection;
     use microsandbox_db::entity::{run as run_entity, sandbox_rootfs as sandbox_rootfs_entity};
-    use microsandbox_db::pool::DbPools;
     use microsandbox_image::{CachedImageMetadata, CachedLayerMetadata, GlobalCache, ImageConfig};
 
     use crate::{
@@ -3455,11 +3441,11 @@ mod tests {
     }
 
     /// Open both pools at `db_path` for tests, with migrations applied.
-    async fn open_test_pools(db_path: &std::path::Path) -> DbPools {
+    async fn open_test_pools(db_path: &std::path::Path) -> DbConnection {
         // Connect timeout matches the production default (30s). 1s was too
         // tight on cold ci runners and surfaced as `PoolTimedOut` flakes
         // before the test body had a chance to run.
-        let pools = DbPools::open(
+        let pools = DbConnection::open(
             db_path,
             1,
             std::time::Duration::from_secs(30),
@@ -3467,7 +3453,7 @@ mod tests {
         )
         .await
         .unwrap();
-        Migrator::up(pools.write().inner(), None).await.unwrap();
+        Migrator::up(pools.inner().unwrap(), None).await.unwrap();
         pools
     }
 
@@ -3890,11 +3876,11 @@ mod tests {
             }),
         );
         config.manifest_digest = Some("sha256:aaaa".into());
-        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(&pools, &config).await.unwrap();
 
         // First pin (no matching manifest in DB, so manifest_id will be None).
         persist_oci_manifest_pin(
-            pools.write(),
+            &pools,
             sandbox_id,
             "sha256:1111111111111111111111111111111111111111111111111111111111111111",
         )
@@ -3903,7 +3889,7 @@ mod tests {
 
         // Second pin replaces the first.
         persist_oci_manifest_pin(
-            pools.write(),
+            &pools,
             sandbox_id,
             "sha256:2222222222222222222222222222222222222222222222222222222222222222",
         )
@@ -3911,7 +3897,7 @@ mod tests {
         .unwrap();
 
         let pins = sandbox_rootfs_entity::Entity::find()
-            .all(pools.write())
+            .all(&pools)
             .await
             .unwrap();
         assert_eq!(pins.len(), 1);
@@ -3934,10 +3920,10 @@ mod tests {
             }),
         );
         config.manifest_digest = Some("sha256:aaaa".into());
-        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(&pools, &config).await.unwrap();
 
         persist_oci_manifest_pin(
-            pools.write(),
+            &pools,
             sandbox_id,
             "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         )
@@ -3946,7 +3932,7 @@ mod tests {
 
         // Replacing with a different digest should delete the old pin.
         persist_oci_manifest_pin(
-            pools.write(),
+            &pools,
             sandbox_id,
             "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         )
@@ -3954,7 +3940,7 @@ mod tests {
         .unwrap();
 
         let pins = sandbox_rootfs_entity::Entity::find()
-            .all(pools.write())
+            .all(&pools)
             .await
             .unwrap();
         assert_eq!(pins.len(), 1);
@@ -3978,9 +3964,9 @@ mod tests {
         );
         config.manifest_digest = Some("sha256:abc123".into());
 
-        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(&pools, &config).await.unwrap();
         let row = super::sandbox_entity::Entity::find_by_id(sandbox_id)
-            .one(pools.write())
+            .one(&pools)
             .await
             .unwrap()
             .unwrap();
@@ -4015,8 +4001,8 @@ mod tests {
         let sandbox_dir = temp.path().join("sandboxes").join("replaceable");
         fs::create_dir_all(sandbox_dir.join("rw")).unwrap();
         let config = test_config("replaceable");
-        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
-        super::update_sandbox_status(pools.write(), sandbox_id, super::SandboxStatus::Stopped)
+        let sandbox_id = insert_sandbox_record(&pools, &config).await.unwrap();
+        super::update_sandbox_status(&pools, sandbox_id, super::SandboxStatus::Stopped)
             .await
             .unwrap();
 
@@ -4030,7 +4016,7 @@ mod tests {
         assert!(!sandbox_dir.exists());
         assert!(
             super::sandbox_entity::Entity::find_by_id(sandbox_id)
-                .one(pools.write())
+                .one(&pools)
                 .await
                 .unwrap()
                 .is_none()
@@ -4044,7 +4030,7 @@ mod tests {
         let pools = open_test_pools(&db_path).await;
 
         let config = test_config("stale");
-        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(&pools, &config).await.unwrap();
         let dead_run_pid = dead_pid();
 
         let run = run_entity::ActiveModel {
@@ -4054,13 +4040,13 @@ mod tests {
             ..Default::default()
         };
         let run_id = run_entity::Entity::insert(run)
-            .exec(pools.write())
+            .exec(pools.inner().unwrap())
             .await
             .unwrap()
             .last_insert_id;
 
         let sandbox = super::sandbox_entity::Entity::find_by_id(sandbox_id)
-            .one(pools.write())
+            .one(&pools)
             .await
             .unwrap()
             .unwrap();
@@ -4070,7 +4056,7 @@ mod tests {
         assert_eq!(reconciled.status, SandboxStatus::Crashed);
 
         let run = run_entity::Entity::find_by_id(run_id)
-            .one(pools.write())
+            .one(&pools)
             .await
             .unwrap()
             .unwrap();
@@ -4089,8 +4075,8 @@ mod tests {
         let pools = open_test_pools(&db_path).await;
 
         let config = test_config("draining-stale");
-        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
-        super::update_sandbox_status(pools.write(), sandbox_id, SandboxStatus::Draining)
+        let sandbox_id = insert_sandbox_record(&pools, &config).await.unwrap();
+        super::update_sandbox_status(&pools, sandbox_id, SandboxStatus::Draining)
             .await
             .unwrap();
 
@@ -4101,13 +4087,13 @@ mod tests {
             ..Default::default()
         };
         let run_id = run_entity::Entity::insert(run)
-            .exec(pools.write())
+            .exec(pools.inner().unwrap())
             .await
             .unwrap()
             .last_insert_id;
 
         let sandbox = super::sandbox_entity::Entity::find_by_id(sandbox_id)
-            .one(pools.write())
+            .one(&pools)
             .await
             .unwrap()
             .unwrap();
@@ -4117,7 +4103,7 @@ mod tests {
         assert_eq!(reconciled.status, SandboxStatus::Stopped);
 
         let run = run_entity::Entity::find_by_id(run_id)
-            .one(pools.write())
+            .one(&pools)
             .await
             .unwrap()
             .unwrap();
@@ -4136,13 +4122,13 @@ mod tests {
         let pools = open_test_pools(&db_path).await;
 
         let config = test_config("draining-no-run");
-        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
-        super::update_sandbox_status(pools.write(), sandbox_id, SandboxStatus::Draining)
+        let sandbox_id = insert_sandbox_record(&pools, &config).await.unwrap();
+        super::update_sandbox_status(&pools, sandbox_id, SandboxStatus::Draining)
             .await
             .unwrap();
 
         let sandbox = super::sandbox_entity::Entity::find_by_id(sandbox_id)
-            .one(pools.write())
+            .one(&pools)
             .await
             .unwrap()
             .unwrap();
@@ -4162,7 +4148,7 @@ mod tests {
         let sandbox_dir = temp.path().join("sandboxes").join("stale-running");
         fs::create_dir_all(sandbox_dir.join("rw")).unwrap();
         let config = test_config("stale-running");
-        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(&pools, &config).await.unwrap();
 
         let run = run_entity::ActiveModel {
             sandbox_id: Set(sandbox_id),
@@ -4171,7 +4157,7 @@ mod tests {
             ..Default::default()
         };
         run_entity::Entity::insert(run)
-            .exec(pools.write())
+            .exec(pools.inner().unwrap())
             .await
             .unwrap();
 
@@ -4185,7 +4171,7 @@ mod tests {
         assert!(!sandbox_dir.exists());
         assert!(
             super::sandbox_entity::Entity::find_by_id(sandbox_id)
-                .one(pools.write())
+                .one(&pools)
                 .await
                 .unwrap()
                 .is_none()
@@ -4202,7 +4188,7 @@ mod tests {
         let sandbox_dir = temp.path().join("sandboxes").join("running");
         fs::create_dir_all(&sandbox_dir).unwrap();
         let config = test_config("running");
-        let sandbox_id = insert_sandbox_record(pools.write(), &config).await.unwrap();
+        let sandbox_id = insert_sandbox_record(&pools, &config).await.unwrap();
 
         let child = Command::new("sleep").arg("30").spawn().unwrap();
         let live_pid = child.id() as i32;
@@ -4217,7 +4203,7 @@ mod tests {
             ..Default::default()
         };
         run_entity::Entity::insert(run)
-            .exec(pools.write())
+            .exec(pools.inner().unwrap())
             .await
             .unwrap();
 
@@ -4234,7 +4220,7 @@ mod tests {
         assert!(!sandbox_dir.exists());
         assert!(
             super::sandbox_entity::Entity::find_by_id(sandbox_id)
-                .one(pools.write())
+                .one(&pools)
                 .await
                 .unwrap()
                 .is_none()
@@ -4290,14 +4276,14 @@ mod tests {
 
         // --- Sandbox A: Running + dead PID → should become Crashed ---
         let cfg_a = test_config("running-dead");
-        let id_a = insert_sandbox_record(pools.write(), &cfg_a).await.unwrap();
+        let id_a = insert_sandbox_record(&pools, &cfg_a).await.unwrap();
         run_entity::Entity::insert(run_entity::ActiveModel {
             sandbox_id: Set(id_a),
             pid: Set(Some(dead)),
             status: Set(run_entity::RunStatus::Running),
             ..Default::default()
         })
-        .exec(pools.write())
+        .exec(pools.inner().unwrap())
         .await
         .unwrap();
 
@@ -4310,21 +4296,21 @@ mod tests {
         });
 
         let cfg_b = test_config("running-alive");
-        let id_b = insert_sandbox_record(pools.write(), &cfg_b).await.unwrap();
+        let id_b = insert_sandbox_record(&pools, &cfg_b).await.unwrap();
         run_entity::Entity::insert(run_entity::ActiveModel {
             sandbox_id: Set(id_b),
             pid: Set(Some(live_pid)),
             status: Set(run_entity::RunStatus::Running),
             ..Default::default()
         })
-        .exec(pools.write())
+        .exec(pools.inner().unwrap())
         .await
         .unwrap();
 
         // --- Sandbox C: Draining + dead PID → should become Stopped ---
         let cfg_c = test_config("draining-dead");
-        let id_c = insert_sandbox_record(pools.write(), &cfg_c).await.unwrap();
-        super::update_sandbox_status(pools.write(), id_c, SandboxStatus::Draining)
+        let id_c = insert_sandbox_record(&pools, &cfg_c).await.unwrap();
+        super::update_sandbox_status(&pools, id_c, SandboxStatus::Draining)
             .await
             .unwrap();
         run_entity::Entity::insert(run_entity::ActiveModel {
@@ -4333,27 +4319,27 @@ mod tests {
             status: Set(run_entity::RunStatus::Running),
             ..Default::default()
         })
-        .exec(pools.write())
+        .exec(pools.inner().unwrap())
         .await
         .unwrap();
 
         // --- Sandbox C2: Draining + no active run → should become Stopped ---
         let cfg_c2 = test_config("draining-no-run");
-        let id_c2 = insert_sandbox_record(pools.write(), &cfg_c2).await.unwrap();
-        super::update_sandbox_status(pools.write(), id_c2, SandboxStatus::Draining)
+        let id_c2 = insert_sandbox_record(&pools, &cfg_c2).await.unwrap();
+        super::update_sandbox_status(&pools, id_c2, SandboxStatus::Draining)
             .await
             .unwrap();
 
         // --- Sandbox D: Stopped → should stay Stopped ---
         let cfg_d = test_config("stopped");
-        let id_d = insert_sandbox_record(pools.write(), &cfg_d).await.unwrap();
-        super::update_sandbox_status(pools.write(), id_d, SandboxStatus::Stopped)
+        let id_d = insert_sandbox_record(&pools, &cfg_d).await.unwrap();
+        super::update_sandbox_status(&pools, id_d, SandboxStatus::Stopped)
             .await
             .unwrap();
 
         // --- Sandbox E: Running + no run record (still starting) → should stay Running ---
         let cfg_e = test_config("starting");
-        let id_e = insert_sandbox_record(pools.write(), &cfg_e).await.unwrap();
+        let id_e = insert_sandbox_record(&pools, &cfg_e).await.unwrap();
 
         // --- Reap: query all Running/Draining, reconcile each ---
         let stale = super::sandbox_entity::Entity::find()
@@ -4361,7 +4347,7 @@ mod tests {
                 super::sandbox_entity::Column::Status
                     .is_in([SandboxStatus::Running, SandboxStatus::Draining]),
             )
-            .all(pools.write())
+            .all(&pools)
             .await
             .unwrap();
 
@@ -4371,7 +4357,7 @@ mod tests {
 
         // --- Assertions ---
         let load = |id| {
-            let read_db = pools.read();
+            let read_db = &pools;
             async move {
                 super::sandbox_entity::Entity::find_by_id(id)
                     .one(read_db)

--- a/sdk/rust/lib/sandbox/modify.rs
+++ b/sdk/rust/lib/sandbox/modify.rs
@@ -1149,7 +1149,7 @@ async fn persist_config(
         updated_at: Set(Some(chrono::Utc::now().naive_utc())),
         ..Default::default()
     }
-    .update(local_backend.db().await?.write())
+    .update(local_backend.db().await?.inner()?)
     .await?;
 
     Ok(())
@@ -1181,7 +1181,7 @@ async fn persist_active_config(
         updated_at: Set(Some(chrono::Utc::now().naive_utc())),
         ..Default::default()
     }
-    .update(local_backend.db().await?.write())
+    .update(local_backend.db().await?.inner()?)
     .await?;
 
     Ok(())

--- a/sdk/rust/lib/snapshot/create.rs
+++ b/sdk/rust/lib/snapshot/create.rs
@@ -52,7 +52,7 @@ pub(super) async fn create_snapshot(
         ));
     }
 
-    let db = local.db().await?.read();
+    let db = local.db().await?;
 
     // Look up the sandbox row + parse its persisted config.
     let model = sandbox_entity::Entity::find()

--- a/sdk/rust/lib/snapshot/downgrade.rs
+++ b/sdk/rust/lib/snapshot/downgrade.rs
@@ -1053,7 +1053,7 @@ fn downgrade_error<T>(
 mod tests {
     use std::time::Duration;
 
-    use microsandbox_db::pool::DbPools;
+    use microsandbox_db::DbConnection;
     use microsandbox_migration::{Migrator, MigratorTrait};
     use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
 
@@ -1072,10 +1072,10 @@ mod tests {
         std::fs::write(artifact.join("upper.ext4"), b"hello").unwrap();
         std::fs::write(artifact.join(V066_DESCRIPTOR_FILENAME), LEGACY).unwrap();
 
-        let pools = DbPools::open(&db_path, 2, Duration::from_secs(5), Duration::from_secs(5))
+        let pools = DbConnection::open(&db_path, 2, Duration::from_secs(5), Duration::from_secs(5))
             .await
             .unwrap();
-        Migrator::up(pools.write().inner(), None).await.unwrap();
+        Migrator::up(pools.inner().unwrap(), None).await.unwrap();
         crate::snapshot::migration::reconcile_managed(&pools, &snapshots)
             .await
             .unwrap();
@@ -1088,7 +1088,7 @@ mod tests {
             LEGACY
         );
 
-        let plan = preflight_managed_v066(pools.write().inner(), &snapshots)
+        let plan = preflight_managed_v066(pools.inner().unwrap(), &snapshots)
             .await
             .unwrap();
         drop(plan);
@@ -1098,7 +1098,7 @@ mod tests {
         )
         .unwrap();
         journal_phase(
-            pools.write().inner(),
+            pools.inner().unwrap(),
             &artifact,
             "legacy_descriptor_published",
         )
@@ -1107,10 +1107,10 @@ mod tests {
 
         // Reconstruct the plan after a crash between exact descriptor
         // publication and the index-graph commit.
-        let plan = preflight_managed_v066(pools.write().inner(), &snapshots)
+        let plan = preflight_managed_v066(pools.inner().unwrap(), &snapshots)
             .await
             .unwrap();
-        let report = execute_managed_v066(pools.write().inner(), &recovery, plan)
+        let report = execute_managed_v066(pools.inner().unwrap(), &recovery, plan)
             .await
             .unwrap();
         assert_eq!(report.artifacts, 1);
@@ -1130,8 +1130,8 @@ mod tests {
         );
 
         let row = pools
-            .write()
             .inner()
+            .unwrap()
             .query_one(Statement::from_string(
                 DatabaseBackend::Sqlite,
                 "SELECT digest, migration_state FROM snapshot_index",
@@ -1148,12 +1148,12 @@ mod tests {
             "reverse_complete"
         );
 
-        Migrator::down(pools.write().inner(), Some(1))
+        Migrator::down(pools.inner().unwrap(), Some(1))
             .await
             .unwrap();
         let count = pools
-            .write()
             .inner()
+            .unwrap()
             .query_one(Statement::from_string(
                 DatabaseBackend::Sqlite,
                 "SELECT COUNT(*) FROM snapshot_index",
@@ -1176,10 +1176,10 @@ mod tests {
         std::fs::write(artifact.join("upper.ext4"), b"hello").unwrap();
         std::fs::write(artifact.join(V066_DESCRIPTOR_FILENAME), LEGACY).unwrap();
 
-        let pools = DbPools::open(&db_path, 2, Duration::from_secs(5), Duration::from_secs(5))
+        let pools = DbConnection::open(&db_path, 2, Duration::from_secs(5), Duration::from_secs(5))
             .await
             .unwrap();
-        Migrator::up(pools.write().inner(), None).await.unwrap();
+        Migrator::up(pools.inner().unwrap(), None).await.unwrap();
         crate::snapshot::migration::reconcile_managed(&pools, &snapshots)
             .await
             .unwrap();
@@ -1190,8 +1190,8 @@ mod tests {
         // complete graph before publishing manifest.json.
         std::fs::remove_file(artifact.join(V066_BACKUP_FILENAME)).unwrap();
         pools
-            .write()
             .inner()
+            .unwrap()
             .execute(Statement::from_string(
                 DatabaseBackend::Sqlite,
                 "DELETE FROM snapshot_artifact_migration",
@@ -1209,8 +1209,8 @@ mod tests {
         let digest = manifest.digest().unwrap();
         std::fs::write(artifact.join(DESCRIPTOR_FILENAME), canonical).unwrap();
         pools
-            .write()
             .inner()
+            .unwrap()
             .execute(Statement::from_sql_and_values(
                 DatabaseBackend::Sqlite,
                 "UPDATE snapshot_index SET digest = ?, migration_state = 'canonical' WHERE artifact_path = ?",
@@ -1219,7 +1219,7 @@ mod tests {
             .await
             .unwrap();
 
-        let error = preflight_managed_v066(pools.write().inner(), &snapshots)
+        let error = preflight_managed_v066(pools.inner().unwrap(), &snapshots)
             .await
             .err()
             .unwrap();
@@ -1232,8 +1232,8 @@ mod tests {
         assert!(artifact.join(DESCRIPTOR_FILENAME).exists());
         assert!(!artifact.join(V066_DESCRIPTOR_FILENAME).exists());
         let state = pools
-            .write()
             .inner()
+            .unwrap()
             .query_one(Statement::from_string(
                 DatabaseBackend::Sqlite,
                 "SELECT migration_state FROM snapshot_index",

--- a/sdk/rust/lib/snapshot/migration.rs
+++ b/sdk/rust/lib/snapshot/migration.rs
@@ -12,7 +12,7 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
-use microsandbox_db::pool::DbPools;
+use microsandbox_db::DbConnection;
 use microsandbox_image::snapshot::migration::{
     V066_BACKUP_FILENAME, V066_DESCRIPTOR_FILENAME, V066PayloadIdentity, V066SourceInfo,
     inspect_v066_source, translate_v066_forward,
@@ -96,10 +96,10 @@ struct PlannedCandidate {
 
 /// Discover and synchronously reconcile managed legacy artifacts.
 pub(crate) async fn reconcile_managed(
-    pools: &DbPools,
+    db: &DbConnection,
     snapshots_dir: &Path,
 ) -> MicrosandboxResult<MigrationReport> {
-    let mut paths = indexed_artifact_paths(pools.write().inner()).await?;
+    let mut paths = indexed_artifact_paths(db.inner()?).await?;
     if snapshots_dir.exists() {
         let mut entries = tokio::fs::read_dir(snapshots_dir).await?;
         while let Some(entry) = entries.next_entry().await? {
@@ -113,20 +113,20 @@ pub(crate) async fn reconcile_managed(
             }
         }
     }
-    reconcile_paths(pools, paths).await
+    reconcile_paths(db, paths).await
 }
 
 /// Reconcile an explicitly opened or newly staged artifact through the same
 /// migration gateway used by startup.
 pub(crate) async fn reconcile_explicit(
-    pools: &DbPools,
+    db: &DbConnection,
     artifact_path: &Path,
 ) -> MicrosandboxResult<MigrationReport> {
-    let mut paths = indexed_artifact_paths(pools.write().inner()).await?;
+    let mut paths = indexed_artifact_paths(db.inner()?).await?;
     paths.insert(artifact_path.to_path_buf());
-    let report = reconcile_paths(pools, paths).await?;
+    let report = reconcile_paths(db, paths).await?;
     if artifact_path.join(V066_DESCRIPTOR_FILENAME).exists() {
-        return Err(load_blocked_error(pools.write().inner(), artifact_path).await?);
+        return Err(load_blocked_error(db.inner()?, artifact_path).await?);
     }
     Ok(report)
 }
@@ -135,7 +135,7 @@ pub(crate) async fn reconcile_explicit(
 /// Staged paths are intentionally not journaled or indexed because failure
 /// discards the stage and promotion chooses the final installation paths.
 pub(crate) async fn normalize_staged(
-    pools: &DbPools,
+    db: &DbConnection,
     artifact_paths: &[PathBuf],
 ) -> MicrosandboxResult<()> {
     let mut pinned = Vec::new();
@@ -166,7 +166,7 @@ pub(crate) async fn normalize_staged(
                 })??,
         );
     }
-    let canonical = indexed_canonical_digests(pools.write().inner()).await?;
+    let canonical = indexed_canonical_digests(db.inner()?).await?;
     let (planned, failures) = plan_graph(hashed, &canonical);
     if let Some((_, error)) = failures.into_iter().next() {
         return Err(error);
@@ -185,10 +185,10 @@ pub(crate) async fn normalize_staged(
 //--------------------------------------------------------------------------------------------------
 
 async fn reconcile_paths(
-    pools: &DbPools,
+    db: &DbConnection,
     paths: BTreeSet<PathBuf>,
 ) -> MicrosandboxResult<MigrationReport> {
-    let db = pools.write().inner();
+    let db = db.inner()?;
     let mut report = MigrationReport::default();
     let mut pinned = Vec::new();
 

--- a/sdk/rust/lib/snapshot/store.rs
+++ b/sdk/rust/lib/snapshot/store.rs
@@ -112,7 +112,7 @@ pub(super) async fn index_upsert(
     digest: &str,
     manifest: &Manifest,
 ) -> MicrosandboxResult<()> {
-    let db = local.db().await?.write();
+    let db = local.db().await?.inner()?;
 
     let created_at = chrono::DateTime::parse_from_rfc3339(&manifest.created_at)
         .map(|d| d.naive_utc())
@@ -246,7 +246,7 @@ pub(super) fn looks_like_path(s: &str) -> bool {
 }
 
 pub(super) async fn list_indexed(local: &LocalBackend) -> MicrosandboxResult<Vec<SnapshotHandle>> {
-    let db = local.db().await?.read();
+    let db = local.db().await?;
     let rows = snapshot_entity::Entity::find()
         .order_by_desc(snapshot_entity::Column::CreatedAt)
         .all(db)
@@ -297,9 +297,9 @@ pub(super) async fn remove_snapshot(
     path_or_name: &str,
     force: bool,
 ) -> MicrosandboxResult<()> {
-    let pools = local.db().await?;
-    let read_db = pools.read();
-    let write_db = pools.write();
+    let db = local.db().await?;
+    let read_db = db;
+    let write_db = db.inner()?;
 
     // Resolve the target row. Accept digest, name, or path.
     let (digest, artifact_path) =
@@ -375,7 +375,7 @@ pub(super) async fn reindex_dir(local: &LocalBackend, dir: &Path) -> Microsandbo
     }
     // After upserts, recompute child_count from parent edges in one pass
     // to keep the cache honest about the current set of artifacts.
-    let db = local.db().await?.write();
+    let db = local.db().await?.inner()?;
     db.execute_unprepared(
         "UPDATE snapshot_index SET child_count = (\
             SELECT COUNT(*) FROM snapshot_index AS c \
@@ -390,7 +390,7 @@ pub(super) async fn get_handle(
     local: &LocalBackend,
     needle: &str,
 ) -> MicrosandboxResult<SnapshotHandle> {
-    let db = local.db().await?.read();
+    let db = local.db().await?;
 
     let row = if needle.starts_with("sha256:") || needle.starts_with("sha512:") {
         snapshot_entity::Entity::find_by_id(needle.to_string())
@@ -421,7 +421,7 @@ pub(super) async fn lookup_by_digest(
     local: &LocalBackend,
     digest: &str,
 ) -> MicrosandboxResult<Option<SnapshotHandle>> {
-    let db = local.db().await?.read();
+    let db = local.db().await?;
     let row = snapshot_entity::Entity::find_by_id(digest.to_string())
         .one(db)
         .await?;

--- a/sdk/rust/lib/volume/mod.rs
+++ b/sdk/rust/lib/volume/mod.rs
@@ -510,13 +510,13 @@ pub(crate) async fn create_local(
             feature: "Volume::create_local".into(),
             available_when: "with a LocalBackend".into(),
         })?;
-    let pools = local_backend.db().await?;
+    let db = local_backend.db().await?;
     let _name_lock = lock_volume_name(local_backend, &config.name)?;
 
     // Check for existing volume.
     let existing = volume_entity::Entity::find()
         .filter(volume_entity::Column::Name.eq(&config.name))
-        .one(pools.read())
+        .one(db)
         .await?;
     if existing.is_some() {
         return Err(MicrosandboxError::VolumeAlreadyExists(config.name));
@@ -548,10 +548,7 @@ pub(crate) async fn create_local(
         ..Default::default()
     };
 
-    if let Err(e) = volume_entity::Entity::insert(model)
-        .exec(pools.write())
-        .await
-    {
+    if let Err(e) = volume_entity::Entity::insert(model).exec(db.inner()?).await {
         let _ = tokio::fs::remove_dir_all(&path).await;
         return Err(e.into());
     }
@@ -581,7 +578,7 @@ pub(crate) async fn get_local(
             feature: "Volume::get_local".into(),
             available_when: "with a LocalBackend".into(),
         })?;
-    let db = local_backend.db().await?.read();
+    let db = local_backend.db().await?;
 
     let model = volume_entity::Entity::find()
         .filter(volume_entity::Column::Name.eq(name))
@@ -601,7 +598,7 @@ pub(crate) async fn list_local(backend: Arc<dyn Backend>) -> MicrosandboxResult<
             feature: "Volume::list_local".into(),
             available_when: "with a LocalBackend".into(),
         })?;
-    let db = local_backend.db().await?.read();
+    let db = local_backend.db().await?;
 
     let models = volume_entity::Entity::find()
         .order_by_desc(volume_entity::Column::CreatedAt)
@@ -622,20 +619,20 @@ pub(crate) async fn remove_local(backend: Arc<dyn Backend>, name: &str) -> Micro
             feature: "Volume::remove_local".into(),
             available_when: "with a LocalBackend".into(),
         })?;
-    let pools = local_backend.db().await?;
+    let db = local_backend.db().await?;
 
     let model = volume_entity::Entity::find()
         .filter(volume_entity::Column::Name.eq(name))
-        .one(pools.read())
+        .one(db)
         .await?
         .ok_or_else(|| MicrosandboxError::VolumeNotFound(name.into()))?;
     let handle = VolumeHandle::from_local_model(backend.clone(), model);
     let _name_lock = lock_volume_name(local_backend, name)?;
     let _disk_lock = lock_disk_volume_for_remove(&handle)?;
-    ensure_volume_not_referenced_by_active_sandbox(pools.read(), name).await?;
+    ensure_volume_not_referenced_by_active_sandbox(db, name).await?;
 
     volume_entity::Entity::delete_by_id(handle.local().expect("local handle").db_id)
-        .exec(pools.write())
+        .exec(db.inner()?)
         .await?;
 
     let path = local_backend.volume_path(name);
@@ -926,7 +923,7 @@ mod tests {
             updated_at: Set(Some(chrono::Utc::now().naive_utc())),
             ..Default::default()
         }
-        .insert(local.db().await.unwrap().write())
+        .insert(local.db().await.unwrap().inner().unwrap())
         .await
         .unwrap();
 


### PR DESCRIPTION
The DB layer used two newtypes (`DbReadConnection`, `DbWriteConnection`) plus a `DbPools` pair to separate read and write traffic. That made intent a compile-time property — but the load-bearing mechanisms were always the *single serialized write connection* and *read concurrency under WAL*, and nothing actually stopped a write from executing on the read pool; the types were convention, not enforcement.

This PR collapses all three into one public `DbConnection` handle and makes the separation structural:

- the read pool opens with `SQLITE_OPEN_READONLY`, so the **engine itself rejects writes on the read lane** (`ConnectionTrait` on `DbConnection` delegates only there);
- writes and maintenance run on the single write connection through the same surface the previous types exposed — `inner()` for direct statements and `transaction()` (unchanged semantics, retry-on-busy) — serialized at pool checkout exactly as before;
- `DbConnection::open_observer` gives read-only consumers (the metrics collector) a handle with **no write lane at all**: `inner()`/`transaction()` fail with an explicit capability error.

Read connections stop issuing writer-establishment pragmas (WAL persists in the file; the writer opens first and sets them). Busy-retry, transaction semantics, migration ordering, and the install-lease flow are preserved — call sites are byte-close to their previous shape (`db.inner()` → `db.inner()?`).

New tests cover the engine-enforced read lane, observer capability errors, pool-checkout write serialization, and read-only opens across the WAL sidecar lifecycle (`-wal`/`-shm` present, absent, and recreated).

Suites: db 7/7 (4 new), sdk 472, cli 257, runtime 38, metrics-collector 93 — all green; workspace fmt/clippy/doc/build clean via pre-commit.