### PR TITLE
feat(sdk): expose insecure/ca-certs registry overrides in Go and Python

### DIFF
--- a/docs/images/overview.mdx
+++ b/docs/images/overview.mdx
@@ -139,7 +139,7 @@ For registries using self-signed or internal CA certificates, point `ca_certs` t
 }
 ```
 
-microsandbox adds these certificates to the default system roots, so public registries continue to work normally.
+microsandbox adds these certificates to the default system roots, so public registries continue to work normally. The same roots can be supplied per-sandbox through the SDK instead: `ca_certs` in Rust, `caCerts` in TypeScript, `registry_ca_certs` in Python, and `WithRegistryCACerts` / `WithRegistryCACertsPath` in Go.
 
 ### Combined configuration
 
@@ -178,10 +178,20 @@ await using sb = await Sandbox.builder("worker")
     .create();
 ```
 
+```python Python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="localhost:5050/my-app:latest",
+    registry_insecure=True,
+)
+```
+
 ```go Go
-// Per-registry TLS configuration is read from ~/.microsandbox/config.json.
 sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("localhost:5050/my-app:latest"),
+    m.WithRegistryInsecure(),
 )
 ```
 </CodeGroup>

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -1457,6 +1457,48 @@ Set credentials for pulling from a private OCI registry. See [`RegistryAuth`](#r
   </div>
 </div>
 
+#### <span className="msb-recv"></span><span className="msb-hn">WithRegistryInsecure()</span>
+
+```go
+func WithRegistryInsecure() SandboxOption
+```
+
+Use plain HTTP for the registry instead of HTTPS, for local or self-hosted registries served without TLS such as `localhost:5050/my-app:latest`. The cloud backend rejects this override.
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithRegistryCACerts()</span>
+
+```go
+func WithRegistryCACerts(pem []byte) SandboxOption
+```
+
+Trust additional PEM-encoded CA certificates when pulling, for registries served with a private certificate authority. Called repeatedly, the bundles accumulate. The cloud backend rejects this override.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>pem</code><span className="msb-type">[]byte</span></div>
+    <div className="msb-param-desc">PEM-encoded CA certificates.</div>
+  </div>
+</div>
+
+#### <span className="msb-recv"></span><span className="msb-hn">WithRegistryCACertsPath()</span>
+
+```go
+func WithRegistryCACertsPath(path string) SandboxOption
+```
+
+Like [`WithRegistryCACerts`](#withregistrycacerts) but reads the PEM bundle from a file. The file is read when [`CreateSandbox`](#m-createsandbox) runs, which fails if it is unreadable. Called repeatedly, the bundles accumulate. The cloud backend rejects this override.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>path</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Path to a PEM file.</div>
+  </div>
+</div>
+
 #### <span className="msb-recv"></span><span className="msb-hn">WithPorts()</span>
 
 ```go

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -1180,7 +1180,7 @@ The keyword arguments accepted by [`create()`](#sandbox-create) and [`create_wit
 | log_level | `str \| `[`LogLevel`](#loglevel) | - | Override log verbosity |
 | registry_auth | [`RegistryAuth`](#registryauth) | - | Private registry credentials |
 | registry_insecure | `bool` | `False` | Pull images over plain HTTP instead of HTTPS (local or self-hosted registries) |
-| registry_ca_certs | `list[bytes \| str \| os.PathLike]` | `[]` | Extra CA roots to trust when pulling. Each entry is either PEM data (`bytes`/`bytearray`) or the path of a PEM file, read when `create()` is called |
+| registry_ca_certs | `list[bytes \| bytearray \| str \| os.PathLike]` | `[]` | Additional CA roots for image pulls. File paths are read when `create()` is called. |
 | volumes | `dict[str, `[`MountConfig`](/sdk/python/volumes)`]` | `{}` | Volume mounts. See [Volumes](/sdk/python/volumes) |
 | patches | `list[`[`PatchConfig`](#patchconfig)`]` | `[]` | Rootfs modifications applied before boot |
 | ports | `dict[int, int] \| Sequence[`[`PortBinding`](/sdk/python/networking#portbinding)`]` | `{}` | Port mappings. Dict form is TCP and binds to `127.0.0.1`; use `PortBinding` for explicit bind addresses or UDP |

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -1179,6 +1179,8 @@ The keyword arguments accepted by [`create()`](#sandbox-create) and [`create_wit
 | pull_policy | `str \| `[`PullPolicy`](#pullpolicy) | `"if-missing"` | Image pull behavior |
 | log_level | `str \| `[`LogLevel`](#loglevel) | - | Override log verbosity |
 | registry_auth | [`RegistryAuth`](#registryauth) | - | Private registry credentials |
+| registry_insecure | `bool` | `False` | Pull images over plain HTTP instead of HTTPS (local or self-hosted registries) |
+| registry_ca_certs | `list[bytes \| str \| os.PathLike]` | `[]` | Extra CA roots to trust when pulling. Each entry is either PEM data (`bytes`/`bytearray`) or the path of a PEM file, read when `create()` is called |
 | volumes | `dict[str, `[`MountConfig`](/sdk/python/volumes)`]` | `{}` | Volume mounts. See [Volumes](/sdk/python/volumes) |
 | patches | `list[`[`PatchConfig`](#patchconfig)`]` | `[]` | Rootfs modifications applied before boot |
 | ports | `dict[int, int] \| Sequence[`[`PortBinding`](/sdk/python/networking#portbinding)`]` | `{}` | Port mappings. Dict form is TCP and binds to `127.0.0.1`; use `PortBinding` for explicit bind addresses or UDP |

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -1513,13 +1513,18 @@ type CreateOptions struct {
 	MaxDurationSecs      uint64               `json:"max_duration_secs,omitempty"`
 	IdleTimeoutSecs      uint64               `json:"idle_timeout_secs,omitempty"`
 	RegistryAuth         *RegistryAuthOptions `json:"registry_auth,omitempty"`
-	Ports                map[uint16]uint16    `json:"ports,omitempty"`
-	PortsUDP             map[uint16]uint16    `json:"ports_udp,omitempty"`
-	PortBindings         []PortBindingOptions `json:"port_bindings,omitempty"`
-	Network              *NetworkOptions      `json:"network,omitempty"`
-	Secrets              []SecretOptions      `json:"secrets,omitempty"`
-	Patches              []PatchOptions       `json:"patches,omitempty"`
-	Volumes              map[string]MountSpec `json:"volumes,omitempty"`
+	// RegistryInsecure pulls over plain HTTP instead of HTTPS.
+	RegistryInsecure bool `json:"registry_insecure,omitempty"`
+	// RegistryCACerts holds PEM-encoded CA root certificate bundles trusted
+	// when pulling.
+	RegistryCACerts []string             `json:"registry_ca_certs,omitempty"`
+	Ports           map[uint16]uint16    `json:"ports,omitempty"`
+	PortsUDP        map[uint16]uint16    `json:"ports_udp,omitempty"`
+	PortBindings    []PortBindingOptions `json:"port_bindings,omitempty"`
+	Network         *NetworkOptions      `json:"network,omitempty"`
+	Secrets         []SecretOptions      `json:"secrets,omitempty"`
+	Patches         []PatchOptions       `json:"patches,omitempty"`
+	Volumes         map[string]MountSpec `json:"volumes,omitempty"`
 }
 
 // InitOptions describes a guest PID-1 init handoff.

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -1012,6 +1012,12 @@ struct SandboxCreateOpts {
     idle_timeout_secs: Option<u64>,
     /// Registry credentials for pulling private images.
     registry_auth: Option<RegistryAuthOpts>,
+    /// Pull the image over plain HTTP instead of HTTPS (registry override).
+    #[serde(default)]
+    registry_insecure: bool,
+    /// PEM-encoded CA root certificates to trust when pulling.
+    #[serde(default)]
+    registry_ca_certs: Vec<String>,
     network: Option<NetworkOpts>,
     /// Top-level ports shorthand: {host_port: guest_port} (TCP).
     #[serde(default)]
@@ -2091,12 +2097,26 @@ pub unsafe extern "C" fn msb_sandbox_create(
             {
                 builder = builder.idle_timeout(secs);
             }
-            if let Some(auth) = opts.registry_auth {
-                builder = builder.registry(|r| {
-                    r.auth(RegistryAuth::Basic {
-                        username: auth.username,
-                        password: auth.password,
-                    })
+            // `registry` overwrites insecure and ca_certs wholesale, so all
+            // three overrides have to be applied in one call.
+            let registry_auth = opts.registry_auth;
+            let registry_insecure = opts.registry_insecure;
+            let registry_ca_certs = opts.registry_ca_certs;
+            if registry_auth.is_some() || registry_insecure || !registry_ca_certs.is_empty() {
+                builder = builder.registry(|mut r| {
+                    if let Some(auth) = registry_auth {
+                        r = r.auth(RegistryAuth::Basic {
+                            username: auth.username,
+                            password: auth.password,
+                        });
+                    }
+                    if registry_insecure {
+                        r = r.insecure();
+                    }
+                    for pem in registry_ca_certs {
+                        r = r.ca_certs(pem.into_bytes());
+                    }
+                    r
                 });
             }
             for (k, v) in opts.env.unwrap_or_default() {

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -56,13 +56,21 @@ type SandboxConfig struct {
 	MaxDuration        time.Duration
 	IdleTimeout        time.Duration
 	RegistryAuth       *RegistryAuth
-	Ports              map[uint16]uint16 // host port → guest port (TCP)
-	PortsUDP           map[uint16]uint16 // host port → guest port (UDP)
-	PortBindings       []PortBinding     // explicit bind address host→guest ports
-	Network            *NetworkConfig
-	Secrets            []SecretEntry
-	Patches            []PatchConfig
-	Volumes            map[string]MountConfig // guest path → mount config
+	// RegistryInsecure pulls the image over plain HTTP instead of HTTPS.
+	RegistryInsecure bool
+	// RegistryCACerts holds PEM-encoded CA root certificates trusted when
+	// pulling the image.
+	RegistryCACerts [][]byte
+	// RegistryCACertPaths holds paths to PEM files whose contents are read
+	// and appended to RegistryCACerts by CreateSandbox.
+	RegistryCACertPaths []string
+	Ports               map[uint16]uint16 // host port → guest port (TCP)
+	PortsUDP            map[uint16]uint16 // host port → guest port (UDP)
+	PortBindings        []PortBinding     // explicit bind address host→guest ports
+	Network             *NetworkConfig
+	Secrets             []SecretEntry
+	Patches             []PatchConfig
+	Volumes             map[string]MountConfig // guest path → mount config
 }
 
 // SandboxOption is a functional option for configuring a sandbox.
@@ -682,6 +690,32 @@ func WithRegistryAuth(auth RegistryAuth) SandboxOption {
 	return func(o *SandboxConfig) {
 		a := auth
 		o.RegistryAuth = &a
+	}
+}
+
+// WithRegistryInsecure pulls the image over plain HTTP instead of HTTPS, for
+// local registries served without TLS (e.g. "localhost:5050/my-app:latest").
+// The cloud backend rejects this override.
+func WithRegistryInsecure() SandboxOption {
+	return func(o *SandboxConfig) { o.RegistryInsecure = true }
+}
+
+// WithRegistryCACerts trusts a PEM-encoded CA bundle when pulling the image,
+// for registries served with a private certificate authority. Called
+// repeatedly, the bundles accumulate. The cloud backend rejects this override.
+func WithRegistryCACerts(pem []byte) SandboxOption {
+	return func(o *SandboxConfig) {
+		o.RegistryCACerts = append(o.RegistryCACerts, append([]byte(nil), pem...))
+	}
+}
+
+// WithRegistryCACertsPath is WithRegistryCACerts with the PEM bundle read from
+// a file. The file is read by CreateSandbox, which fails if it is unreadable.
+// Called repeatedly, the bundles accumulate. The cloud backend rejects this
+// override.
+func WithRegistryCACertsPath(path string) SandboxOption {
+	return func(o *SandboxConfig) {
+		o.RegistryCACertPaths = append(o.RegistryCACertPaths, path)
 	}
 }
 

--- a/sdk/go/options_test.go
+++ b/sdk/go/options_test.go
@@ -724,6 +724,46 @@ func TestWithRegistryAuth(t *testing.T) {
 	}
 }
 
+func TestWithRegistryInsecure(t *testing.T) {
+	o := SandboxConfig{}
+	WithRegistryInsecure()(&o)
+	if !o.RegistryInsecure {
+		t.Error("RegistryInsecure: got false")
+	}
+}
+
+func TestWithRegistryCACerts(t *testing.T) {
+	o := SandboxConfig{}
+	first := []byte("-----BEGIN CERTIFICATE-----\nfirst\n")
+	WithRegistryCACerts(first)(&o)
+	WithRegistryCACerts([]byte("-----BEGIN CERTIFICATE-----\nsecond\n"))(&o)
+	if len(o.RegistryCACerts) != 2 {
+		t.Fatalf("RegistryCACerts: got %d bundles, want 2", len(o.RegistryCACerts))
+	}
+	if string(o.RegistryCACerts[0]) != "-----BEGIN CERTIFICATE-----\nfirst\n" {
+		t.Errorf("RegistryCACerts[0]: got %q", o.RegistryCACerts[0])
+	}
+	if string(o.RegistryCACerts[1]) != "-----BEGIN CERTIFICATE-----\nsecond\n" {
+		t.Errorf("RegistryCACerts[1]: got %q", o.RegistryCACerts[1])
+	}
+	// The option copies its input, so later caller mutations do not leak in.
+	first[0] = 'X'
+	if o.RegistryCACerts[0][0] != '-' {
+		t.Errorf("RegistryCACerts[0] aliases the caller's slice: got %q", o.RegistryCACerts[0])
+	}
+}
+
+func TestWithRegistryCACertsPath(t *testing.T) {
+	o := SandboxConfig{}
+	WithRegistryCACertsPath("/etc/ca/one.pem")(&o)
+	WithRegistryCACertsPath("/etc/ca/two.pem")(&o)
+	if len(o.RegistryCACertPaths) != 2 ||
+		o.RegistryCACertPaths[0] != "/etc/ca/one.pem" ||
+		o.RegistryCACertPaths[1] != "/etc/ca/two.pem" {
+		t.Errorf("RegistryCACertPaths: got %v", o.RegistryCACertPaths)
+	}
+}
+
 func TestWithPortsUDP(t *testing.T) {
 	o := SandboxConfig{}
 	WithPortsUDP(map[uint16]uint16{53: 53})(&o)

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -3,6 +3,8 @@ package microsandbox
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/superradcompany/microsandbox/sdk/go/internal/ffi"
@@ -34,6 +36,10 @@ func CreateSandbox(ctx context.Context, name string, opts ...SandboxOption) (*Sa
 		opt(&o)
 	}
 
+	if err := resolveRegistryCACertPaths(&o); err != nil {
+		return nil, err
+	}
+
 	ffiOpts := buildFFICreateOptions(o)
 
 	inner, err := ffi.CreateSandbox(ctx, name, ffiOpts)
@@ -43,38 +49,53 @@ func CreateSandbox(ctx context.Context, name string, opts ...SandboxOption) (*Sa
 	return &Sandbox{inner: inner}, nil
 }
 
+// resolveRegistryCACertPaths reads every PEM file named by
+// RegistryCACertPaths and appends its contents to RegistryCACerts. The option
+// functions only record paths, since they cannot report a read failure.
+func resolveRegistryCACertPaths(o *SandboxConfig) error {
+	for _, path := range o.RegistryCACertPaths {
+		pem, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("microsandbox: reading registry CA certs %q: %w", path, err)
+		}
+		o.RegistryCACerts = append(o.RegistryCACerts, pem)
+	}
+	return nil
+}
+
 // buildFFICreateOptions translates SandboxConfig into the FFI wire shape.
 // Extracted so tests can assert the JSON envelope without booting the runtime.
 func buildFFICreateOptions(o SandboxConfig) ffi.CreateOptions {
 	ffiOpts := ffi.CreateOptions{
-		Image:           o.Image,
-		ImageFstype:     o.ImageFstype,
-		ImageBind:       o.ImageBind,
-		Snapshot:        o.Snapshot,
-		MemoryMiB:       o.MemoryMiB,
-		CPUs:            o.CPUs,
-		MaxMemoryMiB:    o.MaxMemoryMiB,
-		MaxCPUs:         o.MaxCPUs,
-		Workdir:         o.Workdir,
-		Shell:           o.Shell,
-		SecurityProfile: string(o.SecurityProfile),
-		Hostname:        o.Hostname,
-		User:            o.User,
-		Replace:         o.Replace,
-		Env:             o.Env,
-		Labels:          o.Labels,
-		Detached:        o.Detached,
-		Ephemeral:       o.Ephemeral,
-		Entrypoint:      o.Entrypoint,
-		LogLevel:        string(o.LogLevel),
-		QuietLogs:       o.QuietLogs,
-		Scripts:         o.Scripts,
-		PullPolicy:      string(o.PullPolicy),
-		MaxDurationSecs: durationSecsCeil(o.MaxDuration),
-		IdleTimeoutSecs: durationSecsCeil(o.IdleTimeout),
-		Ports:           o.Ports,
-		PortsUDP:        o.PortsUDP,
-		PortBindings:    buildFFIPortBindings(o.PortBindings),
+		Image:            o.Image,
+		ImageFstype:      o.ImageFstype,
+		ImageBind:        o.ImageBind,
+		Snapshot:         o.Snapshot,
+		MemoryMiB:        o.MemoryMiB,
+		CPUs:             o.CPUs,
+		MaxMemoryMiB:     o.MaxMemoryMiB,
+		MaxCPUs:          o.MaxCPUs,
+		Workdir:          o.Workdir,
+		Shell:            o.Shell,
+		SecurityProfile:  string(o.SecurityProfile),
+		Hostname:         o.Hostname,
+		User:             o.User,
+		Replace:          o.Replace,
+		Env:              o.Env,
+		Labels:           o.Labels,
+		Detached:         o.Detached,
+		Ephemeral:        o.Ephemeral,
+		Entrypoint:       o.Entrypoint,
+		LogLevel:         string(o.LogLevel),
+		QuietLogs:        o.QuietLogs,
+		Scripts:          o.Scripts,
+		PullPolicy:       string(o.PullPolicy),
+		MaxDurationSecs:  durationSecsCeil(o.MaxDuration),
+		IdleTimeoutSecs:  durationSecsCeil(o.IdleTimeout),
+		Ports:            o.Ports,
+		PortsUDP:         o.PortsUDP,
+		PortBindings:     buildFFIPortBindings(o.PortBindings),
+		RegistryInsecure: o.RegistryInsecure,
 	}
 	if o.RootDisk != nil {
 		ffiOpts.RootDisk = buildFFIRootDisk(*o.RootDisk)
@@ -104,6 +125,12 @@ func buildFFICreateOptions(o SandboxConfig) ffi.CreateOptions {
 		ffiOpts.RegistryAuth = &ffi.RegistryAuthOptions{
 			Username: o.RegistryAuth.Username,
 			Password: o.RegistryAuth.Password,
+		}
+	}
+	if len(o.RegistryCACerts) > 0 {
+		ffiOpts.RegistryCACerts = make([]string, 0, len(o.RegistryCACerts))
+		for _, pem := range o.RegistryCACerts {
+			ffiOpts.RegistryCACerts = append(ffiOpts.RegistryCACerts, string(pem))
 		}
 	}
 

--- a/sdk/go/sandbox_options_test.go
+++ b/sdk/go/sandbox_options_test.go
@@ -2,6 +2,8 @@ package microsandbox
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -440,6 +442,55 @@ func TestFFIWireShape_RegistryAuth(t *testing.T) {
 	}
 }
 
+func TestFFIWireShape_RegistryOverrides(t *testing.T) {
+	got := marshalCreateOptions(t,
+		WithImage("localhost:5050/img"),
+		WithRegistryInsecure(),
+		WithRegistryCACerts([]byte("pem-one")),
+		WithRegistryCACerts([]byte("pem-two")),
+	)
+	if got["registry_insecure"] != true {
+		t.Fatalf("registry_insecure = %v", got["registry_insecure"])
+	}
+	certs := mustField(t, got, "registry_ca_certs").([]any)
+	if len(certs) != 2 || certs[0] != "pem-one" || certs[1] != "pem-two" {
+		t.Fatalf("registry_ca_certs = %v", certs)
+	}
+}
+
+func TestResolveRegistryCACertPaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(path, []byte("pem-from-file"), 0o600); err != nil {
+		t.Fatalf("write ca.pem: %v", err)
+	}
+
+	cfg := SandboxConfig{}
+	WithRegistryCACerts([]byte("pem-inline"))(&cfg)
+	WithRegistryCACertsPath(path)(&cfg)
+	if err := resolveRegistryCACertPaths(&cfg); err != nil {
+		t.Fatalf("resolveRegistryCACertPaths: %v", err)
+	}
+	if len(cfg.RegistryCACerts) != 2 ||
+		string(cfg.RegistryCACerts[0]) != "pem-inline" ||
+		string(cfg.RegistryCACerts[1]) != "pem-from-file" {
+		t.Fatalf("RegistryCACerts = %q", cfg.RegistryCACerts)
+	}
+}
+
+func TestResolveRegistryCACertPathsMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.pem")
+	cfg := SandboxConfig{}
+	WithRegistryCACertsPath(missing)(&cfg)
+	err := resolveRegistryCACertPaths(&cfg)
+	if err == nil {
+		t.Fatal("resolveRegistryCACertPaths: got nil error for a missing file")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("error %q does not mention the path %q", err, missing)
+	}
+}
+
 func TestFFIWireShape_Init(t *testing.T) {
 	got := marshalCreateOptions(t,
 		WithImage("alpine"),
@@ -629,7 +680,7 @@ func TestFFIWireShape_EmptyConfigOmitsOptionalFields(t *testing.T) {
 		"image", "snapshot", "memory_mib", "cpus", "max_memory_mib", "max_cpus", "workdir", "shell",
 		"hostname", "user", "replace", "detached", "env", "scripts",
 		"ports", "ports_udp", "network", "secrets", "patches", "volumes",
-		"init", "registry_auth", "root_disk",
+		"init", "registry_auth", "registry_insecure", "registry_ca_certs", "root_disk",
 	} {
 		if _, present := got[key]; present {
 			body, _ := json.Marshal(got)

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -2,7 +2,7 @@ use microsandbox::sandbox::{NetworkPolicy, Patch, PullPolicy, SandboxBuilder, Se
 use microsandbox::{LogLevel, RegistryAuth};
 use microsandbox_network::dns::Nameserver;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyByteArray, PyBytes, PyDict, PyList};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -35,6 +35,8 @@ const KNOWN_CREATE_KWARGS: &[&str] = &[
     "pull_policy",
     "log_level",
     "registry_auth",
+    "registry_insecure",
+    "registry_ca_certs",
     "volumes",
     "patches",
     "ports",
@@ -349,23 +351,33 @@ pub fn sandbox_builder_from_args(
         builder = builder.log_level(level);
     }
 
-    // Registry auth.
-    if let Some(auth) = kwargs.get_item("registry_auth")? {
-        let auth_dict = as_dict(&auth)?;
-        let auth_dict = &auth_dict;
-        let username: String = auth_dict
-            .get_item("username")?
-            .ok_or_else(|| {
-                pyo3::exceptions::PyValueError::new_err("registry_auth.username required")
-            })?
-            .extract()?;
-        let password: String = auth_dict
-            .get_item("password")?
-            .ok_or_else(|| {
-                pyo3::exceptions::PyValueError::new_err("registry_auth.password required")
-            })?
-            .extract()?;
-        builder = builder.registry(|r| r.auth(RegistryAuth::Basic { username, password }));
+    // Registry overrides: auth, plain-HTTP transport, extra CA roots.
+    // `SandboxBuilder::registry` overwrites `insecure` and `ca_certs` on every
+    // call, so all three have to be applied through a single closure.
+    {
+        let auth = parse_registry_auth(kwargs)?;
+        let insecure = match kwargs.get_item("registry_insecure")? {
+            Some(val) if !val.is_none() => val.extract::<bool>().map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err("registry_insecure must be a bool")
+            })?,
+            _ => false,
+        };
+        let ca_certs = parse_registry_ca_certs(kwargs)?;
+
+        if auth.is_some() || insecure || !ca_certs.is_empty() {
+            builder = builder.registry(|mut r| {
+                if let Some(auth) = auth {
+                    r = r.auth(auth);
+                }
+                if insecure {
+                    r = r.insecure();
+                }
+                for pem in ca_certs {
+                    r = r.ca_certs(pem);
+                }
+                r
+            });
+        }
     }
 
     // Volumes.
@@ -1355,6 +1367,62 @@ fn as_dict<'py>(obj: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyDict>> {
         "expected dict or object with _to_dict(), got {}",
         obj.get_type().name()?
     )))
+}
+
+/// Parse the `registry_auth` kwarg into a `RegistryAuth`.
+fn parse_registry_auth(kwargs: &Bound<'_, PyDict>) -> PyResult<Option<RegistryAuth>> {
+    let Some(auth) = kwargs.get_item("registry_auth")? else {
+        return Ok(None);
+    };
+    let auth_dict = as_dict(&auth)?;
+    let auth_dict = &auth_dict;
+    let username: String = auth_dict
+        .get_item("username")?
+        .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("registry_auth.username required"))?
+        .extract()?;
+    let password: String = auth_dict
+        .get_item("password")?
+        .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("registry_auth.password required"))?
+        .extract()?;
+    Ok(Some(RegistryAuth::Basic { username, password }))
+}
+
+/// Parse the `registry_ca_certs` kwarg into PEM blobs. Every entry is either
+/// the PEM data itself (`bytes` / `bytearray`) or the path of a PEM file
+/// (`str` / `os.PathLike`), which is read eagerly so a bad path fails at
+/// `create()` time rather than mid-pull.
+fn parse_registry_ca_certs(kwargs: &Bound<'_, PyDict>) -> PyResult<Vec<Vec<u8>>> {
+    let Some(obj) = kwargs.get_item("registry_ca_certs")? else {
+        return Ok(Vec::new());
+    };
+    if obj.is_none() {
+        return Ok(Vec::new());
+    }
+
+    let entries: &Bound<'_, PyList> = obj.downcast()?;
+    let mut certs = Vec::with_capacity(entries.len());
+    for (index, entry) in entries.iter().enumerate() {
+        // Check for bytes first: `os.fspath` also accepts bytes paths, so
+        // probing for a path up front would read inline PEM data as a filename.
+        if let Ok(data) = entry.downcast::<PyBytes>() {
+            certs.push(data.as_bytes().to_vec());
+        } else if let Ok(data) = entry.downcast::<PyByteArray>() {
+            certs.push(data.to_vec());
+        } else if let Ok(path) = entry.extract::<std::path::PathBuf>() {
+            let data = std::fs::read(&path).map_err(|e| {
+                pyo3::exceptions::PyOSError::new_err(format!(
+                    "failed to read registry_ca_certs entry `{}`: {e}",
+                    path.display()
+                ))
+            })?;
+            certs.push(data);
+        } else {
+            return Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                "registry_ca_certs[{index}] must be PEM bytes or a path to a PEM file"
+            )));
+        }
+    }
+    Ok(certs)
 }
 
 fn parse_scoped_upstream_ca_certs(

--- a/sdk/python/tests/test_registry_overrides.py
+++ b/sdk/python/tests/test_registry_overrides.py
@@ -1,0 +1,96 @@
+"""Unit tests for the registry override kwargs of ``Sandbox.create``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from microsandbox import InvalidConfigError, Sandbox
+
+PEM = b"-----BEGIN CERTIFICATE-----\nQUJD\n-----END CERTIFICATE-----\n"
+
+# `Sandbox.create` never touches a sandbox: an image that cannot exist keeps the
+# awaitable inert even if something ever awaits it by accident.
+MISSING_IMAGE = "/__microsandbox_missing_rootfs__"
+
+
+def assert_kwargs_accepted(name: str, **kwargs: object) -> None:
+    """Assert that ``Sandbox.create`` accepts ``kwargs``.
+
+    Kwargs are validated synchronously, before the awaitable is built, so a
+    rejected kwarg raises right here. Building the awaitable is the next step
+    and needs a running event loop — reaching *that* failure from a sync test
+    means validation passed and no creation work was ever spawned.
+    """
+    with pytest.raises(RuntimeError, match="no running event loop"):
+        Sandbox.create(name, image=MISSING_IMAGE, **kwargs)
+
+
+def test_accepts_insecure_and_ca_certs_in_every_entry_form(tmp_path: Path) -> None:
+    cert_file = tmp_path / "ca.pem"
+    cert_file.write_bytes(PEM)
+
+    assert_kwargs_accepted(
+        "registry-overrides",
+        registry_insecure=True,
+        registry_ca_certs=[PEM, bytearray(PEM), str(cert_file), cert_file],
+    )
+
+
+def test_accepts_auth_alongside_insecure_and_ca_certs(tmp_path: Path) -> None:
+    cert_file = tmp_path / "ca.pem"
+    cert_file.write_bytes(PEM)
+
+    # All three overrides share a single `.registry()` call in the bridge; the
+    # core builder overwrites insecure/ca_certs on every call, so combining
+    # them must not drop any of the three.
+    assert_kwargs_accepted(
+        "registry-overrides-with-auth",
+        registry_auth={"username": "user", "password": "pass"},
+        registry_insecure=True,
+        registry_ca_certs=[cert_file],
+    )
+
+
+@pytest.mark.asyncio
+async def test_overrides_survive_config_materialization() -> None:
+    session = Sandbox.create_with_progress(
+        "registry-overrides-materialize",
+        image=MISSING_IMAGE,
+        registry_insecure=True,
+        registry_ca_certs=[PEM],
+    )
+
+    async with session:
+        assert [event async for event in session.progress] == []
+        # Only the bogus rootfs fails — the registry overrides make it through.
+        with pytest.raises(InvalidConfigError, match="rootfs bind path does not exist"):
+            await session.result()
+
+
+def test_rejects_non_bool_insecure() -> None:
+    with pytest.raises(TypeError, match="registry_insecure must be a bool"):
+        Sandbox.create("bad-insecure", image=MISSING_IMAGE, registry_insecure="yes")
+
+
+def test_rejects_non_list_ca_certs() -> None:
+    with pytest.raises(TypeError):
+        Sandbox.create("bad-ca-certs", image=MISSING_IMAGE, registry_ca_certs="not-a-list")
+
+
+def test_rejects_ca_cert_entry_that_is_neither_bytes_nor_path() -> None:
+    with pytest.raises(TypeError, match=r"registry_ca_certs\[0\] must be PEM bytes or a path"):
+        Sandbox.create("bad-ca-cert-entry", image=MISSING_IMAGE, registry_ca_certs=[123])
+
+
+def test_rejects_unreadable_ca_cert_path() -> None:
+    missing = "/nonexistent/xyz.pem"
+
+    with pytest.raises(OSError, match=missing):
+        Sandbox.create("missing-ca-cert", image=MISSING_IMAGE, registry_ca_certs=[missing])
+
+
+def test_still_rejects_unknown_registry_kwarg() -> None:
+    with pytest.raises(TypeError, match="unexpected keyword argument 'registry_bogus'"):
+        Sandbox.create("unknown-kwarg", image=MISSING_IMAGE, registry_bogus=1)


### PR DESCRIPTION
Closes #1184

## What

Exposes the per-registry transport overrides that already exist in the Rust core (and the global `config.json`) through the Go and Python SDKs, so a sandbox pulling from a local plain-HTTP registry or a private-CA registry no longer needs host-level config:

**Go**
```go
sb, err := m.CreateSandbox(ctx, "worker",
    m.WithImage("localhost:5050/my-app:latest"),
    m.WithRegistryInsecure(),
    m.WithRegistryCACertsPath("/etc/ssl/private-ca.pem"), // or WithRegistryCACerts(pem)
)
```

**Python**
```python
sb = await Sandbox.create(
    "worker",
    image="localhost:5050/my-app:latest",
    registry_insecure=True,
    registry_ca_certs=["/etc/ssl/private-ca.pem", pem_bytes],  # paths or inline PEM
)
```

## Design notes

- **Single `registry()` application.** `SandboxBuilder::registry` overwrites `insecure`/`ca_certs` on every call, so auth + insecure + CA certs are merged into one closure application on both language paths.
- **Eager file reads.** CA-cert paths are read at `CreateSandbox()` / `create()` time so an unreadable file fails up front rather than mid-pull. Go option functions only record paths (they can't return errors); the read happens in `CreateSandbox`.
- **Python entry typing.** Each `registry_ca_certs` entry is either PEM data (`bytes`/`bytearray`) or a PEM file path (`str`/`os.PathLike`). Bytes are checked first — `os.fspath` also accepts bytes paths, so probing for a path first would misread inline PEM as a filename.
- API naming mirrors the existing surfaces: Rust's builder `insecure()`/`ca_certs()`, TS's `caCerts`, and the Go SDK's `WithRegistryAuth` option family.

## Verification

- Go: new unit tests for option accumulation and the FFI JSON envelope (`buildFFICreateOptions` asserted without booting the runtime); `go test` / `go vet` clean.
- Python: new `tests/test_registry_overrides.py` covering kwarg validation (bad types, unreadable paths, bytes-vs-path disambiguation) plus parse-stage acceptance; full Python SDK unit suite passes.
- Docs: `docs/sdk/go/sandbox.mdx` (new option entries), `docs/sdk/python/sandbox.mdx` (two SandboxConfig rows), and `docs/images/overview.mdx` (Python/Go examples in the registry-override section, replacing the stale Go placeholder comment that pointed at `config.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwJyWnd1KkshSrt4vCFC47