### PR TITLE
feat(exec): add combined stdout/stderr output option

### DIFF
--- a/crates/agentd/lib/session.rs
+++ b/crates/agentd/lib/session.rs
@@ -267,7 +267,8 @@ impl RawActivity {
 impl ExecSession {
     /// Spawns a new exec session.
     ///
-    /// If `req.tty` is true, uses a PTY. Otherwise, uses piped stdin/stdout/stderr.
+    /// If `req.tty` is true, uses a PTY. Otherwise, uses piped stdin/stdout/stderr;
+    /// with `req.combined_output`, stderr shares the stdout pipe (`2>&1`).
     /// A background task is spawned to read output and send events via `tx`.
     pub fn spawn(
         id: u32,
@@ -546,8 +547,16 @@ impl ExecSession {
         let mut cmd = Command::new(&req.cmd);
         cmd.args(&req.args)
             .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stdout(Stdio::piped());
+
+        // For combined output the child's stderr is pointed at the stdout
+        // pipe via dup2 in pre_exec (below), so no stderr pipe is created;
+        // sharing one pipe is what preserves the interleaved write order.
+        if req.combined_output {
+            cmd.stderr(Stdio::null());
+        } else {
+            cmd.stderr(Stdio::piped());
+        }
 
         for var in &req.env {
             if let Some((key, val)) = var.split_once('=') {
@@ -566,8 +575,15 @@ impl ExecSession {
 
         // Apply the security profile and resource limits in the child before exec.
         let parsed_rlimits = rlimit::to_libc(&req.rlimits);
+        let combined_output = req.combined_output;
         unsafe {
             cmd.pre_exec(move || {
+                // The standard library has already dup2'd the pipes onto fds
+                // 0-2 by the time pre_exec closures run, so redirecting fd 2
+                // onto fd 1 here lands stderr writes in the stdout pipe.
+                if combined_output && libc::dup2(libc::STDOUT_FILENO, libc::STDERR_FILENO) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
                 // Become a session (and process-group) leader so signals sent
                 // to the group reach every descendant the command spawns, not
                 // just the direct child. The PTY path does the same for its
@@ -1213,6 +1229,7 @@ mod tests {
             rows: 24,
             cols: 80,
             rlimits: Vec::new(),
+            combined_output: false,
         };
 
         let session = ExecSession::spawn(7, &req, tx, None, SecurityProfile::Default)
@@ -1256,6 +1273,67 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_pipe_combined_output_preserves_interleaved_order() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        // Alternating stdout/stderr writes from one sequential process. Each
+        // echo is a single small write, so with a shared pipe the arrival
+        // order must match the emission order exactly.
+        let req = ExecRequest {
+            cmd: "/bin/sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "i=0; while [ $i -lt 32 ]; do echo out$i; echo err$i 1>&2; i=$((i+1)); done"
+                    .to_string(),
+            ],
+            env: vec!["PATH=/usr/local/bin:/usr/bin:/bin".to_string()],
+            cwd: None,
+            user: None,
+            tty: false,
+            rows: 24,
+            cols: 80,
+            rlimits: Vec::new(),
+            combined_output: true,
+        };
+
+        let session = ExecSession::spawn(9, &req, tx, None, SecurityProfile::Default)
+            .expect("spawn pipe session");
+        let mut stdout = Vec::new();
+        let mut stderr_events = 0usize;
+        let mut exit = None;
+
+        let recv_result = time::timeout(Duration::from_secs(15), async {
+            while let Some((id, output)) = rx.recv().await {
+                assert_eq!(id, 9);
+                match output {
+                    SessionOutput::Stdout(data) => stdout.extend_from_slice(&data),
+                    SessionOutput::Stderr(_) => stderr_events += 1,
+                    SessionOutput::Exited(code) => {
+                        exit = Some(code);
+                        break;
+                    }
+                    SessionOutput::Raw(_) => {}
+                }
+            }
+        })
+        .await;
+
+        if recv_result.is_err() {
+            let _ = session.send_signal(libc::SIGKILL);
+            panic!("timed out waiting for combined output");
+        }
+
+        assert_eq!(exit, Some(0));
+        assert_eq!(stderr_events, 0, "combined mode must not emit stderr");
+
+        let expected: String = (0..32).map(|i| format!("out{i}\nerr{i}\n")).collect();
+        assert_eq!(
+            String::from_utf8_lossy(&stdout),
+            expected,
+            "stderr writes must interleave into stdout in emission order",
+        );
+    }
+
     #[test]
     fn test_resolve_user_spec_for_current_uid_gid() {
         let uid = unsafe { libc::getuid() };
@@ -1277,6 +1355,7 @@ mod tests {
             rows: 24,
             cols: 80,
             rlimits: Vec::new(),
+            combined_output: false,
         };
 
         let resolved = resolve_requested_user(&req, Some("0:0")).expect("resolve requested user");
@@ -1295,6 +1374,7 @@ mod tests {
             rows: 24,
             cols: 80,
             rlimits: Vec::new(),
+            combined_output: false,
         };
 
         let uid = unsafe { libc::getuid() };
@@ -1318,6 +1398,7 @@ mod tests {
             rows: 24,
             cols: 80,
             rlimits: Vec::new(),
+            combined_output: false,
         };
 
         let resolved = resolve_requested_user(&req, None).expect("resolve absent user");
@@ -1342,6 +1423,7 @@ mod tests {
             rows: 24,
             cols: 80,
             rlimits: Vec::new(),
+            combined_output: false,
         };
         let user = ResolvedUser {
             uid: 1000,
@@ -1371,6 +1453,7 @@ mod tests {
             rows: 24,
             cols: 80,
             rlimits: Vec::new(),
+            combined_output: false,
         };
         let root = resolve_user_spec(DEFAULT_USER_SPEC).expect("resolve implicit root");
 
@@ -1395,6 +1478,7 @@ mod tests {
             rows: 24,
             cols: 80,
             rlimits: Vec::new(),
+            combined_output: false,
         };
         let user = ResolvedUser {
             uid: 1000,
@@ -1423,6 +1507,7 @@ mod tests {
             rows: 24,
             cols: 80,
             rlimits: Vec::new(),
+            combined_output: false,
         };
 
         let err = ExecSession::spawn(9, &req, tx, None, SecurityProfile::Default)

--- a/crates/cli/lib/commands/exec.rs
+++ b/crates/cli/lib/commands/exec.rs
@@ -48,6 +48,12 @@ pub struct ExecArgs {
     #[arg(long)]
     pub rlimit: Vec<String>,
 
+    /// Combine the command's stderr into its stdout stream (like `2>&1`),
+    /// preserving the interleaved order of writes. All output is then
+    /// written to stdout. PTY sessions (`--tty`) are already combined.
+    #[arg(long)]
+    pub combined_output: bool,
+
     /// Suppress progress output.
     #[arg(short, long)]
     pub quiet: bool,
@@ -137,7 +143,15 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
 
     if args.stream {
         return run_stream(
-            &sandbox, cmd, cmd_args, &env_pairs, &workdir, &args.user, timeout, &rlimits,
+            &sandbox,
+            cmd,
+            cmd_args,
+            &env_pairs,
+            &workdir,
+            &args.user,
+            timeout,
+            &rlimits,
+            args.combined_output,
         )
         .await;
     }
@@ -183,6 +197,9 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
                 );
                 if args.tty {
                     e = e.tty(true);
+                }
+                if args.combined_output {
+                    e = e.combined_output(true);
                 }
                 e
             })
@@ -255,11 +272,14 @@ async fn run_stream(
     user: &Option<String>,
     timeout: Option<Duration>,
     rlimits: &[(RlimitResource, u64, u64)],
+    combined_output: bool,
 ) -> anyhow::Result<()> {
     let mut handle = match sandbox
         .exec_stream_with(cmd, |e| {
             apply_common_exec_opts(
-                e.args(cmd_args).stdin_pipe(),
+                e.args(cmd_args)
+                    .stdin_pipe()
+                    .combined_output(combined_output),
                 env_pairs,
                 workdir,
                 user,

--- a/crates/protocol/lib/exec.rs
+++ b/crates/protocol/lib/exec.rs
@@ -45,6 +45,13 @@ pub struct ExecRequest {
     /// POSIX resource limits to apply to the spawned process via `setrlimit()`.
     #[serde(default)]
     pub rlimits: Vec<ExecRlimit>,
+
+    /// Redirect the command's stderr into its stdout stream (like `2>&1`),
+    /// preserving the interleaved order of writes. All output is then
+    /// delivered as stdout data and no stderr data is produced. Ignored
+    /// when `tty` is true (a PTY is inherently a single combined stream).
+    #[serde(default)]
+    pub combined_output: bool,
 }
 
 /// A POSIX resource limit to apply to a spawned process.
@@ -258,7 +265,16 @@ impl FromStr for ExecRlimit {
 
 #[cfg(test)]
 mod tests {
-    use super::ExecRlimit;
+    use super::{ExecRequest, ExecRlimit};
+
+    #[test]
+    fn test_exec_request_without_combined_output_defaults_to_false() {
+        // A request encoded by an older peer that predates `combined_output`
+        // must decode with the flag off.
+        let json = r#"{"cmd": "/bin/true"}"#;
+        let req: ExecRequest = serde_json::from_str(json).unwrap();
+        assert!(!req.combined_output);
+    }
 
     #[test]
     fn test_exec_rlimit_from_str_uses_soft_for_hard_when_omitted() {

--- a/crates/runtime/lib/startup.rs
+++ b/crates/runtime/lib/startup.rs
@@ -46,6 +46,7 @@ pub(crate) async fn run_startup_command(
         rows: 24,
         cols: 80,
         rlimits: Vec::new(),
+        combined_output: false,
     };
 
     let (_id, mut rx) = client

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -288,6 +288,7 @@ msb exec devbox -- ls -la /app
 | `-u`, `--user` | Run the command as the specified guest user |
 | `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`) |
 | `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`) |
+| `--combined-output` | Combine stderr into stdout (like `2>&1`), preserving interleaved order |
 | `-q`, `--quiet` | Suppress progress output |
 
 <Tip>

--- a/docs/sandboxes/commands.mdx
+++ b/docs/sandboxes/commands.mdx
@@ -192,6 +192,51 @@ for {
 
 </CodeGroup>
 
+## Combined output
+
+Some programs interleave stdout and stderr, and the relative order of the two matters. Because stdout and stderr normally travel through separate pipes, that order is lost by the time both reach you. Combined output redirects stderr into stdout inside the guest — like `2>&1` in a shell — so both share one pipe and arrive in the exact order the program wrote them.
+
+All output is then reported as stdout: stderr stays empty and streaming execs emit no stderr events. The option has no effect with `tty` (a PTY is already a single combined stream).
+
+<CodeGroup>
+```rust Rust
+let output = sb.exec_with("sh", |e| e
+    .args(["-c", "echo one; echo two >&2; echo three"])
+    .combined_output(true)
+).await?;
+println!("{}", output.stdout()?); // "one\ntwo\nthree\n"
+```
+
+```typescript TypeScript
+const output = await sb.execWith("sh", (e) =>
+    e.args(["-c", "echo one; echo two >&2; echo three"]).combinedOutput(true),
+);
+console.log(output.stdout()); // "one\ntwo\nthree\n"
+```
+
+```python Python
+output = await sb.exec(
+    "sh",
+    ["-c", "echo one; echo two >&2; echo three"],
+    combined_output=True,
+)
+print(output.stdout_text)  # "one\ntwo\nthree\n"
+```
+
+```go Go
+output, err := sb.Exec(ctx, "sh",
+    []string{"-c", "echo one; echo two >&2; echo three"},
+    m.WithExecCombinedOutput(),
+)
+fmt.Print(output.Stdout()) // "one\ntwo\nthree\n"
+```
+
+```bash CLI
+msb exec --combined-output worker -- sh -c "echo one; echo two >&2; echo three"
+```
+
+</CodeGroup>
+
 ## Interactive attach
 
 Bridges your terminal directly to a process inside the sandbox for a fully interactive PTY session. Useful for debugging, running REPLs, or anything that expects a real terminal.

--- a/docs/sdk/go/execution.mdx
+++ b/docs/sdk/go/execution.mdx
@@ -816,6 +816,7 @@ Configures a single [`Exec`](#sb-exec) or [`ExecStream`](#sb-execstream) call. M
 | `TTY` | `bool` | Allocate a pseudo-terminal; default `false` |
 | `User` | `string` | Guest user (UID or name) |
 | `Env` | `map[string]string` | Per-command environment variables |
+| `CombinedOutput` | `bool` | Redirect stderr into stdout (`2>&1`), preserving interleaved write order; default `false` |
 
 ### ExecOption
 
@@ -926,6 +927,26 @@ When enabled, the guest process runs with its stdin, stdout, and stderr connecte
     <div className="msb-param-desc"><code>true</code> to allocate a pseudo-terminal.</div>
   </div>
 </div>
+
+#### <span className="msb-hn">WithExecCombinedOutput()</span>
+
+```go
+func WithExecCombinedOutput() ExecOption
+```
+
+<Accordion title="Example">
+
+```go
+out, err := sb.Exec(ctx, "sh",
+    []string{"-c", "echo one; echo two >&2; echo three"},
+    m.WithExecCombinedOutput(),
+)
+fmt.Print(out.Stdout()) // "one\ntwo\nthree\n"
+```
+
+</Accordion>
+
+Redirect the command's stderr into its stdout stream (like `2>&1` in a shell), preserving the interleaved order of writes. All output is then reported through [`Stdout`](#out-stdout) — [`Stderr`](#out-stderr) stays empty and streaming sessions emit no [`ExecEventStderr`](#execeventkind) events. It has no effect with [`WithExecTTY(true)`](#withexectty) (a PTY is already a single combined stream). Sandboxes running an older guest runtime ignore the option and keep the streams separate; restart the sandbox to pick up the current runtime.
 
 #### <span className="msb-hn">WithExecUser()</span>
 

--- a/docs/sdk/python/execution.mdx
+++ b/docs/sdk/python/execution.mdx
@@ -44,6 +44,7 @@ async def exec(
     timeout: float | None = None,
     stdin: Stdin | bytes | str | None = None,
     tty: bool = False,
+    combined_output: bool = False,
     rlimits: list[Rlimit] | None = None,
 ) -> ExecOutput
 ```
@@ -102,6 +103,10 @@ Run a command inside the sandbox and wait for it to complete, buffering all stdo
     <div className="msb-param-desc">Allocate a pseudo-terminal, merging stdout and stderr.</div>
   </div>
   <div className="msb-param">
+    <div className="msb-param-key"><code>combined_output</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc">Redirect stderr into stdout (like <code>2&gt;&amp;1</code>), preserving the interleaved order of writes. All output is then reported as stdout and stderr stays empty. No effect with <code>tty</code> (a PTY is already a single combined stream); ignored by sandboxes running an older guest runtime (streams stay separate — restart the sandbox to pick up the current runtime).</div>
+  </div>
+  <div className="msb-param">
     <div className="msb-param-key"><code>rlimits</code><a className="msb-type" href="#rlimit">list[Rlimit] | None</a></div>
     <div className="msb-param-desc">POSIX resource limits applied to the process.</div>
   </div>
@@ -128,6 +133,7 @@ async def shell(
     timeout: float | None = None,
     stdin: Stdin | bytes | str | None = None,
     tty: bool = False,
+    combined_output: bool = False,
     rlimits: list[Rlimit] | None = None,
 ) -> ExecOutput
 ```
@@ -151,7 +157,7 @@ Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Sh
     <div className="msb-param-desc">Shell command string (e.g. <code>"ls -la /app &amp;&amp; echo done"</code>).</div>
   </div>
   <div className="msb-param">
-    <div className="msb-param-key"><code>cwd, user, env, timeout, stdin, tty, rlimits</code></div>
+    <div className="msb-param-key"><code>cwd, user, env, timeout, stdin, tty, combined_output, rlimits</code></div>
     <div className="msb-param-desc">Same per-call options as <a className="msb-type" href="#sandbox-exec">exec()</a>.</div>
   </div>
 </div>
@@ -180,6 +186,7 @@ async def exec_stream(
     timeout: float | None = None,
     stdin: Stdin | bytes | str | None = None,
     tty: bool = False,
+    combined_output: bool = False,
     rlimits: list[Rlimit] | None = None,
 ) -> ExecHandle
 ```
@@ -213,7 +220,7 @@ Run a command with streaming output. Returns an [`ExecHandle`](#exechandle) that
     <div className="msb-param-desc">Command arguments.</div>
   </div>
   <div className="msb-param">
-    <div className="msb-param-key"><code>cwd, user, env, timeout, stdin, tty, rlimits</code></div>
+    <div className="msb-param-key"><code>cwd, user, env, timeout, stdin, tty, combined_output, rlimits</code></div>
     <div className="msb-param-desc">Same per-call options as <a className="msb-type" href="#sandbox-exec">exec()</a>.</div>
   </div>
 </div>
@@ -239,6 +246,7 @@ async def shell_stream(
     timeout: float | None = None,
     stdin: Stdin | bytes | str | None = None,
     tty: bool = False,
+    combined_output: bool = False,
     rlimits: list[Rlimit] | None = None,
 ) -> ExecHandle
 ```
@@ -266,7 +274,7 @@ Streaming variant of [`shell()`](#sandbox-shell): runs `script` through the conf
     <div className="msb-param-desc">Shell command string.</div>
   </div>
   <div className="msb-param">
-    <div className="msb-param-key"><code>cwd, user, env, timeout, stdin, tty, rlimits</code></div>
+    <div className="msb-param-key"><code>cwd, user, env, timeout, stdin, tty, combined_output, rlimits</code></div>
     <div className="msb-param-desc">Same per-call options as <a className="msb-type" href="#sandbox-exec">exec()</a>.</div>
   </div>
 </div>

--- a/docs/sdk/rust/execution.mdx
+++ b/docs/sdk/rust/execution.mdx
@@ -633,6 +633,35 @@ Allocate a pseudo-terminal. Enable for interactive programs (shells, editors, `t
   </div>
 </div>
 
+#### <span className="msb-recv">.</span><span className="msb-hn">combined_output()</span>
+
+```rust
+fn combined_output(self, enabled: bool) -> Self
+```
+
+<Accordion title="Example">
+
+```rust
+let out = sb.exec_with("sh", |e| e
+    .args(["-c", "echo one; echo two >&2; echo three"])
+    .combined_output(true)
+).await?;
+assert_eq!(out.stdout()?, "one\ntwo\nthree\n");
+```
+
+</Accordion>
+
+Redirect the command's stderr into its stdout stream (like `2>&1` in a shell), preserving the interleaved order of writes. All output is then reported as stdout — stderr stays empty and streaming execs emit no stderr events. Has no effect with [`tty(true)`](#tty) (a PTY is already a single combined stream). On sandboxes running an older guest runtime the flag is ignored and the streams stay separate; restart the sandbox to pick up the current runtime. Default: `false`.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>enabled</code><span className="msb-type">bool</span></div>
+    <div className="msb-param-desc"><code>true</code> to merge stderr into stdout.</div>
+  </div>
+</div>
+
 #### <span className="msb-recv">.</span><span className="msb-hn">stdin_null()</span>
 
 ```rust

--- a/docs/sdk/typescript/execution.mdx
+++ b/docs/sdk/typescript/execution.mdx
@@ -90,7 +90,7 @@ const out = await sandbox.execWith("python3", (e) =>
 
 </Accordion>
 
-Run a command with per-execution overrides. Configure working directory, environment variables, timeout, stdin, TTY allocation, and rlimits via the builder callback. These overrides apply only to this execution and don't change the sandbox's defaults.
+Run a command with per-execution overrides. Configure working directory, environment variables, timeout, stdin, TTY allocation, combined output, and rlimits via the builder callback. These overrides apply only to this execution and don't change the sandbox's defaults.
 
 <p className="msb-label">Parameters</p>
 
@@ -482,6 +482,7 @@ Fluent builder passed to the callback in `execWith(cmd, b => ...)` and `execStre
 | `stdinPipe()` | `() => this` | Open a writable stdin pipe; read it back with [`ExecHandle.takeStdin()`](#exechandle) |
 | `stdinBytes(data)` | `(data: Buffer) => this` | Pre-supply stdin bytes and close it |
 | `tty(enabled)` | `(enabled: boolean) => this` | Allocate a pseudo-terminal |
+| `combinedOutput(enabled)` | `(enabled: boolean) => this` | Redirect stderr into stdout (like `2>&1`), preserving the interleaved order of writes; stderr stays empty and no stderr events are emitted. No effect with `tty` (a PTY is already a single combined stream); ignored by sandboxes running an older guest runtime |
 | `rlimit(resource, limit)` | `(resource: `[`RlimitResource`](#rlimitresource)`, limit: number) => this` | Set both soft and hard rlimit |
 | `rlimitRange(resource, soft, hard)` | `(resource: `[`RlimitResource`](#rlimitresource)`, soft: number, hard: number) => this` | Set distinct soft and hard rlimits |
 

--- a/packages/agent-client/rust/lib/client.rs
+++ b/packages/agent-client/rust/lib/client.rs
@@ -1040,6 +1040,7 @@ mod tests {
             rows: 24,
             cols: 80,
             rlimits: Vec::new(),
+            combined_output: false,
         };
         let (id, _rx) = client
             .stream(MessageType::ExecRequest, &request)
@@ -1237,6 +1238,7 @@ mod tests {
             rows: 24,
             cols: 80,
             rlimits: Vec::new(),
+            combined_output: false,
         };
         let (_id, mut rx) = client
             .stream(MessageType::ExecRequest, &request)

--- a/sdk/go/exec.go
+++ b/sdk/go/exec.go
@@ -58,7 +58,7 @@ func (s *Sandbox) Exec(ctx context.Context, cmd string, args []string, opts ...E
 		opt(&o)
 	}
 
-	ffiOpts := ffi.ExecOptions{Args: args, Cwd: o.Cwd, TTY: o.TTY, User: o.User, Env: o.Env}
+	ffiOpts := ffi.ExecOptions{Args: args, Cwd: o.Cwd, TTY: o.TTY, CombinedOutput: o.CombinedOutput, User: o.User, Env: o.Env}
 	if o.Timeout > 0 {
 		ffiOpts.TimeoutSecs = timeoutSecsCeil(o.Timeout)
 	}
@@ -243,7 +243,7 @@ func (s *Sandbox) ExecStream(ctx context.Context, cmd string, args []string, opt
 	for _, opt := range opts {
 		opt(&o)
 	}
-	ffiOpts := ffi.ExecOptions{Args: args, Cwd: o.Cwd, StdinPipe: o.StdinPipe, TTY: o.TTY, User: o.User, Env: o.Env}
+	ffiOpts := ffi.ExecOptions{Args: args, Cwd: o.Cwd, StdinPipe: o.StdinPipe, TTY: o.TTY, CombinedOutput: o.CombinedOutput, User: o.User, Env: o.Env}
 	if o.Timeout > 0 {
 		ffiOpts.TimeoutSecs = timeoutSecsCeil(o.Timeout)
 	}

--- a/sdk/go/integration/exec_test.go
+++ b/sdk/go/integration/exec_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -350,6 +351,86 @@ func TestExecStreamFailedEventOnMissingBinary(t *testing.T) {
 done:
 	if sawStarted && !sawFailed {
 		t.Error("missing binary should not produce Started without a Failed afterwards")
+	}
+}
+
+// TestExecCombinedOutputPreservesInterleavedOrder verifies that
+// WithExecCombinedOutput redirects stderr into the stdout pipe inside the
+// guest, so alternating writes arrive in emission order and Stderr stays
+// empty.
+func TestExecCombinedOutputPreservesInterleavedOrder(t *testing.T) {
+	ctx := integrationCtx(t)
+	name := "go-sdk-combined-" + t.Name()
+
+	sb, err := createSandbox(t, ctx, name, microsandbox.WithImage(goIntegrationImage))
+	if err != nil {
+		t.Fatalf("CreateSandbox: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = sb.Stop(stopCtx)
+		_ = sb.Close()
+	})
+
+	script := `i=0; while [ $i -lt 16 ]; do echo "out$i"; echo "err$i" >&2; i=$((i+1)); done`
+	out, err := sb.Exec(ctx, "sh", []string{"-c", script}, microsandbox.WithExecCombinedOutput())
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	var want strings.Builder
+	for i := 0; i < 16; i++ {
+		fmt.Fprintf(&want, "out%d\nerr%d\n", i, i)
+	}
+	if out.Stdout() != want.String() {
+		t.Errorf("combined stdout: got %q want %q", out.Stdout(), want.String())
+	}
+	if out.Stderr() != "" {
+		t.Errorf("combined stderr: got %q want empty", out.Stderr())
+	}
+}
+
+// TestExecStreamCombinedOutputEmitsNoStderrEvents verifies the streaming
+// variant delivers everything as stdout events.
+func TestExecStreamCombinedOutputEmitsNoStderrEvents(t *testing.T) {
+	ctx := integrationCtx(t)
+	name := "go-sdk-combined-stream-" + t.Name()
+
+	sb, err := createSandbox(t, ctx, name, microsandbox.WithImage(goIntegrationImage))
+	if err != nil {
+		t.Fatalf("CreateSandbox: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = sb.Stop(stopCtx)
+		_ = sb.Close()
+	})
+
+	h, err := sb.ExecStream(ctx, "sh", []string{"-c", "echo s; echo e >&2"},
+		microsandbox.WithExecCombinedOutput())
+	if err != nil {
+		t.Fatalf("ExecStream: %v", err)
+	}
+	defer h.Close()
+
+	var stdout []byte
+	for {
+		event, err := h.Recv(ctx)
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		switch event.Kind {
+		case microsandbox.ExecEventStdout:
+			stdout = append(stdout, event.Data...)
+		case microsandbox.ExecEventStderr:
+			t.Errorf("unexpected stderr event: %q", event.Data)
+		case microsandbox.ExecEventDone:
+			if got := string(stdout); got != "s\ne\n" {
+				t.Errorf("combined stream stdout: got %q want %q", got, "s\ne\n")
+			}
+			return
+		}
 	}
 }
 

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -2283,13 +2283,15 @@ func RemoveSandbox(ctx context.Context, name string) error {
 
 // ExecOptions configures a single Exec call.
 type ExecOptions struct {
-	Args        []string          `json:"args,omitempty"`
-	Cwd         string            `json:"cwd,omitempty"`
-	TimeoutSecs uint64            `json:"timeout_secs,omitempty"`
-	StdinPipe   bool              `json:"stdin_pipe,omitempty"`
-	TTY         bool              `json:"tty,omitempty"`
-	User        string            `json:"user,omitempty"`
-	Env         map[string]string `json:"env,omitempty"`
+	Args        []string `json:"args,omitempty"`
+	Cwd         string   `json:"cwd,omitempty"`
+	TimeoutSecs uint64   `json:"timeout_secs,omitempty"`
+	StdinPipe   bool     `json:"stdin_pipe,omitempty"`
+	TTY         bool     `json:"tty,omitempty"`
+	// CombinedOutput redirects stderr into the stdout stream (`2>&1`).
+	CombinedOutput bool              `json:"combined_output,omitempty"`
+	User           string            `json:"user,omitempty"`
+	Env            map[string]string `json:"env,omitempty"`
 }
 
 // ExecResult is the collected output of a completed command.

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -3637,6 +3637,7 @@ struct ExecOpts {
     timeout_secs: Option<u64>,
     stdin_pipe: Option<bool>,
     tty: Option<bool>,
+    combined_output: Option<bool>,
     user: Option<String>,
     #[serde(default)]
     env: HashMap<String, String>,
@@ -3668,6 +3669,9 @@ pub unsafe extern "C" fn msb_sandbox_exec(
                     }
                     if let Some(tty) = opts.tty {
                         b = b.tty(tty);
+                    }
+                    if let Some(combined) = opts.combined_output {
+                        b = b.combined_output(combined);
                     }
                     if let Some(secs) = opts.timeout_secs {
                         b = b.timeout(Duration::from_secs(secs));
@@ -4464,6 +4468,9 @@ pub unsafe extern "C" fn msb_sandbox_exec_stream(
                     }
                     if let Some(tty) = opts.tty {
                         b = b.tty(tty);
+                    }
+                    if let Some(combined) = opts.combined_output {
+                        b = b.combined_output(combined);
                     }
                     if let Some(cwd) = opts.cwd {
                         b = b.cwd(cwd);

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -1193,6 +1193,12 @@ type ExecConfig struct {
 	TTY       bool
 	User      string
 	Env       map[string]string
+
+	// CombinedOutput redirects stderr into stdout (like `2>&1`), preserving
+	// the interleaved order of writes. All output is then reported as stdout
+	// and Stderr stays empty. It has no effect with TTY (a PTY is already a
+	// single combined stream).
+	CombinedOutput bool
 }
 
 // ExecOption is a functional option for Exec.
@@ -1220,6 +1226,15 @@ func WithExecStdinPipe() ExecOption {
 // Enable it for interactive programs such as shells, editors, and top.
 func WithExecTTY(enabled bool) ExecOption {
 	return func(o *ExecConfig) { o.TTY = enabled }
+}
+
+// WithExecCombinedOutput redirects the command's stderr into its stdout
+// stream (like `2>&1` in a shell), preserving the interleaved order of
+// writes. All output is then reported as stdout — Stderr stays empty and no
+// stderr events are emitted. It has no effect with TTY (a PTY is already a
+// single combined stream).
+func WithExecCombinedOutput() ExecOption {
+	return func(o *ExecConfig) { o.CombinedOutput = true }
 }
 
 // WithExecUser sets the user to run the command as (UID or name).

--- a/sdk/node-ts/native/exec_options_builder.rs
+++ b/sdk/node-ts/native/exec_options_builder.rs
@@ -42,6 +42,7 @@ pub struct JsExecOptions {
     pub timeout_ms: Option<u32>,
     pub stdin: JsStdinMode,
     pub tty: bool,
+    pub combined_output: bool,
     pub rlimits: Vec<JsRlimit>,
 }
 
@@ -56,6 +57,7 @@ pub struct JsExecOptionsBuilder {
     timeout_ms: Option<u32>,
     stdin: JsStdinMode,
     tty: bool,
+    combined_output: bool,
     rlimits: Vec<JsRlimit>,
 }
 
@@ -79,6 +81,7 @@ impl JsExecOptionsBuilder {
                 data: None,
             },
             tty: false,
+            combined_output: false,
             rlimits: Vec::new(),
         }
     }
@@ -190,6 +193,18 @@ impl JsExecOptionsBuilder {
         self
     }
 
+    /// Redirect stderr into stdout (like `2>&1` in a shell), preserving the
+    /// interleaved order of writes. All output is then reported as stdout —
+    /// stderr stays empty and no stderr events are emitted. Has no effect
+    /// with `tty` (a PTY is already a single combined stream).
+    #[napi(js_name = "combinedOutput")]
+    pub fn combined_output(&mut self, enabled: bool) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.combined_output(enabled));
+        self.combined_output = enabled;
+        self
+    }
+
     #[napi]
     pub fn rlimit(&mut self, resource: String, limit: u32) -> Result<&Self> {
         let res = parse_rlimit_resource(&resource)?;
@@ -227,6 +242,7 @@ impl JsExecOptionsBuilder {
             timeout_ms: self.timeout_ms,
             stdin: self.stdin.clone(),
             tty: self.tty,
+            combined_output: self.combined_output,
             rlimits: self.rlimits.clone(),
         }
     }

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -148,6 +148,13 @@ export declare class ExecOptionsBuilder {
   stdinPipe(): this
   stdinBytes(data: Buffer): this
   tty(enabled: boolean): this
+  /**
+   * Redirect stderr into stdout (like `2>&1` in a shell), preserving the
+   * interleaved order of writes. All output is then reported as stdout —
+   * stderr stays empty and no stderr events are emitted. Has no effect
+   * with `tty` (a PTY is already a single combined stream).
+   */
+  combinedOutput(enabled: boolean): this
   rlimit(resource: string, limit: number): this
   rlimitRange(resource: string, soft: number, hard: number): this
   /** Snapshot the accumulated configuration. */
@@ -1689,6 +1696,7 @@ export interface ExecOptions {
   timeoutMs?: number
   stdin: StdinMode
   tty: boolean
+  combinedOutput: boolean
   rlimits: Array<Rlimit>
 }
 

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -792,6 +792,7 @@ export interface NapiExecOptionsBuilder {
   stdinPipe(): this;
   stdinBytes(data: Buffer): this;
   tty(enabled: boolean): this;
+  combinedOutput(enabled: boolean): this;
   rlimit(resource: string, limit: number): this;
   rlimitRange(resource: string, soft: number, hard: number): this;
 }

--- a/sdk/node-ts/tests/smoke.test.ts
+++ b/sdk/node-ts/tests/smoke.test.ts
@@ -74,6 +74,31 @@ describe.skipIf(!msbPath())("end-to-end smoke", () => {
     expect(code).toBe(7);
   });
 
+  it("combines stderr into stdout in emission order via combinedOutput()", async () => {
+    const script =
+      'i=0; while [ $i -lt 16 ]; do echo "out$i"; echo "err$i" >&2; i=$((i+1)); done';
+    const out = await sb.execWith("sh", (e) =>
+      e.args(["-c", script]).combinedOutput(true),
+    );
+    expect(out.success).toBe(true);
+    let expected = "";
+    for (let i = 0; i < 16; i++) expected += `out${i}\nerr${i}\n`;
+    expect(out.stdout()).toBe(expected);
+    expect(out.stderr()).toBe("");
+
+    const handle = await sb.execStreamWith("sh", (e) =>
+      e.args(["-c", "echo s; echo e >&2"]).combinedOutput(true),
+    );
+    let stdout = "";
+    let sawStderr = false;
+    for await (const ev of handle) {
+      if (ev.kind === "stdout") stdout += new TextDecoder().decode(ev.data);
+      if (ev.kind === "stderr") sawStderr = true;
+    }
+    expect(sawStderr).toBe(false);
+    expect(stdout).toBe("s\ne\n");
+  });
+
   it("resizes a TTY while recv() is pending", async () => {
     const handle = await sb.execStreamWith("sh", (exec) =>
       exec

--- a/sdk/python/integration/test_exec.py
+++ b/sdk/python/integration/test_exec.py
@@ -53,6 +53,38 @@ async def test_exec_kwargs_and_options_dict(sandbox_factory):
 
 
 @pytest.mark.asyncio
+async def test_exec_combined_output_preserves_interleaved_order(sandbox_factory):
+    sandbox = await sandbox_factory("py-sdk-exec-combined")
+
+    script = 'i=0; while [ $i -lt 16 ]; do echo "out$i"; echo "err$i" >&2; i=$((i+1)); done'
+    output = await sandbox.exec("sh", ["-c", script], combined_output=True)
+    assert output.success is True
+    expected = "".join(f"out{i}\nerr{i}\n" for i in range(16))
+    assert output.stdout_text == expected
+    assert output.stderr_text == ""
+
+    via_dict = await sandbox.exec(
+        "sh",
+        {"args": ["-c", "echo a; echo b >&2"], "combined_output": True},
+    )
+    assert via_dict.success is True
+    assert via_dict.stdout_text == "a\nb\n"
+    assert via_dict.stderr_text == ""
+
+    handle = await sandbox.exec_stream(
+        "sh", ["-c", "echo s; echo e >&2"], combined_output=True
+    )
+    kinds = []
+    stdout = b""
+    async for event in handle:
+        kinds.append(event.event_type)
+        if event.event_type == "stdout":
+            stdout += event.data or b""
+    assert "stderr" not in kinds
+    assert stdout == b"s\ne\n"
+
+
+@pytest.mark.asyncio
 async def test_shell_timeout_and_user_env_overrides(sandbox_factory):
     sandbox = await sandbox_factory("py-sdk-exec-opts", env={"BASE_VAR": "base"})
 

--- a/sdk/python/microsandbox/_microsandbox.pyi
+++ b/sdk/python/microsandbox/_microsandbox.pyi
@@ -108,6 +108,7 @@ class Sandbox:
         timeout: float | None = None,
         stdin: Stdin | bytes | str | None = None,
         tty: bool = False,
+        combined_output: bool = False,
         rlimits: list[Rlimit] | None = None,
     ) -> ExecOutput: ...
     async def exec_stream(
@@ -121,6 +122,7 @@ class Sandbox:
         timeout: float | None = None,
         stdin: Stdin | bytes | str | None = None,
         tty: bool = False,
+        combined_output: bool = False,
         rlimits: list[Rlimit] | None = None,
     ) -> ExecHandle: ...
     async def shell(
@@ -133,6 +135,7 @@ class Sandbox:
         timeout: float | None = None,
         stdin: Stdin | bytes | str | None = None,
         tty: bool = False,
+        combined_output: bool = False,
         rlimits: list[Rlimit] | None = None,
     ) -> ExecOutput: ...
     async def shell_stream(
@@ -145,6 +148,7 @@ class Sandbox:
         timeout: float | None = None,
         stdin: Stdin | bytes | str | None = None,
         tty: bool = False,
+        combined_output: bool = False,
         rlimits: list[Rlimit] | None = None,
     ) -> ExecHandle: ...
     def ssh(self) -> SandboxSshOps: ...

--- a/sdk/python/src/sandbox.rs
+++ b/sdk/python/src/sandbox.rs
@@ -419,6 +419,7 @@ impl PySandbox {
         timeout = None,
         stdin = None,
         tty = false,
+        combined_output = false,
         rlimits = None,
     ))]
     fn exec<'py>(
@@ -432,10 +433,21 @@ impl PySandbox {
         timeout: Option<f64>,
         stdin: Option<&Bound<'py, PyAny>>,
         tty: bool,
+        combined_output: bool,
         rlimits: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let (args, opts) = parse_exec_call(args, cwd, user, env, timeout, stdin, tty, rlimits)?;
+        let (args, opts) = parse_exec_call(
+            args,
+            cwd,
+            user,
+            env,
+            timeout,
+            stdin,
+            tty,
+            combined_output,
+            rlimits,
+        )?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
@@ -459,6 +471,7 @@ impl PySandbox {
         timeout = None,
         stdin = None,
         tty = false,
+        combined_output = false,
         rlimits = None,
     ))]
     fn exec_stream<'py>(
@@ -472,10 +485,21 @@ impl PySandbox {
         timeout: Option<f64>,
         stdin: Option<&Bound<'py, PyAny>>,
         tty: bool,
+        combined_output: bool,
         rlimits: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let (args, opts) = parse_exec_call(args, cwd, user, env, timeout, stdin, tty, rlimits)?;
+        let (args, opts) = parse_exec_call(
+            args,
+            cwd,
+            user,
+            env,
+            timeout,
+            stdin,
+            tty,
+            combined_output,
+            rlimits,
+        )?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
@@ -498,6 +522,7 @@ impl PySandbox {
         timeout = None,
         stdin = None,
         tty = false,
+        combined_output = false,
         rlimits = None,
     ))]
     fn shell<'py>(
@@ -510,10 +535,20 @@ impl PySandbox {
         timeout: Option<f64>,
         stdin: Option<&Bound<'py, PyAny>>,
         tty: bool,
+        combined_output: bool,
         rlimits: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let opts = parse_shell_call(cwd, user, env, timeout, stdin, tty, rlimits)?;
+        let opts = parse_shell_call(
+            cwd,
+            user,
+            env,
+            timeout,
+            stdin,
+            tty,
+            combined_output,
+            rlimits,
+        )?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
@@ -536,6 +571,7 @@ impl PySandbox {
         timeout = None,
         stdin = None,
         tty = false,
+        combined_output = false,
         rlimits = None,
     ))]
     fn shell_stream<'py>(
@@ -548,10 +584,20 @@ impl PySandbox {
         timeout: Option<f64>,
         stdin: Option<&Bound<'py, PyAny>>,
         tty: bool,
+        combined_output: bool,
         rlimits: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let opts = parse_shell_call(cwd, user, env, timeout, stdin, tty, rlimits)?;
+        let opts = parse_shell_call(
+            cwd,
+            user,
+            env,
+            timeout,
+            stdin,
+            tty,
+            combined_output,
+            rlimits,
+        )?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let sandbox = Self::clone_sandbox(&inner).await?;
@@ -1154,6 +1200,7 @@ struct ExecOpts {
     env: Vec<(String, String)>,
     timeout_secs: Option<f64>,
     tty: bool,
+    combined_output: bool,
     stdin_mode: Option<String>,
     stdin_data: Option<Vec<u8>>,
     rlimits: Vec<(String, u64, u64)>,
@@ -1176,6 +1223,7 @@ fn parse_exec_call(
     timeout_secs: Option<f64>,
     stdin: Option<&Bound<'_, PyAny>>,
     tty: bool,
+    combined_output: bool,
     rlimits: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<(Vec<String>, ExecOpts)> {
     let (stdin_mode, stdin_data) = parse_stdin(stdin)?;
@@ -1186,6 +1234,7 @@ fn parse_exec_call(
         env: env_to_pairs(env),
         timeout_secs,
         tty,
+        combined_output,
         stdin_mode,
         stdin_data,
         rlimits: parse_rlimits(rlimits)?,
@@ -1216,8 +1265,8 @@ fn validate_exec_options_keys(dict: &Bound<'_, PyDict>) -> PyResult<()> {
             pyo3::exceptions::PyTypeError::new_err("exec option keys must be strings")
         })?;
         match key.as_str() {
-            "args" | "cwd" | "user" | "env" | "timeout" | "tty" | "stdin" | "stdin_data"
-            | "rlimits" => {}
+            "args" | "cwd" | "user" | "env" | "timeout" | "tty" | "combined_output" | "stdin"
+            | "stdin_data" | "rlimits" => {}
             other => {
                 return Err(pyo3::exceptions::PyTypeError::new_err(format!(
                     "unknown exec option: {other}",
@@ -1250,6 +1299,9 @@ fn apply_exec_options_dict(opts: &mut ExecOpts, dict: &Bound<'_, PyDict>) -> PyR
     }
     if let Some(tty) = extract_optional_dict_value::<bool>(dict, "tty")? {
         opts.tty = tty;
+    }
+    if let Some(combined) = extract_optional_dict_value::<bool>(dict, "combined_output")? {
+        opts.combined_output = combined;
     }
     if let Some(stdin) = dict.get_item("stdin")?
         && !stdin.is_none()
@@ -1294,6 +1346,7 @@ fn parse_shell_call(
     timeout_secs: Option<f64>,
     stdin: Option<&Bound<'_, PyAny>>,
     tty: bool,
+    combined_output: bool,
     rlimits: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<ExecOpts> {
     let (stdin_mode, stdin_data) = parse_stdin(stdin)?;
@@ -1304,6 +1357,7 @@ fn parse_shell_call(
         env: env_to_pairs(env),
         timeout_secs,
         tty,
+        combined_output,
         stdin_mode,
         stdin_data,
         rlimits: parse_rlimits(rlimits)?,
@@ -1514,6 +1568,9 @@ fn apply_exec_options(
     }
     if opts.tty {
         builder = builder.tty(true);
+    }
+    if opts.combined_output {
+        builder = builder.combined_output(true);
     }
     // Stdin mode.
     match opts.stdin_mode.as_deref() {

--- a/sdk/rust/lib/sandbox/attach.rs
+++ b/sdk/rust/lib/sandbox/attach.rs
@@ -299,6 +299,7 @@ pub(crate) mod agent {
             true,
             rows,
             cols,
+            false,
         );
         let (id, mut rx) = client.stream(MessageType::ExecRequest, &req).await?;
 
@@ -539,6 +540,7 @@ pub(crate) mod agent {
             true,
             rows,
             cols,
+            false,
         );
         let (id, mut rx) = client.stream(MessageType::ExecRequest, &req).await?;
 

--- a/sdk/rust/lib/sandbox/exec.rs
+++ b/sdk/rust/lib/sandbox/exec.rs
@@ -40,6 +40,9 @@ pub struct ExecOptions {
     /// Allocate a PTY (pseudo-terminal).
     pub tty: bool,
 
+    /// Redirect stderr into stdout (like `2>&1`), preserving interleaved order.
+    pub combined_output: bool,
+
     /// Resource limits applied before exec via `setrlimit()`.
     pub rlimits: Vec<Rlimit>,
 }
@@ -226,6 +229,16 @@ impl ExecOptionsBuilder {
     /// editors, `top`); disable for scripts and batch jobs (default: false).
     pub fn tty(mut self, enabled: bool) -> Self {
         self.options.tty = enabled;
+        self
+    }
+
+    /// Redirect the command's stderr into its stdout stream (like `2>&1` in a
+    /// shell), preserving the interleaved order of writes. All output is then
+    /// reported as stdout — stderr stays empty and no stderr events are
+    /// emitted. Has no effect with `tty` (a PTY is already a single combined
+    /// stream). Default: false.
+    pub fn combined_output(mut self, enabled: bool) -> Self {
+        self.options.combined_output = enabled;
         self
     }
 
@@ -551,6 +564,7 @@ pub(crate) mod agent {
             env,
             rlimits,
             tty,
+            combined_output,
             stdin: stdin_mode,
             timeout: _,
         } = opts;
@@ -565,7 +579,17 @@ pub(crate) mod agent {
         );
 
         let req = build_exec_request(
-            config, cmd, args, cwd, user, &env, &rlimits, tty, rows, cols,
+            config,
+            cmd,
+            args,
+            cwd,
+            user,
+            &env,
+            &rlimits,
+            tty,
+            rows,
+            cols,
+            combined_output,
         );
         let (id, rx) = client.stream(MessageType::ExecRequest, &req).await?;
 

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -1240,6 +1240,7 @@ pub(crate) fn build_exec_request(
     tty: bool,
     rows: u16,
     cols: u16,
+    combined_output: bool,
 ) -> ExecRequest {
     let merged = config::merge_env_pairs(&config.spec.env, env);
     let mut env: Vec<String> = merged
@@ -1273,6 +1274,7 @@ pub(crate) fn build_exec_request(
         rows,
         cols,
         rlimits,
+        combined_output,
     }
 }
 

--- a/sdk/rust/lib/sandbox/ssh.rs
+++ b/sdk/rust/lib/sandbox/ssh.rs
@@ -1012,6 +1012,7 @@ impl SshSession {
             timeout: None,
             stdin: StdinMode::Pipe,
             tty: pty.is_some(),
+            combined_output: false,
             rlimits: Vec::new(),
         };
         let rows = pty.as_ref().map(|p| p.rows).unwrap_or(24);

--- a/sdk/rust/tests/combined_output.rs
+++ b/sdk/rust/tests/combined_output.rs
@@ -1,0 +1,97 @@
+//! Integration tests for combined stdout/stderr output (`2>&1` semantics).
+//!
+//! These tests require KVM (or libkrun on macOS). The `#[msb_test]`
+//! attribute marks them `#[ignore]`, so plain `cargo test --workspace`
+//! skips them. Run them via:
+//!
+//!     cargo nextest run -p microsandbox --test combined_output --run-ignored=only --test-threads 1
+
+use microsandbox::{ExecEvent, Sandbox};
+use test_utils::msb_test;
+
+async fn stop_and_remove(name: &str) {
+    let handle = Sandbox::get(name).await.expect("get");
+    handle.stop().await.expect("stop");
+    Sandbox::remove(name).await.expect("remove");
+}
+
+/// Alternating stdout/stderr writes from one sequential guest process must
+/// arrive in emission order when combined, and stderr must stay empty.
+#[msb_test]
+async fn exec_combined_output_preserves_interleaved_order() {
+    let name = "combined-output-order";
+    let sandbox = Sandbox::builder(name)
+        .image("mirror.gcr.io/library/alpine")
+        .cpus(1)
+        .memory(512)
+        .replace()
+        .create()
+        .await
+        .expect("create sandbox");
+
+    let script = r#"i=0; while [ $i -lt 16 ]; do echo "out$i"; echo "err$i" >&2; i=$((i+1)); done"#;
+    let output = sandbox
+        .exec_with("sh", |e| e.args(["-c", script]).combined_output(true))
+        .await
+        .expect("exec combined");
+
+    stop_and_remove(name).await;
+
+    assert!(output.status().success, "guest command failed");
+    let expected: String = (0..16).map(|i| format!("out{i}\nerr{i}\n")).collect();
+    assert_eq!(
+        output.stdout().expect("stdout utf8"),
+        expected,
+        "stderr writes must interleave into stdout in emission order",
+    );
+    assert_eq!(
+        output.stderr().expect("stderr utf8"),
+        "",
+        "combined mode must leave stderr empty",
+    );
+}
+
+/// The streaming path must deliver everything as stdout events — no stderr
+/// events at all.
+#[msb_test]
+async fn exec_stream_combined_output_emits_no_stderr_events() {
+    let name = "combined-output-stream";
+    let sandbox = Sandbox::builder(name)
+        .image("mirror.gcr.io/library/alpine")
+        .cpus(1)
+        .memory(512)
+        .replace()
+        .create()
+        .await
+        .expect("create sandbox");
+
+    let mut handle = sandbox
+        .exec_stream_with("sh", |e| {
+            e.args(["-c", "echo s; echo e >&2"]).combined_output(true)
+        })
+        .await
+        .expect("exec_stream combined");
+
+    let mut stdout = Vec::new();
+    let mut stderr_events = 0usize;
+    while let Some(event) = handle.recv().await {
+        match event {
+            ExecEvent::Stdout(data) => stdout.extend_from_slice(&data),
+            ExecEvent::Stderr(_) => stderr_events += 1,
+            ExecEvent::Exited { code } => {
+                assert_eq!(code, 0);
+                break;
+            }
+            ExecEvent::Failed(payload) => panic!("exec failed: {payload:?}"),
+            _ => {}
+        }
+    }
+
+    stop_and_remove(name).await;
+
+    assert_eq!(
+        stderr_events, 0,
+        "combined mode must not emit stderr events"
+    );
+    assert_eq!(String::from_utf8_lossy(&stdout), "s\ne\n");
+}


### PR DESCRIPTION
Closes #723

## What

Adds an opt-in combined-output mode to `exec` that redirects the command's stderr into its stdout stream (like `2>&1`), preserving the true interleaved order of writes — across the guest agent, the wire protocol, all four SDKs, and the CLI:

| Surface | API |
| --- | --- |
| Rust SDK | `ExecOptionsBuilder::combined_output(true)` |
| Python SDK | `combined_output=True` on `exec` / `shell` / `exec_stream` / `shell_stream` |
| node-ts SDK | `.combinedOutput(true)` |
| Go SDK | `WithExecCombinedOutput()` / `ExecConfig.CombinedOutput` |
| CLI | `msb exec --combined-output` |

## How

The merge happens at the only layer that can preserve emission order: the guest process's own file descriptors. In pipe mode, agentd points the child's stderr at the stdout pipe via `dup2(1, 2)` in a `pre_exec` hook — the standard library has already dup2'd the pipes onto fds 0–2 by that point, so the redirect lands stderr writes in the stdout pipe and the kernel guarantees ordering on the shared pipe. No stderr pipe is created (`Stdio::null()`), and no userspace re-ordering is involved. In TTY mode the flag is a no-op: a PTY is inherently a single combined stream.

On the wire, `ExecRequest` gains an optional `#[serde(default)] combined_output` field. The host relay routes frames without parsing CBOR, so no host-side changes are needed.

## Compatibility

- Old peer → new agentd: missing field decodes as `false` (covered by a protocol test).
- New SDK → old agentd: the flag is silently ignored and streams stay separate — no data loss, exactly the degradation VERSIONING.md promises for this class of change. Verified empirically against a stale prebuilt agentd; restarting the sandbox with the current runtime picks the feature up.

## Verification

- agentd: all 115 unit tests pass in a Linux container, including a new interleave-order test (32 alternating stdout/stderr writes read back in exact emission order, zero stderr events). Protocol schema snapshot test confirms no unintended surface drift.
- Rust SDK: two new integration tests pass in a real microVM (freshly cross-compiled agentd).
- Python SDK: new integration test passes in a real microVM.
- Go / node-ts: integration cases added (compile/vet clean; VM runs covered by CI).
- CLI smoke: `--combined-output` yields `one/two/three` in order; default behavior unchanged.
- `cargo clippy`, `fmt`, and `cargo doc` (`-D warnings`) all clean.

Docs: new **Combined output** section in `docs/sandboxes/commands.mdx`, the CLI flag table, and per-language entries in each `docs/sdk/<lang>/execution.mdx` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwJyWnd1KkshSrt4vCFC47