### PR TITLE
feat(network): report policy denials to a host-side observer

### DIFF
--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -43,7 +43,7 @@ use super::common::config::NormalizedDnsConfig;
 use super::common::filter::{is_private_ipv4, is_private_ipv6};
 use super::common::transport::Transport;
 use super::nameserver::{read_host_dns_servers, resolve_nameservers};
-use crate::policy::{Action, DomainName, NetworkPolicy};
+use crate::policy::{Action, DomainName, NetworkPolicy, PolicyDenial};
 use crate::shared::{ResolvedHostnameFamily, SharedState};
 use crate::stack::GatewayIps;
 
@@ -184,6 +184,16 @@ impl DnsForwarder {
         // the DNS protocol/port.
         if decide_dns_action(&self.network_policy, &domain, transport).is_deny() {
             tracing::debug!(domain = %domain, "DNS query denied by network policy");
+            // Reported here rather than inside the policy evaluator: the
+            // DNS evaluators take no `SharedState`, and widening their
+            // public signatures would break consumers of this crate.
+            self.shared.report_policy_denial(|| {
+                PolicyDenial::to_domain(
+                    transport.policy_protocol(),
+                    domain.clone(),
+                    Some(transport.upstream_port()),
+                )
+            });
             // NXDOMAIN, not REFUSED: stub resolvers (e.g. glibc) don't
             // fail-fast on REFUSED, so a denied lookup hangs the guest in a
             // deny-by-default sandbox. NXDOMAIN is a synthetic negative that

--- a/crates/network/lib/policy/mod.rs
+++ b/crates/network/lib/policy/mod.rs
@@ -7,6 +7,7 @@
 mod builder;
 pub mod destination;
 mod name;
+mod observer;
 mod types;
 
 //--------------------------------------------------------------------------------------------------
@@ -16,4 +17,5 @@ mod types;
 pub use builder::{BuildError, NetworkPolicyBuilder, RuleBuilder, RuleDestinationBuilder};
 pub use destination::*;
 pub use name::{DomainName, DomainNameError};
+pub use observer::{DenialTarget, PolicyDenial, PolicyObserver};
 pub use types::*;

--- a/crates/network/lib/policy/observer.rs
+++ b/crates/network/lib/policy/observer.rs
@@ -1,0 +1,225 @@
+//! Host-side observation of network policy denials.
+//!
+//! Policy denials are decided deep inside the network stack and, before
+//! this module, were visible only as `tracing` records — and only on some
+//! paths. Embedding code that wants to react to a denial (surface it in a
+//! UI, offer a one-click allowlist entry, audit it) had no programmatic
+//! way to see one.
+//!
+//! A [`PolicyObserver`] is installed on the shared network state and is
+//! invoked from the evaluation choke points themselves rather than from
+//! individual call sites, so a new caller of the policy API cannot forget
+//! to report its denials.
+//!
+//! Observers run inline on the evaluation path. An implementation should
+//! hand the denial to a channel or counter and return; blocking here
+//! blocks guest traffic. Timestamps are left to the observer so the
+//! evaluation path does not read the clock on every denied packet.
+
+use std::net::IpAddr;
+
+use super::types::{Direction, Protocol};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// What the denied traffic was addressed to.
+///
+/// Address-based paths (TCP, UDP, ICMP, ingress) carry a resolved peer.
+/// A DNS query denied by name is refused before any address exists, so it
+/// carries the queried name instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DenialTarget {
+    /// Peer address the decision was evaluated against.
+    Address(IpAddr),
+
+    /// Queried name, for a DNS query denied before resolution.
+    Domain(String),
+}
+
+/// A single denial produced by the policy engine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyDenial {
+    /// Direction the denied traffic was travelling.
+    pub direction: Direction,
+
+    /// Protocol the decision was evaluated under.
+    pub protocol: Protocol,
+
+    /// Peer address, or queried name for a name-only DNS denial.
+    pub target: DenialTarget,
+
+    /// Guest-side port: destination port for egress, listening port for
+    /// ingress. `None` on paths without ports, such as ICMP.
+    pub port: Option<u16>,
+
+    /// Hostname the peer address is known by, when the resolved-hostname
+    /// index or the TLS handshake supplied one. `None` when the traffic
+    /// was addressed numerically.
+    pub hostname: Option<String>,
+}
+
+/// Host-side sink for policy denials.
+///
+/// Installed with `SharedState::set_policy_observer`. Implementations must
+/// be cheap and non-blocking; see the module documentation.
+pub trait PolicyObserver: Send + Sync {
+    /// Called once per denied evaluation.
+    fn on_denied(&self, denial: &PolicyDenial);
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl PolicyDenial {
+    /// Build a denial for traffic addressed to a peer address.
+    pub fn to_address(
+        direction: Direction,
+        protocol: Protocol,
+        addr: IpAddr,
+        port: Option<u16>,
+    ) -> Self {
+        Self {
+            direction,
+            protocol,
+            target: DenialTarget::Address(addr),
+            port,
+            hostname: None,
+        }
+    }
+
+    /// Build a denial for a DNS query refused before resolution.
+    pub fn to_domain(protocol: Protocol, domain: impl Into<String>, port: Option<u16>) -> Self {
+        Self {
+            direction: Direction::Egress,
+            protocol,
+            target: DenialTarget::Domain(domain.into()),
+            port,
+            hostname: None,
+        }
+    }
+
+    /// Attach the hostname the peer address is known by.
+    pub fn with_hostname(mut self, hostname: Option<String>) -> Self {
+        self.hostname = hostname;
+        self
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddr};
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::policy::{Action, NetworkPolicy};
+    use crate::shared::SharedState;
+
+    /// Observer that records every denial handed to it.
+    #[derive(Default)]
+    struct Recorder {
+        denials: Mutex<Vec<PolicyDenial>>,
+    }
+
+    impl PolicyObserver for Recorder {
+        fn on_denied(&self, denial: &PolicyDenial) {
+            self.denials.lock().unwrap().push(denial.clone());
+        }
+    }
+
+    impl Recorder {
+        fn install(shared: &SharedState) -> Arc<Self> {
+            let recorder = Arc::new(Self::default());
+            shared.set_policy_observer(recorder.clone());
+            recorder
+        }
+
+        fn taken(&self) -> Vec<PolicyDenial> {
+            std::mem::take(&mut *self.denials.lock().unwrap())
+        }
+    }
+
+    fn dst(port: u16) -> SocketAddr {
+        SocketAddr::from((Ipv4Addr::new(1, 2, 3, 4), port))
+    }
+
+    #[test]
+    fn denied_egress_is_reported_with_destination_and_port() {
+        let shared = SharedState::new(4);
+        let recorder = Recorder::install(&shared);
+
+        let action = NetworkPolicy::none().evaluate_egress(dst(443), Protocol::Tcp, &shared);
+
+        assert_eq!(action, Action::Deny);
+        let denials = recorder.taken();
+        assert_eq!(denials.len(), 1);
+        assert_eq!(denials[0].direction, Direction::Egress);
+        assert_eq!(denials[0].protocol, Protocol::Tcp);
+        assert_eq!(
+            denials[0].target,
+            DenialTarget::Address(Ipv4Addr::new(1, 2, 3, 4).into())
+        );
+        assert_eq!(denials[0].port, Some(443));
+        assert_eq!(denials[0].hostname, None);
+    }
+
+    #[test]
+    fn allowed_egress_reports_nothing() {
+        let shared = SharedState::new(4);
+        let recorder = Recorder::install(&shared);
+
+        let action = NetworkPolicy::allow_all().evaluate_egress(dst(443), Protocol::Tcp, &shared);
+
+        assert_eq!(action, Action::Allow);
+        assert!(recorder.taken().is_empty());
+    }
+
+    #[test]
+    fn denied_egress_without_port_reports_none() {
+        // The ICMP path evaluates an address with no port at all.
+        let shared = SharedState::new(4);
+        let recorder = Recorder::install(&shared);
+
+        let action = NetworkPolicy::none().evaluate_egress_ip(
+            Ipv4Addr::new(1, 2, 3, 4).into(),
+            Protocol::Icmpv4,
+            &shared,
+        );
+
+        assert_eq!(action, Action::Deny);
+        let denials = recorder.taken();
+        assert_eq!(denials.len(), 1);
+        assert_eq!(denials[0].port, None);
+        assert_eq!(denials[0].protocol, Protocol::Icmpv4);
+    }
+
+    #[test]
+    fn denied_ingress_reports_the_guest_listening_port() {
+        let shared = SharedState::new(4);
+        let recorder = Recorder::install(&shared);
+
+        let action =
+            NetworkPolicy::none().evaluate_ingress(dst(51234), 8080, Protocol::Tcp, &shared);
+
+        assert_eq!(action, Action::Deny);
+        let denials = recorder.taken();
+        assert_eq!(denials.len(), 1);
+        assert_eq!(denials[0].direction, Direction::Ingress);
+        assert_eq!(denials[0].port, Some(8080));
+    }
+
+    #[test]
+    fn denial_without_an_observer_is_a_no_op() {
+        let shared = SharedState::new(4);
+
+        let action = NetworkPolicy::none().evaluate_egress(dst(443), Protocol::Tcp, &shared);
+
+        assert_eq!(action, Action::Deny);
+    }
+}

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -28,6 +28,7 @@ use crate::shared::SharedState;
 
 use super::destination::{matches_cidr, matches_group};
 use super::name::{DomainName, DomainNameError};
+use super::observer::PolicyDenial;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -407,7 +408,33 @@ impl NetworkPolicy {
 
     /// Shared rule walk for the egress public methods. `port = None`
     /// is the ICMP path; rules with a port filter are skipped there.
+    ///
+    /// Every egress denial is reported to the installed
+    /// [`PolicyObserver`](super::PolicyObserver) here rather than at the
+    /// call sites, so a new caller of the egress API cannot omit it.
     fn egress_walk(
+        &self,
+        addr: IpAddr,
+        port: Option<u16>,
+        protocol: Protocol,
+        shared: &SharedState,
+        source: HostnameSource<'_>,
+    ) -> EgressEvaluation {
+        let evaluation = self.egress_walk_inner(addr, port, protocol, shared, source);
+
+        if evaluation == EgressEvaluation::Deny {
+            shared.report_policy_denial(|| {
+                PolicyDenial::to_address(Direction::Egress, protocol, addr, port)
+                    .with_hostname(denied_hostname(addr, shared, source))
+            });
+        }
+
+        evaluation
+    }
+
+    /// Rule walk proper. Split from [`Self::egress_walk`] so the denial
+    /// report has a single exit point to observe.
+    fn egress_walk_inner(
         &self,
         addr: IpAddr,
         port: Option<u16>,
@@ -454,6 +481,31 @@ impl NetworkPolicy {
     /// `ports` filter is matched against `guest_port`, not the peer's
     /// port.
     pub fn evaluate_ingress(
+        &self,
+        peer: SocketAddr,
+        guest_port: u16,
+        protocol: Protocol,
+        shared: &SharedState,
+    ) -> Action {
+        let action = self.ingress_walk(peer, guest_port, protocol, shared);
+
+        if action == Action::Deny {
+            shared.report_policy_denial(|| {
+                PolicyDenial::to_address(Direction::Ingress, protocol, peer.ip(), Some(guest_port))
+                    .with_hostname(denied_hostname(
+                        peer.ip(),
+                        shared,
+                        HostnameSource::CacheOnly,
+                    ))
+            });
+        }
+
+        action
+    }
+
+    /// Rule walk proper. Split from [`Self::evaluate_ingress`] so the
+    /// denial report has a single exit point to observe.
+    fn ingress_walk(
         &self,
         peer: SocketAddr,
         guest_port: u16,
@@ -780,6 +832,30 @@ impl PortRange {
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
+
+/// Best-effort hostname for a denied peer address.
+///
+/// A TLS handshake supplies the name the decision was actually made
+/// against, so it wins. Otherwise the resolved-hostname index is consulted
+/// for a name the guest recently looked up for this address; a numeric
+/// destination has neither and yields `None`.
+fn denied_hostname(
+    addr: IpAddr,
+    shared: &SharedState,
+    source: HostnameSource<'_>,
+) -> Option<String> {
+    if let HostnameSource::Sni(name) = source {
+        return Some(name.to_owned());
+    }
+
+    let mut hostname = None;
+    shared.any_resolved_hostname(addr, |name| {
+        hostname = Some(name.to_owned());
+        true
+    });
+
+    hostname
+}
 
 fn rule_matches_protocol_and_port(rule: &Rule, protocol: Protocol, port: u16) -> bool {
     if !rule.protocols.is_empty() && !rule.protocols.contains(&protocol) {

--- a/crates/network/lib/shared.rs
+++ b/crates/network/lib/shared.rs
@@ -17,6 +17,7 @@ pub use microsandbox_utils::wake_pipe::WakePipe;
 use parking_lot::RwLock;
 
 use crate::addr::normalize_ip_addr;
+use crate::policy::{PolicyDenial, PolicyObserver};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -65,6 +66,9 @@ pub struct SharedState {
 
     /// Optional host-side termination hook used for fatal policy violations.
     termination_hook: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
+
+    /// Optional host-side observer notified of every policy denial.
+    policy_observer: Mutex<Option<Arc<dyn PolicyObserver>>>,
 
     /// Resolved hostname index used to map destination IPs back to queried hostnames.
     resolved_hostnames: RwLock<TtlReverseIndex<ResolvedHostnameKey, IpAddr>>,
@@ -118,6 +122,7 @@ impl SharedState {
             tx_wake: WakePipe::new(),
             proxy_wake: WakePipe::new(),
             termination_hook: Mutex::new(None),
+            policy_observer: Mutex::new(None),
             resolved_hostnames: RwLock::new(TtlReverseIndex::default()),
             gateway_ipv4: OnceLock::new(),
             gateway_ipv6: OnceLock::new(),
@@ -156,6 +161,25 @@ impl SharedState {
         let hook = self.termination_hook.lock().unwrap().clone();
         if let Some(hook) = hook {
             hook();
+        }
+    }
+
+    /// Install a host-side observer for policy denials.
+    pub fn set_policy_observer(&self, observer: Arc<dyn PolicyObserver>) {
+        *self.policy_observer.lock().unwrap() = Some(observer);
+    }
+
+    /// Report a policy denial to the installed observer, if any.
+    ///
+    /// Called from the policy evaluation choke points. The denial is built
+    /// lazily so no allocation happens when no observer is installed.
+    pub fn report_policy_denial<F>(&self, denial: F)
+    where
+        F: FnOnce() -> PolicyDenial,
+    {
+        let observer = self.policy_observer.lock().unwrap().clone();
+        if let Some(observer) = observer {
+            observer.on_denied(&denial());
         }
     }
 


### PR DESCRIPTION
## TL;DR

Closes #691. Adds a `PolicyObserver` on `SharedState` so embedding code can see every network policy denial, reported from the evaluation chokepoints rather than the call sites.

## Description

- While reading the deny paths for #691 I found the reporting is uneven: the policy decision is reached from eight call sites, and only three of them emit anything (`icmp_relay.rs`, `dns/forwarder.rs`, `publisher.rs`). The TCP proxy and the TLS proxy refuse silently. Nothing is exposed to host-side code on any path.
- New `crates/network/lib/policy/observer.rs`: `PolicyDenial` with a `DenialTarget` that separates a resolved peer address from a DNS name refused before resolution, plus the `PolicyObserver` trait.
- `SharedState` gains `policy_observer` next to the existing `termination_hook`, with `set_policy_observer` and `report_policy_denial`. `SharedState` is already threaded through every evaluator, so no evaluator signature changes.
- The report sits at the chokepoints: `egress_walk` and the ingress rule walk were each split so the denial has a single exit point to observe. A new caller of the egress or ingress API cannot forget to report.
- DNS reports from `dns/forwarder.rs` instead, because `evaluate_dns_query` and `evaluate_dns_query_without_name` take no `SharedState` and widening those public signatures would be a breaking change. The reason is written next to the call.
- The denial is built lazily via `FnOnce`, so nothing is allocated when no observer is installed.
- Hostname comes from the TLS `HostnameSource::Sni` when the decision used it, otherwise from the resolved-hostname index. No new public accessor was added for that.

The event shape covers what #691 asked for, minus the timestamp: the observer stamps it, so the evaluation path does not read the clock per denied packet. Happy to add it to the struct instead if you prefer.

## Test Plan

New tests in `policy/observer.rs`, five cases: a denied egress reports destination and port, an allowed egress reports nothing, the portless ICMP path reports `None`, a denied ingress reports the guest listening port, and a denial with no observer installed is a no-op.

```
cargo test -p microsandbox-network --lib policy::observer
    5 passed; 0 failed

cargo test -p microsandbox-network --lib policy::
    124 passed; 0 failed

cargo fmt --all -- --check     clean
cargo clippy -p microsandbox-network --all-targets -- -D warnings     clean
```

Not run: the workspace-wide `cargo test --workspace` and the integration tests that need a VM.

AI usage: the implementation was written with an AI assistant. I read and own every line, and the design decisions above (chokepoint over call site, observer on `SharedState` rather than on the serde-serialized `NetworkPolicy`, DNS reported at the forwarder to avoid a breaking signature change) are mine.