### PR TITLE
feat(network): add port-scoped Rule constructors

### DIFF
--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -109,7 +109,8 @@ pub struct Rule {
     pub protocols: Vec<Protocol>,
 
     /// Port-range set (empty = any port). Always the guest-side port:
-    /// destination port for egress, listening port for ingress.
+    /// destination port for egress, listening port for ingress. A
+    /// non-empty set also excludes ICMP, which carries no ports.
     #[serde(default)]
     pub ports: Vec<PortRange>,
 
@@ -676,42 +677,115 @@ impl Default for NetworkPolicy {
 }
 
 impl Rule {
-    /// Convenience: allow rule for egress, any protocol, any port.
+    /// Convenience: allow rule for egress, any protocol, **every port**.
+    /// See [`Self::allow_egress_ports`] to scope it to specific ports.
     pub fn allow_egress(destination: Destination) -> Self {
         Self::new(Direction::Egress, destination, Action::Allow)
     }
 
-    /// Convenience: deny rule for egress, any protocol, any port.
+    /// Convenience: deny rule for egress, any protocol, **every port**.
+    /// See [`Self::deny_egress_ports`] to scope it to specific ports.
     pub fn deny_egress(destination: Destination) -> Self {
         Self::new(Direction::Egress, destination, Action::Deny)
     }
 
-    /// Convenience: allow rule for ingress, any protocol, any port.
+    /// Convenience: allow rule for ingress, any protocol, **every port**.
+    /// See [`Self::allow_ingress_ports`] to scope it to specific ports.
     pub fn allow_ingress(destination: Destination) -> Self {
         Self::new(Direction::Ingress, destination, Action::Allow)
     }
 
-    /// Convenience: deny rule for ingress, any protocol, any port.
+    /// Convenience: deny rule for ingress, any protocol, **every port**.
+    /// See [`Self::deny_ingress_ports`] to scope it to specific ports.
     pub fn deny_ingress(destination: Destination) -> Self {
         Self::new(Direction::Ingress, destination, Action::Deny)
     }
 
-    /// Convenience: allow rule for either direction, any protocol, any port.
+    /// Convenience: allow rule for either direction, any protocol,
+    /// **every port**. See [`Self::allow_any_ports`] to scope it to specific ports.
     pub fn allow_any(destination: Destination) -> Self {
         Self::new(Direction::Any, destination, Action::Allow)
     }
 
-    /// Convenience: deny rule for either direction, any protocol, any port.
+    /// Convenience: deny rule for either direction, any protocol,
+    /// **every port**. See [`Self::deny_any_ports`] to scope it to specific ports.
     pub fn deny_any(destination: Destination) -> Self {
         Self::new(Direction::Any, destination, Action::Deny)
     }
 
+    /// Allow rule for egress, any protocol, restricted to `ports`.
+    /// Empty `ports` matches every port, as in [`Self::allow_egress`].
+    pub fn allow_egress_ports<I>(destination: Destination, ports: I) -> Self
+    where
+        I: IntoIterator<Item = PortRange>,
+    {
+        Self::with_ports(Direction::Egress, destination, Action::Allow, ports)
+    }
+
+    /// Deny rule for egress, any protocol, restricted to `ports`.
+    /// Empty `ports` matches every port, as in [`Self::deny_egress`].
+    pub fn deny_egress_ports<I>(destination: Destination, ports: I) -> Self
+    where
+        I: IntoIterator<Item = PortRange>,
+    {
+        Self::with_ports(Direction::Egress, destination, Action::Deny, ports)
+    }
+
+    /// Allow rule for ingress, any protocol, restricted to `ports` — the
+    /// guest-side listening ports, never the peer's source port. Empty
+    /// `ports` matches every port, as in [`Self::allow_ingress`].
+    pub fn allow_ingress_ports<I>(destination: Destination, ports: I) -> Self
+    where
+        I: IntoIterator<Item = PortRange>,
+    {
+        Self::with_ports(Direction::Ingress, destination, Action::Allow, ports)
+    }
+
+    /// Deny rule for ingress, any protocol, restricted to `ports`.
+    /// Empty `ports` matches every port, as in [`Self::deny_ingress`].
+    pub fn deny_ingress_ports<I>(destination: Destination, ports: I) -> Self
+    where
+        I: IntoIterator<Item = PortRange>,
+    {
+        Self::with_ports(Direction::Ingress, destination, Action::Deny, ports)
+    }
+
+    /// Allow rule for either direction, any protocol, restricted to
+    /// `ports`. Empty `ports` matches every port, as in [`Self::allow_any`].
+    pub fn allow_any_ports<I>(destination: Destination, ports: I) -> Self
+    where
+        I: IntoIterator<Item = PortRange>,
+    {
+        Self::with_ports(Direction::Any, destination, Action::Allow, ports)
+    }
+
+    /// Deny rule for either direction, any protocol, restricted to
+    /// `ports`. Empty `ports` matches every port, as in [`Self::deny_any`].
+    pub fn deny_any_ports<I>(destination: Destination, ports: I) -> Self
+    where
+        I: IntoIterator<Item = PortRange>,
+    {
+        Self::with_ports(Direction::Any, destination, Action::Deny, ports)
+    }
+
     fn new(direction: Direction, destination: Destination, action: Action) -> Self {
+        Self::with_ports(direction, destination, action, std::iter::empty())
+    }
+
+    fn with_ports<I>(
+        direction: Direction,
+        destination: Destination,
+        action: Action,
+        ports: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = PortRange>,
+    {
         Self {
             direction,
             destination,
             protocols: Vec::new(),
-            ports: Vec::new(),
+            ports: ports.into_iter().collect(),
             action,
         }
     }
@@ -1056,6 +1130,126 @@ mod tests {
             deny.destination,
             Destination::Group(DestinationGroup::Host)
         ));
+    }
+
+    #[test]
+    fn port_scoped_constructors_set_direction_action_and_ports() {
+        let dest = || Destination::Group(DestinationGroup::Host);
+        let ports = [PortRange::single(8080), PortRange::range(9000, 9100)];
+
+        let cases: [(Rule, Direction, Action); 6] = [
+            (
+                Rule::allow_egress_ports(dest(), ports),
+                Direction::Egress,
+                Action::Allow,
+            ),
+            (
+                Rule::deny_egress_ports(dest(), ports),
+                Direction::Egress,
+                Action::Deny,
+            ),
+            (
+                Rule::allow_ingress_ports(dest(), ports),
+                Direction::Ingress,
+                Action::Allow,
+            ),
+            (
+                Rule::deny_ingress_ports(dest(), ports),
+                Direction::Ingress,
+                Action::Deny,
+            ),
+            (
+                Rule::allow_any_ports(dest(), ports),
+                Direction::Any,
+                Action::Allow,
+            ),
+            (
+                Rule::deny_any_ports(dest(), ports),
+                Direction::Any,
+                Action::Deny,
+            ),
+        ];
+
+        for (rule, direction, action) in cases {
+            assert_eq!(rule.direction, direction);
+            assert_eq!(rule.action, action);
+            assert_eq!(rule.ports, ports);
+            assert!(rule.protocols.is_empty());
+            assert!(matches!(
+                rule.destination,
+                Destination::Group(DestinationGroup::Host)
+            ));
+        }
+    }
+
+    #[test]
+    fn port_scoped_constructors_with_no_ports_match_the_all_ports_constructors() {
+        let dest = || Destination::Group(DestinationGroup::Public);
+        let pairs = [
+            (
+                Rule::allow_egress_ports(dest(), []),
+                Rule::allow_egress(dest()),
+            ),
+            (
+                Rule::deny_egress_ports(dest(), []),
+                Rule::deny_egress(dest()),
+            ),
+            (
+                Rule::allow_ingress_ports(dest(), []),
+                Rule::allow_ingress(dest()),
+            ),
+            (
+                Rule::deny_ingress_ports(dest(), []),
+                Rule::deny_ingress(dest()),
+            ),
+            (Rule::allow_any_ports(dest(), []), Rule::allow_any(dest())),
+            (Rule::deny_any_ports(dest(), []), Rule::deny_any(dest())),
+        ];
+
+        for (scoped, unscoped) in pairs {
+            assert_eq!(scoped.direction, unscoped.direction);
+            assert_eq!(scoped.action, unscoped.action);
+            assert_eq!(scoped.protocols, unscoped.protocols);
+            assert_eq!(scoped.ports, unscoped.ports);
+            assert!(scoped.ports.is_empty());
+        }
+    }
+
+    #[test]
+    fn port_scoped_host_rule_grants_only_the_named_service() {
+        let (shared, gw4, _) = shared_with_gateway();
+        let host = || Destination::Group(DestinationGroup::Host);
+        let forward_server = SocketAddr::new(IpAddr::V4(gw4), 8080);
+        let ssh = SocketAddr::new(IpAddr::V4(gw4), 22);
+
+        let all_ports = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::allow_egress(host())],
+        };
+        assert!(
+            all_ports
+                .evaluate_egress(ssh, Protocol::Tcp, &shared)
+                .is_allow(),
+            "the all-ports constructor reaches every host port"
+        );
+
+        let scoped = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::allow_egress_ports(host(), [PortRange::single(8080)])],
+        };
+        assert!(
+            scoped
+                .evaluate_egress(forward_server, Protocol::Tcp, &shared)
+                .is_allow()
+        );
+        assert!(
+            scoped
+                .evaluate_egress(ssh, Protocol::Tcp, &shared)
+                .is_deny(),
+            "ports outside the scoped set fall through to default_egress"
+        );
     }
 
     /// Outbound TCP/443 allow rule pinned to a specific hostname,

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -1186,18 +1186,38 @@ A single policy rule. The `destination` interpretation is direction-dependent: e
 | ports | `Vec<`[`PortRange`](#portrange)`>` | Set semantics; empty = any port |
 | action | [`Action`](#action) | What to do on match |
 
-Convenience constructors build any-protocol, any-port rules:
+Convenience constructors build any-protocol, **any-port** rules — they leave `ports` empty, which matches every port. `Rule::allow_egress(Destination::Group(DestinationGroup::Host))` grants the guest every host port, not just the one service it needs. Reach for the `_ports` variants below when you mean a specific service.
 
 | Method | Description |
 |--------|-------------|
-| `Rule::allow_egress(destination)` | Allow rule, direction `Egress` |
-| `Rule::deny_egress(destination)` | Deny rule, direction `Egress` |
-| `Rule::allow_ingress(destination)` | Allow rule, direction `Ingress` |
-| `Rule::deny_ingress(destination)` | Deny rule, direction `Ingress` |
-| `Rule::allow_any(destination)` | Allow rule, direction `Any` |
-| `Rule::deny_any(destination)` | Deny rule, direction `Any` |
+| `Rule::allow_egress(destination)` | Allow rule, direction `Egress`, all ports |
+| `Rule::deny_egress(destination)` | Deny rule, direction `Egress`, all ports |
+| `Rule::allow_ingress(destination)` | Allow rule, direction `Ingress`, all ports |
+| `Rule::deny_ingress(destination)` | Deny rule, direction `Ingress`, all ports |
+| `Rule::allow_any(destination)` | Allow rule, direction `Any`, all ports |
+| `Rule::deny_any(destination)` | Deny rule, direction `Any`, all ports |
 | `Rule::allow_dns()` | Allow plain DNS (UDP/53 + TCP/53) to the gateway forwarder (`Group::Host`); the one-liner for opening DNS under deny-by-default. See [DNS as egress](/networking/dns#dns-as-egress) |
 | `Rule::deny_dns()` | Deny plain DNS (UDP/53 + TCP/53) to the gateway forwarder; place before profile-generated rules to override automatic DNS |
+
+Port-scoped counterparts take any `IntoIterator<Item = PortRange>` and are otherwise identical. An empty iterator degrades to the all-ports form above; a non-empty one also excludes ICMP, which carries no ports.
+
+| Method | Description |
+|--------|-------------|
+| `Rule::allow_egress_ports(destination, ports)` | Allow rule, direction `Egress`, scoped to `ports` |
+| `Rule::deny_egress_ports(destination, ports)` | Deny rule, direction `Egress`, scoped to `ports` |
+| `Rule::allow_ingress_ports(destination, ports)` | Allow rule, direction `Ingress`, scoped to `ports` |
+| `Rule::deny_ingress_ports(destination, ports)` | Deny rule, direction `Ingress`, scoped to `ports` |
+| `Rule::allow_any_ports(destination, ports)` | Allow rule, direction `Any`, scoped to `ports` |
+| `Rule::deny_any_ports(destination, ports)` | Deny rule, direction `Any`, scoped to `ports` |
+
+```rust
+use microsandbox_network::policy::{Destination, DestinationGroup, PortRange, Rule};
+
+let rule = Rule::allow_egress_ports(
+    Destination::Group(DestinationGroup::Host),
+    [PortRange::single(8080)],
+);
+```
 
 ### Action
 


### PR DESCRIPTION
`Rule::allow_egress(Destination::Group(DestinationGroup::Host))` and the other
`allow_*`/`deny_*` convenience constructors leave `ports` empty, which means "all
ports". The default is documented on the `ports` field, but it is invisible at the call
site: a reader sees `allow_egress(Host)` and does not necessarily register that it
granted every host port rather than the one service it needed.

Add `allow_egress_ports` / `deny_egress_ports` and the ingress and any-direction
counterparts, each taking an `IntoIterator<Item = PortRange>`, so scoping a rule to one
service is as short as the all-ports form. An empty iterator degrades to the existing
all-ports behavior — both paths funnel through the same private constructor, so the
equivalence is structural rather than two implementations that happen to agree.

Also state the all-ports default on the constructors themselves rather than only on the
`ports` field, and note there that a non-empty port set excludes ICMP (the ICMP
evaluation path skips any rule that filters on ports).

Docs: `docs/sdk/rust/networking.mdx` marks the existing constructors as all-ports and
adds a table plus an example for the port-scoped variants.

Suggestion (3) from the issue is not included: `NetworkPolicyBuilder` / `RuleBuilder`
already provide the deliberate port-scoping path via `.port()`, `.port_range()` and
`.ports()`. The gap was only in the raw `Rule::*` constructors.

No behavior change to existing rules or the wire format — the change is purely additive
and serde is untouched.

## Test plan

- `cargo test -p microsandbox-network` — 453 passed, 0 failed
- `cargo clippy -p microsandbox-network --all-targets` — clean
- `cargo fmt --check` — clean

Three tests added to `policy::types::tests`:

- `port_scoped_constructors_set_direction_action_and_ports` — each of the six sets
  direction/action/ports and leaves protocols any-protocol
- `port_scoped_constructors_with_no_ports_match_the_all_ports_constructors` — an empty
  `ports` argument yields a rule equal to the all-ports constructor, for all six pairs
- `port_scoped_host_rule_grants_only_the_named_service` — the reported scenario: under
  `default_egress = Deny`, `allow_egress(Group(Host))` permits gateway:22, while
  `allow_egress_ports(Group(Host), [8080])` permits :8080 and denies :22

I did not run the full integration suite locally (it needs a working microVM host);
happy to narrow down anything else that applies.

Closes #1236