### PR TITLE
chore(release): bump microsandbox to 0.6.9

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -948,8 +948,10 @@ jobs:
           chmod +x build/msb
           ln -sf libkrunfw.so.${{ env.LIBKRUNFW_VERSION }} build/libkrunfw.so.${{ env.LIBKRUNFW_ABI }}
           ln -sf libkrunfw.so.${{ env.LIBKRUNFW_ABI }} build/libkrunfw.so
-          scripts/smoke/cli/image-archive.sh
-          scripts/smoke/cli/split-irqchip-bind-net.sh
+          # Existing runner services may not inherit recently-added groups
+          # until restart. Activate each required device group per smoke test.
+          sg docker -c 'scripts/smoke/cli/image-archive.sh'
+          sg kvm -c 'scripts/smoke/cli/split-irqchip-bind-net.sh'
 
       - name: Disk usage
         if: always()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -948,10 +948,8 @@ jobs:
           chmod +x build/msb
           ln -sf libkrunfw.so.${{ env.LIBKRUNFW_VERSION }} build/libkrunfw.so.${{ env.LIBKRUNFW_ABI }}
           ln -sf libkrunfw.so.${{ env.LIBKRUNFW_ABI }} build/libkrunfw.so
-          # Existing runner services may not inherit recently-added groups
-          # until restart. Activate each required device group per smoke test.
-          sg docker -c 'scripts/smoke/cli/image-archive.sh'
-          sg kvm -c 'scripts/smoke/cli/split-irqchip-bind-net.sh'
+          scripts/smoke/cli/image-archive.sh
+          scripts/smoke/cli/split-irqchip-bind-net.sh
 
       - name: Disk usage
         if: always()

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -65,10 +65,20 @@ jobs:
           cache-bin: false
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev musl-tools
 
       - name: Install Ruby build dependencies
         run: gem install rake rake-compiler test-unit rb_sys --no-document
+
+      # Ruby deliberately compiles the Rust SDK without its prebuilt feature.
+      # Stage the guest agent from this checkout so the filesystem crate can
+      # embed it without reaching for an unpublished GitHub release asset.
+      - name: Build agentd for local SDK checks
+        run: |
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --profile ci --manifest-path crates/agentd/Cargo.toml --target x86_64-unknown-linux-musl
+          mkdir -p build
+          cp target/x86_64-unknown-linux-musl/ci/agentd build/agentd
 
       - name: Check Rust extension
         working-directory: sdk/ruby/ext/microsandbox

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           gem build microsandbox.gemspec
           gem install --local microsandbox-*.gem --no-document
-          ruby --disable-gems -e 'require "rubygems"; require "microsandbox"; abort unless Microsandbox.version == "0.6.8"'
+          ruby --disable-gems -e 'require "rubygems"; require "microsandbox"; abort unless Microsandbox.version == "0.6.9"'
 
       - name: Restore standalone Ruby lockfile
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "base64 0.23.0",
  "chrono",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-go"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "base64 0.23.0",
  "cbindgen",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "chrono",
  "libc",
@@ -3913,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics-collector"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3948,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "chrono",
  "ciborium",
@@ -4024,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "chrono",
  "futures",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "chrono",
  "dprint-plugin-typescript",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "dirs",
  "libc",
