### PR TITLE
feat(sdk): expose active backend context

### DIFF
--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -633,15 +633,17 @@ fn run_async_command_anyhow(
         // runtime processes (`msb sandbox`) now, not the CLI; see
         // `microsandbox_runtime::maintenance`. The CLI no longer spawns a
         // reaper here.
-        // Resolve once, fallibly, before dispatch. Unlike the SDK's ambient
-        // convenience fallback, the CLI must not run locally after an invalid
-        // explicit cloud selection.
-        let backend = microsandbox::resolve_default_backend()?;
-        let backend_info = backend.info();
-        microsandbox::set_default_backend(backend);
+        if !is_backend_independent_maintenance_command(&command) {
+            // Resolve once, fallibly, before backend-dependent dispatch. Unlike
+            // the SDK's ambient convenience fallback, the CLI must not run a
+            // sandbox operation locally after an invalid explicit cloud selection.
+            let backend = microsandbox::resolve_default_backend()?;
+            let backend_info = backend.info();
+            microsandbox::set_default_backend(backend);
 
-        if shows_backend_notice(&command) {
-            microsandbox_cli::ui::notice("Backend", &context::notice_text(&backend_info));
+            if shows_backend_notice(&command) {
+                microsandbox_cli::ui::notice("Backend", &context::notice_text(&backend_info));
+            }
         }
 
         match command {
@@ -689,6 +691,24 @@ fn run_async_command_anyhow(
     })
 }
 
+/// Return whether a command manages the CLI installation rather than a backend.
+///
+/// These commands are deliberately available even when backend configuration is
+/// invalid so users can diagnose, repair, downgrade, or uninstall that setup.
+fn is_backend_independent_maintenance_command(command: &Commands) -> bool {
+    match command {
+        Commands::SchemaBaseline(_)
+        | Commands::Doctor(_)
+        | Commands::Update(_)
+        | Commands::Downgrade(_)
+        | Commands::Self_(_)
+        | Commands::Completion(_) => true,
+        #[cfg(windows)]
+        Commands::WindowsSelfDowngradeSwap(_) => true,
+        _ => false,
+    }
+}
+
 /// Return whether a command benefits from an explicit execution-context notice.
 fn shows_backend_notice(command: &Commands) -> bool {
     matches!(
@@ -716,6 +736,34 @@ fn matches_ssh_command(_command: &Commands) -> bool {
 #[cfg(test)]
 mod command_tests {
     use super::*;
+
+    #[test]
+    fn maintenance_commands_do_not_require_backend_resolution() {
+        let maintenance_commands = [
+            Cli::try_parse_from(["msb", "doctor"]).unwrap().command,
+            Cli::try_parse_from(["msb", "update"]).unwrap().command,
+            Cli::try_parse_from(["msb", "downgrade", "0.6.0"])
+                .unwrap()
+                .command,
+            Cli::try_parse_from(["msb", "self", "doctor"])
+                .unwrap()
+                .command,
+            Cli::try_parse_from(["msb", "completion", "bash"])
+                .unwrap()
+                .command,
+        ];
+
+        for command in &maintenance_commands {
+            assert!(is_backend_independent_maintenance_command(command));
+        }
+
+        let context = Cli::try_parse_from(["msb", "context"]).unwrap();
+        let create = Cli::try_parse_from(["msb", "create", "alpine:3.19"]).unwrap();
+        assert!(!is_backend_independent_maintenance_command(
+            &context.command
+        ));
+        assert!(!is_backend_independent_maintenance_command(&create.command));
+    }
 
     #[test]
     fn backend_notices_cover_requested_commands_only() {

--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -6,9 +6,9 @@ use clap::{CommandFactory, Parser, Subcommand};
 use console::style;
 use microsandbox_cli::{
     commands::{
-        completion, copy, create, exec, image, inspect, install, list, logs, metrics, modify, ping,
-        ps, pull, registry, remove, restart, run, self_cmd, snapshot, start, stop, touch,
-        uninstall, volume,
+        completion, context, copy, create, exec, image, inspect, install, list, logs, metrics,
+        modify, ping, ps, pull, registry, remove, restart, run, self_cmd, snapshot, start, stop,
+        touch, uninstall, volume,
     },
     log_args::{self, LogArgs},
     sandbox_cmd::{self, SandboxArgs},
@@ -82,6 +82,9 @@ enum Commands {
     /// Print the schema baseline owned by this binary (internal).
     #[command(name = "__schema-baseline", hide = true)]
     SchemaBaseline(self_cmd::SchemaBaselineArgs),
+
+    /// Show the active backend and its selection source.
+    Context(context::ContextArgs),
 
     /// Complete a deferred Windows self-update or self-downgrade swap (internal).
     #[cfg(windows)]
@@ -606,6 +609,13 @@ fn run_async_command_anyhow(
     command: Commands,
     log_level: Option<microsandbox::LogLevel>,
 ) -> anyhow::Result<()> {
+    // Internal maintenance commands do not execute sandbox operations and
+    // must remain usable while diagnosing an invalid backend configuration.
+    let command = match command {
+        Commands::SchemaBaseline(args) => return self_cmd::run_schema_baseline(args),
+        command => command,
+    };
+
     // Pull and create can overlap network I/O, decompression, and progress UI.
     // Use a small-but-not-tiny worker pool so foreground UI tasks still get
     // scheduled while multiple layers are downloading and materializing.
@@ -622,9 +632,21 @@ fn run_async_command_anyhow(
         // runtime processes (`msb sandbox`) now, not the CLI; see
         // `microsandbox_runtime::maintenance`. The CLI no longer spawns a
         // reaper here.
+        // Resolve once, fallibly, before dispatch. Unlike the SDK's ambient
+        // convenience fallback, the CLI must not run locally after an invalid
+        // explicit cloud selection.
+        let backend = microsandbox::resolve_default_backend()?;
+        let backend_info = backend.info();
+        microsandbox::set_default_backend(backend);
+
+        if shows_backend_notice(&command) {
+            microsandbox_cli::ui::notice("Backend", &context::notice_text(&backend_info));
+        }
+
         match command {
             Commands::Sandbox(_) => unreachable!("handled before Tokio starts"),
-            Commands::SchemaBaseline(args) => self_cmd::run_schema_baseline(args),
+            Commands::SchemaBaseline(_) => unreachable!("handled before backend resolution"),
+            Commands::Context(args) => context::run(args),
             #[cfg(windows)]
             Commands::WindowsSelfSwap(args) => self_cmd::run_windows_self_swap(args).await,
 
@@ -664,6 +686,65 @@ fn run_async_command_anyhow(
             Commands::Completion(args) => completion::run(args, Cli::command()),
         }
     })
+}
+
+/// Return whether a command benefits from an explicit execution-context notice.
+fn shows_backend_notice(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::Create(_) | Commands::Remove(_) | Commands::Exec(_)
+    ) || cfg!(feature = "ssh") && matches_ssh_command(command)
+}
+
+#[cfg(feature = "ssh")]
+fn matches_ssh_command(command: &Commands) -> bool {
+    match command {
+        Commands::Ssh(args) => !matches!(
+            args.subcommand.as_ref(),
+            Some(microsandbox_cli::commands::ssh::SshCommand::Authorize(_))
+        ),
+        _ => false,
+    }
+}
+
+#[cfg(not(feature = "ssh"))]
+fn matches_ssh_command(_command: &Commands) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod command_tests {
+    use super::*;
+
+    #[test]
+    fn backend_notices_cover_requested_commands_only() {
+        let create = Cli::try_parse_from(["msb", "create", "alpine:3.19"]).unwrap();
+        let remove = Cli::try_parse_from(["msb", "remove", "demo"]).unwrap();
+        let exec = Cli::try_parse_from(["msb", "exec", "demo", "--", "true"]).unwrap();
+        let context = Cli::try_parse_from(["msb", "context"]).unwrap();
+
+        assert!(shows_backend_notice(&create.command));
+        assert!(shows_backend_notice(&remove.command));
+        assert!(shows_backend_notice(&exec.command));
+        assert!(!shows_backend_notice(&context.command));
+    }
+
+    #[cfg(feature = "ssh")]
+    #[test]
+    fn ssh_connect_has_notice_but_authorize_does_not() {
+        let connect = Cli::try_parse_from(["msb", "ssh", "demo"]).unwrap();
+        let authorize = Cli::try_parse_from([
+            "msb",
+            "ssh",
+            "authorize",
+            "--key",
+            "ssh-ed25519 AAAAexample",
+        ])
+        .unwrap();
+
+        assert!(shows_backend_notice(&connect.command));
+        assert!(!shows_backend_notice(&authorize.command));
+    }
 }
 
 #[cfg(all(test, windows))]

--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -84,6 +84,7 @@ enum Commands {
     SchemaBaseline(self_cmd::SchemaBaselineArgs),
 
     /// Show the active backend and its selection source.
+    #[command(visible_alias = "ctx")]
     Context(context::ContextArgs),
 
     /// Complete a deferred Windows self-update or self-downgrade swap (internal).
@@ -722,11 +723,13 @@ mod command_tests {
         let remove = Cli::try_parse_from(["msb", "remove", "demo"]).unwrap();
         let exec = Cli::try_parse_from(["msb", "exec", "demo", "--", "true"]).unwrap();
         let context = Cli::try_parse_from(["msb", "context"]).unwrap();
+        let context_alias = Cli::try_parse_from(["msb", "ctx"]).unwrap();
 
         assert!(shows_backend_notice(&create.command));
         assert!(shows_backend_notice(&remove.command));
         assert!(shows_backend_notice(&exec.command));
         assert!(!shows_backend_notice(&context.command));
+        assert!(matches!(context_alias.command, Commands::Context(_)));
     }
 
     #[cfg(feature = "ssh")]

--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -704,7 +704,7 @@ fn is_backend_independent_maintenance_command(command: &Commands) -> bool {
         | Commands::Self_(_)
         | Commands::Completion(_) => true,
         #[cfg(windows)]
-        Commands::WindowsSelfDowngradeSwap(_) => true,
+        Commands::WindowsSelfSwap(_) => true,
         _ => false,
     }
 }

--- a/crates/cli/lib/commands/context.rs
+++ b/crates/cli/lib/commands/context.rs
@@ -1,0 +1,103 @@
+//! `msb context` command — show the active SDK backend without exposing credentials.
+
+use clap::Args;
+use microsandbox::BackendInfo;
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Show the active backend, endpoint, and selection source.
+#[derive(Debug, Args)]
+pub struct ContextArgs {
+    /// Output format (json).
+    #[arg(long, value_name = "FORMAT", value_parser = ["json"])]
+    pub format: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb context` command.
+pub fn run(args: ContextArgs) -> anyhow::Result<()> {
+    let info = microsandbox::default_backend_info();
+    if args.format.as_deref() == Some("json") {
+        println!("{}", serde_json::to_string_pretty(&info)?);
+        return Ok(());
+    }
+
+    render_human(&info).print();
+    Ok(())
+}
+
+/// Format the concise stderr notice used before mutating and interactive commands.
+pub fn notice_text(info: &BackendInfo) -> String {
+    match info.api_url.as_deref() {
+        Some(api_url) => format!("{} · {api_url}", info.kind.as_str()),
+        None => info.kind.as_str().to_string(),
+    }
+}
+
+fn render_human(info: &BackendInfo) -> ui::Table {
+    let mut table = ui::Table::new(&["FIELD", "VALUE"]);
+    table.add_row(vec!["Backend".into(), info.kind.as_str().into()]);
+    if let Some(api_url) = &info.api_url {
+        table.add_row(vec!["API URL".into(), api_url.clone()]);
+    }
+    table.add_row(vec!["Source".into(), info.source.as_str().into()]);
+    if let Some(profile) = &info.profile {
+        table.add_row(vec!["Profile".into(), profile.clone()]);
+    }
+    table
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use microsandbox::{BackendKind, BackendSelectionSource};
+
+    use super::*;
+
+    fn cloud_info() -> BackendInfo {
+        BackendInfo {
+            kind: BackendKind::Cloud,
+            api_url: Some("https://api.microsandbox.dev".into()),
+            source: BackendSelectionSource::MsbApiKey,
+            profile: None,
+        }
+    }
+
+    #[test]
+    fn human_context_uses_existing_table_style() {
+        let rendered = render_human(&cloud_info()).render();
+        assert!(rendered.contains("Backend"));
+        assert!(rendered.contains("cloud"));
+        assert!(rendered.contains("https://api.microsandbox.dev"));
+        assert!(rendered.contains("MSB_API_KEY"));
+        assert!(!rendered.contains("msb_ak_"));
+    }
+
+    #[test]
+    fn json_context_is_structured_and_secret_safe() {
+        let rendered = serde_json::to_string(&cloud_info()).unwrap();
+        assert_eq!(
+            rendered,
+            r#"{"kind":"cloud","api_url":"https://api.microsandbox.dev","source":"MSB_API_KEY"}"#
+        );
+        assert!(!rendered.contains("msb_ak_"));
+    }
+
+    #[test]
+    fn notice_is_concise() {
+        assert_eq!(
+            notice_text(&cloud_info()),
+            "cloud · https://api.microsandbox.dev"
+        );
+    }
+}

--- a/crates/cli/lib/commands/mod.rs
+++ b/crates/cli/lib/commands/mod.rs
@@ -10,6 +10,7 @@ use crate::ui;
 
 pub mod common;
 pub mod completion;
+pub mod context;
 pub mod copy;
 pub mod create;
 pub mod exec;

--- a/crates/cli/lib/ui.rs
+++ b/crates/cli/lib/ui.rs
@@ -368,6 +368,14 @@ pub fn warn(msg: &str) {
     eprintln!("{} {msg}", style("warn:").yellow().bold());
 }
 
+/// Print a concise informational notice to stderr.
+///
+/// This uses the same action-line geometry as progress and success output so
+/// diagnostics remain visually consistent without contaminating stdout.
+pub fn notice(label: &str, detail: &str) {
+    eprintln!("   {} {:<12} {}", style("•").cyan(), label, detail);
+}
+
 /// Print a warning message with `→`-prefixed context lines.
 ///
 /// Mirrors [`error_with_lines`] but with a yellow `warn:` label. As there, the

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -292,6 +292,8 @@ msb context
 msb context --format json
 ```
 
+`msb ctx` is a shorter alias for `msb context`.
+
 The SDKs expose the same secret-safe information. It includes the backend kind, cloud API URL, selection source, and profile when applicable, but never the API key:
 
 <CodeGroup>

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -282,3 +282,45 @@ export MSB_API_KEY=msb_...
 `MSB_API_URL` is optional and defaults to `https://api.microsandbox.dev`. It only overrides the endpoint. Neither `MSB_API_KEY` nor `MSB_API_URL` selects Cloud on its own, so leaving cloud credentials in a shell does not unexpectedly reroute local workloads.
 
 Selecting a cloud profile with `MSB_PROFILE` or `active_profile` is also explicit Cloud intent when that profile has `"backend": "cloud"`. `MSB_BACKEND=cloud` without a usable API key or cloud profile returns a configuration error; it never falls back to Local.
+
+### Inspect the active backend
+
+Use `msb context` before running CLI commands when you want to confirm where sandboxes will execute. The human-readable output uses the regular CLI table style; JSON is available for scripts:
+
+```bash
+msb context
+msb context --format json
+```
+
+The SDKs expose the same secret-safe information. It includes the backend kind, cloud API URL, selection source, and profile when applicable, but never the API key:
+
+<CodeGroup>
+```typescript TypeScript
+import { defaultBackendInfo } from "microsandbox";
+
+console.log(defaultBackendInfo());
+console.log(sandbox.backendKind);
+```
+
+```python Python
+from microsandbox import default_backend_info
+
+print(default_backend_info())
+print(sandbox.backend_kind)
+```
+
+```rust Rust
+let info = microsandbox::default_backend_info();
+println!("{}", info.kind.as_str());
+println!("{}", sandbox.backend_kind().as_str());
+```
+
+```go Go
+info, err := microsandbox.DefaultBackendInfo()
+if err != nil {
+    return err
+}
+fmt.Println(info.Kind)
+fmt.Println(sandbox.BackendKind())
+```
+</CodeGroup>

--- a/sdk/go/backend.go
+++ b/sdk/go/backend.go
@@ -1,0 +1,54 @@
+package microsandbox
+
+import (
+	"fmt"
+
+	"github.com/superradcompany/microsandbox/sdk/go/internal/ffi"
+)
+
+// BackendKind identifies where sandbox operations execute.
+type BackendKind string
+
+const (
+	// BackendLocal runs microVMs on the calling host.
+	BackendLocal BackendKind = "local"
+	// BackendCloud routes operations to the microsandbox cloud API.
+	BackendCloud BackendKind = "cloud"
+	// BackendUnknown means the loaded compatibility bundle predates backend introspection.
+	BackendUnknown BackendKind = "unknown"
+)
+
+// BackendInfo is a secret-safe description of the active SDK backend.
+// It intentionally never contains the API key.
+type BackendInfo struct {
+	Kind    BackendKind `json:"kind"`
+	APIURL  string      `json:"api_url,omitempty"`
+	Source  string      `json:"source"`
+	Profile string      `json:"profile,omitempty"`
+}
+
+// DefaultBackendInfo returns the backend selected and cached by the native SDK.
+func DefaultBackendInfo() (BackendInfo, error) {
+	info, err := ffi.DefaultBackendInfo()
+	if err != nil {
+		return BackendInfo{}, wrapFFI(err)
+	}
+	if info == nil {
+		return BackendInfo{}, fmt.Errorf(
+			"microsandbox: backend info unavailable in the loaded native bundle; update the SDK runtime",
+		)
+	}
+	return BackendInfo{
+		Kind:    BackendKind(info.Kind),
+		APIURL:  stringValue(info.APIURL),
+		Source:  info.Source,
+		Profile: stringValue(info.Profile),
+	}, nil
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/sdk/go/backend_test.go
+++ b/sdk/go/backend_test.go
@@ -1,0 +1,31 @@
+package microsandbox
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBackendInfoJSONIsSecretSafe(t *testing.T) {
+	info := BackendInfo{
+		Kind:   BackendCloud,
+		APIURL: "https://api.microsandbox.dev",
+		Source: "MSB_API_KEY",
+	}
+	rendered, err := json.Marshal(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(rendered), "msb_ak_") {
+		t.Fatalf("backend info leaked an API key: %s", rendered)
+	}
+	if !strings.Contains(string(rendered), `"kind":"cloud"`) {
+		t.Fatalf("backend kind missing from JSON: %s", rendered)
+	}
+}
+
+func TestBackendKindsAreStable(t *testing.T) {
+	if BackendLocal != "local" || BackendCloud != "cloud" || BackendUnknown != "unknown" {
+		t.Fatal("backend kind wire names changed")
+	}
+}

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -102,6 +102,7 @@ typedef void     (*msb_set_sdk_msb_path_fn)(const char *path);
 typedef uint64_t (*msb_cancel_alloc_fn)(void);
 typedef void     (*msb_cancel_trigger_fn)(uint64_t id);
 typedef void     (*msb_cancel_unregister_fn)(uint64_t id);
+typedef char *(*msb_default_backend_info_fn)(uint8_t *buf, size_t buf_len);
 
 typedef char *(*msb_sandbox_create_fn)(uint64_t cancel_id, const char *name, const char *opts_json, uint8_t *buf, size_t buf_len);
 typedef char *(*msb_sandbox_lookup_fn)(uint64_t cancel_id, const char *name, uint8_t *buf, size_t buf_len);
@@ -250,6 +251,7 @@ static msb_cancel_trigger_fn     ptr_msb_cancel_trigger     = NULL;
 static msb_cancel_unregister_fn  ptr_msb_cancel_unregister  = NULL;
 static msb_sandbox_create_fn     ptr_msb_sandbox_create     = NULL;
 static msb_sandbox_lookup_fn     ptr_msb_sandbox_lookup     = NULL;
+static msb_default_backend_info_fn ptr_msb_default_backend_info = NULL;
 static msb_sandbox_connect_fn    ptr_msb_sandbox_connect    = NULL;
 static msb_sandbox_start_fn      ptr_msb_sandbox_start      = NULL;
 static msb_sandbox_handle_stop_fn ptr_msb_sandbox_handle_stop = NULL;
@@ -393,6 +395,14 @@ static char load_error[1024] = {0};
 		} \
 	} while (0)
 
+// Optional symbols let a newly-built Go package load an older embedded FFI
+// bundle. Calls using the new capability detect the missing function and
+// return an explicit unavailable result without breaking unrelated methods.
+#define RESOLVE_OPTIONAL(name) \
+	do { \
+		ptr_##name = (name##_fn)dlsym(lib_handle, #name); \
+	} while (0)
+
 // load_microsandbox opens the shared library at path and resolves every
 // msb_* symbol. Returns NULL on success or a static error string on failure.
 // Idempotent: returns NULL immediately if already loaded.
@@ -411,6 +421,7 @@ const char *load_microsandbox(const char *path) {
 	RESOLVE(msb_cancel_alloc);
 	RESOLVE(msb_cancel_trigger);
 	RESOLVE(msb_cancel_unregister);
+	RESOLVE_OPTIONAL(msb_default_backend_info);
 	RESOLVE(msb_sandbox_create);
 	RESOLVE(msb_sandbox_lookup);
 	RESOLVE(msb_sandbox_connect);
@@ -569,6 +580,10 @@ char *call_msb_sandbox_create(uint64_t cancel_id, const char *name, const char *
 }
 char *call_msb_sandbox_lookup(uint64_t cancel_id, const char *name, uint8_t *buf, size_t buf_len) {
 	return ptr_msb_sandbox_lookup ? ptr_msb_sandbox_lookup(cancel_id, name, buf, buf_len) : NULL;
+}
+
+char *call_msb_default_backend_info(uint8_t *buf, size_t buf_len) {
+	return ptr_msb_default_backend_info ? ptr_msb_default_backend_info(buf, buf_len) : NULL;
 }
 char *call_msb_sandbox_connect(uint64_t cancel_id, const char *name, uint8_t *buf, size_t buf_len) {
 	return ptr_msb_sandbox_connect ? ptr_msb_sandbox_connect(cancel_id, name, buf, buf_len) : NULL;
@@ -1100,8 +1115,9 @@ const (
 // Safe for concurrent use from multiple goroutines; Close uses an atomic
 // swap so concurrent Close calls produce exactly one Rust-side release.
 type Sandbox struct {
-	handle atomic.Uint64
-	name   string
+	handle      atomic.Uint64
+	name        string
+	backendKind string
 }
 
 // SandboxPingResult is the FFI shape returned by ping operations.
@@ -1145,6 +1161,14 @@ func (s *Sandbox) h() C.uint64_t { return C.uint64_t(s.handle.Load()) }
 
 // Name returns the sandbox name supplied at creation time.
 func (s *Sandbox) Name() string { return s.name }
+
+// BackendKind returns the backend retained by this sandbox.
+func (s *Sandbox) BackendKind() string {
+	if s.backendKind == "" {
+		return "unknown"
+	}
+	return s.backendKind
+}
 
 // call invokes fn with a fresh 1 MiB buffer and a Rust-side cancellation
 // token. It runs fn on a goroutine and selects on ctx.Done; if the context
@@ -1711,7 +1735,8 @@ func CreateSandbox(ctx context.Context, name string, opts CreateOptions) (*Sandb
 		return nil, err
 	}
 	var resp struct {
-		Handle uint64 `json:"handle"`
+		Handle      uint64 `json:"handle"`
+		BackendKind string `json:"backend_kind"`
 	}
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		// Rust has allocated a handle we can no longer trust. Best-effort
@@ -1722,7 +1747,7 @@ func CreateSandbox(ctx context.Context, name string, opts CreateOptions) (*Sandb
 		}
 		return nil, fmt.Errorf("parse create response: %w", err)
 	}
-	s := &Sandbox{name: name}
+	s := &Sandbox{name: name, backendKind: resp.BackendKind}
 	s.handle.Store(resp.Handle)
 	return s, nil
 }
@@ -1744,7 +1769,8 @@ func ConnectSandbox(ctx context.Context, name string) (*Sandbox, error) {
 		return nil, err
 	}
 	var resp struct {
-		Handle uint64 `json:"handle"`
+		Handle      uint64 `json:"handle"`
+		BackendKind string `json:"backend_kind"`
 	}
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		if h := salvageHandle(out); h != 0 {
@@ -1752,7 +1778,7 @@ func ConnectSandbox(ctx context.Context, name string) (*Sandbox, error) {
 		}
 		return nil, fmt.Errorf("parse connect response: %w", err)
 	}
-	s := &Sandbox{name: name}
+	s := &Sandbox{name: name, backendKind: resp.BackendKind}
 	s.handle.Store(resp.Handle)
 	return s, nil
 }
@@ -1764,6 +1790,15 @@ type SandboxHandleInfo struct {
 	ConfigJSON    string `json:"config_json"`
 	CreatedAtUnix *int64 `json:"created_at_unix"`
 	UpdatedAtUnix *int64 `json:"updated_at_unix"`
+	BackendKind   string `json:"backend_kind"`
+}
+
+// BackendInfo is the secret-safe backend diagnostic shape returned by Rust.
+type BackendInfo struct {
+	Kind    string  `json:"kind"`
+	APIURL  *string `json:"api_url"`
+	Source  string  `json:"source"`
+	Profile *string `json:"profile"`
 }
 
 // SandboxStopResult is the JSON payload returned after observing a stopped sandbox.
@@ -1905,7 +1940,8 @@ func StartSandbox(ctx context.Context, name string, detached bool) (*Sandbox, er
 		return nil, err
 	}
 	var resp struct {
-		Handle uint64 `json:"handle"`
+		Handle      uint64 `json:"handle"`
+		BackendKind string `json:"backend_kind"`
 	}
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		if h := salvageHandle(out); h != 0 {
@@ -1913,7 +1949,7 @@ func StartSandbox(ctx context.Context, name string, detached bool) (*Sandbox, er
 		}
 		return nil, fmt.Errorf("parse start response: %w", err)
 	}
-	s := &Sandbox{name: name}
+	s := &Sandbox{name: name, backendKind: resp.BackendKind}
 	s.handle.Store(resp.Handle)
 	return s, nil
 }
@@ -4012,6 +4048,38 @@ func Version() (string, error) {
 		return "", fmt.Errorf("parse version: %w", err)
 	}
 	return resp.Version, nil
+}
+
+// DefaultBackendInfo returns secret-safe information about the backend cached
+// by the native SDK resolver. A nil result means the loaded compatibility
+// bundle predates backend introspection.
+func DefaultBackendInfo() (*BackendInfo, error) {
+	if err := ensureLoaded(); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, defaultBufSize)
+	errPtr := C.call_msb_default_backend_info((*C.uint8_t)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
+	if errPtr != nil {
+		msg := C.GoString(errPtr)
+		C.call_msb_free_string(errPtr)
+		var e Error
+		if jerr := json.Unmarshal([]byte(msg), &e); jerr != nil {
+			e = Error{Kind: KindInternal, Message: msg}
+		}
+		return nil, &e
+	}
+	end := 0
+	for end < len(buf) && buf[end] != 0 {
+		end++
+	}
+	if end == 0 {
+		return nil, nil
+	}
+	var info BackendInfo
+	if err := json.Unmarshal(buf[:end], &info); err != nil {
+		return nil, fmt.Errorf("parse backend info: %w", err)
+	}
+	return &info, nil
 }
 
 // AgentSocketPath resolves the host-side path of a sandbox's agentd relay

--- a/sdk/go/native/microsandbox_go_ffi.h
+++ b/sdk/go/native/microsandbox_go_ffi.h
@@ -638,6 +638,11 @@ char *msb_volume_fs_op(uint64_t cancel_id,
  */
 char *msb_version(unsigned char *buf, uintptr_t buf_len);
 
+/**
+ * Return secret-safe information about the active default backend.
+ */
+char *msb_default_backend_info(unsigned char *buf, uintptr_t buf_len);
+
 char *msb_image_get(uint64_t cancel_id,
                     const char *reference,
                     unsigned char *buf,

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -2209,8 +2209,13 @@ pub unsafe extern "C" fn msb_sandbox_create(
             } else {
                 builder.create().await?
             };
+            let backend_kind = sandbox.backend_kind().as_str();
             let handle = register(sandbox)?;
-            Ok(format!(r#"{{"handle":{handle}}}"#))
+            Ok(serde_json::json!({
+                "handle": handle,
+                "backend_kind": backend_kind,
+            })
+            .to_string())
         }))
     })
 }
@@ -2345,6 +2350,7 @@ pub unsafe extern "C" fn msb_sandbox_lookup(
                 "config_json": h.config_json(),
                 "created_at_unix": h.created_at().map(|t| t.timestamp()),
                 "updated_at_unix": h.updated_at().map(|t| t.timestamp()),
+                "backend_kind": h.backend_kind().as_str(),
             })
             .to_string())
         }))
