### PR TITLE
Reap adopted guest children

### DIFF
--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -1,6 +1,6 @@
 //! Main agent loop: serial I/O, session management, heartbeat.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{File, OpenOptions};
 use std::os::fd::AsRawFd;
@@ -10,6 +10,7 @@ use std::time::Instant;
 
 use chrono::Utc;
 use tokio::io::unix::AsyncFd;
+use tokio::signal::unix::{self, SignalKind};
 use tokio::sync::{mpsc, watch};
 use tokio::time::{self, Duration};
 
@@ -155,6 +156,11 @@ pub async fn run(
     let mut serial_out_buf = Vec::new();
 
     let mut state = AgentState::default();
+
+    // Session tasks own their direct children's exit statuses. PID 1 can also
+    // adopt descendants after an exec leader exits, so handle SIGCHLD here to
+    // reap only adopted zombies without racing those session tasks.
+    let mut child_signal = unix::signal(SignalKind::child())?;
 
     // Channel for session output events.
     let (session_tx, mut session_rx) = mpsc::unbounded_channel::<(u32, SessionOutput)>();
@@ -346,6 +352,10 @@ pub async fn run(
                 if !serial_out_buf.is_empty() {
                     flush_write_buf(&async_port, &mut serial_out_buf).await?;
                 }
+            }
+
+            _ = child_signal.recv() => {
+                reap_adopted_zombies(state.sessions.values().map(|session| session.pid() as i32));
             }
         }
     }
@@ -771,6 +781,44 @@ fn spawn_heartbeat_thread(
             }
         })
         .expect("failed to spawn agentd heartbeat thread")
+}
+
+/// Reap exited children adopted by this PID 1 without consuming active exec
+/// session leaders, whose reader tasks own their exit statuses.
+fn reap_adopted_zombies(active_session_pids: impl Iterator<Item = i32>) {
+    let active_session_pids: HashSet<_> = active_session_pids.collect();
+    let parent_pid = std::process::id() as i32;
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<i32>().ok())
+        else {
+            continue;
+        };
+        if active_session_pids.contains(&pid) {
+            continue;
+        }
+        let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
+            continue;
+        };
+        let Some((_, fields)) = stat.rsplit_once(')') else {
+            continue;
+        };
+        let fields: Vec<_> = fields.split_whitespace().collect();
+        if fields.first() != Some(&"Z")
+            || fields.get(1).and_then(|ppid| ppid.parse::<i32>().ok()) != Some(parent_pid)
+        {
+            continue;
+        }
+        unsafe {
+            libc::waitpid(pid, std::ptr::null_mut(), libc::WNOHANG);
+        }
+    }
 }
 
 fn heartbeat_snapshot(state: &AgentState, activity: &ActivityTracker) -> HeartbeatSnapshot {

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -418,6 +418,19 @@ pub struct SandboxOpts {
     #[arg(long)]
     pub secret: Vec<String>,
 
+    /// Inject a secret only as one exact request-header credential.
+    ///
+    /// Format:
+    /// `ENV@HOST[,HOST...];header=NAME[;scheme=SCHEME]`.
+    /// The optional scheme is followed by exactly one space before the
+    /// placeholder. This option is available only while creating a sandbox.
+    #[cfg(feature = "net")]
+    #[arg(
+        long = "secret-exact-header",
+        value_name = "ENV@HOST;header=NAME[;scheme=SCHEME]"
+    )]
+    pub secret_exact_header: Vec<String>,
+
     /// Action when a secret is sent to a disallowed host (block, block-and-log, block-and-terminate, passthrough).
     #[cfg(feature = "net")]
     #[arg(long)]
