### PR TITLE
fix(network): handle additional half-close races

### DIFF
--- a/crates/network/lib/conn.rs
+++ b/crates/network/lib/conn.rs
@@ -396,7 +396,10 @@ impl ConnectionTracker {
             }
 
             let socket = sockets.get::<tcp::Socket>(handle);
-            if socket.state() == tcp::State::Established {
+            if matches!(
+                socket.state(),
+                tcp::State::Established | tcp::State::CloseWait
+            ) {
                 conn.proxy_spawned = true;
 
                 if let Some(channels) = conn.proxy_channels.take() {

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -533,6 +533,39 @@ impl DnsForwarder {
         handle.changed().await.ok()?;
         handle.borrow().clone()
     }
+
+    /// Build a forwarder for proxy tests whose queries are handled locally.
+    #[cfg(test)]
+    pub(crate) async fn for_proxy_test(shared: Arc<SharedState>, gateway: GatewayIps) -> Arc<Self> {
+        let config = Arc::new(NormalizedDnsConfig::from_config(
+            crate::config::DnsConfig::default(),
+        ));
+        let upstream = SocketAddr::from(([127, 0, 0, 1], 9));
+        let udp = build_udp_client(upstream, config.query_timeout)
+            .await
+            .expect("test UDP client should initialize");
+        let gateway_ips = Arc::new(
+            gateway
+                .ipv4
+                .map(IpAddr::V4)
+                .into_iter()
+                .chain(gateway.ipv6.map(IpAddr::V6))
+                .collect(),
+        );
+
+        Arc::new(Self {
+            configured: vec![ConfiguredUpstream {
+                addr: upstream,
+                udp,
+                tcp: OnceCell::new(),
+            }],
+            gateway_ips,
+            network_policy: Arc::new(NetworkPolicy::allow_all()),
+            shared,
+            gateway,
+            config,
+        })
+    }
 }
 
 /// Return whether a private/reserved DNS answer was explicitly made reachable.

--- a/crates/network/lib/dns/proxies/dot.rs
+++ b/crates/network/lib/dns/proxies/dot.rs
@@ -246,7 +246,7 @@ impl DotProxy {
                             self.drain_plaintext()?;
                             self.dispatch_ready_queries(&resp_tx);
                         }
-                        Ok(None) => return Ok(()),
+                        Ok(None) => break,
                         Err(_) => {
                             tracing::debug!(dst = %self.dst, "DoT: idle timeout, closing connection");
                             return Ok(());
@@ -261,6 +261,17 @@ impl DotProxy {
                 }
             }
         }
+
+        // Stop accepting queries from the guest. Dropping the root sender lets
+        // `resp_rx` close after all in-flight tasks drop their cloned senders.
+        drop(resp_tx);
+        while let Some(response) = resp_rx.recv().await {
+            self.write_plaintext(&frame(&response))?;
+            self.flush_to_guest().await?;
+        }
+
+        self.guest_tls.send_close_notify();
+        self.flush_to_guest().await
     }
 
     /// Drain all complete DNS frames from the plaintext buffer and