@@ -2370,8 +2376,13 @@ pub unsafe extern "C" fn msb_sandbox_connect(
         let name = unsafe { cstr(name) }?;
         Ok(Box::pin(async move {
             let sb = Sandbox::get(&name).await?.connect().await?;
+            let backend_kind = sb.backend_kind().as_str();
             let handle = register(sb)?;
-            Ok(format!(r#"{{"handle":{handle}}}"#))
+            Ok(serde_json::json!({
+                "handle": handle,
+                "backend_kind": backend_kind,
+            })
+            .to_string())
         }))
     })
 }
@@ -2402,8 +2413,13 @@ pub unsafe extern "C" fn msb_sandbox_start(
             } else {
                 h.start().await.map_err(FfiError::from)?
             };
+            let backend_kind = sb.backend_kind().as_str();
             let handle = register(sb)?;
-            Ok(format!(r#"{{"handle":{handle}}}"#))
+            Ok(serde_json::json!({
+                "handle": handle,
+                "backend_kind": backend_kind,
+            })
+            .to_string())
         }))
     })
 }
@@ -2953,10 +2969,11 @@ fn sandbox_handle_json(h: &microsandbox::sandbox::SandboxHandle) -> String {
         None => "null".to_string(),
     };
     format!(
-        r#"{{"name":{name},"status":"{status}","config_json":{config},"created_at_unix":{created},"updated_at_unix":{updated}}}"#,
+        r#"{{"name":{name},"status":"{status}","config_json":{config},"created_at_unix":{created},"updated_at_unix":{updated},"backend_kind":"{backend_kind}"}}"#,
         name = name_json,
         status = sandbox_status_str(h.status_snapshot()),
         config = cfg_json,
+        backend_kind = h.backend_kind().as_str(),
     )
 }
 
