### PR TITLE
docs: make the docs cloud-native

### DIFF
--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -1,0 +1,5343 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "microsandbox cloud API",
+    "description": "REST API for microsandbox cloud: sandbox and volume lifecycle, organization context, quotas, usage, and audit events, authenticated with an organization API key.",
+    "version": "0.1.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.microsandbox.dev"
+    }
+  ],
+  "security": [
+    {
+      "api_key": []
+    }
+  ],
+  "paths": {
+    "/v1/sandboxes": {
+      "get": {
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "List sandboxes",
+        "operationId": "list_sandboxes",
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Pagination cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Page size (default 20, max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "labels",
+            "in": "query",
+            "description": "JSON object of labels to AND-match",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of sandboxes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedSandboxResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Create a sandbox",
+        "operationId": "create_sandbox",
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "description": "If `true`, durably queue the sandbox for immediate orchestrator dispatch.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "wait_for",
+            "in": "query",
+            "description": "Optional lifecycle state to wait for after durable start admission.",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/SandboxWaitFor"
+                }
+              ]
+            }
+          },
+          {
+            "name": "wait_timeout",
+            "in": "query",
+            "description": "Server-side wait budget in seconds; valid only with `wait_for`.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSandboxRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Sandbox created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_request",
+                    "message": "invalid request",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Name already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "name_already_exists",
+                    "message": "'name' already exists",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Readiness wait capacity exhausted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "rate_limited",
+                    "message": "too many requests",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Orchestrator unreachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "orchestrator_unreachable",
+                    "message": "orchestrator unreachable",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/sandboxes/by-name/{name}": {
+      "get": {
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Get a sandbox by name",
+        "operationId": "get_by_name",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Sandbox name (unique within the org)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sandbox details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Destroy a sandbox by name",
+        "operationId": "delete_by_name",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Sandbox name (unique within the org)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sandbox destroyed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Orchestrator unreachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "orchestrator_unreachable",
+                    "message": "orchestrator unreachable",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/sandboxes/by-name/{name}/start": {
+      "post": {
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Start a sandbox by name",
+        "operationId": "start_by_name",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Sandbox name (unique within the org)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "wait_for",
+            "in": "query",
+            "description": "Optional lifecycle state to wait for after durable start admission.",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/SandboxWaitFor"
+                }
+              ]
+            }
+          },
+          {
+            "name": "wait_timeout",
+            "in": "query",
+            "description": "Server-side wait budget in seconds; valid only with `wait_for`.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sandbox start admitted or requested wait completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Invalid state transition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_state_transition",
+                    "message": "invalid state transition",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Readiness wait capacity exhausted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "rate_limited",
+                    "message": "too many requests",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Orchestrator unreachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "orchestrator_unreachable",
+                    "message": "orchestrator unreachable",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/sandboxes/by-name/{name}/stop": {
+      "post": {
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Stop a sandbox by name",
+        "operationId": "stop_by_name",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Sandbox name (unique within the org)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sandbox stopping",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Invalid state transition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_state_transition",
+                    "message": "invalid state transition",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Orchestrator unreachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "orchestrator_unreachable",
+                    "message": "orchestrator unreachable",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/sandboxes/{sandbox_id}": {
+      "get": {
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Get a sandbox",
+        "operationId": "get_sandbox",
+        "parameters": [
+          {
+            "name": "sandbox_id",
+            "in": "path",
+            "description": "Sandbox ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sandbox details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Destroy a sandbox",
+        "operationId": "delete_sandbox",
+        "parameters": [
+          {
+            "name": "sandbox_id",
+            "in": "path",
+            "description": "Sandbox ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sandbox destroyed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Sandbox orchestrator unreachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "orchestrator_unreachable",
+                    "message": "orchestrator unreachable",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Rename a sandbox",
+        "operationId": "update_sandbox",
+        "parameters": [
+          {
+            "name": "sandbox_id",
+            "in": "path",
+            "description": "Sandbox ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSandboxRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Updated sandbox",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid name/slug",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_request",
+                    "message": "invalid request",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Name or slug already taken",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "name_already_exists",
+                    "message": "'name' already exists",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/sandboxes/{sandbox_id}/start": {
+      "post": {
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Start a sandbox",
+        "operationId": "start_sandbox",
+        "parameters": [
+          {
+            "name": "sandbox_id",
+            "in": "path",
+            "description": "Sandbox ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "wait_for",
+            "in": "query",
+            "description": "Optional lifecycle state to wait for after durable start admission.",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/SandboxWaitFor"
+                }
+              ]
+            }
+          },
+          {
+            "name": "wait_timeout",
+            "in": "query",
+            "description": "Server-side wait budget in seconds; valid only with `wait_for`.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sandbox start admitted or requested wait completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Invalid state transition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_state_transition",
+                    "message": "invalid state transition",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Readiness wait capacity exhausted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "rate_limited",
+                    "message": "too many requests",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Orchestrator unreachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "orchestrator_unreachable",
+                    "message": "orchestrator unreachable",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/sandboxes/{sandbox_id}/stop": {
+      "post": {
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Stop a sandbox",
+        "operationId": "stop_sandbox",
+        "parameters": [
+          {
+            "name": "sandbox_id",
+            "in": "path",
+            "description": "Sandbox ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sandbox stopping",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Invalid state transition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_state_transition",
+                    "message": "invalid state transition",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Sandbox orchestrator unreachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "orchestrator_unreachable",
+                    "message": "orchestrator unreachable",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/volumes": {
+      "get": {
+        "tags": [
+          "Volumes"
+        ],
+        "summary": "List volumes",
+        "operationId": "list_volumes",
+        "responses": {
+          "200": {
+            "description": "The org's volumes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/VolumeResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Volumes"
+        ],
+        "summary": "Create a named volume",
+        "operationId": "create_volume",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateVolumeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Volume created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VolumeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_request",
+                    "message": "invalid request",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Volume name already in use",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "name_already_exists",
+                    "message": "'name' already exists",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/volumes/{id}": {
+      "delete": {
+        "tags": [
+          "Volumes"
+        ],
+        "summary": "Schedule a volume for deletion",
+        "operationId": "delete_volume",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Volume id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Volume scheduled for deletion",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Volume not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The default volume cannot be deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_request",
+                    "message": "the host volume cannot be deleted",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Volumes"
+        ],
+        "summary": "Set or clear a volume's storage cap",
+        "operationId": "update_volume",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Volume id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateVolumeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Volume updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VolumeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (e.g. cap exceeds the org cap)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_request",
+                    "message": "invalid request",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Volume not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The host volume cannot be capped",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_request",
+                    "message": "the host volume cannot be capped",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/quotas": {
+      "get": {
+        "tags": [
+          "Quotas"
+        ],
+        "summary": "Get quota usage",
+        "operationId": "get_quotas",
+        "responses": {
+          "200": {
+            "description": "Quota usage",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuotaUsage"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Org not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "org_not_found",
+                    "message": "org not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/billing/usage": {
+      "get": {
+        "tags": [
+          "Usage"
+        ],
+        "summary": "Get a usage summary",
+        "operationId": "get_usage",
+        "responses": {
+          "200": {
+            "description": "Usage summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsageSummary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/billing/usage/sandbox": {
+      "get": {
+        "tags": [
+          "Usage"
+        ],
+        "summary": "Get per-sandbox usage",
+        "operationId": "get_sandbox_breakdown",
+        "responses": {
+          "200": {
+            "description": "Per-sandbox / per-day usage",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsageBreakdown"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/billing/usage/storage": {
+      "get": {
+        "tags": [
+          "Usage"
+        ],
+        "summary": "Get per-volume storage usage",
+        "operationId": "get_storage_breakdown",
+        "responses": {
+          "200": {
+            "description": "Per-volume / per-day storage usage",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StorageBreakdown"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/events": {
+      "get": {
+        "tags": [
+          "Audit events"
+        ],
+        "summary": "List audit events",
+        "operationId": "list_events",
+        "parameters": [
+          {
+            "name": "event_type",
+            "in": "query",
+            "description": "Filter by event type (e.g. \"api_key_created\").",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "description": "Only return events at or after this timestamp.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "description": "Only return events at or before this timestamp.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor from a previous response.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of items to return (default: 20, max: 100).",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of audit events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedEventResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/events/{event_id}": {
+      "get": {
+        "tags": [
+          "Audit events"
+        ],
+        "summary": "Get an audit event",
+        "operationId": "get_event",
+        "parameters": [
+          {
+            "name": "event_id",
+            "in": "path",
+            "description": "Event ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Event details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Event not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "sandbox_not_found",
+                    "message": "resource not found",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/me/org": {
+      "get": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "Get the current organization",
+        "description": "The slug-prefixed `GET /v1/orgs/:slug` returns the user's role; here the\nkey is treated as `Owner` (matches `OrgContext` semantics), so the\nreturned role is informational rather than a real per-user binding.",
+        "operationId": "get_org",
+        "responses": {
+          "200": {
+            "description": "Organization bound to this API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgWithRole"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/members": {
+      "get": {
+        "tags": [
+          "Members"
+        ],
+        "summary": "List organization members",
+        "operationId": "list_members",
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Pagination cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Page size (default 20, max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of members",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedMemberResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": {
+                    "code": "invalid_api_key",
+                    "message": "unauthorized",
+                    "details": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Action": {
+        "type": "string",
+        "description": "Action to take on traffic matched by a [`Rule`] (or a policy default).",
+        "enum": [
+          "allow",
+          "deny"
+        ]
+      },
+      "CertCacheConfig": {
+        "type": "object",
+        "description": "Per-domain certificate cache configuration.",
+        "properties": {
+          "capacity": {
+            "type": "integer",
+            "description": "Maximum number of cached certificates. Default: 1000.",
+            "minimum": 0
+          },
+          "validity_hours": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Certificate validity duration in hours. Default: 24.",
+            "minimum": 0
+          }
+        }
+      },
+      "CloudCreateSandboxRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CloudSandboxSpec",
+            "description": "The cloud sandbox specification, flattened onto the request body."
+          }
+        ],
+        "description": "Wire shape of a cloud sandbox create request body.\n\nFlattens [`CloudSandboxSpec`] onto the request body, so on the wire this is\nbyte-identical to `CloudSandboxSpec`. The generated bindings surface the\nflattened shape as `CloudSandboxSpec` directly."
+      },
+      "CloudDiskImageFormat": {
+        "type": "string",
+        "description": "Disk image format for cloud disk-image sources. Twin of [`DiskImageFormat`]\nwith a snake_case wire.",
+        "enum": [
+          "qcow2",
+          "raw",
+          "vmdk"
+        ]
+      },
+      "CloudHostPattern": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Exact hostname match.",
+            "required": [
+              "value",
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "exact"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "description": "Hostname to match exactly."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Wildcard match (e.g. `*.openai.com`).",
+            "required": [
+              "value",
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "wildcard"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "description": "Wildcard pattern."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Any host (dangerous - the secret can be exfiltrated).",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "any"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "Host allowlist pattern for cloud secrets. Twin of [`HostPattern`], with the\ndomain's scalar variants normalized to `{ value }` for a uniform union."
+      },
+      "CloudNetworkSpec": {
+        "type": "object",
+        "description": "Cloud network specification: a subset of the domain [`NetworkSpec`].\nInterface overrides, host port mapping, DNS, TLS interception, and host-CA\ntrust are not part of this type. `deny_unknown_fields` - posting an omitted\nfield is an error, not a silent drop.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether networking is enabled for this sandbox.",
+            "default": true
+          },
+          "max_connections": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Max concurrent guest connections.",
+            "default": null,
+            "minimum": 0
+          },
+          "policy": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/NetworkPolicy",
+                "description": "Egress/ingress policy."
+              }
+            ],
+            "default": null
+          },
+          "secrets": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CloudSecretsConfig",
+                "description": "Secret-injection config."
+              }
+            ],
+            "default": null
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudPatch": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Write text content to a file.",
+            "required": [
+              "path",
+              "content",
+              "replace",
+              "type"
+            ],
+            "properties": {
+              "content": {
+                "type": "string",
+                "description": "Text content to write."
+              },
+              "mode": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "File permissions, such as `0o644`. `None` uses the default.",
+                "minimum": 0
+              },
+              "path": {
+                "type": "string",
+                "description": "Absolute guest path, such as `/etc/app.conf`."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Allow replacing a file that already exists in the rootfs."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "text"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Write raw bytes to a file.",
+            "required": [
+              "path",
+              "content",
+              "replace",
+              "type"
+            ],
+            "properties": {
+              "content": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 0
+                },
+                "description": "Raw byte content to write."
+              },
+              "mode": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "File permissions, such as `0o644`. `None` uses the default.",
+                "minimum": 0
+              },
+              "path": {
+                "type": "string",
+                "description": "Absolute guest path."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Allow replacing a file that already exists in the rootfs."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "file"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Copy a file from the host into the rootfs.",
+            "required": [
+              "src",
+              "dst",
+              "replace",
+              "type"
+            ],
+            "properties": {
+              "dst": {
+                "type": "string",
+                "description": "Absolute guest destination path."
+              },
+              "mode": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "File permissions. `None` preserves source permissions.",
+                "minimum": 0
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Allow replacing a file that already exists in the rootfs."
+              },
+              "src": {
+                "type": "string",
+                "description": "Host path to copy from."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "copy_file"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Copy a directory from the host into the rootfs.",
+            "required": [
+              "src",
+              "dst",
+              "replace",
+              "type"
+            ],
+            "properties": {
+              "dst": {
+                "type": "string",
+                "description": "Absolute guest destination path."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Allow replacing files that already exist in the rootfs."
+              },
+              "src": {
+                "type": "string",
+                "description": "Host directory to copy from."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "copy_dir"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Create a symlink.",
+            "required": [
+              "target",
+              "link",
+              "replace",
+              "type"
+            ],
+            "properties": {
+              "link": {
+                "type": "string",
+                "description": "Absolute guest path where the symlink is created."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Allow replacing a path that already exists in the rootfs."
+              },
+              "target": {
+                "type": "string",
+                "description": "Symlink target path."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "symlink"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Create a directory.",
+            "required": [
+              "path",
+              "type"
+            ],
+            "properties": {
+              "mode": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Directory permissions, such as `0o755`. `None` uses the default.",
+                "minimum": 0
+              },
+              "path": {
+                "type": "string",
+                "description": "Absolute guest path."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "mkdir"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Remove a file or directory.",
+            "required": [
+              "path",
+              "type"
+            ],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Absolute guest path to remove."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "remove"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Append content to an existing file.",
+            "required": [
+              "path",
+              "content",
+              "type"
+            ],
+            "properties": {
+              "content": {
+                "type": "string",
+                "description": "Content to append."
+              },
+              "path": {
+                "type": "string",
+                "description": "Absolute guest path of the file to append to."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "append"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "Rootfs patch applied before VM start. Twin of [`Patch`], internally tagged\nwith a snake_case `type` instead of the domain's external PascalCase tag."
+      },
+      "CloudPullPolicy": {
+        "type": "string",
+        "description": "Cloud pull policy. Twin of domain [`PullPolicy`] with a snake_case wire.",
+        "enum": [
+          "if_missing",
+          "always",
+          "never"
+        ]
+      },
+      "CloudRlimit": {
+        "type": "object",
+        "description": "A POSIX resource limit. Twin of [`Rlimit`] using [`CloudRlimitResource`].",
+        "required": [
+          "resource",
+          "soft",
+          "hard"
+        ],
+        "properties": {
+          "hard": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Hard limit (ceiling, requires privileges to raise).",
+            "minimum": 0
+          },
+          "resource": {
+            "$ref": "#/components/schemas/CloudRlimitResource",
+            "description": "Resource type."
+          },
+          "soft": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Soft limit (can be raised up to the hard limit by the process).",
+            "minimum": 0
+          }
+        }
+      },
+      "CloudRlimitResource": {
+        "type": "string",
+        "description": "POSIX resource-limit identifiers. Twin of [`RlimitResource`] with a\nsnake_case wire.",
+        "enum": [
+          "cpu",
+          "fsize",
+          "data",
+          "stack",
+          "core",
+          "rss",
+          "nproc",
+          "nofile",
+          "memlock",
+          "as",
+          "locks",
+          "sigpending",
+          "msgqueue",
+          "nice",
+          "rtprio",
+          "rttime"
+        ]
+      },
+      "CloudRootfsSource": {
+        "type": "object",
+        "description": "Root filesystem source. The hosted cloud accepts OCI images only.",
+        "required": [
+          "type",
+          "reference"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "oci"
+            ]
+          },
+          "reference": {
+            "type": "string",
+            "description": "OCI image reference, e.g. `python:3.12`."
+          }
+        }
+      },
+      "CloudSandboxResources": {
+        "type": "object",
+        "description": "Cloud resource request.",
+        "properties": {
+          "disk_size_mib": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Writable disk size in MiB. Applies only to OCI root filesystems.",
+            "default": null,
+            "minimum": 0
+          },
+          "memory_mib": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Guest memory in MiB.",
+            "default": 512,
+            "minimum": 0
+          },
+          "vcpus": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of virtual CPUs.",
+            "default": 1,
+            "minimum": 0
+          }
+        }
+      },
+      "CloudSandboxRuntimeOptions": {
+        "type": "object",
+        "description": "Cloud guest runtime options: a subset of [`SandboxRuntimeOptions`]. The\nhostname and the metrics-sampling knobs are not part of this type.\n`deny_unknown_fields`.",
+        "properties": {
+          "cmd": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "Command override.",
+            "default": null
+          },
+          "entrypoint": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "Entrypoint override.",
+            "default": null
+          },
+          "log_level": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SandboxLogLevel",
+                "description": "Runtime log level."
+              }
+            ],
+            "default": null
+          },
+          "scripts": {
+            "type": "object",
+            "description": "Named in-guest scripts.",
+            "default": {},
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "shell": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Default shell.",
+            "default": null
+          },
+          "user": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Guest user.",
+            "default": null
+          },
+          "workdir": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Working directory for guest commands.",
+            "default": null
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudSandboxSpec": {
+        "type": "object",
+        "description": "Cloud sandbox specification carried on create routes.",
+        "properties": {
+          "env": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EnvVar"
+            },
+            "description": "Environment variables visible to commands in the sandbox.",
+            "default": []
+          },
+          "image": {
+            "$ref": "#/components/schemas/CloudRootfsSource"
+          },
+          "init": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/HandoffInit",
+                "description": "Hand off PID 1 to a guest init binary after agentd setup."
+              }
+            ],
+            "default": null
+          },
+          "labels": {
+            "type": "object",
+            "description": "User-defined labels attached to the sandbox.",
+            "default": {},
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "lifecycle": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SandboxPolicy",
+                "description": "Sandbox lifecycle policy."
+              }
+            ],
+            "default": {
+              "ephemeral": false,
+              "idle_timeout_secs": null,
+              "max_duration_secs": null
+            }
+          },
+          "mounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CloudVolumeMount"
+            },
+            "description": "Volume mounts.",
+            "default": []
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique sandbox name.",
+            "default": ""
+          },
+          "network": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CloudNetworkSpec",
+                "description": "Network specification."
+              }
+            ],
+            "default": {
+              "enabled": true
+            }
+          },
+          "patches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CloudPatch"
+            },
+            "description": "Rootfs patches applied before VM start.",
+            "default": []
+          },
+          "pull_policy": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CloudPullPolicy",
+                "description": "Pull policy for OCI images."
+              }
+            ],
+            "default": "if_missing"
+          },
+          "resources": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CloudSandboxResources",
+                "description": "CPU, memory, and user-facing disk resources."
+              }
+            ],
+            "default": {
+              "memory_mib": 512,
+              "vcpus": 1
+            }
+          },
+          "rlimits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CloudRlimit"
+            },
+            "description": "Sandbox-wide resource limits inherited by guest processes.",
+            "default": []
+          },
+          "runtime": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CloudSandboxRuntimeOptions",
+                "description": "Guest runtime options."
+              }
+            ],
+            "default": {
+              "cmd": null,
+              "entrypoint": null,
+              "log_level": null,
+              "scripts": {},
+              "shell": null,
+              "user": null,
+              "workdir": null
+            }
+          },
+          "security_profile": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SecurityProfile",
+                "description": "In-guest security profile."
+              }
+            ],
+            "default": "default"
+          }
+        }
+      },
+      "CloudSecretEntry": {
+        "type": "object",
+        "description": "A single cloud secret entry. Twin of domain [`SecretEntry`].",
+        "required": [
+          "env_var",
+          "placeholder"
+        ],
+        "properties": {
+          "allowed_hosts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CloudHostPattern"
+            },
+            "description": "Hosts allowed to receive this secret."
+          },
+          "env_var": {
+            "type": "string",
+            "description": "Environment variable name exposed to the sandbox."
+          },
+          "injection": {
+            "$ref": "#/components/schemas/SecretInjection",
+            "description": "Where the secret may be injected."
+          },
+          "on_violation": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CloudViolationAction",
+                "description": "Per-secret violation action overriding the config default."
+              }
+            ]
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "Placeholder the sandbox sees instead of the real value."
+          },
+          "require_tls_identity": {
+            "type": "boolean",
+            "description": "Require verified TLS identity before substituting (default: true)."
+          },
+          "source": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CloudSecretSource",
+                "description": "Host-side source resolved into `value` at spawn time."
+              }
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "The secret value (empty when `source` carries a reference instead)."
+          }
+        }
+      },
+      "CloudSecretSource": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Read from a host environment variable at apply time.",
+            "required": [
+              "var",
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "env"
+                ]
+              },
+              "var": {
+                "type": "string",
+                "description": "Host environment variable name."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Read from a host-side secret store reference.",
+            "required": [
+              "reference",
+              "type"
+            ],
+            "properties": {
+              "reference": {
+                "type": "string",
+                "description": "Store-specific secret reference."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "store"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "Host-side source for a cloud secret. Twin of [`SecretSource`]."
+      },
+      "CloudSecretsConfig": {
+        "type": "object",
+        "description": "Secret-injection config for the cloud API. Twin of domain [`SecretsConfig`].",
+        "properties": {
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CloudSecretEntry"
+            },
+            "description": "Secrets to inject."
+          },
+          "on_violation": {
+            "$ref": "#/components/schemas/CloudViolationAction",
+            "description": "Default action when a placeholder leaks to a disallowed host."
+          }
+        }
+      },
+      "CloudViolationAction": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Block the request silently.",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "block"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Block and log (default).",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "block_and_log"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Block and terminate the sandbox.",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "block_and_terminate"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Forward the request with the placeholder unchanged for matching hosts.",
+            "required": [
+              "hosts",
+              "type"
+            ],
+            "properties": {
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CloudHostPattern"
+                },
+                "description": "Hosts for which the placeholder passes through unchanged."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "passthrough"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "Action on a cloud secret violation. Twin of [`ViolationAction`], with\n`Passthrough`'s host list normalized to a `hosts` field."
+      },
+      "CloudVolumeMount": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Bind mount a host directory into the guest.",
+            "required": [
+              "host",
+              "guest",
+              "type"
+            ],
+            "properties": {
+              "guest": {
+                "type": "string",
+                "description": "Guest path to mount at."
+              },
+              "host": {
+                "type": "string",
+                "description": "Host directory to bind into the guest."
+              },
+              "host_permissions": {
+                "$ref": "#/components/schemas/HostPermissions",
+                "description": "Host permission policy applied to the mount."
+              },
+              "options": {
+                "$ref": "#/components/schemas/MountOptions",
+                "description": "Mount options (read-only, no-exec, …)."
+              },
+              "quota_mib": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Optional guest-write quota in MiB.",
+                "minimum": 0
+              },
+              "stat_virtualization": {
+                "$ref": "#/components/schemas/StatVirtualization",
+                "description": "How guest `stat()` results are virtualized."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "bind"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Mount a named volume into the guest.",
+            "required": [
+              "name",
+              "guest",
+              "type"
+            ],
+            "properties": {
+              "guest": {
+                "type": "string",
+                "description": "Guest path to mount at."
+              },
+              "host_permissions": {
+                "$ref": "#/components/schemas/HostPermissions",
+                "description": "Host permission policy applied to the mount."
+              },
+              "name": {
+                "type": "string",
+                "description": "Named volume to mount."
+              },
+              "options": {
+                "$ref": "#/components/schemas/MountOptions",
+                "description": "Mount options (read-only, no-exec, …)."
+              },
+              "stat_virtualization": {
+                "$ref": "#/components/schemas/StatVirtualization",
+                "description": "How guest `stat()` results are virtualized."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "named"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Temporary filesystem backed by guest memory.",
+            "required": [
+              "guest",
+              "type"
+            ],
+            "properties": {
+              "guest": {
+                "type": "string",
+                "description": "Guest path to mount at."
+              },
+              "options": {
+                "$ref": "#/components/schemas/MountOptions",
+                "description": "Mount options (read-only, no-exec, …)."
+              },
+              "size_mib": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Optional size cap in MiB.",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "tmpfs"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Mount a disk image file as a virtio-blk device at a guest path.",
+            "required": [
+              "host",
+              "guest",
+              "format",
+              "type"
+            ],
+            "properties": {
+              "format": {
+                "$ref": "#/components/schemas/CloudDiskImageFormat",
+                "description": "Disk image format."
+              },
+              "fstype": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Inner filesystem type (auto-detected if absent)."
+              },
+              "guest": {
+                "type": "string",
+                "description": "Guest path to mount at."
+              },
+              "host": {
+                "type": "string",
+                "description": "Host path to the disk image file."
+              },
+              "options": {
+                "$ref": "#/components/schemas/MountOptions",
+                "description": "Mount options (read-only, no-exec, …)."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "disk_image"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "Cloud volume mount. Internal-tagged mirror of the domain [`VolumeMount`];\nthe transient `create` field is not carried on the wire."
+      },
+      "CreateSandboxRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CloudCreateSandboxRequest",
+            "description": "The microsandbox sandbox specification - image, resources, runtime, env,\nmounts, network, lifecycle - flattened onto the request body."
+          },
+          {
+            "type": "object",
+            "properties": {
+              "registry": {
+                "$ref": "#/components/schemas/RegistrySelection",
+                "description": "Registry-credential selection for the image pull. Absent ⇒ `Auto`\n(infer the credential from the image's registry host). Credential-only:\nthis never changes *where* the image is pulled from - the image string\ncontrols that - only *which* stored credential, if any, is presented."
+              },
+              "slug": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Optional globally-unique slug - the SSH username token. Lowercase\nletters, digits, and single hyphens; 3-63 chars. Omitted ⇒ a dictionary\nslug is generated. Must be globally unique (409 on conflict)."
+              }
+            }
+          }
+        ],
+        "description": "What the user sends in `POST /v1/sandboxes`.\n\nThe body *is* a microsandbox [`CloudSandboxSpec`] - carried verbatim through the\nshared [`CloudCreateSandboxRequest`] envelope (flattened onto the wire) so it\ncan never drift from the cross-repo contract - plus the cloud-only fields\nthat have no place in the shared spec: the globally-unique SSH `slug` and the\nregistry-credential selection. (Writable-disk size now lives in the spec's\n`resources.disk_size_mib`.)"
+      },
+      "CreateVolumeRequest": {
+        "type": "object",
+        "description": "POST /v1/orgs/{slug}/volumes",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "capacity_gib": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Optional per-volume storage cap in GiB (#496). Omitted/`null` = no\nper-volume limit (the org's plan cap still governs). Must be `>= 1` and\n`<= the org's storage cap`.",
+            "minimum": 0
+          },
+          "labels": {
+            "type": "object",
+            "description": "User-defined labels (free-form string map). Omitted = none. Keys using a\nplatform-reserved prefix are rejected.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "Volume name, unique within the org. Lowercase alphanumeric with single\ninternal hyphens (e.g. `team-ml`). Creates a `managed` volume; the host\ndisk is system-provisioned and has no name."
+          },
+          "storage": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/VolumeType",
+                "description": "Physical backing for the volume. Omitted = `block` (the default and only\nvalue today)."
+              }
+            ]
+          }
+        }
+      },
+      "Destination": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Match any destination.",
+            "enum": [
+              "any"
+            ]
+          },
+          {
+            "type": "object",
+            "description": "IP address or CIDR block (e.g. `\"1.2.3.4\"`, `\"10.0.0.0/8\"`).",
+            "required": [
+              "cidr"
+            ],
+            "properties": {
+              "cidr": {
+                "type": "string",
+                "description": "IP address or CIDR block (e.g. `\"1.2.3.4\"`, `\"10.0.0.0/8\"`)."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Exact domain name (e.g. `\"example.com\"`).",
+            "required": [
+              "domain"
+            ],
+            "properties": {
+              "domain": {
+                "type": "string",
+                "description": "Exact domain name (e.g. `\"example.com\"`)."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Domain suffix - the apex and any subdomain of it.",
+            "required": [
+              "domain_suffix"
+            ],
+            "properties": {
+              "domain_suffix": {
+                "type": "string",
+                "description": "Domain suffix - the apex and any subdomain of it."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "A pre-defined destination group.",
+            "required": [
+              "group"
+            ],
+            "properties": {
+              "group": {
+                "$ref": "#/components/schemas/DestinationGroup",
+                "description": "A pre-defined destination group."
+              }
+            }
+          }
+        ],
+        "description": "Traffic destination filter for a [`Rule`].\n\nThe `Cidr`, `Domain`, and `DomainSuffix` leaves carry their canonical\nstring form (e.g. `\"10.0.0.0/8\"`, `\"example.com\"`); the local network\nengine re-parses and validates them into its richer internal types at\nload time."
+      },
+      "DestinationGroup": {
+        "type": "string",
+        "description": "Pre-defined destination category for a [`Destination::Group`] match.",
+        "enum": [
+          "public",
+          "loopback",
+          "private",
+          "link_local",
+          "metadata",
+          "multicast",
+          "host"
+        ]
+      },
+      "Direction": {
+        "type": "string",
+        "description": "Direction a [`Rule`] applies to.",
+        "enum": [
+          "egress",
+          "ingress",
+          "any"
+        ]
+      },
+      "DiskImageFormat": {
+        "type": "string",
+        "description": "Disk image format for virtio-blk root filesystems and volume mounts.",
+        "enum": [
+          "Qcow2",
+          "Raw",
+          "Vmdk"
+        ]
+      },
+      "DnsConfig": {
+        "type": "object",
+        "description": "DNS interception and filtering settings. Carried in [`NetworkSpec::dns`].",
+        "properties": {
+          "nameservers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Upstream nameservers as `IP`, `IP:PORT`, `HOST`, or `HOST:PORT`\nstrings. Empty falls back to the host's `/etc/resolv.conf`.",
+            "default": []
+          },
+          "query_timeout_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Per-query timeout in milliseconds. Default: 5000.",
+            "default": 5000,
+            "minimum": 0
+          },
+          "rebind_protection": {
+            "type": "boolean",
+            "description": "Whether DNS-rebinding protection is enabled. Default: true.",
+            "default": true
+          }
+        }
+      },
+      "EnvVar": {
+        "type": "object",
+        "description": "Environment variable entry.",
+        "required": [
+          "key",
+          "value"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Environment variable name."
+          },
+          "value": {
+            "type": "string",
+            "description": "Environment variable value."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "description": "Error envelope returned by every non-2xx response.",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Stable machine-readable error code, e.g. `invalid_api_key`."
+              },
+              "message": {
+                "type": "string",
+                "description": "Human-readable description of the error."
+              },
+              "details": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Optional structured context for the error."
+              }
+            }
+          }
+        }
+      },
+      "EventActor": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "user_id",
+              "label",
+              "redacted_email",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "user"
+                ]
+              },
+              "label": {
+                "type": "string"
+              },
+              "redacted_email": {
+                "type": "string"
+              },
+              "user_id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "api_key_id",
+              "name",
+              "kind"
+            ],
+            "properties": {
+              "api_key_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "api_key"
+                ]
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "code",
+              "label",
+              "kind"
+            ],
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "system"
+                ]
+              },
+              "label": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "The authorized SSH key that authenticated a front-door session. The\nprincipal SSH actually proves at connect is the *key*, not a person -\nthe scope-only model (D8) doesn't bind a key to a user (a global key may\nbe shared), so the session is attributed to the key (label + fingerprint),\nwhile whoever registered it rides the event payload as `added_by`.",
+            "required": [
+              "key_id",
+              "fingerprint",
+              "kind"
+            ],
+            "properties": {
+              "fingerprint": {
+                "type": "string",
+                "description": "`SHA256:…` fingerprint."
+              },
+              "key_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "ssh_key"
+                ]
+              },
+              "label": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human label set at registration (e.g. `alice-laptop`), if any."
+              }
+            }
+          }
+        ],
+        "description": "Maximum total length, in characters, of the truncated `command` field in\nImmutable actor snapshot stored alongside an event."
+      },
+      "EventResponse": {
+        "type": "object",
+        "description": "A single audit/lifecycle event returned by the API.",
+        "required": [
+          "id",
+          "org_id",
+          "category",
+          "event_type",
+          "actor",
+          "payload",
+          "timestamp"
+        ],
+        "properties": {
+          "actor": {
+            "$ref": "#/components/schemas/EventActor"
+          },
+          "category": {
+            "type": "string"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "org_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "payload": {},
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "HandoffInit": {
+        "type": "object",
+        "description": "Fully-assembled handoff-init specification.",
+        "required": [
+          "cmd"
+        ],
+        "properties": {
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Supplemental argv. `argv[0]` is implicitly `cmd`."
+          },
+          "cmd": {
+            "type": "string",
+            "description": "Init binary: absolute path inside the guest rootfs, or the literal `auto`.\n\nAlways a Linux-style `/`-separated path - never build it with host OS path APIs, whose semantics diverge on Windows (`\\` separators, `/sbin/init` treated as relative)."
+          },
+          "env": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": false,
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "description": "Extra env vars merged on top of the inherited env."
+          }
+        }
+      },
+      "HostPermissions": {
+        "type": "string",
+        "description": "Host permission propagation policy for a virtiofs-backed volume mount.\n\nSerializes/deserializes as the lowercase variant name (`\"private\"`, `\"mirror\"`) to align with the CLI and NAPI spellings.",
+        "enum": [
+          "private",
+          "mirror"
+        ]
+      },
+      "InterceptCaConfig": {
+        "type": "object",
+        "description": "Certificate authority configuration for TLS interception.",
+        "properties": {
+          "cert_path": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Path to an existing CA certificate PEM file. If `None`, a CA is\nauto-generated and persisted."
+          },
+          "key_path": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Path to an existing CA private key PEM file. If `None`, a key is\nauto-generated and persisted."
+          }
+        }
+      },
+      "InterfaceOverrides": {
+        "type": "object",
+        "description": "Optional guest interface overrides. Unset fields are derived from the\nsandbox slot by the local network engine. Carried in\n[`NetworkSpec::interface`].",
+        "properties": {
+          "ipv4_address": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Guest IPv4 address (e.g. `172.16.0.2`). Default: derived from slot.",
+            "default": null
+          },
+          "ipv4_pool": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Guest IPv4 pool CIDR (e.g. `\"172.16.0.0/12\"`). Default: derived from slot.",
+            "default": null
+          },
+          "ipv6_address": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Guest IPv6 address. Default: derived from slot.",
+            "default": null
+          },
+          "ipv6_pool": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Guest IPv6 pool CIDR. Default: derived from slot.",
+            "default": null
+          },
+          "mac": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "Guest MAC address as six octets. Default: derived from slot.",
+            "default": null
+          },
+          "mtu": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Interface MTU. Default: 1500.",
+            "default": null,
+            "minimum": 0
+          }
+        }
+      },
+      "MessageResponse": {
+        "type": "object",
+        "description": "Simple message response for operations without a body.",
+        "required": [
+          "message"
+        ],
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "MountOptions": {
+        "type": "object",
+        "description": "Guest mount behavior shared by every volume mount kind.",
+        "properties": {
+          "nodev": {
+            "type": "boolean",
+            "description": "Whether device files on the mount are ignored.",
+            "default": false
+          },
+          "noexec": {
+            "type": "boolean",
+            "description": "Whether direct execution from the mount is disabled.\n\nThis prevents `execve` of binaries or scripts located on the mount. Interpreters can still read files from the mount, for example `sh /mnt/script.sh`, because the interpreter itself executes from a different filesystem.",
+            "default": false
+          },
+          "nosuid": {
+            "type": "boolean",
+            "description": "Whether setuid and setgid privilege elevation from files on the mount is ignored.",
+            "default": false
+          },
+          "readonly": {
+            "type": "boolean",
+            "description": "Whether the mount is read-only.\n\nGuest writes fail with the kernel's read-only filesystem behavior. Virtiofs-backed mounts also reject writes on the host-side filesystem server as defense in depth.",
+            "default": false
+          }
+        }
+      },
+      "NetworkPolicy": {
+        "type": "object",
+        "description": "Egress/ingress network policy: an ordered [`Rule`] list plus a\nper-direction default [`Action`]. Carried in [`NetworkSpec::policy`].",
+        "properties": {
+          "default_egress": {
+            "$ref": "#/components/schemas/Action",
+            "description": "Default action for egress traffic matching no rule. Default: `Deny`."
+          },
+          "default_ingress": {
+            "$ref": "#/components/schemas/Action",
+            "description": "Default action for ingress traffic matching no rule. Default: `Deny`."
+          },
+          "rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Rule"
+            },
+            "description": "Ordered rules, evaluated first-match-wins per direction."
+          }
+        }
+      },
+      "OrgMemberResponse": {
+        "type": "object",
+        "description": "Member with joined user profile data - repository read view.",
+        "required": [
+          "id",
+          "user_id",
+          "email",
+          "role",
+          "joined_at"
+        ],
+        "properties": {
+          "avatar_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "email": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "joined_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "role": {
+            "$ref": "#/components/schemas/OrgRole"
+          },
+          "user_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "OrgRole": {
+        "type": "string",
+        "description": "Organization membership role.",
+        "enum": [
+          "owner",
+          "admin",
+          "member",
+          "viewer"
+        ]
+      },
+      "OrgWithRole": {
+        "type": "object",
+        "description": "Organization with the requesting user's role included.",
+        "required": [
+          "id",
+          "name",
+          "slug",
+          "mfa_required",
+          "role",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "mfa_required": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/OrgRole"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "PaginatedEventResponse": {
+        "type": "object",
+        "description": "Wrapper for paginated event responses (needed for OpenAPI schema generation).",
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventResponse"
+            }
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "PaginatedMemberResponse": {
+        "type": "object",
+        "description": "Paginated list of organization members.",
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrgMemberResponse"
+            }
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "PaginatedSandboxResponse": {
+        "type": "object",
+        "description": "Paginated list of sandboxes.",
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SandboxResponse"
+            }
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "PoolUsage": {
+        "type": "object",
+        "description": "An org's monthly pool usage against its hard-cap pools - the shared home of\nthe exhaustion predicates, whether read per-org (embedded in `QuotaUsage`)\nor in the quota monitor's batched sweep (`OrgPoolUsage`).",
+        "required": [
+          "hard_cap",
+          "vcpu_hours_used",
+          "memory_gib_hours_used"
+        ],
+        "properties": {
+          "hard_cap": {
+            "type": "boolean",
+            "description": "Whether the plan hard-stops at its included pools (no overflow).\nDERIVED (not a stored column): true iff the resolved plan is unpriced -\nan unpriced plan has no overage path, so its pools become walls."
+          },
+          "included_memory_gib_hours": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Included memory GiB-hours/month; `None` = unlimited."
+          },
+          "included_vcpu_hours": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Included vCPU-hours/month; `None` = unlimited. On `hard_cap` plans this\nis the compute wall; on priced plans, usage beyond it is metered overage."
+          },
+          "memory_gib_hours_used": {
+            "type": "number",
+            "format": "double",
+            "description": "Memory GiB-hours consumed this billing month (compute-on-read from `sandbox_runs`)."
+          },
+          "vcpu_hours_used": {
+            "type": "number",
+            "format": "double",
+            "description": "vCPU-hours consumed this billing month (compute-on-read from `sandbox_runs`)."
+          }
+        }
+      },
+      "PortProtocol": {
+        "type": "string",
+        "description": "Transport protocol for a published port.",
+        "enum": [
+          "tcp",
+          "udp"
+        ]
+      },
+      "PortRange": {
+        "type": "object",
+        "description": "Inclusive guest-side port range for a [`Rule`] match.",
+        "required": [
+          "start",
+          "end"
+        ],
+        "properties": {
+          "end": {
+            "type": "integer",
+            "format": "int32",
+            "description": "End port (inclusive).",
+            "minimum": 0
+          },
+          "start": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Start port (inclusive).",
+            "minimum": 0
+          }
+        }
+      },
+      "Protocol": {
+        "type": "string",
+        "description": "Protocol filter for a [`Rule`].",
+        "enum": [
+          "tcp",
+          "udp",
+          "icmpv4",
+          "icmpv6"
+        ]
+      },
+      "PublishedPortSpec": {
+        "type": "object",
+        "description": "A published port mapping between host and guest.",
+        "required": [
+          "host_port",
+          "guest_port",
+          "host_bind"
+        ],
+        "properties": {
+          "guest_port": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Guest-side port to forward to.",
+            "minimum": 0
+          },
+          "host_bind": {
+            "type": "string",
+            "description": "Host address to bind. Defaults to loopback."
+          },
+          "host_port": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Host-side port to bind.",
+            "minimum": 0
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/PortProtocol",
+            "description": "Transport protocol."
+          }
+        }
+      },
+      "QuotaUsage": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PoolUsage"
+          },
+          {
+            "type": "object",
+            "required": [
+              "pool_exhausted",
+              "total_sandboxes",
+              "concurrent_ephemeral_running",
+              "concurrent_persistent_running",
+              "is_suspended"
+            ],
+            "properties": {
+              "concurrent_ephemeral_running": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Currently running/starting ephemeral sandboxes."
+              },
+              "concurrent_persistent_running": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Currently running/starting persistent sandboxes."
+              },
+              "included_disk_gib_hours": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Included writable-disk GiB-hours/month (display/billing only - never a wall)."
+              },
+              "included_storage_gib": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Included durable-storage GiB/month."
+              },
+              "is_suspended": {
+                "type": "boolean",
+                "description": "Whether sandbox usage has been manually suspended for the organization."
+              },
+              "max_concurrent_ephemeral_running": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Maximum simultaneously-running ephemeral sandboxes."
+              },
+              "max_concurrent_persistent_running": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Maximum simultaneously-running persistent sandboxes."
+              },
+              "max_disk_size_mib_per_sandbox": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Maximum writable disk size (MiB) per sandbox."
+              },
+              "max_memory_mib_per_sandbox": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Maximum memory (MiB) per sandbox."
+              },
+              "max_sandboxes": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Maximum total sandboxes the org can have."
+              },
+              "max_total_storage_gib": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Per-org durable-storage hard cap (GiB)."
+              },
+              "max_uptime_minutes_per_sandbox": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Maximum uptime per sandbox (minutes), if set."
+              },
+              "max_vcpus_per_sandbox": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Maximum CPU cores per sandbox."
+              },
+              "pool_exhausted": {
+                "type": "boolean",
+                "description": "Snapshot of [`PoolUsage::pool_exhausted`] at read time, for API\nconsumers - true when this org's sandboxes are being stopped and starts\nrefused."
+              },
+              "total_sandboxes": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Total sandboxes (all states) for the org."
+              }
+            }
+          }
+        ],
+        "description": "Resolved quota limits and current usage for an organization.\n\nLimits are resolved via COALESCE: per-org override > plan. Every limit is\n`Option`: `None` = unlimited (counts/budgets) or the system/node max\n(per-sandbox vcpu/memory/disk). There is no magic 0."
+      },
+      "RegistrySelection": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Infer a stored credential from the image registry host.",
+            "required": [
+              "mode"
+            ],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "auto"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Force an anonymous pull.",
+            "required": [
+              "mode"
+            ],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "anonymous"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Use an already-stored organization credential.",
+            "required": [
+              "credential_id",
+              "mode"
+            ],
+            "properties": {
+              "credential_id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Id of a configured `OrgRegistryCredential` belonging to the org."
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "specific"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Use plaintext credentials for this create-and-start operation only.",
+            "required": [
+              "username",
+              "password",
+              "mode"
+            ],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "inline"
+                ]
+              },
+              "password": {
+                "type": "string",
+                "format": "password",
+                "description": "Registry password or access token. Always redacted from `Debug`."
+              },
+              "username": {
+                "type": "string",
+                "description": "Registry username."
+              }
+            }
+          }
+        ],
+        "description": "Registry credential selection accepted on sandbox-create requests.\n\n`Inline` is deliberately request-only: its plaintext fields must be vaulted\nbefore persistence and must never enter the sandbox row, a worker launch\ndefinition, a log, or an API response."
+      },
+      "Rlimit": {
+        "type": "object",
+        "description": "A POSIX resource limit.",
+        "required": [
+          "resource",
+          "soft",
+          "hard"
+        ],
+        "properties": {
+          "hard": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Hard limit (ceiling, requires privileges to raise).",
+            "minimum": 0
+          },
+          "resource": {
+            "$ref": "#/components/schemas/RlimitResource",
+            "description": "Resource type."
+          },
+          "soft": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Soft limit (can be raised up to hard limit by the process).",
+            "minimum": 0
+          }
+        }
+      },
+      "RlimitResource": {
+        "type": "string",
+        "description": "POSIX resource limit identifiers.",
+        "enum": [
+          "Cpu",
+          "Fsize",
+          "Data",
+          "Stack",
+          "Core",
+          "Rss",
+          "Nproc",
+          "Nofile",
+          "Memlock",
+          "As",
+          "Locks",
+          "Sigpending",
+          "Msgqueue",
+          "Nice",
+          "Rtprio",
+          "Rttime"
+        ]
+      },
+      "Rule": {
+        "type": "object",
+        "description": "A single egress/ingress policy rule. Evaluated first-match-wins per\ndirection.",
+        "required": [
+          "direction",
+          "destination",
+          "action"
+        ],
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/Action",
+            "description": "Action to take on a match."
+          },
+          "destination": {
+            "$ref": "#/components/schemas/Destination",
+            "description": "Destination filter (direction-dependent interpretation)."
+          },
+          "direction": {
+            "$ref": "#/components/schemas/Direction",
+            "description": "Direction this rule applies to."
+          },
+          "ports": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PortRange"
+            },
+            "description": "Guest-side port-range set; empty matches any port."
+          },
+          "protocols": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Protocol"
+            },
+            "description": "Protocol set; empty matches any protocol."
+          }
+        }
+      },
+      "SandboxDailyUsage": {
+        "type": "object",
+        "description": "Compute usage for one sandbox on one UTC day, across both billed dimensions.\n\nComputed on read from `sandbox_runs` (not from the billing provider) - open runs accrue\nagainst `now()`, so a *running* sandbox shows live usage. Quantities are\nseconds-based (vCPU-seconds, MiB-seconds), the same units the metering events\ncarry; display converts to vCPU-hours / GiB-hours. Sum over days for a\nsandbox's period total; sum over sandboxes for the daily series.",
+        "required": [
+          "sandbox_id",
+          "day",
+          "vcpu_seconds",
+          "mem_mib_seconds",
+          "disk_mib_seconds"
+        ],
+        "properties": {
+          "day": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC midnight of the day this usage falls in."
+          },
+          "disk_mib_seconds": {
+            "type": "number",
+            "format": "double",
+            "description": "Σ(overlap_secs × disk_mib) for this sandbox on this day - provisioned\nwritable disk billed on the same GiB-seconds basis while the sandbox runs."
+          },
+          "mem_mib_seconds": {
+            "type": "number",
+            "format": "double",
+            "description": "Σ(overlap_secs × mem_mib) for this sandbox on this day."
+          },
+          "sandbox_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "vcpu_seconds": {
+            "type": "number",
+            "format": "double",
+            "description": "Σ(overlap_secs × vcpus) for this sandbox on this day."
+          }
+        }
+      },
+      "SandboxIdentity": {
+        "type": "object",
+        "description": "Minimal sandbox display info - the directory that turns the `sandbox_id`s in\na [`UsageBreakdown`]'s rows into human labels without a second round-trip.",
+        "required": [
+          "id",
+          "name",
+          "slug"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          }
+        }
+      },
+      "SandboxLogLevel": {
+        "type": "string",
+        "description": "Runtime log verbosity for sandbox specs.",
+        "enum": [
+          "error",
+          "warn",
+          "info",
+          "debug",
+          "trace"
+        ]
+      },
+      "SandboxMountResponse": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Host-subpath bind mount.",
+            "required": [
+              "guest",
+              "options",
+              "stat_virtualization",
+              "host_permissions",
+              "type"
+            ],
+            "properties": {
+              "guest": {
+                "type": "string"
+              },
+              "host_permissions": {
+                "$ref": "#/components/schemas/HostPermissions"
+              },
+              "options": {
+                "$ref": "#/components/schemas/MountOptions"
+              },
+              "quota_mib": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "minimum": 0
+              },
+              "stat_virtualization": {
+                "$ref": "#/components/schemas/StatVirtualization"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Bind"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Named-volume mount.",
+            "required": [
+              "guest",
+              "options",
+              "stat_virtualization",
+              "host_permissions",
+              "type"
+            ],
+            "properties": {
+              "guest": {
+                "type": "string"
+              },
+              "host_permissions": {
+                "$ref": "#/components/schemas/HostPermissions"
+              },
+              "options": {
+                "$ref": "#/components/schemas/MountOptions"
+              },
+              "stat_virtualization": {
+                "$ref": "#/components/schemas/StatVirtualization"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Named"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Guest-memory tmpfs.",
+            "required": [
+              "guest",
+              "options",
+              "type"
+            ],
+            "properties": {
+              "guest": {
+                "type": "string"
+              },
+              "options": {
+                "$ref": "#/components/schemas/MountOptions"
+              },
+              "size_mib": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Tmpfs"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Disk-image mount.",
+            "required": [
+              "guest",
+              "format",
+              "options",
+              "type"
+            ],
+            "properties": {
+              "format": {
+                "$ref": "#/components/schemas/DiskImageFormat"
+              },
+              "fstype": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "guest": {
+                "type": "string"
+              },
+              "options": {
+                "$ref": "#/components/schemas/MountOptions"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "DiskImage"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "A mount, projected for the user: guest path + options, never the resolved\nvolume id / source."
+      },
+      "SandboxNetworkResponse": {
+        "type": "object",
+        "description": "Network config, projected for the user. Secrets drop their vault path.",
+        "required": [
+          "enabled",
+          "ports",
+          "trust_host_cas"
+        ],
+        "properties": {
+          "dns": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DnsConfig"
+              }
+            ]
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "interface": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/InterfaceOverrides"
+              }
+            ]
+          },
+          "max_connections": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "policy": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/NetworkPolicy"
+              }
+            ]
+          },
+          "ports": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PublishedPortSpec"
+            }
+          },
+          "secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SandboxSecretResponse"
+            }
+          },
+          "tls": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TlsConfig"
+              }
+            ]
+          },
+          "trust_host_cas": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SandboxPolicy": {
+        "type": "object",
+        "description": "Sandbox lifecycle policy.",
+        "properties": {
+          "ephemeral": {
+            "type": "boolean",
+            "description": "Whether the sandbox is ephemeral.\n\nEphemeral sandboxes are one-off: the host runtime that owns the\nprocess removes the persisted DB row and on-disk state when the VM\nreaches a terminal status, and other host runtimes opportunistically\nclean up ephemeral leftovers from runtimes that died before they\ncould self-clean. Defaults to `false` (persistent); named and created\nsandboxes stay inspectable and restartable after they stop."
+          },
+          "idle_timeout_secs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Idle timeout in seconds. `None` = no idle detection.",
+            "minimum": 0
+          },
+          "max_duration_secs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Hard cap on total sandbox lifetime in seconds. `None` = run forever.",
+            "minimum": 0
+          }
+        }
+      },
+      "SandboxResponse": {
+        "type": "object",
+        "description": "The API view of a [`Sandbox`]: an explicit allowlist of user-facing fields.\nInternal columns (registry selection, sync bookkeeping, resolved refs) never\nappear; the resolved spec surfaces only as the curated [`SandboxSpecResponse`].",
+        "required": [
+          "id",
+          "org_id",
+          "name",
+          "slug",
+          "status",
+          "ephemeral",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ephemeral": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "last_failure_message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable reason for the last failure."
+          },
+          "name": {
+            "type": "string"
+          },
+          "org_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "spec": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SandboxSpecResponse",
+                "description": "Curated projection of the resolved spec; absent until resolved."
+              }
+            ]
+          },
+          "started_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "Latest run's start time; `null` if the sandbox has never run."
+          },
+          "status": {
+            "$ref": "#/components/schemas/SandboxStatus"
+          },
+          "status_reason": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SandboxStatusReason",
+                "description": "Scheduler condition while `status` is `starting`."
+              }
+            ]
+          },
+          "stopped_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "Latest run's stop time; `null` while open or never run."
+          }
+        }
+      },
+      "SandboxRuntimeOptions": {
+        "type": "object",
+        "description": "Guest runtime options for a sandbox.",
+        "properties": {
+          "cmd": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "Image command override.",
+            "default": null
+          },
+          "disable_metrics_sample": {
+            "type": "boolean",
+            "description": "Force-disable metrics sampling regardless of `metrics_sample_interval_ms`.",
+            "default": false
+          },
+          "entrypoint": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "Image entrypoint override.",
+            "default": null
+          },
+          "hostname": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Guest hostname override.",
+            "default": null
+          },
+          "log_level": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SandboxLogLevel",
+                "description": "Runtime log verbosity."
+              }
+            ],
+            "default": null
+          },
+          "metrics_sample_interval_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Metrics sampling interval in milliseconds. `None` disables sampling.",
+            "default": 1000,
+            "minimum": 0
+          },
+          "scripts": {
+            "type": "object",
+            "description": "Named scripts available inside the guest.",
+            "default": {},
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "shell": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Default shell for scripts and interactive sessions.",
+            "default": null
+          },
+          "user": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Guest user identity override.",
+            "default": null
+          },
+          "workdir": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Working directory inside the guest.",
+            "default": null
+          }
+        }
+      },
+      "SandboxSecretResponse": {
+        "type": "object",
+        "description": "A network secret, projected for the user: the env var, placeholder, and its\nallow-list / injection policy. The value isn't in the resolved spec at all,\nand the OpenBao vault path is never exposed.",
+        "required": [
+          "env_var",
+          "placeholder",
+          "allowed_hosts",
+          "injection"
+        ],
+        "properties": {
+          "allowed_hosts": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "env_var": {
+            "type": "string"
+          },
+          "injection": {
+            "type": "object"
+          },
+          "on_violation": {
+            "type": "object"
+          },
+          "placeholder": {
+            "type": "string"
+          }
+        }
+      },
+      "SandboxSpecResponse": {
+        "type": "object",
+        "description": "A curated, user-facing projection of a sandbox's resolved spec. Built from\n[`ResolvedSandboxSpec`]; omits every internal resolution (secret\nvalues/vault paths, volume ids).",
+        "required": [
+          "resources",
+          "runtime",
+          "env",
+          "labels",
+          "rlimits",
+          "lifecycle",
+          "mounts",
+          "network"
+        ],
+        "properties": {
+          "env": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EnvVar"
+            },
+            "description": "Environment variables."
+          },
+          "image": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "OCI image reference the sandbox boots; `null` for a non-OCI rootfs."
+          },
+          "labels": {
+            "type": "object",
+            "description": "User-defined labels.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "lifecycle": {
+            "$ref": "#/components/schemas/SandboxPolicy",
+            "description": "Lifecycle policy."
+          },
+          "mounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SandboxMountResponse"
+            },
+            "description": "Volume mounts - guest path + options only; volume ids omitted."
+          },
+          "network": {
+            "$ref": "#/components/schemas/SandboxNetworkResponse",
+            "description": "Network config - secret values/vault paths omitted."
+          },
+          "resources": {
+            "$ref": "#/components/schemas/CloudSandboxResources",
+            "description": "CPU, memory, and writable-disk sizing."
+          },
+          "rlimits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Rlimit"
+            },
+            "description": "Resource limits."
+          },
+          "runtime": {
+            "$ref": "#/components/schemas/SandboxRuntimeOptions",
+            "description": "Guest runtime options."
+          }
+        }
+      },
+      "SandboxStatus": {
+        "type": "string",
+        "description": "Sandbox lifecycle status.",
+        "enum": [
+          "created",
+          "starting",
+          "running",
+          "stopping",
+          "stopped",
+          "failed"
+        ]
+      },
+      "SandboxStatusReason": {
+        "type": "string",
+        "description": "Why a submitted sandbox is still waiting for placement on a worker. Only\nmeaningful while `status` is `starting`.",
+        "enum": [
+          "scheduling",
+          "insufficient_capacity"
+        ]
+      },
+      "SandboxWaitFor": {
+        "type": "string",
+        "enum": [
+          "running"
+        ],
+        "description": "Lifecycle state an opt-in create request may wait to observe."
+      },
+      "ScopedUpstreamCaCert": {
+        "type": "object",
+        "description": "A CA certificate PEM file trusted only for matching upstream hosts.",
+        "required": [
+          "pattern",
+          "path"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Path to the CA certificate PEM file."
+          },
+          "pattern": {
+            "type": "string",
+            "description": "Host pattern this CA applies to. Supports exact hosts and `*.suffix` wildcards."
+          }
+        }
+      },
+      "ScopedVerifyUpstream": {
+        "type": "object",
+        "description": "An upstream certificate verification override for matching hosts.",
+        "required": [
+          "pattern",
+          "verify"
+        ],
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "description": "Host pattern this override applies to. Supports exact hosts and `*.suffix` wildcards."
+          },
+          "verify": {
+            "type": "boolean",
+            "description": "Whether to verify matching upstream server certificates."
+          }
+        }
+      },
+      "SecretInjection": {
+        "type": "object",
+        "description": "Where in the HTTP request a secret can be injected.",
+        "properties": {
+          "basic_auth": {
+            "type": "boolean",
+            "description": "Substitute in HTTP Basic Auth (default: true)."
+          },
+          "body": {
+            "type": "boolean",
+            "description": "Substitute in request body (default: false).\n\nFixed-length HTTP/1 bodies up to 16 MiB update `Content-Length`;\nlarger fixed-length bodies are blocked. Chunked HTTP/1 bodies are\ndecoded and re-encoded with fresh chunk sizes. Encoded bodies pass\nthrough unchanged. HTTP/2 DATA-frame body substitution is not\nsupported; matching body placeholders are blocked."
+          },
+          "headers": {
+            "type": "boolean",
+            "description": "Substitute in HTTP headers (default: true)."
+          },
+          "query_params": {
+            "type": "boolean",
+            "description": "Substitute in URL query parameters (default: false)."
+          }
+        }
+      },
+      "SecurityProfile": {
+        "type": "string",
+        "description": "Sandbox-level in-guest security profile.",
+        "enum": [
+          "default",
+          "restricted"
+        ]
+      },
+      "StatVirtualization": {
+        "type": "string",
+        "description": "Stat virtualization policy for a virtiofs-backed volume mount.\n\nSerializes/deserializes as the lowercase variant name (`\"strict\"`, `\"relaxed\"`, `\"off\"`) so persisted JSON aligns with the CLI grammar (`stat-virt=strict|relaxed|off`) and the NAPI string contract.",
+        "enum": [
+          "strict",
+          "relaxed",
+          "off"
+        ]
+      },
+      "StorageBreakdown": {
+        "type": "object",
+        "description": "Per-volume durable-storage usage breakdown for an org over a window:\nper-(volume, day) rows plus a directory of the volumes they reference. The\nstorage sibling of [`UsageBreakdown`](crate::UsageBreakdown). Deleted volumes'\naccruals persist, so `rows` may reference `volume_id`s absent from `volumes`;\nthe client labels those as deleted.",
+        "required": [
+          "rows",
+          "volumes"
+        ],
+        "properties": {
+          "rows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StorageDailyUsage"
+            }
+          },
+          "volumes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VolumeIdentity"
+            }
+          }
+        }
+      },
+      "StorageDailyUsage": {
+        "type": "object",
+        "description": "Durable-storage usage for one volume on one UTC day, computed on read from\n`storage_accruals`. `mib_seconds` is Σ(used_mib × overlap_seconds) over the\nday; display converts to GiB-hours or an average GiB. Sum over days for a\nvolume's period total; sum over volumes for the daily series. The storage\nsibling of [`SandboxDailyUsage`](crate::SandboxDailyUsage).",
+        "required": [
+          "volume_id",
+          "day",
+          "mib_seconds"
+        ],
+        "properties": {
+          "day": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC midnight of the day this usage falls in."
+          },
+          "mib_seconds": {
+            "type": "number",
+            "format": "double",
+            "description": "Σ(used_mib × overlap_seconds) for this volume on this day."
+          },
+          "volume_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "TlsConfig": {
+        "type": "object",
+        "description": "TLS interception configuration. Carried in [`NetworkSpec::tls`](NetworkSpec).\n\nThe local network engine terminates TCP at its in-process stack, so TLS MITM\nis handled by proxy tasks - these fields configure which ports/domains are\nintercepted and how the interception CA is sourced.",
+        "properties": {
+          "block_quic_on_intercept": {
+            "type": "boolean",
+            "description": "Drop UDP to intercepted ports when TLS interception is active, forcing\nQUIC traffic to fall back to TCP/TLS."
+          },
+          "bypass": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Domains to bypass (no MITM). Supports exact match and `*.suffix` wildcards."
+          },
+          "cache": {
+            "$ref": "#/components/schemas/CertCacheConfig",
+            "description": "Per-domain certificate cache configuration."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether TLS interception is enabled."
+          },
+          "intercept_ca": {
+            "$ref": "#/components/schemas/InterceptCaConfig",
+            "description": "Interception CA configuration. The TLS proxy uses this CA to sign\nper-domain certs it presents to the guest during interception."
+          },
+          "intercepted_ports": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "TCP ports subject to TLS interception (default: `[443]`)."
+          },
+          "scoped_upstream_ca_cert": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScopedUpstreamCaCert"
+            },
+            "description": "Host-scoped CA certificate PEM files to trust for upstream server verification."
+          },
+          "scoped_verify_upstream": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScopedVerifyUpstream"
+            },
+            "description": "Host-scoped upstream verification overrides."
+          },
+          "upstream_ca_cert": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "CA certificate PEM files to trust for upstream server verification."
+          },
+          "verify_upstream": {
+            "type": "boolean",
+            "description": "Whether to verify the upstream server's TLS certificate."
+          }
+        }
+      },
+      "UpdateSandboxRequest": {
+        "type": "object",
+        "description": "Request body for `PATCH /v1/orgs/:slug/sandboxes/:id` - rename a sandbox.\nEach field updates only when present; omit one to leave it unchanged.\n`name` is the per-org display label; `slug` is the globally-unique SSH\naddress handle (changing it breaks existing `ssh <old-slug>@msb.run`).",
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "New per-org display name. Omit to leave unchanged."
+          },
+          "slug": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "New globally-unique slug (the SSH username token). Omit to leave unchanged."
+          }
+        }
+      },
+      "UpdateVolumeRequest": {
+        "type": "object",
+        "description": "PATCH /v1/orgs/{slug}/volumes/{id} - update the cap and/or labels (#496).\n\nEvery field is independently optional: an **omitted** field is left unchanged.\n`capacity_gib` uses the double-`Option` distinction - omit to leave as-is,\nexplicit `null` to clear the cap, a number to set it.",
+        "properties": {
+          "capacity_gib": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "New per-volume storage cap in GiB. Omitted = unchanged; `null` = clear the\ncap (back to no per-volume limit); a value sets it. A set value must be\n`>= 1` and `<= the org's storage cap`.",
+            "minimum": 0
+          },
+          "labels": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Replacement label set. Omitted = unchanged; an object replaces the labels\nwholesale (an empty object clears them). Reserved-prefix keys are rejected.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UsageBreakdown": {
+        "type": "object",
+        "description": "Compute-on-read usage breakdown for an org over a window: per-(sandbox, day)\nquantity rows plus a directory of the sandboxes they reference. The frontend\ngroups `rows` by sandbox (for the per-sandbox table) or by day (for the\nchart) and labels them via `sandboxes`.",
+        "required": [
+          "rows",
+          "sandboxes"
+        ],
+        "properties": {
+          "rows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SandboxDailyUsage"
+            }
+          },
+          "sandboxes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SandboxIdentity"
+            }
+          }
+        }
+      },
+      "UsageDailyPoint": {
+        "type": "object",
+        "description": "One day's metered quantity for a single billable metric - the unit of a\nusage time-series chart. Cost is intentionally omitted: invoices are\nperiod-aggregated, so a per-day dollar figure would have to be derived.",
+        "required": [
+          "date",
+          "metric",
+          "quantity"
+        ],
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Start of the day window (UTC)."
+          },
+          "metric": {
+            "type": "string",
+            "description": "Billable-metric name this quantity belongs to."
+          },
+          "quantity": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "UsageLineItem": {
+        "type": "object",
+        "description": "A single line item in a usage summary.",
+        "required": [
+          "name",
+          "quantity",
+          "unit",
+          "amount_cents"
+        ],
+        "properties": {
+          "amount_cents": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "number",
+            "format": "double"
+          },
+          "unit": {
+            "type": "string"
+          }
+        }
+      },
+      "UsageSummary": {
+        "type": "object",
+        "description": "Usage summary from the billing provider.",
+        "required": [
+          "period_start",
+          "period_end",
+          "line_items",
+          "total_cents"
+        ],
+        "properties": {
+          "daily": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UsageDailyPoint"
+            },
+            "description": "Per-day metered quantities for charting. One entry per (day, metric).\nEmpty when no daily series is available (e.g. provider error)."
+          },
+          "line_items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UsageLineItem"
+            },
+            "description": "Period-aggregated breakdown - one entry per billable metric / charge."
+          },
+          "period_end": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "period_start": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "projected_spend_cents": {
+            "type": "integer",
+            "format": "int64",
+            "description": "End-of-period spend projection: `total_cents` linearly extrapolated over\nthe billing period. Equals `total_cents` when the period can't be\nextrapolated (no future end, or zero elapsed). Never below `total_cents`."
+          },
+          "storage_gib": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double",
+            "description": "Current durable-storage usage (GiB) for the org, from the latest hourly\nreading. `None` when storage hasn't been sampled (juicefs-ops disabled or\nno volumes). Drives the storage allowance bar; cost is in `line_items`."
+          },
+          "total_cents": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "VolumeIdentity": {
+        "type": "object",
+        "description": "Minimal volume display info - the directory that turns the `volume_id`s in a\n[`StorageBreakdown`](crate::StorageBreakdown)'s rows into human labels. A\ndeleted volume's accruals outlive its row, so a breakdown may reference ids\nabsent from this directory; the client labels those as deleted.",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "`None` for the host volume (nameless)."
+          }
+        }
+      },
+      "VolumeKind": {
+        "type": "string",
+        "description": "What kind of volume this is - its storage source / role. The host volume is\nthe org's single shared \"host disk\"; managed volumes are user-created, named,\nplatform-provisioned (JuiceFS over our object store). (A future `External`\nvariant - bring-your-own S3/GCS - is intentionally out of scope for now.)",
+        "enum": [
+          "host",
+          "managed"
+        ]
+      },
+      "VolumeResponse": {
+        "type": "object",
+        "description": "Volume metadata returned in list/create responses. The GCS storage path is\nderived (not stored) and never exposed.",
+        "required": [
+          "id",
+          "kind",
+          "storage",
+          "status",
+          "labels",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "capacity_bytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "The volume's configured per-volume storage cap in bytes, or `null` when\nno cap is set (#496). Derived from the stored `capacity_gib` (the user's\nconfigured intent) - the effective ceiling is `min(this, org cap)`.",
+            "minimum": 0
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/VolumeKind",
+            "description": "`host` - the org's shared host disk (not deletable); `managed` - a\nuser-created named volume."
+          },
+          "labels": {
+            "type": "object",
+            "description": "User-defined labels (empty object when none set).",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "User-facing name. `null` for the host volume (it has no name; it's\nidentified by `kind`)."
+          },
+          "status": {
+            "$ref": "#/components/schemas/VolumeStatus"
+          },
+          "storage": {
+            "$ref": "#/components/schemas/VolumeType",
+            "description": "How the volume is physically backed (`block` today)."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "used_bytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Bytes currently used under this volume's subtree. `null` when usage is\nunavailable - the usage service is disabled or unreachable (list degrades\ngracefully rather than failing) - or on create/delete, which don't sample\nit.",
+            "minimum": 0
+          }
+        }
+      },
+      "VolumeStatus": {
+        "type": "string",
+        "description": "Lifecycle status of a volume.",
+        "enum": [
+          "active",
+          "deleting"
+        ]
+      },
+      "VolumeType": {
+        "type": "string",
+        "description": "How a volume is physically backed - distinct from [`VolumeKind`] (ownership).\nEvery volume is `Block` today; the enum exists so future backings can be added\n(and reported to the SDK) without another schema change.",
+        "enum": [
+          "block"
+        ]
+      }
+    },
+    "securitySchemes": {
+      "api_key": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Organization API key (msb_…) - org-scoped programmatic access."
+      }
+    }
+  }
+}