@@ -397,4 +408,138 @@ fn is_complete_client_hello(buf: &[u8]) -> bool {
     }
     let record_len = u16::from_be_bytes([buf[3], buf[4]]) as usize;
     buf.len() >= 5 + record_len
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use hickory_net::proto::op::{Message, MessageType, OpCode, Query};
+    use hickory_net::proto::rr::{Name, RecordType};
+    use hickory_net::proto::serialize::binary::{BinDecodable, BinEncodable};
+    use rustls::pki_types::ServerName;
+
+    use super::*;
+    use crate::dns::forwarder::DnsForwarder;
+    use crate::stack::GatewayIps;
+    use crate::tls::ca::CertAuthority;
+    use crate::tls::certgen::generate_domain_cert;
+
+    const TEST_DOMAIN: &str = "dns.test";
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn guest_eof_preserves_pending_response() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let shared = Arc::new(SharedState::new(8));
+        let gateway = GatewayIps {
+            ipv4: Some("100.96.0.1".parse().unwrap()),
+            ipv6: None,
+        };
+        let forwarder = DnsForwarder::for_proxy_test(shared.clone(), gateway).await;
+        let (guest_tls, mut client_tls) = connected_tls_pair();
+        let (from_guest_tx, from_smoltcp) = mpsc::channel(1);
+        let (to_smoltcp, mut to_guest_rx) = mpsc::channel(8);
+
+        let mut query = Message::new(0x4242, MessageType::Query, OpCode::Query);
+        query.metadata.recursion_desired = true;
+        query.add_query(Query::query(
+            Name::from_ascii(crate::HOST_ALIAS).unwrap(),
+            RecordType::A,
+        ));
+
+        let mut proxy = DotProxy {
+            guest_tls,
+            from_smoltcp,
+            to_smoltcp,
+            plaintext_buf: frame(&query.to_bytes().unwrap()),
+            tls_out_buf: Vec::with_capacity(CLIENT_HELLO_BUF_SIZE),
+            shared,
+            dst: SocketAddr::from(([100, 96, 0, 1], 853)),
+            sni: TEST_DOMAIN.to_string(),
+            forwarder,
+        };
+
+        // The guest half-closes after its complete query. On a current-thread
+        // runtime, the spawned forwarder cannot run until dispatch_loop yields.
+        drop(from_guest_tx);
+        proxy.dispatch_loop().await.unwrap();
+
+        let mut encrypted = Vec::new();
+        while let Ok(chunk) = to_guest_rx.try_recv() {
+            encrypted.extend_from_slice(&chunk);
+        }
+        assert!(
+            !encrypted.is_empty(),
+            "pending DoT response must survive guest EOF",
+        );
+
+        let mut encrypted = encrypted.as_slice();
+        while !encrypted.is_empty() {
+            client_tls.read_tls(&mut encrypted).unwrap();
+            client_tls.process_new_packets().unwrap();
+        }
+
+        let mut plaintext = Vec::new();
+        loop {
+            let mut buf = [0u8; 4096];
+            match client_tls.reader().read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => plaintext.extend_from_slice(&buf[..n]),
+                Err(ref error) if error.kind() == io::ErrorKind::WouldBlock => break,
+                Err(error) => panic!("failed to read DoT response: {error}"),
+            }
+        }
+        let response = take_message(&mut plaintext).expect("framed DoT response");
+        let response = Message::from_bytes(&response).expect("valid DNS response");
+        assert_eq!(response.metadata.id, 0x4242);
+        assert_eq!(response.answers.len(), 1);
+    }
+
+    fn connected_tls_pair() -> (rustls::ServerConnection, rustls::ClientConnection) {
+        let ca = CertAuthority::generate();
+        let domain_cert = generate_domain_cert(TEST_DOMAIN, &ca, 1).unwrap();
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(ca.cert_der.clone()).unwrap();
+        let client_config = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        let mut client = rustls::ClientConnection::new(
+            Arc::new(client_config),
+            ServerName::try_from(TEST_DOMAIN.to_string()).unwrap(),
+        )
+        .unwrap();
+        let mut server = rustls::ServerConnection::new(domain_cert.server_config.clone()).unwrap();
+
+        for _ in 0..8 {
+            let mut client_bytes = Vec::new();
+            while client.wants_write() {
+                client.write_tls(&mut client_bytes).unwrap();
+            }
+            if !client_bytes.is_empty() {
+                server.read_tls(&mut client_bytes.as_slice()).unwrap();
+                server.process_new_packets().unwrap();
+            }
+
+            let mut server_bytes = Vec::new();
+            while server.wants_write() {
+                server.write_tls(&mut server_bytes).unwrap();
+            }
+            if !server_bytes.is_empty() {
+                client.read_tls(&mut server_bytes.as_slice()).unwrap();
+                client.process_new_packets().unwrap();
+            }
+
+            if !client.is_handshaking()
+                && !server.is_handshaking()
+                && !client.wants_write()
+                && !server.wants_write()
+            {
+                return (server, client);
+            }
+        }
+
+        panic!("TLS handshake did not complete");
+    }
 }

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -1732,8 +1732,8 @@ mod tests {
     }
 
     /// Drive guest→server handshake to ESTABLISHED, returning (server_isn,
