### PR TITLE
docs(changelog): group entries by month

### DIFF
--- a/docs/changelog/2026-04-03.mdx
+++ b/docs/changelog/2026-04-03.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of April 3, 2026"
+sidebarTitle: "Week of the 3rd"
 description: "The microsandbox rewrite around an embeddable SDK, smoltcp networking, and a composable filesystem."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-04-10.mdx
+++ b/docs/changelog/2026-04-10.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of April 10, 2026"
+sidebarTitle: "Week of the 10th"
 description: "File-level volume mounts, TypeScript SDK streams, and `msb shell` removal."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-04-17.mdx
+++ b/docs/changelog/2026-04-17.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of April 17, 2026"
+sidebarTitle: "Week of the 17th"
 description: "New Python SDK, Docker image publishing, and TLS proxy fixes."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-04-24.mdx
+++ b/docs/changelog/2026-04-24.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of April 24, 2026"
+sidebarTitle: "Week of the 24th"
 description: "Block-backed OCI rootfs, guest rlimits, and TypeScript SDK improvements."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-05-01.mdx
+++ b/docs/changelog/2026-05-01.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of May 1, 2026"
+sidebarTitle: "Week of the 1st"
 description: "TypeScript SDK redesign, network policy redesign, disk-image volumes, and more."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-05-15.mdx
+++ b/docs/changelog/2026-05-15.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of May 15, 2026"
+sidebarTitle: "Week of the 15th"
 description: "Go SDK, file-first disk snapshots, guest init handoff, exec and boot logs, and DNS egress policy."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-05-22.mdx
+++ b/docs/changelog/2026-05-22.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of May 22, 2026"
+sidebarTitle: "Week of the 22nd"
 description: "Rotation-aware log streaming, raw agent client across SDKs, per-mount passthroughfs policies, network policy CLI cleanup, configurable port bind addresses, and ergonomic --script."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-05-29.mdx
+++ b/docs/changelog/2026-05-29.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of May 29, 2026"
+sidebarTitle: "Week of the 29th"
 description: "Native SSH and SFTP, configurable OCI upper size, msb copy and rootfs patch flags, hardened mount options, env-backed secret shorthand, and a fix for multi-second published-port stalls."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-06-05.mdx
+++ b/docs/changelog/2026-06-05.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of June 5, 2026"
+sidebarTitle: "Week of the 5th"
 description: "OTLP sandbox metrics, SSH TCP forwarding, image archive commands, pruning, Python image management, Homebrew install, and smoother host upgrades."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-06-12.mdx
+++ b/docs/changelog/2026-06-12.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of June 12, 2026"
+sidebarTitle: "Week of the 12th"
 description: "Guest runtime metrics, idempotent named volumes, unified sandbox lifecycle APIs, explicit mount kind flags, cleaner installer, raw agent socket paths, and richer secret violation logs."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-06-19.mdx
+++ b/docs/changelog/2026-06-19.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of June 19, 2026"
+sidebarTitle: "Week of the 19th"
 description: "Local and cloud backend routing in the SDKs, detached image init entrypoints, shared sandbox spec types, secret substitution through HTTP CONNECT tunnels and plain HTTP, and snapshot import hardening."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-06-26.mdx
+++ b/docs/changelog/2026-06-26.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of June 26, 2026"
+sidebarTitle: "Week of the 26th"
 description: "Windows host support, guest-write quotas for virtiofs mounts, host-directory bind rootfs across all SDKs, non-PTY bidirectional `exec --stream`, upper disk usage metrics, an `msb doctor` command, runtime-owned ephemeral cleanup, and a round of SDK and runtime fixes."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-07-05.mdx
+++ b/docs/changelog/2026-07-05.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of July 5, 2026"
+sidebarTitle: "Week of the 5th"
 description: "Modify existing sandboxes, inspect resize headroom, trust private TLS upstreams, load images faster, and pick up CLI, network, and SDK fixes."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-07-10.mdx
