### PR TITLE
test(network): bound invalid-host secret test exec

### DIFF
--- a/sdk/rust/tests/plain_http_secret.rs
+++ b/sdk/rust/tests/plain_http_secret.rs
@@ -246,12 +246,16 @@ async fn plain_http_invalid_host_blocks_host_bound_secret() {
 
     // Test: no Host header. The exec outcome is irrelevant (the proxy drops the
     // connection, which can leave `nc` waiting for a response) — only what the
-    // server sees.
+    // server sees. Bound the exec through the SDK so agentd kills the entire
+    // process group; BusyBox `timeout` can leave a pipeline's `nc` orphaned.
     let _ = sb
-        .shell(format!(
-            "timeout 5 sh -c 'printf \"GET / HTTP/1.0\\r\\nAuthorization: Bearer %s\\r\\n\\r\\n\" \
-             \"$API_KEY\" | nc host.microsandbox.internal {test_port}' || true"
-        ))
+        .shell_with(
+            format!(
+                "printf 'GET / HTTP/1.0\\r\\nAuthorization: Bearer %s\\r\\n\\r\\n' \"$API_KEY\" \
+                 | nc host.microsandbox.internal {test_port}"
+            ),
+            |exec| exec.timeout(std::time::Duration::from_secs(5)),
+        )
         .await;
 
     // With the host unprovable the secret is ineligible, so the request is


### PR DESCRIPTION
## TL;DR

Bound the invalid-host plain-HTTP secret test through the SDK exec timeout so a blocked `nc` cannot leave the integration test hanging.

## Description

- Remove the in-guest BusyBox `timeout` wrapper from the no-Host request.
- Apply the five-second timeout to the complete SDK exec session.
- Document why process-group cleanup is required for the netcat pipeline.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo nextest run -p microsandbox --test plain_http_secret plain_http_invalid_host_blocks_host_bound_secret --run-ignored=only` (4 consecutive passes: 25.992s, 28.442s, 26.416s, 24.656s)
- Repository hygiene and formatting pre-commit hooks
- Workspace Clippy, docs, and CLI build hooks were skipped after shared Cargo/sccache contention prevented them from completing locally; CI will run the full checks.