-    /// guest_seq_after_handshake) and the spawned NewConnection channels.
-    fn establish(
+    /// guest_seq_after_handshake).
+    fn handshake(
         tracker: &mut ConnectionTracker,
         device: &mut SmoltcpDevice,
         iface: &mut Interface,
@@ -1741,7 +1741,7 @@ mod tests {
         shared: &Arc<SharedState>,
         now: Instant,
         guest_port: u16,
-    ) -> (i32, i32, Vec<crate::conn::NewConnection>) {
+    ) -> (i32, i32) {
         let src = SocketAddr::new(Ipv4Addr::from(GUEST_IP).into(), guest_port);
         let dst = SocketAddr::new(Ipv4Addr::from(SERVER_IP).into(), 443);
 
@@ -1800,7 +1800,23 @@ mod tests {
             "socket should be ESTABLISHED after handshake",
         );
 
-        // 3) Poll loop detects the established connection and spawns a proxy.
+        (server_isn, guest_isn + 1)
+    }
+
+    /// Complete a guest→server handshake and hand the connection to a proxy.
+    fn establish(
+        tracker: &mut ConnectionTracker,
+        device: &mut SmoltcpDevice,
+        iface: &mut Interface,
+        sockets: &mut SocketSet<'_>,
+        shared: &Arc<SharedState>,
+        now: Instant,
+        guest_port: u16,
+    ) -> (i32, i32, Vec<crate::conn::NewConnection>) {
+        let (server_isn, guest_seq) =
+            handshake(tracker, device, iface, sockets, shared, now, guest_port);
+
+        // Poll loop detects the established connection and spawns a proxy.
         let new_conns = tracker.take_new_connections(sockets);
         assert_eq!(
             new_conns.len(),
@@ -1808,7 +1824,7 @@ mod tests {
             "one new connection should be handed off"
         );
 
-        (server_isn, guest_isn + 1, new_conns)
+        (server_isn, guest_seq, new_conns)
     }
 
     #[test]
@@ -2092,6 +2108,58 @@ mod tests {
         assert!(
             !tracker.create_tcp_socket(src, dst, &mut sockets),
             "creation at the limit must be refused",
+        );
+    }
+
+    #[test]
+    fn guest_fin_before_proxy_spawn_is_handed_off() {
+        let shared = Arc::new(SharedState::new(64));
+        let poll_config = leak_poll_config();
+        let mut device = SmoltcpDevice::new(shared.clone(), poll_config.mtu);
+        let mut iface = create_interface(&mut device, &poll_config);
+        let mut sockets = SocketSet::new(vec![]);
+        let mut tracker = ConnectionTracker::new(None);
+        let now = smoltcp_now();
+        let guest_port = 54323;
+        let (server_isn, guest_seq) = handshake(
+            &mut tracker,
+            &mut device,
+            &mut iface,
+            &mut sockets,
+            &shared,
+            now,
+            guest_port,
+        );
+
+        // The production poll loop drains every queued guest frame before
+        // taking new connections, so the FIN can be processed before the
+        // proxy task is spawned.
+        ingress(
+            build_tcp_frame(
+                guest_port,
+                443,
+                TcpControl::Fin,
+                guest_seq,
+                Some(server_isn + 1),
+                &[],
+            ),
+            &mut device,
+            &mut iface,
+            &mut sockets,
+            &shared,
+            now,
+        );
+        assert_eq!(
+            only_tcp_state(&sockets),
+            Some(tcp::State::CloseWait),
+            "guest FIN should arrive before the proxy handoff",
+        );
+
+        let new_conns = tracker.take_new_connections(&mut sockets);
+        assert_eq!(
+            new_conns.len(),
+            1,
+            "a connection that reached CLOSE_WAIT still needs a proxy task",
         );
     }
 }


### PR DESCRIPTION
## TL;DR

Builds on #1181 with two additional half-close improvements.

## Description

- Hand off connections that reach `CLOSE_WAIT` before proxy spawn.
- Preserve pending DoT responses after guest EOF.
- Add regression coverage for both orderings.

## Test Plan

- `cargo test -p microsandbox-network --lib`
- Repository pre-commit hooks