@@ -5100,6 +5117,18 @@ pub unsafe extern "C" fn msb_version(buf: *mut c_uchar, buf_len: usize) -> *mut 
     run(buf, buf_len, || {
         let v = env!("CARGO_PKG_VERSION");
         Ok(format!(r#"{{"version":"{v}"}}"#))
+    })
+}
+
+/// Return secret-safe information about the active default backend.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn msb_default_backend_info(
+    buf: *mut c_uchar,
+    buf_len: usize,
+) -> *mut c_char {
+    run(buf, buf_len, || {
+        serde_json::to_string(&microsandbox::default_backend_info())
+            .map_err(|error| FfiError::internal(format!("serialize backend info: {error}")))
     })
 }
 

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -23,6 +23,9 @@ type Sandbox struct {
 	inner *ffi.Sandbox
 }
 
+// BackendKind returns the backend retained by this sandbox.
+func (s *Sandbox) BackendKind() BackendKind { return BackendKind(s.inner.BackendKind()) }
+
 // CreateSandbox creates and boots a new sandbox. The returned Sandbox owns the
 // VM process — call Close (or Stop + Close) when done.
 //
@@ -563,15 +566,21 @@ type SandboxHandle struct {
 	configJSON    string
 	createdAtUnix *int64
 	updatedAtUnix *int64
+	backendKind   BackendKind
 }
 
 func newSandboxHandle(info *ffi.SandboxHandleInfo) *SandboxHandle {
+	backendKind := BackendKind(info.BackendKind)
+	if backendKind == "" {
+		backendKind = BackendUnknown
+	}
 	return &SandboxHandle{
 		name:          info.Name,
 		status:        SandboxStatus(info.Status),
 		configJSON:    info.ConfigJSON,
 		createdAtUnix: info.CreatedAtUnix,
 		updatedAtUnix: info.UpdatedAtUnix,
+		backendKind:   backendKind,
 	}
 }
 