@@ -538,6 +551,7 @@ impl SandboxOpts {
             || !self.tls_upstream_ca_cert_for.is_empty()
             || !self.tls_no_verify_upstream_for.is_empty()
             || !self.secret.is_empty()
+            || !self.secret_exact_header.is_empty()
             || self.on_secret_violation.is_some();
 
         #[cfg(not(feature = "net"))]
@@ -1503,23 +1517,40 @@ fn apply_network_opts(
     // Secrets. `create` persists a host-side source reference, not the raw
     // value: the plaintext is read from the host environment at spawn time so
     // the durable config never stores secret material at rest.
-    let mut secret_specs: Vec<(String, Vec<String>)> = Vec::new();
+    let mut secret_specs: Vec<(String, Vec<String>, Option<(String, Option<String>)>)> = Vec::new();
     for secret_str in &opts.secret {
         let (env_var, hosts) = parse_secret(secret_str, "create")?;
         match secret_specs
             .iter_mut()
-            .find(|(existing, _)| *existing == env_var)
+            .find(|(existing, _, _)| *existing == env_var)
         {
-            Some((_, existing_hosts)) => existing_hosts.extend(hosts),
-            None => secret_specs.push((env_var, hosts)),
+            Some((_, existing_hosts, None)) => existing_hosts.extend(hosts),
+            Some((_, _, Some(_))) => unreachable!("exact-header secrets are parsed afterwards"),
+            None => secret_specs.push((env_var, hosts, None)),
         }
     }
-    for (env_var, hosts) in secret_specs {
+    for secret_str in &opts.secret_exact_header {
+        let (env_var, hosts, name, scheme) = parse_secret_exact_header(secret_str)?;
+        if secret_specs
+            .iter()
+            .any(|(existing, _, _)| *existing == env_var)
+        {
+            anyhow::bail!("secret {env_var:?} cannot mix or repeat exact-header declarations");
+        }
+        secret_specs.push((env_var, hosts, Some((name, scheme))));
+    }
+    for (env_var, hosts, exact_header) in secret_specs {
         let source = microsandbox::sandbox::SecretSource::Env {
             var: env_var.clone(),
         };
         builder = builder.secret(|mut s| {
             s = s.env(&env_var).source(source);
+            if let Some((name, scheme)) = exact_header {
+                s = s
+                    .inject_headers(false)
+                    .inject_basic_auth(false)
+                    .exact_header(name, scheme);
+            }
             for host in hosts {
                 s = allow_secret_host(s, &host);
             }
@@ -1956,6 +1987,47 @@ pub(crate) fn parse_secret(spec: &str, command: &str) -> anyhow::Result<(String,
     }
 
     Ok((env_var, hosts))
+}
+
+/// Parse a provider-neutral exact-header secret declaration:
+/// `ENV@HOST[,HOST...];header=NAME[;scheme=SCHEME]`.
+#[cfg(feature = "net")]
+fn parse_secret_exact_header(
+    spec: &str,
+) -> anyhow::Result<(String, Vec<String>, String, Option<String>)> {
+    let mut parts = spec.split(';');
+    let secret = parts.next().unwrap_or_default();
+    let (env_var, hosts) = parse_secret(secret, "create")?;
+    let mut header = None;
+    let mut scheme = None;
+
+    for part in parts {
+        let (key, value) = part.split_once('=').ok_or_else(|| {
+            anyhow::anyhow!(
+                "exact-header secret options must use key=value in \
+                 ENV@HOST;header=NAME[;scheme=SCHEME]"
+            )
+        })?;
+        if value.is_empty() {
+            anyhow::bail!("exact-header secret {key} must not be empty");
+        }
+        match key {
+            "header" if header.is_none() => header = Some(value.to_string()),
+            "scheme" if scheme.is_none() => scheme = Some(value.to_string()),
+            "header" | "scheme" => {
+                anyhow::bail!("exact-header secret option {key:?} is declared more than once")
+            }
+            _ => anyhow::bail!("unknown exact-header secret option {key:?}"),
+        }
+    }
+
+    let header = header.ok_or_else(|| {
+        anyhow::anyhow!(
+            "exact-header secret must include header=NAME in \
+             ENV@HOST;header=NAME[;scheme=SCHEME]"
+        )
+    })?;
+    Ok((env_var, hosts, header, scheme))
 }
 
 #[cfg(feature = "net")]
@@ -2516,6 +2588,9 @@ mod tests {
 
         assert_eq!(secrets.len(), 1);
         assert_eq!(secrets[0].env_var, "API_KEY");
+        assert!(secrets[0].injection.headers);
+        assert!(secrets[0].injection.basic_auth);
+        assert!(secrets[0].injection.exact_headers.is_empty());
         assert_eq!(
             secrets[0].allowed_hosts,
             vec![
@@ -2524,6 +2599,106 @@ mod tests {
                 HostPattern::Any,
             ]
         );
+    }
+
+    #[cfg(feature = "net")]
+    #[tokio::test]
+    async fn apply_sandbox_opts_builds_source_backed_exact_header_secret() {
+        use microsandbox::sandbox::SecretSource;
+
+        let opts = SandboxOpts {
+            secret_exact_header: vec![
+                "API_KEY@api.example.com;header=Authorization;scheme=Bearer".into(),
+            ],
+            ..Default::default()
+        };
+        let config = apply_sandbox_opts(SandboxBuilder::new("test").image("alpine"), &opts)
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        let secret = &config
+            .spec
+            .network
+            .secrets
+            .expect("network secrets")
+            .secrets[0];
+
+        assert!(secret.value.is_empty());
+        assert_eq!(
+            secret.source,
+            Some(SecretSource::Env {
+                var: "API_KEY".into()
+            })
+        );
+        assert!(!secret.injection.headers);
+        assert!(!secret.injection.basic_auth);
+        assert_eq!(secret.injection.exact_headers.len(), 1);
+        assert_eq!(secret.injection.exact_headers[0].name, "Authorization");
+        assert_eq!(
+            secret.injection.exact_headers[0].scheme.as_deref(),
+            Some("Bearer")
+        );
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn apply_sandbox_opts_rejects_duplicate_or_mixed_exact_header_declarations() {
+        for opts in [
+            SandboxOpts {
+                secret: vec!["API_KEY@api.example.com".into()],
+                secret_exact_header: vec!["API_KEY@api2.example.com;header=X-Api-Key".into()],
+                ..Default::default()
+            },
+            SandboxOpts {
+                secret_exact_header: vec![
+                    "API_KEY@api.example.com;header=X-Api-Key".into(),
+                    "API_KEY@api2.example.com;header=X-Api-Key".into(),
+                ],
+                ..Default::default()
+            },
+        ] {
+            let err = match apply_sandbox_opts(SandboxBuilder::new("test").image("alpine"), &opts) {
+                Ok(_) => panic!("duplicate secret declaration should fail"),
+                Err(err) => err.to_string(),
+            };
+            assert!(err.contains("cannot mix or repeat"), "{err}");
+        }
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn parse_secret_exact_header_is_general_and_rejects_ambiguous_options() {
+        assert_eq!(
+            parse_secret_exact_header(
+                "API_KEY@api.example.com;header=Proxy-Authorization;scheme=Token"
+            )
+            .unwrap(),
+            (
+                "API_KEY".into(),
+                vec!["api.example.com".into()],
+                "Proxy-Authorization".into(),
+                Some("Token".into()),
+            )
+        );
+        assert_eq!(
+            parse_secret_exact_header("API_KEY@api.example.com;header=X-Api-Key").unwrap(),
+            (
+                "API_KEY".into(),
+                vec!["api.example.com".into()],
+                "X-Api-Key".into(),
+                None,
+            )
+        );
+
+        for invalid in [
+            "API_KEY@api.example.com",
+            "API_KEY@api.example.com;scheme=Bearer",
+            "API_KEY@api.example.com;header=X-Key;header=X-Other",
+            "API_KEY@api.example.com;header=X-Key;unknown=value",
+        ] {
+            assert!(parse_secret_exact_header(invalid).is_err(), "{invalid}");
+        }
     }
 
     #[cfg(feature = "net")]

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -1517,7 +1517,8 @@ fn apply_network_opts(
     // Secrets. `create` persists a host-side source reference, not the raw
     // value: the plaintext is read from the host environment at spawn time so
     // the durable config never stores secret material at rest.
-    let mut secret_specs: Vec<(String, Vec<String>, Option<(String, Option<String>)>)> = Vec::new();
+    type SecretSpec = (String, Vec<String>, Option<(String, Option<String>)>);
+    let mut secret_specs: Vec<SecretSpec> = Vec::new();
     for secret_str in &opts.secret {
         let (env_var, hosts) = parse_secret(secret_str, "create")?;
         match secret_specs
@@ -1546,10 +1547,7 @@ fn apply_network_opts(
         builder = builder.secret(|mut s| {
             s = s.env(&env_var).source(source);
             if let Some((name, scheme)) = exact_header {
-                s = s
-                    .inject_headers(false)
-                    .inject_basic_auth(false)
-                    .exact_header(name, scheme);
+                s = s.exact_header(name, scheme);
             }
             for host in hosts {
                 s = allow_secret_host(s, &host);
@@ -1950,7 +1948,7 @@ fn parse_port_mapping(spec: &str) -> anyhow::Result<(std::net::IpAddr, u16, u16,
 }
 
 /// Parse a `--secret ENV@HOST[,HOST...]` spec into `(env_var, hosts)` for
-/// `command` (`create` or `modify`).
+/// `context` (the command or option that accepted the declaration).
 ///
 /// The value is NOT read here: the CLI records a host-side source reference
 /// (`{kind: env, var: ENV}`) that is resolved from the host environment when
@@ -1960,11 +1958,11 @@ fn parse_port_mapping(spec: &str) -> anyhow::Result<(std::net::IpAddr, u16, u16,
 /// The inline `ENV=VALUE@HOST` form is rejected loudly: the shell would leak
 /// the value regardless, so the value path is SDK-only. Users are pointed at
 /// the `ENV@HOST[,HOST...]` env-var form instead.
-pub(crate) fn parse_secret(spec: &str, command: &str) -> anyhow::Result<(String, Vec<String>)> {
+pub(crate) fn parse_secret(spec: &str, context: &str) -> anyhow::Result<(String, Vec<String>)> {
     if let Some(eq_pos) = spec.find('=') {
         let env_var = &spec[..eq_pos];
         anyhow::bail!(
-            "inline secret values (`{env_var}=VALUE@HOST`) are not supported by `{command}`: \
+            "inline secret values (`{env_var}=VALUE@HOST`) are not supported by `{context}`: \
              the value would be stored in the sandbox config at rest. Export the value as a \
              host environment variable and reference it with `{env_var}@HOST` instead, which \
              is resolved from the environment at start time."
@@ -1997,7 +1995,7 @@ fn parse_secret_exact_header(
 ) -> anyhow::Result<(String, Vec<String>, String, Option<String>)> {
     let mut parts = spec.split(';');
     let secret = parts.next().unwrap_or_default();
-    let (env_var, hosts) = parse_secret(secret, "create")?;
+    let (env_var, hosts) = parse_secret(secret, "--secret-exact-header")?;
     let mut header = None;
     let mut scheme = None;
 
@@ -2690,6 +2688,11 @@ mod tests {
                 None,
             )
         );
+        let inline = parse_secret_exact_header("API_KEY=value@api.example.com;header=X-Api-Key")
+            .unwrap_err()
+            .to_string();
+        assert!(inline.contains("`--secret-exact-header`"), "{inline}");
+        assert!(!inline.contains("`create`"), "{inline}");
 
         for invalid in [
             "API_KEY@api.example.com",

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -455,6 +455,22 @@ mod tests {
 
     #[cfg(feature = "net")]
     #[test]
+    fn secret_exact_header_parses_as_creation_option() {
+        let args = parse_run_args(&[
+            "--secret-exact-header",
+            "API_KEY@api.example.com;header=Authorization;scheme=Bearer",
+            "alpine",
+        ]);
+
+        assert_eq!(
+            args.sandbox.secret_exact_header,
+            ["API_KEY@api.example.com;header=Authorization;scheme=Bearer"]
+        );
+        assert!(args.sandbox.secret.is_empty());
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
     fn net_profile_conflicts_with_low_level_default_baselines() {
         for conflicting in ["--no-net", "--net-default"] {
             let mut argv = vec!["msb", "--net", "public", conflicting];

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -545,13 +545,16 @@ impl SecretBuilder {
         self
     }
 
-    /// Add a provider-neutral exact request-header placement.
+    /// Restrict this secret to a provider-neutral exact request-header placement.
     ///
     /// Set `scheme` to `Some("Bearer")` for
     /// `Authorization: Bearer <placeholder>`, or `None` for a header whose
-    /// complete value is the placeholder. To make the secret exact-header
-    /// only, also disable broad header and Basic Auth injection.
+    /// complete value is the placeholder. This disables broad header and
+    /// Basic Auth injection. Configure [`SecretInjection`] directly when an
+    /// exact-header rule should be additive to those legacy modes.
     pub fn exact_header(mut self, name: impl Into<String>, scheme: Option<String>) -> Self {
+        self.injection.headers = false;
+        self.injection.basic_auth = false;
         self.injection.exact_headers.push(SecretExactHeader {
             name: name.into(),
             scheme,
@@ -853,6 +856,26 @@ mod tests {
         // Serialized durable form carries the reference, not a value.
         let json = serde_json::to_string(&secret).unwrap();
         assert!(json.contains("\"var\":\"HOST_API_KEY\""));
+    }
+
+    #[test]
+    fn secret_builder_exact_header_disables_broad_header_modes() {
+        let secret = SecretBuilder::new()
+            .env("API_KEY")
+            .value("secret-value")
+            .allow_host("api.example.com")
+            .exact_header("Proxy-Authorization", Some("Token".into()))
+            .build();
+
+        assert!(!secret.injection.headers);
+        assert!(!secret.injection.basic_auth);
+        assert_eq!(
+            secret.injection.exact_headers,
+            vec![SecretExactHeader {
+                name: "Proxy-Authorization".into(),
+                scheme: Some("Token".into()),
+            }]
+        );
     }
 
     #[test]

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -16,7 +16,7 @@ use crate::policy::{BuildError, NetworkPolicy};
 use zeroize::Zeroizing;
 
 use crate::secrets::config::{
-    HostPattern, SecretEntry, SecretInjection, SecretSource, ViolationAction,
+    HostPattern, SecretEntry, SecretExactHeader, SecretInjection, SecretSource, ViolationAction,
 };
 use microsandbox_types::{ScopedUpstreamCaCert, ScopedVerifyUpstream, TlsConfig};
 
@@ -542,6 +542,20 @@ impl SecretBuilder {
     /// Configure Basic Auth injection (default: true).
     pub fn inject_basic_auth(mut self, enabled: bool) -> Self {
         self.injection.basic_auth = enabled;
+        self
+    }
+
+    /// Add a provider-neutral exact request-header placement.
+    ///
+    /// Set `scheme` to `Some("Bearer")` for
+    /// `Authorization: Bearer <placeholder>`, or `None` for a header whose
+    /// complete value is the placeholder. To make the secret exact-header
+    /// only, also disable broad header and Basic Auth injection.
+    pub fn exact_header(mut self, name: impl Into<String>, scheme: Option<String>) -> Self {
+        self.injection.exact_headers.push(SecretExactHeader {
+            name: name.into(),
+            scheme,
+        });
         self
     }
 

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -1533,7 +1533,8 @@ mod tests {
                 allowed_hosts: vec![HostPattern::Any],
                 injection: SecretInjection {
                     headers: true,
-                    basic_auth: false,
+                    basic_auth: true,
+                    exact_headers: Vec::new(),
                     query_params: false,
                     body: false,
                 },
@@ -1738,7 +1739,8 @@ mod tests {
                 allowed_hosts: vec![HostPattern::Exact("example.com".into())],
                 injection: SecretInjection {
                     headers: true,
-                    basic_auth: false,
+                    basic_auth: true,
+                    exact_headers: Vec::new(),
                     query_params: false,
                     body: false,
                 },

--- a/crates/network/lib/secrets/config.rs
+++ b/crates/network/lib/secrets/config.rs
@@ -7,8 +7,8 @@
 //! engine-internal query helpers used by the proxy.
 
 pub use microsandbox_types::{
-    HostPattern, MAX_SECRET_PLACEHOLDER_BYTES, SecretConfigError, SecretEntry, SecretInjection,
-    SecretSource, SecretsConfig, ViolationAction,
+    HostPattern, MAX_SECRET_PLACEHOLDER_BYTES, SecretConfigError, SecretEntry, SecretExactHeader,
+    SecretInjection, SecretSource, SecretsConfig, ViolationAction,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -38,6 +38,7 @@ impl SecretsConfigExt for SecretsConfig {
             !secret.require_tls_identity
                 && (secret.injection.headers
                     || secret.injection.basic_auth
+                    || !secret.injection.exact_headers.is_empty()
                     || secret.injection.query_params
                     || secret.injection.body)
         })

--- a/crates/network/lib/secrets/handler.rs
+++ b/crates/network/lib/secrets/handler.rs
@@ -7,13 +7,15 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
+use std::ops::Range;
 
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use httlib_hpack::{Decoder as HpackDecoder, Encoder as HpackEncoder};
 use percent_encoding::percent_decode;
 
 use super::config::{
-    HostPattern, MAX_SECRET_PLACEHOLDER_BYTES, SecretEntry, SecretsConfig, ViolationAction,
+    HostPattern, MAX_SECRET_PLACEHOLDER_BYTES, SecretEntry, SecretExactHeader, SecretsConfig,
+    ViolationAction,
 };
 use crate::shared::SharedState;
 
@@ -148,6 +150,7 @@ struct Http2State {
     preface_seen: bool,
     buffer: Vec<u8>,
     header_block: Option<Http2HeaderBlock>,
+    highest_client_stream_id: u32,
     open_request_streams: HashSet<u32>,
     data_tails: HashMap<u32, Vec<u8>>,
     request_summaries: HashMap<u32, RequestSummary>,
@@ -233,6 +236,7 @@ struct EligibleSecret {
     value: zeroize::Zeroizing<String>,
     inject_headers: bool,
     inject_basic_auth: bool,
+    exact_headers: Vec<SecretExactHeader>,
     inject_query_params: bool,
     inject_body: bool,
     require_tls_identity: bool,
@@ -308,37 +312,62 @@ enum PlaceholderMatchForm {
 
 impl EligibleSecret {
     /// Returns true if any of the header-side injection scopes is enabled
-    /// (`headers`, `basic_auth`, or `query_params`).
+    /// (`headers`, `basic_auth`, exact headers, or query parameters).
     fn wants_header_injection(&self) -> bool {
-        self.inject_headers || self.inject_basic_auth || self.inject_query_params
+        self.inject_headers
+            || self.inject_basic_auth
+            || !self.exact_headers.is_empty()
+            || self.inject_query_params
     }
 
     /// Returns true when the current header bytes contain this secret's
     /// placeholder in a header-substitution scope.
-    fn may_substitute_in_headers(&self, headers: &[u8]) -> bool {
+    fn may_substitute_in_headers(&self, headers: &[u8], initial_http1_headers: bool) -> bool {
         if !self.wants_header_injection() {
             return false;
         }
 
         let needle = self.placeholder.as_bytes();
-        if (self.inject_headers || self.inject_query_params) && contains_bytes(headers, needle) {
+        if self.inject_query_params && contains_bytes(headers, needle) {
             return true;
         }
 
-        // Search decoded Basic auth credentials, not the raw header value.
-        if self.inject_basic_auth {
-            return basic_auth_decoded_contains(
+        if self.inject_headers && contains_bytes(headers, needle) {
+            return true;
+        }
+        if self.inject_basic_auth
+            && basic_auth_decoded_contains(
                 String::from_utf8_lossy(headers).as_ref(),
                 &self.placeholder,
-            );
+            )
+        {
+            return true;
         }
 
-        false
+        initial_http1_headers
+            && exact_header_http1_credential_range(headers, needle, &self.exact_headers).is_some()
     }
 
     /// Substitute this secret's placeholder in the headers portion, scoped by
-    /// the secret's `headers` / `basic_auth` / `query_params` flags.
-    fn substitute_in_headers(&self, headers: &str) -> String {
+    /// its header placement and query-parameter settings.
+    fn substitute_in_headers(&self, headers: &[u8], initial_http1_headers: bool) -> Vec<u8> {
+        let mut bytes = headers.to_vec();
+
+        if initial_http1_headers
+            && let Some(range) = exact_header_http1_credential_range(
+                &bytes,
+                self.placeholder.as_bytes(),
+                &self.exact_headers,
+            )
+        {
+            bytes.splice(range, self.value.as_bytes().iter().copied());
+        }
+
+        if !self.inject_headers && !self.inject_basic_auth && !self.inject_query_params {
+            return bytes;
+        }
+
+        let headers = String::from_utf8_lossy(&bytes);
         let mut result = String::with_capacity(headers.len());
         for (i, line) in headers.split("\r\n").enumerate() {
             if i > 0 {
@@ -349,7 +378,7 @@ impl EligibleSecret {
                 None => result.push_str(line),
             }
         }
-        result
+        result.into_bytes()
     }
 
     /// Substitute this secret's placeholder in a single header line. Returns
@@ -378,8 +407,7 @@ impl EligibleSecret {
     /// Decode `Basic <base64>` credentials, substitute the placeholder in the
     /// decoded `user:password`, and return the re-encoded line. Returns `None`
     /// if the line isn't `Basic` scheme or the decoded credentials don't
-    /// contain the placeholder. Non-Basic schemes (e.g. `Bearer`) are handled
-    /// by `inject_headers` instead.
+    /// contain the placeholder.
     fn substitute_basic_auth_header(&self, line: &str) -> Option<String> {
         let decoded = decode_basic_credentials(line)?;
         if !decoded.contains(&self.placeholder) {
@@ -465,6 +493,7 @@ impl Default for Http2State {
             preface_seen: false,
             buffer: Vec::new(),
             header_block: None,
+            highest_client_stream_id: 0,
             open_request_streams: HashSet::new(),
             data_tails: HashMap::new(),
             request_summaries: HashMap::new(),
@@ -592,6 +621,7 @@ impl SecretsHandler {
                     value: secret.value.clone(),
                     inject_headers: secret.injection.headers,
                     inject_basic_auth: secret.injection.basic_auth,
+                    exact_headers: secret.injection.exact_headers.clone(),
                     inject_query_params: secret.injection.query_params,
                     inject_body: secret.injection.body,
                     require_tls_identity: secret.require_tls_identity,
@@ -655,8 +685,7 @@ impl SecretsHandler {
     /// Substitute secrets in plaintext data (guest → server direction).
     ///
     /// Splits the HTTP message on `\r\n\r\n` to scope substitution:
-    /// - `headers`: substitutes in the header portion (before boundary)
-    /// - `basic_auth`: substitutes in Authorization headers specifically
+    /// - `headers`: applies the configured closed header-placement mode
     /// - `query_params`: substitutes in the request line (first line, query portion)
     /// - `body`: substitutes in the body portion (after boundary)
     ///
@@ -868,7 +897,7 @@ impl SecretsHandler {
         }
 
         // Start with borrowed bytes; allocate only when a substitution is needed.
-        let mut header_str = None;
+        let mut header_out: Option<Vec<u8>> = None;
         let mut body = None;
 
         for secret in &self.eligible_for_substitution {
@@ -877,11 +906,9 @@ impl SecretsHandler {
                 continue;
             }
 
-            // Header substitution still uses string helpers after a scoped match.
-            if secret.may_substitute_in_headers(header_bytes) {
-                let current = header_str
-                    .get_or_insert_with(|| String::from_utf8_lossy(header_bytes).into_owned());
-                *current = secret.substitute_in_headers(current);
+            let current = header_out.as_deref().unwrap_or(header_bytes);
+            if secret.may_substitute_in_headers(current, boundary.is_some()) {
+                header_out = Some(secret.substitute_in_headers(current, boundary.is_some()));
             }
 
             // Body substitution works on bytes so encoded payloads stay valid.
@@ -897,9 +924,9 @@ impl SecretsHandler {
             }
         }
 
-        let header_changed = header_str
+        let header_changed = header_out
             .as_ref()
-            .is_some_and(|headers| headers.as_bytes() != header_bytes);
+            .is_some_and(|headers| headers.as_slice() != header_bytes);
         let body_changed = body.is_some();
 
         // No header or body replacement was produced. Forward this request
@@ -908,7 +935,7 @@ impl SecretsHandler {
             return self.append_pipelined_spillover(data, this_request, spillover);
         }
 
-        let header_len = header_str
+        let header_len = header_out
             .as_ref()
             .map_or(header_bytes.len(), |headers| headers.len());
         let body_len = body.as_ref().map_or(body_bytes.len(), Vec::len);
@@ -917,16 +944,19 @@ impl SecretsHandler {
         let body_bytes_out = body.as_deref().unwrap_or(body_bytes);
         // Update Content-Length only when body substitution changed the size.
         if body_changed && body_bytes_out.len() != body_bytes.len() {
-            let headers = match header_str {
-                Some(headers) => update_content_length(&headers, body_bytes_out.len()),
+            let headers = match header_out {
+                Some(headers) => update_content_length(
+                    String::from_utf8_lossy(&headers).as_ref(),
+                    body_bytes_out.len(),
+                ),
                 None => update_content_length(
                     String::from_utf8_lossy(header_bytes).as_ref(),
                     body_bytes_out.len(),
                 ),
             };
             output.extend_from_slice(headers.as_bytes());
-        } else if let Some(headers) = header_str {
-            output.extend_from_slice(headers.as_bytes());
+        } else if let Some(headers) = header_out {
+            output.extend_from_slice(&headers);
         } else {
             output.extend_from_slice(header_bytes);
         }
@@ -1038,9 +1068,9 @@ impl SecretsHandler {
             HttpState::InChunkedBody { state }
         };
 
-        if let Some(headers) = self.substitute_header_bytes(header_bytes) {
+        if let Some(headers) = self.substitute_header_bytes(header_bytes, true) {
             let mut output = Vec::with_capacity(headers.len() + body_part.len() + spillover.len());
-            output.extend_from_slice(headers.as_bytes());
+            output.extend_from_slice(&headers);
             output.extend_from_slice(body_part);
             if !spillover.is_empty() {
                 let next_out = self.substitute(spillover)?;
@@ -1084,7 +1114,7 @@ impl SecretsHandler {
         };
 
         let header_len = header_bytes.len();
-        let header_out = self.substitute_header_bytes(header_bytes);
+        let header_out = self.substitute_header_bytes(header_bytes, true);
         let mut output = Vec::with_capacity(
             header_out
                 .as_ref()
@@ -1093,7 +1123,7 @@ impl SecretsHandler {
                 + spillover.len(),
         );
         if let Some(headers) = header_out {
-            output.extend_from_slice(headers.as_bytes());
+            output.extend_from_slice(&headers);
         } else {
             output.extend_from_slice(header_bytes);
         }
@@ -1281,10 +1311,26 @@ impl SecretsHandler {
         })
     }
 
-    fn substitute_http2_headers(&self, headers: &mut [(Vec<u8>, Vec<u8>)]) {
+    fn substitute_http2_headers(
+        &self,
+        headers: &mut [(Vec<u8>, Vec<u8>)],
+        is_initial_request: bool,
+    ) {
         for secret in &self.eligible_for_substitution {
             if secret.require_tls_identity && !self.tls_intercepted {
                 continue;
+            }
+
+            if is_initial_request
+                && let Some(index) = exact_header_http2_header_index(
+                    headers,
+                    secret.placeholder.as_bytes(),
+                    &secret.exact_headers,
+                )
+            {
+                let value = &mut headers[index].1;
+                let credential_start = value.len() - secret.placeholder.len();
+                value.splice(credential_start.., secret.value.as_bytes().iter().copied());
             }
 
             for (name, value) in headers.iter_mut() {
@@ -1324,20 +1370,23 @@ impl SecretsHandler {
         }
     }
 
-    fn substitute_header_bytes(&self, header_bytes: &[u8]) -> Option<String> {
-        let mut header_str: Option<String> = None;
+    fn substitute_header_bytes(
+        &self,
+        header_bytes: &[u8],
+        initial_http1_headers: bool,
+    ) -> Option<Vec<u8>> {
+        let mut headers: Option<Vec<u8>> = None;
         for secret in &self.eligible_for_substitution {
             if secret.require_tls_identity && !self.tls_intercepted {
                 continue;
             }
-            if secret.may_substitute_in_headers(header_bytes) {
-                let current = header_str
-                    .get_or_insert_with(|| String::from_utf8_lossy(header_bytes).into_owned());
-                *current = secret.substitute_in_headers(current);
+            let current = headers.as_deref().unwrap_or(header_bytes);
+            if secret.may_substitute_in_headers(current, initial_http1_headers) {
+                headers = Some(secret.substitute_in_headers(current, initial_http1_headers));
             }
         }
 
-        header_str.filter(|headers| headers.as_bytes() != header_bytes)
+        headers.filter(|headers| headers.as_slice() != header_bytes)
     }
 
     fn consume_chunked_body_with_violation_detection(
@@ -1762,9 +1811,13 @@ impl Http2State {
         let mut headers = self.decode_headers(&block.block)?;
         let is_initial_request = !self.open_request_streams.contains(&block.stream_id);
         if is_initial_request {
+            if block.stream_id <= self.highest_client_stream_id {
+                return Err(ViolationAction::Block);
+            }
             if self.open_request_streams.len() >= MAX_HTTP2_TRACKED_STREAMS {
                 return Err(ViolationAction::Block);
             }
+            self.highest_client_stream_id = block.stream_id;
             self.open_request_streams.insert(block.stream_id);
         } else if !block.end_stream {
             return Err(ViolationAction::Block);
@@ -1787,7 +1840,7 @@ impl Http2State {
             Some(block.stream_id),
         ))?;
 
-        handler.substitute_http2_headers(&mut headers);
+        handler.substitute_http2_headers(&mut headers, is_initial_request);
         let encoded = self.encode_headers(&headers)?;
         append_http2_header_frames(output, block.stream_id, block.end_stream, &encoded)?;
         if block.end_stream {
@@ -1865,6 +1918,166 @@ fn is_authorization_header(line: &str) -> bool {
     line.as_bytes()
         .get(..14)
         .is_some_and(|b| b.eq_ignore_ascii_case(b"authorization:"))
+}
+
+/// Return the exact credential byte range for one eligible provider-neutral
+/// HTTP/1 exact-header rule.
+///
+/// Eligibility requires a valid HTTP/1 request line and exactly one
+/// matching field. The field value may start with SP/HTAB, then must contain
+/// the configured optional scheme, exactly one SP when a scheme is present,
+/// and the complete placeholder.
+fn exact_header_http1_credential_range(
+    headers: &[u8],
+    placeholder: &[u8],
+    rules: &[SecretExactHeader],
+) -> Option<Range<usize>> {
+    if placeholder.is_empty() || rules.is_empty() {
+        return None;
+    }
+
+    let request_line_end = headers.windows(2).position(|window| window == b"\r\n")?;
+    let request_line = std::str::from_utf8(&headers[..request_line_end]).ok()?;
+    let version = http_request_version(request_line)?;
+    if !version.starts_with("HTTP/1.") {
+        return None;
+    }
+
+    let mut unique_range = None;
+    for rule in rules {
+        let mut cursor = request_line_end + 2;
+        let mut matching_header_count = 0usize;
+        let mut rule_range = None;
+        let mut previous_was_matching_header = false;
+
+        while cursor < headers.len() {
+            let line_end = headers[cursor..]
+                .windows(2)
+                .position(|window| window == b"\r\n")
+                .map(|offset| cursor + offset)?;
+            if line_end == cursor {
+                break;
+            }
+
+            let line = &headers[cursor..line_end];
+            if line
+                .first()
+                .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+            {
+                if previous_was_matching_header {
+                    rule_range = None;
+                    matching_header_count = 2;
+                    break;
+                }
+                cursor = line_end + 2;
+                continue;
+            }
+
+            previous_was_matching_header = false;
+            if let Some(colon) = line.iter().position(|byte| *byte == b':')
+                && line[..colon].eq_ignore_ascii_case(rule.name.as_bytes())
+            {
+                previous_was_matching_header = true;
+                matching_header_count += 1;
+                if matching_header_count > 1 {
+                    rule_range = None;
+                    break;
+                }
+
+                let value_start = cursor + colon + 1;
+                rule_range = exact_header_credential_start(
+                    &headers[value_start..line_end],
+                    placeholder,
+                    rule.scheme.as_deref(),
+                )
+                .map(|relative| value_start + relative..line_end);
+            }
+
+            cursor = line_end + 2;
+        }
+
+        if matching_header_count == 1
+            && let Some(range) = rule_range
+        {
+            if unique_range.is_some() {
+                return None;
+            }
+            unique_range = Some(range);
+        }
+    }
+
+    unique_range
+}
+
+/// Return the unique HTTP/2 field index whose name and complete credential
+/// match one configured exact-header rule.
+fn exact_header_http2_header_index(
+    headers: &[(Vec<u8>, Vec<u8>)],
+    placeholder: &[u8],
+    rules: &[SecretExactHeader],
+) -> Option<usize> {
+    let mut unique_index = None;
+
+    for rule in rules {
+        let mut matching_header_count = 0usize;
+        let mut rule_index = None;
+        for (index, (name, value)) in headers.iter().enumerate() {
+            if !name.eq_ignore_ascii_case(rule.name.as_bytes()) {
+                continue;
+            }
+            matching_header_count += 1;
+            if matching_header_count > 1 {
+                rule_index = None;
+                break;
+            }
+            if exact_header_credential_start(value, placeholder, rule.scheme.as_deref()).is_some() {
+                rule_index = Some(index);
+            }
+        }
+        if matching_header_count == 1
+            && let Some(index) = rule_index
+        {
+            if unique_index.is_some() {
+                return None;
+            }
+            unique_index = Some(index);
+        }
+    }
+
+    unique_index
+}
+
+/// Return the offset where an exact credential starts in a header value,
+/// after optional leading SP/HTAB and an optional scheme plus one SP.
+fn exact_header_credential_start(
+    value: &[u8],
+    placeholder: &[u8],
+    scheme: Option<&str>,
+) -> Option<usize> {
+    if placeholder.is_empty() {
+        return None;
+    }
+
+    let leading = value
+        .iter()
+        .take_while(|byte| matches!(byte, b' ' | b'\t'))
+        .count();
+    let value = &value[leading..];
+    let credential_start = if let Some(scheme) = scheme {
+        let scheme_len = scheme.len();
+        if !value
+            .get(..scheme_len)?
+            .eq_ignore_ascii_case(scheme.as_bytes())
+            || value.get(scheme_len) != Some(&b' ')
+        {
+            return None;
+        }
+        scheme_len + 1
+    } else {
+        0
+    };
+    let credential = value.get(credential_start..)?;
+    (credential == placeholder).then_some(leading + credential_start)
 }
 
 fn is_http2_preface_prefix(data: &[u8]) -> bool {
@@ -3096,6 +3309,20 @@ mod tests {
         SecretInjection {
             headers: false,
             basic_auth: true,
+            exact_headers: Vec::new(),
+            query_params: false,
+            body: false,
+        }
+    }
+
+    fn exact_bearer_header_only() -> SecretInjection {
+        SecretInjection {
+            headers: false,
+            basic_auth: false,
+            exact_headers: vec![SecretExactHeader {
+                name: "Authorization".into(),
+                scheme: Some("Bearer".into()),
+            }],
             query_params: false,
             body: false,
         }
@@ -4015,7 +4242,7 @@ mod tests {
         let config = make_config(vec![secret]);
         let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
 
-        // basic_auth only handles Basic credentials; Bearer needs inject_headers.
+        // Basic-only placement does not handle Bearer or arbitrary headers.
         let input = b"GET / HTTP/1.1\r\nAuthorization: Bearer $KEY\r\nX-Custom: $KEY\r\n\r\n";
         let output = handler.substitute(input).unwrap();
         let result = String::from_utf8(output.into_owned()).unwrap();
@@ -4069,6 +4296,7 @@ mod tests {
         secret.injection = SecretInjection {
             headers: false,
             basic_auth: false,
+            exact_headers: Vec::new(),
             query_params: false,
             body: false,
         };
@@ -4083,11 +4311,138 @@ mod tests {
     }
 
     #[test]
+    fn exact_bearer_header_substitutes_singleton_http1_header() {
+        let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+        secret.injection = exact_bearer_header_only();
+        let config = make_config(vec![secret]);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
+
+        let input =
+            b"GET / HTTP/1.1\r\nHost: api.openai.com\r\naUtHoRiZaTiOn:\t BeArEr $KEY\r\nX-Other: $KEY\r\n\r\n";
+        let output = handler.substitute(input).unwrap().into_owned();
+        let output = String::from_utf8(output).unwrap();
+
+        assert!(output.contains("aUtHoRiZaTiOn:\t BeArEr real-secret"));
+        assert!(output.contains("X-Other: $KEY"));
+    }
+
+    #[test]
+    fn exact_header_only_is_not_hardwired_to_authorization_or_bearer() {
+        let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+        secret.injection = SecretInjection {
+            headers: false,
+            basic_auth: false,
+            exact_headers: vec![
+                SecretExactHeader {
+                    name: "X-Api-Key".into(),
+                    scheme: None,
+                },
+                SecretExactHeader {
+                    name: "Proxy-Authorization".into(),
+                    scheme: Some("Token".into()),
+                },
+            ],
+            query_params: false,
+            body: false,
+        };
+        let config = make_config(vec![secret]);
+
+        for (header, expected) in [
+            ("X-Api-Key:\t $KEY", "X-Api-Key:\t real-secret"),
+            (
+                "Proxy-Authorization: tOkEn $KEY",
+                "Proxy-Authorization: tOkEn real-secret",
+            ),
+        ] {
+            let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
+            let input = format!("GET / HTTP/1.1\r\n{header}\r\n\r\n");
+            let output = handler.substitute(input.as_bytes()).unwrap().into_owned();
+            assert!(String::from_utf8(output).unwrap().contains(expected));
+        }
+    }
+
+    #[test]
+    fn exact_bearer_header_rejects_malformed_and_wrong_http1_placements() {
+        let rejected = [
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nX-Token: $KEY\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Basic $KEY\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer,$KEY\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer$KEY\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer  $KEY\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer\t$KEY\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer $KEY \r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer prefix$KEY\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer $KEYsuffix\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer $KEY,other\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer $KEY\r\nAuthorization: Bearer $KEY\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer $KEY\r\n continued\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer $KEY\r\n\tcontinued\r\n\r\n",
+            "Authorization: Bearer $KEY\r\n\r\n",
+        ];
+
+        for input in rejected {
+            let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+            secret.injection = exact_bearer_header_only();
+            let config = make_config(vec![secret]);
+            let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
+            let output = handler.substitute(input.as_bytes()).unwrap().into_owned();
+
+            assert!(
+                !contains_bytes(&output, b"real-secret"),
+                "unexpected substitution for {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn exact_bearer_header_never_substitutes_http1_trailers() {
+        let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+        secret.injection = exact_bearer_header_only();
+        let config = make_config(vec![secret]);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let input = b"POST / HTTP/1.1\r\nHost: api.openai.com\r\nTransfer-Encoding: chunked\r\nTrailer: Authorization\r\n\r\n0\r\nAuthorization: Bearer $KEY\r\n\r\n";
+
+        let output = handler.substitute(input).unwrap().into_owned();
+
+        assert!(!contains_bytes(&output, b"real-secret"));
+        assert!(contains_bytes(&output, b"Authorization: Bearer $KEY"));
+    }
+
+    #[test]
+    fn exact_bearer_header_requires_tls_identity() {
+        let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+        secret.injection = exact_bearer_header_only();
+        let config = make_config(vec![secret]);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", false);
+        let input = b"GET / HTTP/1.1\r\nAuthorization: Bearer $KEY\r\n\r\n";
+
+        let output = handler.substitute(input).unwrap().into_owned();
+
+        assert!(!contains_bytes(&output, b"real-secret"));
+        assert!(contains_bytes(&output, b"Authorization: Bearer $KEY"));
+    }
+
+    #[test]
+    fn exact_bearer_header_rejects_disallowed_destination() {
+        let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+        secret.injection = exact_bearer_header_only();
+        let config = make_config(vec![secret]);
+        let mut handler = SecretsHandler::new(&config, "evil.example", true);
+        let input = b"GET / HTTP/1.1\r\nAuthorization: Bearer $KEY\r\n\r\n";
+
+        assert_eq!(
+            handler.substitute(input).unwrap_err(),
+            ViolationAction::Block
+        );
+    }
+
+    #[test]
     fn query_params_substitution() {
         let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
         secret.injection = SecretInjection {
             headers: false,
             basic_auth: false,
+            exact_headers: Vec::new(),
             query_params: true,
             body: false,
         };
@@ -4108,6 +4463,7 @@ mod tests {
         secret.injection = SecretInjection {
             headers: false,
             basic_auth: false,
+            exact_headers: Vec::new(),
             query_params: true,
             body: false,
         };
@@ -4362,7 +4718,7 @@ mod tests {
     #[test]
     fn header_only_secret_does_not_leak_into_body_continuation_chunk() {
         // Security regression: a secret with the default injection scopes
-        // (inject_headers=true, inject_body=false) must NOT substitute its
+        // (headers=any, inject_body=false) must NOT substitute its
         // placeholder when the placeholder appears in body bytes. Without
         // the framing fix, a body-continuation chunk was parsed as headers
         // and run through `substitute_in_headers`, which replaces the
@@ -4901,6 +5257,196 @@ mod tests {
     }
 
     #[test]
+    fn exact_bearer_header_substitutes_singleton_http2_header() {
+        let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+        secret.injection = exact_bearer_header_only();
+        let config = make_config(vec![secret]);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let request = h2_request(
+            &[
+                (b":method", b"GET"),
+                (b":scheme", b"https"),
+                (b":authority", b"api.openai.com"),
+                (b":path", b"/"),
+                (b"AuThOrIzAtIoN", b"\t BeArEr $KEY"),
+                (b"x-other", b"$KEY"),
+            ],
+            true,
+        );
+
+        let output = handler.substitute(&request).unwrap().into_owned();
+        let headers = decode_first_h2_headers(&output);
+
+        assert_eq!(
+            h2_header_value(&headers, b"authorization"),
+            "\t BeArEr real-secret"
+        );
+        assert_eq!(h2_header_value(&headers, b"x-other"), "$KEY");
+    }
+
+    #[test]
+    fn exact_bearer_header_rejects_malformed_and_duplicate_http2_headers() {
+        let rejected: &[&[(&[u8], &[u8])]] = &[
+            &[(b"x-token", b"$KEY")],
+            &[(b"authorization", b"Basic $KEY")],
+            &[(b"authorization", b"Bearer,$KEY")],
+            &[(b"authorization", b"Bearer$KEY")],
+            &[(b"authorization", b"Bearer  $KEY")],
+            &[(b"authorization", b"Bearer\t$KEY")],
+            &[(b"authorization", b"Bearer $KEY ")],
+            &[(b"authorization", b"Bearer prefix$KEY")],
+            &[(b"authorization", b"Bearer $KEYsuffix")],
+            &[(b"authorization", b"Bearer $KEY,other")],
+            &[
+                (b"authorization", b"Bearer $KEY"),
+                (b"Authorization", b"Bearer $KEY"),
+            ],
+            &[(b"authorization", b"Bearer $KEY\x7f")],
+        ];
+
+        for extra in rejected {
+            let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+            secret.injection = exact_bearer_header_only();
+            let config = make_config(vec![secret]);
+            let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
+            let mut headers: Vec<(&[u8], &[u8])> = vec![
+                (b":method", b"GET"),
+                (b":scheme", b"https"),
+                (b":authority", b"api.openai.com"),
+                (b":path", b"/"),
+            ];
+            headers.extend_from_slice(extra);
+            let request = h2_request(&headers, true);
+            let output = handler.substitute(&request).unwrap().into_owned();
+            let decoded = decode_first_h2_headers(&output);
+
+            assert!(
+                decoded
+                    .iter()
+                    .all(|(_, value)| !contains_bytes(value, b"real-secret")),
+                "unexpected substitution for {extra:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn exact_bearer_header_never_substitutes_http2_trailing_headers() {
+        let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+        secret.injection = exact_bearer_header_only();
+        let config = make_config(vec![secret]);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let request = h2_request(
+            &[
+                (b":method", b"POST"),
+                (b":scheme", b"https"),
+                (b":authority", b"api.openai.com"),
+                (b":path", b"/"),
+            ],
+            false,
+        );
+        handler.substitute(&request).unwrap();
+
+        let mut trailers = Vec::new();
+        append_h2_headers(
+            &mut trailers,
+            1,
+            &[(b"authorization", b"Bearer $KEY")],
+            true,
+        );
+        let output = handler.substitute(&trailers).unwrap().into_owned();
+        let mut framed = HTTP2_PREFACE.to_vec();
+        framed.extend_from_slice(&output);
+        let headers = decode_first_h2_headers(&framed);
+
+        assert_eq!(h2_header_value(&headers, b"authorization"), "Bearer $KEY");
+    }
+
+    #[test]
+    fn exact_bearer_header_rejects_reused_http2_stream_after_headers_end_stream() {
+        let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+        secret.injection = exact_bearer_header_only();
+        let config = make_config(vec![secret]);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let request = h2_request(
+            &[
+                (b":method", b"GET"),
+                (b":scheme", b"https"),
+                (b":authority", b"api.openai.com"),
+                (b":path", b"/first"),
+            ],
+            true,
+        );
+        handler.substitute(&request).unwrap();
+
+        let mut reused = Vec::new();
+        append_h2_headers(
+            &mut reused,
+            1,
+            &[
+                (b":method", b"GET"),
+                (b":scheme", b"https"),
+                (b":authority", b"api.openai.com"),
+                (b":path", b"/reused"),
+                (b"authorization", b"Bearer $KEY"),
+            ],
+            true,
+        );
+
+        assert_eq!(
+            handler.substitute(&reused).unwrap_err(),
+            ViolationAction::Block
+        );
+    }
+
+    #[test]
+    fn exact_bearer_header_rejects_reused_http2_stream_after_data_end_stream() {
+        let mut secret = make_secret("$KEY", "real-secret", "api.openai.com");
+        secret.injection = exact_bearer_header_only();
+        let config = make_config(vec![secret]);
+        let mut handler = SecretsHandler::new(&config, "api.openai.com", true);
+        let request = h2_request(
+            &[
+                (b":method", b"POST"),
+                (b":scheme", b"https"),
+                (b":authority", b"api.openai.com"),
+                (b":path", b"/first"),
+            ],
+            false,
+        );
+        handler.substitute(&request).unwrap();
+
+        let mut completed = Vec::new();
+        append_http2_frame(
+            &mut completed,
+            HTTP2_FRAME_DATA,
+            HTTP2_FLAG_END_STREAM,
+            1,
+            b"",
+        )
+        .unwrap();
+        handler.substitute(&completed).unwrap();
+
+        let mut reused = Vec::new();
+        append_h2_headers(
+            &mut reused,
+            1,
+            &[
+                (b":method", b"GET"),
+                (b":scheme", b"https"),
+                (b":authority", b"api.openai.com"),
+                (b":path", b"/reused"),
+                (b"authorization", b"Bearer $KEY"),
+            ],
+            true,
+        );
+
+        assert_eq!(
+            handler.substitute(&reused).unwrap_err(),
+            ViolationAction::Block
+        );
+    }
+
+    #[test]
     fn tls_intercepted_http2_preface_can_span_tls_reads() {
         let ip = Ipv4Addr::new(203, 0, 113, 38);
         let shared = SharedState::new(16);
@@ -4939,6 +5485,7 @@ mod tests {
         secret.injection = SecretInjection {
             headers: false,
             basic_auth: true,
+            exact_headers: Vec::new(),
             query_params: true,
             body: false,
         };

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -60,6 +60,7 @@ Common flags:
 | `--net` | Add a high-level network profile (`public`, `private`, `host`, `all`, or `none`) |
 | `--net-rule` | Add a network policy rule |
 | `--secret` | Inject a host-held secret for an allowed destination |
+| `--secret-exact-header` | Inject a host-held secret only as an exact request-header credential (`ENV@HOST;header=NAME[;scheme=SCHEME]`) |
 | `--tmpfs` | Mount an in-memory filesystem |
 | `--copy`, `--copy-file`, `--copy-dir`, `--mkdir`, `--rm` | Patch the rootfs before boot |
 

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -27,8 +27,6 @@ let sb = Sandbox::builder("worker")
         .value(std::env::var("GITHUB_TOKEN")?)
         .allow_host("api.github.com")
         .allow_host_pattern("*.githubusercontent.com")
-        .inject_headers(false)
-        .inject_basic_auth(false)
         .exact_header("Authorization", Some("Bearer".into()))
     )
     .secret_env("SERVICE_API_KEY", service_api_key, "api.example.com")
@@ -46,8 +44,6 @@ await using sb = await Sandbox.builder("worker")
             .value(process.env.GITHUB_TOKEN!)
             .allowHost("api.github.com")
             .allowHostPattern("*.githubusercontent.com")
-            .injectHeaders(false)
-            .injectBasicAuth(false)
             .exactHeader("Authorization", "Bearer"),
     )
     .secretEnv("SERVICE_API_KEY", process.env.SERVICE_API_KEY!, "api.example.com")
@@ -124,9 +120,11 @@ authority from reflecting a correctly placed request header, and it does
 not restrict request methods or paths. Keep the allowed authority trustworthy
 and its host list narrow.
 
-The new `exact_headers` list is additive. Existing serialized configurations
-still default `headers` and `basic_auth` to `true`, exactly as before. Strict
-exact-header-only configurations explicitly set both legacy flags to `false`.
+The low-level `exact_headers` list is additive. Existing serialized
+configurations still default `headers` and `basic_auth` to `true`, exactly as
+before. The Rust/Node `exact_header`/`exactHeader` helpers and the Python/Go
+exact-header factories disable both legacy modes for an exact-header-only
+secret.
 
 <Warning>
   **Raw values are saved to disk.** When you pass a raw value through an SDK (`.value(..)`, `secret_env()`, or a value-based rotate), it is stored as-is in the sandbox config file and stays there until you rotate the secret to a reference. The sandbox behaves the same either way; the only difference is what ends up on disk. Prefer references whenever the value is available in a host environment variable.

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -27,6 +27,9 @@ let sb = Sandbox::builder("worker")
         .value(std::env::var("GITHUB_TOKEN")?)
         .allow_host("api.github.com")
         .allow_host_pattern("*.githubusercontent.com")
+        .inject_headers(false)
+        .inject_basic_auth(false)
+        .exact_header("Authorization", Some("Bearer".into()))
     )
     .secret_env("SERVICE_API_KEY", service_api_key, "api.example.com")
     .create()
@@ -42,7 +45,10 @@ await using sb = await Sandbox.builder("worker")
         s.env("GITHUB_TOKEN")
             .value(process.env.GITHUB_TOKEN!)
             .allowHost("api.github.com")
-            .allowHostPattern("*.githubusercontent.com"),
+            .allowHostPattern("*.githubusercontent.com")
+            .injectHeaders(false)
+            .injectBasicAuth(false)
+            .exactHeader("Authorization", "Bearer"),
     )
     .secretEnv("SERVICE_API_KEY", process.env.SERVICE_API_KEY!, "api.example.com")
     .create();
@@ -56,9 +62,11 @@ sb = await Sandbox.create(
     "worker",
     image="python",
     secrets=[
-        Secret.env(
+        Secret.exact_header(
             "GITHUB_TOKEN",
             value=os.environ["GITHUB_TOKEN"],
+            header="Authorization",
+            scheme="Bearer",
             allow_hosts=["api.github.com"],
             allow_host_patterns=["*.githubusercontent.com"],
         ),
@@ -75,7 +83,8 @@ sb = await Sandbox.create(
 sb, err := m.CreateSandbox(ctx, "worker",
     m.WithImage("python"),
     m.WithSecrets(
-        m.Secret.Env("GITHUB_TOKEN", os.Getenv("GITHUB_TOKEN"),
+        m.Secret.ExactHeader("GITHUB_TOKEN", os.Getenv("GITHUB_TOKEN"),
+            "Authorization", "Bearer",
             m.SecretEnvOptions{
                 AllowHosts:        []string{"api.github.com"},
                 AllowHostPatterns: []string{"*.githubusercontent.com"},
@@ -90,13 +99,34 @@ sb, err := m.CreateSandbox(ctx, "worker",
 
 ```bash CLI
 msb create python --name worker \
-  --secret "GITHUB_TOKEN@api.github.com,*.githubusercontent.com" \
+  --secret-exact-header \
+    "GITHUB_TOKEN@api.github.com,*.githubusercontent.com;header=Authorization;scheme=Bearer" \
   --secret "SERVICE_API_KEY@api.example.com"
 ```
 
 </CodeGroup>
 
-In the CLI form, `ENV@HOST[,HOST...]` records a host-side source reference: the real value is read from the same-named host environment variable when the sandbox starts, and never lands in the durable config. The inline `ENV=VALUE@HOST` form is rejected on both `msb create` and `msb modify` — shell history and process listings would leak the value regardless — so providing a raw value is SDK-only.
+In the CLI form, `ENV@HOST[,HOST...]` records a host-side source reference: the real value is read from the same-named host environment variable when the sandbox starts, and never lands in the durable config. Existing `--secret` behavior remains unchanged. Use `--secret-exact-header 'ENV@HOST;header=NAME[;scheme=SCHEME]'` when a credential must occupy one exact initial request header. Declare each environment name once and put multiple hosts in its comma-separated host list. The inline `ENV=VALUE@HOST` form is rejected on both `msb create` and `msb modify` — shell history and process listings would leak the value regardless — so providing a raw value is SDK-only.
+
+## Exact-header placement
+
+Exact-header placement is provider-neutral. A rule supplies a field `name` and
+an optional authentication `scheme`. Substitution happens only when the initial
+HTTP/1.1 or HTTP/2 request has exactly one matching field whose complete value
+is `[scheme SP]<placeholder>` (apart from leading SP/HTAB and ASCII case for the
+field name and scheme). It never substitutes into another field, malformed or
+combined credentials, duplicate target fields, request trailers, query strings,
+or bodies unless those legacy scopes are enabled explicitly.
+
+This prevents a guest from moving the placeholder into an arbitrary header and
+having the real credential placed there. It does not prevent the allowed
+authority from reflecting a correctly placed request header, and it does
+not restrict request methods or paths. Keep the allowed authority trustworthy
+and its host list narrow.
+
+The new `exact_headers` list is additive. Existing serialized configurations
+still default `headers` and `basic_auth` to `true`, exactly as before. Strict
+exact-header-only configurations explicitly set both legacy flags to `false`.
 
 <Warning>
   **Raw values are saved to disk.** When you pass a raw value through an SDK (`.value(..)`, `secret_env()`, or a value-based rotate), it is stored as-is in the sandbox config file and stays there until you rotate the secret to a reference. The sandbox behaves the same either way; the only difference is what ends up on disk. Prefer references whenever the value is available in a host environment variable.
@@ -122,6 +152,10 @@ msb modify worker --secret GITHUB_TOKEN@api.github.com   # add or rotate
 msb modify worker --secret-rm SERVICE_API_KEY            # remove
 ```
 </CodeGroup>
+
+`msb modify --secret` changes material and hosts without changing an existing
+secret's header placement. There is intentionally no `modify
+--secret-exact-header`; choose the placement when the sandbox is created.
 
 Secret changes through modify are Rust-SDK and CLI only for now. See [Tuning](/sandboxes/tuning) for how changes are planned and applied.
 

--- a/docs/sdk/go/secrets.mdx
+++ b/docs/sdk/go/secrets.mdx
@@ -105,6 +105,10 @@ m.Secret.Env("STRIPE_KEY", os.Getenv("STRIPE_KEY"),
 
 Build a [`SecretEntry`](#secretentrystruct) that maps an environment variable to a real value. The guest sees a placeholder; the real value is substituted by the TLS proxy only when traffic goes to an allowed host. Pass an empty [`SecretEnvOptions`](#secretenvoptionsstruct)`{}` when no extra tuning is needed.
 
+`Secret.ExactHeader(envVar, value, name, scheme, opts)` creates a
+provider-neutral exact-header-only secret. Use an empty `scheme` when the
+complete field value is the placeholder.
+
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
@@ -147,6 +151,9 @@ A single credential the network proxy substitutes at the transport layer. The va
 | `AllowHostPatterns` | `[]string` | Wildcard host patterns, e.g. `"*.openai.com"` |
 | `Placeholder` | `string` | Custom placeholder shown inside the sandbox in place of the secret. Auto-generated from `EnvVar` when empty. Custom values must be non-empty, at most 1024 bytes, and cannot contain NUL, CR, or LF |
 | `RequireTLS` | `*bool` | Require a verified TLS identity before substituting. Defaults to `true` when `nil` |
+| `InjectHeaders` | `*bool` | Broad literal request-header substitution; `nil` preserves the existing default (`true`) |
+| `InjectBasicAuth` | `*bool` | Decoded HTTP Basic Auth substitution; `nil` preserves the existing default (`true`) |
+| `ExactHeaders` | `[]SecretExactHeader` | Provider-neutral exact request-header rules |
 | `OnViolation` | [`ViolationAction`](#violationactionstring-enum) | Override the sandbox-wide action when this secret is detected going to a disallowed host. The last non-empty value across all secrets wins, since the runtime applies it network-wide |
 
 ### SecretEnvOptions<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
@@ -161,7 +168,21 @@ Tunes [`Secret.Env`](#secret-env) beyond the required `envVar` and `value`.
 | `AllowHostPatterns` | `[]string` | Wildcard host patterns |
 | `Placeholder` | `string` | Custom placeholder: non-empty, up to 1024 bytes, no NUL/CR/LF |
 | `RequireTLS` | `*bool` | Require a verified TLS identity before substituting. Defaults to `true` when `nil` |
+| `InjectHeaders` | `*bool` | Broad literal request-header substitution; `nil` preserves the existing default |
+| `InjectBasicAuth` | `*bool` | Decoded Basic Auth substitution; `nil` preserves the existing default |
+| `ExactHeaders` | `[]SecretExactHeader` | Provider-neutral exact request-header rules |
 | `OnViolation` | [`ViolationAction`](#violationactionstring-enum) | Per-secret violation action |
+
+### SecretExactHeader<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Name` | `string` | HTTP field name, compared ASCII case-insensitively |
+| `Scheme` | `string` | Optional authentication scheme, compared ASCII case-insensitively |
+
+Exact-header placement prevents wrong-field substitution. It does not restrict
+methods or paths, scan responses, or prevent an allowed authority from
+reflecting a correctly placed request-header value.
 
 ### ViolationAction<span className="msb-tag is-type" style={{marginLeft: "8px"}}>string enum</span>
 

--- a/docs/sdk/go/secrets.mdx
+++ b/docs/sdk/go/secrets.mdx
@@ -105,10 +105,6 @@ m.Secret.Env("STRIPE_KEY", os.Getenv("STRIPE_KEY"),
 
 Build a [`SecretEntry`](#secretentrystruct) that maps an environment variable to a real value. The guest sees a placeholder; the real value is substituted by the TLS proxy only when traffic goes to an allowed host. Pass an empty [`SecretEnvOptions`](#secretenvoptionsstruct)`{}` when no extra tuning is needed.
 
-`Secret.ExactHeader(envVar, value, name, scheme, opts)` creates a
-provider-neutral exact-header-only secret. Use an empty `scheme` when the
-complete field value is the placeholder.
-
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
@@ -135,6 +131,52 @@ complete field value is the placeholder.
   </div>
 </div>
 
+#### <span className="msb-recv">Secret.</span><span className="msb-hn">ExactHeader()</span>
+
+```go
+func (secretFactory) ExactHeader(
+    envVar, value, name, scheme string,
+    opts SecretEnvOptions,
+) SecretEntry
+```
+
+Create a secret restricted to one provider-neutral exact request-header rule.
+The factory overrides `opts.InjectHeaders`, `opts.InjectBasicAuth`, and
+`opts.ExactHeaders` to disable the broad modes and install the specified rule.
+The target field must occur once in the initial request and its complete value
+must be `[scheme SP]<placeholder>`.
+
+`name` and a non-empty `scheme` must each be a valid HTTP token: ASCII letters,
+digits, or one of ``!#$%&'*+-.^_`|~``. The factory does not validate them
+locally; `CreateSandbox` returns a secret-configuration error for an invalid
+name or scheme. Pass an empty `scheme` when the placeholder is the complete
+field value. The remaining `opts` fields retain their ordinary meaning.
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>envVar</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Environment variable holding the placeholder inside the sandbox.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Real secret value.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Exact HTTP field name, compared ASCII case-insensitively.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>scheme</code><span className="msb-type">string</span></div>
+    <div className="msb-param-desc">Optional authentication scheme. Empty means no scheme.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#secretenvoptionsstruct">SecretEnvOptions</a></div>
+    <div className="msb-param-desc">Allowed hosts, placeholder, TLS, and violation settings.</div>
+  </div>
+</div>
+
 ## Types
 
 ### SecretEntry<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
@@ -153,7 +195,7 @@ A single credential the network proxy substitutes at the transport layer. The va
 | `RequireTLS` | `*bool` | Require a verified TLS identity before substituting. Defaults to `true` when `nil` |
 | `InjectHeaders` | `*bool` | Broad literal request-header substitution; `nil` preserves the existing default (`true`) |
 | `InjectBasicAuth` | `*bool` | Decoded HTTP Basic Auth substitution; `nil` preserves the existing default (`true`) |
-| `ExactHeaders` | `[]SecretExactHeader` | Provider-neutral exact request-header rules |
+| `ExactHeaders` | `[]SecretExactHeader` | Additive provider-neutral exact request-header rules. Setting this field directly does not change `InjectHeaders` or `InjectBasicAuth` |
 | `OnViolation` | [`ViolationAction`](#violationactionstring-enum) | Override the sandbox-wide action when this secret is detected going to a disallowed host. The last non-empty value across all secrets wins, since the runtime applies it network-wide |
 
 ### SecretEnvOptions<span className="msb-tag is-type" style={{marginLeft: "8px"}}>struct</span>
@@ -179,6 +221,10 @@ Tunes [`Secret.Env`](#secret-env) beyond the required `envVar` and `value`.
 |-------|------|-------------|
 | `Name` | `string` | HTTP field name, compared ASCII case-insensitively |
 | `Scheme` | `string` | Optional authentication scheme, compared ASCII case-insensitively |
+
+Both fields use HTTP-token syntax when non-empty. Invalid names or schemes are
+reported by `CreateSandbox`; constructing the Go struct alone does not validate
+them.
 
 Exact-header placement prevents wrong-field substitution. It does not restrict
 methods or paths, scan responses, or prevent an allowed authority from

--- a/docs/sdk/python/secrets.mdx
+++ b/docs/sdk/python/secrets.mdx
@@ -27,6 +27,13 @@ sb = await Sandbox.create(
 
 ## Factory methods
 
+#### <span className="msb-recv">Secret.</span><span className="msb-hn">exact_header()</span>
+
+`Secret.exact_header(...)` accepts the same value, host, placeholder, TLS, and
+violation arguments as `Secret.env(...)`, plus a field `header` and optional
+authentication `scheme`. It disables the two legacy broad header modes and
+adds one provider-neutral exact request-header rule.
+
 #### <span className="msb-recv">Secret.</span><span className="msb-hn">env()</span>
 
 ```python
@@ -251,10 +258,22 @@ Controls where in the HTTP request the secret value can be substituted.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| headers | `bool` | `True` | Substitute the placeholder anywhere it appears in the headers. |
-| basic_auth | `bool` | `True` | Decode `Authorization: Basic <base64>` credentials, substitute the placeholder in the decoded `user:password`, and re-encode. Other schemes (`Bearer`, `Digest`) are handled by `headers`. |
+| headers | `bool` | `True` | Broad literal request-header substitution. |
+| basic_auth | `bool` | `True` | Decoded HTTP Basic Auth substitution. |
+| exact_headers | `tuple[SecretExactHeader, ...]` | `()` | Provider-neutral exact request-header rules. |
 | query_params | `bool` | `False` | Substitute in the request line's query string. |
 | body | `bool` | `False` | Substitute in request bodies when microsandbox can inspect and rewrite them safely. Encoded bodies are forwarded unchanged, and body placeholders in unsupported body formats are blocked instead of being leaked. |
+
+### SecretExactHeader
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `str` | HTTP field name, compared ASCII case-insensitively. |
+| `scheme` | `str \| None` | Optional authentication scheme, compared ASCII case-insensitively. |
+
+Exact-header placement prevents wrong-field substitution, but it does not
+restrict methods or paths, scan responses, or prevent an allowed authority
+from reflecting a correctly placed request-header value.
 
 ### ViolationAction
 

--- a/docs/sdk/python/secrets.mdx
+++ b/docs/sdk/python/secrets.mdx
@@ -29,10 +29,54 @@ sb = await Sandbox.create(
 
 #### <span className="msb-recv">Secret.</span><span className="msb-hn">exact_header()</span>
 
-`Secret.exact_header(...)` accepts the same value, host, placeholder, TLS, and
-violation arguments as `Secret.env(...)`, plus a field `header` and optional
-authentication `scheme`. It disables the two legacy broad header modes and
-adds one provider-neutral exact request-header rule.
+```python
+@staticmethod
+def exact_header(
+    env_var: str,
+    *,
+    value: str,
+    header: str,
+    scheme: str | None = None,
+    allow_hosts: Sequence[str] = (),
+    allow_host_patterns: Sequence[str] = (),
+    placeholder: str | None = None,
+    require_tls: bool = True,
+    on_violation: ViolationAction | ViolationPolicy = ViolationAction.BLOCK_AND_LOG,
+) -> SecretEntry
+```
+
+Create a secret restricted to one provider-neutral exact request-header rule.
+The factory disables broad header and decoded Basic Auth substitution. The
+target field must occur once in the initial request and its complete value
+must be `[scheme SP]<placeholder>`.
+
+`header` and a present `scheme` must each be a non-empty HTTP token: ASCII
+letters, digits, or one of ``!#$%&'*+-.^_`|~``. The factory does not perform
+that validation locally; sandbox creation fails with a secret-configuration
+error if either value is invalid. An omitted `scheme` requires the placeholder
+to be the complete field value. All other arguments have the same meaning and
+defaults as [`Secret.env()`](#secret-env).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>env_var</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Environment variable holding the placeholder inside the sandbox.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>value</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Real secret value. Keyword-only and required.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>header</code><span className="msb-type">str</span></div>
+    <div className="msb-param-desc">Exact HTTP field name, compared ASCII case-insensitively. Keyword-only and required.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>scheme</code><span className="msb-type">str | None</span></div>
+    <div className="msb-param-desc">Optional authentication scheme, compared ASCII case-insensitively. Default <code>None</code>.</div>
+  </div>
+</div>
 
 #### <span className="msb-recv">Secret.</span><span className="msb-hn">env()</span>
 
@@ -260,7 +304,7 @@ Controls where in the HTTP request the secret value can be substituted.
 |-------|------|---------|-------------|
 | headers | `bool` | `True` | Broad literal request-header substitution. |
 | basic_auth | `bool` | `True` | Decoded HTTP Basic Auth substitution. |
-| exact_headers | `tuple[SecretExactHeader, ...]` | `()` | Provider-neutral exact request-header rules. |
+| exact_headers | `tuple[SecretExactHeader, ...]` | `()` | Additive provider-neutral exact request-header rules. Setting this field directly does not change `headers` or `basic_auth`. |
 | query_params | `bool` | `False` | Substitute in the request line's query string. |
 | body | `bool` | `False` | Substitute in request bodies when microsandbox can inspect and rewrite them safely. Encoded bodies are forwarded unchanged, and body placeholders in unsupported body formats are blocked instead of being leaked. |
 
@@ -270,6 +314,10 @@ Controls where in the HTTP request the secret value can be substituted.
 |-------|------|-------------|
 | `name` | `str` | HTTP field name, compared ASCII case-insensitively. |
 | `scheme` | `str \| None` | Optional authentication scheme, compared ASCII case-insensitively. |
+
+Both fields use HTTP-token syntax when present. Invalid names or schemes are
+rejected during sandbox creation; constructing the Python dataclass alone does
+not validate them.
 
 Exact-header placement prevents wrong-field substitution, but it does not
 restrict methods or paths, scan responses, or prevent an allowed authority

--- a/docs/sdk/rust/secrets.mdx
+++ b/docs/sdk/rust/secrets.mdx
@@ -46,7 +46,7 @@ let entry = SecretBuilder::new()
 
 </Accordion>
 
-Start building a secret with defaults: no env var, no value, no allowed hosts, the default [`SecretInjection`](#secretinjection) (headers and Basic Auth on, query and body off), no per-secret violation override, and `require_tls_identity = true`. You rarely call this yourself: [`SandboxBuilder::secret(|s| s...)`](/sdk/rust/sandbox#secret) hands you a fresh builder and calls [`build()`](#build) for you. `SecretBuilder::default()` is equivalent.
+Start building a secret with defaults: no env var, no value, no allowed hosts, the default [`SecretInjection`](#secretinjection) (legacy header and Basic Auth substitution on; exact headers, query, and body off), no per-secret violation override, and `require_tls_identity = true`. You rarely call this yourself: [`SandboxBuilder::secret(|s| s...)`](/sdk/rust/sandbox#secret) hands you a fresh builder and calls [`build()`](#build) for you. `SecretBuilder::default()` is equivalent.
 
 <p className="msb-label">Returns</p>
 
@@ -236,14 +236,15 @@ When `true`, the secret is only substituted on TLS-intercepted connections where
 fn inject_headers(self, enabled: bool) -> Self
 ```
 
-Control whether the placeholder is replaced anywhere in HTTP headers. This is the most common injection scope, covering `Authorization: Bearer $MSB_...` and similar patterns. Default: `true`.
+Control broad literal substitution in HTTP request headers. Existing
+configurations default this to `true`.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>enabled</code><span className="msb-type">bool</span></div>
-    <div className="msb-param-desc">Substitute in headers. Default: <code>true</code>.</div>
+    <div className="msb-param-desc">Substitute in arbitrary headers. Default: <code>true</code>.</div>
   </div>
 </div>
 
@@ -253,16 +254,19 @@ Control whether the placeholder is replaced anywhere in HTTP headers. This is th
 fn inject_basic_auth(self, enabled: bool) -> Self
 ```
 
-Control whether `Authorization: Basic <base64>` credentials are decoded, substituted in the decoded `user:password`, then re-encoded. Orthogonal to [`inject_headers`](#inject_headers): this flag handles the encoded-credentials case for the Basic scheme; `inject_headers` handles literal substitution in any header line, including non-Basic Authorization schemes (`Bearer`, `Digest`). Default: `true`.
+Control decoded HTTP Basic Auth substitution. Existing configurations default
+this to `true`.
 
-<p className="msb-label">Parameters</p>
+#### <span className="msb-recv">.</span><span className="msb-hn">exact_header()</span>
 
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><code>enabled</code><span className="msb-type">bool</span></div>
-    <div className="msb-param-desc">Substitute inside Basic Auth credentials. Default: <code>true</code>.</div>
-  </div>
-</div>
+```rust
+fn exact_header(self, name: impl Into<String>, scheme: Option<String>) -> Self
+```
+
+Add a provider-neutral exact request-header rule. The target field must occur
+once in the initial request and its complete value must be
+`[scheme SP]<placeholder>`. Disable `inject_headers` and `inject_basic_auth`
+for an exact-header-only secret.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">inject_query()</span>
 
@@ -350,7 +354,7 @@ let sb = Sandbox::builder("agent")
 
 </Accordion>
 
-Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`. The placeholder is auto-generated as `$MSB_<env_var>` and the default injection scopes apply (headers and Basic Auth enabled, query and body disabled).
+Equivalent to `.secret(|s| s.env(env_var).value(value).allow_host(allowed_host))`. The placeholder is auto-generated as `$MSB_<env_var>` and the default injection scopes apply (broad header and Basic Auth substitution enabled, query and body disabled).
 
 <p className="msb-label">Parameters</p>
 
@@ -448,14 +452,26 @@ The materialized, serializable form of a secret that is handed to the network en
 
 <p className="msb-backref">used by <a href="#secretentry">SecretEntry</a></p>
 
-Which parts of an outbound HTTP request the placeholder may be substituted in. Set through the [`inject_*`](#inject_headers) methods on [`SecretBuilder`](#secretbuilder).
+Which parts of an outbound HTTP request the placeholder may be substituted in. Existing serialized configurations retain their original defaults.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `headers` | `bool` | `true` | Substitute anywhere in HTTP headers. |
-| `basic_auth` | `bool` | `true` | Substitute inside decoded `Authorization: Basic` credentials. |
+| `headers` | `bool` | `true` | Broad literal request-header substitution. |
+| `basic_auth` | `bool` | `true` | Decoded HTTP Basic Auth substitution. |
+| `exact_headers` | `Vec<SecretExactHeader>` | empty | Provider-neutral exact request-header rules. |
 | `query_params` | `bool` | `false` | Substitute in the URL query string. |
 | `body` | `bool` | `false` | Substitute in HTTP/1 request bodies (see [`inject_body()`](#inject_body) for limits). |
+
+### SecretExactHeader
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String` | HTTP field name, compared ASCII case-insensitively. |
+| `scheme` | `Option<String>` | Optional HTTP authentication scheme, compared ASCII case-insensitively. |
+
+Exact-header placement prevents wrong-field substitution. It does not restrict
+methods or paths, scan responses, or prevent an allowed authority from
+reflecting a correctly placed request-header value.
 
 ### ViolationAction
 

--- a/docs/sdk/rust/secrets.mdx
+++ b/docs/sdk/rust/secrets.mdx
@@ -263,10 +263,33 @@ this to `true`.
 fn exact_header(self, name: impl Into<String>, scheme: Option<String>) -> Self
 ```
 
-Add a provider-neutral exact request-header rule. The target field must occur
-once in the initial request and its complete value must be
-`[scheme SP]<placeholder>`. Disable `inject_headers` and `inject_basic_auth`
-for an exact-header-only secret.
+Restrict the secret to one provider-neutral exact request-header rule. The
+target field must occur once in the initial request and its complete value
+must be `[scheme SP]<placeholder>`. Calling this method disables broad header
+and decoded Basic Auth substitution; calling it again adds another allowed
+exact field while keeping those broad modes disabled. Construct
+[`SecretInjection`](#secretinjection) directly when exact rules should instead
+be additive.
+
+`name` and a present `scheme` must each be a non-empty HTTP token: ASCII
+letters, digits, or one of ``!#$%&'*+-.^_`|~``. The builder records invalid
+values, but [`SecretEntry::validate()`](#secretentry) and
+`NetworkBuilder::build()` reject them with
+[`InvalidExactHeaderName`](#secretconfigerror) or
+[`InvalidExactHeaderScheme`](#secretconfigerror).
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>name</code><span className="msb-type">impl Into&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Exact HTTP field name, compared ASCII case-insensitively.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>scheme</code><span className="msb-type">Option&lt;String&gt;</span></div>
+    <div className="msb-param-desc">Optional authentication scheme. <code>Some("Bearer")</code> requires <code>Bearer SP</code> before the placeholder; <code>None</code> requires the placeholder to be the complete field value.</div>
+  </div>
+</div>
 
 #### <span className="msb-recv">.</span><span className="msb-hn">inject_query()</span>
 
@@ -458,7 +481,7 @@ Which parts of an outbound HTTP request the placeholder may be substituted in. E
 |-------|------|---------|-------------|
 | `headers` | `bool` | `true` | Broad literal request-header substitution. |
 | `basic_auth` | `bool` | `true` | Decoded HTTP Basic Auth substitution. |
-| `exact_headers` | `Vec<SecretExactHeader>` | empty | Provider-neutral exact request-header rules. |
+| `exact_headers` | `Vec<SecretExactHeader>` | empty | Additive provider-neutral exact request-header rules. Setting this field directly does not change `headers` or `basic_auth`. |
 | `query_params` | `bool` | `false` | Substitute in the URL query string. |
 | `body` | `bool` | `false` | Substitute in HTTP/1 request bodies (see [`inject_body()`](#inject_body) for limits). |
 
@@ -502,3 +525,5 @@ Why a secret entry failed validation. Each variant carries the offending `secret
 | `PlaceholderTooLong` | The placeholder exceeds `MAX_SECRET_PLACEHOLDER_BYTES` (carries `actual_bytes`, `max_bytes`). |
 | `PlaceholderContainsNul` | The placeholder contains NUL. |
 | `PlaceholderContainsLineBreak` | The placeholder contains CR or LF. |
+| `InvalidExactHeaderName` | An exact-header field name is not a non-empty HTTP token (carries `header_index`). |
+| `InvalidExactHeaderScheme` | A present exact-header authentication scheme is not a non-empty HTTP token (carries `header_index`). |

--- a/docs/sdk/typescript/secrets.mdx
+++ b/docs/sdk/typescript/secrets.mdx
@@ -166,14 +166,15 @@ When `true`, the secret is only substituted on TLS-intercepted connections where
 injectHeaders(enabled: boolean): this
 ```
 
-Control whether the placeholder is replaced anywhere in HTTP headers. This is the most common injection scope, covering `Authorization: Bearer $MSB_...` and similar patterns. Default: `true`.
+Control broad literal request-header substitution. Existing configurations
+default this to `true`.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
-    <div className="msb-param-desc">Substitute in headers. Default: <code>true</code>.</div>
+    <div className="msb-param-desc">Substitute in arbitrary headers. Default: <code>true</code>.</div>
   </div>
 </div>
 
@@ -183,16 +184,19 @@ Control whether the placeholder is replaced anywhere in HTTP headers. This is th
 injectBasicAuth(enabled: boolean): this
 ```
 
-Control whether `Authorization: Basic <base64>` credentials are decoded, substituted in the decoded `user:password`, then re-encoded. Orthogonal to [`injectHeaders`](#injectheaders): this flag handles the encoded-credentials case for the Basic scheme; `injectHeaders` handles literal substitution in any header line, including non-Basic Authorization schemes (`Bearer`, `Digest`). Default: `true`.
+Control decoded HTTP Basic Auth substitution. Existing configurations default
+this to `true`.
 
-<p className="msb-label">Parameters</p>
+#### <span className="msb-recv">.</span><span className="msb-hn">exactHeader()</span>
 
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><code>enabled</code><span className="msb-type">boolean</span></div>
-    <div className="msb-param-desc">Substitute inside Basic Auth credentials. Default: <code>true</code>.</div>
-  </div>
-</div>
+```typescript
+exactHeader(name: string, scheme?: string): this
+```
+
+Add a provider-neutral exact request-header rule. The target field must occur
+once in the initial request and its complete value must be
+`[scheme SP]<placeholder>`. Disable broad header and Basic Auth substitution
+for an exact-header-only secret.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">injectQuery()</span>
 
@@ -378,7 +382,9 @@ await using sb = await Sandbox.builder("payments-worker")
       .value(process.env.STRIPE_KEY!)
       .allowHost("api.stripe.com")
       .allowHostPattern("*.stripe.com")
-      .injectHeaders(true)
+      .injectHeaders(false)
+      .injectBasicAuth(false)
+      .exactHeader("Authorization", "Bearer")
       .injectQuery(false),
   )
   .create();
@@ -583,14 +589,28 @@ The object produced by [`SecretBuilder.build()`](#build). You normally construct
 
 <p className="msb-backref">Used by <a href="#secretentry">SecretEntry.injection</a></p>
 
-Controls where the TLS proxy substitutes the placeholder with the real value. Each field is optional; omitted fields use the default. Set through the [`inject*`](#injectheaders) methods on [`SecretBuilder`](#secretbuilder).
+Controls where the TLS proxy substitutes the placeholder with the real value. The legacy booleans retain their existing defaults; exact-header rules are additive.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `headers?` | `boolean` | `true` | Replace the placeholder anywhere in HTTP headers. |
-| `basicAuth?` | `boolean` | `true` | Decode `Authorization: Basic <base64>` credentials, substitute in the decoded `user:password`, and re-encode. Other schemes (`Bearer`, `Digest`) are handled by `headers`. |
+| `headers?` | `boolean` | `true` | Broad literal request-header substitution. |
+| `basicAuth?` | `boolean` | `true` | Decoded HTTP Basic Auth substitution. |
+| `exactHeaders?` | `readonly SecretExactHeader[]` | empty | Provider-neutral exact request-header rules. |
 | `queryParams?` | `boolean` | `false` | Replace the placeholder in URL query parameters. |
 | `body?` | `boolean` | `false` | Replace the placeholder in request bodies when microsandbox can inspect and rewrite them safely. Encoded bodies are forwarded unchanged, and body placeholders in unsupported body formats are blocked instead of being leaked. |
+
+### SecretExactHeader
+
+```typescript
+interface SecretExactHeader {
+  readonly name: string;
+  readonly scheme?: string;
+}
+```
+
+Exact-header placement prevents wrong-field substitution. It does not restrict
+methods or paths, scan responses, or prevent an allowed authority from
+reflecting a correctly placed request-header value.
 
 ### ViolationAction
 

--- a/docs/sdk/typescript/secrets.mdx
+++ b/docs/sdk/typescript/secrets.mdx
@@ -193,10 +193,11 @@ this to `true`.
 exactHeader(name: string, scheme?: string): this
 ```
 
-Add a provider-neutral exact request-header rule. The target field must occur
-once in the initial request and its complete value must be
-`[scheme SP]<placeholder>`. Disable broad header and Basic Auth substitution
-for an exact-header-only secret.
+Restrict the secret to one provider-neutral exact request-header rule. The
+target field must occur once in the initial request and its complete value must
+be `[scheme SP]<placeholder>`. Calling this method disables broad header and
+decoded Basic Auth substitution; subsequent calls add exact fields while
+keeping those broad modes disabled.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">injectQuery()</span>
 
@@ -382,8 +383,6 @@ await using sb = await Sandbox.builder("payments-worker")
       .value(process.env.STRIPE_KEY!)
       .allowHost("api.stripe.com")
       .allowHostPattern("*.stripe.com")
-      .injectHeaders(false)
-      .injectBasicAuth(false)
       .exactHeader("Authorization", "Bearer")
       .injectQuery(false),
   )

--- a/docs/security/secrets.mdx
+++ b/docs/security/secrets.mdx
@@ -4,7 +4,7 @@ description: "How credentials stay on the host, and the exact boundary of the gu
 icon: "key"
 ---
 
-"Secrets that can't leak" is a real guarantee with a precise shape. This page describes exactly how it works and, just as important, what it does and does not protect against. For the configuration surface like binding secrets, allow lists, and placeholders, see [Secrets](/sandboxes/secrets).
+Secret isolation has a precise boundary. This page describes exactly how it works and, just as important, what it does and does not protect against. For the configuration surface like binding secrets, allow lists, placeholders, and exact-header placement, see [Secrets](/sandboxes/secrets).
 
 ## The idea
 
@@ -16,7 +16,10 @@ So a workload can call an API with a credential it never actually holds.
 
 1. You bind a secret to an environment variable and list the hosts it's allowed for.
 2. The guest's environment receives a placeholder (`$MSB_<env_var>` by default), never the real value.
-3. The workload uses the placeholder as if it were the credential, in a header, auth field, query string, or body.
+3. The workload uses the placeholder as if it were the credential. A secret's
+   injection configuration decides whether broad headers, decoded Basic
+   authorization, provider-neutral exact headers, query strings, or bodies
+   are eligible.
 4. On egress to an allowed host, the host-side proxy decrypts the intercepted TLS, verifies the request is really going where it claims, substitutes the real value, and forwards it upstream.
 5. The upstream server receives the real credential. The guest never did.
 
@@ -33,23 +36,41 @@ A placeholder only becomes a real value when **every** one of these holds. They 
 - **DNS pin.** The destination IP was actually resolved for that host through the interceptor, so a hard-coded IP with a forged SNI doesn't qualify.
 - **TLS identity.** By default a secret requires intercepted TLS, so it is never substituted over a connection the host can't see into.
 - **Authority alignment.** For intercepted HTTP, the request's `Host` or `:authority` must match the SNI, which closes domain-fronting.
+- **Placement match.** An exact-header-only secret requires one initial field
+  matching the configured name and optional scheme with the exact supported
+  byte grammar. Other fields, malformed or duplicate target fields, and
+  trailers never receive the real value.
 
 If any check fails, the placeholder is left untouched. The request goes out carrying a useless string, or it's blocked, depending on your policy.
 
 ## What this protects
 
 - **The credential cannot leak to a host you didn't allow.** Send the placeholder to `evil.com` and `evil.com` receives the placeholder, not the secret.
-- **A captured guest is worthless for the secret.** A memory dump, a leaked image, or a malicious process inside the VM will only ever find the placeholder.
+- **The credential is absent from guest state at rest.** A memory dump or
+  leaked guest image contains the placeholder rather than the host-held value.
 - **Hard-coded-IP and SNI-spoof exfiltration attempts** don't receive the injection at all, because they fail the DNS pin or authority checks.
+- **Wrong-field reflection attempts can be excluded.** Exact-header placement
+  prevents a guest from putting the placeholder in an arbitrary header and
+  causing the real credential to be placed there.
 
 ## What this does not protect
 
 Being candid about the edges matters more than the headline.
 
 - **The allowed endpoint receives the real credential.** This stops exfiltration to *other* hosts. It does not stop the host you explicitly allowed from misusing what you sent it. Keep allow lists narrow.
+- **A correctly placed credential is still delivered to the allowed
+  authority.** Exact-header placement does not scan responses, restrict methods
+  or paths, or prevent that authority from reflecting the request-header value.
+- **Broad headers remain the compatibility default.** Existing serialized
+  configurations and SDK calls retain broad header and decoded Basic Auth
+  substitution. Exact-header-only secrets explicitly disable those legacy
+  modes and add one or more exact rules.
 - **It needs TLS interception for that host.** Over a bypassed-TLS domain, or plain HTTP with the default TLS-identity requirement on, no substitution happens. That's by design, since the host can't verify where opaque traffic is really going. You can opt a secret into plain-HTTP injection, but it's weaker and not recommended.
 - **A few content shapes aren't rewritten.** Placeholders inside HTTP/2 request bodies, non-identity-encoded (for example gzipped) bodies, or very large fixed-length bodies aren't substituted. When an injection is eligible but can't be substituted safely, the request is blocked rather than sent wrong.
-- **Real values live in host process memory.** They're held as plain strings for the sandbox's lifetime and aren't specially zeroized. Anyone who can read the host process's memory is already on the trusted side of the boundary, and [host compromise is out of scope](/security/overview#scope-what-the-boundary-covers) for the model.
+- **Real values live in host process memory.** Anyone who can read the host
+  process's memory is already on the trusted side of the boundary, and [host
+  compromise is out of scope](/security/overview#scope-what-the-boundary-covers)
+  for the model.
 
 ## Where the values live
 

--- a/examples/python/net-secrets/main.py
+++ b/examples/python/net-secrets/main.py
@@ -31,7 +31,9 @@ async def main():
 
     # 2. HTTPS to allowed host — proxy substitutes secret, request succeeds.
     output = await sb.shell(
-        "wget -q -O /dev/null --timeout=10 https://example.com && echo OK || echo FAIL"
+        "wget -q -O /dev/null --timeout=10 "
+        "--header='Authorization: Bearer $MSB_API_KEY' "
+        "https://example.com && echo OK || echo FAIL"
     )
     print(f"HTTPS to example.com (allowed): {output.stdout_text.strip()}")
 
@@ -42,7 +44,9 @@ async def main():
         "https://cloudflare.com 2>&1 && echo OK || echo BLOCKED"
     )
     lines = output.stdout_text.strip().splitlines()
-    print(f"HTTPS to cloudflare.com with placeholder (disallowed): {lines[-1] if lines else '?'}")
+    print(
+        f"HTTPS to cloudflare.com with placeholder (disallowed): {lines[-1] if lines else '?'}"
+    )
 
     await sb.stop()
     await Sandbox.remove("net-secrets")

--- a/examples/python/net-secrets/main.py
+++ b/examples/python/net-secrets/main.py
@@ -13,7 +13,13 @@ async def main():
         cpus=1,
         memory=512,
         secrets=[
-            Secret.env("API_KEY", value="sk-real-secret-123", allow_hosts=["example.com"]),
+            Secret.exact_header(
+                "API_KEY",
+                value="sk-real-secret-123",
+                header="Authorization",
+                scheme="Bearer",
+                allow_hosts=["example.com"],
+            ),
         ],
         replace=True,
     )

--- a/examples/rust/net-secrets/bin/main.rs
+++ b/examples/rust/net-secrets/bin/main.rs
@@ -14,8 +14,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             s.env("API_KEY")
                 .value("sk-real-secret-123")
                 .allow_host("example.com")
-                .inject_headers(false)
-                .inject_basic_auth(false)
                 .exact_header("Authorization", Some("Bearer".into()))
         })
         .replace()
@@ -30,7 +28,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Allowed host: the TLS proxy substitutes the placeholder for the real
     // secret in-flight, so the request goes through.
     let output = sandbox
-        .shell("wget -q -O /dev/null --timeout=10 https://example.com && echo OK || echo FAIL")
+        .shell(concat!(
+            "wget -q -O /dev/null --timeout=10 ",
+            "--header='Authorization: Bearer $MSB_API_KEY' ",
+            "https://example.com && echo OK || echo FAIL",
+        ))
         .await?;
     println!(
         "HTTPS to example.com (allowed): {}",

--- a/examples/rust/net-secrets/bin/main.rs
+++ b/examples/rust/net-secrets/bin/main.rs
@@ -4,12 +4,20 @@ use microsandbox::Sandbox;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // `secret_env` auto-enables TLS interception; placeholder is `$MSB_API_KEY`.
+    // Exact-header-only placement auto-enables TLS interception; placeholder
+    // is `$MSB_API_KEY`.
     let sandbox = Sandbox::builder("net-secrets")
         .image("alpine")
         .cpus(1)
         .memory(512)
-        .secret_env("API_KEY", "sk-real-secret-123", "example.com")
+        .secret(|s| {
+            s.env("API_KEY")
+                .value("sk-real-secret-123")
+                .allow_host("example.com")
+                .inject_headers(false)
+                .inject_basic_auth(false)
+                .exact_header("Authorization", Some("Bearer".into()))
+        })
         .replace()
         .create()
         .await?;

--- a/examples/typescript/net-secrets/main.ts
+++ b/examples/typescript/net-secrets/main.ts
@@ -1,12 +1,20 @@
 import { Sandbox } from "microsandbox";
 
-// Secret with placeholder substitution and host allowlist. The 3-arg
-// shorthand auto-generates the placeholder as `$MSB_API_KEY`.
+// Exact-header-only secret with a host allowlist. The placeholder is
+// auto-generated as `$MSB_API_KEY`.
 await using sandbox = await Sandbox.builder("net-secrets")
   .image("alpine")
   .cpus(1)
   .memory(512)
-  .secretEnv("API_KEY", "sk-real-secret-123", "example.com")
+  .secret((s) =>
+    s
+      .env("API_KEY")
+      .value("sk-real-secret-123")
+      .allowHost("example.com")
+      .injectHeaders(false)
+      .injectBasicAuth(false)
+      .exactHeader("Authorization", "Bearer"),
+  )
   .replace()
   .create();
 

--- a/examples/typescript/net-secrets/main.ts
+++ b/examples/typescript/net-secrets/main.ts
@@ -11,8 +11,6 @@ await using sandbox = await Sandbox.builder("net-secrets")
       .env("API_KEY")
       .value("sk-real-secret-123")
       .allowHost("example.com")
-      .injectHeaders(false)
-      .injectBasicAuth(false)
       .exactHeader("Authorization", "Bearer"),
   )
   .replace()
@@ -24,7 +22,7 @@ console.log(`Guest env: API_KEY=${env.stdout().trim()}`);
 
 // 2. HTTPS to allowed host — proxy substitutes secret, request succeeds.
 const allowed = await sandbox.shell(
-  "wget -q -O /dev/null --timeout=10 https://example.com && echo OK || echo FAIL",
+  "wget -q -O /dev/null --timeout=10 --header='Authorization: Bearer $MSB_API_KEY' https://example.com && echo OK || echo FAIL",
 );
 console.log(`HTTPS to example.com (allowed): ${allowed.stdout().trim()}`);
 

--- a/packages/microsandbox-types/rust/lib/domain.rs
+++ b/packages/microsandbox-types/rust/lib/domain.rs
@@ -1696,6 +1696,24 @@ pub enum HostPattern {
     Any,
 }
 
+/// One provider-neutral exact request-header placement for a secret.
+///
+/// The header value must consist of optional leading SP/HTAB, the optional
+/// case-insensitive HTTP authentication scheme followed by exactly one SP,
+/// and the complete placeholder. No trailing bytes are allowed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+pub struct SecretExactHeader {
+    /// HTTP field name, compared ASCII case-insensitively.
+    pub name: String,
+
+    /// Optional HTTP authentication scheme, compared ASCII
+    /// case-insensitively. For example, `Bearer`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<String>,
+}
+
 /// Where in the HTTP request a secret can be injected.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -1708,6 +1726,14 @@ pub struct SecretInjection {
     /// Substitute in HTTP Basic Auth (default: true).
     #[serde(default = "default_true")]
     pub basic_auth: bool,
+
+    /// Additional exact request-header placements.
+    ///
+    /// This is additive so existing serialized configurations and SDK calls
+    /// keep their behavior. For a strict exact-header-only secret, disable
+    /// `headers` and `basic_auth` and configure one exact header.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exact_headers: Vec<SecretExactHeader>,
 
     /// Substitute in URL query parameters (default: false).
     #[serde(default)]
@@ -1809,6 +1835,26 @@ pub enum SecretConfigError {
         /// Index of the invalid secret entry.
         secret_index: usize,
     },
+
+    /// An exact-header field name is not a valid HTTP token.
+    #[error("secret #{secret_index}: exact header #{header_index} name must be a valid HTTP token")]
+    InvalidExactHeaderName {
+        /// Index of the invalid secret entry.
+        secret_index: usize,
+        /// Index of the invalid exact-header rule.
+        header_index: usize,
+    },
+
+    /// An exact-header scheme is not a valid HTTP token.
+    #[error(
+        "secret #{secret_index}: exact header #{header_index} scheme must be a valid HTTP token"
+    )]
+    InvalidExactHeaderScheme {
+        /// Index of the invalid secret entry.
+        secret_index: usize,
+        /// Index of the invalid exact-header rule.
+        header_index: usize,
+    },
 }
 
 impl SecretsConfig {
@@ -1830,7 +1876,22 @@ impl SecretEntry {
             return Err(SecretConfigError::MissingAllowedHosts { secret_index });
         }
 
-        validate_placeholder(&self.placeholder, secret_index)
+        validate_placeholder(&self.placeholder, secret_index)?;
+        for (header_index, header) in self.injection.exact_headers.iter().enumerate() {
+            if !is_http_token(&header.name) {
+                return Err(SecretConfigError::InvalidExactHeaderName {
+                    secret_index,
+                    header_index,
+                });
+            }
+            if header.scheme.as_deref().is_some_and(|s| !is_http_token(s)) {
+                return Err(SecretConfigError::InvalidExactHeaderScheme {
+                    secret_index,
+                    header_index,
+                });
+            }
+        }
+        Ok(())
     }
 }
 
@@ -1891,6 +1952,7 @@ impl Default for SecretInjection {
         Self {
             headers: true,
             basic_auth: true,
+            exact_headers: Vec::new(),
             query_params: false,
             body: false,
         }
@@ -1936,6 +1998,30 @@ fn validate_placeholder(placeholder: &str, secret_index: usize) -> Result<(), Se
     }
 
     Ok(())
+}
+
+fn is_http_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2418,6 +2504,79 @@ mod tests {
             serde_json::from_str(r#"{"max_duration_secs":60,"idle_timeout_secs":null}"#).unwrap();
         assert!(!decoded.ephemeral);
         assert_eq!(decoded.max_duration_secs, Some(60));
+    }
+
+    #[test]
+    fn secret_injection_preserves_legacy_defaults_and_round_trips_exact_headers() {
+        let defaulted: SecretInjection = serde_json::from_str("{}").unwrap();
+        assert!(defaulted.headers);
+        assert!(defaulted.basic_auth);
+        assert!(defaulted.exact_headers.is_empty());
+
+        let legacy: SecretInjection =
+            serde_json::from_str(r#"{"headers":false,"basic_auth":true}"#).unwrap();
+        assert!(!legacy.headers);
+        assert!(legacy.basic_auth);
+        assert!(legacy.exact_headers.is_empty());
+
+        let injection = SecretInjection {
+            headers: false,
+            basic_auth: false,
+            exact_headers: vec![SecretExactHeader {
+                name: "Authorization".into(),
+                scheme: Some("Bearer".into()),
+            }],
+            query_params: false,
+            body: false,
+        };
+        let json = serde_json::to_value(&injection).unwrap();
+        assert_eq!(json["exact_headers"][0]["name"], "Authorization");
+        assert_eq!(json["exact_headers"][0]["scheme"], "Bearer");
+        assert_eq!(
+            serde_json::from_value::<SecretInjection>(json)
+                .unwrap()
+                .exact_headers,
+            injection.exact_headers
+        );
+    }
+
+    #[test]
+    fn secret_exact_header_rejects_invalid_http_tokens() {
+        let entry = |name: &str, scheme: Option<&str>| SecretEntry {
+            env_var: "API_KEY".into(),
+            value: Zeroizing::new("secret".into()),
+            source: None,
+            placeholder: "$API_KEY".into(),
+            allowed_hosts: vec![HostPattern::Exact("api.example.com".into())],
+            injection: SecretInjection {
+                headers: false,
+                basic_auth: false,
+                exact_headers: vec![SecretExactHeader {
+                    name: name.into(),
+                    scheme: scheme.map(str::to_owned),
+                }],
+                query_params: false,
+                body: false,
+            },
+            on_violation: None,
+            require_tls_identity: true,
+        };
+
+        assert_eq!(
+            entry("X Bad Header", None).validate(0),
+            Err(SecretConfigError::InvalidExactHeaderName {
+                secret_index: 0,
+                header_index: 0,
+            })
+        );
+        assert_eq!(
+            entry("Authorization", Some("Not A Scheme")).validate(0),
+            Err(SecretConfigError::InvalidExactHeaderScheme {
+                secret_index: 0,
+                header_index: 0,
+            })
+        );
+        assert!(entry("X-Api-Key", Some("Token")).validate(0).is_ok());
     }
 
     #[test]

--- a/packages/microsandbox-types/rust/lib/lib.rs
+++ b/packages/microsandbox-types/rust/lib/lib.rs
@@ -31,9 +31,9 @@ pub use domain::{
     NamedVolumeMode, NetworkPolicy, NetworkSpec, OciRootfsSource, Patch, PortProtocol, PortRange,
     Protocol, PublishedPortSpec, PullPolicy, Rlimit, RlimitResource, RootDisk, RootfsSource, Rule,
     SandboxLogLevel, SandboxPolicy, SandboxResources, SandboxRuntimeOptions, SandboxSpec,
-    ScopedUpstreamCaCert, ScopedVerifyUpstream, SecretConfigError, SecretEntry, SecretInjection,
-    SecretsConfig, SecurityProfile, SnapshotSpec, StatVirtualization, TlsConfig, ViolationAction,
-    VolumeKind, VolumeMount, VolumeSpec,
+    ScopedUpstreamCaCert, ScopedVerifyUpstream, SecretConfigError, SecretEntry, SecretExactHeader,
+    SecretInjection, SecretsConfig, SecurityProfile, SnapshotSpec, StatVirtualization, TlsConfig,
+    ViolationAction, VolumeKind, VolumeMount, VolumeSpec,
 };
 pub use error::{TypesError, TypesResult};
 pub use modify::{

--- a/packages/microsandbox-types/rust/lib/typescript.rs
+++ b/packages/microsandbox-types/rust/lib/typescript.rs
@@ -16,7 +16,7 @@ use crate::{
     CloudSecretEntry, CloudSecretSource, CloudSecretsConfig, CloudViolationAction,
     CloudVolumeMount, Destination, DestinationGroup, Direction, EnvVar, HandoffInit,
     HostPermissions, MountOptions, NetworkPolicy, PortRange, Protocol, Rule, SandboxLogLevel,
-    SandboxPolicy, SecretInjection, SecurityProfile, StatVirtualization,
+    SandboxPolicy, SecretExactHeader, SecretInjection, SecurityProfile, StatVirtualization,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -43,6 +43,7 @@ const DOMAIN_TYPE_NAMES: &[&str] = &[
     "Rule",
     "SandboxLogLevel",
     "SandboxPolicy",
+    "SecretExactHeader",
     "SecretInjection",
     "SecurityProfile",
     "StatVirtualization",
@@ -115,6 +116,7 @@ pub fn domain_declarations() -> Vec<String> {
         MountOptions::decl(&cfg),
         StatVirtualization::decl(&cfg),
         HostPermissions::decl(&cfg),
+        SecretExactHeader::decl(&cfg),
         SecretInjection::decl(&cfg),
         NetworkPolicy::decl(&cfg),
         Rule::decl(&cfg),

--- a/packages/microsandbox-types/typescript/src/domain.ts
+++ b/packages/microsandbox-types/typescript/src/domain.ts
@@ -81,6 +81,18 @@ export type StatVirtualization = "strict" | "relaxed" | "off";
 
 export type HostPermissions = "private" | "mirror";
 
+export type SecretExactHeader = {
+  /**
+   * HTTP field name, compared ASCII case-insensitively.
+   */
+  name: string;
+  /**
+   * Optional HTTP authentication scheme, compared ASCII
+   * case-insensitively. For example, `Bearer`.
+   */
+  scheme?: string | null;
+};
+
 export type SecretInjection = {
   /**
    * Substitute in HTTP headers (default: true).
@@ -90,6 +102,14 @@ export type SecretInjection = {
    * Substitute in HTTP Basic Auth (default: true).
    */
   basic_auth: boolean;
+  /**
+   * Additional exact request-header placements.
+   *
+   * This is additive so existing serialized configurations and SDK calls
+   * keep their behavior. For a strict exact-header-only secret, disable
+   * `headers` and `basic_auth` and configure one exact header.
+   */
+  exact_headers?: Array<SecretExactHeader>;
   /**
    * Substitute in URL query parameters (default: false).
    */

--- a/sdk/go/examples/secrets/main.go
+++ b/sdk/go/examples/secrets/main.go
@@ -38,9 +38,11 @@ func main() {
 
 	sb, err := microsandbox.CreateSandbox(ctx, name,
 		microsandbox.WithImage("alpine:3.19"),
-		microsandbox.WithSecrets(microsandbox.Secret.Env(
+		microsandbox.WithSecrets(microsandbox.Secret.ExactHeader(
 			envVarInGuest,
 			secretValue,
+			"Authorization",
+			"Bearer",
 			microsandbox.SecretEnvOptions{
 				AllowHosts:  []string{allowedHost},
 				Placeholder: placeholder,

--- a/sdk/go/examples/secrets/main.go
+++ b/sdk/go/examples/secrets/main.go
@@ -21,7 +21,7 @@ import (
 const (
 	secretValue   = "super-secret-value-abcxyz"
 	placeholder   = "$MY_API_KEY_PLACEHOLDER"
-	allowedHost   = "api.example.com"
+	allowedHost   = "example.com"
 	envVarInGuest = "MY_API_KEY"
 )
 
@@ -83,6 +83,18 @@ func main() {
 		log.Fatalf("FAIL: secret value found in full env dump")
 	}
 	fmt.Printf("  full env dump contains no secret value (%d bytes scanned)\n", len(out.Stdout()))
+
+	// 3. Allowed HTTPS request: the placeholder occupies the configured field
+	// and the proxy replaces it in flight.
+	out, err = sb.Shell(ctx,
+		"wget -q -O /dev/null --timeout=10 "+
+			"--header='Authorization: Bearer "+placeholder+"' "+
+			"https://example.com && echo OK",
+	)
+	if err != nil || !strings.Contains(out.Stdout(), "OK") {
+		log.Fatalf("FAIL: allowed exact-header request: err=%v output=%q", err, out.Stdout())
+	}
+	fmt.Println("  allowed exact-header request succeeded")
 
 	fmt.Println("OK — secrets example passed")
 }

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -1650,13 +1650,22 @@ type ScopedVerifyUpstream struct {
 
 // SecretOptions is the JSON representation of a single credential.
 type SecretOptions struct {
-	EnvVar            string   `json:"env_var"`
-	Value             string   `json:"value"`
-	AllowHosts        []string `json:"allow_hosts,omitempty"`
-	AllowHostPatterns []string `json:"allow_host_patterns,omitempty"`
-	Placeholder       string   `json:"placeholder,omitempty"`
-	RequireTLS        *bool    `json:"require_tls,omitempty"`
-	OnViolation       string   `json:"on_violation,omitempty"`
+	EnvVar            string                     `json:"env_var"`
+	Value             string                     `json:"value"`
+	AllowHosts        []string                   `json:"allow_hosts,omitempty"`
+	AllowHostPatterns []string                   `json:"allow_host_patterns,omitempty"`
+	Placeholder       string                     `json:"placeholder,omitempty"`
+	RequireTLS        *bool                      `json:"require_tls,omitempty"`
+	InjectHeaders     *bool                      `json:"inject_headers,omitempty"`
+	InjectBasicAuth   *bool                      `json:"inject_basic_auth,omitempty"`
+	ExactHeaders      []SecretExactHeaderOptions `json:"exact_headers,omitempty"`
+	OnViolation       string                     `json:"on_violation,omitempty"`
+}
+
+// SecretExactHeaderOptions is one exact request-header wire rule.
+type SecretExactHeaderOptions struct {
+	Name   string `json:"name"`
+	Scheme string `json:"scheme,omitempty"`
 }
 
 // PatchOptions is the JSON representation of a single rootfs patch.

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -904,11 +904,21 @@ struct SecretOpts {
     allow_host_patterns: Vec<String>,
     placeholder: Option<String>,
     require_tls: Option<bool>,
+    inject_headers: Option<bool>,
+    inject_basic_auth: Option<bool>,
+    #[serde(default)]
+    exact_headers: Vec<SecretExactHeaderOpts>,
     /// Per-network (sandbox-wide) violation action override. The Node/Python
     /// SDKs accept this as a per-secret field on `SecretEntry`; it ends up
     /// applied at the network builder level. We honour it the same way:
     /// the last seen non-null value wins.
     on_violation: Option<String>,
+}
+
+#[derive(Clone, serde::Deserialize)]
+struct SecretExactHeaderOpts {
+    name: String,
+    scheme: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
@@ -1626,6 +1636,9 @@ fn apply_secret(
     }
     let placeholder = s.placeholder.clone();
     let require_tls = s.require_tls;
+    let inject_headers = s.inject_headers;
+    let inject_basic_auth = s.inject_basic_auth;
+    let exact_headers = s.exact_headers.clone();
     let on_violation = s
         .on_violation
         .as_ref()
@@ -1645,6 +1658,15 @@ fn apply_secret(
         }
         if let Some(req) = require_tls {
             sb = sb.require_tls_identity(req);
+        }
+        if let Some(enabled) = inject_headers {
+            sb = sb.inject_headers(enabled);
+        }
+        if let Some(enabled) = inject_basic_auth {
+            sb = sb.inject_basic_auth(enabled);
+        }
+        for header in &exact_headers {
+            sb = sb.exact_header(header.name.clone(), header.scheme.clone());
         }
         if let Some(action) = on_violation {
             sb = sb.on_violation(move |_| ViolationActionBuilder::from_action(action));

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -1100,6 +1100,17 @@ type SecretEntry struct {
 	// Defaults to true when nil.
 	RequireTLS *bool
 
+	// InjectHeaders controls broad HTTP header substitution. Nil preserves the
+	// runtime default (true).
+	InjectHeaders *bool
+
+	// InjectBasicAuth controls decoded HTTP Basic Auth substitution. Nil
+	// preserves the runtime default (true).
+	InjectBasicAuth *bool
+
+	// ExactHeaders adds provider-neutral exact request-header placements.
+	ExactHeaders []SecretExactHeader
+
 	// OnViolation overrides the sandbox-level action when this secret is
 	// detected going to a disallowed host. The last non-empty value across
 	// all secrets wins (matches Node/Python behaviour, since the runtime
@@ -1113,7 +1124,18 @@ type SecretEnvOptions struct {
 	AllowHostPatterns []string
 	Placeholder       string
 	RequireTLS        *bool
+	InjectHeaders     *bool
+	InjectBasicAuth   *bool
+	ExactHeaders      []SecretExactHeader
 	OnViolation       ViolationAction
+}
+
+// SecretExactHeader is one provider-neutral exact request-header placement.
+// Scheme is optional; when set, exactly one space separates it from the
+// placeholder.
+type SecretExactHeader struct {
+	Name   string
+	Scheme string
 }
 
 // secretFactory is the factory namespace matching Node's `Secret.env(...)` and
@@ -1138,8 +1160,24 @@ func (secretFactory) Env(envVar, value string, opts SecretEnvOptions) SecretEntr
 		AllowHostPatterns: opts.AllowHostPatterns,
 		Placeholder:       opts.Placeholder,
 		RequireTLS:        opts.RequireTLS,
+		InjectHeaders:     opts.InjectHeaders,
+		InjectBasicAuth:   opts.InjectBasicAuth,
+		ExactHeaders:      opts.ExactHeaders,
 		OnViolation:       opts.OnViolation,
 	}
+}
+
+// ExactHeader returns a SecretEntry restricted to one exact request header.
+// Other SecretEnvOptions retain their ordinary meaning.
+func (secretFactory) ExactHeader(
+	envVar, value, name, scheme string,
+	opts SecretEnvOptions,
+) SecretEntry {
+	disabled := false
+	opts.InjectHeaders = &disabled
+	opts.InjectBasicAuth = &disabled
+	opts.ExactHeaders = []SecretExactHeader{{Name: name, Scheme: scheme}}
+	return Secret.Env(envVar, value, opts)
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/go/options_test.go
+++ b/sdk/go/options_test.go
@@ -463,6 +463,28 @@ func TestSecretEnvFactory(t *testing.T) {
 	}
 }
 
+func TestSecretExactHeaderFactory(t *testing.T) {
+	s := Secret.ExactHeader(
+		"TOK",
+		"synthetic-token",
+		"Proxy-Authorization",
+		"Token",
+		SecretEnvOptions{AllowHosts: []string{"api.example.com"}},
+	)
+
+	if s.InjectHeaders == nil || *s.InjectHeaders {
+		t.Fatal("InjectHeaders should be explicitly false")
+	}
+	if s.InjectBasicAuth == nil || *s.InjectBasicAuth {
+		t.Fatal("InjectBasicAuth should be explicitly false")
+	}
+	if len(s.ExactHeaders) != 1 ||
+		s.ExactHeaders[0].Name != "Proxy-Authorization" ||
+		s.ExactHeaders[0].Scheme != "Token" {
+		t.Fatalf("ExactHeaders = %#v", s.ExactHeaders)
+	}
+}
+
 func TestWithPatches(t *testing.T) {
 	o := SandboxConfig{}
 	p1 := Patch.Text("/etc/foo", "bar\n", PatchOptions{})

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -170,7 +170,18 @@ func buildFFICreateOptions(o SandboxConfig) ffi.CreateOptions {
 			AllowHostPatterns: s.AllowHostPatterns,
 			Placeholder:       s.Placeholder,
 			RequireTLS:        s.RequireTLS,
-			OnViolation:       string(s.OnViolation),
+			InjectHeaders:     s.InjectHeaders,
+			InjectBasicAuth:   s.InjectBasicAuth,
+			ExactHeaders: func() []ffi.SecretExactHeaderOptions {
+				headers := make([]ffi.SecretExactHeaderOptions, 0, len(s.ExactHeaders))
+				for _, header := range s.ExactHeaders {
+					headers = append(headers, ffi.SecretExactHeaderOptions{
+						Name: header.Name, Scheme: header.Scheme,
+					})
+				}
+				return headers
+			}(),
+			OnViolation: string(s.OnViolation),
 		})
 	}
 

--- a/sdk/go/sandbox_options_test.go
+++ b/sdk/go/sandbox_options_test.go
@@ -601,6 +601,29 @@ func TestFFIWireShape_Secrets(t *testing.T) {
 	}
 }
 
+func TestFFIWireShape_ExactHeaderSecretPlacement(t *testing.T) {
+	got := marshalCreateOptions(t,
+		WithImage("alpine"),
+		WithSecrets(Secret.ExactHeader(
+			"API_KEY",
+			"synthetic-token",
+			"Proxy-Authorization",
+			"Token",
+			SecretEnvOptions{AllowHosts: []string{"api.example.com"}},
+		)),
+	)
+	secs := mustField(t, got, "secrets").([]any)
+	s := secs[0].(map[string]any)
+	if s["inject_headers"] != false || s["inject_basic_auth"] != false {
+		t.Fatalf("legacy header toggles = %v/%v", s["inject_headers"], s["inject_basic_auth"])
+	}
+	headers := s["exact_headers"].([]any)
+	header := headers[0].(map[string]any)
+	if header["name"] != "Proxy-Authorization" || header["scheme"] != "Token" {
+		t.Fatalf("exact_headers = %v", headers)
+	}
+}
+
 func TestFFIWireShape_NetworkProfile(t *testing.T) {
 	got := marshalCreateOptions(t,
 		WithImage("alpine"),

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -1326,6 +1326,8 @@ export declare class SecretBuilder {
   injectHeaders(enabled: boolean): this
   /** Configure Basic Auth injection (default: true). */
   injectBasicAuth(enabled: boolean): this
+  /** Add one provider-neutral exact request-header placement. */
+  exactHeader(name: string, scheme?: string | undefined | null): this
   /** Configure URL query parameter injection (default: false). */
   injectQuery(enabled: boolean): this
   /** Configure request body injection (default: false). */
@@ -2172,8 +2174,15 @@ export interface SecretEntry {
 export interface SecretInjection {
   headers: boolean
   basicAuth: boolean
+  exactHeaders?: Array<SecretExactHeader>
   queryParams: boolean
   body: boolean
+}
+
+/** One provider-neutral exact request-header placement. */
+export interface SecretExactHeader {
+  name: string
+  scheme?: string
 }
 
 /**

--- a/sdk/node-ts/native/secret_builder.rs
+++ b/sdk/node-ts/native/secret_builder.rs
@@ -143,7 +143,7 @@ impl JsSecretBuilder {
         self
     }
 
-    /// Add one provider-neutral exact request-header placement.
+    /// Restrict the secret to provider-neutral exact request-header placements.
     #[napi(js_name = "exactHeader")]
     pub fn exact_header(&mut self, name: String, scheme: Option<String>) -> &Self {
         let prev = self.take_inner();

--- a/sdk/node-ts/native/secret_builder.rs
+++ b/sdk/node-ts/native/secret_builder.rs
@@ -38,8 +38,17 @@ pub struct JsSecretEntry {
 pub struct JsSecretInjection {
     pub headers: bool,
     pub basic_auth: bool,
+    pub exact_headers: Option<Vec<JsSecretExactHeader>>,
     pub query_params: bool,
     pub body: bool,
+}
+
+/// One provider-neutral exact request-header placement.
+#[derive(Clone)]
+#[napi(object, js_name = "SecretExactHeader")]
+pub struct JsSecretExactHeader {
+    pub name: String,
+    pub scheme: Option<String>,
 }
 
 /// Fluent builder for a single secret entry.
@@ -131,6 +140,14 @@ impl JsSecretBuilder {
     pub fn inject_basic_auth(&mut self, enabled: bool) -> &Self {
         let prev = self.take_inner();
         self.inner = Some(prev.inject_basic_auth(enabled));
+        self
+    }
+
+    /// Add one provider-neutral exact request-header placement.
+    #[napi(js_name = "exactHeader")]
+    pub fn exact_header(&mut self, name: String, scheme: Option<String>) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.exact_header(name, scheme));
         self
     }
 
@@ -243,6 +260,17 @@ pub(crate) fn to_js_secret_entry(entry: RustSecretEntry) -> JsSecretEntry {
         injection: JsSecretInjection {
             headers: entry.injection.headers,
             basic_auth: entry.injection.basic_auth,
+            exact_headers: (!entry.injection.exact_headers.is_empty()).then(|| {
+                entry
+                    .injection
+                    .exact_headers
+                    .into_iter()
+                    .map(|header| JsSecretExactHeader {
+                        name: header.name,
+                        scheme: header.scheme,
+                    })
+                    .collect()
+            }),
             query_params: entry.injection.query_params,
             body: entry.injection.body,
         },

--- a/sdk/node-ts/src/index.ts
+++ b/sdk/node-ts/src/index.ts
@@ -382,6 +382,10 @@ export const InterfaceOverridesBuilder = napi.InterfaceOverridesBuilder;
 export type InterfaceOverridesBuilder = NapiInterfaceOverridesBuilder;
 export type PullProgressEvent = NapiPullProgressEvent;
 export type PullProgressStream = NapiPullProgressStream;
+export type {
+  SecretExactHeader,
+  SecretInjection,
+} from "./network-config.js";
 
 // Setup + module-level helpers
 export { Setup, install, isInstalled, setup } from "./setup.js";

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -876,6 +876,7 @@ export interface NapiSecretBuilder {
   requireTlsIdentity(enabled: boolean): this;
   injectHeaders(enabled: boolean): this;
   injectBasicAuth(enabled: boolean): this;
+  exactHeader(name: string, scheme?: string): this;
   injectQuery(enabled: boolean): this;
   injectBody(enabled: boolean): this;
   onViolation(
@@ -898,8 +899,14 @@ export interface NapiSecretEntry {
 export interface NapiSecretInjection {
   readonly headers: boolean;
   readonly basicAuth: boolean;
+  readonly exactHeaders?: readonly NapiSecretExactHeader[];
   readonly queryParams: boolean;
   readonly body: boolean;
+}
+
+export interface NapiSecretExactHeader {
+  readonly name: string;
+  readonly scheme?: string;
 }
 
 export interface NapiNetworkBuilder {

--- a/sdk/node-ts/src/network-config.ts
+++ b/sdk/node-ts/src/network-config.ts
@@ -41,10 +41,17 @@ export interface TlsConfig {
   readonly interceptCaKeyPath: string | null;
 }
 
+/** One provider-neutral exact request-header placement. */
+export interface SecretExactHeader {
+  readonly name: string;
+  readonly scheme?: string;
+}
+
 /** Where in the HTTP request the secret value can be substituted. */
 export interface SecretInjection {
   readonly headers?: boolean;
   readonly basicAuth?: boolean;
+  readonly exactHeaders?: readonly SecretExactHeader[];
   readonly queryParams?: boolean;
   readonly body?: boolean;
 }

--- a/sdk/node-ts/tests/unit/builders.test.ts
+++ b/sdk/node-ts/tests/unit/builders.test.ts
@@ -14,7 +14,10 @@ import {
   SecretBuilder,
   Stdin,
 } from "../../dist/index.js";
-
+import type {
+  SecretExactHeader,
+  SecretInjection,
+} from "../../dist/index.js";
 
 describe("intoRootfsSource", () => {
   it("treats absolute paths as bind mounts", () => {
@@ -497,6 +500,35 @@ describe("NetworkBuilder.secretEnvSimple (3-arg shorthand)", () => {
 });
 
 describe("NetworkBuilder secret passthrough", () => {
+  it("builds a provider-neutral exact-header-only placement", () => {
+    const exactHeader: SecretExactHeader = {
+      name: "Proxy-Authorization",
+      scheme: "Token",
+    };
+    const injection: SecretInjection = {
+      headers: false,
+      basicAuth: false,
+      exactHeaders: [exactHeader],
+    };
+    const secret = new SecretBuilder()
+      .env("API_KEY")
+      .value("synthetic-token")
+      .allowHost("api.example.com")
+      .injectHeaders(false)
+      .injectBasicAuth(false)
+      .exactHeader(exactHeader.name, exactHeader.scheme)
+      .build();
+
+    expect(injection.exactHeaders).toEqual([exactHeader]);
+    expect(secret.injection).toMatchObject({
+      headers: false,
+      basicAuth: false,
+      exactHeaders: [exactHeader],
+      queryParams: false,
+      body: false,
+    });
+  });
+
   it("builds global passthrough violation policy", () => {
     const cfg = new NetworkBuilder()
       .onSecretViolation((v) =>

--- a/sdk/node-ts/tests/unit/builders.test.ts
+++ b/sdk/node-ts/tests/unit/builders.test.ts
@@ -514,8 +514,6 @@ describe("NetworkBuilder secret passthrough", () => {
       .env("API_KEY")
       .value("synthetic-token")
       .allowHost("api.example.com")
-      .injectHeaders(false)
-      .injectBasicAuth(false)
       .exactHeader(exactHeader.name, exactHeader.scheme)
       .build();
 

--- a/sdk/python/microsandbox/__init__.py
+++ b/sdk/python/microsandbox/__init__.py
@@ -142,6 +142,7 @@ from microsandbox.types import (
     ScopedVerifyUpstream,
     Secret,
     SecretEntry,
+    SecretExactHeader,
     SecretInjection,
     SecurityProfile,
     Size,
@@ -243,6 +244,7 @@ __all__ = [
     # Secrets & TLS
     "Secret",
     "SecretEntry",
+    "SecretExactHeader",
     "SecretInjection",
     "ScopedUpstreamCACert",
     "ScopedVerifyUpstream",

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -592,12 +592,25 @@ class Patch:
 #--------------------------------------------------------------------------------------------------
 
 @dataclass(frozen=True, slots=True)
+class SecretExactHeader:
+    """One provider-neutral exact request-header placement."""
+    name: str
+    scheme: str | None = None
+
+    def _to_dict(self) -> dict:
+        d = {"name": self.name}
+        if self.scheme is not None:
+            d["scheme"] = self.scheme
+        return d
+
+@dataclass(frozen=True, slots=True)
 class SecretInjection:
     """Where in the HTTP request the secret value can be substituted."""
     headers: bool = True
     basic_auth: bool = True
     query_params: bool = False
     body: bool = False
+    exact_headers: tuple[SecretExactHeader, ...] = ()
 
     def _to_dict(self) -> dict:
         d: dict = {}
@@ -605,6 +618,8 @@ class SecretInjection:
             d["headers"] = False
         if not self.basic_auth:
             d["basic_auth"] = False
+        if self.exact_headers:
+            d["exact_headers"] = [header._to_dict() for header in self.exact_headers]
         if self.query_params:
             d["query_params"] = True
         if self.body:
@@ -665,6 +680,35 @@ class Secret:
             require_tls=require_tls,
             on_violation=on_violation,
             injection=injection if injection is not None else SecretInjection(),
+        )
+
+    @staticmethod
+    def exact_header(
+        env_var: str,
+        *,
+        value: str,
+        header: str,
+        scheme: str | None = None,
+        allow_hosts: Sequence[str] = (),
+        allow_host_patterns: Sequence[str] = (),
+        placeholder: str | None = None,
+        require_tls: bool = True,
+        on_violation: ViolationAction | ViolationPolicy = ViolationAction.BLOCK_AND_LOG,
+    ) -> SecretEntry:
+        """Create a secret restricted to one exact request header."""
+        return Secret.env(
+            env_var,
+            value=value,
+            allow_hosts=allow_hosts,
+            allow_host_patterns=allow_host_patterns,
+            placeholder=placeholder,
+            require_tls=require_tls,
+            on_violation=on_violation,
+            injection=SecretInjection(
+                headers=False,
+                basic_auth=False,
+                exact_headers=(SecretExactHeader(name=header, scheme=scheme),),
+            ),
         )
 
 #--------------------------------------------------------------------------------------------------

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -1265,17 +1265,34 @@ fn apply_secret(
     let placeholder: Option<String> = extract_opt(secret, "placeholder")?;
     let require_tls: Option<bool> = extract_opt(secret, "require_tls")?;
 
-    let (inject_headers, inject_basic_auth, inject_query_params, inject_body) =
+    let (inject_headers, inject_basic_auth, exact_headers, inject_query_params, inject_body) =
         if let Some(injection_obj) = secret.get_item("injection")? {
             let injection = as_dict(&injection_obj)?;
+            let exact_headers =
+                if let Some(exact_headers_obj) = injection.get_item("exact_headers")? {
+                    let exact_headers = exact_headers_obj.cast::<PyList>()?;
+                    exact_headers
+                        .iter()
+                        .map(|item| {
+                            let header = as_dict(&item)?;
+                            Ok((
+                                extract_required::<String>(&header, "name")?,
+                                extract_opt::<String>(&header, "scheme")?,
+                            ))
+                        })
+                        .collect::<PyResult<Vec<_>>>()?
+                } else {
+                    Vec::new()
+                };
             (
                 extract_opt::<bool>(&injection, "headers")?,
                 extract_opt::<bool>(&injection, "basic_auth")?,
+                exact_headers,
                 extract_opt::<bool>(&injection, "query_params")?,
                 extract_opt::<bool>(&injection, "body")?,
             )
         } else {
-            (None, None, None, None)
+            (None, None, Vec::new(), None, None)
         };
 
     Ok(builder.secret(|s| {
@@ -1302,6 +1319,9 @@ fn apply_secret(
         }
         if let Some(v) = inject_basic_auth {
             s = s.inject_basic_auth(v);
+        }
+        for (name, scheme) in exact_headers {
+            s = s.exact_header(name, scheme);
         }
         if let Some(v) = inject_query_params {
             s = s.inject_query(v);

--- a/sdk/python/tests/test_types_enums.py
+++ b/sdk/python/tests/test_types_enums.py
@@ -7,7 +7,13 @@ and stringify to their values under both `str()` and `format()`.
 
 from __future__ import annotations
 
-from microsandbox import LogLevel, PullPolicy
+from microsandbox import (
+    LogLevel,
+    PullPolicy,
+    Secret,
+    SecretExactHeader,
+    SecretInjection,
+)
 
 
 def test_enum_members_compare_equal_to_values() -> None:
@@ -19,3 +25,38 @@ def test_enum_members_stringify_to_values() -> None:
     assert str(PullPolicy.IF_MISSING) == "if-missing"
     assert f"{PullPolicy.IF_MISSING}" == "if-missing"
     assert format(LogLevel.WARN) == "warn"
+
+
+def test_exact_header_secret_is_provider_neutral() -> None:
+    entry = Secret.exact_header(
+        "API_KEY",
+        value="synthetic-token",
+        header="Proxy-Authorization",
+        scheme="Token",
+        allow_hosts=("api.example.com",),
+    )
+
+    assert entry.injection == SecretInjection(
+        headers=False,
+        basic_auth=False,
+        exact_headers=(
+            SecretExactHeader(name="Proxy-Authorization", scheme="Token"),
+        ),
+    )
+    assert entry._to_dict()["injection"] == {
+        "headers": False,
+        "basic_auth": False,
+        "exact_headers": [
+            {"name": "Proxy-Authorization", "scheme": "Token"},
+        ],
+    }
+
+
+def test_secret_injection_preserves_legacy_positional_arguments() -> None:
+    injection = SecretInjection(False, True, True, True)
+
+    assert injection.headers is False
+    assert injection.basic_auth is True
+    assert injection.query_params is True
+    assert injection.body is True
+    assert injection.exact_headers == ()

--- a/sdk/rust/lib/image/mod.rs
+++ b/sdk/rust/lib/image/mod.rs
@@ -952,6 +952,11 @@ async fn upsert_config_record<C: ConnectionTrait>(
         .as_ref()
         .map(serde_json::to_string)
         .transpose()?;
+    let labels_json = if config.labels.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&config.labels)?)
+    };
 
     let now = chrono::Utc::now().naive_utc();
 
@@ -969,7 +974,7 @@ async fn upsert_config_record<C: ConnectionTrait>(
         entrypoint: Set(entrypoint_json),
         working_dir: Set(config.working_dir.clone()),
         user: Set(config.user.clone()),
-        labels: Set(None),
+        labels: Set(labels_json),
         stop_signal: Set(None),
         created_at: Set(Some(now)),
         ..Default::default()
@@ -1094,6 +1099,12 @@ async fn try_persist_fast_path(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use microsandbox_image::{CachedImageMetadata, ImageConfig};
+
+    use super::*;
+
     #[test]
     fn test_default_backend_image_api_methods_stay_available() {
         // Compile-time tripwire for the pre-backend-routing Rust API shape.
@@ -1106,5 +1117,39 @@ mod tests {
         let _ = super::Image::prune;
         let _ = super::Image::load;
         let _ = super::Image::save;
+    }
+
+    #[tokio::test]
+    async fn persist_preserves_oci_labels_for_inspection() {
+        let temp = tempfile::tempdir().unwrap();
+        let local = LocalBackend::builder()
+            .home(temp.path())
+            .build()
+            .await
+            .unwrap();
+        let reference = "registry.example.com/acme/labeled-image:latest";
+        let metadata = CachedImageMetadata {
+            manifest_digest:
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            config_digest:
+                "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".into(),
+            raw_manifest_json: r#"{"schemaVersion":2,"layers":[]}"#.into(),
+            raw_config_json: r#"{"config":{"Labels":{"org.example.feature":"enabled"}}}"#.into(),
+            config: ImageConfig {
+                labels: HashMap::from([("org.example.feature".into(), "enabled".into())]),
+                ..Default::default()
+            },
+            layers: Vec::new(),
+        };
+
+        Image::persist(&local, reference, metadata).await.unwrap();
+
+        let detail = Image::inspect_local(&local, reference).await.unwrap();
+        assert_eq!(
+            detail.config.unwrap().labels,
+            Some(serde_json::json!({
+                "org.example.feature": "enabled"
+            }))
+        );
     }
 }

--- a/sdk/rust/lib/lib.rs
+++ b/sdk/rust/lib/lib.rs
@@ -59,10 +59,10 @@ pub use sandbox::{
     PlannedChange, ResourceConvergenceState, ResourceKind, ResourceResizeStatus, Sandbox,
     SandboxConfig, SandboxListBuilder, SandboxMetrics, SandboxMetricsReport, SandboxMetricsState,
     SandboxModificationBuilder, SandboxModificationPatch, SandboxModificationPlan, SandboxPage,
-    SandboxPingResult, SandboxTouchResult, SecretChangeKind, SecretModificationPatch,
-    SecretPatchBuilder, SecretPlannedChange, SecretSource, all_sandbox_metrics,
-    all_sandbox_metrics_local, all_sandbox_metrics_reports_local, sandbox_metrics_report_local,
-    validate_sandbox_name,
+    SandboxPingResult, SandboxTouchResult, SecretChangeKind, SecretExactHeader,
+    SecretModificationPatch, SecretPatchBuilder, SecretPlannedChange, SecretSource,
+    all_sandbox_metrics, all_sandbox_metrics_local, all_sandbox_metrics_reports_local,
+    sandbox_metrics_report_local, validate_sandbox_name,
 };
 #[cfg(feature = "net")]
 pub use sandbox::{NetworkPolicy, NetworkProfile};

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -118,6 +118,7 @@ pub use microsandbox_types::PullPolicy;
 pub use microsandbox_types::{
     EnvVar, MAX_HOSTNAME_BYTES, MAX_SANDBOX_NAME_BYTES, NetworkSpec, PortProtocol,
     PublishedPortSpec, SandboxLogLevel, SandboxResources, SandboxRuntimeOptions, SandboxSpec,
+    SecretExactHeader,
 };
 pub use modify::{
     ChangeKind, ConfigPlannedChange, ModificationConflict, ModificationDisposition,

--- a/sdk/rust/lib/sandbox/modify.rs
+++ b/sdk/rust/lib/sandbox/modify.rs
@@ -3640,7 +3640,20 @@ mod tests {
     #[cfg(feature = "net")]
     #[test]
     fn applying_source_rotate_drops_inlined_value_and_keeps_placeholder() {
+        use microsandbox_network::secrets::config::SecretExactHeader;
+
         let mut config = config_with_secret("API_KEY", SECRET_SENTINEL);
+        let mut network = config.local_network_config().unwrap();
+        network.secrets.secrets[0].injection.headers = false;
+        network.secrets.secrets[0].injection.basic_auth = false;
+        network.secrets.secrets[0]
+            .injection
+            .exact_headers
+            .push(SecretExactHeader {
+                name: "Authorization".into(),
+                scheme: Some("Bearer".into()),
+            });
+        config.set_local_network_config(network).unwrap();
         let patch = patch_with_specs(vec![source_spec("API_KEY", &[])]);
 
         apply_secret_patch_to_config(&mut config, &patch).unwrap();
@@ -3657,6 +3670,14 @@ mod tests {
         // Rotation keeps the guest-visible placeholder and host allow-list.
         assert_eq!(entry.placeholder, "$MSB_API_KEY");
         assert_eq!(entry.allowed_hosts.len(), 1);
+        assert!(!entry.injection.headers);
+        assert!(!entry.injection.basic_auth);
+        assert_eq!(entry.injection.exact_headers.len(), 1);
+        assert_eq!(entry.injection.exact_headers[0].name, "Authorization");
+        assert_eq!(
+            entry.injection.exact_headers[0].scheme.as_deref(),
+            Some("Bearer")
+        );
     }
 
     #[cfg(feature = "net")]


### PR DESCRIPTION
## Summary
- reap zombie children adopted by the normal guest PID 1 agent
- preserve exit-status ownership for active exec-session leaders

## Root cause
The normal agent waited for direct exec-session children and reaped during shutdown, but it did not reap descendants adopted after their session parent exited.

## Validation
- `cargo test -p microsandbox-agentd --lib`
- real microVM probe that orphaned a Python child and verified its `/proc` entry disappeared