+++ b/docs/changelog/2026-07-10.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of July 10, 2026"
+sidebarTitle: "Week of the 10th"
 description: "Structured root disk for OCI sandboxes, default symlink protection on mount roots, secret modify across every SDK, offline OCI upper growth, cleaner guest shutdown, and a batch of snapshot, filesystem, and lifecycle fixes."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-07-17.mdx
+++ b/docs/changelog/2026-07-17.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of July 17, 2026"
+sidebarTitle: "Week of the 17th"
 description: "Image archives on every SDK, a finalized snapshot API with dest_dir and --from-snapshot, hole-perfect snapshot archives across platforms, a newer guest kernel, and a batch of secret, snapshot, and SDK fixes."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-07-24.mdx
+++ b/docs/changelog/2026-07-24.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of July 24, 2026"
+sidebarTitle: "Week of the 24th"
 description: "Composable network profiles across CLI and SDKs, bidirectional snapshot migration with msb self downgrade, msb run -d that honors image CMD, TTY resize in every SDK, and Go SDK on Windows."
 icon: "bolt"
 ---

--- a/docs/changelog/2026-07-31.mdx
+++ b/docs/changelog/2026-07-31.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Week of July 31, 2026"
+sidebarTitle: "Week of the 31st"
 description: "Unified cloud backend in every SDK with paginated sandbox listings, per-registry insecure and custom-CA overrides in Go and Python, msb completion for shell tab-completion, a shared log registry for tailing many sandboxes, and fixes for guest TCP half-close, DNS upstream failover, and cloud exec reconnects."
 icon: "bolt"
 ---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -238,24 +238,54 @@
       },
       {
         "tab": "Changelog",
-        "pages": [
-          "changelog/2026-07-31",
-          "changelog/2026-07-24",
-          "changelog/2026-07-17",
-          "changelog/2026-07-10",
-          "changelog/2026-07-05",
-          "changelog/2026-06-26",
-          "changelog/2026-06-19",
-          "changelog/2026-06-12",
-          "changelog/2026-06-05",
-          "changelog/2026-05-29",
-          "changelog/2026-05-22",
-          "changelog/2026-05-15",
-          "changelog/2026-05-01",
-          "changelog/2026-04-24",
-          "changelog/2026-04-17",
-          "changelog/2026-04-10",
-          "changelog/2026-04-03"
+        "groups": [
+          {
+            "group": "Releases",
+            "icon": "clock-rotate-left",
+            "pages": [
+              {
+                "group": "July 2026",
+                "expanded": true,
+                "pages": [
+                  "changelog/2026-07-31",
+                  "changelog/2026-07-24",
+                  "changelog/2026-07-17",
+                  "changelog/2026-07-10",
+                  "changelog/2026-07-05"
+                ]
+              },
+              {
+                "group": "June 2026",
+                "expanded": false,
+                "pages": [
+                  "changelog/2026-06-26",
+                  "changelog/2026-06-19",
+                  "changelog/2026-06-12",
+                  "changelog/2026-06-05"
+                ]
+              },
+              {
+                "group": "May 2026",
+                "expanded": false,
+                "pages": [
+                  "changelog/2026-05-29",
+                  "changelog/2026-05-22",
+                  "changelog/2026-05-15",
+                  "changelog/2026-05-01"
+                ]
+              },
+              {
+                "group": "April 2026",
+                "expanded": false,
+                "pages": [
+                  "changelog/2026-04-24",
+                  "changelog/2026-04-17",
+                  "changelog/2026-04-10",
+                  "changelog/2026-04-03"
+                ]
+              }
+            ]
+          }
         ]
       }
     ]


### PR DESCRIPTION
Groups the changelog by month instead of a flat weekly list.

## What changed
- Weekly entries now nest under collapsible **month headers** (July 2026, June 2026, May 2026, April 2026) inside a "Releases" parent. The latest month is expanded; older months are collapsed by default.
- Each entry gets a `sidebarTitle` ("Week of the 17th") so the sidebar reads cleanly under its month, while the page keeps its full "Week of July 17, 2026" heading.

No content changes to the entries themselves; navigation only.