@@ -580,6 +589,9 @@ func (h *SandboxHandle) Name() string { return h.name }
 
 // Status returns the sandbox's last-known lifecycle status.
 func (h *SandboxHandle) Status() SandboxStatus { return h.status }
+
+// BackendKind returns the backend retained by this handle.
+func (h *SandboxHandle) BackendKind() BackendKind { return h.backendKind }
 
 // ConfigJSON returns the raw JSON configuration stored for this sandbox.
 func (h *SandboxHandle) ConfigJSON() string { return h.configJSON }

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -664,6 +664,7 @@ module.exports.JsVolumeFsWriteSink = nativeBinding.JsVolumeFsWriteSink
 module.exports.VolumeHandle = nativeBinding.VolumeHandle
 module.exports.JsVolumeHandle = nativeBinding.JsVolumeHandle
 module.exports.allSandboxMetrics = nativeBinding.allSandboxMetrics
+module.exports.defaultBackendInfo = nativeBinding.defaultBackendInfo
 module.exports.defaultBackendKind = nativeBinding.defaultBackendKind
 module.exports.imageGet = nativeBinding.imageGet
 module.exports.imageInspect = nativeBinding.imageInspect

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -854,6 +854,8 @@ export declare class Sandbox {
    * Sandbox names are limited to 128 UTF-8 bytes.
    */
   static remove(name: string): Promise<void>
+  /** Backend retained by this sandbox (`"local"` or `"cloud"`). */
+  get backendKind(): string
   /** Sandbox name. Names are limited to 128 UTF-8 bytes. */
   get name(): Promise<string>
   /** Whether this handle owns the sandbox lifecycle (attached mode). */
@@ -1218,6 +1220,8 @@ export declare class SandboxHandle {
   get name(): string
   /** Status at time of query: "running", "stopped", "crashed", or "draining". */
   get status(): string
+  /** Backend retained by this handle (`"local"` or `"cloud"`). */
+  get backendKind(): string
   /** Raw config JSON string from the database. */
   get configJson(): string
   /** Return a fresh handle for the same sandbox. */
@@ -1666,6 +1670,9 @@ export interface AttachOptions {
   rlimits: Array<JsRlimit>
 }
 
+/** Return secret-safe information about the active default backend. */
+export declare function defaultBackendInfo(): JsBackendInfo
+
 /** Return the active default backend kind (`"local"` or `"cloud"`). */
 export declare function defaultBackendKind(): string
 
@@ -1826,6 +1833,14 @@ export declare function install(): Promise<void>
 
 /** Check if msb and libkrunfw are installed and available. */
 export declare function isInstalled(): boolean
+
+/** Secret-safe backend diagnostics returned to JavaScript. */
+export interface JsBackendInfo {
+  kind: string
+  apiUrl?: string
+  source: string
+  profile?: string
+}
 
 /** One page returned by `Sandbox.list` / `Sandbox.listWith`. */
 export interface JsSandboxPage {

--- a/sdk/node-ts/native/runtime_config.rs
+++ b/sdk/node-ts/native/runtime_config.rs
@@ -13,6 +13,19 @@ static BACKEND_SCOPES: OnceLock<Mutex<HashMap<u32, Arc<dyn microsandbox::Backend
     OnceLock::new();
 
 //--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Secret-safe backend diagnostics returned to JavaScript.
+#[napi(object, object_from_js = false)]
+pub struct JsBackendInfo {
+    pub kind: String,
+    pub api_url: Option<String>,
+    pub source: String,
+    pub profile: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
 
@@ -84,9 +97,18 @@ pub fn pop_default_backend(token: u32) -> napi::Result<()> {
 /// Return the active default backend kind (`"local"` or `"cloud"`).
 #[napi(js_name = "defaultBackendKind")]
 pub fn default_backend_kind() -> &'static str {
-    match microsandbox::default_backend().kind() {
-        microsandbox::BackendKind::Local => "local",
-        microsandbox::BackendKind::Cloud => "cloud",
+    microsandbox::default_backend().kind().as_str()
+}
+
+/// Return secret-safe information about the active default backend.
+#[napi(js_name = "defaultBackendInfo")]
+pub fn default_backend_info() -> JsBackendInfo {
+    let info = microsandbox::default_backend_info();
+    JsBackendInfo {
+        kind: info.kind.as_str().to_string(),
+        api_url: info.api_url,
+        source: info.source.as_str().to_string(),
+        profile: info.profile,
     }
 }
 

--- a/sdk/node-ts/native/sandbox.rs
+++ b/sdk/node-ts/native/sandbox.rs
@@ -27,6 +27,7 @@ use crate::types::*;
 #[napi]
 pub struct Sandbox {
     inner: Arc<Mutex<Option<microsandbox::sandbox::Sandbox>>>,
+    backend_kind: &'static str,
 }
 
 /// One page returned by `Sandbox.list` / `Sandbox.listWith`.
@@ -70,8 +71,10 @@ pub struct JsLogStream {
 
 impl Sandbox {
     pub fn from_rust(inner: microsandbox::sandbox::Sandbox) -> Self {
+        let backend_kind = inner.backend_kind().as_str();
         Sandbox {
             inner: Arc::new(Mutex::new(Some(inner))),
+            backend_kind,
         }
     }
 }
@@ -90,9 +93,7 @@ impl Sandbox {
         let inner = microsandbox::sandbox::Sandbox::start(&name)
             .await
             .map_err(to_napi_error)?;
-        Ok(Sandbox {
-            inner: Arc::new(Mutex::new(Some(inner))),
-        })
+        Ok(Sandbox::from_rust(inner))
     }
 
     /// Start an existing stopped sandbox (detached mode).
@@ -103,9 +104,7 @@ impl Sandbox {
         let inner = microsandbox::sandbox::Sandbox::start_detached(&name)
             .await
             .map_err(to_napi_error)?;
-        Ok(Sandbox {
-            inner: Arc::new(Mutex::new(Some(inner))),
-        })
+        Ok(Sandbox::from_rust(inner))
     }
 
     //----------------------------------------------------------------------------------------------
@@ -166,6 +165,12 @@ impl Sandbox {
     //----------------------------------------------------------------------------------------------
     // Properties
     //----------------------------------------------------------------------------------------------
+
+    /// Backend retained by this sandbox (`"local"` or `"cloud"`).
+    #[napi(getter)]
+    pub fn backend_kind(&self) -> &'static str {
+        self.backend_kind
+    }
 
     /// Sandbox name. Names are limited to 128 UTF-8 bytes.
     #[napi(getter)]

--- a/sdk/node-ts/native/sandbox_handle.rs
+++ b/sdk/node-ts/native/sandbox_handle.rs
@@ -42,6 +42,12 @@ impl JsSandboxHandle {
         format!("{:?}", self.inner.status_snapshot()).to_lowercase()
     }
 
+    /// Backend retained by this handle (`"local"` or `"cloud"`).
+    #[napi(getter)]
+    pub fn backend_kind(&self) -> &'static str {
+        self.inner.backend_kind().as_str()
+    }
+
     /// Raw config JSON string from the database.
     #[napi(getter)]
     pub fn config_json(&self) -> String {

--- a/sdk/node-ts/src/index.ts
+++ b/sdk/node-ts/src/index.ts
@@ -12,11 +12,12 @@ export {
   type RawFrame,
 } from "./agent.js";
 export {
+  defaultBackendInfo,
   defaultBackendKind,
   setDefaultBackend,
   withDefaultBackend,
 } from "./runtime.js";
-export type { DefaultBackend } from "./runtime.js";
+export type { BackendInfo, DefaultBackend } from "./runtime.js";
 export type { DeploymentProfile } from "./deployment-profile.js";
 
 // Sandbox lifecycle and execution

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -39,6 +39,7 @@ export interface NativeBindings {
   ) => number;
   readonly popDefaultBackend?: (token: number) => void;
   readonly defaultBackendKind?: () => "local" | "cloud";
+  readonly defaultBackendInfo?: () => NapiBackendInfo;
   readonly Sandbox: NapiSandboxStatic;
   readonly SandboxBuilder: NapiSandboxBuilderCtor;
   readonly Volume: NapiVolumeStatic;
@@ -83,6 +84,20 @@ export interface NativeBindings {
   readonly isInstalled: () => boolean;
   readonly allSandboxMetrics: () => Promise<Record<string, NapiSandboxMetrics>>;
   readonly AgentClient: NapiAgentClientStatic;
+}
+
+export interface NapiBackendInfo {
+  kind: "local" | "cloud";
+  apiUrl?: string;
+  source:
+    | "programmatic"
+    | "MSB_BACKEND"
+    | "MSB_API_KEY"
+    | "MSB_PROFILE"
+    | "profile"
+    | "active_profile"
+    | "default";
+  profile?: string;
 }
 
 export interface NapiAgentClientStatic {
@@ -221,6 +236,7 @@ export interface NapiSandboxBuilder extends NapiSandboxBuilderSetters {
 }
 
 export interface NapiSandbox {
+  readonly backendKind: "local" | "cloud";
   configJson(): Promise<string>;
   exec(cmd: string, args?: string[]): Promise<NapiExecOutput>;
   execWithBuilder(cmd: string, builder: NapiExecOptionsBuilder): Promise<NapiExecOutput>;
@@ -255,6 +271,7 @@ export interface NapiSandbox {
 export interface NapiSandboxHandle {
   readonly name: string;
   readonly status: string;
+  readonly backendKind: "local" | "cloud";
   readonly configJson: string;
   readonly createdAt: number | null;
   readonly updatedAt: number | null;

--- a/sdk/node-ts/src/runtime.ts
+++ b/sdk/node-ts/src/runtime.ts
@@ -13,6 +13,21 @@ export type DefaultBackend =
       profile: string;
     };
 
+/** Secret-safe information about the active default backend. */
+export interface BackendInfo {
+  kind: "local" | "cloud";
+  apiUrl?: string;
+  source:
+    | "programmatic"
+    | "MSB_BACKEND"
+    | "MSB_API_KEY"
+    | "MSB_PROFILE"
+    | "profile"
+    | "active_profile"
+    | "default";
+  profile?: string;
+}
+
 /** Set the process-wide default backend used by SDK entry points. */
 export function setDefaultBackend(backend: DefaultBackend): void {
   const setNative = napi.setDefaultBackend;
@@ -63,6 +78,15 @@ export function defaultBackendKind(): "local" | "cloud" {
   const getNative = napi.defaultBackendKind;
   if (!getNative) {
     throw new Error("native defaultBackendKind binding is unavailable");
+  }
+  return getNative();
+}
+
+/** Return secret-safe information about the active default backend. */
+export function defaultBackendInfo(): BackendInfo {
+  const getNative = napi.defaultBackendInfo;
+  if (!getNative) {
+    throw new Error("native defaultBackendInfo binding is unavailable");
   }
   return getNative();
 }

--- a/sdk/node-ts/src/sandbox-handle.ts
+++ b/sdk/node-ts/src/sandbox-handle.ts
@@ -39,6 +39,8 @@ export class SandboxHandle {
   /** Sandbox name. Names are limited to 128 UTF-8 bytes. */
   readonly name: string;
   readonly status: SandboxStatus;
+  /** Backend retained by this handle. */
+  readonly backendKind: "local" | "cloud";
   readonly configJson: string;
   readonly createdAt: Date | null;
   readonly updatedAt: Date | null;
@@ -48,6 +50,7 @@ export class SandboxHandle {
     this.inner = inner;
     this.name = inner.name;
     this.status = inner.status as SandboxStatus;
+    this.backendKind = inner.backendKind;
     this.configJson = inner.configJson;
     this.createdAt =
       typeof inner.createdAt === "number" ? new Date(inner.createdAt) : null;

--- a/sdk/node-ts/src/sandbox.ts
+++ b/sdk/node-ts/src/sandbox.ts
@@ -164,12 +164,15 @@ export class Sandbox implements AsyncDisposable {
   /** Sandbox name. Names are limited to 128 UTF-8 bytes. */
   readonly name: string;
   readonly ownsLifecycle: boolean;
+  /** Backend retained by this sandbox. */
+  readonly backendKind: "local" | "cloud";
 
   /** @internal use `Sandbox.builder(name).create()` */
   constructor(inner: NapiSandbox, name: string, ownsLifecycle = true) {
     this.inner = inner;
     this.name = name;
     this.ownsLifecycle = ownsLifecycle;
+    this.backendKind = inner.backendKind;
   }
 
   // -- statics ------------------------------------------------------------

--- a/sdk/node-ts/tests/unit/backend-info.test.ts
+++ b/sdk/node-ts/tests/unit/backend-info.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { defaultBackendInfo, defaultBackendKind } from "../../src/index.js";
+import { defaultBackendInfo, defaultBackendKind } from "../../dist/index.js";
 
 describe("backend introspection", () => {
   it("returns structured, secret-safe default backend information", () => {

--- a/sdk/node-ts/tests/unit/backend-info.test.ts
+++ b/sdk/node-ts/tests/unit/backend-info.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultBackendInfo, defaultBackendKind } from "../../src/index.js";
+
+describe("backend introspection", () => {
+  it("returns structured, secret-safe default backend information", () => {
+    const info = defaultBackendInfo();
+
+    expect(["local", "cloud"]).toContain(info.kind);
+    expect(info.kind).toBe(defaultBackendKind());
+    expect(info).not.toHaveProperty("apiKey");
+    expect(info).not.toHaveProperty("api_key");
+    if (info.kind === "cloud") {
+      expect(info.apiUrl).toMatch(/^https?:\/\//);
+    } else {
+      expect(info.apiUrl).toBeUndefined();
+    }
+  });
+});

--- a/sdk/python/microsandbox/__init__.py
+++ b/sdk/python/microsandbox/__init__.py
@@ -3,6 +3,7 @@
 import os as _os
 
 from microsandbox._microsandbox import (
+    BackendInfo,
     ExecEvent,
     ExecHandle,
     ExecOutput,
@@ -41,6 +42,7 @@ from microsandbox._microsandbox import (
     VolumeHandle,
     all_sandbox_metrics,
     backend_scope,
+    default_backend_info,
     default_backend_kind,
     install,
     is_installed,
@@ -177,6 +179,9 @@ if "MSB_PATH" not in _os.environ:
         _set_runtime_msb_path(str(_bundled_msb))
 
 __all__ = [
+    # Backend selection
+    "BackendInfo",
+    "default_backend_info",
     # Sandbox lifecycle (native)
     "Sandbox",
     "SandboxHandle",

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -27,6 +27,19 @@ struct PyBackendScope {
     previous: Option<Arc<dyn microsandbox::Backend>>,
 }
 
+/// Secret-safe information about an SDK backend.
+#[pyclass(name = "BackendInfo", frozen)]
+struct PyBackendInfo {
+    #[pyo3(get)]
+    kind: String,
+    #[pyo3(get)]
+    api_url: Option<String>,
+    #[pyo3(get)]
+    source: String,
+    #[pyo3(get)]
+    profile: Option<String>,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
@@ -42,6 +55,7 @@ fn _microsandbox(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(set_default_backend, m)?)?;
     m.add_function(wrap_pyfunction!(backend_scope, m)?)?;
     m.add_function(wrap_pyfunction!(default_backend_kind, m)?)?;
+    m.add_function(wrap_pyfunction!(default_backend_info, m)?)?;
     m.add_function(wrap_pyfunction!(resolved_msb_path, m)?)?;
     m.add_function(wrap_pyfunction!(metrics::all_sandbox_metrics, m)?)?;
     m.add_class::<sandbox::PySandbox>()?;
@@ -83,6 +97,7 @@ fn _microsandbox(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<fs::PyFsEntry>()?;
     m.add_class::<fs::PyFsMetadata>()?;
     m.add_class::<PyBackendScope>()?;
+    m.add_class::<PyBackendInfo>()?;
     Ok(())
 }
 
@@ -161,6 +176,18 @@ fn default_backend_kind(py: Python<'_>) -> PyResult<PyObject> {
         microsandbox::BackendKind::Cloud => "cloud",
     };
     crate::helpers::str_enum_member(py, "BackendKind", kind)
+}
+
+/// Return secret-safe information about the active default backend.
+#[pyfunction]
+fn default_backend_info() -> PyBackendInfo {
+    let info = microsandbox::default_backend_info();
+    PyBackendInfo {
+        kind: info.kind.as_str().to_string(),
+        api_url: info.api_url,
+        source: info.source.as_str().to_string(),
+        profile: info.profile,
+    }
 }
 
 /// Return the `msb` binary path the native resolver would currently use.

--- a/sdk/python/src/sandbox.rs
+++ b/sdk/python/src/sandbox.rs
@@ -215,6 +215,17 @@ impl PySandbox {
     // Static Methods — Creation
     //----------------------------------------------------------------------------------------------
 
+    /// Backend retained by this sandbox (`"local"` or `"cloud"`).
+    #[getter]
+    fn backend_kind(&self) -> PyResult<String> {
+        let guard = self
+            .inner
+            .try_lock()
+            .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("sandbox is busy"))?;
+        let sandbox = guard.as_ref().ok_or_else(crate::error::consumed)?;
+        Ok(sandbox.backend_kind().as_str().to_string())
+    }
+
     /// Create a sandbox from a name and keyword-only configuration.
     ///
     /// Sandbox names are limited to 128 UTF-8 bytes.

--- a/sdk/python/src/sandbox_handle.rs
+++ b/sdk/python/src/sandbox_handle.rs
@@ -60,6 +60,16 @@ impl PySandboxHandle {
         )
     }
 
+    /// Backend retained by this handle (`"local"` or `"cloud"`).
+    #[getter]
+    fn backend_kind(&self) -> PyResult<String> {
+        let guard = self
+            .inner
+            .try_lock()
+            .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("handle is busy"))?;
+        Ok(guard.backend_kind().as_str().to_string())
+    }
+
     /// Raw config JSON string.
     #[getter]
     fn config_json(&self) -> PyResult<String> {

--- a/sdk/python/tests/test_backend_info.py
+++ b/sdk/python/tests/test_backend_info.py
@@ -1,0 +1,13 @@
+from microsandbox import default_backend_info, default_backend_kind
+
+
+def test_default_backend_info_is_structured_and_secret_safe() -> None:
+    info = default_backend_info()
+
+    assert info.kind in {"local", "cloud"}
+    assert info.kind == default_backend_kind()
+    assert not hasattr(info, "api_key")
+    if info.kind == "cloud":
+        assert info.api_url.startswith(("http://", "https://"))
+    else:
+        assert info.api_url is None

--- a/sdk/rust/lib/backend/cloud/mod.rs
+++ b/sdk/rust/lib/backend/cloud/mod.rs
@@ -33,7 +33,9 @@ use tokio_tungstenite::{
 };
 
 use self::http::urlencoding;
-use super::{Backend, BackendKind, SandboxBackend, VolumeBackend};
+use super::{
+    Backend, BackendInfo, BackendKind, BackendSelectionSource, SandboxBackend, VolumeBackend,
+};
 use crate::{MicrosandboxError, MicrosandboxResult};
 
 //--------------------------------------------------------------------------------------------------
@@ -80,6 +82,8 @@ pub struct CloudBackend {
     url: String,
     api_key: String,
     http: reqwest::Client,
+    selection_source: BackendSelectionSource,
+    profile: Option<String>,
 }
 
 /// Fluent builder for `CloudBackend`. Use for tuned construction.
@@ -136,7 +140,9 @@ impl CloudBackend {
         {
             builder = builder.url(url);
         }
-        builder.build()
+        Ok(builder
+            .build()?
+            .with_selection(BackendSelectionSource::MsbApiKey, None))
     }
 
     /// Construct from a named SDK profile in `~/.microsandbox/config.json`.
@@ -155,6 +161,17 @@ impl CloudBackend {
     /// Configured msb-cloud endpoint URL (no trailing slash).
     pub fn url(&self) -> &str {
         &self.url
+    }
+
+    /// Attach resolver provenance without changing cloud credentials.
+    pub(crate) fn with_selection(
+        mut self,
+        selection_source: BackendSelectionSource,
+        profile: Option<String>,
+    ) -> Self {
+        self.selection_source = selection_source;
+        self.profile = profile;
+        self
     }
 }
 
@@ -306,7 +323,13 @@ impl CloudBackendBuilder {
                 })?
         };
 
-        Ok(CloudBackend { url, api_key, http })
+        Ok(CloudBackend {
+            url,
+            api_key,
+            http,
+            selection_source: BackendSelectionSource::Programmatic,
+            profile: None,
+        })
     }
 }
 
@@ -317,6 +340,15 @@ impl CloudBackendBuilder {
 impl Backend for CloudBackend {
     fn kind(&self) -> BackendKind {
         BackendKind::Cloud
+    }
+
+    fn info(&self) -> BackendInfo {
+        BackendInfo {
+            kind: BackendKind::Cloud,
+            api_url: Some(self.url.clone()),
+            source: self.selection_source,
+            profile: self.profile.clone(),
+        }
     }
 
     fn sandboxes(&self) -> &dyn SandboxBackend {
@@ -547,6 +579,17 @@ mod tests {
         let b = CloudBackend::new("https://msb.example.com", "msb_test_abc").unwrap();
         assert_eq!(b.kind(), BackendKind::Cloud);
         assert_eq!(b.url(), "https://msb.example.com");
+        assert_eq!(b.info().source, BackendSelectionSource::Programmatic);
+    }
+
+    #[test]
+    fn backend_info_never_serializes_api_key() {
+        let b = CloudBackend::new("https://msb.example.com", "msb_test_super_secret").unwrap();
+        let json = serde_json::to_string(&b.info()).unwrap();
+
+        assert!(json.contains("https://msb.example.com"));
+        assert!(!json.contains("msb_test_super_secret"));
+        assert!(!json.contains("api_key"));
     }
 
     #[test]

--- a/sdk/rust/lib/backend/local/mod.rs
+++ b/sdk/rust/lib/backend/local/mod.rs
@@ -36,7 +36,9 @@ use microsandbox_types::DeploymentProfile;
 use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, DbErr, Statement};
 use tokio::sync::OnceCell;
 
-use super::{Backend, BackendKind, SandboxBackend, VolumeBackend};
+use super::{
+    Backend, BackendInfo, BackendKind, BackendSelectionSource, SandboxBackend, VolumeBackend,
+};
 use crate::{MicrosandboxError, MicrosandboxResult};
 use crate::{
     SandboxConfig,
@@ -57,6 +59,8 @@ pub struct LocalBackend {
     config: Arc<LocalConfig>,
     db: OnceCell<DbPools>,
     deployment_profile: Option<DeploymentProfile>,
+    selection_source: BackendSelectionSource,
+    profile: Option<String>,
 }
 
 /// Fluent builder for [`LocalBackend`]. Construct via [`LocalBackend::builder`].
@@ -116,11 +120,21 @@ impl LocalBackend {
     /// `LocalBackend` instance, so callers never end up with two backends
     /// racing on the same SQLite file.
     pub fn lazy() -> Self {
+        Self::lazy_with_selection(BackendSelectionSource::Programmatic, None)
+    }
+
+    /// Construct a lazy local backend with resolver provenance attached.
+    pub(crate) fn lazy_with_selection(
+        selection_source: BackendSelectionSource,
+        profile: Option<String>,
+    ) -> Self {
         let config = Arc::new(load_persisted_config_or_default().unwrap_or_default());
         Self {
             config,
             db: OnceCell::new(),
             deployment_profile: None,
+            selection_source,
+            profile,
         }
     }
 
@@ -402,6 +416,8 @@ impl LocalBackendBuilder {
             config: Arc::new(config),
             db: OnceCell::new(),
             deployment_profile,
+            selection_source: BackendSelectionSource::Programmatic,
+            profile: None,
         }
     }
 
@@ -534,6 +550,15 @@ impl MigrationLock {
 impl Backend for LocalBackend {
     fn kind(&self) -> BackendKind {
         BackendKind::Local
+    }
+
+    fn info(&self) -> BackendInfo {
+        BackendInfo {
+            kind: BackendKind::Local,
+            api_url: None,
+            source: self.selection_source,
+            profile: self.profile.clone(),
+        }
     }
 
     fn sandboxes(&self) -> &dyn SandboxBackend {
@@ -771,6 +796,8 @@ mod tests {
             config: Arc::new(LocalConfig::default()),
             db: OnceCell::new(),
             deployment_profile: Some(DeploymentProfile::MultiTenant),
+            selection_source: BackendSelectionSource::Programmatic,
+            profile: None,
         };
         let mut config = SandboxConfig::default();
         config.spec.name = "profile-test".into();
@@ -790,6 +817,8 @@ mod tests {
             config: Arc::new(LocalConfig::default()),
             db: OnceCell::new(),
             deployment_profile: None,
+            selection_source: BackendSelectionSource::Programmatic,
+            profile: None,
         };
         let mut config = SandboxConfig::default();
         config.spec.deployment_profile = DeploymentProfile::MultiTenant;

--- a/sdk/rust/lib/backend/mod.rs
+++ b/sdk/rust/lib/backend/mod.rs
@@ -49,6 +49,8 @@ use std::{
     time::Duration,
 };
 
+use serde::{Deserialize, Serialize};
+
 use crate::MicrosandboxResult;
 use crate::error::{Operation, UnsupportedReason};
 
@@ -58,12 +60,86 @@ use crate::error::{Operation, UnsupportedReason};
 
 /// Which backend variant a [`Backend`] implementation represents. Returned by
 /// [`Backend::kind`] for runtime introspection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum BackendKind {
     /// Local libkrun + agentd backend. Spawns microVMs on the calling host.
     Local,
     /// Remote backend talking to an msb-cloud control plane over HTTP.
     Cloud,
+}
+
+/// How the active backend was selected.
+///
+/// This describes the selector, never its credential value. Backend
+/// diagnostics therefore cannot expose `MSB_API_KEY`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BackendSelectionSource {
+    /// Installed directly through an SDK constructor or setter.
+    #[serde(rename = "programmatic")]
+    Programmatic,
+    /// Selected explicitly by `MSB_BACKEND`.
+    #[serde(rename = "MSB_BACKEND")]
+    MsbBackend,
+    /// Selected implicitly by a non-empty `MSB_API_KEY`.
+    #[serde(rename = "MSB_API_KEY")]
+    MsbApiKey,
+    /// Selected by the profile named in `MSB_PROFILE`.
+    #[serde(rename = "MSB_PROFILE")]
+    MsbProfile,
+    /// Selected by an explicit SDK profile constructor.
+    #[serde(rename = "profile")]
+    Profile,
+    /// Selected by `active_profile` in the SDK config file.
+    #[serde(rename = "active_profile")]
+    ActiveProfile,
+    /// Selected by the SDK's final local fallback.
+    #[serde(rename = "default")]
+    Default,
+}
+
+/// Secret-safe description of an SDK backend.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackendInfo {
+    /// Local or cloud execution.
+    pub kind: BackendKind,
+    /// Effective cloud API endpoint. Absent for local backends.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_url: Option<String>,
+    /// Selector that chose this backend.
+    pub source: BackendSelectionSource,
+    /// Selected SDK profile, when profile-based selection was used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl BackendKind {
+    /// Stable lowercase name used by language bindings and diagnostics.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Cloud => "cloud",
+        }
+    }
+}
+
+impl BackendSelectionSource {
+    /// Stable public name for this selection source.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Programmatic => "programmatic",
+            Self::MsbBackend => "MSB_BACKEND",
+            Self::MsbApiKey => "MSB_API_KEY",
+            Self::MsbProfile => "MSB_PROFILE",
+            Self::Profile => "profile",
+            Self::ActiveProfile => "active_profile",
+            Self::Default => "default",
+        }
+    }
 }
 
 /// Top-level routing trait for SDK dispatch. Implementations route to
@@ -78,6 +154,16 @@ pub enum BackendKind {
 pub trait Backend: Send + Sync + 'static {
     /// Return the kind of backend this is (`Local` or `Cloud`).
     fn kind(&self) -> BackendKind;
+
+    /// Return a secret-safe description of this backend.
+    fn info(&self) -> BackendInfo {
+        BackendInfo {
+            kind: self.kind(),
+            api_url: None,
+            source: BackendSelectionSource::Programmatic,
+            profile: None,
+        }
+    }
 
     /// Return the sandbox lifecycle backend.
     fn sandboxes(&self) -> &dyn SandboxBackend;
@@ -164,6 +250,14 @@ pub fn default_backend() -> Arc<dyn Backend> {
         .read()
         .expect("DEFAULT backend RwLock poisoned")
         .clone()
+}
+
+/// Return a secret-safe description of the active default backend.
+///
+/// Like [`default_backend`], the first call freezes ambient environment and
+/// profile resolution for the process.
+pub fn default_backend_info() -> BackendInfo {
+    default_backend().info()
 }
 
 /// Run `future` with `backend` installed as the default for the duration of

--- a/sdk/rust/lib/backend/profile.rs
+++ b/sdk/rust/lib/backend/profile.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use super::{Backend, CloudBackend, LocalBackend};
+use super::{Backend, BackendSelectionSource, CloudBackend, LocalBackend};
 use crate::{MicrosandboxError, MicrosandboxResult};
 
 //--------------------------------------------------------------------------------------------------
@@ -134,7 +134,10 @@ pub fn resolve_default_backend() -> MicrosandboxResult<Arc<dyn Backend>> {
     let backend_kind = std::env::var("MSB_BACKEND").ok();
     let parsed_backend_kind = parse_backend_kind(backend_kind.as_deref())?;
     if parsed_backend_kind == Some(ProfileBackend::Local) {
-        return Ok(Arc::new(LocalBackend::lazy()));
+        return Ok(Arc::new(LocalBackend::lazy_with_selection(
+            BackendSelectionSource::MsbBackend,
+            None,
+        )));
     }
 
     let api_key = std::env::var("MSB_API_KEY").ok();
@@ -147,19 +150,25 @@ pub fn resolve_default_backend() -> MicrosandboxResult<Arc<dyn Backend>> {
                     "MSB_BACKEND=cloud requires a non-empty MSB_API_KEY".into(),
                 )
             })?;
-        return Ok(Arc::new(cloud));
+        return Ok(Arc::new(
+            cloud.with_selection(BackendSelectionSource::MsbBackend, None),
+        ));
     }
 
     let cfg = load_sdk_config()?;
+    let env_profile = std::env::var("MSB_PROFILE").ok();
     let selection = select_backend(
         backend_kind.as_deref(),
         api_key.as_deref(),
-        std::env::var("MSB_PROFILE").ok().as_deref(),
+        env_profile.as_deref(),
         cfg.active_profile.as_deref(),
     )?;
 
     match selection {
-        BackendSelection::Local => Ok(Arc::new(LocalBackend::lazy())),
+        BackendSelection::Local => Ok(Arc::new(LocalBackend::lazy_with_selection(
+            BackendSelectionSource::Default,
+            None,
+        ))),
         BackendSelection::DirectCloud => {
             let cloud = direct_cloud_backend(std::env::var("MSB_API_URL").ok(), api_key)?
                 .ok_or_else(|| {
@@ -167,7 +176,9 @@ pub fn resolve_default_backend() -> MicrosandboxResult<Arc<dyn Backend>> {
                         "MSB_BACKEND=cloud requires a non-empty MSB_API_KEY".into(),
                     )
                 })?;
-            Ok(Arc::new(cloud))
+            Ok(Arc::new(
+                cloud.with_selection(BackendSelectionSource::MsbBackend, None),
+            ))
         }
         BackendSelection::Profile {
             name,
@@ -183,7 +194,18 @@ pub fn resolve_default_backend() -> MicrosandboxResult<Arc<dyn Backend>> {
                     "MSB_BACKEND=cloud cannot select local profile {name:?}"
                 )));
             }
-            backend_from_profile(&name, profile)
+            let source = if require_cloud {
+                BackendSelectionSource::MsbBackend
+            } else if env_profile
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|name| !name.is_empty())
+            {
+                BackendSelectionSource::MsbProfile
+            } else {
+                BackendSelectionSource::ActiveProfile
+            };
+            backend_from_profile(&name, profile, source)
         }
     }
 }
@@ -245,10 +267,20 @@ fn select_backend(
 }
 
 /// Build a backend instance from a named profile.
-fn backend_from_profile(name: &str, profile: &Profile) -> MicrosandboxResult<Arc<dyn Backend>> {
+fn backend_from_profile(
+    name: &str,
+    profile: &Profile,
+    source: BackendSelectionSource,
+) -> MicrosandboxResult<Arc<dyn Backend>> {
     match profile.backend {
-        ProfileBackend::Local => Ok(Arc::new(LocalBackend::lazy())),
-        ProfileBackend::Cloud => Ok(Arc::new(cloud_backend_from_profile_parts(name, profile)?)),
+        ProfileBackend::Local => Ok(Arc::new(LocalBackend::lazy_with_selection(
+            source,
+            Some(name.to_string()),
+        ))),
+        ProfileBackend::Cloud => Ok(Arc::new(
+            cloud_backend_from_profile_parts(name, profile)?
+                .with_selection(source, Some(name.to_string())),
+        )),
     }
 }
 
@@ -257,7 +289,8 @@ pub(crate) fn cloud_backend_from_profile(name: &str) -> MicrosandboxResult<Cloud
     let profile = cfg.profiles.get(name).ok_or_else(|| {
         MicrosandboxError::InvalidConfig(format!("profile {name:?} not found in SDK config"))
     })?;
-    cloud_backend_from_profile_parts(name, profile)
+    Ok(cloud_backend_from_profile_parts(name, profile)?
+        .with_selection(BackendSelectionSource::Profile, Some(name.to_string())))
 }
 
 fn cloud_backend_from_profile_parts(
@@ -387,6 +420,8 @@ fn sdk_config_path() -> PathBuf {
 mod tests {
     use super::*;
 
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn sdk_config_parses_minimal() {
         let json = r#"{
@@ -478,8 +513,10 @@ mod tests {
             url: None,
             api_key_ref: None,
         };
-        let b = backend_from_profile("local", &p).unwrap();
+        let b = backend_from_profile("local", &p, BackendSelectionSource::MsbProfile).unwrap();
         assert_eq!(b.kind(), super::super::BackendKind::Local);
+        assert_eq!(b.info().source, BackendSelectionSource::MsbProfile);
+        assert_eq!(b.info().profile.as_deref(), Some("local"));
     }
 
     #[test]
@@ -489,8 +526,10 @@ mod tests {
             url: Some("https://msb.example.com".into()),
             api_key_ref: Some("inline:msb_live_abc".into()),
         };
-        let b = backend_from_profile("prod", &p).unwrap();
+        let b = backend_from_profile("prod", &p, BackendSelectionSource::ActiveProfile).unwrap();
         assert_eq!(b.kind(), super::super::BackendKind::Cloud);
+        assert_eq!(b.info().source, BackendSelectionSource::ActiveProfile);
+        assert_eq!(b.info().profile.as_deref(), Some("prod"));
     }
 
     #[test]
@@ -599,6 +638,7 @@ mod tests {
 
     #[test]
     fn resolve_default_backend_honors_explicit_local_over_cloud_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::set_var("MSB_BACKEND", " local ");
             std::env::set_var("MSB_API_URL", "https://msb.example.com");
@@ -614,6 +654,30 @@ mod tests {
         }
 
         assert_eq!(b.kind(), super::super::BackendKind::Local);
+        assert_eq!(b.info().source, BackendSelectionSource::MsbBackend);
+    }
+
+    #[test]
+    fn explicit_cloud_without_credentials_fails_closed() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var("MSB_BACKEND", "cloud");
+            std::env::remove_var("MSB_API_KEY");
+            std::env::remove_var("MSB_PROFILE");
+            std::env::set_var("MSB_CONFIG_PATH", "/definitely/missing/msb-config.json");
+        }
+
+        let error = match resolve_default_backend() {
+            Ok(_) => panic!("explicit cloud selection must not fall back to local"),
+            Err(error) => error,
+        };
+
+        unsafe {
+            std::env::remove_var("MSB_BACKEND");
+            std::env::remove_var("MSB_CONFIG_PATH");
+        }
+
+        assert!(error.to_string().contains("MSB_BACKEND=cloud requires"));
     }
 
     #[test]
@@ -634,6 +698,6 @@ mod tests {
             url: Some("https://msb.example.com".into()),
             api_key_ref: None,
         };
-        assert!(backend_from_profile("prod", &p).is_err());
+        assert!(backend_from_profile("prod", &p, BackendSelectionSource::ActiveProfile).is_err());
     }
 }

--- a/sdk/rust/lib/backend/profile.rs
+++ b/sdk/rust/lib/backend/profile.rs
@@ -420,8 +420,6 @@ fn sdk_config_path() -> PathBuf {
 mod tests {
     use super::*;
 
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     #[test]
     fn sdk_config_parses_minimal() {
         let json = r#"{
@@ -474,6 +472,8 @@ mod tests {
 
     #[test]
     fn api_key_ref_env_when_set() {
+        let _env_guard = crate::test_support::lock_env();
+        // SAFETY: every environment-mutating SDK unit test holds the shared lock.
         unsafe { std::env::set_var("MSB_TEST_RESOLVE_API_KEY", " msb_test_xyz ") };
         let key = resolve_api_key_ref("p", "env:MSB_TEST_RESOLVE_API_KEY").unwrap();
         assert_eq!(key, "msb_test_xyz");
@@ -482,6 +482,8 @@ mod tests {
 
     #[test]
     fn api_key_ref_env_rejects_empty_value() {
+        let _env_guard = crate::test_support::lock_env();
+        // SAFETY: every environment-mutating SDK unit test holds the shared lock.
         unsafe { std::env::set_var("MSB_TEST_EMPTY_API_KEY", "   ") };
         assert!(resolve_api_key_ref("p", "env:MSB_TEST_EMPTY_API_KEY").is_err());
         unsafe { std::env::remove_var("MSB_TEST_EMPTY_API_KEY") };
@@ -489,6 +491,8 @@ mod tests {
 
     #[test]
     fn api_key_ref_env_missing() {
+        let _env_guard = crate::test_support::lock_env();
+        // SAFETY: every environment-mutating SDK unit test holds the shared lock.
         unsafe { std::env::remove_var("MSB_TEST_DEFINITELY_NOT_SET") };
         assert!(resolve_api_key_ref("p", "env:MSB_TEST_DEFINITELY_NOT_SET").is_err());
     }
@@ -638,7 +642,8 @@ mod tests {
 
     #[test]
     fn resolve_default_backend_honors_explicit_local_over_cloud_env() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _env_guard = crate::test_support::lock_env();
+        // SAFETY: every environment-mutating SDK unit test holds the shared lock.
         unsafe {
             std::env::set_var("MSB_BACKEND", " local ");
             std::env::set_var("MSB_API_URL", "https://msb.example.com");
@@ -659,7 +664,8 @@ mod tests {
 
     #[test]
     fn explicit_cloud_without_credentials_fails_closed() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _env_guard = crate::test_support::lock_env();
+        // SAFETY: every environment-mutating SDK unit test holds the shared lock.
         unsafe {
             std::env::set_var("MSB_BACKEND", "cloud");
             std::env::remove_var("MSB_API_KEY");

--- a/sdk/rust/lib/lib.rs
+++ b/sdk/rust/lib/lib.rs
@@ -4,6 +4,8 @@
 #![allow(clippy::module_inception)]
 
 mod error;
+#[cfg(test)]
+mod test_support;
 
 //--------------------------------------------------------------------------------------------------
 // Exports

--- a/sdk/rust/lib/lib.rs
+++ b/sdk/rust/lib/lib.rs
@@ -27,15 +27,16 @@ pub use agent::{
     RawFrame, StreamHandle,
 };
 pub use backend::{
-    Backend, BackendKind, CloudBackend, CloudBackendBuilder, CloudCreateSandboxRequest,
-    CloudCreateSandboxResponse, CloudErrorBody, CloudErrorDetails, CloudMessageResponse,
-    CloudPaginated, CloudSandboxStatus, CloudSandboxStatusReason, CloudVolumeKind,
-    CloudVolumeStatus, DEFAULT_CLOUD_API_URL, LocalBackend, LocalBackendBuilder, Profile,
-    ProfileBackend, SandboxBackend, SandboxCloudState, SandboxHandleCloudState, SandboxHandleInner,
-    SandboxHandleLocalState, SandboxInner, SandboxLocalState, SdkConfig, VolumeBackend,
-    VolumeCloudState, VolumeHandleCloudState, VolumeHandleInner, VolumeHandleLocalState,
-    VolumeInner, VolumeLocalState, default_backend, load_sdk_config, resolve_default_backend,
-    set_default_backend, swap_default_backend, with_backend,
+    Backend, BackendInfo, BackendKind, BackendSelectionSource, CloudBackend, CloudBackendBuilder,
+    CloudCreateSandboxRequest, CloudCreateSandboxResponse, CloudErrorBody, CloudErrorDetails,
+    CloudMessageResponse, CloudPaginated, CloudSandboxStatus, CloudSandboxStatusReason,
+    CloudVolumeKind, CloudVolumeStatus, DEFAULT_CLOUD_API_URL, LocalBackend, LocalBackendBuilder,
+    Profile, ProfileBackend, SandboxBackend, SandboxCloudState, SandboxHandleCloudState,
+    SandboxHandleInner, SandboxHandleLocalState, SandboxInner, SandboxLocalState, SdkConfig,
+    VolumeBackend, VolumeCloudState, VolumeHandleCloudState, VolumeHandleInner,
+    VolumeHandleLocalState, VolumeInner, VolumeLocalState, default_backend, default_backend_info,
+    load_sdk_config, resolve_default_backend, set_default_backend, swap_default_backend,
+    with_backend,
 };
 pub use config::set_sdk_libkrunfw_path as set_libkrunfw_path;
 pub use error::*;

--- a/sdk/rust/lib/sandbox/config.rs
+++ b/sdk/rust/lib/sandbox/config.rs
@@ -1638,8 +1638,8 @@ mod tests {
     #[cfg(feature = "net")]
     #[test]
     fn spawn_resolver_reads_source_from_host_env() {
-        // SAFETY: variable name is unique to this test, so no other test
-        // races on it.
+        let _env_guard = crate::test_support::lock_env();
+        // SAFETY: every environment-mutating SDK unit test holds the shared lock.
         unsafe { std::env::set_var("MSB_TEST_RESOLVE_SOURCE", SECRET_SENTINEL) };
 
         let config = config_with_source_secret(Some("MSB_TEST_RESOLVE_SOURCE"));
@@ -1653,7 +1653,6 @@ mod tests {
         let durable = config.local_network_config().unwrap();
         assert!(durable.secrets.secrets[0].value.is_empty());
 
-        // SAFETY: variable name is unique to this test.
         unsafe { std::env::remove_var("MSB_TEST_RESOLVE_SOURCE") };
     }
 

--- a/sdk/rust/lib/sandbox/modify.rs
+++ b/sdk/rust/lib/sandbox/modify.rs
@@ -3781,7 +3781,8 @@ mod tests {
         // The live control batch carries the value only for socket transport;
         // any Debug-logged form of the request shows [redacted] instead.
         let rotated_value = format!("{SECRET_SENTINEL}-rotated");
-        // SAFETY: unique variable name; no concurrent reader of this var.
+        let _env_guard = crate::test_support::lock_env();
+        // SAFETY: every environment-mutating SDK unit test holds the shared lock.
         unsafe { std::env::set_var("API_KEY_MODIFY_LEAK_TEST", &rotated_value) };
         let mut live_patch = patch.clone();
         live_patch.secrets[0].source = Some(SecretSource::Env {

--- a/sdk/rust/lib/test_support.rs
+++ b/sdk/rust/lib/test_support.rs
@@ -1,0 +1,19 @@
+//! Shared synchronization helpers for crate unit tests.
+
+use std::sync::{Mutex, MutexGuard};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Serializes process-global environment mutation across SDK unit tests.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Lock process-global environment mutation for the duration of a unit test.
+pub(crate) fn lock_env() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner())
+}


### PR DESCRIPTION
## TL;DR

- Expose secret-safe backend details in Rust, TypeScript, Python, and Go.
- Add per-sandbox backend kind accessors so retained objects reveal where they execute.
- Add `msb context` plus existing-style backend notices for create, remove, exec, and SSH.
- Make explicit invalid cloud CLI configuration fail closed instead of silently dispatching locally.

## Description

Applications can now inspect the resolved default backend, its cloud API URL, the selector that chose it, and its profile when applicable. The diagnostic shape never contains the API key.

```typescript
import { defaultBackendInfo } from "microsandbox";

console.log(defaultBackendInfo());
console.log(sandbox.backendKind);
```

```python
from microsandbox import default_backend_info

print(default_backend_info())
print(sandbox.backend_kind)
```

```rust
let info = microsandbox::default_backend_info();
println!("{}", info.kind.as_str());
println!("{}", sandbox.backend_kind().as_str());
```

```go
info, err := microsandbox.DefaultBackendInfo()
if err != nil {
    return err
}
fmt.Println(info.Kind)
fmt.Println(sandbox.BackendKind())
```

The CLI exposes the same information through its existing table UI, with structured output for automation:

```bash
msb context
msb ctx
msb context --format json
```

Create, remove, exec, and interactive SSH commands show a concise backend notice on stderr, preserving machine-readable stdout. `ssh authorize` is excluded because it does not open a sandbox session. The CLI resolves the backend once and fallibly before dispatch, so `MSB_BACKEND=cloud` without credentials or a cloud profile now reports a configuration error rather than falling back to local. SDK ambient fallback behavior remains unchanged for compatibility.

The Go FFI resolves the new global introspection symbol optionally, so a newer Go package can still load an older native bundle; calling the unavailable capability returns an explicit upgrade error.

## Test Plan

- [x] `cargo test -p microsandbox --lib backend::`
- [x] `cargo test -p microsandbox-cli context --lib --bin msb`
- [x] `cargo test -p microsandbox-cli --bin msb`
- [x] `cargo clippy -p microsandbox --lib -p microsandbox-cli --bin msb -- -D warnings`
- [x] `pnpm typecheck && pnpm test -- --run tests/unit/backend-info.test.ts`
- [x] `go test ./...`
- [x] Python native build, backend-info pytest, and Ruff validation
- [x] Manual local/cloud/JSON `msb context`, API-key redaction, and invalid-cloud fail-closed checks
- [x] Full repository pre-commit pipeline, including workspace and agentd Clippy, docs, CLI build, and Python checks
