### PR TITLE
fix(cli): reconnect cloud sandboxes for exec and ssh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,6 +3407,7 @@ dependencies = [
  "tracing",
  "typed-builder",
  "typed-path",
+ "webpki-roots 1.0.6",
  "which",
  "windows-sys 0.61.2",
  "zeroize",
@@ -7220,8 +7221,12 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7525,6 +7530,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ time = "0.3"
 tempfile = "3.15"
 thiserror = "2.0"
 tokio = { version = "1.52", features = ["full"] }
-tokio-tungstenite = "0.29.0"
+tokio-tungstenite = { version = "0.29.0", features = ["rustls-tls-webpki-roots"] }
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -161,6 +161,7 @@ rustls = { version = "0.23", default-features = false, features = [
 tokio-rustls = "0.26"
 rustls-pemfile = "2"
 rustls-native-certs = "0.8"
+webpki-roots = "1"
 rcgen = { version = "0.14", features = ["x509-parser"] }
 lru = "0.18.0"
 parking_lot = "0.12"

--- a/crates/cli/lib/commands/mod.rs
+++ b/crates/cli/lib/commands/mod.rs
@@ -64,9 +64,10 @@ pub async fn resolve_and_start(name: &str, quiet: bool) -> anyhow::Result<Sandbo
 
     match handle.status_snapshot() {
         SandboxStatus::Running | SandboxStatus::Draining => {
-            // Connect to the running sandbox process via the agent relay.
+            // Rebuild a live sandbox. Local connects to the agent relay now;
+            // cloud agent operations establish their WebSocket lazily.
             let sandbox = handle.connect().await?;
-            if sandbox.client().is_legacy_protocol() && !quiet {
+            if sandbox.local().is_some() && sandbox.client().is_legacy_protocol() && !quiet {
                 // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
                 // compatibility for versions before 0.5 is no longer supported.
                 ui::warn(&format!(

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -58,6 +58,7 @@ nix = { workspace = true, features = ["process", "signal", "term"] }
 notify.workspace = true
 rand.workspace = true
 reqwest.workspace = true
+rustls.workspace = true
 russh = { workspace = true, optional = true }
 russh-sftp = { workspace = true, optional = true }
 scopeguard.workspace = true
@@ -74,6 +75,7 @@ tracing.workspace = true
 typed-builder.workspace = true
 typed-path.workspace = true
 which.workspace = true
+webpki-roots.workspace = true
 zeroize.workspace = true
 
 [build-dependencies]
@@ -85,7 +87,6 @@ tar.workspace = true
 ipnetwork.workspace = true
 microsandbox-network.workspace = true
 rcgen.workspace = true
-rustls.workspace = true
 tempfile.workspace = true
 test-utils.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/sdk/rust/lib/backend/cloud/mod.rs
+++ b/sdk/rust/lib/backend/cloud/mod.rs
@@ -13,13 +13,13 @@ pub(in crate::backend) mod sandbox;
 mod volume;
 mod ws_io;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use futures::future::BoxFuture;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use tokio_tungstenite::{
-    connect_async,
+    Connector, connect_async_tls_with_config,
     tungstenite::{
         client::IntoClientRequest,
         http::{
@@ -38,6 +38,13 @@ use crate::{MicrosandboxError, MicrosandboxResult};
 //--------------------------------------------------------------------------------------------------
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Cached TLS configuration for cloud agent WebSockets.
+///
+/// Building this explicitly avoids Rustls's process-global crypto-provider
+/// selection, which is ambiguous when an embedding application enables both
+/// Ring and AWS-LC through different dependencies.
+static CLOUD_AGENT_TLS_CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
 
 /// Default User-Agent header value.
 fn default_user_agent() -> String {
@@ -132,6 +139,37 @@ impl CloudBackend {
     pub fn url(&self) -> &str {
         &self.url
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Build the isolated Rustls connector used by cloud agent WebSockets.
+fn cloud_agent_tls_connector() -> MicrosandboxResult<Connector> {
+    let config = if let Some(config) = CLOUD_AGENT_TLS_CONFIG.get() {
+        Arc::clone(config)
+    } else {
+        let roots =
+            rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let config = rustls::ClientConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .map_err(|error| {
+                MicrosandboxError::Runtime(format!(
+                    "cloud agent TLS protocol configuration: {error}"
+                ))
+            })?
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        let config = Arc::new(config);
+
+        // A concurrent first connection may win initialization. Reuse its
+        // equivalent immutable config instead of changing global TLS state.
+        Arc::clone(CLOUD_AGENT_TLS_CONFIG.get_or_init(|| config))
+    };
+
+    Ok(Connector::Rustls(config))
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -303,9 +341,13 @@ impl Backend for CloudBackend {
                     })?,
                 );
 
-                let (socket, _) = connect_async(request).await.map_err(|e| {
-                    MicrosandboxError::Runtime(format!("cloud agent websocket: {e}"))
-                })?;
+                let connector = cloud_agent_tls_connector()?;
+                let (socket, _) =
+                    connect_async_tls_with_config(request, None, false, Some(connector))
+                        .await
+                        .map_err(|e| {
+                            MicrosandboxError::Runtime(format!("cloud agent websocket: {e}"))
+                        })?;
 
                 crate::agent::AgentClient::connect_stream_with_timeout(
                     self::ws_io::WsByteStream::new(socket),
@@ -349,6 +391,14 @@ impl From<CloudBackend> for Arc<dyn Backend> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn agent_tls_connector_uses_explicit_rustls_config() {
+        assert!(matches!(
+            cloud_agent_tls_connector().unwrap(),
+            Connector::Rustls(_)
+        ));
+    }
 
     #[test]
     fn new_succeeds_with_url_and_key() {

--- a/sdk/rust/lib/backend/cloud/sandbox.rs
+++ b/sdk/rust/lib/backend/cloud/sandbox.rs
@@ -387,9 +387,19 @@ fn ensure_cloud_sandbox_ready(cloud: &CloudCreateSandboxResponse) -> Microsandbo
 /// otherwise agent operations use SDK defaults. Lifecycle start must never
 /// depend on the optional inspection projection.
 fn sandbox_config_from_cloud(cloud: &CloudCreateSandboxResponse) -> SandboxConfig {
-    let mut config = cloud
-        .spec
-        .clone()
+    sandbox_config_from_cloud_spec(&cloud.name, cloud.spec.clone())
+}
+
+/// Decode the server-owned spec projection carried by a cloud handle.
+///
+/// Agent operations only require a best-effort runtime config. The response
+/// projection may be absent or curated, so reconnecting must preserve the
+/// lifecycle contract without requiring a complete create request.
+pub(crate) fn sandbox_config_from_cloud_spec(
+    name: &str,
+    spec: Option<serde_json::Value>,
+) -> SandboxConfig {
+    let mut config = spec
         .and_then(|value| {
             serde_json::from_value::<microsandbox_types::CloudSandboxSpec>(value).ok()
         })
@@ -402,7 +412,7 @@ fn sandbox_config_from_cloud(cloud: &CloudCreateSandboxResponse) -> SandboxConfi
 
     // The top-level response name is canonical even when a complete spec was
     // unavailable or carried stale inspection data.
-    config.spec.name = cloud.name.clone();
+    config.spec.name = name.to_string();
     config
 }
 

--- a/sdk/rust/lib/backend/sandbox.rs
+++ b/sdk/rust/lib/backend/sandbox.rs
@@ -31,7 +31,9 @@ use crate::sandbox::{
 
 // Keep the pre-split path `crate::backend::sandbox::cloud_status_to_sandbox_status`
 // working for callers like `sandbox/handle.rs`.
-pub(crate) use super::cloud::sandbox::cloud_status_to_sandbox_status;
+pub(crate) use super::cloud::sandbox::{
+    cloud_status_to_sandbox_status, sandbox_config_from_cloud_spec,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Type Aliases

--- a/sdk/rust/lib/sandbox/handle.rs
+++ b/sdk/rust/lib/sandbox/handle.rs
@@ -13,8 +13,8 @@ use sea_orm::EntityTrait;
 use crate::{
     MicrosandboxError, MicrosandboxResult,
     backend::{
-        Backend, CloudCreateSandboxResponse, SandboxHandleCloudState, SandboxHandleInner,
-        SandboxHandleLocalState,
+        Backend, CloudCreateSandboxResponse, SandboxCloudState, SandboxHandleCloudState,
+        SandboxHandleInner, SandboxHandleLocalState,
     },
     db::entity::sandbox as sandbox_entity,
     error::Operation,
@@ -26,7 +26,8 @@ use super::{Sandbox, SandboxConfig, SandboxModificationBuilder, SandboxStatus, S
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-/// Default timeout for [`SandboxHandle::connect`].
+/// Default timeout for the eager local agent connection made by
+/// [`SandboxHandle::connect`].
 pub const DEFAULT_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Default timeout for [`SandboxHandle::stop`] before escalation.
@@ -45,8 +46,9 @@ pub const DEFAULT_KILL_TIMEOUT: std::time::Duration = std::time::Duration::from_
 /// remove) without requiring a live agent bridge. Obtained via
 /// [`Sandbox::get`] or [`Sandbox::list`].
 ///
-/// For full runtime capabilities (exec, shell, fs), call [`start`](SandboxHandle::start)
-/// to boot the sandbox and obtain a live [`Sandbox`] handle.
+/// For full runtime capabilities (exec, shell, fs), call
+/// [`connect`](SandboxHandle::connect) when the sandbox is already running, or
+/// [`start`](SandboxHandle::start) to boot a stopped sandbox.
 pub struct SandboxHandle {
     backend: Arc<dyn Backend>,
     inner: SandboxHandleInner,
@@ -345,49 +347,84 @@ impl SandboxHandle {
             .await
     }
 
-    /// Connect to a running sandbox via the agent relay socket. **Local
-    /// handles only** — cloud sandbox attach is HTTP/WS and not wired up in
-    /// this delegation.
+    /// Connect to a running sandbox and return a live handle.
+    ///
+    /// Local sandboxes establish the agent relay connection eagerly. Cloud
+    /// sandboxes return a backend-bound handle whose exec, SSH, and filesystem
+    /// operations open authenticated agent WebSockets on demand.
     pub async fn connect(&self) -> MicrosandboxResult<Sandbox> {
         self.connect_with_timeout(DEFAULT_CONNECT_TIMEOUT).await
     }
 
-    /// Connect to a running sandbox with an explicit agent handshake timeout.
+    /// Connect to a running sandbox with an explicit local agent handshake
+    /// timeout.
+    ///
+    /// Cloud reconnect is lazy and does not open an agent WebSocket here, so
+    /// this timeout applies only to local handles.
     pub async fn connect_with_timeout(
         &self,
         timeout: std::time::Duration,
     ) -> MicrosandboxResult<Sandbox> {
-        let local = self
-            .local()
-            .ok_or_else(|| MicrosandboxError::local_only(Operation::SandboxHandleConnect))?;
-        if local.status != SandboxStatus::Running && local.status != SandboxStatus::Draining {
+        if !matches!(
+            self.status_snapshot(),
+            SandboxStatus::Running | SandboxStatus::Draining
+        ) {
             return Err(MicrosandboxError::SandboxNotRunning(format!(
                 "'{}' is not running (status: {:?})",
-                self.name, local.status
+                self.name,
+                self.status_snapshot()
             )));
         }
 
-        let local_backend = self
-            .backend
-            .as_local()
-            .ok_or_else(|| MicrosandboxError::local_only(Operation::SandboxHandleConnect))?;
-        let client = crate::sandbox::fs::agent::connect_agent_with_timeout(
-            local_backend,
-            &self.name,
-            timeout,
-        )
-        .await?;
-        let config: SandboxConfig = serde_json::from_str(&local.config_json)?;
+        match &self.inner {
+            SandboxHandleInner::Local(local) => {
+                let local_backend = self.backend.as_local().ok_or_else(|| {
+                    MicrosandboxError::local_only(Operation::SandboxHandleConnect)
+                })?;
+                let client = crate::sandbox::fs::agent::connect_agent_with_timeout(
+                    local_backend,
+                    &self.name,
+                    timeout,
+                )
+                .await?;
+                let config: SandboxConfig = serde_json::from_str(&local.config_json)?;
 
-        Ok(Sandbox::from_local(
-            self.backend.clone(),
-            crate::backend::SandboxLocalState {
-                db_id: local.db_id,
-                handle: None,
-                client: Arc::new(client),
-            },
-            config,
-        ))
+                Ok(Sandbox::from_local(
+                    self.backend.clone(),
+                    crate::backend::SandboxLocalState {
+                        db_id: local.db_id,
+                        handle: None,
+                        client: Arc::new(client),
+                    },
+                    config,
+                ))
+            }
+            SandboxHandleInner::Cloud(cloud) => {
+                // The cloud handle stores the optional curated spec exactly as
+                // returned by the API. Decode it on reconnect, falling back to
+                // SDK defaults when the server intentionally omitted it.
+                let spec = serde_json::from_str(&cloud.config_json)?;
+                let config =
+                    crate::backend::sandbox::sandbox_config_from_cloud_spec(&self.name, spec);
+                let created_at = cloud.created_at.ok_or_else(|| {
+                    MicrosandboxError::Runtime(format!(
+                        "cloud sandbox {:?} is missing its creation timestamp",
+                        self.name
+                    ))
+                })?;
+
+                Ok(Sandbox::from_cloud_state(
+                    self.backend.clone(),
+                    SandboxCloudState {
+                        id: cloud.id.clone(),
+                        org_id: cloud.org_id.clone(),
+                        created_at,
+                    },
+                    self.name.clone(),
+                    config,
+                ))
+            }
+        }
     }
 
     /// Check whether agentd is reachable without refreshing the sandbox idle timer.
@@ -677,5 +714,62 @@ impl std::fmt::Debug for SandboxHandle {
             .field("backend_kind", &self.backend.kind())
             .field("status", &self.status_snapshot())
             .finish()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::{BackendKind, CloudBackend, CloudSandboxStatus};
+
+    #[tokio::test]
+    async fn cloud_connect_rebuilds_live_sandbox_without_http_request() {
+        let handle = cloud_handle(CloudSandboxStatus::Running);
+
+        let sandbox = handle.connect().await.unwrap();
+
+        assert_eq!(sandbox.name(), "cloud-connect-test");
+        assert_eq!(sandbox.backend_kind(), BackendKind::Cloud);
+        assert_eq!(sandbox.cloud().unwrap().id, "sandbox-id");
+        assert_eq!(sandbox.config().spec.name, "cloud-connect-test");
+    }
+
+    #[tokio::test]
+    async fn cloud_connect_rejects_stopped_sandbox() {
+        let handle = cloud_handle(CloudSandboxStatus::Stopped);
+
+        let result = handle.connect().await;
+
+        assert!(matches!(
+            result,
+            Err(MicrosandboxError::SandboxNotRunning(_))
+        ));
+    }
+
+    fn cloud_handle(status: CloudSandboxStatus) -> SandboxHandle {
+        let backend: Arc<dyn Backend> =
+            Arc::new(CloudBackend::new("https://unused.invalid", "msb_test_connect").unwrap());
+        SandboxHandle::from_cloud(
+            backend,
+            CloudCreateSandboxResponse {
+                id: "sandbox-id".into(),
+                org_id: "org-id".into(),
+                name: "cloud-connect-test".into(),
+                slug: "cloud-connect-test".into(),
+                status,
+                status_reason: None,
+                spec: None,
+                ephemeral: false,
+                created_at: chrono::Utc::now(),
+                started_at: None,
+                stopped_at: None,
+                last_failure_message: None,
+            },
+        )
+        .unwrap()
     }
 }

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -462,16 +462,28 @@ impl Sandbox {
         cloud: crate::backend::CloudCreateSandboxResponse,
         config: SandboxConfig,
     ) -> Self {
+        let state = crate::backend::SandboxCloudState {
+            id: cloud.id,
+            org_id: cloud.org_id,
+            created_at: cloud.created_at,
+        };
+        Self::from_cloud_state(backend, state, cloud.name, config)
+    }
+
+    /// Build an outer `Sandbox` from cloud state already captured by a
+    /// [`SandboxHandle`]. Cloud agent operations establish their own
+    /// authenticated WebSocket lazily, so reconnecting does not need to hold
+    /// an eager agent client.
+    pub(crate) fn from_cloud_state(
+        backend: Arc<dyn crate::backend::Backend>,
+        state: crate::backend::SandboxCloudState,
+        name: String,
+        config: SandboxConfig,
+    ) -> Self {
         Self {
             backend,
-            inner: Arc::new(crate::backend::SandboxInner::Cloud(
-                crate::backend::SandboxCloudState {
-                    id: cloud.id,
-                    org_id: cloud.org_id,
-                    created_at: cloud.created_at,
-                },
-            )),
-            name: cloud.name,
+            inner: Arc::new(crate::backend::SandboxInner::Cloud(state)),
+            name,
             config,
         }
     }


### PR DESCRIPTION
## TL;DR
Let the CLI reopen running cloud sandboxes for exec, SSH, and filesystem operations. Add a self-contained Rustls WebSocket connector so those agent operations work over hosted WSS endpoints.

## Description
- Make `SandboxHandle::connect()` rebuild an operational cloud `Sandbox` without restarting it or opening a redundant agent connection.
- Preserve the eager local relay connection while cloud exec, SSH, and filesystem operations continue to dial the authenticated agent WebSocket lazily.
- Decode the optional curated cloud spec during reconnect and fall back to SDK defaults when the API intentionally omits it.
- Restrict the legacy agent-protocol warning to local sandboxes so generic CLI resolution does not call the local-only `Sandbox::client()` accessor for cloud handles.
- Enable WSS with an explicit Ring-backed Rustls client and WebPKI roots, avoiding process-global crypto-provider selection and OpenSSL system dependencies.
- Reject reconnect attempts for cloud sandboxes that are not running and cover both status handling and TLS connector construction with unit tests.

```bash
export MSB_API_URL="https://api.example.com"
export MSB_API_KEY="msb_ak_..."

msb exec my-sandbox -- echo hello
msb ssh my-sandbox
```

## Test Plan
- [x] `cargo fmt --all -- --check` exits 0
- [x] `CI=true cargo clippy --workspace -- -D warnings` exits 0
- [x] `CI=1 cargo test -p microsandbox --lib` passes 482 tests with 2 platform-specific tests ignored
- [x] `CI=1 cargo test -p microsandbox-cli --lib` passes all 257 tests
- [x] `CI=1 cargo build -p microsandbox-cli --bin msb` succeeds and the macOS binary is codesigned with `msb-entitlements.plist`
- [x] Live staging create, exec over WSS, interactive SSH through tmux, stop, and remove all complete successfully