--- a/docs/api-reference/overview.mdx
+++ b/docs/api-reference/overview.mdx
@@ -1,0 +1,60 @@
+---
+title: "Overview"
+description: "The REST API behind the SDKs and CLI"
+icon: "book-open"
+---
+
+<Note>
+  microsandbox cloud is in [private beta](/cloud/overview); the API is available to organizations with access.
+</Note>
+
+The microsandbox cloud REST API manages sandboxes, volumes, quotas, usage, and audit events for your organization. It is the control-plane API behind the SDKs and CLI. Reach for it directly from environments without an SDK, or for automation around usage and auditing.
+
+For running code in sandboxes (exec, streaming, PTY, file transfer, SSH), use the [SDKs](/sdk/overview) or [CLI](/cli/overview). They speak the sandbox command channel, which is not part of this REST surface.
+
+## Base URL
+
+```text
+https://api.microsandbox.dev
+```
+
+## Authentication
+
+Authenticate every request with an organization API key (`msb_...`) as a bearer token. Keys are created in the [dashboard](https://dashboard.microsandbox.dev/access/api-keys). The key identifies your organization; no org identifier appears in these paths.
+
+```bash
+curl https://api.microsandbox.dev/v1/sandboxes \
+  -H "Authorization: Bearer $MSB_API_KEY"
+```
+
+## Errors
+
+Errors return an `error` object with a stable machine-readable `code`, a human-readable `message`, and optional structured `details`:
+
+```json
+{
+  "error": {
+    "code": "invalid_api_key",
+    "message": "unauthorized",
+    "details": null
+  }
+}
+```
+
+## Pagination
+
+List endpoints use cursor pagination. Pass `limit` to size the page and `cursor` to continue from a previous response:
+
+```json
+{
+  "data": [ ... ],
+  "has_more": true,
+  "next_cursor": "eyJv..."
+}
+```
+
+Request the next page with `?cursor=<next_cursor>`; `has_more: false` means you have everything.
+
+## Usage and billing
+
+The usage endpoints report metered consumption for the current period. Reported cost figures are estimates; the [dashboard](https://dashboard.microsandbox.dev/billing) is the source of truth for billing.

--- a/docs/cli/image-commands.mdx
+++ b/docs/cli/image-commands.mdx
@@ -5,9 +5,7 @@ description: Pull and manage OCI images from the CLI
 icon: "layer-group"
 ---
 
-<Note>
-  **Cloud:** Image commands manage the local cache and are local-only. On cloud, specify an OCI image when creating the sandbox and it is resolved and pulled for you.
-</Note>
+<Tooltip tip="Image commands manage the local cache. On microsandbox cloud, specify an OCI image when creating the sandbox and it is pulled for you."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ## msb pull
 

--- a/docs/cli/image-commands.mdx
+++ b/docs/cli/image-commands.mdx
@@ -5,6 +5,10 @@ description: Pull and manage OCI images from the CLI
 icon: "layer-group"
 ---
 
+<Note>
+  **Cloud:** Image commands manage the local cache and are local-only. On cloud, specify an OCI image when creating the sandbox and it is resolved and pulled for you.
+</Note>
+
 ## msb pull
 
 Pre-pull an image to the local cache. Layers are fetched in parallel with per-layer progress bars. Once cached, layers are content-addressable and deduplicated, so shared layers across images are only stored once.

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -7,6 +7,8 @@ icon: "book"
 
 The `msb` CLI lets you create, manage, and interact with sandboxes from the terminal. It auto-detects TTY and interactivity, so no `-it` flags are needed. If your terminal is interactive, `msb` acts accordingly.
 
+The same CLI drives [microsandbox cloud](/cloud/overview) when an API key is set. A few commands are local-only or limited on cloud (image-cache commands, `msb metrics`, bounded `msb logs`, `msb ssh serve`, disk-sized volume creation); pages flag these individually, and the [compatibility matrix](/cloud/compatibility) lists them.
+
 ## Install
 
 <CodeGroup>

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -67,9 +67,11 @@ Use `msb run --help` for the full flag list.
 
 Published ports bind to `127.0.0.1` by default. Use an explicit bind address only when the sandbox service should be reachable beyond localhost. On Windows, opening a published port can trigger a Windows Defender Firewall prompt for `msb.exe`. Keep the bind on `127.0.0.1` for local-only development, and allow private/public network access only when you intentionally bind beyond loopback.
 
+On microsandbox cloud, publishing host ports is not available; expose the service through a cloud-reachable endpoint instead.
+
 ### Network profiles
 
-`--net` is repeatable and accepts comma-separated profiles. `public`, `private`, and `host` compose; DNS through the sandbox gateway is enabled automatically and only once. `all` and `none` are terminal policies and cannot be mixed with the three positive profiles.
+`--net` is repeatable and accepts comma-separated profiles. `public`, `private`, and `host` compose; DNS through the sandbox gateway is enabled automatically and only once. `all` and `none` are terminal policies and cannot be mixed with the three positive profiles. On microsandbox cloud, the `host` profile does not refer to the machine running the CLI; use a network endpoint reachable from the cloud worker.
 
 ```bash
 msb run alpine --net public
@@ -138,6 +140,8 @@ msb create --replace-with-timeout 30s python --name worker  # Give the old one 3
 msb create --replace-with-timeout 0 python --name worker    # SIGKILL immediately
 ```
 
+On microsandbox cloud, `--replace` and `--replace-with-timeout` are not available; remove the existing sandbox first, then create the replacement.
+
 ## msb start
 
 Resume a stopped sandbox. Name one or more sandboxes, or select them by label.
@@ -172,9 +176,7 @@ same durability semantics as a sudden power loss on a physical
 machine. For durable writes, workloads should `fsync` important data
 themselves.
 
-<Note>
-  **Cloud:** `--force` is not yet available; stops are always graceful.
-</Note>
+On cloud, `--force` is not yet available; stops are always graceful.
 
 | Flag | Description |
 |------|-------------|
@@ -206,6 +208,8 @@ msb restart -t 30 devbox
 
 ## msb ping
 
+<Tooltip tip="Not yet available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 Check whether one or more running sandbox agents are reachable. `msb ping` talks to `agentd` with `core.ping` and does not refresh the sandbox idle timer.
 
 ```bash
@@ -217,10 +221,6 @@ msb ping api --touch
 
 Use `--touch` when a successful health check should also refresh the idle timer. Without `--touch`, ping is a pure reachability check.
 
-<Note>
-  **Cloud:** `msb ping` and `msb touch` are not yet available.
-</Note>
-
 | Flag | Description |
 |------|-------------|
 | `--label` | Ping every sandbox carrying this label (`KEY=VALUE`). Repeatable; AND-matched. Unioned with any named sandboxes |
@@ -228,6 +228,8 @@ Use `--touch` when a successful health check should also refresh the idle timer.
 | `-q`, `--quiet` | Suppress progress output |
 
 ## msb touch
+
+<Tooltip tip="Not yet available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 Explicitly refresh the idle timer for one or more running sandboxes. `msb touch` sends `core.touch`; it is the intentional keepalive command for long-lived idle sandboxes.
 
@@ -244,11 +246,9 @@ msb touch --label app=engine
 
 ## msb modify
 
-Change a running sandbox's configuration. Every change is planned and applied all-or-nothing. CPU and memory resize live within the `max_cpus` / `max_memory` ceilings; other changes that can't apply live need `--restart` or `--next-start`.
+<Tooltip tip="Not yet available on microsandbox cloud; recreate the sandbox with the new configuration."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** `msb modify` is not yet available; recreate the sandbox with the new configuration.
-</Note>
+Change a running sandbox's configuration. Every change is planned and applied all-or-nothing. CPU and memory resize live within the `max_cpus` / `max_memory` ceilings; other changes that can't apply live need `--restart` or `--next-start`.
 
 ```bash
 msb modify api --cpus 4                     # live when 4 <= max_cpus
@@ -257,7 +257,7 @@ msb modify api --max-memory 16G --next-start # raise the ceiling on next start
 msb modify api --cpus 8 --dry-run           # show the plan, apply nothing
 ```
 
-`max_cpus` and `max_memory` are boot-time reservations chosen at create time. They default to the effective `cpus`/`memory`, which leaves no headroom; live growth beyond them is impossible without a restart. Reserving capacity costs almost nothing (parked vCPUs and lazily-backed memory), so set them above the initial values at create time if the sandbox may need to grow.
+`max_cpus` and `max_memory` are boot-time reservations chosen at create time. They default to the effective `cpus`/`memory`, which leaves no headroom; live growth beyond them is impossible without a restart. Reserving capacity costs almost nothing (parked vCPUs and lazily-backed memory), so set them above the initial values at create time if the sandbox may need to grow. On microsandbox cloud, these ceilings are not carried; recreate the sandbox to resize beyond its initial values.
 
 Live resize is not necessarily instant. When an accepted resize has not fully settled, the apply output includes a convergence table with a `STATE` column. The values are: `applied` (requested, actual, and enforced values match), `converging` (the guest is still onlining CPUs or plugging memory), `guest-refused` (the guest would not cooperate; the host enforces the new limit anyway), and `failed`. JSON output (`--format json`) carries the same states in `resize_status`.
 
@@ -327,11 +327,9 @@ Host-to-sandbox and sandbox-to-host forms follow `docker cp` syntax. Same-sandbo
 
 ## msb logs
 
-Read captured output from a sandbox. Each sandbox stores its captured stdio under `<sandbox-dir>/logs/exec.log` as JSON Lines, plus runtime/kernel diagnostics in `runtime.log`/`kernel.log`. The command works on running and stopped sandboxes alike; there is no protocol traffic, just a file read.
+<Tooltip tip="Not yet available on microsandbox cloud; follow output live with the SDK and persist it externally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** `msb logs` is not yet available. Follow output live with the SDK and persist it externally when you need retention.
-</Note>
+Read captured output from a sandbox. Each sandbox stores its captured stdio under `<sandbox-dir>/logs/exec.log` as JSON Lines, plus runtime/kernel diagnostics in `runtime.log`/`kernel.log`. The command works on running and stopped sandboxes alike; there is no protocol traffic, just a file read.
 
 ```bash
 # Captured user-program output (default sources: stdout + stderr + output)
@@ -428,11 +426,9 @@ The `CPUS` and `MEM` columns show the sandbox's allocation as `effective / max`,
 
 ## msb metrics
 
-Show live CPU, memory, disk, network, and optional upper disk metrics for running sandboxes.
+<Tooltip tip="Not yet available on microsandbox cloud; instrument the workload with an external monitoring system."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** `msb metrics` is not yet available. Instrument the workload itself with an external monitoring system.
-</Note>
+Show live CPU, memory, disk, network, and optional upper disk metrics for running sandboxes.
 
 ```bash
 msb metrics                 # All running sandboxes (one-shot table)
@@ -473,6 +469,8 @@ The `CPU` and `MEM` denominators come from the catalog's **active config**, so t
 `--format json` and `--follow` keep the raw cumulative counters (no rate conversion) and add `state` and `cpus` fields.
 
 ## msb inspect
+
+<Tooltip tip="On microsandbox cloud, text output omits parsed configuration details; use --format json to view the raw cloud specification."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 Show detailed configuration and status.
 

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -172,6 +172,10 @@ same durability semantics as a sudden power loss on a physical
 machine. For durable writes, workloads should `fsync` important data
 themselves.
 
+<Note>
+  **Cloud:** `--force` is not yet available; stops are always graceful.
+</Note>
+
 | Flag | Description |
 |------|-------------|
 | `--label` | Stop every sandbox carrying this label (`KEY=VALUE`). Repeatable; AND-matched. Unioned with any named sandboxes |
@@ -213,6 +217,10 @@ msb ping api --touch
 
 Use `--touch` when a successful health check should also refresh the idle timer. Without `--touch`, ping is a pure reachability check.
 
+<Note>
+  **Cloud:** `msb ping` and `msb touch` are not yet available.
+</Note>
+
 | Flag | Description |
 |------|-------------|
 | `--label` | Ping every sandbox carrying this label (`KEY=VALUE`). Repeatable; AND-matched. Unioned with any named sandboxes |
@@ -238,6 +246,10 @@ msb touch --label app=engine
 
 Change a running sandbox's configuration. Every change is planned and applied all-or-nothing. CPU and memory resize live within the `max_cpus` / `max_memory` ceilings; other changes that can't apply live need `--restart` or `--next-start`.
 
+<Note>
+  **Cloud:** `msb modify` is not yet available; recreate the sandbox with the new configuration.
+</Note>
+
 ```bash
 msb modify api --cpus 4                     # live when 4 <= max_cpus
 msb modify api --env MODE=prod --restart    # restart to apply now
@@ -245,13 +257,13 @@ msb modify api --max-memory 16G --next-start # raise the ceiling on next start
 msb modify api --cpus 8 --dry-run           # show the plan, apply nothing
 ```
 
-`max_cpus` and `max_memory` are boot-time reservations chosen at create time. They default to the effective `cpus`/`memory`, which leaves no headroom — live growth beyond them is impossible without a restart. Reserving capacity costs almost nothing (parked vCPUs and lazily-backed memory), so set them above the initial values at create time if the sandbox may need to grow.
+`max_cpus` and `max_memory` are boot-time reservations chosen at create time. They default to the effective `cpus`/`memory`, which leaves no headroom; live growth beyond them is impossible without a restart. Reserving capacity costs almost nothing (parked vCPUs and lazily-backed memory), so set them above the initial values at create time if the sandbox may need to grow.
 
 Live resize is not necessarily instant. When an accepted resize has not fully settled, the apply output includes a convergence table with a `STATE` column. The values are: `applied` (requested, actual, and enforced values match), `converging` (the guest is still onlining CPUs or plugging memory), `guest-refused` (the guest would not cooperate; the host enforces the new limit anyway), and `failed`. JSON output (`--format json`) carries the same states in `resize_status`.
 
-Env and workdir changes on a running sandbox apply to future execs only — running processes keep their current environment. The plan reports this as a warning.
+Env and workdir changes on a running sandbox apply to future execs only; running processes keep their current environment. The plan reports this as a warning.
 
-`--secret NAME@HOST[,HOST...]` adds or rotates a secret from the same-named host environment variable, recording a source reference — the value itself never rides in the command. The inline `NAME=VALUE@HOST` form is rejected, same as on `msb create`: shell history and process listings would leak the value, so providing a raw value is SDK-only.
+`--secret NAME@HOST[,HOST...]` adds or rotates a secret from the same-named host environment variable, recording a source reference; the value itself never rides in the command. The inline `NAME=VALUE@HOST` form is rejected, same as on `msb create`: shell history and process listings would leak the value, so providing a raw value is SDK-only.
 
 | Flag | Description |
 |------|-------------|
@@ -316,6 +328,10 @@ Host-to-sandbox and sandbox-to-host forms follow `docker cp` syntax. Same-sandbo
 ## msb logs
 
 Read captured output from a sandbox. Each sandbox stores its captured stdio under `<sandbox-dir>/logs/exec.log` as JSON Lines, plus runtime/kernel diagnostics in `runtime.log`/`kernel.log`. The command works on running and stopped sandboxes alike; there is no protocol traffic, just a file read.
+
+<Note>
+  **Cloud:** `msb logs` is not yet available. Follow output live with the SDK and persist it externally when you need retention.
+</Note>
 
 ```bash
 # Captured user-program output (default sources: stdout + stderr + output)
@@ -413,6 +429,10 @@ The `CPUS` and `MEM` columns show the sandbox's allocation as `effective / max`,
 ## msb metrics
 
 Show live CPU, memory, disk, network, and optional upper disk metrics for running sandboxes.
+
+<Note>
+  **Cloud:** `msb metrics` is not yet available. Instrument the workload itself with an external monitoring system.
+</Note>
 
 ```bash
 msb metrics                 # All running sandboxes (one-shot table)

--- a/docs/cli/ssh-commands.mdx
+++ b/docs/cli/ssh-commands.mdx
@@ -45,6 +45,10 @@ The default authorization file is `<MSB_HOME>/ssh/authorized_keys`, or `~/.micro
 
 Serve a sandbox over SSH for external OpenSSH, SFTP, local TCP forwarding, dynamic TCP forwarding, or `ProxyCommand` clients.
 
+<Note>
+  **Cloud:** Serving a local SSH listener is not available; use `msb ssh` native sessions instead.
+</Note>
+
 ```bash
 msb ssh serve devbox
 msb ssh serve devbox --host 127.0.0.1 --port 2222

--- a/docs/cli/ssh-commands.mdx
+++ b/docs/cli/ssh-commands.mdx
@@ -43,11 +43,9 @@ The default authorization file is `<MSB_HOME>/ssh/authorized_keys`, or `~/.micro
 
 ## msb ssh serve
 
-Serve a sandbox over SSH for external OpenSSH, SFTP, local TCP forwarding, dynamic TCP forwarding, or `ProxyCommand` clients.
+<Tooltip tip="Not available on microsandbox cloud; use msb ssh native sessions instead."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** Serving a local SSH listener is not available; use `msb ssh` native sessions instead.
-</Note>
+Serve a sandbox over SSH for external OpenSSH, SFTP, local TCP forwarding, dynamic TCP forwarding, or `ProxyCommand` clients.
 
 ```bash
 msb ssh serve devbox

--- a/docs/cli/volume-commands.mdx
+++ b/docs/cli/volume-commands.mdx
@@ -9,6 +9,8 @@ Named volumes persist independently of sandboxes and are stored by default under
 
 ## msb volume create
 
+<Tooltip tip="On microsandbox cloud, create a named volume before mounting it; disk-kind volumes and size are not available, and quota must be a whole number of GiB."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```bash
 msb volume create my-data
 msb volume create --name my-data
@@ -37,13 +39,11 @@ msb volume ls -q               # Names only
 
 ## msb volume inspect
 
+<Tooltip tip="Not yet available on microsandbox cloud; read volume metadata through the SDK."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```bash
 msb volume inspect my-data
 ```
-
-<Note>
-  **Cloud:** `msb volume inspect` is not yet available; read volume metadata through the SDK.
-</Note>
 
 ## msb volume rm
 

--- a/docs/cli/volume-commands.mdx
+++ b/docs/cli/volume-commands.mdx
@@ -41,6 +41,10 @@ msb volume ls -q               # Names only
 msb volume inspect my-data
 ```
 
+<Note>
+  **Cloud:** `msb volume inspect` is not yet available; read volume metadata through the SDK.
+</Note>
+
 ## msb volume rm
 
 ```bash

--- a/docs/cloud/compatibility.mdx
+++ b/docs/cloud/compatibility.mdx
@@ -16,7 +16,7 @@ The core workflow (create, execute, connect, persist) is identical on both backe
 
 | Capability | SDK | CLI |
 |---|:---:|:---:|
-| [Backend auto-selection](/configuration#backend-profiles) | ✅ | ✅ |
+| [Backend auto-selection](/getting-started/backends) | ✅ | ✅ |
 | [Sandbox: lifecycle](/sandboxes/lifecycle) (create, configure, list, inspect, reconnect, start, stop, restart, remove) | ✅ | ✅ |
 | [Sandbox: execution](/sandboxes/commands) (exec, shell, streaming, interactive PTY) | ✅ | ✅ |
 | [Filesystem: guest access](/sandboxes/filesystem) | ✅ | ⚠️ |

--- a/docs/cloud/compatibility.mdx
+++ b/docs/cloud/compatibility.mdx
@@ -1,0 +1,57 @@
+---
+title: "Compatibility"
+description: "What the SDK and CLI support on microsandbox cloud today"
+icon: "table-list"
+---
+
+<Note>
+  microsandbox cloud is in [private beta](/cloud/overview). This page was last reviewed on **August 2, 2026**. Capabilities that are limited or unavailable today are actively being worked on, and will move up this page as they become available on cloud.
+</Note>
+
+The SDKs and CLI expose one surface for both backends, and almost all of it behaves identically on cloud. This page lists what works today, what is limited, and the recommended alternative for anything not yet available.
+
+## Fully supported
+
+The core workflow (create, execute, connect, persist) is identical on both backends.
+
+| Capability | SDK | CLI |
+|---|:---:|:---:|
+| [Backend auto-selection](/configuration#backend-profiles) | ✅ | ✅ |
+| [Sandbox: lifecycle](/sandboxes/lifecycle) (create, configure, list, inspect, reconnect, start, stop, restart, remove) | ✅ | ✅ |
+| [Sandbox: execution](/sandboxes/commands) (exec, shell, streaming, interactive PTY) | ✅ | ✅ |
+| [Filesystem: guest access](/sandboxes/filesystem) | ✅ | ⚠️ |
+| [Filesystem: copy from the host](/sandboxes/filesystem#copy-from-host) | ✅ | ✅ |
+| [Networking: policies and profiles](/networking/overview) | ✅ | ✅ |
+| [SSH: client sessions](/sandboxes/ssh) | ✅ | ✅ |
+| SSH: SFTP (no dedicated CLI command) | ✅ | N/A |
+| [Logs: live follow](/sandboxes/logs#read-from-the-sdk) | ✅ | ❌ |
+| [Volumes: create, mount, tmpfs](/sandboxes/volumes) (named volumes, tmpfs, manage) | ✅ | ✅ |
+
+## Not yet available
+
+| Capability | Use instead |
+|---|---|
+| [Sandbox: disk snapshots](/sandboxes/snapshots) | [Named volumes](/sandboxes/volumes#named-volumes) for state that must survive sandbox replacement |
+| [Sandbox: force kill and drain](/sandboxes/lifecycle#kill-immediately) | Graceful [stop](/sandboxes/lifecycle#stop-and-restart) |
+| [Sandbox: ping and touch](/sandboxes/lifecycle#ping-and-touch) | N/A |
+| [Sandbox: modify and resize](/sandboxes/tuning#change-model) | Recreate with the new configuration |
+| [Sandbox: resource metrics](/sandboxes/metrics) | External monitoring of the workload itself |
+| [Logs: historical reads](/sandboxes/logs) | SDK [live follow](/sandboxes/logs#read-from-the-sdk), persisted externally |
+| [Images: cache management](/images/overview#image-storage) | Specify an OCI image on create; cloud pulls it for you |
+| [Networking: published ports](/networking/overview#port-mapping) | N/A |
+| [Networking: custom nameservers](/networking/dns#pinning-nameservers) | Platform-managed DNS |
+| [Networking: TLS interception and host-CA trust](/networking/tls) | N/A |
+| [Volumes: host-side access to unmounted volumes](/sandboxes/volumes#sharing-and-host-side-access) | Mount the volume, then use the sandbox filesystem |
+
+## Limited
+
+| Capability | SDK | CLI | Guidance |
+|---|:---:|:---:|---|
+| [Sandbox: duration and idle policies](/sandboxes/lifecycle#sandbox-process-policies) | ⚠️ | ⚠️ | Stop and remove sandboxes explicitly |
+| Sandbox: custom hostname | ⚠️ | ⚠️ | Cloud assigns the hostname |
+| Images: pull progress | ⚠️ | ⚠️ | Use normal create; cloud reports no per-layer progress |
+| [SSH: reusable server](/sandboxes/ssh#external-clients) | ⚠️ | ❌ | SDK works with explicit key material; otherwise use `msb ssh` |
+| [Volumes: bind and disk-image mounts](/sandboxes/volumes#bind-mounts) | ⚠️ | ⚠️ | Host paths resolve against your org's [host volume](/sandboxes/volumes), not the machine running the SDK or CLI |
+| Volumes: metadata | ✅ | ❌ | Use the SDK |
+
+**Legend:** ✅ available · ⚠️ limited · ❌ unavailable · N/A not applicable

--- a/docs/cloud/overview.mdx
+++ b/docs/cloud/overview.mdx
@@ -82,63 +82,9 @@ Hardware virtualization support on your machine is not needed for cloud sandboxe
 
 The same key also authenticates the [REST API](/api-reference/overview) directly, so you can manage sandboxes, volumes, and usage over plain HTTPS without an SDK. Command execution, file transfer, and SSH ride the sandbox command channel, which the SDKs and CLI handle for you.
 
-## Choosing a backend explicitly
-
-You don't need anything beyond the API key: exporting `MSB_API_KEY` is the whole setup. The overrides below exist for the cases where a process must be explicit; pick at most one.
-
-**Force a backend for a single command or shell** with `MSB_BACKEND`, for example to use the local runtime while a key is exported:
-
-```bash
-MSB_BACKEND=local msb run python -- python -V   # force local
-MSB_BACKEND=cloud msb ls                        # explicit cloud
-```
-
-**Select in code** when the application should decide regardless of its environment. This overrides environment and profile resolution:
-
-<CodeGroup>
-```rust Rust
-use microsandbox::{set_default_backend, CloudBackend, LocalBackend};
-
-// reads MSB_API_KEY
-set_default_backend(CloudBackend::from_env()?);
-
-// or: pass the key explicitly
-set_default_backend(CloudBackend::with_api_key(api_key)?);
-
-// or: force the local runtime
-set_default_backend(LocalBackend::lazy());
-```
-
-```typescript TypeScript
-import { setDefaultBackend } from "microsandbox";
-
-setDefaultBackend({ kind: "cloud", apiKey: process.env.MSB_API_KEY! });
-
-// or: force the local runtime
-setDefaultBackend("local");
-```
-
-```python Python
-import os
-from microsandbox import set_default_backend
-
-set_default_backend("cloud", api_key=os.environ["MSB_API_KEY"])
-
-# or: force the local runtime
-set_default_backend("local")
-```
-
-```go Go
-// The Go SDK selects the backend from the environment: set MSB_API_KEY
-// (or MSB_PROFILE) before the first microsandbox call.
-os.Setenv("MSB_API_KEY", apiKey)
-```
-</CodeGroup>
-
-**Set per-project defaults** with [backend profiles](/configuration#backend-profiles) in `config.json` when you switch between local and cloud regularly. The full resolution order is documented there.
-
 ## What to know
 
+- **Backend selection.** The API key alone selects the cloud. For explicit control (forcing local, choosing in code, per-project profiles), see [Backends](/getting-started/backends).
 - **Compatibility.** Almost the entire SDK and CLI surface behaves identically. The exceptions and their alternatives are listed on the [compatibility page](/cloud/compatibility).
 - **Networking.** Cloud sandboxes get a cloud-assigned hostname. SSH works through the same `msb ssh` and SDK SSH clients you use locally.
 - **Images.** Specify any OCI image on create; the cloud resolves and pulls it for you. Local image-cache commands don't apply.
@@ -155,8 +101,8 @@ os.Setenv("MSB_API_KEY", apiKey)
     The REST API behind the SDKs, authenticated with your API key.
   </Card>
 
-  <Card title="Backend profiles" icon="gear" href="/configuration#backend-profiles">
-    Switch between local and cloud from one config file.
+  <Card title="Backends" icon="route" href="/getting-started/backends">
+    Force local, select in code, or switch with profiles.
   </Card>
 
   <Card title="Quickstart" icon="bolt" href="/getting-started/quickstart">

--- a/docs/cloud/overview.mdx
+++ b/docs/cloud/overview.mdx
@@ -1,0 +1,165 @@
+---
+title: "Overview"
+description: "Run the same sandboxes on hosted infrastructure with an API key"
+icon: "cloud"
+---
+
+<Note>
+  microsandbox cloud is in **private beta**, and currently requires you to explicitly [request access](https://dashboard.microsandbox.dev/signup). If you already have access, you can get your API key from the [dashboard](https://dashboard.microsandbox.dev/access/api-keys).
+</Note>
+
+microsandbox cloud runs your sandboxes on hosted infrastructure. The SDKs and the `msb` CLI are the same ones you use locally: the same builders, the same commands, the same code. An API key is the only thing that changes; there is no URL, daemon, or extra configuration.
+
+```bash
+export MSB_API_KEY="msb_..."
+```
+
+## Same code, different backend
+
+Everything from the [quickstart](/getting-started/quickstart) works unchanged. With the API key exported, this creates a sandbox on cloud instead of your machine:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::Sandbox;
+
+let sb = Sandbox::builder("hello")
+    .image("python")
+    .memory(512)
+    .create()
+    .await?;
+
+let output = sb.exec("python", ["-c", "print('Hello from the cloud!')"]).await?;
+println!("{}", output.stdout()?);
+
+sb.stop().await?;
+```
+
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("hello")
+    .image("python")
+    .memory(512)
+    .create();
+
+const output = await sb.exec("python", ["-c", "print('Hello from the cloud!')"]);
+console.log(output.stdout());
+```
+
+```python Python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create("hello", image="python", memory=512)
+
+output = await sb.exec("python", ["-c", "print('Hello from the cloud!')"])
+print(output.stdout_text)
+
+await sb.stop()
+```
+
+```go Go
+sb, err := m.CreateSandbox(ctx, "hello",
+    m.WithImage("python"),
+    m.WithMemory(512),
+)
+if err != nil {
+    return err
+}
+defer sb.Stop(ctx)
+
+output, err := sb.Exec(ctx, "python", []string{"-c", "print('Hello from the cloud!')"})
+fmt.Println(output.Stdout())
+```
+
+```bash CLI
+msb run python -- python3 -c "print('Hello from the cloud!')"
+```
+</CodeGroup>
+
+Hardware virtualization support on your machine is not needed for cloud sandboxes; `msb doctor` checks apply to the local runtime only.
+
+## REST API
+
+The same key also authenticates the [REST API](/api-reference/overview) directly, so you can manage sandboxes, volumes, and usage over plain HTTPS without an SDK. Command execution, file transfer, and SSH ride the sandbox command channel, which the SDKs and CLI handle for you.
+
+## Choosing a backend explicitly
+
+You don't need anything beyond the API key: exporting `MSB_API_KEY` is the whole setup. The overrides below exist for the cases where a process must be explicit; pick at most one.
+
+**Force a backend for a single command or shell** with `MSB_BACKEND`, for example to use the local runtime while a key is exported:
+
+```bash
+MSB_BACKEND=local msb run python -- python -V   # force local
+MSB_BACKEND=cloud msb ls                        # explicit cloud
+```
+
+**Select in code** when the application should decide regardless of its environment. This overrides environment and profile resolution:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{set_default_backend, CloudBackend, LocalBackend};
+
+// reads MSB_API_KEY
+set_default_backend(CloudBackend::from_env()?);
+
+// or: pass the key explicitly
+set_default_backend(CloudBackend::with_api_key(api_key)?);
+
+// or: force the local runtime
+set_default_backend(LocalBackend::lazy());
+```
+
+```typescript TypeScript
+import { setDefaultBackend } from "microsandbox";
+
+setDefaultBackend({ kind: "cloud", apiKey: process.env.MSB_API_KEY! });
+
+// or: force the local runtime
+setDefaultBackend("local");
+```
+
+```python Python
+import os
+from microsandbox import set_default_backend
+
+set_default_backend("cloud", api_key=os.environ["MSB_API_KEY"])
+
+# or: force the local runtime
+set_default_backend("local")
+```
+
+```go Go
+// The Go SDK selects the backend from the environment: set MSB_API_KEY
+// (or MSB_PROFILE) before the first microsandbox call.
+os.Setenv("MSB_API_KEY", apiKey)
+```
+</CodeGroup>
+
+**Set per-project defaults** with [backend profiles](/configuration#backend-profiles) in `config.json` when you switch between local and cloud regularly. The full resolution order is documented there.
+
+## What to know
+
+- **Compatibility.** Almost the entire SDK and CLI surface behaves identically. The exceptions and their alternatives are listed on the [compatibility page](/cloud/compatibility).
+- **Networking.** Cloud sandboxes get a cloud-assigned hostname. SSH works through the same `msb ssh` and SDK SSH clients you use locally.
+- **Images.** Specify any OCI image on create; the cloud resolves and pulls it for you. Local image-cache commands don't apply.
+- **Keys and billing.** API keys, usage, and invoices live in the [dashboard](https://dashboard.microsandbox.dev).
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Cloud compatibility" icon="table-list" href="/cloud/compatibility">
+    What works today, what's limited, and what to use instead.
+  </Card>
+
+  <Card title="API reference" icon="brackets-curly" href="/api-reference/overview">
+    The REST API behind the SDKs, authenticated with your API key.
+  </Card>
+
+  <Card title="Backend profiles" icon="gear" href="/configuration#backend-profiles">
+    Switch between local and cloud from one config file.
+  </Card>
+
+  <Card title="Quickstart" icon="bolt" href="/getting-started/quickstart">
+    New to microsandbox? Start here; everything carries over.
+  </Card>
+</CardGroup>

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -141,6 +141,8 @@ let cfg = backend.config();
 let msb = cfg.resolve_msb_path()?;
 ```
 
+`LocalBackend` has two plain constructors alongside the builder. `LocalBackend::lazy()` is synchronous and defers opening (and migrating) the local sandbox database until the first operation; it is what backend resolution uses when no backend is set explicitly. `LocalBackend::new().await?` opens the database up front, so startup fails fast if the database is unusable.
+
 ## `sandbox_defaults`
 
 Defaults applied to every sandbox unless overridden per-sandbox.

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -1,6 +1,6 @@
 ---
-title: config.json
-description: Global config.json reference
+title: Global config
+description: Reference for the global config.json shared by the CLI and SDKs
 icon: "gear"
 ---
 
@@ -88,8 +88,8 @@ microsandbox reads its global configuration from `~/.microsandbox/config.json`. 
 | `sandbox_defaults` | [reference](#sandbox_defaults) | Defaults applied to every sandbox |
 | `registries` | [reference](#registries) | Container registry authentication |
 | `metrics` | [reference](#metrics) | Live metrics shared-memory registry settings |
-| `active_profile` | `null` | Default backend profile name |
-| `profiles` | `{}` | Named backend profiles |
+| `active_profile` | `null` | Default [backend profile](#profiles) name |
+| `profiles` | [reference](#profiles) | Named [backend profiles](/getting-started/backends) |
 
 ## `database`
 
@@ -234,50 +234,19 @@ When pulling from a registry, microsandbox resolves credentials in this order:
 |-------|---------|-------------|
 | `capacity` | `0` | Number of slots reserved in the live metrics shared-memory registry. `0` uses the built-in default. Stop all sandboxes for the same home before changing this value. |
 
-## Backend profiles
+## `profiles`
 
-Backend profiles let CLI and SDK calls choose between the local runtime and a cloud backend from the same `config.json` file.
+Named backend profiles keyed by profile name; `active_profile` selects the default. How profiles participate in backend selection, including the full resolution order, is documented in [Backends](/getting-started/backends).
 
-```json
-{
-  "active_profile": "prod",
-  "profiles": {
-    "prod": {
-      "backend": "cloud",
-      "api_key_ref": "env:MSB_API_KEY"
-    },
-    "local": {
-      "backend": "local"
-    }
-  }
-}
-```
+| Field | Default | Description |
+|-------|---------|-------------|
+| `backend` | required | `local` or `cloud` |
+| `api_key_ref` | none | Credential reference; required for `cloud` profiles |
+| `url` | `https://api.microsandbox.dev` | Cloud endpoint override for development, self-hosted, or on-prem control planes |
 
-Use `active_profile` for the default profile. Use `MSB_PROFILE=<name>` to override it for a single command:
-
-```bash
-MSB_PROFILE=prod msb run python -- python -V
-```
-
-Cloud profiles require `api_key_ref`. The `url` field is optional and defaults to `https://api.microsandbox.dev`; set it only for a development, self-hosted, or on-prem control plane. Supported credential references are:
+Supported credential references for `api_key_ref`:
 
 | Prefix | Description |
 |--------|-------------|
 | `env:<VAR_NAME>` | Read the API key from an environment variable |
 | `inline:<API_KEY>` | Store the API key directly in `config.json`; use only for development or CI |
-
-Backend resolution uses this order:
-
-1. Programmatic backend set by the SDK
-2. `MSB_BACKEND=local`, or a non-empty `MSB_API_KEY`
-3. `MSB_PROFILE=<name>`
-4. `active_profile`
-5. Local runtime
-
-For hosted cloud usage, the API key is sufficient:
-
-```bash
-export MSB_API_KEY=msb_...
-```
-
-`MSB_API_URL` only overrides the cloud endpoint; it never selects the cloud backend without an API key.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,6 +30,7 @@
             "pages": [
               "getting-started/introduction",
               "getting-started/quickstart",
+              "getting-started/backends",
               "getting-started/agents"
             ]
           },
@@ -97,14 +98,15 @@
         ]
       },
       {
-        "tab": "References",
+        "tab": "SDKs & CLI",
         "groups": [
           {
             "group": "Getting Started",
             "icon": "flag",
             "pages": [
               "sdk/overview",
-              "sdk/errors"
+              "sdk/errors",
+              "configuration"
             ]
           },
           {
@@ -191,112 +193,110 @@
               "cli/volume-commands",
               "cli/image-commands"
             ]
-          },
+          }
+        ]
+      },
+      {
+        "tab": "API Reference",
+        "groups": [
           {
-            "group": "API Reference",
-            "icon": "brackets-curly",
+            "group": "Getting Started",
+            "icon": "book-open",
             "pages": [
-              "api-reference/overview",
-              {
-                "group": "Sandboxes",
-                "icon": "cube",
-                "openapi": {
-                  "source": "/api-reference/openapi.json",
-                  "directory": "api-reference/endpoints"
-                },
-                "pages": [
-                  "POST /v1/sandboxes",
-                  "GET /v1/sandboxes",
-                  "GET /v1/sandboxes/{sandbox_id}",
-                  "GET /v1/sandboxes/by-name/{name}",
-                  "POST /v1/sandboxes/{sandbox_id}/start",
-                  "POST /v1/sandboxes/by-name/{name}/start",
-                  "POST /v1/sandboxes/{sandbox_id}/stop",
-                  "POST /v1/sandboxes/by-name/{name}/stop",
-                  "PATCH /v1/sandboxes/{sandbox_id}",
-                  "DELETE /v1/sandboxes/{sandbox_id}",
-                  "DELETE /v1/sandboxes/by-name/{name}"
-                ]
-              },
-              {
-                "group": "Volumes",
-                "icon": "hard-drive",
-                "openapi": {
-                  "source": "/api-reference/openapi.json",
-                  "directory": "api-reference/endpoints"
-                },
-                "pages": [
-                  "POST /v1/volumes",
-                  "GET /v1/volumes",
-                  "PATCH /v1/volumes/{id}",
-                  "DELETE /v1/volumes/{id}"
-                ]
-              },
-              {
-                "group": "Quotas",
-                "icon": "gauge-high",
-                "openapi": {
-                  "source": "/api-reference/openapi.json",
-                  "directory": "api-reference/endpoints"
-                },
-                "pages": [
-                  "GET /v1/quotas"
-                ]
-              },
-              {
-                "group": "Usage",
-                "icon": "chart-line",
-                "openapi": {
-                  "source": "/api-reference/openapi.json",
-                  "directory": "api-reference/endpoints"
-                },
-                "pages": [
-                  "GET /v1/billing/usage",
-                  "GET /v1/billing/usage/sandbox",
-                  "GET /v1/billing/usage/storage"
-                ]
-              },
-              {
-                "group": "Audit events",
-                "icon": "clipboard-list",
-                "openapi": {
-                  "source": "/api-reference/openapi.json",
-                  "directory": "api-reference/endpoints"
-                },
-                "pages": [
-                  "GET /v1/events",
-                  "GET /v1/events/{event_id}"
-                ]
-              },
-              {
-                "group": "Organization",
-                "icon": "building",
-                "openapi": {
-                  "source": "/api-reference/openapi.json",
-                  "directory": "api-reference/endpoints"
-                },
-                "pages": [
-                  "GET /v1/me/org"
-                ]
-              },
-              {
-                "group": "Members",
-                "icon": "users",
-                "openapi": {
-                  "source": "/api-reference/openapi.json",
-                  "directory": "api-reference/endpoints"
-                },
-                "pages": [
-                  "GET /v1/members"
-                ]
-              }
+              "api-reference/overview"
             ]
           },
           {
-            "group": "Configuration",
-            "icon": "gear",
+            "group": "Sandboxes",
+            "icon": "cube",
+            "openapi": {
+              "source": "/api-reference/openapi.json",
+              "directory": "api-reference/endpoints"
+            },
             "pages": [
-              "configuration"
+              "POST /v1/sandboxes",
+              "GET /v1/sandboxes",
+              "GET /v1/sandboxes/{sandbox_id}",
+              "GET /v1/sandboxes/by-name/{name}",
+              "POST /v1/sandboxes/{sandbox_id}/start",
+              "POST /v1/sandboxes/by-name/{name}/start",
+              "POST /v1/sandboxes/{sandbox_id}/stop",
+              "POST /v1/sandboxes/by-name/{name}/stop",
+              "PATCH /v1/sandboxes/{sandbox_id}",
+              "DELETE /v1/sandboxes/{sandbox_id}",
+              "DELETE /v1/sandboxes/by-name/{name}"
+            ]
+          },
+          {
+            "group": "Volumes",
+            "icon": "hard-drive",
+            "openapi": {
+              "source": "/api-reference/openapi.json",
+              "directory": "api-reference/endpoints"
+            },
+            "pages": [
+              "POST /v1/volumes",
+              "GET /v1/volumes",
+              "PATCH /v1/volumes/{id}",
+              "DELETE /v1/volumes/{id}"
+            ]
+          },
+          {
+            "group": "Quotas",
+            "icon": "gauge-high",
+            "openapi": {
+              "source": "/api-reference/openapi.json",
+              "directory": "api-reference/endpoints"
+            },
+            "pages": [
+              "GET /v1/quotas"
+            ]
+          },
+          {
+            "group": "Usage",
+            "icon": "chart-line",
+            "openapi": {
+              "source": "/api-reference/openapi.json",
+              "directory": "api-reference/endpoints"
+            },
+            "pages": [
+              "GET /v1/billing/usage",
+              "GET /v1/billing/usage/sandbox",
+              "GET /v1/billing/usage/storage"
+            ]
+          },
+          {
+            "group": "Audit events",
+            "icon": "clipboard-list",
+            "openapi": {
+              "source": "/api-reference/openapi.json",
+              "directory": "api-reference/endpoints"
+            },
+            "pages": [
+              "GET /v1/events",
+              "GET /v1/events/{event_id}"
+            ]
+          },
+          {
+            "group": "Organization",
+            "icon": "building",
+            "openapi": {
+              "source": "/api-reference/openapi.json",
+              "directory": "api-reference/endpoints"
+            },
+            "pages": [
+              "GET /v1/me/org"
+            ]
+          },
+          {
+            "group": "Members",
+            "icon": "users",
+            "openapi": {
+              "source": "/api-reference/openapi.json",
+              "directory": "api-reference/endpoints"
+            },
+            "pages": [
+              "GET /v1/members"
             ]
           }
         ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,6 +34,14 @@
             ]
           },
           {
+            "group": "Cloud",
+            "icon": "cloud",
+            "pages": [
+              "cloud/overview",
+              "cloud/compatibility"
+            ]
+          },
+          {
             "group": "Sandboxes",
             "icon": "box",
             "pages": [
@@ -185,6 +193,106 @@
             ]
           },
           {
+            "group": "API Reference",
+            "icon": "brackets-curly",
+            "pages": [
+              "api-reference/overview",
+              {
+                "group": "Sandboxes",
+                "icon": "cube",
+                "openapi": {
+                  "source": "/api-reference/openapi.json",
+                  "directory": "api-reference/endpoints"
+                },
+                "pages": [
+                  "POST /v1/sandboxes",
+                  "GET /v1/sandboxes",
+                  "GET /v1/sandboxes/{sandbox_id}",
+                  "GET /v1/sandboxes/by-name/{name}",
+                  "POST /v1/sandboxes/{sandbox_id}/start",
+                  "POST /v1/sandboxes/by-name/{name}/start",
+                  "POST /v1/sandboxes/{sandbox_id}/stop",
+                  "POST /v1/sandboxes/by-name/{name}/stop",
+                  "PATCH /v1/sandboxes/{sandbox_id}",
+                  "DELETE /v1/sandboxes/{sandbox_id}",
+                  "DELETE /v1/sandboxes/by-name/{name}"
+                ]
+              },
+              {
+                "group": "Volumes",
+                "icon": "hard-drive",
+                "openapi": {
+                  "source": "/api-reference/openapi.json",
+                  "directory": "api-reference/endpoints"
+                },
+                "pages": [
+                  "POST /v1/volumes",
+                  "GET /v1/volumes",
+                  "PATCH /v1/volumes/{id}",
+                  "DELETE /v1/volumes/{id}"
+                ]
+              },
+              {
+                "group": "Quotas",
+                "icon": "gauge-high",
+                "openapi": {
+                  "source": "/api-reference/openapi.json",
+                  "directory": "api-reference/endpoints"
+                },
+                "pages": [
+                  "GET /v1/quotas"
+                ]
+              },
+              {
+                "group": "Usage",
+                "icon": "chart-line",
+                "openapi": {
+                  "source": "/api-reference/openapi.json",
+                  "directory": "api-reference/endpoints"
+                },
+                "pages": [
+                  "GET /v1/billing/usage",
+                  "GET /v1/billing/usage/sandbox",
+                  "GET /v1/billing/usage/storage"
+                ]
+              },
+              {
+                "group": "Audit events",
+                "icon": "clipboard-list",
+                "openapi": {
+                  "source": "/api-reference/openapi.json",
+                  "directory": "api-reference/endpoints"
+                },
+                "pages": [
+                  "GET /v1/events",
+                  "GET /v1/events/{event_id}"
+                ]
+              },
+              {
+                "group": "Organization",
+                "icon": "building",
+                "openapi": {
+                  "source": "/api-reference/openapi.json",
+                  "directory": "api-reference/endpoints"
+                },
+                "pages": [
+                  "GET /v1/me/org"
+                ]
+              },
+              {
+                "group": "Members",
+                "icon": "users",
+                "openapi": {
+                  "source": "/api-reference/openapi.json",
+                  "directory": "api-reference/endpoints"
+                },
+                "pages": [
+                  "GET /v1/members"
+                ]
+              }
+            ]
+          },
+          {
             "group": "Configuration",
             "icon": "gear",
             "pages": [
@@ -269,7 +377,7 @@
   "appearance": {
     "default": "system"
   },
-  "description": "Easy, fast, local microVMs for untrusted workloads",
+  "description": "Easy, fast microVMs for untrusted workloads, on your machine or in the cloud",
   "footer": {
     "socials": {
       "github": "https://github.com/superradcompany/microsandbox",

--- a/docs/getting-started/backends.mdx
+++ b/docs/getting-started/backends.mdx
@@ -1,0 +1,108 @@
+---
+title: "Backends"
+description: "How the SDK and CLI choose between the local runtime and the cloud"
+icon: "route"
+---
+
+The SDKs and the `msb` CLI expose one surface with two backends behind it: the local runtime on your machine, and [microsandbox cloud](/cloud/overview). Every call resolves a backend the same way, and the same code runs against either.
+
+Most applications never choose explicitly. A non-empty `MSB_API_KEY` selects the cloud; no key means the local runtime:
+
+```bash
+export MSB_API_KEY="msb_..."   # cloud
+unset MSB_API_KEY              # local
+```
+
+The sections below are the explicit overrides, in the order they win. Pick at most one.
+
+## Environment
+
+The `MSB_BACKEND` environment variable forces a backend for a single command or shell, for example to use the local runtime while a key is exported:
+
+```bash
+MSB_BACKEND=local msb run python -- python -V   # force local
+MSB_BACKEND=cloud msb ls                        # explicit cloud
+```
+
+## Code
+
+Programmatic selection wins over environment and profile resolution. Use it when the application should decide regardless of its environment:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::{set_default_backend, CloudBackend, LocalBackend};
+
+// reads MSB_API_KEY
+set_default_backend(CloudBackend::from_env()?);
+
+// or: pass the key explicitly
+set_default_backend(CloudBackend::with_api_key(api_key)?);
+
+// or: force the local runtime
+set_default_backend(LocalBackend::lazy());
+```
+
+```typescript TypeScript
+import { setDefaultBackend } from "microsandbox";
+
+setDefaultBackend({ kind: "cloud", apiKey: process.env.MSB_API_KEY! });
+
+// or: force the local runtime
+setDefaultBackend("local");
+```
+
+```python Python
+import os
+from microsandbox import set_default_backend
+
+set_default_backend("cloud", api_key=os.environ["MSB_API_KEY"])
+
+# or: force the local runtime
+set_default_backend("local")
+```
+
+```go Go
+// The Go SDK selects the backend from the environment: set MSB_API_KEY
+// (or MSB_PROFILE) before the first microsandbox call.
+os.Setenv("MSB_API_KEY", apiKey)
+```
+</CodeGroup>
+
+## Profiles
+
+Profiles give named backend configurations in `config.json`, useful when you switch between local and cloud regularly or keep per-project defaults:
+
+```json
+{
+  "active_profile": "prod",
+  "profiles": {
+    "prod": {
+      "backend": "cloud",
+      "api_key_ref": "env:MSB_API_KEY"
+    },
+    "local": {
+      "backend": "local"
+    }
+  }
+}
+```
+
+`active_profile` sets the default. `MSB_PROFILE=<name>` overrides it for a single command:
+
+```bash
+MSB_PROFILE=prod msb run python -- python -V
+```
+
+Cloud profiles require `api_key_ref`. The `url` field is optional and defaults to `https://api.microsandbox.dev`; set it only for a development, self-hosted, or on-prem control plane. See the [profiles schema](/configuration#profiles) for the allowed fields and credential-reference formats.
+
+## Resolution order
+
+Backend resolution uses this order:
+
+1. Programmatic backend set by the SDK
+2. `MSB_BACKEND=local`, or a non-empty `MSB_API_KEY`
+3. `MSB_PROFILE=<name>`
+4. `active_profile`
+5. Local runtime
+
+`MSB_API_URL` only overrides the cloud endpoint; it never selects the cloud backend without an API key.

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Introduction"
-description: "Easy, fast, local microVMs for untrusted workloads"
+description: "Easy, fast microVMs for untrusted workloads"
 icon: "house"
 ---
 
-microsandbox is a local microVM runtime for untrusted workloads: AI agents, user code, plugins, package installs, CI jobs, dev environments, scrapers, and automation.
+microsandbox is a local-first microVM runtime for untrusted workloads: AI agents, user code, plugins, package installs, CI jobs, dev environments, scrapers, and automation.
 
-Each sandbox is a lightweight VM with its own Linux kernel, filesystem, and network boundary. Your app or the `msb` CLI starts it locally, talks to it through a host-guest command channel, and controls what it can access.
+Each sandbox is a lightweight VM with its own Linux kernel, filesystem, and network boundary. Your app or the `msb` CLI starts it on your machine or on [microsandbox cloud](/cloud/overview) with an API key, talks to it through a host-guest command channel, and controls what it can access.
 
 It keeps the familiar workflow of OCI images and command execution, while moving risky work out of the host process.
 
@@ -22,6 +22,7 @@ It keeps the familiar workflow of OCI images and command execution, while moving
 
 - **Hardware isolation.** Each sandbox is a VM, not a container namespace on the host kernel.
 - **Local runtime.** The SDK starts the sandbox process directly. No daemon, remote service, or infrastructure setup.
+- **Cloud when you want it.** The same SDK and CLI run sandboxes on [hosted infrastructure](/cloud/overview); an API key is the only change.
 - **Fast startup.** Sandboxes are lightweight enough to create from application code.
 - **Docker-like inputs.** Use familiar OCI images from Docker Hub, GHCR, ECR, GCR, or another registry.
 - **Programmable controls.** Configure resources, volumes, secrets, networking, and lifecycle from the CLI or SDK.
@@ -111,8 +112,8 @@ fmt.Println(out.Stdout())
     Install microsandbox and run your first sandbox.
   </Card>
 
-  <Card title="Tuning" icon="sliders" href="/sandboxes/tuning">
-    Learn how sandbox settings change.
+  <Card title="microsandbox cloud" icon="cloud" href="/cloud/overview">
+    Run the same sandboxes on hosted infrastructure.
   </Card>
 
   <Card title="CLI overview" icon="terminal" href="/cli/overview">

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -5,7 +5,7 @@ icon: "bolt"
 ---
 
 <Note>
-  microsandbox requires **glibc-based Linux with KVM**, **macOS with Apple Silicon** (M-series chip), or **Windows 11 with Windows Hypervisor Platform** enabled. All local backends use hardware virtualization.
+  Running locally requires **glibc-based Linux with KVM**, **macOS with Apple Silicon** (M-series chip), or **Windows 11 with Windows Hypervisor Platform** enabled. All local backends use hardware virtualization. [microsandbox cloud](/cloud/overview) has no hardware requirements.
 </Note>
 
 <Tip>
@@ -18,7 +18,7 @@ icon: "bolt"
 
 <Steps>
   <Step title="Install microsandbox">
-    Install the SDK for the language you are using, and install the `msb` CLI for terminal workflows such as managing images, volumes, and sandboxes. Both run microsandbox locally; there is no separate server or daemon to set up.
+    Install the SDK for the language you are using, and install the `msb` CLI for terminal workflows such as managing images, volumes, and sandboxes. Both run microsandbox locally by default; there is no separate server or daemon to set up. The same install also drives [microsandbox cloud](/cloud/overview) when an API key is set.
 
     <CodeGroup>
     ```bash Rust
@@ -150,8 +150,13 @@ The `exec` call uses the host-guest command channel, not SSH and not the sandbox
   Because exec doesn't go through the network, it works even when a sandbox has networking disabled via `.disable_network()` and no network interfaces at all.
 </Tip>
 
+<Tip>
+  Want the same sandbox on hosted infrastructure? Export `MSB_API_KEY` and the code above runs on [microsandbox cloud](/cloud/overview) unchanged.
+</Tip>
+
 ## Next steps
 
+- [Run on microsandbox cloud](/cloud/overview): the same code on hosted infrastructure
 - [Tune sandbox settings](/sandboxes/tuning): resize headroom, labels, secrets, and storage
 - [Troubleshoot Linux setup](/troubleshooting/linux): KVM, `/dev/kvm`, and permissions
 - [Troubleshoot macOS setup](/troubleshooting/macos): Apple Silicon and local runtime checks

--- a/docs/images/disk-images.mdx
+++ b/docs/images/disk-images.mdx
@@ -10,6 +10,10 @@ This is a fundamentally different path from OCI images. With OCI, microsandbox s
 
 Use disk images when you need a pre-built VM template, a custom kernel configuration, or an OS that isn't available as a container image.
 
+<Note>
+  **Cloud:** Booting from a disk image references a file on the caller's host and is local-only. On cloud, publish the filesystem as an OCI image instead.
+</Note>
+
 ## Supported formats
 
 | Format | Description |

--- a/docs/images/disk-images.mdx
+++ b/docs/images/disk-images.mdx
@@ -4,15 +4,13 @@ description: Boot from QCOW2, Raw, or VMDK disk images
 icon: "compact-disc"
 ---
 
+<Tooltip tip="Booting from a disk image references a file on the caller host and is local-only. On microsandbox cloud, publish the filesystem as an OCI image instead."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 In addition to OCI container images, microsandbox can boot a sandbox directly from a disk image file. The guest gets raw block device access, and its kernel mounts the filesystem from the device directly.
 
 This is a fundamentally different path from OCI images. With OCI, microsandbox stacks image layers as a copy-on-write filesystem. With disk images, the guest owns the block device. No overlay, no copy-on-write between sandboxes.
 
 Use disk images when you need a pre-built VM template, a custom kernel configuration, or an OS that isn't available as a container image.
-
-<Note>
-  **Cloud:** Booting from a disk image references a file on the caller's host and is local-only. On cloud, publish the filesystem as an OCI image instead.
-</Note>
 
 ## Supported formats
 

--- a/docs/images/overview.mdx
+++ b/docs/images/overview.mdx
@@ -109,11 +109,9 @@ sb, err := m.CreateSandbox(ctx, "worker",
 
 ## Registry TLS
 
-By default, microsandbox connects to registries over HTTPS using system CA roots. You can customize this per-registry in `~/.microsandbox/config.json`.
+<Tooltip tip="Plain-HTTP registries and custom CA certificates are not supported on microsandbox cloud; images are pulled from HTTPS registries only."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** Plain-HTTP registries and custom CA certificates are not supported; cloud pulls images from HTTPS registries only.
-</Note>
+By default, microsandbox connects to registries over HTTPS using system CA roots. You can customize this per-registry in `~/.microsandbox/config.json`.
 
 ### Plain HTTP registries
 
@@ -192,6 +190,8 @@ sb, err := m.CreateSandbox(ctx, "worker",
 
 ## Image storage
 
+<Tooltip tip="Image-cache commands are local-only. On microsandbox cloud, specify an OCI image on create and it is pulled for you."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 Images are cached in the global microsandbox home directory:
 
 | Path | Description |
@@ -206,10 +206,6 @@ Layers are content-addressable and deduplicated. If `python:3.12` and `python:3.
 <Tip>
   Use `msb pull` from the CLI to pre-pull images before creating sandboxes. This avoids blocking on a download during `Sandbox.create`.
 </Tip>
-
-<Note>
-  **Cloud:** Image-cache commands are local-only. Specify an OCI image when creating the sandbox; cloud resolves and pulls it for you.
-</Note>
 
 Use `msb image prune` to remove cached images that are not used by any sandbox or indexed snapshot and reclaim dangling image artifacts. Prune keeps images referenced by existing sandboxes or snapshots. It cleans up image metadata, unreachable manifests, orphaned layers, layer EROFS artifacts, fsmeta EROFS artifacts, and VMDK descriptor artifacts.
 

--- a/docs/images/overview.mdx
+++ b/docs/images/overview.mdx
@@ -111,6 +111,10 @@ sb, err := m.CreateSandbox(ctx, "worker",
 
 By default, microsandbox connects to registries over HTTPS using system CA roots. You can customize this per-registry in `~/.microsandbox/config.json`.
 
+<Note>
+  **Cloud:** Plain-HTTP registries and custom CA certificates are not supported; cloud pulls images from HTTPS registries only.
+</Note>
+
 ### Plain HTTP registries
 
 Local registries often run without TLS. Mark them as insecure to connect over plain HTTP:
@@ -202,6 +206,10 @@ Layers are content-addressable and deduplicated. If `python:3.12` and `python:3.
 <Tip>
   Use `msb pull` from the CLI to pre-pull images before creating sandboxes. This avoids blocking on a download during `Sandbox.create`.
 </Tip>
+
+<Note>
+  **Cloud:** Image-cache commands are local-only. Specify an OCI image when creating the sandbox; cloud resolves and pulls it for you.
+</Note>
 
 Use `msb image prune` to remove cached images that are not used by any sandbox or indexed snapshot and reclaim dangling image artifacts. Prune keeps images referenced by existing sandboxes or snapshots. It cleans up image metadata, unreachable manifests, orphaned layers, layer EROFS artifacts, fsmeta EROFS artifacts, and VMDK descriptor artifacts.
 

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -98,6 +98,10 @@ msb create python --name safe-agent --net-default allow \
 
 ## Pinning nameservers
 
+<Note>
+  **Cloud:** Custom nameservers are not available; cloud sandboxes use platform-managed DNS.
+</Note>
+
 By default the sandbox picks up the host's resolver list automatically:
 
 - **macOS**: reads `State:/Network/Global/DNS` from the system configuration store, with `/etc/resolv.conf` as a fallback when the store isn't available.

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -98,9 +98,7 @@ msb create python --name safe-agent --net-default allow \
 
 ## Pinning nameservers
 
-<Note>
-  **Cloud:** Custom nameservers are not available; cloud sandboxes use platform-managed DNS.
-</Note>
+<Tooltip tip="Custom nameservers are not available on microsandbox cloud; cloud sandboxes use platform-managed DNS."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 By default the sandbox picks up the host's resolver list automatically:
 

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -166,6 +166,10 @@ Rules can target groups like `public`, `private`, and `host`, or specific IPs, C
 
 Publish a guest port when a service inside the sandbox should be reachable from the host. Published ports bind to `127.0.0.1` by default.
 
+<Note>
+  **Cloud:** Publishing host ports is not available; there is no local host to publish to.
+</Note>
+
 <CodeGroup>
 ```rust Rust
 let sb = Sandbox::builder("api")

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -164,11 +164,9 @@ Rules can target groups like `public`, `private`, and `host`, or specific IPs, C
 
 ## Port mapping
 
-Publish a guest port when a service inside the sandbox should be reachable from the host. Published ports bind to `127.0.0.1` by default.
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud; there is no local host to publish to."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** Publishing host ports is not available; there is no local host to publish to.
-</Note>
+Publish a guest port when a service inside the sandbox should be reachable from the host. Published ports bind to `127.0.0.1` by default.
 
 <CodeGroup>
 ```rust Rust
@@ -209,6 +207,8 @@ Use an explicit bind address, such as `0.0.0.0`, only when you intentionally wan
 On Windows, the first published port may trigger a Windows Defender Firewall prompt for `msb.exe` because the runtime opens a host listening socket. For local development, keep the bind address on `127.0.0.1`. Only allow private/public network access in the firewall prompt when you intentionally bind a published port beyond loopback.
 
 ## Reaching the host
+
+<Tooltip tip="The host group is backend-relative; on microsandbox cloud it does not refer to the machine running the SDK or CLI, so expose local services through a reachable network endpoint."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 From inside the sandbox, `host.microsandbox.internal` resolves to the host machine. The default policy denies host access, so allow the `host` group when a sandbox needs to call a dev server, database, or other local service.
 

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -6,6 +6,10 @@ icon: "lock"
 
 Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server. That's how features like per-host secret injection and URL-level policy checks can see inside what would otherwise be an opaque stream.
 
+<Note>
+  **Cloud:** TLS interception and host-CA trust are not yet available on cloud sandboxes.
+</Note>
+
 ## How it works
 
 When you enable TLS interception:

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -4,11 +4,9 @@ description: HTTPS inspection with an auto-generated CA
 icon: "lock"
 ---
 
-Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server. That's how features like per-host secret injection and URL-level policy checks can see inside what would otherwise be an opaque stream.
+<Tooltip tip="TLS interception and host-CA trust are not yet available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** TLS interception and host-CA trust are not yet available on cloud sandboxes.
-</Note>
+Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server. That's how features like per-host secret injection and URL-level policy checks can see inside what would otherwise be an opaque stream.
 
 ## How it works
 

--- a/docs/observability/deep-dive.mdx
+++ b/docs/observability/deep-dive.mdx
@@ -5,6 +5,8 @@ description: Flags, emitted metrics, attributes, and operational notes for msb-m
 icon: "magnifying-glass"
 ---
 
+<Tooltip tip="This page covers msb-metrics, which reads host-local shared memory and is local-only. It does not apply to microsandbox cloud sandboxes."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 Everything beyond the Quick start for the
 [`msb-metrics`](/observability/msb-metrics) sidecar: the complete flag
 set, what it emits, the attributes attached to each datapoint, and the

--- a/docs/observability/msb-metrics.mdx
+++ b/docs/observability/msb-metrics.mdx
@@ -23,6 +23,10 @@ programmatic per-sandbox reads from application code, use
 shared-memory registry and can coexist; the diagram below shows how
 they relate.
 
+<Note>
+  **Cloud:** `msb-metrics` reads host-local shared memory, so it applies to the local runtime and self-hosted deployments only.
+</Note>
+
 ## Where it fits
 
 ```mermaid

--- a/docs/observability/msb-metrics.mdx
+++ b/docs/observability/msb-metrics.mdx
@@ -5,6 +5,8 @@ description: msb-metrics, the sidecar binary that ships microsandbox metrics ove
 icon: "gauge"
 ---
 
+<Tooltip tip="msb-metrics reads host-local shared memory, so it applies to the local runtime and self-hosted deployments only."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 `msb-metrics` is a sibling process. It reads the microsandbox
 shared-memory metrics registry on a fixed interval and ships
 per-sandbox metrics to any OpenTelemetry-compatible backend.
@@ -22,10 +24,6 @@ programmatic per-sandbox reads from application code, use
 [`Sandbox::metrics()`](/sandboxes/metrics). All three read the same
 shared-memory registry and can coexist; the diagram below shows how
 they relate.
-
-<Note>
-  **Cloud:** `msb-metrics` reads host-local shared memory, so it applies to the local runtime and self-hosted deployments only.
-</Note>
 
 ## Where it fits
 

--- a/docs/recipes/docker/docker-in-sandbox.mdx
+++ b/docs/recipes/docker/docker-in-sandbox.mdx
@@ -4,6 +4,8 @@ description: Start dockerd inside a microsandbox VM and run containers from an i
 icon: "docker"
 ---
 
+<Tooltip tip="On microsandbox cloud, create the named volume separately (no disk-kind or size options) and omit replace-on-create; those settings are not available."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 This recipe starts a complete Docker environment inside a microsandbox VM. It is useful for sandboxed builds, agent workflows that need their own Docker daemon, or experiments you do not want leaking onto the dev machine. The host's Docker setup, if any, is left untouched.
 
 The command below boots the `docker:dind` image, starts Docker inside the sandbox, waits for it to be ready, and then opens an interactive shell. From there, Docker commands run against the daemon inside the sandbox, not your host.

--- a/docs/recipes/docker/local-images.mdx
+++ b/docs/recipes/docker/local-images.mdx
@@ -4,6 +4,8 @@ description: Use locally built Docker images with microsandbox
 icon: "boxes-stacked"
 ---
 
+<Tooltip tip="This recipe uses the local image cache. On microsandbox cloud, specify an OCI image when creating the sandbox and it is pulled for you."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 microsandbox cannot read Docker's private local image store directly. If you build an image locally with `docker build`, export it with `docker save` and load it into microsandbox:
 
 ```bash

--- a/docs/recipes/metrics-backends/datadog.mdx
+++ b/docs/recipes/metrics-backends/datadog.mdx
@@ -4,6 +4,8 @@ description: Ship msb-metrics output to Datadog via the Datadog Agent's OTLP rec
 icon: "chart-line"
 ---
 
+<Tooltip tip="This page covers msb-metrics, which reads host-local shared memory and is local-only. It does not apply to microsandbox cloud sandboxes."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 <Note>
 This recipe ships data emitted by [`msb-metrics`](/observability/msb-metrics).
 See the msb-metrics page for the flag reference, metric names, and

--- a/docs/recipes/metrics-backends/grafana-alloy.mdx
+++ b/docs/recipes/metrics-backends/grafana-alloy.mdx
@@ -4,6 +4,8 @@ description: Forward msb-metrics output to Grafana Cloud (or anywhere) via local
 icon: "route"
 ---
 
+<Tooltip tip="This page covers msb-metrics, which reads host-local shared memory and is local-only. It does not apply to microsandbox cloud sandboxes."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 <Note>
 This recipe ships data emitted by [`msb-metrics`](/observability/msb-metrics).
 See the msb-metrics page for the flag reference, metric names, and

--- a/docs/recipes/metrics-backends/grafana-cloud.mdx
+++ b/docs/recipes/metrics-backends/grafana-cloud.mdx
@@ -4,6 +4,8 @@ description: Ship msb-metrics output to Grafana Cloud's OTLP gateway
 icon: "cloud-arrow-up"
 ---
 
+<Tooltip tip="This page covers msb-metrics, which reads host-local shared memory and is local-only. It does not apply to microsandbox cloud sandboxes."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 <Note>
 This recipe ships data emitted by [`msb-metrics`](/observability/msb-metrics).
 See the msb-metrics page for the flag reference, metric names, and

--- a/docs/recipes/metrics-backends/otel-collector.mdx
+++ b/docs/recipes/metrics-backends/otel-collector.mdx
@@ -4,6 +4,8 @@ description: Inspect msb-metrics output locally with the OpenTelemetry Collector
 icon: "terminal"
 ---
 
+<Tooltip tip="This page covers msb-metrics, which reads host-local shared memory and is local-only. It does not apply to microsandbox cloud sandboxes."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 <Note>
 This recipe ships data emitted by [`msb-metrics`](/observability/msb-metrics).
 See the msb-metrics page for the flag reference, metric names, and

--- a/docs/recipes/metrics-backends/prometheus.mdx
+++ b/docs/recipes/metrics-backends/prometheus.mdx
@@ -4,6 +4,8 @@ description: Ship msb-metrics output directly to Prometheus's OTLP ingestion end
 icon: "fire"
 ---
 
+<Tooltip tip="This page covers msb-metrics, which reads host-local shared memory and is local-only. It does not apply to microsandbox cloud sandboxes."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 <Note>
 This recipe ships data emitted by [`msb-metrics`](/observability/msb-metrics).
 See the msb-metrics page for the flag reference, metric names, and

--- a/docs/sandboxes/labels.mdx
+++ b/docs/sandboxes/labels.mdx
@@ -61,11 +61,9 @@ The OCI image's own labels (`LABEL` instructions, `org.opencontainers.image.*`, 
 
 ## Change while running
 
-Add, change, or remove labels without recreating the sandbox:
+<Tooltip tip="modify is not yet available on microsandbox cloud; set labels at create time."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** `modify` is not yet available; set labels at create time.
-</Note>
+Add, change, or remove labels without recreating the sandbox:
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sandboxes/labels.mdx
+++ b/docs/sandboxes/labels.mdx
@@ -63,6 +63,10 @@ The OCI image's own labels (`LABEL` instructions, `org.opencontainers.image.*`, 
 
 Add, change, or remove labels without recreating the sandbox:
 
+<Note>
+  **Cloud:** `modify` is not yet available; set labels at create time.
+</Note>
+
 <CodeGroup>
 ```rust Rust
 sb.modify().label("tier", "web").remove_label("stale").apply().await?;
@@ -125,7 +129,7 @@ msb restart --label app=engine     # restart every match
 msb rm --force --label app=engine  # remove every match
 ```
 
-It works the same on `ps`, `ls`, `start`, `stop`, `restart`, `ping`, `touch`, and `rm`.
+It works the same on `ps`, `ls`, `start`, `stop`, `restart`, `ping`, `touch`, and `rm`. On cloud, `ping` and `touch` are not yet available.
 
 ## Attribute metrics
 

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -171,6 +171,10 @@ See [Tuning](/sandboxes/tuning) for the change model, CPU and memory resize, lab
 
 Use `ping` to check that a running sandbox's guest agent is reachable, and `touch` to intentionally refresh its idle timer. Ping is a health check only: it does not count as sandbox activity and will not keep an idle sandbox alive by itself. Touch is the explicit keepalive.
 
+<Note>
+  **Cloud:** Ping and touch are not yet available.
+</Note>
+
 <CodeGroup>
 ```rust Rust
 let ping = sb.ping().await?;
@@ -192,6 +196,10 @@ msb ping worker --touch
 ## Kill immediately
 
 If a sandbox is unresponsive (e.g., stuck in a tight loop or a panic), force-kill it. The sandbox is terminated immediately with no graceful shutdown.
+
+<Note>
+  **Cloud:** Force kill is not yet available; use a graceful [stop](#stop-and-restart).
+</Note>
 
 <CodeGroup>
 ```rust Rust
@@ -242,6 +250,10 @@ err := sb.Detach(ctx)
 ## Request drain
 
 Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and transitions to `Stopped` when all in-flight commands complete. This is useful for zero-downtime rotation of worker sandboxes.
+
+<Note>
+  **Cloud:** Drain is not yet available; use a graceful [stop](#stop-and-restart).
+</Note>
 
 <CodeGroup>
 ```rust Rust
@@ -395,6 +407,10 @@ Use [`msb logs`](/cli/sandbox-commands#msb-logs) or the SDK `logs()` method to r
 ## Sandbox process policies
 
 For production workloads, configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
+
+<Note>
+  **Cloud:** Duration and idle policies are limited today; stop and remove sandboxes explicitly when your workload finishes.
+</Note>
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -169,11 +169,9 @@ See [Tuning](/sandboxes/tuning) for the change model, CPU and memory resize, lab
 
 ## Ping and touch
 
-Use `ping` to check that a running sandbox's guest agent is reachable, and `touch` to intentionally refresh its idle timer. Ping is a health check only: it does not count as sandbox activity and will not keep an idle sandbox alive by itself. Touch is the explicit keepalive.
+<Tooltip tip="Not yet available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** Ping and touch are not yet available.
-</Note>
+Use `ping` to check that a running sandbox's guest agent is reachable, and `touch` to intentionally refresh its idle timer. Ping is a health check only: it does not count as sandbox activity and will not keep an idle sandbox alive by itself. Touch is the explicit keepalive.
 
 <CodeGroup>
 ```rust Rust
@@ -195,11 +193,9 @@ msb ping worker --touch
 
 ## Kill immediately
 
-If a sandbox is unresponsive (e.g., stuck in a tight loop or a panic), force-kill it. The sandbox is terminated immediately with no graceful shutdown.
+<Tooltip tip="Not yet available on microsandbox cloud; use a graceful stop instead."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** Force kill is not yet available; use a graceful [stop](#stop-and-restart).
-</Note>
+If a sandbox is unresponsive (e.g., stuck in a tight loop or a panic), force-kill it. The sandbox is terminated immediately with no graceful shutdown. On cloud, use a graceful [stop](#stop-and-restart).
 
 <CodeGroup>
 ```rust Rust
@@ -249,11 +245,9 @@ err := sb.Detach(ctx)
 
 ## Request drain
 
-Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and transitions to `Stopped` when all in-flight commands complete. This is useful for zero-downtime rotation of worker sandboxes.
+<Tooltip tip="Not yet available on microsandbox cloud; use a graceful stop instead."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** Drain is not yet available; use a graceful [stop](#stop-and-restart).
-</Note>
+Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and transitions to `Stopped` when all in-flight commands complete. This is useful for zero-downtime rotation of worker sandboxes.
 
 <CodeGroup>
 ```rust Rust
@@ -406,11 +400,9 @@ Use [`msb logs`](/cli/sandbox-commands#msb-logs) or the SDK `logs()` method to r
 
 ## Sandbox process policies
 
-For production workloads, configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
+<Tooltip tip="Duration and idle policies are limited on microsandbox cloud today; stop and remove sandboxes explicitly when your workload finishes."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** Duration and idle policies are limited today; stop and remove sandboxes explicitly when your workload finishes.
-</Note>
+For production workloads, configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sandboxes/logs.mdx
+++ b/docs/sandboxes/logs.mdx
@@ -4,11 +4,9 @@ description: Capture, read, and diagnose sandbox output
 icon: "scroll"
 ---
 
-Every sandbox records captured output to disk so you can read it later, even after the sandbox stops or crashes. Use `msb logs <name>` from the CLI or `logs()` from the SDK.
+<Tooltip tip="Live SDK log following works on microsandbox cloud; historical and bounded log reads are not yet available. Persist followed output externally when you need retention."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** Live SDK log following is supported; historical and bounded log reads are not yet available. Persist followed output externally when you need retention.
-</Note>
+Every sandbox records captured output to disk so you can read it later, even after the sandbox stops or crashes. Use `msb logs <name>` from the CLI or `logs()` from the SDK.
 
 ## Read logs
 

--- a/docs/sandboxes/logs.mdx
+++ b/docs/sandboxes/logs.mdx
@@ -6,6 +6,10 @@ icon: "scroll"
 
 Every sandbox records captured output to disk so you can read it later, even after the sandbox stops or crashes. Use `msb logs <name>` from the CLI or `logs()` from the SDK.
 
+<Note>
+  **Cloud:** Live SDK log following is supported; historical and bounded log reads are not yet available. Persist followed output externally when you need retention.
+</Note>
+
 ## Read logs
 
 ```bash

--- a/docs/sandboxes/metrics.mdx
+++ b/docs/sandboxes/metrics.mdx
@@ -9,6 +9,10 @@ Query resource usage for a running sandbox: CPU, memory, and more. Get a single 
 OCI sandboxes also expose optional upper filesystem fields for capacity dashboards. Guest-visible `upper_used_bytes` and `upper_free_bytes` are available when the protected bundled-kernel reporter is fresh. Host-observed `upper_host_allocated_bytes` is available when microsandbox can inspect the writable upper image from the host. SDKs surface those as nullable fields (`Option`, `null`, `None`, or `nil`) because custom kernels and non-OCI roots may not provide them.
 
 <Note>
+  **Cloud:** SDK and CLI resource metrics are not yet available. Instrument the workload itself with an external monitoring system.
+</Note>
+
+<Note>
 Need continuous shipping to Grafana, Datadog, Prometheus, or any other OTel-compatible backend? See [`msb-metrics`](/observability/msb-metrics), a sidecar binary that reads the same data and ships it over OTLP.
 </Note>
 

--- a/docs/sandboxes/metrics.mdx
+++ b/docs/sandboxes/metrics.mdx
@@ -4,13 +4,11 @@ description: Monitor sandbox resource usage
 icon: "chart-line"
 ---
 
+<Tooltip tip="SDK and CLI resource metrics are not yet available on microsandbox cloud; instrument the workload with an external monitoring system."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 Query resource usage for a running sandbox: CPU, memory, and more. Get a single point-in-time snapshot, or open a streaming subscription that delivers updates at a fixed interval.
 
 OCI sandboxes also expose optional upper filesystem fields for capacity dashboards. Guest-visible `upper_used_bytes` and `upper_free_bytes` are available when the protected bundled-kernel reporter is fresh. Host-observed `upper_host_allocated_bytes` is available when microsandbox can inspect the writable upper image from the host. SDKs surface those as nullable fields (`Option`, `null`, `None`, or `nil`) because custom kernels and non-OCI roots may not provide them.
-
-<Note>
-  **Cloud:** SDK and CLI resource metrics are not yet available. Instrument the workload itself with an external monitoring system.
-</Note>
 
 <Note>
 Need continuous shipping to Grafana, Datadog, Prometheus, or any other OTel-compatible backend? See [`msb-metrics`](/observability/msb-metrics), a sidecar binary that reads the same data and ships it over OTLP.

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -4,7 +4,7 @@ description: What sandboxes are and how to configure them
 icon: "circle-info"
 ---
 
-A sandbox is a local microVM with its own Linux kernel, filesystem, and network stack. Your application or the `msb` CLI starts it as a child process, then talks to the guest agent to run commands, move files, and control lifecycle.
+A sandbox is a microVM with its own Linux kernel, filesystem, and network stack. Your application or the `msb` CLI starts it as a child process on your machine or on [microsandbox cloud](/cloud/overview), then talks to the guest agent to run commands, move files, and control lifecycle.
 
 The security boundary is hardware virtualization, not Linux namespaces. That makes sandboxes a good fit for untrusted workloads: user-submitted code, AI agent actions, plugins, dependency installs, CI jobs, scrapers, and tools that should not inherit the host process's full privileges.
 
@@ -51,7 +51,7 @@ let sb = Sandbox::builder("worker")
     .cpus(2)
     .env("DEBUG", "true")
     .label("user.id", "alice")
-    .volume("/app/src", |v| v.bind("./src").readonly())
+    .volume("/tmp/scratch", |v| v.tmpfs().size(100))
     .create()
     .await?;
 ```
@@ -63,7 +63,7 @@ await using sb = await Sandbox.builder("worker")
     .cpus(2)
     .env("DEBUG", "true")
     .label("user.id", "alice")
-    .volume("/app/src", (m) => m.bind("./src").readonly())
+    .volume("/tmp/scratch", (m) => m.tmpfs().size(100))
     .create();
 ```
 
@@ -75,7 +75,7 @@ sb = await Sandbox.create(
     cpus=2,
     env={"DEBUG": "true"},
     labels={"user.id": "alice"},
-    volumes={"/app/src": Volume.bind("./src", readonly=True)},
+    volumes={"/tmp/scratch": Volume.tmpfs(size_mib=100)},
 )
 ```
 
@@ -87,7 +87,7 @@ sb, err := m.CreateSandbox(ctx, "worker",
     m.WithEnv(map[string]string{"DEBUG": "true"}),
     m.WithLabels(map[string]string{"user.id": "alice"}),
     m.WithMounts(map[string]m.MountConfig{
-        "/app/src": m.Mount.Bind("./src", m.MountOptions{Readonly: true}),
+        "/tmp/scratch": m.Mount.Tmpfs(m.TmpfsOptions{SizeMiB: 100}),
     }),
 )
 ```
@@ -98,7 +98,7 @@ msb create python --name worker \
   -m 1G \
   -e DEBUG=true \
   --label user.id=alice \
-  -v ./src:/app/src:ro
+  --tmpfs /tmp/scratch:100
 ```
 </CodeGroup>
 

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -43,6 +43,8 @@ Sandbox names must be non-empty and no longer than 128 UTF-8 bytes.
 
 ## Common configuration
 
+<Tooltip tip="max_cpus and max_memory are not carried on microsandbox cloud; set the CPU and memory you need at creation and recreate the sandbox to resize."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 <CodeGroup>
 ```rust Rust
 let sb = Sandbox::builder("worker")
@@ -133,6 +135,8 @@ actions, metric attribution, and OCI image labels.
 
 ## Image sources
 
+<Tooltip tip="microsandbox cloud supports OCI root filesystems only; host-directory and disk-image root filesystems are local-only."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 Most sandboxes start from an OCI image:
 
 ```bash
@@ -156,6 +160,8 @@ OCI images use a copy-on-write overlay so sandboxes can share cached base layers
 See [Images](/images/overview) and [Disk Images](/images/disk-images) for the full image model.
 
 ## Naming conflicts
+
+<Tooltip tip="Replace-on-create is not available on microsandbox cloud; remove the existing sandbox first, then create the replacement."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 Creating a sandbox fails if another sandbox already has the same name. Use replace when you want a fresh sandbox with that name:
 

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -104,11 +104,9 @@ In the CLI form, `ENV@HOST[,HOST...]` records a host-side source reference: the 
 
 ## Change while running
 
-Add, rotate, or remove secrets without a restart. Guest code keeps using the same placeholder; only the value injected at the network boundary changes.
+<Tooltip tip="modify is not yet available on microsandbox cloud; recreate the sandbox to change its secrets."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** `modify` is not yet available; recreate the sandbox to change its secrets.
-</Note>
+Add, rotate, or remove secrets without a restart. Guest code keeps using the same placeholder; only the value injected at the network boundary changes.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -96,7 +96,7 @@ msb create python --name worker \
 
 </CodeGroup>
 
-In the CLI form, `ENV@HOST[,HOST...]` records a host-side source reference. microsandbox reads the real value from the same-named host environment variable when the sandbox starts; the value never lands in the durable config. The inline `ENV=VALUE@HOST` form is rejected on both `msb create` and `msb modify` — shell history and process listings would leak the value regardless — so providing a raw value is SDK-only.
+In the CLI form, `ENV@HOST[,HOST...]` records a host-side source reference: the real value is read from the same-named host environment variable when the sandbox starts, and never lands in the durable config. The inline `ENV=VALUE@HOST` form is rejected on both `msb create` and `msb modify` (shell history and process listings would leak the value regardless), so providing a raw value is SDK-only.
 
 <Warning>
   **Raw values are saved to disk.** When you pass a raw value through an SDK (`.value(..)`, `secret_env()`, or a value-based rotate), it is stored as-is in the sandbox config file and stays there until you rotate the secret to a reference. The sandbox behaves the same either way; the only difference is what ends up on disk. Prefer references whenever the value is available in a host environment variable.
@@ -105,6 +105,10 @@ In the CLI form, `ENV@HOST[,HOST...]` records a host-side source reference. micr
 ## Change while running
 
 Add, rotate, or remove secrets without a restart. Guest code keeps using the same placeholder; only the value injected at the network boundary changes.
+
+<Note>
+  **Cloud:** `modify` is not yet available; recreate the sandbox to change its secrets.
+</Note>
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sandboxes/snapshots.mdx
+++ b/docs/sandboxes/snapshots.mdx
@@ -4,11 +4,9 @@ description: Capture a sandbox's writable layer as a portable artifact
 icon: "code-branch"
 ---
 
-A snapshot is a portable, on-disk capture of a sandbox's writable filesystem. Move it with `scp`, archive it as `.tar.zst`, or boot fresh sandboxes from it.
+<Tooltip tip="Disk snapshots are local-only. On microsandbox cloud, use a named volume for state that must survive sandbox replacement."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** Disk snapshots are local-only. On cloud, use a [named volume](/sandboxes/volumes#named-volumes) for state that must survive sandbox replacement.
-</Note>
+A snapshot is a portable, on-disk capture of a sandbox's writable filesystem. Move it with `scp`, archive it as `.tar.zst`, or boot fresh sandboxes from it.
 
 <Note>
 Snapshots are **disk-only** and require a sandbox that is not running. Stopped and crashed sandboxes can be snapshotted; running, draining, and paused sandboxes are rejected.

--- a/docs/sandboxes/snapshots.mdx
+++ b/docs/sandboxes/snapshots.mdx
@@ -7,6 +7,10 @@ icon: "code-branch"
 A snapshot is a portable, on-disk capture of a sandbox's writable filesystem. Move it with `scp`, archive it as `.tar.zst`, or boot fresh sandboxes from it.
 
 <Note>
+  **Cloud:** Disk snapshots are local-only. On cloud, use a [named volume](/sandboxes/volumes#named-volumes) for state that must survive sandbox replacement.
+</Note>
+
+<Note>
 Snapshots are **disk-only** and require a sandbox that is not running. Stopped and crashed sandboxes can be snapshotted; running, draining, and paused sandboxes are rejected.
 </Note>
 

--- a/docs/sandboxes/ssh.mdx
+++ b/docs/sandboxes/ssh.mdx
@@ -167,11 +167,9 @@ data, err := sftp.Read(ctx, "/tmp/hello.txt")
 
 ## External clients
 
-External client mode exposes a sandbox as an SSH server for tools that already speak SSH. This is the closest match for normal SSH usage: authorize a public key, serve the sandbox, then connect with `ssh` or `sftp`.
+<Tooltip tip="msb ssh serve is not available on microsandbox cloud. The SDK reusable server works when you supply explicit host-key and authorized-key material; native sessions work unchanged."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** `msb ssh serve` is not available. The SDK's reusable server works when you supply explicit host-key and authorized-key material; [native sessions](#native-sessions) work unchanged.
-</Note>
+External client mode exposes a sandbox as an SSH server for tools that already speak SSH. This is the closest match for normal SSH usage: authorize a public key, serve the sandbox, then connect with `ssh` or `sftp`.
 
 ### Authorize a key
 

--- a/docs/sandboxes/ssh.mdx
+++ b/docs/sandboxes/ssh.mdx
@@ -169,6 +169,10 @@ data, err := sftp.Read(ctx, "/tmp/hello.txt")
 
 External client mode exposes a sandbox as an SSH server for tools that already speak SSH. This is the closest match for normal SSH usage: authorize a public key, serve the sandbox, then connect with `ssh` or `sftp`.
 
+<Note>
+  **Cloud:** `msb ssh serve` is not available. The SDK's reusable server works when you supply explicit host-key and authorized-key material; [native sessions](#native-sessions) work unchanged.
+</Note>
+
 ### Authorize a key
 
 ```bash

--- a/docs/sandboxes/tuning.mdx
+++ b/docs/sandboxes/tuning.mdx
@@ -4,13 +4,11 @@ description: Change sandbox settings without recreating it
 icon: "sliders"
 ---
 
+<Tooltip tip="modify and live resize are not yet available on microsandbox cloud; create a replacement sandbox with the new configuration."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 A sandbox's configuration is the host-side record that says how to run it: image, CPU and memory, environment, labels, mounts, network policy, secrets, and lifecycle settings.
 
 Some configuration is fixed when the VM boots. Some can change while the sandbox is running. Use `modify` when you want to change an existing sandbox without recreating it.
-
-<Note>
-  **Cloud:** `modify` and live resize are not yet available; create a replacement sandbox with the new configuration.
-</Note>
 
 ## Create time
 

--- a/docs/sandboxes/tuning.mdx
+++ b/docs/sandboxes/tuning.mdx
@@ -8,6 +8,10 @@ A sandbox's configuration is the host-side record that says how to run it: image
 
 Some configuration is fixed when the VM boots. Some can change while the sandbox is running. Use `modify` when you want to change an existing sandbox without recreating it.
 
+<Note>
+  **Cloud:** `modify` and live resize are not yet available; create a replacement sandbox with the new configuration.
+</Note>
+
 ## Create time
 
 Most settings are chosen when you create the sandbox. If the sandbox may need more CPU or memory later, set `max_cpus` and `max_memory` above the starting size so it has live resize headroom:

--- a/docs/sandboxes/volumes.mdx
+++ b/docs/sandboxes/volumes.mdx
@@ -4,42 +4,19 @@ description: Persist and share data across sandboxes
 icon: "hard-drive"
 ---
 
-Volumes give a sandbox direct filesystem access to persistent storage or in-memory filesystems. They're useful for persisting data across restarts, sharing data between sandboxes, or mounting host data into the guest. They're also significantly faster than the [filesystem API](/sandboxes/filesystem) (which transfers files individually), so for anything beyond ad-hoc reads and writes, volumes are the way to go.
-
-microsandbox supports four types of mounts: bind mounts, named volumes, tmpfs, and disk-image volumes. All four work on both backends.
-
 <Note>
-  **Cloud:** Volumes run on fast block storage managed by the platform. Every organization automatically gets a **host volume**: think of it as the disk of the one computer all your org's sandboxes run on. It can never be deleted, and the host paths in bind and disk-image mounts resolve against it; like host paths locally, nothing on it is mounted into a sandbox unless you ask. Named volumes are the same storage under a name you choose.
+  **Cloud:** Volumes use fast block storage managed by the platform. Every organization automatically gets an undeletable **host volume**: think of it as the disk of the one computer all its sandboxes run on, and it is what bind and disk-image mounts resolve against.
 </Note>
 
-Mounts use normal Linux behavior by default: writable, executable, suid-enabled, and device-enabled. Adjust with:
+Volumes give a sandbox persistent or shared storage by mounting host data, managed storage, disk images, or in-memory filesystems into the guest. Mounts provide direct filesystem access and are significantly faster than the [filesystem API](/sandboxes/filesystem), which transfers files individually, so they are preferable for anything beyond ad-hoc reads and writes.
 
-- `readonly` / `ro` when the guest should not write to the mount.
-- `noexec` when files on the mount should not be executed directly.
-- `nosuid` when setuid/setgid bits should be ignored.
-- `nodev` when device files should be ignored.
-
-`noexec` does not stop interpreters from reading scripts from the mount, for example `sh /app/src/script.sh`.
-
-For stronger in-guest hardening, create the sandbox with the restricted security profile. Restricted sandboxes set `no_new_privs`, drop mount-admin capability from user commands, and force `nosuid,nodev` on user mounts. This profile is incompatible with workloads such as `sudo` and Docker-in-Docker.
-
-CLI mount flags use `SOURCE:DEST[:OPTIONS]`. The `:` before `OPTIONS` starts the option block, and commas separate options inside that block.
-
-| Flag | Source | Options |
-|------|--------|---------|
-| `--mount-dir` | Host directory | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
-| `--mount-file` | Host file | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
-| `--mount-named` | Named volume | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `kind=dir\|disk`, `size=<size>` for `kind=disk`, `quota=<size>` for directory volumes; directory-backed named volumes also support `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
-| `--mount-disk` | Host disk image | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `format=raw\|qcow2\|vmdk`, `fstype=<type>` |
-| `--tmpfs` | Guest path | `ro`, `rw`, `noexec`, `nosuid`, `nodev`; size may be passed as `PATH:SIZE[:OPTIONS]` |
+microsandbox supports four mount types on both backends: bind mounts, named volumes, disk-image volumes, and tmpfs.
 
 ## Bind mounts
 
-Mount a directory from the host directly into the sandbox. Changes inside the sandbox are reflected on the host, and vice versa.
+<Tooltip tip="The host path resolves against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** The host path resolves against your organization's host volume, not the computer running the SDK or CLI.
-</Note>
+Mount a directory from the host directly into the sandbox. Changes inside the sandbox are reflected on the host, and vice versa.
 
 <CodeGroup>
 ```rust Rust
@@ -100,6 +77,8 @@ msb create alpine --name config-reader \
 ```
 
 ## Named volumes
+
+<Tooltip tip="On microsandbox cloud, create named volumes before mounting them; create-on-mount, disk-kind volumes, and size are not available, and quota must be a whole number of GiB."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 microsandbox manages named volumes and stores them by default under `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox, so you can create a volume, populate it, and mount it into different sandboxes over time.
 
@@ -225,13 +204,11 @@ msb create docker:dind --name docker-demo \
 
 ### Sharing and host-side access
 
+<Tooltip tip="Host-side access to an unmounted volume is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem instead."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 Mount the same directory-backed named volume into multiple sandboxes when they need to share files. Use `readonly` on consumers that should not write. Disk-backed named volumes are attached as block devices; use one writable sandbox at a time, or read-only mounts where sharing is intended.
 
 Directory-backed named volumes are also accessible from the host without a running sandbox, so you can pre-populate a cache or inspect output after the sandbox stops. Disk-backed named volumes store guest data inside `disk.raw`; host filesystem helpers operate on the managed volume directory, not the filesystem inside the disk image.
-
-<Note>
-  **Cloud:** Host-side access to an unmounted volume is not available. Mount the volume into a sandbox and use the [sandbox filesystem](/sandboxes/filesystem) instead.
-</Note>
 
 ### Manage volumes
 
@@ -265,11 +242,9 @@ msb volume rm old-cache
 
 ## Disk-image volumes
 
-Disk-image volumes attach a host disk image as a virtio-blk device and mount its inner filesystem at a guest path. Use them when you want persistent state isolated from ordinary host filesystem metadata, or when distributing a prebuilt filesystem image. The disk format defaults from the file extension (`.qcow2`, `.raw`, `.vmdk`; otherwise raw), and the inner filesystem type is auto-detected unless you set `fstype`.
+<Tooltip tip="The host path resolves against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-<Note>
-  **Cloud:** The image path resolves against your organization's host volume, not your local filesystem.
-</Note>
+Disk-image volumes attach a host disk image as a virtio-blk device and mount its inner filesystem at a guest path. Use them when you want persistent state isolated from ordinary host filesystem metadata, or when distributing a prebuilt filesystem image. The disk format defaults from the file extension (`.qcow2`, `.raw`, `.vmdk`; otherwise raw), and the inner filesystem type is auto-detected unless you set `fstype`.
 
 <CodeGroup>
 ```rust Rust
@@ -357,6 +332,31 @@ msb create alpine --name worker \
 ```
 
 </CodeGroup>
+
+## Mount options
+
+Mounts use normal Linux behavior by default: writable, executable, suid-enabled, and device-enabled. Adjust with:
+
+- `readonly` / `ro` when the guest should not write to the mount.
+- `noexec` when files on the mount should not be executed directly.
+- `nosuid` when setuid/setgid bits should be ignored.
+- `nodev` when device files should be ignored.
+
+`noexec` does not stop interpreters from reading scripts from the mount, for example `sh /app/src/script.sh`.
+
+For stronger in-guest hardening, create the sandbox with the restricted security profile. Restricted sandboxes set `no_new_privs`, drop mount-admin capability from user commands, and force `nosuid,nodev` on user mounts. This profile is incompatible with workloads such as `sudo` and Docker-in-Docker.
+
+### CLI syntax and flags
+
+CLI mount flags use `SOURCE:DEST[:OPTIONS]`. The `:` before `OPTIONS` starts the option block, and commas separate options inside that block.
+
+| Flag | Source | Options |
+|------|--------|---------|
+| `--mount-dir` | Host directory | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
+| `--mount-file` | Host file | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
+| `--mount-named` | Named volume | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `kind=dir\|disk`, `size=<size>` for `kind=disk`, `quota=<size>` for directory volumes; directory-backed named volumes also support `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
+| `--mount-disk` | Host disk image | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `format=raw\|qcow2\|vmdk`, `fstype=<type>` |
+| `--tmpfs` | Guest path | `ro`, `rw`, `noexec`, `nosuid`, `nodev`; size may be passed as `PATH:SIZE[:OPTIONS]` |
 
 ## Combining mounts
 

--- a/docs/sandboxes/volumes.mdx
+++ b/docs/sandboxes/volumes.mdx
@@ -4,9 +4,13 @@ description: Persist and share data across sandboxes
 icon: "hard-drive"
 ---
 
-Volumes give a sandbox direct filesystem access to host-side storage or in-memory filesystems. They're useful for persisting data across restarts, sharing data between sandboxes, or mounting host data into the guest. They're also significantly faster than the [filesystem API](/sandboxes/filesystem) (which transfers files individually), so for anything beyond ad-hoc reads and writes, volumes are the way to go.
+Volumes give a sandbox direct filesystem access to persistent storage or in-memory filesystems. They're useful for persisting data across restarts, sharing data between sandboxes, or mounting host data into the guest. They're also significantly faster than the [filesystem API](/sandboxes/filesystem) (which transfers files individually), so for anything beyond ad-hoc reads and writes, volumes are the way to go.
 
-microsandbox supports four types of mounts: bind mounts, named volumes, tmpfs, and disk-image volumes.
+microsandbox supports four types of mounts: bind mounts, named volumes, tmpfs, and disk-image volumes. All four work on both backends.
+
+<Note>
+  **Cloud:** Volumes run on fast block storage managed by the platform. Every organization automatically gets a **host volume**: think of it as the disk of the one computer all your org's sandboxes run on. It can never be deleted, and the host paths in bind and disk-image mounts resolve against it; like host paths locally, nothing on it is mounted into a sandbox unless you ask. Named volumes are the same storage under a name you choose.
+</Note>
 
 Mounts use normal Linux behavior by default: writable, executable, suid-enabled, and device-enabled. Adjust with:
 
@@ -32,6 +36,10 @@ CLI mount flags use `SOURCE:DEST[:OPTIONS]`. The `:` before `OPTIONS` starts the
 ## Bind mounts
 
 Mount a directory from the host directly into the sandbox. Changes inside the sandbox are reflected on the host, and vice versa.
+
+<Note>
+  **Cloud:** The host path resolves against your organization's host volume, not the computer running the SDK or CLI.
+</Note>
 
 <CodeGroup>
 ```rust Rust
@@ -221,6 +229,10 @@ Mount the same directory-backed named volume into multiple sandboxes when they n
 
 Directory-backed named volumes are also accessible from the host without a running sandbox, so you can pre-populate a cache or inspect output after the sandbox stops. Disk-backed named volumes store guest data inside `disk.raw`; host filesystem helpers operate on the managed volume directory, not the filesystem inside the disk image.
 
+<Note>
+  **Cloud:** Host-side access to an unmounted volume is not available. Mount the volume into a sandbox and use the [sandbox filesystem](/sandboxes/filesystem) instead.
+</Note>
+
 ### Manage volumes
 
 <CodeGroup>
@@ -254,6 +266,10 @@ msb volume rm old-cache
 ## Disk-image volumes
 
 Disk-image volumes attach a host disk image as a virtio-blk device and mount its inner filesystem at a guest path. Use them when you want persistent state isolated from ordinary host filesystem metadata, or when distributing a prebuilt filesystem image. The disk format defaults from the file extension (`.qcow2`, `.raw`, `.vmdk`; otherwise raw), and the inner filesystem type is auto-detected unless you set `fstype`.
+
+<Note>
+  **Cloud:** The image path resolves against your organization's host volume, not your local filesystem.
+</Note>
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sdk/errors.mdx
+++ b/docs/sdk/errors.mdx
@@ -356,6 +356,8 @@ The CLI prepends the same payload as a styled `error:` block before any captured
 
 ## Resource cleanup
 
+<Tooltip tip="Rust drop and TypeScript await using do not stop microsandbox cloud sandboxes, because cloud handles do not own the host process; call stop() or remove() explicitly."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 Sandboxes hold compute resources, so release them when done. In Rust, `Drop` handles cleanup when the sandbox goes out of scope. In TypeScript, prefer `await using` (Node 22+) which calls `Sandbox.stop()` automatically when the binding leaves scope. In Go, pair every `CreateSandbox` with a `defer` that calls `Stop` + `Close`.
 
 <CodeGroup>

--- a/docs/sdk/go/agent-client.mdx
+++ b/docs/sdk/go/agent-client.mdx
@@ -71,6 +71,8 @@ Frame flag: this message requests sandbox shutdown. Also available as `FLAG_SHUT
 
 #### <span className="msb-recv">m.</span><span className="msb-hn">ConnectAgentSandbox()</span>
 
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func ConnectAgentSandbox(ctx context.Context, name string) (*AgentClient, error)
 ```
@@ -116,6 +118,8 @@ Connect to a running sandbox by name. Resolves the sandbox's relay socket path a
 </div>
 
 #### <span className="msb-recv">m.</span><span className="msb-hn">ConnectAgentPath()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func ConnectAgentPath(ctx context.Context, path string) (*AgentClient, error)
@@ -167,6 +171,8 @@ Connect to an `agentd` relay socket by path. Use this when you already have the 
 </div>
 
 #### <span className="msb-recv">m.</span><span className="msb-hn">AgentSocketPath()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func AgentSocketPath(name string) (string, error)

--- a/docs/sdk/go/images.mdx
+++ b/docs/sdk/go/images.mdx
@@ -3,6 +3,8 @@ title: Images
 description: Go SDK - Image cache API reference
 ---
 
+<Tooltip tip="The image-cache API manages the local cache and is local-only. On microsandbox cloud, specify an OCI image when creating the sandbox and it is pulled for you."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 Inspect and prune the local OCI image cache: the images that sandbox creation has already pulled. Images can also be loaded into the cache from local archives and saved back out to archive files, so locally built images work without a registry. Everything is reached through the package-level `Image` value, or through an [`ImageHandle`](#imagehandle) once you hold one.
 
 ```go

--- a/docs/sdk/go/images.mdx
+++ b/docs/sdk/go/images.mdx
@@ -309,7 +309,7 @@ fmt.Println(report.LayersRemoved, "layers removed")
 func (imageFactory) Load(ctx context.Context, inputPath string, tags ...string) ([]*ImageHandle, error)
 ```
 
-Import images from a local archive — a `docker save` tarball or an OCI Image Layout archive — into the cache, so locally built images can be used without a registry. Variadic `tags` apply extra references to the first image in the archive.
+Import images from a local archive (a `docker save` tarball or an OCI Image Layout archive) into the cache, so locally built images can be used without a registry. Variadic `tags` apply extra references to the first image in the archive.
 
 <p className="msb-label">Parameters</p>
 

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -521,6 +521,8 @@ Read persisted output from the sandbox's `exec.log`. Backed by an on-disk file, 
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">LogStream()</span>
 
+<Tooltip tip="On microsandbox cloud, log streaming is follow-only; set follow. Bounded, non-follow reads are not available."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (s *Sandbox) LogStream(ctx context.Context, opts LogStreamOptions) (*LogStreamHandle, error)
 ```
@@ -937,6 +939,8 @@ Release the Rust-side handle **without** stopping the VM. Use on sandboxes creat
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">Close()</span>
 
+<Tooltip tip="On microsandbox cloud this does not stop the sandbox; the cloud handle does not own the host process, so call stop() or remove() explicitly."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (s *Sandbox) Close() error
 ```
@@ -952,6 +956,8 @@ defer sb.Close()
 Release the Rust-side handle. Safe to call multiple times; the second call returns an error with `Kind == ErrInvalidHandle`. For a sandbox created with [`WithDetached`](#withdetached), `Close` stops the VM, use [`Detach`](#sb-detach) instead to leave it running.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">OwnsLifecycle()</span>
+
+<Tooltip tip="On microsandbox cloud this is false; the cloud worker owns the sandbox process, not your handle."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func (s *Sandbox) OwnsLifecycle() (bool, error)
@@ -969,6 +975,8 @@ Report whether this handle owns the VM process. When `true`, closing or stopping
 </div>
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">OwnsLifecycleOrFalse()</span>
+
+<Tooltip tip="On microsandbox cloud this is false; the cloud worker owns the sandbox process, not your handle."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func (s *Sandbox) OwnsLifecycleOrFalse() bool
@@ -990,6 +998,8 @@ Convenience wrapper around [`OwnsLifecycle`](#sb-ownslifecycle) that swallows th
 Functional options for [`CreateSandbox`](#m-createsandbox). Map and slice options merge across repeated calls; single-value setters like [`WithImage`](#withimage) replace. Simple setters are demonstrated by the [Typical flow](#typical-flow) above.
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithImage()</span>
+
+<Tooltip tip="On microsandbox cloud, only OCI image references are accepted; host-directory and disk-image root filesystems are local-only."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func WithImage(image string) SandboxOption
@@ -1085,6 +1095,8 @@ Set the guest memory limit in MiB. This is a limit, not an upfront reservation. 
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithMaxMemory()</span>
 
+<Tooltip tip="On microsandbox cloud these ceilings are not carried; the maximum is pinned to the initial value. Recreate the sandbox to resize."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func WithMaxMemory(mebibytes uint32) SandboxOption
 ```
@@ -1118,6 +1130,8 @@ Set the number of virtual CPUs. This is a limit, not a reservation. Default: `1`
 </div>
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithMaxCPUs()</span>
+
+<Tooltip tip="On microsandbox cloud these ceilings are not carried; the maximum is pinned to the initial value. Recreate the sandbox to resize."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func WithMaxCPUs(cpus uint8) SandboxOption
@@ -1241,6 +1255,8 @@ Attach a single label. Shorthand for [`WithLabels`](#withlabels) with one entry.
 </div>
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithHostname()</span>
+
+<Tooltip tip="On microsandbox cloud, the hostname is assigned by the platform; a value set here is ignored."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func WithHostname(hostname string) SandboxOption
@@ -1741,6 +1757,8 @@ Append `content` to an existing file at `path`. If the file lives in a lower ima
 
 #### <span className="msb-recv">Patch.</span><span className="msb-hn">Mkdir()</span>
 
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (patchFactory) Mkdir(path string, opts PatchOptions) PatchConfig
 ```
@@ -1804,6 +1822,8 @@ Create a symlink at `link` pointing to `target`. Only `opts.Replace` is honored.
 
 #### <span className="msb-recv">Patch.</span><span className="msb-hn">CopyFile()</span>
 
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (patchFactory) CopyFile(src, dst string, opts PatchOptions) PatchConfig
 ```
@@ -1828,6 +1848,8 @@ Copy a single host file at `src` into the guest rootfs at `dst`.
 </div>
 
 #### <span className="msb-recv">Patch.</span><span className="msb-hn">CopyDir()</span>
+
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func (patchFactory) CopyDir(src, dst string, opts PatchOptions) PatchConfig

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -297,6 +297,8 @@ Delete a stopped sandbox and all its persisted state from disk. Fails if the san
 
 #### <span className="msb-recv">m.</span><span className="msb-hn">AllSandboxMetrics()</span>
 
+<Tooltip tip="Resource metrics are not available on microsandbox cloud; use an external monitoring system."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func AllSandboxMetrics(ctx context.Context) (map[string]*Metrics, error)
 ```
@@ -478,6 +480,8 @@ Return an SSH accessor for opening a native in-process SSH client or preparing a
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">Logs()</span>
 
+<Tooltip tip="Bounded log reads are not available on microsandbox cloud; follow live with log streaming and persist output externally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (s *Sandbox) Logs(ctx context.Context, opts LogOptions) ([]LogEntry, error)
 ```
@@ -562,6 +566,8 @@ Start a streaming log subscription against a live sandbox. Pass `LogStreamOption
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">Ping()</span>
 
+<Tooltip tip="Not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (s *Sandbox) Ping(ctx context.Context) (*SandboxPingResult, error)
 ```
@@ -591,6 +597,8 @@ Check that the running sandbox's guest agent is reachable without refreshing idl
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">Touch()</span>
 
+<Tooltip tip="Not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (s *Sandbox) Touch(ctx context.Context) (*SandboxTouchResult, error)
 ```
@@ -619,6 +627,8 @@ Explicitly refresh the running sandbox's idle activity. This sends `core.touch`,
 </div>
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">Modify()</span>
+
+<Tooltip tip="modify is not available on microsandbox cloud; recreate the sandbox with the new configuration."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func (s *Sandbox) Modify(ctx context.Context, opts ModifyOptions) (*SandboxModificationPlan, error)
@@ -682,6 +692,8 @@ A live CPU or memory resize can take a moment to settle. The new limits are enfo
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">Metrics()</span>
 
+<Tooltip tip="Resource metrics are not available on microsandbox cloud; use an external monitoring system."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (s *Sandbox) Metrics(ctx context.Context) (*Metrics, error)
 ```
@@ -708,6 +720,8 @@ Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk 
 </div>
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">MetricsStream()</span>
+
+<Tooltip tip="Resource metrics are not available on microsandbox cloud; use an external monitoring system."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func (s *Sandbox) MetricsStream(ctx context.Context, interval time.Duration) (*MetricsStreamHandle, error)
@@ -834,6 +848,8 @@ Request graceful shutdown and return once the request is sent, without waiting f
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">Kill()</span>
 
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (s *Sandbox) Kill(ctx context.Context, opts ...KillOption) error
 ```
@@ -859,6 +875,8 @@ Force-terminate the sandbox with SIGKILL and wait until stopped state is observe
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">RequestKill()</span>
 
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (s *Sandbox) RequestKill(ctx context.Context) error
 ```
@@ -866,6 +884,8 @@ func (s *Sandbox) RequestKill(ctx context.Context) error
 Request force termination and return once the request is sent, without waiting for the sandbox to reach stopped state.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">RequestDrain()</span>
+
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func (s *Sandbox) RequestDrain(ctx context.Context) error
@@ -1004,6 +1024,8 @@ Set the writable overlay upper size for an OCI image, in MiB. Valid only with an
 </div>
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithImageDisk()</span>
+
+<Tooltip tip="Disk-image root filesystems are not available on microsandbox cloud; use an OCI image."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func WithImageDisk(path string, fstype string) SandboxOption
@@ -1254,6 +1276,8 @@ Set the default guest user (UID or name) for all commands.
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithReplace()</span>
 
+<Tooltip tip="Replace-on-create is not available on microsandbox cloud; remove the existing sandbox first."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func WithReplace() SandboxOption
 ```
@@ -1261,6 +1285,8 @@ func WithReplace() SandboxOption
 Replace any existing sandbox with the same name. Sends SIGTERM, waits up to 10s for graceful exit, then escalates to SIGKILL. Without this, creation fails on name conflict. Use [`WithReplaceWithTimeout`](#withreplacewithtimeout) to set a different window.
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithReplaceWithTimeout()</span>
+
+<Tooltip tip="Replace-on-create is not available on microsandbox cloud; remove the existing sandbox first."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func WithReplaceWithTimeout(timeout time.Duration) SandboxOption
@@ -1459,6 +1485,8 @@ Set credentials for pulling from a private OCI registry. See [`RegistryAuth`](#r
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithPorts()</span>
 
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func WithPorts(ports map[uint16]uint16) SandboxOption
 ```
@@ -1476,6 +1504,8 @@ Publish guest TCP ports onto host ports (map key = host port, value = guest port
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithPortsUDP()</span>
 
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func WithPortsUDP(ports map[uint16]uint16) SandboxOption
 ```
@@ -1492,6 +1522,8 @@ Publish guest UDP ports onto host ports. The default host bind address is `127.0
 </div>
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithPortBindings()</span>
+
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func WithPortBindings(bindings ...PortBinding) SandboxOption

--- a/docs/sdk/go/ssh.mdx
+++ b/docs/sdk/go/ssh.mdx
@@ -108,6 +108,8 @@ Open a native in-process SSH client to this sandbox. Generates an ephemeral Ed25
 
 #### <span className="msb-recv">ssh.</span><span className="msb-hn">PrepareServer()</span>
 
+<Tooltip tip="On microsandbox cloud, the reusable server works when you supply explicit host-key and authorized-key material; the convenience defaults are local-only."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (ssh *SandboxSSHOps) PrepareServer(ctx context.Context, opts ...SSHServerOption) (*SSHServer, error)
 ```

--- a/docs/sdk/go/volumes.mdx
+++ b/docs/sdk/go/volumes.mdx
@@ -889,7 +889,7 @@ Tuning struct for [`Mount.Bind`](#mount-bind), [`Mount.Named`](#mount-named), an
 | `Noexec` | `bool` | Prevent direct execution from the mount |
 | `Nosuid` | `bool` | Ignore setuid and setgid privilege elevation from files on the mount |
 | `Nodev` | `bool` | Ignore device files on the mount |
-| `QuotaMiB` | `uint32` | Guest-write quota in MiB, bounding growth beyond the host directory's existing contents; zero keeps the protective default (bind mounts only — named volumes use [`NamedVolumeOptions.QuotaMiB`](#namedvolumeoptions)) |
+| `QuotaMiB` | `uint32` | Guest-write quota in MiB, bounding growth beyond the host directory's existing contents; zero keeps the protective default (bind mounts only; named volumes use [`NamedVolumeOptions.QuotaMiB`](#namedvolumeoptions)) |
 | `StatVirtualization` | `StatVirtualization` | Per-mount stat-virtualization policy (virtiofs only) |
 | `HostPermissions` | `HostPermissions` | Per-mount host-permission propagation policy (virtiofs only) |
 

--- a/docs/sdk/go/volumes.mdx
+++ b/docs/sdk/go/volumes.mdx
@@ -202,6 +202,8 @@ Return the host filesystem path of the volume's data directory.
 
 #### <span className="msb-recv">v.</span><span className="msb-hn">FS()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (v *Volume) FS() *VolumeFs
 ```
@@ -337,6 +339,8 @@ Return the creation timestamp, or the zero `time.Time` value if unknown.
 
 #### <span className="msb-recv">h.</span><span className="msb-hn">FS()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (h *VolumeHandle) FS() *VolumeFs
 ```
@@ -385,6 +389,8 @@ Return the absolute host path of the volume's data directory.
 
 #### <span className="msb-recv">vfs.</span><span className="msb-hn">Read()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (fs *VolumeFs) Read(relPath string) ([]byte, error)
 ```
@@ -411,6 +417,8 @@ Read the contents of a file relative to the volume root.
 
 #### <span className="msb-recv">vfs.</span><span className="msb-hn">ReadString()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func (fs *VolumeFs) ReadString(relPath string) (string, error)
 ```
@@ -418,6 +426,8 @@ func (fs *VolumeFs) ReadString(relPath string) (string, error)
 Read a file and return its contents as a UTF-8 string.
 
 #### <span className="msb-recv">vfs.</span><span className="msb-hn">Write()</span>
+
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func (fs *VolumeFs) Write(relPath string, data []byte) error
@@ -439,6 +449,8 @@ Write data to a file, creating or truncating it. Created files use mode `0o644`.
 </div>
 
 #### <span className="msb-recv">vfs.</span><span className="msb-hn">WriteString()</span>
+
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func (fs *VolumeFs) WriteString(relPath, content string) error

--- a/docs/sdk/go/volumes.mdx
+++ b/docs/sdk/go/volumes.mdx
@@ -505,6 +505,8 @@ Functional options passed to [`CreateVolume`](#createvolume), plus the [`Mount`]
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithVolumeKind()</span>
 
+<Tooltip tip="Disk-kind volumes are not available on microsandbox cloud; use a directory-backed named volume."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```go
 func WithVolumeKind(kind VolumeKind) VolumeOption
 ```
@@ -521,6 +523,8 @@ Select the volume kind. Valid values are [`VolumeKindDir`](#volumekind) (default
 </div>
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithVolumeSize()</span>
+
+<Tooltip tip="Disk-kind volumes are not available on microsandbox cloud; use a directory-backed named volume."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func WithVolumeSize(mebibytes uint32) VolumeOption
@@ -703,6 +707,8 @@ Mount an ephemeral in-memory filesystem. Contents are discarded when the sandbox
 </div>
 
 #### <span className="msb-recv">Mount.</span><span className="msb-hn">Disk()</span>
+
+<Tooltip tip="On microsandbox cloud, the disk-image path resolves against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```go
 func (mountFactory) Disk(hostPath string, opts DiskOptions) MountConfig

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -4,7 +4,7 @@ description: Install the SDK and create your first sandbox
 icon: "play"
 ---
 
-The SDK embeds the microsandbox runtime directly into your application. Creating a sandbox spawns a local VM as a child process; there is no daemon to install and no server to connect to.
+The SDK embeds the microsandbox runtime directly into your application. Running locally, creating a sandbox spawns a VM as a child process; there is no daemon to install and no server to connect to. With an API key set, the same SDK runs sandboxes on [microsandbox cloud](/cloud/overview) instead.
 
 ## Installation
 

--- a/docs/sdk/python/agent-client.mdx
+++ b/docs/sdk/python/agent-client.mdx
@@ -30,6 +30,8 @@ await client.close()                                # 4. close
 
 #### <span className="msb-recv">AgentClient.</span><span className="msb-hn">connect_sandbox()</span>
 
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 @classmethod
 async def connect_sandbox(cls, name: str, *, timeout: float | None = None) -> AgentClient
@@ -68,6 +70,8 @@ Connect to a running sandbox by name. Sandbox names are limited to 128 UTF-8 byt
 </div>
 
 #### <span className="msb-recv">AgentClient.</span><span className="msb-hn">connect()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```python
 @classmethod
@@ -108,6 +112,8 @@ Connect to an agent relay socket by path. Use this when you already know the soc
 </div>
 
 #### <span className="msb-recv">AgentClient.</span><span className="msb-hn">socket_path()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```python
 @staticmethod

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -319,6 +319,8 @@ The sandbox name. This is an async method; call `await sb.name()`.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">owns_lifecycle</span>
 
+<Tooltip tip="On microsandbox cloud this is false; the cloud worker owns the sandbox process, not your handle."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 @property
 async def owns_lifecycle(self) -> bool
@@ -769,6 +771,8 @@ The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pas
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">log_stream()</span>
 
+<Tooltip tip="On microsandbox cloud, log streaming is follow-only; set follow. Bounded, non-follow reads are not available."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 async def log_stream(
     self,
@@ -1045,6 +1049,8 @@ Append `content` to an existing file at `path`. If the file lives in a lower ima
 
 #### <span className="msb-recv">Patch.</span><span className="msb-hn">mkdir()</span>
 
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 @staticmethod
 def mkdir(path: str, *, mode: int | None = None) -> PatchConfig
@@ -1085,6 +1091,8 @@ Delete a file or directory at `path`. Idempotent: a no-op if the path doesn't ex
 
 #### <span className="msb-recv">Patch.</span><span className="msb-hn">copy_file()</span>
 
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 @staticmethod
 def copy_file(src: str, dst: str, *, mode: int | None = None, replace: bool = False) -> PatchConfig
@@ -1114,6 +1122,8 @@ Copy a single host file at `src` into the guest rootfs at `dst`.
 </div>
 
 #### <span className="msb-recv">Patch.</span><span className="msb-hn">copy_dir()</span>
+
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```python
 @staticmethod

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -455,6 +455,8 @@ Attach your terminal to the sandbox's default shell for an interactive session.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">ping()</span>
 
+<Tooltip tip="Not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 async def ping(self) -> SandboxPingResult
 ```
@@ -481,6 +483,8 @@ Check that the running sandbox's guest agent is reachable without refreshing idl
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">touch()</span>
 
+<Tooltip tip="Not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 async def touch(self) -> SandboxTouchResult
 ```
@@ -506,6 +510,8 @@ Explicitly refresh the running sandbox's idle activity. This sends `core.touch`,
 </div>
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">modify()</span>
+
+<Tooltip tip="modify is not available on microsandbox cloud; recreate the sandbox with the new configuration."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```python
 async def modify(
@@ -625,6 +631,8 @@ A live CPU or memory resize can take a moment to settle. The new limits are enfo
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">metrics()</span>
 
+<Tooltip tip="Resource metrics are not available on microsandbox cloud; use an external monitoring system."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 async def metrics(self) -> SandboxMetrics
 ```
@@ -650,6 +658,8 @@ Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk 
 </div>
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">metrics_stream()</span>
+
+<Tooltip tip="Resource metrics are not available on microsandbox cloud; use an external monitoring system."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```python
 async def metrics_stream(self, interval: float = 1.0) -> MetricsStream
@@ -686,6 +696,8 @@ Stream resource metrics at a regular interval. The returned [`MetricsStream`](#m
 </div>
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">logs()</span>
+
+<Tooltip tip="Bounded log reads are not available on microsandbox cloud; follow live with log streaming and persist output externally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```python
 async def logs(
@@ -857,6 +869,8 @@ Request graceful shutdown and return once the request is sent, without waiting f
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">kill()</span>
 
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 async def kill(self, timeout: float | None = None) -> None
 ```
@@ -882,6 +896,8 @@ Force-terminate the sandbox and wait until stopped state is observed. No gracefu
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">request_kill()</span>
 
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 async def request_kill(self) -> None
 ```
@@ -897,6 +913,8 @@ await sb.request_kill()
 Request force termination and return once the signal is sent, without waiting for stopped state.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">request_drain()</span>
+
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```python
 async def request_drain(self) -> None

--- a/docs/sdk/python/ssh.mdx
+++ b/docs/sdk/python/ssh.mdx
@@ -99,6 +99,8 @@ Connect a native in-process SSH client to this sandbox. Generates an ephemeral c
 
 #### <span className="msb-recv">ssh.</span><span className="msb-hn">prepare_server()</span>
 
+<Tooltip tip="On microsandbox cloud, serving works when you supply explicit host-key and authorized-key material; the convenience defaults are local-only."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 async def prepare_server(
     *,

--- a/docs/sdk/python/volumes.mdx
+++ b/docs/sdk/python/volumes.mdx
@@ -460,6 +460,8 @@ Host-side filesystem operations on a named volume, obtained via the `fs` propert
 
 #### <span className="msb-recv">fs.</span><span className="msb-hn">read()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 async def read(path: str) -> bytes
 ```
@@ -495,6 +497,8 @@ Read the entire contents of a file as raw bytes.
 
 #### <span className="msb-recv">fs.</span><span className="msb-hn">read_text()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```python
 async def read_text(path: str) -> str
 ```
@@ -520,6 +524,8 @@ Read the entire contents of a file and decode it as UTF-8.
 </div>
 
 #### <span className="msb-recv">fs.</span><span className="msb-hn">write()</span>
+
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```python
 async def write(path: str, data: bytes) -> None

--- a/docs/sdk/rust/agent-client.mdx
+++ b/docs/sdk/rust/agent-client.mdx
@@ -45,6 +45,8 @@ client.close().await;                                // 4. close
 
 #### <span className="msb-recv">agent::</span><span className="msb-hn">connect_sandbox()</span>
 
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn connect_sandbox(name: &str) -> AgentClientResult<AgentClient>
 ```
@@ -80,6 +82,8 @@ Resolve a sandbox name to its agent relay socket path and connect, using the def
 </div>
 
 #### <span className="msb-recv">agent::</span><span className="msb-hn">connect_sandbox_with_timeout()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn connect_sandbox_with_timeout(name: &str, timeout: Duration) -> AgentClientResult<AgentClient>
@@ -124,6 +128,8 @@ Like [`connect_sandbox`](#agentconnect_sandbox), but with an explicit handshake 
 
 #### <span className="msb-recv">AgentClient::</span><span className="msb-hn">connect()</span>
 
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn connect(sock_path: impl AsRef<Path>) -> AgentClientResult<AgentClient>
 ```
@@ -161,6 +167,8 @@ Connect to an arbitrary agent relay socket by path, using the default ten-second
 
 #### <span className="msb-recv">AgentClient::</span><span className="msb-hn">connect_with_timeout()</span>
 
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn connect_with_timeout(sock_path: impl AsRef<Path>, timeout: Duration) -> AgentClientResult<AgentClient>
 ```
@@ -190,6 +198,8 @@ Connect to an arbitrary agent relay socket by path with an explicit handshake ti
 </div>
 
 #### <span className="msb-recv">AgentClient::</span><span className="msb-hn">connect_with_deadline()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn connect_with_deadline(sock_path: impl AsRef<Path>, deadline: Instant) -> AgentClientResult<AgentClient>
@@ -221,6 +231,8 @@ Connect to an arbitrary agent relay socket by path with an explicit handshake de
 
 #### <span className="msb-recv">AgentClient::</span><span className="msb-hn">connect_sandbox()</span>
 
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn connect_sandbox(name: &str) -> AgentClientResult<AgentClient>
 ```
@@ -246,6 +258,8 @@ Resolve a sandbox name to its agent socket path and connect. Equivalent to the m
 </div>
 
 #### <span className="msb-recv">AgentClient::</span><span className="msb-hn">connect_sandbox_with_timeout()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn connect_sandbox_with_timeout(name: &str, timeout: Duration) -> AgentClientResult<AgentClient>
@@ -276,6 +290,8 @@ Resolve a sandbox name to its agent socket path and connect with an explicit han
 </div>
 
 #### <span className="msb-recv">AgentClient::</span><span className="msb-hn">socket_path()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn socket_path(name: &str) -> MicrosandboxResult<PathBuf>
@@ -782,6 +798,8 @@ Bytes-in/bytes-out wrapper around [`AgentClient`](#agentclient), with concrete, 
 
 #### <span className="msb-recv">AgentBridge::</span><span className="msb-hn">connect_sandbox()</span>
 
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn connect_sandbox(name: &str) -> AgentClientResult<AgentBridge>
 ```
@@ -807,6 +825,8 @@ Connect to a sandbox by name, resolving the socket path from SDK config. Sandbox
 </div>
 
 #### <span className="msb-recv">AgentBridge::</span><span className="msb-hn">connect_sandbox_with_timeout()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn connect_sandbox_with_timeout(name: &str, timeout: Duration) -> AgentClientResult<AgentBridge>
@@ -838,6 +858,8 @@ Connect to a sandbox by name with an explicit handshake timeout.
 
 #### <span className="msb-recv">AgentBridge::</span><span className="msb-hn">connect_path()</span>
 
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn connect_path(path: &str) -> AgentClientResult<AgentBridge>
 ```
@@ -863,6 +885,8 @@ Connect to an arbitrary agentd relay socket by path.
 </div>
 
 #### <span className="msb-recv">AgentBridge::</span><span className="msb-hn">connect_path_with_timeout()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn connect_path_with_timeout(path: &str, timeout: Duration) -> AgentClientResult<AgentBridge>

--- a/docs/sdk/rust/filesystem.mdx
+++ b/docs/sdk/rust/filesystem.mdx
@@ -581,7 +581,7 @@ println!("{:?}", link_meta.kind);
 
 </Accordion>
 
-Get metadata, choosing whether to follow a final symlink. With `follow_symlink = false` you stat the link itself rather than its target. Local backend only; cloud returns `Unsupported`.
+Get metadata, choosing whether to follow a final symlink. With `follow_symlink = false` you stat the link itself rather than its target.
 
 <p className="msb-label">Parameters</p>
 
@@ -624,7 +624,7 @@ sb.fs().set_stat("/app/run.sh", true, FsSetAttrs {
 
 </Accordion>
 
-Update metadata on a file or directory: mode, owner uid/gid, size, and access/modification times. Only the fields you set on [`FsSetAttrs`](#fssetattrs) are applied. Local backend only; cloud returns `Unsupported`.
+Update metadata on a file or directory: mode, owner uid/gid, size, and access/modification times. Only the fields you set on [`FsSetAttrs`](#fssetattrs) are applied.
 
 <p className="msb-label">Parameters</p>
 
@@ -658,7 +658,7 @@ println!("-> {target}");
 
 </Accordion>
 
-Read the target of a symbolic link, returning the literal target text. Local backend only; cloud returns `Unsupported`.
+Read the target of a symbolic link, returning the literal target text.
 
 <p className="msb-label">Parameters</p>
 
@@ -692,7 +692,7 @@ sb.fs().symlink("/app/releases/v2", "/app/current").await?;
 
 </Accordion>
 
-Create a symbolic link at `link_path` that points to `target`. Local backend only; cloud returns `Unsupported`.
+Create a symbolic link at `link_path` that points to `target`.
 
 <p className="msb-label">Parameters</p>
 
@@ -844,7 +844,7 @@ Copy a file from the sandbox to the host machine.
 
 <p className="msb-backref">Returned by <a href="/sdk/rust/sandbox#sb-fs">sb.fs()</a></p>
 
-Filesystem operations handle for a running sandbox, borrowing the parent sandbox's backend and name (it is generic over a lifetime, `SandboxFsOps<'a>`). Every method dispatches through the same host-guest channel as command execution. Local routes to `core.fs.*` agent messages; cloud returns `Unsupported` per method until cloud guest-fs lands. All operations are listed in the sections above.
+Filesystem operations handle for a running sandbox, borrowing the parent sandbox's backend and name (it is generic over a lifetime, `SandboxFsOps<'a>`). Every method dispatches through the same host-guest channel as command execution: `core.fs.*` agent messages over the relay socket locally, or the agent WebSocket route on cloud. Handle-based helpers (`stat_handle` and friends) require the live local agent client and return `Unsupported` on cloud. All operations are listed in the sections above.
 
 `with_backend(backend, name)` is a public constructor for FFI shims that re-assemble a `SandboxFsOps` per call; most callers obtain one via [`sb.fs()`](/sdk/rust/sandbox#sb-fs).
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -736,6 +736,8 @@ Set the network access policy. Pass a profile-composed or builder-constructed [`
 
 #### <span className="msb-recv">.</span><span className="msb-hn">port()</span>
 
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 <a id="nb-port"></a>
 
 ```rust
@@ -759,6 +761,8 @@ Publish a TCP port from the sandbox to the host. The default host bind address i
 
 #### <span className="msb-recv">.</span><span className="msb-hn">port_udp()</span>
 
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn port_udp(self, host_port: u16, guest_port: u16) -> Self
 ```
@@ -766,6 +770,8 @@ fn port_udp(self, host_port: u16, guest_port: u16) -> Self
 Publish a UDP port. The default host bind address is `127.0.0.1`.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">port_bind()</span>
+
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn port_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self
@@ -791,6 +797,8 @@ Publish a TCP port on a specific host bind address, such as `0.0.0.0`.
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">port_udp_bind()</span>
+
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn port_udp_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -800,6 +800,8 @@ Publish a UDP port on a specific host bind address.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">dns()</span>
 
+<Tooltip tip="Custom nameservers are not available on microsandbox cloud; cloud uses platform-managed DNS."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn dns(self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self
 ```
@@ -821,6 +823,8 @@ Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
 
 #### <span className="msb-recv">.</span><span className="msb-hn">tls()</span>
 
+<Tooltip tip="TLS interception and host-CA trust are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn tls(self, f: impl FnOnce(TlsBuilder) -> TlsBuilder) -> Self
 ```
@@ -828,6 +832,8 @@ fn tls(self, f: impl FnOnce(TlsBuilder) -> TlsBuilder) -> Self
 Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
 
 #### <span className="msb-recv">.</span><span className="msb-hn">trust_host_cas()</span>
+
+<Tooltip tip="TLS interception and host-CA trust are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn trust_host_cas(self, enabled: bool) -> Self
@@ -854,6 +860,8 @@ Limit the maximum number of concurrent network connections from the sandbox. Def
 
 #### <span className="msb-recv">.</span><span className="msb-hn">ipv4_pool()</span>
 
+<Tooltip tip="Interface and IP-pool overrides are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn ipv4_pool(self, pool: Ipv4Network) -> Self
 ```
@@ -871,6 +879,8 @@ Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `1
 
 #### <span className="msb-recv">.</span><span className="msb-hn">ipv6_pool()</span>
 
+<Tooltip tip="Interface and IP-pool overrides are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn ipv6_pool(self, pool: Ipv6Network) -> Self
 ```
@@ -878,6 +888,8 @@ fn ipv6_pool(self, pool: Ipv6Network) -> Self
 Set the IPv6 pool used to derive per-sandbox `/64` guest prefixes. Defaults to `fd42:6d73:62::/48`. A pool with a prefix longer than `/64` records [`BuildError::InvalidIpv6Pool`](#builderror).
 
 #### <span className="msb-recv">.</span><span className="msb-hn">interface()</span>
+
+<Tooltip tip="Interface and IP-pool overrides are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn interface(self, overrides: InterfaceOverrides) -> Self
@@ -949,6 +961,8 @@ Builder for DNS interception, used in [`NetworkBuilder::dns(|d| d...)`](#dns). O
 
 #### <span className="msb-recv">.</span><span className="msb-hn">nameservers()</span>
 
+<Tooltip tip="Custom nameservers are not available on microsandbox cloud; cloud uses platform-managed DNS."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn nameservers<I>(self, nameservers: I) -> Self
 where
@@ -1006,6 +1020,8 @@ Skip TLS interception for hosts matching this glob (e.g. `"*.internal.corp"`). U
 
 #### <span className="msb-recv">.</span><span className="msb-hn">intercepted_ports()</span>
 
+<Tooltip tip="TLS interception and host-CA trust are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn intercepted_ports(self, ports: Vec<u16>) -> Self
 ```
@@ -1030,6 +1046,8 @@ Block QUIC/HTTP3 on intercepted ports, forcing TCP/TLS fallback. Default: `true`
 
 #### <span className="msb-recv">.</span><span className="msb-hn">intercept_ca_cert()</span>
 
+<Tooltip tip="TLS interception and host-CA trust are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn intercept_ca_cert(self, path: impl Into<PathBuf>) -> Self
 ```
@@ -1037,6 +1055,8 @@ fn intercept_ca_cert(self, path: impl Into<PathBuf>) -> Self
 PEM file used as the intercepting CA's certificate. Pair with [`intercept_ca_key()`](#intercept_ca_key) to provide a stable CA across sandbox restarts. If unset, a CA is auto-generated and persisted.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">intercept_ca_key()</span>
+
+<Tooltip tip="TLS interception and host-CA trust are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn intercept_ca_key(self, path: impl Into<PathBuf>) -> Self

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -625,6 +625,8 @@ Get the sandbox name.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">owns_lifecycle()</span>
 
+<Tooltip tip="On microsandbox cloud this is false; the cloud worker owns the sandbox process, not your handle."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn owns_lifecycle(&self) -> bool
 ```
@@ -793,6 +795,8 @@ Set the number of virtual CPUs. This is a limit, not a reservation. Default: `1`
 
 #### <span className="msb-recv">.</span><span className="msb-hn">max_cpus()</span>
 
+<Tooltip tip="On microsandbox cloud these ceilings are not carried; the maximum is pinned to the initial value. Recreate the sandbox to resize."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn max_cpus(self, count: u8) -> Self
 ```
@@ -932,6 +936,8 @@ Set an environment variable visible to all commands. Can be called multiple time
 
 #### <span className="msb-recv">.</span><span className="msb-hn">hostname()</span>
 
+<Tooltip tip="On microsandbox cloud, the hostname is assigned by the platform; a value set here is ignored."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn hostname(self, hostname: impl Into<String>) -> Self
 ```
@@ -1036,6 +1042,8 @@ Like [`init`](#init), but with a closure-builder for argv and env vars. Mirrors 
 
 #### <span className="msb-recv">.</span><span className="msb-hn">image()</span>
 
+<Tooltip tip="On microsandbox cloud, only OCI image references are accepted; host-directory and disk-image root filesystems are local-only."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn image(self, image: impl IntoImage) -> Self
 ```
@@ -1052,6 +1060,8 @@ Set the root filesystem source. Accepts OCI image names, local directory paths, 
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">image_with()</span>
+
+<Tooltip tip="On microsandbox cloud, only OCI image references are accepted; host-directory and disk-image root filesystems are local-only."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn image_with(self, f: impl FnOnce(ImageBuilder) -> ImageBuilder) -> Self
@@ -1133,6 +1143,8 @@ Set the guest memory size. Physical pages are only allocated as the guest touche
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">max_memory()</span>
+
+<Tooltip tip="On microsandbox cloud these ceilings are not carried; the maximum is pinned to the initial value. Recreate the sandbox to resize."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn max_memory(self, size: impl Into<Mebibytes>) -> Self
@@ -1301,6 +1313,8 @@ Control when the OCI image is pulled from the registry.
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">registry()</span>
+
+<Tooltip tip="On microsandbox cloud, plain-HTTP and custom-CA registry options are not available; credential auth still works."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn registry(self, f: impl FnOnce(RegistryConfigBuilder) -> RegistryConfigBuilder) -> Self
@@ -1510,6 +1524,8 @@ Append `content` to an existing file at `path`. If the file lives in a lower ima
 
 #### <span className="msb-recv">.</span><span className="msb-hn">copy_dir()</span>
 
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn copy_dir(self, src: impl Into<PathBuf>, dst: impl Into<String>, replace: bool) -> Self
 ```
@@ -1534,6 +1550,8 @@ Recursively copy a host directory at `src` into the guest rootfs at `dst`.
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">copy_file()</span>
+
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn copy_file(
@@ -1604,6 +1622,8 @@ Write raw bytes at `path`.
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">mkdir()</span>
+
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn mkdir(self, path: impl Into<String>, mode: Option<u32>) -> Self
@@ -1746,6 +1766,8 @@ Set the desired effective vCPU count. Applies live to a running sandbox when the
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">max_cpus()</span>
+
+<Tooltip tip="On microsandbox cloud these ceilings are not carried; the maximum is pinned to the initial value. Recreate the sandbox to resize."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn max_cpus(self, max_cpus: u8) -> Self
@@ -1905,6 +1927,8 @@ Set the desired effective guest memory in MiB. Same as [`memory()`](#memory-2) w
 
 #### <span className="msb-recv">.</span><span className="msb-hn">max_memory()</span>
 
+<Tooltip tip="On microsandbox cloud these ceilings are not carried; the maximum is pinned to the initial value. Recreate the sandbox to resize."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn max_memory(self, size: impl Into<Mebibytes>) -> Self
 ```
@@ -1921,6 +1945,8 @@ Set the desired boot-time maximum hotpluggable memory. Capacity is fixed at boot
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">max_memory_mib()</span>
+
+<Tooltip tip="On microsandbox cloud these ceilings are not carried; the maximum is pinned to the initial value. Recreate the sandbox to resize."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn max_memory_mib(self, max_memory_mib: u32) -> Self

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -280,6 +280,8 @@ Release the handle without stopping the sandbox. The sandbox continues running a
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">drain()</span>
 
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn drain(&self) -> MicrosandboxResult<()>
 ```
@@ -295,6 +297,8 @@ sb.drain().await?;
 Start a graceful drain. Existing commands run to completion, but new `exec` calls are rejected. The sandbox transitions to `Stopped` when all in-flight commands finish. Useful for zero-downtime rotation of worker sandboxes.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">request_drain()</span>
+
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn request_drain(&self) -> MicrosandboxResult<()>
@@ -329,6 +333,8 @@ Get a filesystem handle for reading and writing files inside the running sandbox
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">kill()</span>
 
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn kill(&self) -> MicrosandboxResult<()>
 ```
@@ -345,6 +351,8 @@ Force-terminate the sandbox immediately with SIGKILL. No graceful shutdown - use
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">kill_with_timeout()</span>
 
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn kill_with_timeout(&self, timeout: Duration) -> MicrosandboxResult<()>
 ```
@@ -353,6 +361,8 @@ Force-terminate the sandbox and wait up to `timeout` for stopped-state observati
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">request_kill()</span>
 
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn request_kill(&self) -> MicrosandboxResult<()>
 ```
@@ -360,6 +370,8 @@ async fn request_kill(&self) -> MicrosandboxResult<()>
 Request force termination and return once the request is sent, without waiting for stopped-state observation.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">metrics()</span>
+
+<Tooltip tip="Resource metrics are not available on microsandbox cloud; use an external monitoring system."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn metrics(&self) -> MicrosandboxResult<SandboxMetrics>
@@ -386,6 +398,8 @@ Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk 
 </div>
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">metrics_stream()</span>
+
+<Tooltip tip="Resource metrics are not available on microsandbox cloud; use an external monitoring system."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn metrics_stream(&self, interval: Duration) -> impl Stream<Item = MicrosandboxResult<SandboxMetrics>>
@@ -425,6 +439,8 @@ Stream resource metrics at a regular interval. Returns an async stream that yiel
 </div>
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">logs()</span>
+
+<Tooltip tip="Bounded log reads are not available on microsandbox cloud; follow live with log streaming and persist output externally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn logs(&self, opts: &LogOptions) -> MicrosandboxResult<Vec<LogEntry>>
@@ -496,6 +512,8 @@ The default sources are `Stdout`, `Stderr`, and `Output` (PTY-merged). Pass `Log
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">ping()</span>
 
+<Tooltip tip="Not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn ping(&self) -> MicrosandboxResult<SandboxPingResult>
 ```
@@ -522,6 +540,8 @@ Check whether the running sandbox's guest agent is reachable. This sends `core.p
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">touch()</span>
 
+<Tooltip tip="Not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn touch(&self) -> MicrosandboxResult<SandboxTouchResult>
 ```
@@ -547,6 +567,8 @@ Explicitly refresh the running sandbox's idle timer. This sends `core.touch`; us
 </div>
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">modify()</span>
+
+<Tooltip tip="modify is not available on microsandbox cloud; recreate the sandbox with the new configuration."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn modify(&self) -> SandboxModificationBuilder
@@ -1163,6 +1185,8 @@ Modify the rootfs before the VM boots. Patches go into the writable layer - the 
 
 #### <span className="msb-recv">.</span><span className="msb-hn">port()</span>
 
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn port(self, host_port: u16, guest_port: u16) -> Self
 ```
@@ -1183,6 +1207,8 @@ Publish a TCP port from the sandbox to the host. The default host bind address i
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">port_bind()</span>
+
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn port_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self
@@ -1209,6 +1235,8 @@ Publish a TCP port on a specific host bind address, such as `0.0.0.0`.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">port_udp()</span>
 
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn port_udp(self, host_port: u16, guest_port: u16) -> Self
 ```
@@ -1229,6 +1257,8 @@ Publish a UDP port. The default host bind address is `127.0.0.1`.
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">port_udp_bind()</span>
+
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn port_udp_bind(self, host_bind: IpAddr, host_port: u16, guest_port: u16) -> Self
@@ -1305,6 +1335,8 @@ Configure registry connection settings for the sandbox image pull, including exp
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">replace()</span>
+
+<Tooltip tip="Replace-on-create is not available on microsandbox cloud; remove the existing sandbox first."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn replace(self) -> Self

--- a/docs/sdk/rust/ssh.mdx
+++ b/docs/sdk/rust/ssh.mdx
@@ -218,6 +218,8 @@ Alias for [`server`](#ssh-server).
 
 #### <span className="msb-recv">ssh.</span><span className="msb-hn">server_with()</span>
 
+<Tooltip tip="On microsandbox cloud, serving works when you supply explicit host-key and authorized-key material; the convenience defaults are local-only."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn server_with(
     &self,
@@ -257,6 +259,8 @@ Prepare a server endpoint with custom host-key, authorization, guest-user, or SF
 </div>
 
 #### <span className="msb-recv">ssh.</span><span className="msb-hn">prepare_server_with()</span>
+
+<Tooltip tip="On microsandbox cloud, serving works when you supply explicit host-key and authorized-key material; the convenience defaults are local-only."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn prepare_server_with(

--- a/docs/sdk/rust/ssh.mdx
+++ b/docs/sdk/rust/ssh.mdx
@@ -170,6 +170,8 @@ Alias for [`connect_with`](#ssh-connect_with).
 
 #### <span className="msb-recv">ssh.</span><span className="msb-hn">server()</span>
 
+<Tooltip tip="Serving with the convenience defaults is not available on microsandbox cloud; supply explicit host-key and authorized-key material, or use the SSH client."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn server(&self) -> MicrosandboxResult<SshServer>
 ```
@@ -196,6 +198,8 @@ Prepare a reusable SSH server endpoint for this sandbox. Loads or creates the ho
 </div>
 
 #### <span className="msb-recv">ssh.</span><span className="msb-hn">prepare_server()</span>
+
+<Tooltip tip="Serving with the convenience defaults is not available on microsandbox cloud; supply explicit host-key and authorized-key material, or use the SSH client."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn prepare_server(&self) -> MicrosandboxResult<SshServer>

--- a/docs/sdk/rust/volumes.mdx
+++ b/docs/sdk/rust/volumes.mdx
@@ -1113,6 +1113,8 @@ Create a directory-backed named volume (mounted through virtiofs). This is the d
 
 #### <span className="msb-recv">.</span><span className="msb-hn">disk()</span>
 
+<Tooltip tip="Disk-kind volumes are not available on microsandbox cloud; use a directory-backed named volume."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn disk(self) -> Self
 ```
@@ -1120,6 +1122,8 @@ fn disk(self) -> Self
 Create a raw ext4 disk-image named volume (mounted through virtio-blk). Requires [`.size()`](#size).
 
 #### <span className="msb-recv">.</span><span className="msb-hn">size()</span>
+
+<Tooltip tip="Disk-kind volumes are not available on microsandbox cloud; use a directory-backed named volume."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn size(self, size: impl Into<Mebibytes>) -> Self
@@ -1151,6 +1155,8 @@ Set the disk volume's capacity. Required for disk volumes; rejected for director
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">quota()</span>
+
+<Tooltip tip="On microsandbox cloud, quota sets a storage cap and must be a whole number of GiB."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn quota(self, size: impl Into<Mebibytes>) -> Self
@@ -1278,6 +1284,8 @@ Mount a named volume created via [`Volume::create()`](#volumecreate). The volume
 
 #### <span className="msb-recv">.</span><span className="msb-hn">named_with()</span>
 
+<Tooltip tip="On microsandbox cloud, create the named volume before mounting; create-on-mount, disk-kind, and size are not available."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn named_with(
     self,
@@ -1327,6 +1335,8 @@ fn tmpfs(self) -> Self
 Use an in-memory filesystem. Contents are discarded when the sandbox stops. Good for scratch space, temp files, and build artifacts. Cap its size with [`.size()`](#mb-size).
 
 #### <span className="msb-recv">.</span><span className="msb-hn">disk()</span>
+
+<Tooltip tip="On microsandbox cloud, the disk-image path resolves against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 <a id="mb-disk"></a>
 
@@ -1548,6 +1558,8 @@ Use directory-backed storage for a created volume. This is the default. Clears a
 
 #### <span className="msb-recv">.</span><span className="msb-hn">disk()</span>
 
+<Tooltip tip="Disk-kind volumes are not available on microsandbox cloud; use a directory-backed named volume."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 <a id="nv-disk"></a>
 
 ```rust
@@ -1557,6 +1569,8 @@ fn disk(self) -> Self
 Use raw ext4 disk-image storage for a created volume. Requires [`.size()`](#nv-size). Clears any previously set quota.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">size()</span>
+
+<Tooltip tip="Disk-kind volumes are not available on microsandbox cloud; use a directory-backed named volume."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 <a id="nv-size"></a>
 
@@ -1576,6 +1590,8 @@ Set disk capacity for a created disk volume. Accepts a bare `u32` (MiB) or a `Si
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">quota()</span>
+
+<Tooltip tip="On microsandbox cloud, quota sets a storage cap and must be a whole number of GiB."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 <a id="nv-quota"></a>
 

--- a/docs/sdk/rust/volumes.mdx
+++ b/docs/sdk/rust/volumes.mdx
@@ -233,6 +233,8 @@ The storage kind: [`Directory`](#volumekind) or [`Disk`](#volumekind).
 
 #### <span className="msb-recv">vol.</span><span className="msb-hn">fs()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn fs(&self) -> VolumeFs<'_>
 ```
@@ -385,6 +387,8 @@ Local-only volume state. Returns `Some` for local-backed volumes, `None` for clo
 
 #### <span className="msb-recv">vol.</span><span className="msb-hn">cloud()</span>
 
+<Tooltip tip="Returns state only for cloud-backed volumes; None on the local backend."><span className="msb-badge-cloud">Cloud-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn cloud(&self) -> Option<&VolumeCloudState>
 ```
@@ -439,6 +443,8 @@ The storage kind: [`Directory`](#volumekind) or [`Disk`](#volumekind).
 </div>
 
 #### <span className="msb-recv">h.</span><span className="msb-hn">fs()</span>
+
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 fn fs(&self) -> VolumeFs<'_>
@@ -652,6 +658,8 @@ Local-only handle state. Returns `Some` for local-backed handles, `None` for clo
 
 #### <span className="msb-recv">h.</span><span className="msb-hn">cloud()</span>
 
+<Tooltip tip="Returns state only for cloud-backed volume handles; None on the local backend."><span className="msb-badge-cloud">Cloud-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 fn cloud(&self) -> Option<&VolumeHandleCloudState>
 ```
@@ -672,6 +680,8 @@ Cloud-only handle state. Returns `Some` for cloud-backed handles, `None` for loc
 Host-side filesystem operations on a named volume, obtained via [`Volume::fs()`](#vol-fs) or [`VolumeHandle::fs()`](#h-fs). Unlike [`SandboxFsOps`](/sdk/rust/filesystem), which goes through the agent protocol, `VolumeFs` reads and writes the volume's bytes directly. Paths are relative to the volume root; a leading `/` is stripped, and path traversal outside the root is rejected.
 
 #### <span className="msb-recv">fs.</span><span className="msb-hn">read()</span>
+
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn read(&self, path: &str) -> MicrosandboxResult<Bytes>
@@ -707,6 +717,8 @@ Read an entire file into memory as raw bytes.
 
 #### <span className="msb-recv">fs.</span><span className="msb-hn">read_to_string()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn read_to_string(&self, path: &str) -> MicrosandboxResult<String>
 ```
@@ -740,6 +752,8 @@ Read an entire file into memory as a UTF-8 string.
 </div>
 
 #### <span className="msb-recv">fs.</span><span className="msb-hn">read_stream()</span>
+
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn read_stream(&self, path: &str) -> MicrosandboxResult<VolumeFsReadStream>
@@ -778,6 +792,8 @@ Open a file for streaming reads. Returns a [`VolumeFsReadStream`](#volumefsreads
 
 #### <span className="msb-recv">fs.</span><span className="msb-hn">write()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```rust
 async fn write(&self, path: &str, data: impl AsRef<[u8]>) -> MicrosandboxResult<()>
 ```
@@ -806,6 +822,8 @@ Write data to a file, creating parent directories as needed. Overwrites if the f
 </div>
 
 #### <span className="msb-recv">fs.</span><span className="msb-hn">write_stream()</span>
+
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```rust
 async fn write_stream(&self, path: &str) -> MicrosandboxResult<VolumeFsWriteSink>

--- a/docs/sdk/typescript/agent-client.mdx
+++ b/docs/sdk/typescript/agent-client.mdx
@@ -57,6 +57,8 @@ Frame flag: this message requests sandbox shutdown.
 
 #### <span className="msb-recv">AgentClient.</span><span className="msb-hn">connectSandbox()</span>
 
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 static connectSandbox(name: string, opts?: AgentConnectOptions): Promise<AgentClient>
 ```
@@ -94,6 +96,8 @@ Connect to a running sandbox by name. Resolves the sandbox's relay socket path a
 </div>
 
 #### <span className="msb-recv">AgentClient.</span><span className="msb-hn">connect()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 static connect(path: string, opts?: AgentConnectOptions): Promise<AgentClient>
@@ -133,6 +137,8 @@ Connect to an `agentd` relay socket by path. Use this when you already have the 
 </div>
 
 #### <span className="msb-recv">AgentClient.</span><span className="msb-hn">socketPath()</span>
+
+<Tooltip tip="Connecting an agent client by socket path is local-only; on microsandbox cloud the SDK uses the agent WebSocket route internally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 static socketPath(name: string): string

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -440,6 +440,8 @@ Set the policy. Accepts a [`NetworkPolicy`](#networkpolicy-2) literal or factory
 
 #### <span className="msb-recv">.</span><span className="msb-hn">port()</span>
 
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 port(host: number, guest: number): this
 ```
@@ -460,6 +462,8 @@ Publish a TCP port from the guest to the host. The default host bind address is 
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">portBind()</span>
+
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 portBind(bind: string, host: number, guest: number): this
@@ -486,6 +490,8 @@ Publish a TCP port on a specific host bind address, such as `0.0.0.0`.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">portUdp()</span>
 
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 portUdp(host: number, guest: number): this
 ```
@@ -506,6 +512,8 @@ Publish a UDP port from the guest to the host. The default host bind address is 
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">portUdpBind()</span>
+
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 portUdpBind(bind: string, host: number, guest: number): this

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -532,6 +532,8 @@ Publish a UDP port on a specific host bind address.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">dns()</span>
 
+<Tooltip tip="Custom nameservers are not available on microsandbox cloud; cloud uses platform-managed DNS."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 dns(configure: (b: DnsBuilder) => DnsBuilder): this
 ```
@@ -557,6 +559,8 @@ Configure DNS interception. See [`DnsBuilder`](#dnsbuilder).
 
 #### <span className="msb-recv">.</span><span className="msb-hn">tls()</span>
 
+<Tooltip tip="TLS interception and host-CA trust are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 tls(configure: (b: TlsBuilder) => TlsBuilder): this
 ```
@@ -573,6 +577,8 @@ Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">trustHostCAs()</span>
+
+<Tooltip tip="TLS interception and host-CA trust are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 trustHostCAs(enabled: boolean): this
@@ -608,6 +614,8 @@ Limit the maximum number of concurrent network connections from the sandbox.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">ipv4Pool()</span>
 
+<Tooltip tip="Interface and IP-pool overrides are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 ipv4Pool(pool: string): this
 ```
@@ -625,6 +633,8 @@ Set the IPv4 pool used to derive per-sandbox `/30` guest subnets. Defaults to `1
 
 #### <span className="msb-recv">.</span><span className="msb-hn">ipv6Pool()</span>
 
+<Tooltip tip="Interface and IP-pool overrides are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 ipv6Pool(pool: string): this
 ```
@@ -641,6 +651,8 @@ Set the IPv6 pool used to derive per-sandbox `/64` guest prefixes. Defaults to `
 </div>
 
 #### <span className="msb-recv" id="nb-interface">.</span><span className="msb-hn">interface()</span>
+
+<Tooltip tip="Interface and IP-pool overrides are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 interface(configure: (b: InterfaceOverridesBuilder) => InterfaceOverridesBuilder): this
@@ -1541,6 +1553,8 @@ Toggle DNS rebinding protection. When enabled, DNS responses resolving to privat
 
 #### <span className="msb-recv">.</span><span className="msb-hn">nameservers()</span>
 
+<Tooltip tip="Custom nameservers are not available on microsandbox cloud; cloud uses platform-managed DNS."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 nameservers(servers: string[]): this
 ```
@@ -1621,6 +1635,8 @@ Verify upstream server certificates only when the upstream SNI matches `pattern`
 
 #### <span className="msb-recv">.</span><span className="msb-hn">interceptedPorts()</span>
 
+<Tooltip tip="TLS interception and host-CA trust are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 interceptedPorts(ports: number[]): this
 ```
@@ -1655,6 +1671,8 @@ Block QUIC on intercepted ports, forcing TCP/TLS fallback.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">interceptCaCert()</span>
 
+<Tooltip tip="TLS interception and host-CA trust are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 interceptCaCert(path: string): this
 ```
@@ -1671,6 +1689,8 @@ Path to a PEM file used as the intercepting CA's certificate.
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">interceptCaKey()</span>
+
+<Tooltip tip="TLS interception and host-CA trust are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 interceptCaKey(path: string): this

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -336,6 +336,8 @@ Get a filesystem handle for reading and writing files inside the running sandbox
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">kill()</span>
 
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 kill(): Promise<void>
 ```
@@ -351,6 +353,8 @@ await sandbox.kill(); // no graceful shutdown
 Force-terminate the sandbox and wait until stopped state is observed. No graceful shutdown - use when the sandbox is unresponsive. Pending writes that the workload hasn't `fsync`'d may be lost, same durability semantics as a sudden power loss on a physical machine. Prefer [`stop()`](#sandbox-stop) for graceful shutdown that gives the workload a chance to flush.
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">killWithTimeout()</span>
+
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 killWithTimeout(timeoutMs: number): Promise<void>
@@ -376,6 +380,8 @@ Force-terminate the sandbox and wait up to `timeoutMs` for stopped-state observa
 </div>
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">logs()</span>
+
+<Tooltip tip="Bounded log reads are not available on microsandbox cloud; follow live with log streaming and persist output externally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 logs(opts?: LogReadOptions): Promise<LogEntry[]>
@@ -474,6 +480,8 @@ Stream captured output as it appears, with optional follow. Backed by the same o
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">ping()</span>
 
+<Tooltip tip="Not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 ping(): Promise<SandboxPingResult>
 ```
@@ -500,6 +508,8 @@ Check that the running sandbox's guest agent is reachable without refreshing idl
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">touch()</span>
 
+<Tooltip tip="Not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 touch(): Promise<SandboxTouchResult>
 ```
@@ -525,6 +535,8 @@ Explicitly refresh the running sandbox's idle activity. This sends `core.touch`,
 </div>
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">modify()</span>
+
+<Tooltip tip="modify is not available on microsandbox cloud; recreate the sandbox with the new configuration."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 modify(opts?: ModifyOptions): Promise<SandboxModificationPlan>
@@ -579,6 +591,8 @@ A live CPU or memory resize can take a moment to settle. The new limits are enfo
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">metrics()</span>
 
+<Tooltip tip="Resource metrics are not available on microsandbox cloud; use an external monitoring system."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 metrics(): Promise<SandboxMetrics>
 ```
@@ -604,6 +618,8 @@ Get a point-in-time snapshot of the sandbox's resource usage: CPU, memory, disk 
 </div>
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">metricsStream()</span>
+
+<Tooltip tip="Resource metrics are not available on microsandbox cloud; use an external monitoring system."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 metricsStream(intervalMs: number): Promise<MetricsStream>
@@ -642,6 +658,8 @@ Stream resource metrics at a regular interval. The returned [`MetricsStream`](#m
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">requestDrain()</span>
 
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 requestDrain(): Promise<void>
 ```
@@ -658,6 +676,8 @@ await sandbox.waitUntilStopped();
 Request a graceful drain and return once the request is sent. Existing commands run to completion, but new `exec` calls are rejected. The sandbox transitions to `stopped` when all in-flight commands finish. Use [`waitUntilStopped()`](#sandbox-waituntilstopped) when the caller needs stopped-state observation. Useful for zero-downtime rotation of worker sandboxes.
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">requestKill()</span>
+
+<Tooltip tip="Not available on microsandbox cloud; use a graceful stop."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 requestKill(): Promise<void>
@@ -1363,6 +1383,8 @@ Modify the rootfs before the VM boots. Patches go into the writable layer - the 
 
 #### <span className="msb-recv">.</span><span className="msb-hn">port()</span>
 
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 port(host: number, guest: number): this
 ```
@@ -1383,6 +1405,8 @@ Publish a TCP port from the sandbox to the host. The default host bind address i
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">portBind()</span>
+
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 portBind(bind: string, host: number, guest: number): this
@@ -1409,6 +1433,8 @@ Publish a TCP port on a specific host bind address, such as `"0.0.0.0"`.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">portUdp()</span>
 
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 portUdp(host: number, guest: number): this
 ```
@@ -1429,6 +1455,8 @@ Publish a UDP port. The default host bind address is `127.0.0.1`.
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">portUdpBind()</span>
+
+<Tooltip tip="Publishing host ports is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 portUdpBind(bind: string, host: number, guest: number): this
@@ -1508,6 +1536,8 @@ Configure the OCI registry connection: authentication, insecure transport, and C
 
 #### <span className="msb-recv">.</span><span className="msb-hn">replace()</span>
 
+<Tooltip tip="Replace-on-create is not available on microsandbox cloud; remove the existing sandbox first."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 replace(): this
 ```
@@ -1515,6 +1545,8 @@ replace(): this
 If a sandbox with the same name already exists, stop it (10s SIGTERM grace, then SIGKILL), remove it, and create a fresh one. Without this, creation fails on name conflict.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">replaceWithTimeout()</span>
+
+<Tooltip tip="Replace-on-create is not available on microsandbox cloud; remove the existing sandbox first."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 replaceWithTimeout(timeoutMs: number): this

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -443,6 +443,8 @@ The default sources are `"stdout"`, `"stderr"`, and `"output"` (PTY-merged). Pas
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">logStream()</span>
 
+<Tooltip tip="On microsandbox cloud, log streaming is follow-only; set follow. Bounded, non-follow reads are not available."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 logStream(opts?: LogStreamOptions): Promise<LogStream>
 ```
@@ -795,6 +797,8 @@ Block until the sandbox is observed in a terminal non-running state, without tri
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">[Symbol.asyncDispose]()</span>
 
+<Tooltip tip="On microsandbox cloud this does not stop the sandbox; the cloud handle does not own the host process, so call stop() or remove() explicitly."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 [Symbol.asyncDispose](): Promise<void>
 ```
@@ -852,6 +856,8 @@ Set the number of virtual CPUs. This is a limit, not a reservation.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">maxCpus()</span>
 
+<Tooltip tip="On microsandbox cloud these ceilings are not carried; the maximum is pinned to the initial value. Recreate the sandbox to resize."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 maxCpus(n: number): this
 ```
@@ -897,6 +903,8 @@ Build and boot the sandbox. By default the sandbox is attached - it stops when t
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">createWithPullProgress()</span>
+
+<Tooltip tip="On microsandbox cloud, per-layer pull progress is not reported; creation still completes."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 createWithPullProgress(): Promise<PullProgressCreate>
@@ -949,6 +957,8 @@ Create in detached/background mode when `true`. A detached sandbox survives afte
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">disableMetricsSample()</span>
+
+<Tooltip tip="Metrics sampling does not apply on microsandbox cloud, where resource metrics are unavailable."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 disableMetricsSample(): this
@@ -1055,6 +1065,8 @@ Boot from a previously captured snapshot instead of a fresh image. The image ref
 
 #### <span className="msb-recv">.</span><span className="msb-hn">hostname()</span>
 
+<Tooltip tip="On microsandbox cloud, the hostname is assigned by the platform; a value set here is ignored."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 hostname(name: string): this
 ```
@@ -1106,6 +1118,8 @@ Auto-drain the sandbox after this many seconds of inactivity (no active exec ses
 
 #### <span className="msb-recv">.</span><span className="msb-hn">image()</span>
 
+<Tooltip tip="On microsandbox cloud, only OCI image references are accepted; host-directory and disk-image root filesystems are local-only."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 image(src: string): this
 ```
@@ -1122,6 +1136,8 @@ Set the root filesystem source. Accepts OCI image names (`"alpine"`), local dire
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">imageWith()</span>
+
+<Tooltip tip="On microsandbox cloud, only OCI image references are accepted; host-directory and disk-image root filesystems are local-only."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 imageWith(configure: (b: ImageBuilder) => ImageBuilder): this
@@ -1304,6 +1320,8 @@ Set the guest memory size in MiB. Physical pages are only allocated as the guest
 
 #### <span className="msb-recv">.</span><span className="msb-hn">maxMemory()</span>
 
+<Tooltip tip="On microsandbox cloud these ceilings are not carried; the maximum is pinned to the initial value. Recreate the sandbox to resize."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 maxMemory(mib: number): this
 ```
@@ -1320,6 +1338,8 @@ Set the boot-time maximum hotpluggable guest memory in MiB. This reserves the en
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">metricsSampleIntervalMs()</span>
+
+<Tooltip tip="Metrics sampling does not apply on microsandbox cloud, where resource metrics are unavailable."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 metricsSampleIntervalMs(ms: number): this
@@ -1507,6 +1527,8 @@ quietLogs(): this
 Suppress sandbox process log output.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">registry()</span>
+
+<Tooltip tip="On microsandbox cloud, plain-HTTP and custom-CA registry options are not available; credential auth still works."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 registry(configure: (b: RegistryBuilder) => RegistryBuilder): this
@@ -1805,6 +1827,8 @@ Append `content` to an existing file at `path`. If the file lives in a lower ima
 
 #### <span className="msb-recv">.</span><span className="msb-hn">copyDir()</span>
 
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 copyDir(src: string, dst: string, opts?: { replace?: boolean }): this
 ```
@@ -1829,6 +1853,8 @@ Recursively copy a host directory at `src` into the guest rootfs at `dst`.
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">copyFile()</span>
+
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 copyFile(src: string, dst: string, opts?: { mode?: number; replace?: boolean }): this
@@ -1887,6 +1913,8 @@ Write raw bytes at `path`.
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">mkdir()</span>
+
+<Tooltip tip="On microsandbox cloud, host sources resolve against your organization's host volume, not the computer running the SDK or CLI."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 mkdir(path: string, opts?: { mode?: number }): this

--- a/docs/sdk/typescript/snapshots.mdx
+++ b/docs/sdk/typescript/snapshots.mdx
@@ -313,7 +313,7 @@ List indexed snapshots from the local DB cache.
 static listDir(dir: string): Promise<Snapshot[]>
 ```
 
-Walk a directory and parse each subdirectory's manifest. Does not touch the index — useful for inspecting external snapshot collections that were never loaded. Skips entries that don't look like snapshot artifacts.
+Walk a directory and parse each subdirectory's manifest. Does not touch the index, which makes it useful for inspecting external snapshot collections that were never loaded. Skips entries that don't look like snapshot artifacts.
 
 <p className="msb-label">Parameters</p>
 
@@ -722,7 +722,7 @@ Compute and record a content-integrity hash of the upper layer at creation time,
 resumable(): this
 ```
 
-Request a `"resumable"` snapshot (disk plus VM state). Accepted by the builder, but [`.create()`](#create) currently returns an `Unsupported` error — resumable snapshots have not landed yet.
+Request a `"resumable"` snapshot (disk plus VM state). Accepted by the builder, but [`.create()`](#create) currently returns an `Unsupported` error; resumable snapshots have not landed yet.
 
 ---
 

--- a/docs/sdk/typescript/ssh.mdx
+++ b/docs/sdk/typescript/ssh.mdx
@@ -87,6 +87,8 @@ Open a native in-process SSH client connected to the sandbox.
 
 #### <span className="msb-recv">ssh.</span><span className="msb-hn">prepareServer()</span>
 
+<Tooltip tip="On microsandbox cloud, the reusable server works when you supply explicit host-key and authorized-key material; the convenience defaults are local-only."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 prepareServer(opts?: SshServerOptions): Promise<SshServer>
 ```

--- a/docs/sdk/typescript/volumes.mdx
+++ b/docs/sdk/typescript/volumes.mdx
@@ -184,6 +184,8 @@ Absolute host path to the volume's directory. By default volumes live under `~/.
 
 #### <span className="msb-recv">volume.</span><span className="msb-hn">fs()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 fs(): VolumeFs
 ```
@@ -343,6 +345,8 @@ Host-side filesystem operations on a volume's directory. Obtained via [`volume.f
 
 #### <span className="msb-recv">vfs.</span><span className="msb-hn">read()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 read(path: string): Promise<Uint8Array>
 ```
@@ -377,6 +381,8 @@ Read a file's full contents as bytes.
 
 #### <span className="msb-recv">vfs.</span><span className="msb-hn">readToString()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 readToString(path: string): Promise<string>
 ```
@@ -410,6 +416,8 @@ Read a file's full contents as a UTF-8 string.
 </div>
 
 #### <span className="msb-recv">vfs.</span><span className="msb-hn">readStream()</span>
+
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 readStream(path: string): Promise<VolumeFsReadStream>
@@ -448,6 +456,8 @@ Open a streaming reader for a file, for chunked reads of large files without loa
 
 #### <span className="msb-recv">vfs.</span><span className="msb-hn">write()</span>
 
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 write(path: string, data: Uint8Array | string): Promise<void>
 ```
@@ -476,6 +486,8 @@ Write a file, replacing any existing contents. Strings are encoded as UTF-8.
 </div>
 
 #### <span className="msb-recv">vfs.</span><span className="msb-hn">writeStream()</span>
+
+<Tooltip tip="Unmounted-volume filesystem access is not available on microsandbox cloud; mount the volume into a sandbox and use the sandbox filesystem."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 writeStream(path: string): Promise<VolumeFsWriteSink>

--- a/docs/sdk/typescript/volumes.mdx
+++ b/docs/sdk/typescript/volumes.mdx
@@ -225,6 +225,8 @@ Create a directory-backed volume. This is the default, so calling it is only nee
 
 #### <span className="msb-recv">.</span><span className="msb-hn">disk()</span>
 
+<Tooltip tip="Disk-kind volumes are not available on microsandbox cloud; use a directory-backed named volume."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 disk(): this
 ```
@@ -244,6 +246,8 @@ Create a raw ext4 disk-backed volume. Pair with [`size()`](#size) to set the cap
 
 #### <span className="msb-recv">.</span><span className="msb-hn">size()</span>
 
+<Tooltip tip="Disk-kind volumes are not available on microsandbox cloud; use a directory-backed named volume."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 ```typescript
 size(mib: number): this
 ```
@@ -260,6 +264,8 @@ Set the disk capacity in MiB. Required after [`disk()`](#disk).
 </div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">quota()</span>
+
+<Tooltip tip="On microsandbox cloud, quota sets a storage cap and must be a whole number of GiB."><span className="msb-badge-note">On cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
 quota(mib: number): this

--- a/docs/style.css
+++ b/docs/style.css
@@ -222,3 +222,139 @@ details.accordion:has(.code-block) { margin-top: 0.5rem !important; }
   .msb-params { grid-template-columns: 1fr; }
   .msb-param { row-gap: 2px; }
 }
+
+/* ----------------------------------------------------------------------------
+ * Availability badges: small pills rendered inside headings to mark sections
+ * whose feature is local-only (not yet on cloud).
+ * -------------------------------------------------------------------------- */
+.msb-badge-local {
+  display: inline-block;
+  margin-top: -0.35rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #5f3caf;
+  background: #f6efff;
+  border: 1px solid rgba(109, 75, 196, 0.25);
+}
+
+.dark .msb-badge-local {
+  color: #c9b1ff;
+  background: rgba(191, 132, 254, 0.12);
+  border-color: rgba(191, 132, 254, 0.3);
+}
+
+.msb-badge-local svg,
+.msb-badge-local [class*="mask"] {
+  display: inline-block;
+  vertical-align: -0.12em;
+  margin-left: 0.1rem;
+}
+
+/* The info icon is the tooltip affordance; drop the wrapper's dotted underline. */
+span:has(> .msb-badge-local) {
+  text-decoration: none !important;
+}
+
+.msb-badge-limited {
+  display: inline-block;
+  margin-top: -0.35rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #8a5a00;
+  background: #fdf6e7;
+  border: 1px solid rgba(180, 120, 0, 0.28);
+}
+
+.dark .msb-badge-limited {
+  color: #e8c37a;
+  background: rgba(232, 195, 122, 0.1);
+  border-color: rgba(232, 195, 122, 0.28);
+}
+
+.msb-badge-limited svg,
+.msb-badge-limited [class*="mask"] {
+  display: inline-block;
+  vertical-align: -0.12em;
+  margin-left: 0.1rem;
+}
+
+span:has(> .msb-badge-limited) {
+  text-decoration: none !important;
+}
+
+/* Masked tooltip icons inherit each pill's text color. */
+.msb-badge-local svg,
+.msb-badge-local [class*="mask"],
+.msb-badge-limited svg,
+.msb-badge-limited [class*="mask"] {
+  background-color: currentColor !important;
+}
+
+.msb-badge-cloud {
+  display: inline-block;
+  margin-top: -0.35rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #0b6bcb;
+  background: #eef6ff;
+  border: 1px solid rgba(11, 107, 203, 0.25);
+}
+
+.dark .msb-badge-cloud {
+  color: #8ec2f2;
+  background: rgba(142, 194, 242, 0.1);
+  border-color: rgba(142, 194, 242, 0.28);
+}
+
+.msb-badge-cloud svg,
+.msb-badge-cloud [class*="mask"] {
+  display: inline-block;
+  vertical-align: -0.12em;
+  margin-left: 0.1rem;
+  background-color: currentColor !important;
+}
+
+span:has(> .msb-badge-cloud) {
+  text-decoration: none !important;
+}
+
+/* Neutral cloud-note pill: behaves differently on cloud but fully works (not a limitation). */
+.msb-badge-note {
+  display: inline-block;
+  margin-top: -0.35rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #475569;
+  background: #f1f5f9;
+  border: 1px solid rgba(71, 85, 105, 0.2);
+}
+
+.dark .msb-badge-note {
+  color: #94a3b8;
+  background: rgba(148, 163, 184, 0.1);
+  border-color: rgba(148, 163, 184, 0.24);
+}
+
+.msb-badge-note svg,
+.msb-badge-note [class*="mask"] {
+  display: inline-block;
+  vertical-align: -0.12em;
+  margin-left: 0.1rem;
+  background-color: currentColor !important;
+}
+
+span:has(> .msb-badge-note) {
+  text-decoration: none !important;
+}

--- a/scripts/sync-docs-openapi.py
+++ b/scripts/sync-docs-openapi.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Derive the public Cloud API reference spec from the live msb-api OpenAPI spec.
+
+Selects the organization API-key surface (operations authenticated with the
+`api_key` scheme), drops operations the hosted Cloud does not yet support
+publicly, rewrites implementation-oriented summaries into reader-facing
+titles, and prunes unreferenced schemas. The result is checked in at
+docs/api-reference/openapi.json and rendered by Mintlify.
+
+Usage:
+  scripts/sync-docs-openapi.py            # rewrite docs/api-reference/openapi.json
+  scripts/sync-docs-openapi.py --check    # exit 1 if the checked-in spec is stale
+  scripts/sync-docs-openapi.py --source /path/to/openapi.json
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+LIVE_SPEC_URL = "https://api.microsandbox.dev/docs/openapi.json"
+OUTPUT = Path(__file__).resolve().parent.parent / "docs" / "api-reference" / "openapi.json"
+
+# Operations excluded even though they carry api_key auth. Keyed by
+# (METHOD, path); the value documents why the operation is held back.
+POLICY_EXCLUDE = {
+    ("GET", "/v1/sandboxes/{sandbox_id}/metrics"): "resource metrics not yet public on Cloud",
+    ("GET", "/v1/billing"): "billing account state is dashboard-facing",
+    ("GET", "/v1/billing/invoices"): "invoice flows are dashboard-facing",
+    ("GET", "/v1/billing/invoices/{invoice_id}"): "invoice flows are dashboard-facing",
+    ("GET", "/v1/billing/plans"): "plan selection is dashboard-facing",
+}
+
+# Every operation expected in the public reference; the script fails if one
+# disappears from the live spec so removals are always a conscious decision.
+EXPECTED = {
+    ("GET", "/v1/sandboxes"),
+    ("POST", "/v1/sandboxes"),
+    ("GET", "/v1/sandboxes/{sandbox_id}"),
+    ("PATCH", "/v1/sandboxes/{sandbox_id}"),
+    ("DELETE", "/v1/sandboxes/{sandbox_id}"),
+    ("POST", "/v1/sandboxes/{sandbox_id}/start"),
+    ("POST", "/v1/sandboxes/{sandbox_id}/stop"),
+    ("GET", "/v1/sandboxes/by-name/{name}"),
+    ("DELETE", "/v1/sandboxes/by-name/{name}"),
+    ("POST", "/v1/sandboxes/by-name/{name}/start"),
+    ("POST", "/v1/sandboxes/by-name/{name}/stop"),
+    ("GET", "/v1/volumes"),
+    ("POST", "/v1/volumes"),
+    ("PATCH", "/v1/volumes/{id}"),
+    ("DELETE", "/v1/volumes/{id}"),
+    ("GET", "/v1/events"),
+    ("GET", "/v1/events/{event_id}"),
+    ("GET", "/v1/me/org"),
+    ("GET", "/v1/members"),
+    ("GET", "/v1/quotas"),
+    ("GET", "/v1/billing/usage"),
+    ("GET", "/v1/billing/usage/sandbox"),
+    ("GET", "/v1/billing/usage/storage"),
+}
+
+SUMMARY_PREFIX = re.compile(r"^(GET|POST|PUT|PATCH|DELETE)\s+\S+\s+[—–-]+\s+", re.IGNORECASE)
+PAREN_NOISE = re.compile(r"\s*\((API key[^)]*|Member\+|Admin\+|Owner only)\)")
+
+# Sidebar group per upstream tag, in display order. Mintlify renders tag names
+# verbatim as nav groups, so raw tags like `audit-log` are retitled here.
+TAG_GROUPS = {
+    "sandboxes": "Sandboxes",
+    "volumes": "Volumes",
+    "quotas": "Quotas",
+    "billing": "Usage",
+    "audit-log": "Audit events",
+    "organizations": "Organization",
+    "members": "Members",
+}
+
+# Schemas referenced by operations but missing from the live spec's components
+# (upstream utoipa registration gaps). Injected here so the published spec has
+# no dangling $refs; remove entries once the upstream spec registers them.
+INJECTED_SCHEMAS = {
+    "SandboxWaitFor": {
+        "type": "string",
+        "enum": ["running"],
+        "description": "Lifecycle state an opt-in create request may wait to observe.",
+    },
+    # The live spec types the create-request rootfs source as a bare object;
+    # the hosted cloud accepts OCI images only, so publish that shape.
+    "CloudRootfsSource": {
+        "type": "object",
+        "description": "Root filesystem source. The hosted cloud accepts OCI images only.",
+        "required": ["type", "reference"],
+        "properties": {
+            "type": {"type": "string", "enum": ["oci"]},
+            "reference": {
+                "type": "string",
+                "description": "OCI image reference, e.g. `python:3.12`.",
+            },
+        },
+    },
+    # Error responses in the live spec carry no body schema; every non-2xx
+    # response returns this envelope (verified against the live API).
+    "ErrorResponse": {
+        "type": "object",
+        "description": "Error envelope returned by every non-2xx response.",
+        "required": ["error"],
+        "properties": {
+            "error": {
+                "type": "object",
+                "required": ["code", "message"],
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": "Stable machine-readable error code, e.g. `invalid_api_key`.",
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Human-readable description of the error.",
+                    },
+                    "details": {
+                        "type": ["object", "null"],
+                        "description": "Optional structured context for the error.",
+                    },
+                },
+            },
+        },
+    },
+    # utoipa collapses the generic PaginatedResponse<T> into one shared schema
+    # whose items ended up typed as org members. Publish a concrete pagination
+    # schema per list endpoint instead.
+    "PaginatedSandboxResponse": {
+        "type": "object",
+        "description": "Paginated list of sandboxes.",
+        "required": ["data", "has_more"],
+        "properties": {
+            "data": {"type": "array", "items": {"$ref": "#/components/schemas/SandboxResponse"}},
+            "has_more": {"type": "boolean"},
+            "next_cursor": {"type": ["string", "null"]},
+        },
+    },
+    "PaginatedMemberResponse": {
+        "type": "object",
+        "description": "Paginated list of organization members.",
+        "required": ["data", "has_more"],
+        "properties": {
+            "data": {"type": "array", "items": {"$ref": "#/components/schemas/OrgMemberResponse"}},
+            "has_more": {"type": "boolean"},
+            "next_cursor": {"type": ["string", "null"]},
+        },
+    },
+}
+
+def error_example(status: str, description: str) -> dict | None:
+    """Representative error envelope for a response, using real ErrorCode values.
+
+    409 (and other conflict-style) codes differ per endpoint, so the example is
+    chosen from the operation's response description rather than the status
+    alone. Unrecognized 409 descriptions fail the sync so a new conflict shape
+    never ships with a wrong example.
+    """
+    d = (description or "").lower()
+    if "state transition" in d:
+        code, msg = "invalid_state_transition", "invalid state transition"
+    elif "cannot be deleted" in d:
+        code, msg = "invalid_request", "the host volume cannot be deleted"
+    elif "cannot be capped" in d:
+        code, msg = "invalid_request", "the host volume cannot be capped"
+    elif "already" in d:
+        code, msg = "name_already_exists", "'name' already exists"
+    elif "org not found" in d:
+        code, msg = "org_not_found", "org not found"
+    elif status == "409":
+        sys.exit(f"error: unrecognized 409 description {description!r}; add an example rule")
+    elif status == "404":
+        code, msg = "sandbox_not_found", "resource not found"
+    elif status == "400":
+        code, msg = "invalid_request", "invalid request"
+    elif status == "401":
+        code, msg = "invalid_api_key", "unauthorized"
+    elif status == "429":
+        code, msg = "rate_limited", "too many requests"
+    elif status == "502":
+        code, msg = "orchestrator_unreachable", "orchestrator unreachable"
+    else:
+        return None
+    return {"error": {"code": code, "message": msg, "details": None}}
+
+# 200-response schema overrides for operations whose upstream response type is
+# the collapsed generic PaginatedResponse.
+RESPONSE_OVERRIDES = {
+    ("GET", "/v1/sandboxes"): "PaginatedSandboxResponse",
+    ("GET", "/v1/members"): "PaginatedMemberResponse",
+}
+
+# Reader-facing titles for operations whose upstream summaries carry internal
+# phrasing the mechanical cleanup can't fix.
+SUMMARY_OVERRIDES = {
+    ("GET", "/v1/events"): "List audit events",
+    ("GET", "/v1/events/{event_id}"): "Get an audit event",
+    ("GET", "/v1/billing/usage"): "Get a usage summary",
+    ("GET", "/v1/billing/usage/sandbox"): "Get per-sandbox usage",
+    ("GET", "/v1/billing/usage/storage"): "Get per-volume storage usage",
+    ("GET", "/v1/me/org"): "Get the current organization",
+    ("GET", "/v1/members"): "List organization members",
+    ("GET", "/v1/quotas"): "Get quota usage",
+}
+
+
+def clean_summary(summary: str) -> str:
+    """Strip the method-and-path prefix and role parentheticals upstream summaries carry."""
+    s = " ".join(summary.split())
+    s = SUMMARY_PREFIX.sub("", s)
+    s = PAREN_NOISE.sub("", s)
+    s = s.rstrip(" .")
+    return s[:1].upper() + s[1:] if s else s
+
+
+def op_uses_api_key(op: dict) -> bool:
+    # Public endpoints (auth, health, waitlist) declare no op-level security and
+    # fall back to the spec default; only explicit api_key ops are in scope.
+    return any("api_key" in requirement for requirement in op.get("security", []))
+
+
+def collect_refs(node, refs: set):
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/components/schemas/"):
+            refs.add(ref.rsplit("/", 1)[1])
+        for value in node.values():
+            collect_refs(value, refs)
+    elif isinstance(node, list):
+        for value in node:
+            collect_refs(value, refs)
+
+
+def curate(spec: dict) -> dict:
+    paths = {}
+    seen = set()
+    for path, ops in spec["paths"].items():
+        kept = {}
+        for method, op in ops.items():
+            if not isinstance(op, dict):
+                continue
+            key = (method.upper(), path)
+            if op.get("x-hidden") or key in POLICY_EXCLUDE:
+                continue
+            if not op_uses_api_key(op):
+                continue
+            op = dict(op)
+            if key in SUMMARY_OVERRIDES:
+                op["summary"] = SUMMARY_OVERRIDES[key]
+            elif "summary" in op:
+                op["summary"] = clean_summary(op["summary"])
+            op["security"] = [{"api_key": []}]
+            tags = [t for t in op.get("tags", []) if t in TAG_GROUPS]
+            if not tags:
+                sys.exit(f"error: {method.upper()} {path} has no tag in TAG_GROUPS")
+            op["tags"] = [TAG_GROUPS[tags[0]]]
+            if key in RESPONSE_OVERRIDES:
+                ok = op["responses"]["200"]["content"]["application/json"]
+                ok["schema"] = {"$ref": f"#/components/schemas/{RESPONSE_OVERRIDES[key]}"}
+            for status, resp in op["responses"].items():
+                if not status.startswith("2") and "content" not in resp:
+                    body = {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}
+                    example = error_example(status, resp.get("description", ""))
+                    if example is not None:
+                        body["example"] = example
+                    resp["content"] = {"application/json": body}
+            kept[method] = op
+            seen.add(key)
+        if kept:
+            paths[path] = kept
+
+    # The shared generic must never leak into the published contract: its item
+    # type is whichever instantiation utoipa registered, not the endpoint's.
+    leaked = json.dumps(paths).count('#/components/schemas/PaginatedResponse"')
+    if leaked:
+        sys.exit(
+            "error: an operation still references the collapsed PaginatedResponse "
+            "schema; add it to RESPONSE_OVERRIDES with its real item type"
+        )
+
+    # Order paths by display-group order so the sidebar leads with Sandboxes.
+    group_rank = {name: i for i, name in enumerate(TAG_GROUPS.values())}
+    paths = dict(
+        sorted(
+            paths.items(),
+            key=lambda kv: (min(group_rank[op["tags"][0]] for op in kv[1].values()), kv[0]),
+        )
+    )
+
+    missing = EXPECTED - seen
+    if missing:
+        listing = ", ".join(f"{m} {p}" for m, p in sorted(missing))
+        sys.exit(f"error: expected operations missing from the live spec: {listing}")
+    unexpected = seen - EXPECTED
+    if unexpected:
+        listing = ", ".join(f"{m} {p}" for m, p in sorted(unexpected))
+        sys.exit(
+            "error: new api_key operations appeared in the live spec; review and add "
+            f"them to EXPECTED or POLICY_EXCLUDE: {listing}"
+        )
+
+    # Close over every schema transitively referenced by the kept operations.
+    refs: set = set()
+    collect_refs(paths, refs)
+    schemas = dict(spec.get("components", {}).get("schemas", {}))
+    schemas.update(INJECTED_SCHEMAS)
+    while True:
+        extra: set = set()
+        for name in refs:
+            if name in schemas:
+                collect_refs(schemas[name], extra)
+        if extra <= refs:
+            break
+        refs |= extra
+
+    dangling = sorted(refs - schemas.keys())
+    if dangling:
+        sys.exit(
+            "error: operations reference schemas absent from the live spec: "
+            f"{', '.join(dangling)}; register them upstream or add to INJECTED_SCHEMAS"
+        )
+
+    # The spec types the create-request rootfs source as a bare object; point
+    # it at the injected OCI-only schema until upstream emits a real one.
+    if "CloudSandboxSpec" in schemas:
+        props = schemas["CloudSandboxSpec"].get("properties", {})
+        if "image" in props:
+            props["image"] = {"$ref": "#/components/schemas/CloudRootfsSource"}
+            refs.add("CloudRootfsSource")
+
+    return {
+        "openapi": spec["openapi"],
+        "info": {
+            "title": "microsandbox cloud API",
+            "description": (
+                "REST API for microsandbox cloud: sandbox and volume lifecycle, "
+                "organization context, quotas, usage, and audit events, authenticated "
+                "with an organization API key."
+            ),
+            "version": spec["info"]["version"],
+        },
+        "servers": [{"url": "https://api.microsandbox.dev"}],
+        "security": [{"api_key": []}],
+        "paths": paths,
+        "components": {
+            "schemas": {name: schemas[name] for name in sorted(refs) if name in schemas},
+            "securitySchemes": {
+                "api_key": spec["components"]["securitySchemes"]["api_key"],
+            },
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", help="path to a local spec instead of the live URL")
+    parser.add_argument("--check", action="store_true", help="fail if the output is stale")
+    args = parser.parse_args()
+
+    if args.source:
+        spec = json.loads(Path(args.source).read_text())
+    else:
+        with urllib.request.urlopen(LIVE_SPEC_URL) as response:
+            spec = json.load(response)
+
+    rendered = json.dumps(curate(spec), indent=2, ensure_ascii=False) + "\n"
+    # House style bans em dashes; upstream doc comments still use them, so
+    # normalize to plain dashes until the source text is reworded.
+    rendered = rendered.replace("—", "-").replace("–", "-")
+
+    if args.check:
+        if not OUTPUT.exists() or OUTPUT.read_text() != rendered:
+            sys.exit(f"error: {OUTPUT} is stale; run scripts/sync-docs-openapi.py")
+        print("api reference spec is up to date")
+        return
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(rendered)
+    print(f"wrote {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Makes the docs native to microsandbox cloud without disturbing the existing structure. Local-first stays the default voice; cloud is surfaced where it matters.

## What's in it

**Cloud onboarding**
- New **Backends** page (Getting Started) owning backend selection: `MSB_API_KEY`, `MSB_BACKEND`, in-code selection, profiles, and the resolution order.
- Cloud overview + compatibility pages; positioning made backend-neutral ("local-first" rather than "local-only").
- Configuration renamed to **Global config** and slimmed to a pure `config.json` schema reference.

**API reference**
- New API Reference tab under References, generated from a checked-in curated OpenAPI spec (organization API-key surface only) via `scripts/sync-docs-openapi.py`.
- Per-group icons; grouped by resource in usage order. The script fixes upstream spec gaps (pagination item types, OCI image schema, error envelope + per-status examples) and fails closed on drift.

**Cloud-availability signposting**
A four-state pill system (info-icon tooltips), applied only where cloud behavior differs — silence means it works identically on both backends:
- **Local-only** — feature errors on cloud (verified against the cloud backend's `Unsupported` returns)
- **On cloud** — behaves differently but fully works (host-volume path resolution, cloud-assigned hostname, OCI-only images, …)
- **Limited on cloud** — reduced capability (follow-only log streaming, no-auto-stop dispose, …)
- **Cloud-only** — only meaningful on cloud

Guide, CLI, and SDK reference pages are annotated method-by-method where they differ; wholly-local pages (metrics recipes, disk snapshots) carry a page-level badge or banner.

## Notes
- Every SDK-reference verdict was verified against `sdk/rust/lib/backend/cloud/` source; a few automated over-marks were corrected (e.g. `stop()` fully works and is intentionally unbadged).
- Follow-up (separate repo): move the OpenAPI schemas the sync script injects into msb-api's own `utoipa` annotations so the injections can be dropped.