### PR TITLE
chore(release): bump microsandbox to 0.6.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "base64",
  "chrono",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "base64",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-go"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "base64",
  "cbindgen",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3553,7 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "chrono",
  "libc",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics-collector"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "base64",
  "bytes",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3676,7 +3676,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "chrono",
  "futures",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "chrono",
  "dprint-plugin-typescript",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "dirs",
  "libc",
@@ -7028,14 +7028,14 @@ dependencies = [
 
 [[package]]
 name = "test-init"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "test-macros"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7044,7 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.6.7"
+version = "0.6.8"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -65,18 +65,18 @@ panic = "abort"
 # Exact (`=`) pins: these crates share private, unstable APIs across patch
 # releases, so every published version must resolve its siblings to the same
 # version. Caret would let an older release pull newer siblings and break.
-microsandbox = { version = "=0.6.7", path = "sdk/rust", default-features = false }
-microsandbox-agent-client = { version = "=0.6.7", path = "packages/agent-client/rust" }
-microsandbox-db = { version = "=0.6.7", path = "crates/db" }
-microsandbox-filesystem = { version = "=0.6.7", path = "crates/filesystem", default-features = false }
-microsandbox-image = { version = "=0.6.7", path = "crates/image" }
-microsandbox-metrics = { version = "=0.6.7", path = "crates/metrics" }
-microsandbox-types = { version = "=0.6.7", path = "packages/microsandbox-types/rust" }
-microsandbox-migration = { version = "=0.6.7", path = "crates/migration" }
-microsandbox-network = { version = "=0.6.7", path = "crates/network" }
-microsandbox-protocol = { version = "=0.6.7", path = "crates/protocol" }
-microsandbox-runtime = { version = "=0.6.7", path = "crates/runtime", default-features = false }
-microsandbox-utils = { version = "=0.6.7", path = "crates/utils" }
+microsandbox = { version = "=0.6.8", path = "sdk/rust", default-features = false }
+microsandbox-agent-client = { version = "=0.6.8", path = "packages/agent-client/rust" }
+microsandbox-db = { version = "=0.6.8", path = "crates/db" }
+microsandbox-filesystem = { version = "=0.6.8", path = "crates/filesystem", default-features = false }
+microsandbox-image = { version = "=0.6.8", path = "crates/image" }
+microsandbox-metrics = { version = "=0.6.8", path = "crates/metrics" }
+microsandbox-types = { version = "=0.6.8", path = "packages/microsandbox-types/rust" }
+microsandbox-migration = { version = "=0.6.8", path = "crates/migration" }
+microsandbox-network = { version = "=0.6.8", path = "crates/network" }
+microsandbox-protocol = { version = "=0.6.8", path = "crates/protocol" }
+microsandbox-runtime = { version = "=0.6.8", path = "crates/runtime", default-features = false }
+microsandbox-utils = { version = "=0.6.8", path = "crates/utils" }
 msb_krun = "=0.1.25"
 msb_krun_utils = "=0.1.25"
 test-macros = { path = "crates/test-macros" }

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -67,7 +67,6 @@ microsandbox reads its global configuration from `~/.microsandbox/config.json`. 
   "profiles": {
     "prod": {
       "backend": "cloud",
-      "url": "https://cloud.example.com",
       "api_key_ref": "env:MSB_API_KEY"
     },
     "local": {
@@ -243,7 +242,6 @@ Backend profiles let CLI and SDK calls choose between the local runtime and a cl
   "profiles": {
     "prod": {
       "backend": "cloud",
-      "url": "https://cloud.example.com",
       "api_key_ref": "env:MSB_API_KEY"
     },
     "local": {
@@ -259,7 +257,7 @@ Use `active_profile` for the default profile. Use `MSB_PROFILE=<name>` to overri
 MSB_PROFILE=prod msb run python -- python -V
 ```
 
-Cloud profiles require `url` and `api_key_ref`. Supported credential references are:
+Cloud profiles require `api_key_ref`. The `url` field is optional and defaults to `https://api.microsandbox.dev`; set it only for a development, self-hosted, or on-prem control plane. Supported credential references are:
 
 | Prefix | Description |
 |--------|-------------|
@@ -269,7 +267,15 @@ Cloud profiles require `url` and `api_key_ref`. Supported credential references 
 Backend resolution uses this order:
 
 1. Programmatic backend set by the SDK
-2. `MSB_BACKEND=local`, or `MSB_API_URL` plus `MSB_API_KEY`
+2. `MSB_BACKEND=local`, or a non-empty `MSB_API_KEY`
 3. `MSB_PROFILE=<name>`
 4. `active_profile`
 5. Local runtime
+
+For hosted cloud usage, the API key is sufficient:
+
+```bash
+export MSB_API_KEY=msb_...
+```
+
+`MSB_API_URL` only overrides the cloud endpoint; it never selects the cloud backend without an API key.

--- a/examples/python/cloud-backend/main.py
+++ b/examples/python/cloud-backend/main.py
@@ -1,23 +1,14 @@
 """Cloud backend lifecycle and live-log example."""
 
 import asyncio
-import os
 import time
 
-from microsandbox import Sandbox, default_backend_kind, set_default_backend
+from microsandbox import Sandbox, default_backend_kind
 
 
 def configure_cloud_backend():
-    profile = os.getenv("MSB_PROFILE")
-    if profile:
-        set_default_backend("cloud", profile=profile)
-    else:
-        url = os.environ["MSB_API_URL"]
-        api_key = os.environ["MSB_API_KEY"]
-        set_default_backend("cloud", url=url, api_key=api_key)
-
     if default_backend_kind() != "cloud":
-        raise RuntimeError("expected cloud backend")
+        raise RuntimeError("set MSB_API_KEY or select a cloud profile")
 
 
 async def wait_until_stopped(name: str):

--- a/examples/rust/cloud-backend/bin/main.rs
+++ b/examples/rust/cloud-backend/bin/main.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use futures::StreamExt;
 use microsandbox::logs::{LogSource, LogStreamOptions};
 use microsandbox::sandbox::SandboxStatus;
-use microsandbox::{BackendKind, CloudBackend, Sandbox, set_default_backend};
+use microsandbox::{BackendKind, Sandbox};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -71,16 +71,9 @@ async fn main() -> anyhow::Result<()> {
 }
 
 fn configure_cloud_backend() -> anyhow::Result<()> {
-    let cloud = if let Ok(profile) = std::env::var("MSB_PROFILE") {
-        CloudBackend::from_profile(profile.trim())?
-    } else {
-        CloudBackend::from_env()?
-    };
-    set_default_backend(cloud);
-
     let kind = microsandbox::default_backend().kind();
     if kind != BackendKind::Cloud {
-        anyhow::bail!("expected cloud backend, got {kind:?}");
+        anyhow::bail!("set MSB_API_KEY or select a cloud profile; got {kind:?}");
     }
     Ok(())
 }

--- a/examples/typescript/cloud-backend/main.ts
+++ b/examples/typescript/cloud-backend/main.ts
@@ -1,24 +1,11 @@
 import {
   Sandbox,
   defaultBackendKind,
-  setDefaultBackend,
 } from "microsandbox";
 
 function configureCloudBackend() {
-  const profile = process.env.MSB_PROFILE;
-  if (profile) {
-    setDefaultBackend({ kind: "cloud", profile });
-  } else {
-    const url = process.env.MSB_API_URL;
-    const apiKey = process.env.MSB_API_KEY;
-    if (!url || !apiKey) {
-      throw new Error("set MSB_PROFILE or both MSB_API_URL and MSB_API_KEY");
-    }
-    setDefaultBackend({ kind: "cloud", url, apiKey });
-  }
-
   if (defaultBackendKind() !== "cloud") {
-    throw new Error("expected cloud backend");
+    throw new Error("set MSB_API_KEY or select a cloud profile");
   }
 }
 

--- a/examples/typescript/cloud-backend/package.json
+++ b/examples/typescript/cloud-backend/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/init-handoff/package.json
+++ b/examples/typescript/init-handoff/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/snapshot-fork/package.json
+++ b/examples/typescript/snapshot-fork/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.7"
+    "microsandbox": "0.6.8"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/packages/agent-client/rust/README.md
+++ b/packages/agent-client/rust/README.md
@@ -10,19 +10,19 @@ Use this crate when you already have an agent relay endpoint and want direct pro
 
 ```toml
 [dependencies]
-microsandbox-agent-client = "0.6.7"
-microsandbox-protocol = "0.6.7"
+microsandbox-agent-client = "0.6.8"
+microsandbox-protocol = "0.6.8"
 ```
 
 The crate is transport-agnostic by default. Enable exactly the transport adapter you need:
 
 ```toml
 # Local microsandbox relay sockets.
-microsandbox-agent-client = { version = "0.6.7", features = ["uds"] }
+microsandbox-agent-client = { version = "0.6.8", features = ["uds"] }
 
 # Any caller-owned byte-stream transport (e.g. a pre-authenticated WebSocket
 # adapted to bytes).
-microsandbox-agent-client = { version = "0.6.7", features = ["stream"] }
+microsandbox-agent-client = { version = "0.6.8", features = ["stream"] }
 ```
 
 The high-level `microsandbox` SDK enables `uds` explicitly because local sandboxes are reached through Unix domain sockets.
@@ -99,7 +99,7 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
 Enable the `stream` feature:
 
 ```toml
-microsandbox-agent-client = { version = "0.6.7", features = ["stream"] }
+microsandbox-agent-client = { version = "0.6.8", features = ["stream"] }
 ```
 
 Drive the client over any `AsyncRead + AsyncWrite` — the caller owns the dial and any authentication, then hands over the connected stream:

--- a/packages/agent-client/typescript/package-lock.json
+++ b/packages/agent-client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/agent-client",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "Apache-2.0",
       "dependencies": {
         "cbor-x": "^1.6.0"

--- a/packages/agent-client/typescript/package.json
+++ b/packages/agent-client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "type": "module",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/microsandbox-types/rust/README.md
+++ b/packages/microsandbox-types/rust/README.md
@@ -25,7 +25,7 @@ Backend-private materialized state stays out: registry credentials, local CA pat
 
 ```toml
 [dependencies]
-microsandbox-types = "0.6.7"
+microsandbox-types = "0.6.8"
 ```
 
 ```rust

--- a/packages/microsandbox-types/typescript/package-lock.json
+++ b/packages/microsandbox-types/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/types",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6"

--- a/packages/microsandbox-types/typescript/package.json
+++ b/packages/microsandbox-types/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "type": "module",
   "main": "./dist/cloud.js",
   "types": "./dist/cloud.d.ts",

--- a/sdk/go/examples/cloud-backend/main.go
+++ b/sdk/go/examples/cloud-backend/main.go
@@ -2,7 +2,7 @@
 //
 // Run from sdk/go:
 //
-//	MSB_API_URL=https://cloud.example.com MSB_API_KEY=... go run ./examples/cloud-backend
+//	MSB_API_KEY=... go run ./examples/cloud-backend
 //
 // Or configure ~/.microsandbox/config.json and run:
 //
@@ -22,9 +22,8 @@ import (
 )
 
 func main() {
-	if os.Getenv("MSB_PROFILE") == "" &&
-		(os.Getenv("MSB_API_URL") == "" || os.Getenv("MSB_API_KEY") == "") {
-		log.Fatal("set MSB_PROFILE or both MSB_API_URL and MSB_API_KEY")
+	if os.Getenv("MSB_PROFILE") == "" && os.Getenv("MSB_API_KEY") == "" {
+		log.Fatal("set MSB_API_KEY or select a cloud profile")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)

--- a/sdk/go/setup.go
+++ b/sdk/go/setup.go
@@ -32,7 +32,7 @@ const libkrunfwABI = "5"
 
 // libkrunfwVersion is the full version of the prebuilt libkrunfw shipped in
 // each release tarball.
-const libkrunfwVersion = "5.6.0"
+const libkrunfwVersion = "5.6.1"
 
 // githubOrg / githubRepo locate the GitHub release assets for the
 // msb + libkrunfw download (FFI library ships embedded in the SDK).

--- a/sdk/go/setup.go
+++ b/sdk/go/setup.go
@@ -24,7 +24,7 @@ import (
 // embedded FFI library and the downloaded msb+libkrunfw artefacts are
 // both pinned to this version. Bump when cutting a new SDK release so
 // it matches published binaries.
-const sdkVersion = "0.6.7"
+const sdkVersion = "0.6.8"
 
 // libkrunfwABI is the major SONAME version of libkrunfw that msb links
 // against.

--- a/sdk/go/setup_test.go
+++ b/sdk/go/setup_test.go
@@ -31,9 +31,9 @@ func TestPlatformRuntimeFiles(t *testing.T) {
 			name:      "linux",
 			goos:      "linux",
 			msb:       "msb",
-			libkrunfw: "libkrunfw.so.5.6.0",
+			libkrunfw: "libkrunfw.so.5.6.1",
 			symlinks: [][2]string{
-				{"libkrunfw.so.5", "libkrunfw.so.5.6.0"},
+				{"libkrunfw.so.5", "libkrunfw.so.5.6.1"},
 				{"libkrunfw.so", "libkrunfw.so.5"},
 			},
 		},

--- a/sdk/go/smoke_test.go
+++ b/sdk/go/smoke_test.go
@@ -52,8 +52,11 @@ func smokeSetup(t *testing.T) context.Context {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 
-	if err := EnsureInstalled(ctx); err != nil {
-		t.Fatalf("EnsureInstalled: %v", err)
+	// These are no-KVM FFI boundary tests. Load the freshly built library
+	// directly instead of downloading a runtime from a release that may not
+	// exist yet while its version-bump PR is still under review.
+	if _, err := RuntimeVersion(); err != nil {
+		t.Fatalf("load FFI library: %v", err)
 	}
 	return ctx
 }

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.6.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/node-ts/native/runtime_config.rs
+++ b/sdk/node-ts/native/runtime_config.rs
@@ -36,8 +36,8 @@ pub fn set_runtime_libkrunfw_path(path: String) {
 
 /// Set the process-wide default backend.
 ///
-/// `kind="local"` selects the local backend. `kind="cloud"` requires either
-/// `url` + `api_key`, or `profile`.
+/// `kind="local"` selects the local backend. `kind="cloud"` requires either an
+/// API key (with an optional URL override), or a profile.
 #[napi(js_name = "setDefaultBackend")]
 pub fn set_default_backend(
     kind: String,
@@ -102,13 +102,13 @@ fn build_backend(
             let cloud = if let Some(profile) = profile {
                 microsandbox::CloudBackend::from_profile(&profile)
             } else {
-                let url = url.ok_or_else(|| {
-                    napi::Error::from_reason("cloud backend requires url + apiKey or profile")
-                })?;
                 let api_key = api_key.ok_or_else(|| {
-                    napi::Error::from_reason("cloud backend requires url + apiKey or profile")
+                    napi::Error::from_reason("cloud backend requires apiKey or profile")
                 })?;
-                microsandbox::CloudBackend::new(url, api_key)
+                match url {
+                    Some(url) => microsandbox::CloudBackend::new(url, api_key),
+                    None => microsandbox::CloudBackend::with_api_key(api_key),
+                }
             }
             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
             Ok(Arc::new(cloud))

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/npm/win32-arm64-msvc/package.json
+++ b/sdk/node-ts/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-win32-arm64-msvc",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Windows arm64.",
   "os": ["win32"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/win32-x64-msvc/package.json
+++ b/sdk/node-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-win32-x64-msvc",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Windows x64.",
   "os": ["win32"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -22,11 +22,11 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.6.7",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.7",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.6.7",
-        "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.7",
-        "@superradcompany/microsandbox-win32-x64-msvc": "0.6.7"
+        "@superradcompany/microsandbox-darwin-arm64": "0.6.8",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.8",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.6.8",
+        "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.8",
+        "@superradcompany/microsandbox-win32-x64-msvc": "0.6.8"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1851,84 +1851,19 @@
       "license": "MIT"
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.6.7.tgz",
-      "integrity": "sha512-uaRsjIoWJqaUSqGoUxxpodTVJECDHJO1wJR0rh9FXevweNAnQlwqsGzmE9j/NF7Q5l/KB4sTjp7LVTAtw8wqTg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.6.7.tgz",
-      "integrity": "sha512-oL5l8YQg9owGuHsGZKJv1biaVGjMvye87R6t4cfg1sPMfxxU8Z8pY4HSv3cd92/auDo/MiXqtpPM8GOpPcAk1w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.6.7.tgz",
-      "integrity": "sha512-fFTDskm79zYOBFFMMi3ok4JUHD0lxRCN0X2vghdMutLnAoa/T/FjTzzvuQ9A98oddwKSaD0Mtow5Ggp+hEtzdQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-win32-arm64-msvc": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-win32-arm64-msvc/-/microsandbox-win32-arm64-msvc-0.6.7.tgz",
-      "integrity": "sha512-qxp4QftpSUq0d0TCXv/jXdzRZr0QDS7vtDaF/8Ghq51NuMy6e47BYUmcjapj0Is+KJhTHhum/IQsx7en/IMwoQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-win32-x64-msvc": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-win32-x64-msvc/-/microsandbox-win32-x64-msvc-0.6.7.tgz",
-      "integrity": "sha512-a5SH8e2brZzI+dPBdAr4i4e+1mZXdMdKXbgTudBJMR8zGuUl3y3bQKe0iLxInSjlmt5CMHkNkVsyZocPuvRozQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -51,11 +51,11 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.6.7",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.7",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.6.7",
-    "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.7",
-    "@superradcompany/microsandbox-win32-x64-msvc": "0.6.7"
+    "@superradcompany/microsandbox-darwin-arm64": "0.6.8",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.8",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.6.8",
+    "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.8",
+    "@superradcompany/microsandbox-win32-x64-msvc": "0.6.8"
   },
   "files": [
     "dist",

--- a/sdk/node-ts/src/runtime.ts
+++ b/sdk/node-ts/src/runtime.ts
@@ -4,7 +4,8 @@ export type DefaultBackend =
   | "local"
   | {
       kind: "cloud";
-      url: string;
+      /** Override the hosted API endpoint. Defaults to https://api.microsandbox.dev. */
+      url?: string;
       apiKey: string;
     }
   | {

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -110,7 +110,7 @@ fn set_runtime_libkrunfw_path(path: String) {
 /// Set the process-wide default backend.
 ///
 /// `kind="local"` selects the local libkrun backend. `kind="cloud"` requires
-/// either `url` + `api_key`, or `profile`.
+/// either `api_key` (with an optional `url` override), or `profile`.
 #[pyfunction]
 #[pyo3(signature = (kind, *, url=None, api_key=None, profile=None))]
 fn set_default_backend(
@@ -185,17 +185,15 @@ fn build_backend(
             let cloud = if let Some(profile) = profile {
                 microsandbox::CloudBackend::from_profile(&profile)
             } else {
-                let url = url.ok_or_else(|| {
-                    pyo3::exceptions::PyValueError::new_err(
-                        "cloud backend requires url + api_key or profile",
-                    )
-                })?;
                 let api_key = api_key.ok_or_else(|| {
                     pyo3::exceptions::PyValueError::new_err(
-                        "cloud backend requires url + api_key or profile",
+                        "cloud backend requires api_key or profile",
                     )
                 })?;
-                microsandbox::CloudBackend::new(url, api_key)
+                match url {
+                    Some(url) => microsandbox::CloudBackend::new(url, api_key),
+                    None => microsandbox::CloudBackend::with_api_key(api_key),
+                }
             }
             .map_err(error::to_py_err)?;
             Ok(Arc::new(cloud))

--- a/sdk/rust/lib/backend/cloud/mod.rs
+++ b/sdk/rust/lib/backend/cloud/mod.rs
@@ -4,7 +4,9 @@
 //! plain HTTP; logs stream over SSE; exec, attach, and guest-fs ride the agent
 //! WebSocket route through the shared agent client (see the `DialAgent` impl).
 //!
-//! Construction is URL + API key first; `from_env` and `from_profile` are sugar.
+//! Construction requires an API key. Hosted-cloud callers use the default
+//! endpoint; `new`, environment configuration, and profiles can override it
+//! for development, self-hosted, and on-prem deployments.
 //! Auth is API-key-only — the same `msb_live_*` / `msb_test_*` tokens msb-cloud
 //! issues today. No OAuth or session credentials are honored here.
 
@@ -37,6 +39,9 @@ use crate::{MicrosandboxError, MicrosandboxResult};
 // Constants
 //--------------------------------------------------------------------------------------------------
 
+/// Hosted microsandbox API endpoint used when no cloud URL is configured.
+pub const DEFAULT_CLOUD_API_URL: &str = "https://api.microsandbox.dev";
+
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Default User-Agent header value.
@@ -57,7 +62,8 @@ fn default_user_agent() -> String {
 /// Constructors:
 /// - [`CloudBackend::new`] — primary; explicit URL + key. Works for hosted SaaS,
 ///   self-hosted, and on-prem deployments identically.
-/// - [`CloudBackend::from_env`] — reads `MSB_API_URL` + `MSB_API_KEY`.
+/// - [`CloudBackend::with_api_key`] — hosted SaaS with the default API URL.
+/// - [`CloudBackend::from_env`] — reads `MSB_API_KEY`; `MSB_API_URL` is optional.
 /// - [`CloudBackend::from_profile`] — reads a named profile from the SDK config.
 /// - [`CloudBackend::builder`] — tuned construction (custom client, timeout,
 ///   user agent).
@@ -71,7 +77,6 @@ pub struct CloudBackend {
 ///
 /// ```ignore
 /// let cloud = CloudBackend::builder()
-///     .url("https://msb.example.com")
 ///     .api_key(key)
 ///     .request_timeout(Duration::from_secs(60))
 ///     .build()?;
@@ -98,21 +103,31 @@ impl CloudBackend {
         Self::builder().url(url).api_key(api_key).build()
     }
 
-    /// Construct from `MSB_API_URL` + `MSB_API_KEY` env vars.
+    /// Construct for hosted microsandbox using [`DEFAULT_CLOUD_API_URL`].
+    pub fn with_api_key(api_key: impl Into<String>) -> MicrosandboxResult<Self> {
+        Self::builder().api_key(api_key).build()
+    }
+
+    /// Construct from `MSB_API_KEY` and an optional `MSB_API_URL` override.
     ///
-    /// Returns `InvalidConfig` if either is missing or empty.
+    /// Returns `InvalidConfig` if `MSB_API_KEY` is missing or empty. A missing
+    /// or empty `MSB_API_URL` uses [`DEFAULT_CLOUD_API_URL`].
     pub fn from_env() -> MicrosandboxResult<Self> {
-        let url = std::env::var("MSB_API_URL").map_err(|_| {
-            MicrosandboxError::InvalidConfig(
-                "MSB_API_URL not set — required for cloud backend".into(),
-            )
-        })?;
         let api_key = std::env::var("MSB_API_KEY").map_err(|_| {
             MicrosandboxError::InvalidConfig(
                 "MSB_API_KEY not set — required for cloud backend".into(),
             )
         })?;
-        Self::new(url.trim(), api_key.trim())
+
+        let mut builder = Self::builder().api_key(api_key.trim());
+        if let Some(url) = std::env::var("MSB_API_URL")
+            .ok()
+            .map(|url| url.trim().to_string())
+            .filter(|url| !url.is_empty())
+        {
+            builder = builder.url(url);
+        }
+        builder.build()
     }
 
     /// Construct from a named SDK profile in `~/.microsandbox/config.json`.
@@ -195,12 +210,11 @@ impl CloudBackendBuilder {
         self
     }
 
-    /// Build the `CloudBackend`. Errors when URL or API key are missing, or
-    /// when the underlying HTTP client fails to construct.
+    /// Build the `CloudBackend`. Uses [`DEFAULT_CLOUD_API_URL`] when `.url(...)`
+    /// was not called. Errors when the API key is missing or invalid, an
+    /// explicitly supplied URL is empty, or the HTTP client fails to construct.
     pub fn build(self) -> MicrosandboxResult<CloudBackend> {
-        let url = self.url.ok_or_else(|| {
-            MicrosandboxError::InvalidConfig("CloudBackend requires a URL (call .url(...))".into())
-        })?;
+        let url = self.url.as_deref().unwrap_or(DEFAULT_CLOUD_API_URL);
         let url = url.trim();
         if url.is_empty() {
             return Err(MicrosandboxError::InvalidConfig(
@@ -364,8 +378,15 @@ mod tests {
     }
 
     #[test]
-    fn builder_rejects_missing_url() {
-        assert!(CloudBackendBuilder::default().api_key("k").build().is_err());
+    fn with_api_key_uses_default_cloud_url() {
+        let b = CloudBackend::with_api_key("msb_test_abc").unwrap();
+        assert_eq!(b.url(), DEFAULT_CLOUD_API_URL);
+    }
+
+    #[test]
+    fn builder_uses_default_cloud_url() {
+        let b = CloudBackendBuilder::default().api_key("k").build().unwrap();
+        assert_eq!(b.url(), DEFAULT_CLOUD_API_URL);
     }
 
     #[test]
@@ -396,15 +417,6 @@ mod tests {
     #[test]
     fn builder_rejects_whitespace_key() {
         assert!(CloudBackend::new("https://x", "   ").is_err());
-    }
-
-    #[test]
-    fn from_env_errors_when_url_missing() {
-        // Note: this test can race with parallel tests setting env vars. Just
-        // verify the function returns an error when MSB_API_URL is clearly absent;
-        // we don't try to scrub env state.
-        unsafe { std::env::remove_var("MSB_API_URL") };
-        assert!(CloudBackend::from_env().is_err());
     }
 
     #[test]

--- a/sdk/rust/lib/backend/mod.rs
+++ b/sdk/rust/lib/backend/mod.rs
@@ -11,9 +11,10 @@
 //! ## Ambient default
 //!
 //! [`default_backend`] returns the process-wide default. [`set_default_backend`]
-//! installs one; if never called, the first access lazy-initialises to
-//! [`LocalBackend::lazy`]. [`with_backend`] scopes an override to one async
-//! future (and any tasks it spawns) via `tokio::task_local!`.
+//! installs one; if never called, the first access resolves environment and
+//! profile configuration before falling back to [`LocalBackend::lazy`].
+//! [`with_backend`] scopes an override to one async future (and any tasks it
+//! spawns) via `tokio::task_local!`.
 //!
 //! See `planning/microsandbox/design/api/local-cloud-backend.md` for the
 //! full trait-surface spec, and `planning/microsandbox/design/api/ambient-backend.md`
@@ -25,7 +26,7 @@ mod profile;
 pub(crate) mod sandbox;
 pub(crate) mod volume;
 
-pub use cloud::{CloudBackend, CloudBackendBuilder};
+pub use cloud::{CloudBackend, CloudBackendBuilder, DEFAULT_CLOUD_API_URL};
 use futures::future::BoxFuture;
 pub use local::{LocalBackend, LocalBackendBuilder};
 pub use microsandbox_types::{
@@ -118,8 +119,8 @@ pub trait Backend: Send + Sync + 'static {
 // Functions: Ambient default
 //--------------------------------------------------------------------------------------------------
 
-/// Process-wide default backend. Lazy-initialised to `LocalBackend::lazy()`
-/// on first access if `set_default_backend` has not been called.
+/// Process-wide default backend. Lazy-initialised from environment/profile
+/// configuration, with `LocalBackend::lazy()` as the final fallback.
 static DEFAULT: OnceLock<RwLock<Arc<dyn Backend>>> = OnceLock::new();
 
 /// Install a process-wide default backend.

--- a/sdk/rust/lib/backend/profile.rs
+++ b/sdk/rust/lib/backend/profile.rs
@@ -4,7 +4,8 @@
 //!
 //! 1. Programmatic: explicit `.backend(b)` on a builder or
 //!    `microsandbox::set_default_backend(...)` — handled by the caller, not here.
-//! 2. Env: `MSB_BACKEND=local` → local, `MSB_API_URL` + `MSB_API_KEY` → cloud.
+//! 2. Env: `MSB_BACKEND=local` → local, non-empty `MSB_API_KEY` → cloud.
+//!    `MSB_API_URL` optionally overrides the hosted API endpoint.
 //! 3. Env: `MSB_PROFILE=<name>` → look up that profile in the config file.
 //! 4. Config: `active_profile` field → use that profile.
 //! 5. Fallback: `LocalBackend`.
@@ -46,14 +47,14 @@ pub struct SdkConfig {
     pub profiles: HashMap<String, Profile>,
 }
 
-/// A single named profile. Either local (no extra config) or cloud (URL + key
-/// reference).
+/// A single named profile. Either local (no extra config) or cloud (key
+/// reference plus an optional URL override).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Profile {
     /// Which backend this profile selects.
     pub backend: ProfileBackend,
 
-    /// Cloud-only: the API endpoint URL.
+    /// Cloud-only: API endpoint override. Hosted cloud uses the SDK default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 
@@ -116,29 +117,30 @@ pub fn load_sdk_config() -> MicrosandboxResult<SdkConfig> {
 /// not here.
 pub fn resolve_default_backend() -> MicrosandboxResult<Arc<dyn Backend>> {
     // Tier 2a: explicit backend kind via env.
-    if let Ok(kind) = std::env::var("MSB_BACKEND") {
+    let explicitly_cloud = if let Ok(kind) = std::env::var("MSB_BACKEND") {
         match kind.trim().to_ascii_lowercase().as_str() {
             "local" => return Ok(Arc::new(LocalBackend::lazy())),
-            "cloud" => {
-                // Cloud without explicit URL/key — fall through to profile lookup,
-                // since the user may have set MSB_PROFILE separately.
-            }
+            // Fall through to direct credentials or profile lookup. Keeping
+            // this bit lets us reject an explicit cloud request that resolves
+            // to neither instead of silently treating its URL as a signal.
+            "cloud" => true,
             other => {
                 return Err(MicrosandboxError::InvalidConfig(format!(
                     "MSB_BACKEND must be 'local' or 'cloud', got {other:?}"
                 )));
             }
         }
-    }
+    } else {
+        false
+    };
 
-    // Tier 2b: direct env (MSB_API_URL + MSB_API_KEY) — explicit cloud override.
-    if let (Ok(url), Ok(key)) = (std::env::var("MSB_API_URL"), std::env::var("MSB_API_KEY")) {
-        let url = url.trim();
-        let key = key.trim();
-        if !url.is_empty() && !key.is_empty() {
-            let cloud = CloudBackend::new(url, key)?;
-            return Ok(Arc::new(cloud));
-        }
+    // Tier 2b: a non-empty API key selects cloud. The URL is an optional
+    // endpoint override and must never select cloud by itself.
+    if let Some(cloud) = direct_cloud_backend(
+        std::env::var("MSB_API_URL").ok(),
+        std::env::var("MSB_API_KEY").ok(),
+    )? {
+        return Ok(Arc::new(cloud));
     }
 
     // Tier 3 / 4: profile selection via env or config file.
@@ -155,7 +157,18 @@ pub fn resolve_default_backend() -> MicrosandboxResult<Arc<dyn Backend>> {
                 "active profile {name:?} not found in SDK config"
             ))
         })?;
+        if explicitly_cloud && profile.backend != ProfileBackend::Cloud {
+            return Err(MicrosandboxError::InvalidConfig(format!(
+                "MSB_BACKEND=cloud cannot select local profile {name:?}"
+            )));
+        }
         return backend_from_profile(&name, profile);
+    }
+
+    if explicitly_cloud {
+        return Err(MicrosandboxError::InvalidConfig(
+            "MSB_BACKEND=cloud requires a non-empty MSB_API_KEY or a cloud profile".into(),
+        ));
     }
 
     // Tier 5: local fallback.
@@ -188,18 +201,42 @@ fn cloud_backend_from_profile_parts(
         )));
     }
 
-    let url = profile.url.as_ref().ok_or_else(|| {
-        MicrosandboxError::InvalidConfig(format!(
-            "profile {name:?} backend=cloud requires a 'url' field"
-        ))
-    })?;
     let key_ref = profile.api_key_ref.as_ref().ok_or_else(|| {
         MicrosandboxError::InvalidConfig(format!(
             "profile {name:?} backend=cloud requires an 'api_key_ref' field"
         ))
     })?;
     let api_key = resolve_api_key_ref(name, key_ref)?;
-    CloudBackend::new(url.as_str(), api_key)
+    match profile.url.as_deref() {
+        Some(url) => CloudBackend::new(url, api_key),
+        None => CloudBackend::with_api_key(api_key),
+    }
+}
+
+/// Resolve direct environment values without reading ambient state. Keeping
+/// this decision pure makes the dispatch invariant explicit and testable: an
+/// API URL can override an endpoint, but only an API key selects cloud.
+fn direct_cloud_backend(
+    api_url: Option<String>,
+    api_key: Option<String>,
+) -> MicrosandboxResult<Option<CloudBackend>> {
+    let Some(api_key) = api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|api_key| !api_key.is_empty())
+    else {
+        return Ok(None);
+    };
+
+    let api_url = api_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|api_url| !api_url.is_empty());
+    let cloud = match api_url {
+        Some(api_url) => CloudBackend::new(api_url, api_key)?,
+        None => CloudBackend::with_api_key(api_key)?,
+    };
+    Ok(Some(cloud))
 }
 
 /// Resolve an `api_key_ref` string (`keyring:…` / `env:VAR` / `inline:msb_…`)
@@ -388,6 +425,28 @@ mod tests {
     }
 
     #[test]
+    fn direct_cloud_env_uses_default_url_with_api_key_only() {
+        let cloud = direct_cloud_backend(None, Some(" msb_live_abc ".into()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(cloud.url(), super::super::DEFAULT_CLOUD_API_URL);
+    }
+
+    #[test]
+    fn direct_cloud_env_does_not_dispatch_from_url_alone() {
+        assert!(
+            direct_cloud_backend(Some("https://msb.example.com".into()), None)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            direct_cloud_backend(Some("https://msb.example.com".into()), Some("   ".into()))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
     fn cloud_backend_from_profile_parts_rejects_local_profile() {
         let p = Profile {
             backend: ProfileBackend::Local,
@@ -417,13 +476,14 @@ mod tests {
     }
 
     #[test]
-    fn backend_from_cloud_profile_missing_url() {
+    fn backend_from_cloud_profile_missing_url_uses_default() {
         let p = Profile {
             backend: ProfileBackend::Cloud,
             url: None,
             api_key_ref: Some("inline:msb_live_abc".into()),
         };
-        assert!(backend_from_profile("prod", &p).is_err());
+        let cloud = cloud_backend_from_profile_parts("prod", &p).unwrap();
+        assert_eq!(cloud.url(), super::super::DEFAULT_CLOUD_API_URL);
     }
 
     #[test]

--- a/sdk/rust/lib/lib.rs
+++ b/sdk/rust/lib/lib.rs
@@ -30,11 +30,11 @@ pub use backend::{
     Backend, BackendKind, CloudBackend, CloudBackendBuilder, CloudCreateSandboxRequest,
     CloudCreateSandboxResponse, CloudErrorBody, CloudErrorDetails, CloudMessageResponse,
     CloudPaginated, CloudSandboxStatus, CloudSandboxStatusReason, CloudVolumeKind,
-    CloudVolumeStatus, LocalBackend, LocalBackendBuilder, Profile, ProfileBackend, SandboxBackend,
-    SandboxCloudState, SandboxHandleCloudState, SandboxHandleInner, SandboxHandleLocalState,
-    SandboxInner, SandboxLocalState, SdkConfig, VolumeBackend, VolumeCloudState,
-    VolumeHandleCloudState, VolumeHandleInner, VolumeHandleLocalState, VolumeInner,
-    VolumeLocalState, default_backend, load_sdk_config, resolve_default_backend,
+    CloudVolumeStatus, DEFAULT_CLOUD_API_URL, LocalBackend, LocalBackendBuilder, Profile,
+    ProfileBackend, SandboxBackend, SandboxCloudState, SandboxHandleCloudState, SandboxHandleInner,
+    SandboxHandleLocalState, SandboxInner, SandboxLocalState, SdkConfig, VolumeBackend,
+    VolumeCloudState, VolumeHandleCloudState, VolumeHandleInner, VolumeHandleLocalState,
+    VolumeInner, VolumeLocalState, default_backend, load_sdk_config, resolve_default_backend,
     set_default_backend, swap_default_backend, with_backend,
 };
 pub use config::set_sdk_libkrunfw_path as set_libkrunfw_path;


### PR DESCRIPTION
## TL;DR
Advance the microsandbox release train and integration references from 0.6.7 to 0.6.8. Hosted cloud SDK usage now needs only `MSB_API_KEY`; the API URL defaults to `https://api.microsandbox.dev`.

## Description
- Bump all Rust crates, shared TypeScript packages, SDK release metadata, native package manifests, current TypeScript examples, and generated Node native-loader version checks to 0.6.8.
- Default cloud backends to `https://api.microsandbox.dev` when no URL is supplied across Rust, Python, TypeScript, Go, and SDK profiles.
- Keep implicit cloud dispatch gated exclusively by a non-empty API key; `MSB_API_URL` remains an optional development, self-hosted, or on-prem endpoint override and never selects cloud by itself.
- Refresh publishable npm lock metadata while retaining optional stubs for unpublished Node native packages until the post-publish lock refresh.
- Update active Rust dependency examples to 0.6.8 while preserving the historical v0.6.7-to-v0.6.6 snapshot migration identifier.
- Point the MCP and skills submodules at their pushed 0.6.8 commits ([MCP PR #24](https://github.com/superradcompany/microsandbox-mcp/pull/24), [skills PR #22](https://github.com/superradcompany/skills/pull/22)).
- Release changes since 0.6.7 include the shared `LogRegistry` for followed streams plus release hardening for kernel downloads, npm lock metadata, and gated Winget publishing.

## Test Plan
- [x] `cargo fmt --all -- --check && CI=1 MSB_HOME=/tmp/msb-bump-0.6.8-runtime cargo check --workspace`
- [x] `CI=1 MSB_HOME=/tmp/msb-bump-0.6.8-runtime cargo test --workspace && CI=1 MSB_HOME=/tmp/msb-bump-0.6.8-runtime cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p microsandbox --lib --no-default-features --features net,ssh` (484 passed, 2 ignored)
- [x] `cargo clippy -p microsandbox --lib --no-default-features --features net,ssh -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p microsandbox --no-default-features --features net,ssh --no-deps`
- [x] Native Rust checks for `microsandbox-py`, `microsandbox-node`, and `microsandbox-go`, plus Node TypeScript build and typecheck
- [x] Cloud/profile tests covering key-only dispatch, URL-only non-dispatch, hosted URL fallback, and custom URL override
- [x] `cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate -- --check` and shared TypeScript package build, typecheck, and tests
- [x] `cd sdk/go && go test -count=1 .` and Node SDK build, typecheck, and 123 unit tests
- [x] Python SDK ABI3 wheel build, 39 passing tests with 1 skipped, and `uv run ruff check .`
- [x] `npm pack --dry-run` for all three npm packages and `cargo package --allow-dirty --no-verify` for the 15 release crates