@@ -7448,14 +7448,14 @@ dependencies = [
 
 [[package]]
 name = "test-init"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "test-macros"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7464,7 +7464,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-go"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "base64 0.23.1",
  "cbindgen",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "chrono",
  "libc",
@@ -3948,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics-collector"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -4046,7 +4046,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "chrono",
  "ciborium",
@@ -4061,7 +4061,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "chrono",
  "futures",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -4113,7 +4113,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "chrono",
  "dprint-plugin-typescript",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "dirs",
  "libc",
@@ -4142,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-vsock"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "libc",
  "msb_krun",
@@ -7546,14 +7546,14 @@ dependencies = [
 
 [[package]]
 name = "test-init"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "test-macros"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7562,7 +7562,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.6.8"
+version = "0.6.9"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -65,18 +65,18 @@ panic = "abort"
 # Exact (`=`) pins: these crates share private, unstable APIs across patch
 # releases, so every published version must resolve its siblings to the same
 # version. Caret would let an older release pull newer siblings and break.
-microsandbox = { version = "=0.6.8", path = "sdk/rust", default-features = false }
-microsandbox-agent-client = { version = "=0.6.8", path = "packages/agent-client/rust" }
-microsandbox-db = { version = "=0.6.8", path = "crates/db" }
-microsandbox-filesystem = { version = "=0.6.8", path = "crates/filesystem", default-features = false }
-microsandbox-image = { version = "=0.6.8", path = "crates/image" }
-microsandbox-metrics = { version = "=0.6.8", path = "crates/metrics" }
-microsandbox-types = { version = "=0.6.8", path = "packages/microsandbox-types/rust" }
-microsandbox-migration = { version = "=0.6.8", path = "crates/migration" }
-microsandbox-network = { version = "=0.6.8", path = "crates/network" }
-microsandbox-protocol = { version = "=0.6.8", path = "crates/protocol" }
-microsandbox-runtime = { version = "=0.6.8", path = "crates/runtime", default-features = false }
-microsandbox-utils = { version = "=0.6.8", path = "crates/utils" }
+microsandbox = { version = "=0.6.9", path = "sdk/rust", default-features = false }
+microsandbox-agent-client = { version = "=0.6.9", path = "packages/agent-client/rust" }
+microsandbox-db = { version = "=0.6.9", path = "crates/db" }
+microsandbox-filesystem = { version = "=0.6.9", path = "crates/filesystem", default-features = false }
+microsandbox-image = { version = "=0.6.9", path = "crates/image" }
+microsandbox-metrics = { version = "=0.6.9", path = "crates/metrics" }
+microsandbox-types = { version = "=0.6.9", path = "packages/microsandbox-types/rust" }
+microsandbox-migration = { version = "=0.6.9", path = "crates/migration" }
+microsandbox-network = { version = "=0.6.9", path = "crates/network" }
+microsandbox-protocol = { version = "=0.6.9", path = "crates/protocol" }
+microsandbox-runtime = { version = "=0.6.9", path = "crates/runtime", default-features = false }
+microsandbox-utils = { version = "=0.6.9", path = "crates/utils" }
 msb_krun = "=0.1.25"
 msb_krun_utils = "=0.1.25"
 test-macros = { path = "crates/test-macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,23 @@ tar = "0.4"
 time = "0.3"
 tempfile = "3.15"
 thiserror = "2.0"
-tokio = { version = "1.52", features = ["full"] }
+# Keep Tokio's full capability set without its optional parking_lot backend.
+# A Ruby process may fork after the native runtime has started; inherited
+# parking_lot waiter state can reference worker threads that do not survive in
+# the child, causing the rebuilt runtime to segfault.
+tokio = { version = "1.52", features = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "process",
+    "rt",
+    "rt-multi-thread",
+    "signal",
+    "sync",
+    "time",
+] }
 tokio-tungstenite = { version = "0.30.0", features = ["rustls-tls-webpki-roots"] }
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.6.8"
+version = "0.6.9"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -75,19 +75,19 @@ strip = false
 # Exact (`=`) pins: these crates share private, unstable APIs across patch
 # releases, so every published version must resolve its siblings to the same
 # version. Caret would let an older release pull newer siblings and break.
-microsandbox = { version = "=0.6.8", path = "sdk/rust", default-features = false }
-microsandbox-agent-client = { version = "=0.6.8", path = "packages/agent-client/rust" }
-microsandbox-db = { version = "=0.6.8", path = "crates/db" }
-microsandbox-filesystem = { version = "=0.6.8", path = "crates/filesystem", default-features = false }
-microsandbox-image = { version = "=0.6.8", path = "crates/image" }
-microsandbox-metrics = { version = "=0.6.8", path = "crates/metrics" }
-microsandbox-types = { version = "=0.6.8", path = "packages/microsandbox-types/rust" }
-microsandbox-migration = { version = "=0.6.8", path = "crates/migration" }
-microsandbox-network = { version = "=0.6.8", path = "crates/network" }
-microsandbox-protocol = { version = "=0.6.8", path = "crates/protocol" }
-microsandbox-runtime = { version = "=0.6.8", path = "crates/runtime", default-features = false }
-microsandbox-utils = { version = "=0.6.8", path = "crates/utils" }
-microsandbox-vsock = { version = "=0.6.8", path = "crates/vsock" }
+microsandbox = { version = "=0.6.9", path = "sdk/rust", default-features = false }
+microsandbox-agent-client = { version = "=0.6.9", path = "packages/agent-client/rust" }
+microsandbox-db = { version = "=0.6.9", path = "crates/db" }
+microsandbox-filesystem = { version = "=0.6.9", path = "crates/filesystem", default-features = false }
+microsandbox-image = { version = "=0.6.9", path = "crates/image" }
+microsandbox-metrics = { version = "=0.6.9", path = "crates/metrics" }
+microsandbox-types = { version = "=0.6.9", path = "packages/microsandbox-types/rust" }
+microsandbox-migration = { version = "=0.6.9", path = "crates/migration" }
+microsandbox-network = { version = "=0.6.9", path = "crates/network" }
+microsandbox-protocol = { version = "=0.6.9", path = "crates/protocol" }
+microsandbox-runtime = { version = "=0.6.9", path = "crates/runtime", default-features = false }
+microsandbox-utils = { version = "=0.6.9", path = "crates/utils" }
+microsandbox-vsock = { version = "=0.6.9", path = "crates/vsock" }
 msb_krun = "=0.1.31"
 msb_krun_utils = "=0.1.31"
 test-macros = { path = "crates/test-macros" }

--- a/examples/typescript/cloud-backend/package.json
+++ b/examples/typescript/cloud-backend/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/init-handoff/package.json
+++ b/examples/typescript/init-handoff/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/snapshot-fork/package.json
+++ b/examples/typescript/snapshot-fork/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.8"
+    "microsandbox": "0.6.9"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/packages/agent-client/rust/README.md
+++ b/packages/agent-client/rust/README.md
@@ -10,19 +10,19 @@ Use this crate when you already have an agent relay endpoint and want direct pro
 
 ```toml
 [dependencies]
-microsandbox-agent-client = "0.6.8"
-microsandbox-protocol = "0.6.8"
+microsandbox-agent-client = "0.6.9"
+microsandbox-protocol = "0.6.9"
 ```
 
 The crate is transport-agnostic by default. Enable exactly the transport adapter you need:
 
 ```toml
 # Local microsandbox relay sockets.
-microsandbox-agent-client = { version = "0.6.8", features = ["uds"] }
+microsandbox-agent-client = { version = "0.6.9", features = ["uds"] }
 
 # Any caller-owned byte-stream transport (e.g. a pre-authenticated WebSocket
 # adapted to bytes).
-microsandbox-agent-client = { version = "0.6.8", features = ["stream"] }
+microsandbox-agent-client = { version = "0.6.9", features = ["stream"] }
 ```
 
 The high-level `microsandbox` SDK enables `uds` explicitly because local sandboxes are reached through Unix domain sockets.
@@ -99,7 +99,7 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
 Enable the `stream` feature:
 
 ```toml
-microsandbox-agent-client = { version = "0.6.8", features = ["stream"] }
+microsandbox-agent-client = { version = "0.6.9", features = ["stream"] }
 ```
 
 Drive the client over any `AsyncRead + AsyncWrite` — the caller owns the dial and any authentication, then hands over the connected stream:

--- a/packages/agent-client/typescript/package-lock.json
+++ b/packages/agent-client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/agent-client",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "Apache-2.0",
       "dependencies": {
         "cbor-x": "^1.6.0"

--- a/packages/agent-client/typescript/package.json
+++ b/packages/agent-client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "type": "module",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/microsandbox-types/rust/README.md
+++ b/packages/microsandbox-types/rust/README.md
@@ -25,7 +25,7 @@ Backend-private materialized state stays out: registry credentials, local CA pat
 
 ```toml
 [dependencies]
-microsandbox-types = "0.6.8"
+microsandbox-types = "0.6.9"
 ```
 
 ```rust

--- a/packages/microsandbox-types/typescript/package-lock.json
+++ b/packages/microsandbox-types/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/types",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6"

--- a/packages/microsandbox-types/typescript/package.json
+++ b/packages/microsandbox-types/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "type": "module",
   "main": "./dist/cloud.js",
   "types": "./dist/cloud.d.ts",

--- a/scripts/smoke/cli/image-archive.sh
+++ b/scripts/smoke/cli/image-archive.sh
@@ -4,13 +4,26 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 MSB_BIN="${MSB_BIN:-${ROOT_DIR}/build/msb}"
-IMAGE="${MSB_CLI_SMOKE_DOCKER_IMAGE:-mirror.gcr.io/library/alpine:3.20}"
 TAG="${MSB_CLI_SMOKE_ARCHIVE_TAG:-msb-archive-smoke:ci}"
 
 if [[ ! -x "$MSB_BIN" ]]; then
   echo "msb binary is not executable: $MSB_BIN" >&2
   exit 1
 fi
+
+if ! command -v sha256sum >/dev/null 2>&1; then
+  echo "sha256sum is required for image archive smoke tests" >&2
+  exit 1
+fi
+
+case "$(uname -m)" in
+  x86_64) architecture="amd64" ;;
+  aarch64 | arm64) architecture="arm64" ;;
+  *)
+    echo "unsupported smoke-test architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
 
 smoke_root="$(mktemp -d "${TMPDIR:-/tmp}/msb-image-archive-smoke.XXXXXX")"
 created_home=0
@@ -29,19 +42,27 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Persistent pull-request runners must not access the root-equivalent Docker
-# socket, so prefer a daemonless export when skopeo is available.
-if command -v skopeo >/dev/null 2>&1; then
-  skopeo copy --retry-times 5 \
-    "docker://${IMAGE}" \
-    "docker-archive:${smoke_root}/docker-input.tar:${TAG}"
-elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-  docker image inspect "$IMAGE" >/dev/null 2>&1 || docker pull "$IMAGE" >/dev/null
-  docker save "$IMAGE" -o "$smoke_root/docker-input.tar"
-else
-  echo "skopeo or an accessible Docker daemon is required for image archive smoke tests" >&2
-  exit 1
-fi
+# Build the smallest useful `docker save` fixture locally. The smoke test only
+# needs a valid config, manifest, and layer to exercise the CLI archive path;
+# constructing them here avoids depending on a privileged Docker socket or a
+# registry from self-hosted runners.
+mkdir -p "$smoke_root/docker-input/layer" "$smoke_root/layer-root"
+printf 'hello from archive\n' > "$smoke_root/layer-root/hello.txt"
+tar -cf "$smoke_root/docker-input/layer/layer.tar" -C "$smoke_root/layer-root" hello.txt
+
+layer_digest="$(sha256sum "$smoke_root/docker-input/layer/layer.tar" | awk '{print $1}')"
+config_path="$smoke_root/docker-input/config.json"
+printf '{"architecture":"%s","os":"linux","config":{"Cmd":["cat","/hello.txt"]},"rootfs":{"type":"layers","diff_ids":["sha256:%s"]}}' \
+  "$architecture" "$layer_digest" > "$config_path"
+
+config_digest="$(sha256sum "$config_path" | awk '{print $1}')"
+config_name="${config_digest}.json"
+mv "$config_path" "$smoke_root/docker-input/$config_name"
+printf '[{"Config":"%s","RepoTags":null,"Layers":["layer/layer.tar"]}]' \
+  "$config_name" > "$smoke_root/docker-input/manifest.json"
+
+tar -cf "$smoke_root/docker-input.tar" -C "$smoke_root/docker-input" \
+  "$config_name" manifest.json layer/layer.tar
 
 "$MSB_BIN" load -i "$smoke_root/docker-input.tar" --tag "$TAG" --quiet
 "$MSB_BIN" save -o "$smoke_root/docker-output.tar" --quiet "$TAG"

--- a/sdk/go/setup.go
+++ b/sdk/go/setup.go
@@ -24,7 +24,7 @@ import (
 // embedded FFI library and the downloaded msb+libkrunfw artefacts are
 // both pinned to this version. Bump when cutting a new SDK release so
 // it matches published binaries.
-const sdkVersion = "0.6.8"
+const sdkVersion = "0.6.9"
 
 // libkrunfwABI is the major SONAME version of libkrunfw that msb links
 // against.

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.6.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/npm/win32-arm64-msvc/package.json
+++ b/sdk/node-ts/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-win32-arm64-msvc",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Windows arm64.",
   "os": ["win32"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/win32-x64-msvc/package.json
+++ b/sdk/node-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-win32-x64-msvc",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Windows x64.",
   "os": ["win32"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -22,11 +22,11 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.6.8",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.8",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.6.8",
-        "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.8",
-        "@superradcompany/microsandbox-win32-x64-msvc": "0.6.8"
+        "@superradcompany/microsandbox-darwin-arm64": "0.6.9",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.9",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.6.9",
+        "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.9",
+        "@superradcompany/microsandbox-win32-x64-msvc": "0.6.9"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1851,84 +1851,19 @@
       "license": "MIT"
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.6.8.tgz",
-      "integrity": "sha512-SbPo2mb5sEWY7Sry9lxlh762oX5G4RI4Xq2i6U9covTe+4MIFznNSCPIntoCcpzVwt4VNIukvEdyTsI9kITJLw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.6.8.tgz",
-      "integrity": "sha512-cMgS/pE6N2LTbdGYMNiSzfxlsD0F1fhVuCFuIULxGfGyK+zmrYHgTgV0K6n9UQY+PjseOvNn//T7FJQ7SwyJ3g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.6.8.tgz",
-      "integrity": "sha512-JCYgBsCf00bX2RA7YhdFdNOQHsWJFXYM3WJi1ONx3jLdUpiMKAVRZxCSPJe/UrFoRiqfj49AmgIBNtvs+2Ns9g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-win32-arm64-msvc": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-win32-arm64-msvc/-/microsandbox-win32-arm64-msvc-0.6.8.tgz",
-      "integrity": "sha512-cWXaHBleVZbTddVYiUSuChNbHWhzTnNkgBqhisSDcFa1FBa0g5sBzTBlcC0RAseMzs4F+6YqLbD040QOe/6deQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@superradcompany/microsandbox-win32-x64-msvc": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-win32-x64-msvc/-/microsandbox-win32-x64-msvc-0.6.8.tgz",
-      "integrity": "sha512-Asfn+8+CplKh05MyJIoRJzLCl1Z05B/n6Lc6+tpfFKmHjMkQw976L67AqqBQq4AxfkakBcpZYVHZQqUDxl5Fow==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
+      "optional": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -51,11 +51,11 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.6.8",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.8",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.6.8",
-    "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.8",
-    "@superradcompany/microsandbox-win32-x64-msvc": "0.6.8"
+    "@superradcompany/microsandbox-darwin-arm64": "0.6.9",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.9",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.6.9",
+    "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.9",
+    "@superradcompany/microsandbox-win32-x64-msvc": "0.6.9"
   },
   "files": [
     "dist",

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -53,11 +53,11 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.6.8",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.8",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.6.8",
-    "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.8",
-    "@superradcompany/microsandbox-win32-x64-msvc": "0.6.8"
+    "@superradcompany/microsandbox-darwin-arm64": "0.6.9",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.9",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.6.9",
+    "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.9",
+    "@superradcompany/microsandbox-win32-x64-msvc": "0.6.9"
   },
   "files": [
     "dist",

--- a/sdk/ruby/ext/microsandbox/Cargo.toml
+++ b/sdk/ruby/ext/microsandbox/Cargo.toml
@@ -15,5 +15,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 magnus = "0.8.2"
-microsandbox_core = { package = "microsandbox", version = "=0.6.9", default-features = false, features = ["net", "prebuilt", "ssh"] }
+microsandbox_core = { package = "microsandbox", version = "=0.6.9", default-features = false, features = ["net", "ssh"] }
 tokio = { version = "1.52", features = ["rt-multi-thread", "time"] }

--- a/sdk/ruby/ext/microsandbox/Cargo.toml
+++ b/sdk/ruby/ext/microsandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsandbox-ruby"
-version = "0.6.8"
+version = "0.6.9"
 edition = "2024"
 rust-version = "1.85"
 description = "Ruby bindings for the microsandbox Rust SDK."
@@ -15,5 +15,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 magnus = "0.8.2"
-microsandbox_core = { package = "microsandbox", version = "=0.6.8", default-features = false, features = ["net", "prebuilt", "ssh"] }
+microsandbox_core = { package = "microsandbox", version = "=0.6.9", default-features = false, features = ["net", "prebuilt", "ssh"] }
 tokio = { version = "1.52", features = ["rt-multi-thread", "time"] }

--- a/sdk/ruby/ext/microsandbox/src/lib.rs
+++ b/sdk/ruby/ext/microsandbox/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
     mem::ManuallyDrop,
     panic::{AssertUnwindSafe, catch_unwind},
     sync::{
-        Arc, Mutex,
+        Arc, Condvar, Mutex,
         atomic::{AtomicPtr, AtomicU32, Ordering},
     },
     time::Duration,
@@ -45,11 +45,54 @@ unsafe extern "C" {
     ) -> *mut c_void;
 }
 
-/// Carrier for a oneshot receiver, accessed from the C callback inside
-/// `rb_thread_call_without_gvl`.
+/// Per-call completion state created in the process that starts the operation.
+///
+/// Tokio's blocking oneshot receiver caches a thread parker. Reusing that
+/// inherited cache after `fork(2)` can dereference stale synchronization state,
+/// so the Ruby extension waits on a fresh condition variable instead.
+struct BlockingState<T> {
+    result: Mutex<Option<T>>,
+    ready: Condvar,
+}
+
+impl<T> BlockingState<T> {
+    fn new() -> Self {
+        Self {
+            result: Mutex::new(None),
+            ready: Condvar::new(),
+        }
+    }
+
+    fn complete(&self, value: T) {
+        let mut result = self
+            .result
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        *result = Some(value);
+        self.ready.notify_one();
+    }
+
+    fn wait(&self) -> T {
+        let mut result = self
+            .result
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        loop {
+            if let Some(value) = result.take() {
+                return value;
+            }
+            result = self
+                .ready
+                .wait(result)
+                .unwrap_or_else(|error| error.into_inner());
+        }
+    }
+}
+
+/// Carrier accessed from the C callback inside `rb_thread_call_without_gvl`.
 struct BlockingRecv<T> {
-    rx: Option<tokio::sync::oneshot::Receiver<T>>,
-    result: Option<std::thread::Result<Option<T>>>,
+    state: Arc<BlockingState<Result<T, tokio::task::JoinError>>>,
+    result: Option<std::thread::Result<Result<T, tokio::task::JoinError>>>,
 }
 
 fn catch_callback<F, T>(callback: F) -> std::thread::Result<T>
@@ -71,13 +114,7 @@ fn panic_message(panic: &(dyn std::any::Any + Send)) -> &str {
 
 unsafe extern "C" fn do_blocking_recv<T>(data: *mut c_void) -> *mut c_void {
     let carrier = unsafe { &mut *(data as *mut BlockingRecv<T>) };
-    let receiver = carrier.rx.take();
-    carrier.result = Some(catch_callback(move || {
-        receiver
-            .expect("GVL callback invoked twice")
-            .blocking_recv()
-            .ok()
-    }));
+    carrier.result = Some(catch_callback(|| carrier.state.wait()));
     std::ptr::null_mut()
 }
 
@@ -205,12 +242,15 @@ where
     F: Future<Output = T> + Send + 'static,
     T: Send + 'static,
 {
-    let (tx, rx) = tokio::sync::oneshot::channel();
-    runtime()?.spawn(async move {
-        let _ = tx.send(future.await);
+    let runtime = runtime()?;
+    let state = Arc::new(BlockingState::new());
+    let task = runtime.spawn(future);
+    let completion = Arc::clone(&state);
+    runtime.spawn(async move {
+        completion.complete(task.await);
     });
     let mut carrier = BlockingRecv {
-        rx: Some(rx),
+        state,
         result: None,
     };
     unsafe {
@@ -222,11 +262,23 @@ where
         );
     }
     match carrier.result.take() {
-        Some(Ok(Some(value))) => Ok(value),
-        Some(Ok(None)) => Err(Error::new(
+        Some(Ok(Ok(value))) => Ok(value),
+        Some(Ok(Err(error))) if error.is_cancelled() => Err(Error::new(
             ruby.exception_runtime_error(),
             "sandbox operation was canceled",
         )),
+        Some(Ok(Err(error))) => {
+            let message = if error.is_panic() {
+                let panic = error.into_panic();
+                panic_message(panic.as_ref()).to_owned()
+            } else {
+                error.to_string()
+            };
+            Err(Error::new(
+                ruby.exception_runtime_error(),
+                format!("native operation panicked while the Ruby GVL was released: {message}"),
+            ))
+        }
         Some(Err(panic)) => Err(Error::new(
             ruby.exception_runtime_error(),
             format!(
@@ -2171,7 +2223,19 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
 
 #[cfg(test)]
 mod runtime_tests {
-    use super::{catch_callback, panic_message};
+    use std::{sync::Arc, thread};
+
+    use super::{BlockingState, catch_callback, panic_message};
+
+    #[test]
+    fn blocking_state_waits_for_completion() {
+        let state = Arc::new(BlockingState::new());
+        let completion = Arc::clone(&state);
+        let worker = thread::spawn(move || completion.complete(42));
+
+        assert_eq!(state.wait(), 42);
+        worker.join().unwrap();
+    }
 
     #[test]
     fn no_gvl_callback_panics_are_captured() {

--- a/sdk/ruby/lib/microsandbox/version.rb
+++ b/sdk/ruby/lib/microsandbox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Microsandbox
-  VERSION = "0.6.8"
+  VERSION = "0.6.9"
 end


### PR DESCRIPTION
## TL;DR

Bump the microsandbox release train from 0.6.8 to 0.6.9 across Rust crates, shared packages, SDKs, TypeScript examples, MCP, and the microsandbox skill.

## Description

- Move all `microsandbox*` Rust workspace packages and exact internal dependency pins to 0.6.9, including the new `microsandbox-vsock` crate from `main`.
- Bump `@microsandbox/agent-client`, `@microsandbox/types`, the Node, Go, and Ruby SDK release metadata, and current Rust install snippets to 0.6.9.
- Update TypeScript examples and native Node platform package references to 0.6.9.
- Regenerate Cargo and npm release lock metadata; unpublished Node platform packages remain optional lockfile stubs until the post-publish refresh.
- Preserve the explicit Cloud-selection docs in [microsandbox-mcp#26](https://github.com/superradcompany/microsandbox-mcp/pull/26) and [skills#24](https://github.com/superradcompany/skills/pull/24), then advance the gitlinks through the separate 0.6.9 release PRs [microsandbox-mcp#25](https://github.com/superradcompany/microsandbox-mcp/pull/25) and [skills#23](https://github.com/superradcompany/skills/pull/23).
- Include the main SDK and runtime changes since 0.6.8: explicit backend selection, deployment profiles, active backend context, Cloud compatibility and default-volume support, flat OCI roots, Go `AttachWith`, and standardized Python closed-value enums.
- Include the remaining release fixes since 0.6.8: shell completions, DNS failover, TCP half-close handling, agent child reaping, Windows release swaps, Cloud WSS system CAs, registry overrides, dependency updates, and SDK documentation corrections.

## Test Plan

- [x] `cargo fmt --all -- --check`, `CI=1 MSB_HOME=/tmp/msb-release-0.6.9 cargo check --workspace`, workspace docs, and the `msb` build
- [x] `CARGO_INCREMENTAL=0 CI=1 MSB_HOME=/tmp/msb-release-0.6.9 cargo test --workspace`
- [x] `CARGO_INCREMENTAL=0 CI=1 MSB_HOME=/tmp/msb-release-0.6.9 cargo clippy --workspace -- -D warnings`
- [x] Build, typecheck, and test the shared TypeScript packages and Node SDK; run standard Go tests, the TypeScript generator check, Python Ruff, Ruby release-version consistency, and MCP tests.
- [ ] `cd sdk/python && uv sync --group dev && uv run maturin develop --release && uv run pytest` (deferred: the unpublished 0.6.9 runtime assets require a full local release build, which exceeded the available disk; the Python Rust crate is covered by the workspace tests and Ruff passed)
- [ ] `cd sdk/go && MICROSANDBOX_FFI_PATH=../../target/debug/libmicrosandbox_go_ffi.dylib go test -tags 'smoke microsandbox_ffi_path' -count=1 -timeout 2m .` (deferred: the native FFI build exceeded the available disk; `go test -count=1 .` passed)

<!-- greptile_comment -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22superradcompany%2Fmicrosandbox%22%20on%20the%20existing%20branch%20%22appcypher%2Fbump-msb-0-6-9%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22appcypher%2Fbump-msb-0-6-9%22.%0A%0AGreploop%20superradcompany%2Fmicrosandbox%20PR%20%231267%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=superradcompany%2Fmicrosandbox&pr=1267&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22superradcompany%2Fmicrosandbox%22%20on%20the%20existing%20branch%20%22appcypher%2Fbump-msb-0-6-9%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22appcypher%2Fbump-msb-0-6-9%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fruby.yml%3A57-58%0A**Standalone%20lockfile%20remains%20stale**%0A%0AWhen%20a%20source-gem%20or%20standalone%20Ruby%20extension%20build%20uses%20the%20committed%20lockfile%2C%20the%20manifest%20requires%20%60microsandbox%20%3D0.6.9%60%20while%20that%20lockfile%20still%20selects%200.6.8%2C%20causing%20locked%20dependency%20resolution%20to%20fail.%20This%20workflow%20only%20substitutes%20the%20workspace%20lockfile%20during%20CI%20and%20restores%20the%20incompatible%20standalone%20lockfile%20afterward.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=superradcompany%2Fmicrosandbox&pr=1267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fruby.yml%3A57-58%0A**Standalone%20lockfile%20remains%20stale**%0A%0AWhen%20a%20source-gem%20or%20standalone%20Ruby%20extension%20build%20uses%20the%20committed%20lockfile%2C%20the%20manifest%20requires%20%60microsandbox%20%3D0.6.9%60%20while%20that%20lockfile%20still%20selects%200.6.8%2C%20causing%20locked%20dependency%20resolution%20to%20fail.%20This%20workflow%20only%20substitutes%20the%20workspace%20lockfile%20during%20CI%20and%20restores%20the%20incompatible%20standalone%20lockfile%20afterward.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=superradcompany%2Fmicrosandbox&pr=1267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/ruby.yml:57-58
**Standalone lockfile remains stale**

When a source-gem or standalone Ruby extension build uses the committed lockfile, the manifest requires `microsandbox =0.6.9` while that lockfile still selects 0.6.8, causing locked dependency resolution to fail. This workflow only substitutes the workspace lockfile during CI and restores the incompatible standalone lockfile afterward.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (7): Last reviewed commit: ["fix(ruby): avoid parking-lot state acros..."](https://github.com/superradcompany/microsandbox/commit/2bc2ada1e4415178206072f19a42d1edaf03d6d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53418249)</sub>

<!-- /greptile_comment -->