### PR TITLE
feat(runtime): share writeback pressure live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,8 +4164,7 @@ dependencies = [
 [[package]]
 name = "msb_krun"
 version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8ee04c9ab5ac9849d288f9b38cb143dcde304b97fdf8b9fd027ef945a94a7c"
+source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -4184,8 +4183,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_arch"
 version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd265469aa37265b2de6d4e6ebcf536e2cc915bffd014a8bb0034fedd74d838"
+source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -4199,14 +4197,12 @@ dependencies = [
 [[package]]
 name = "msb_krun_arch_gen"
 version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8472690b285cf4ead92816b468662b5468fce99a0597f4f6f54696d313254e"
+source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
 
 [[package]]
 name = "msb_krun_cpuid"
 version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1057ddf1b7a1c9ef8178986066b2c018a8dc54f0ffdc69356ce1b621e1088a9c"
+source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -4216,8 +4212,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_devices"
 version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f622af9b0ff353abddcc1c3fca9e1613b67f613be15776df1b4f246b52245b2f"
+source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -4246,8 +4241,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_hvf"
 version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2025a231679bf342281c19e64eef7cfd120882e60ade8ef533c16b9fe246d1"
+source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -4258,8 +4252,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_kernel"
 version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c05990d373eb5c26c9179c5d9c87f4025721c4c30187d74e74a8d0d03c6e16"
+source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
 dependencies = [
  "msb_krun_utils",
  "vm-memory",
@@ -4268,8 +4261,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_polly"
 version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fcc828ea3d4aa1c5da02ed1433bc81ce3f1ede5c65dbb756a4b03271109aae"
+source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -4278,8 +4270,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_smbios"
 version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6d617b90458c041da4ee3a4cb8f548eb750eed8b50cc87ed8c0d6a9276070c"
+source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
 dependencies = [
  "vm-memory",
 ]
@@ -4287,8 +4278,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_utils"
 version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f881a3a5ab9d960c829c77dfab765cffac2208e6bea52d456c6d2e7495f2b5"
+source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -4303,8 +4293,7 @@ dependencies = [
 [[package]]
 name = "msb_krun_vmm"
 version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bf27d7dbd535afd4f25071de0c0fc83023d574d58eea39d682c4c58cc7571"
+source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,8 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.26"
-source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0dc8bd4d9f56f4a418e4a671b52c0939874cb3605b8c8defdaba46a393d811"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -4182,8 +4183,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.26"
-source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a00354baae50de4380c7063310e0b4d717b4416de2996985686df8279bd1d11"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -4196,13 +4198,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.26"
-source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8e2f19da08eafa0ad8b2f71654c20f393b3682132a3254c0bbe4f045e88060"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.26"
-source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695fd3ecdff794333d6081766279d258828e47dfa6d65d36118fba42a54fab4f"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -4211,8 +4215,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.26"
-source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a1a067fabeb7051f69c206c019779e330dcf9b83b94110e2c57f5882a45c058"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -4240,8 +4245,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.26"
-source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38155b938d3cd83e5d8136b93399d2cadab9894945398265d4e2b89e7d763aa"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -4251,8 +4257,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.26"
-source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f213e99af32073c1ac28f1230a8559b7c26a07ed51a702194944a35db2b889"
 dependencies = [
  "msb_krun_utils",
  "vm-memory",
@@ -4260,8 +4267,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.26"
-source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afd50664467149435e242ea818390ac69815b65508c257ff40f67e7509909ae"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -4269,16 +4277,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.26"
-source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce4022d2bbfb8943ff35a9835ed184f83bce8b6d821a4f781b73421b4d11a02"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.26"
-source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e4b71cd539d1ff7e212930e06fe3c005e59630df67f838ba9b33884ab3b49"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -4292,8 +4302,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.26"
-source = "git+https://github.com/superradcompany/libkrun.git?rev=cf18cc46c49d9394ff4d07867aa73cb49321f166#cf18cc46c49d9394ff4d07867aa73cb49321f166"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb5cb4c2d8461ce3cf385fb30eccb3955df0162d05ea07785437da67740da62"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,8 @@ microsandbox-network = { version = "=0.6.8", path = "crates/network" }
 microsandbox-protocol = { version = "=0.6.8", path = "crates/protocol" }
 microsandbox-runtime = { version = "=0.6.8", path = "crates/runtime", default-features = false }
 microsandbox-utils = { version = "=0.6.8", path = "crates/utils" }
-msb_krun = "=0.1.26"
-msb_krun_utils = "=0.1.26"
+msb_krun = { version = "=0.1.26", git = "https://github.com/superradcompany/libkrun.git", rev = "cf18cc46c49d9394ff4d07867aa73cb49321f166" }
+msb_krun_utils = { version = "=0.1.26", git = "https://github.com/superradcompany/libkrun.git", rev = "cf18cc46c49d9394ff4d07867aa73cb49321f166" }
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,8 @@ microsandbox-network = { version = "=0.6.8", path = "crates/network" }
 microsandbox-protocol = { version = "=0.6.8", path = "crates/protocol" }
 microsandbox-runtime = { version = "=0.6.8", path = "crates/runtime", default-features = false }
 microsandbox-utils = { version = "=0.6.8", path = "crates/utils" }
-msb_krun = { version = "=0.1.26", git = "https://github.com/superradcompany/libkrun.git", rev = "cf18cc46c49d9394ff4d07867aa73cb49321f166" }
-msb_krun_utils = { version = "=0.1.26", git = "https://github.com/superradcompany/libkrun.git", rev = "cf18cc46c49d9394ff4d07867aa73cb49321f166" }
+msb_krun = "=0.1.28"
+msb_krun_utils = "=0.1.28"
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }
 

--- a/crates/db/lib/entity/writeback_allocation.rs
+++ b/crates/db/lib/entity/writeback_allocation.rs
@@ -1,4 +1,4 @@
-//! Entity definition for active host-global writeback reservations.
+//! Entity definition for active host-global writeback pressure members.
 
 use sea_orm::entity::prelude::*;
 
@@ -6,29 +6,29 @@ use sea_orm::entity::prelude::*;
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// One active dirty-credit reservation owned by a sandbox run.
+/// One active dirty-credit pool member owned by a sandbox run.
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "writeback_allocation")]
 pub struct Model {
     /// Cryptographically random allocation identifier.
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: String,
-    /// Run that originally acquired the reservation.
+    /// Run that originally acquired the membership.
     ///
-    /// This is deliberately not a foreign key: crash recovery must retain dirty credit even if
+    /// This is deliberately not a foreign key: crash recovery must retain membership even if
     /// lifecycle cleanup removes the run row before another runtime can inspect the stale lease.
     pub run_id: i32,
     /// Owner-only lock-file basename held for the process lifetime.
     pub lease_name: String,
-    /// Hard limit passed to each eligible writable raw disk.
+    /// Maximum limit passed to each eligible writable raw disk.
     pub per_disk_limit_bytes: i64,
-    /// Number of disks charged to this reservation.
+    /// Number of disks represented by this membership.
     pub disk_count: i32,
-    /// Total dirty credit reserved by this run.
+    /// Requested maximum across all disks, retained for schema compatibility and diagnostics.
     pub reserved_bytes: i64,
-    /// Host-global pool observed when the reservation was admitted.
+    /// Host-global pool requested when the membership was created.
     pub pool_bytes: i64,
-    /// Linux boot identifier recorded when dirty credit was admitted.
+    /// Linux boot identifier recorded when the member joined the pressure pool.
     pub boot_id: String,
     /// Sorted Linux backing-filesystem device identities (`major:minor`, comma-separated).
     pub backing_devices: String,
@@ -36,7 +36,7 @@ pub struct Model {
     pub created_at: DateTime,
 }
 
-/// Writeback reservations intentionally have no cascading database relation.
+/// Writeback memberships intentionally have no cascading database relation.
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
 

--- a/crates/runtime/lib/launch.rs
+++ b/crates/runtime/lib/launch.rs
@@ -45,7 +45,7 @@ pub struct LaunchConfig {
     /// Internal directory containing process-held CPU allocation leases.
     pub cpu_lease_dir: PathBuf,
 
-    /// Internal directory containing process-held writeback admission leases.
+    /// Internal directory containing process-held writeback pressure leases.
     pub writeback_lease_dir: PathBuf,
 
     /// Requested host CPU placement policy.
@@ -65,7 +65,7 @@ pub struct LaunchConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block_writeback_limit_bytes: Option<u64>,
 
-    /// Host-global dirty-credit pool used for spawn-time admission.
+    /// Host-global dirty-credit pool shared fairly by live writable disks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block_writeback_pool_bytes: Option<u64>,
 

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -60,6 +60,9 @@ const EXIT_REASON_AGENT_UNRESPONSIVE: u8 = 5;
 const EXIT_REASON_SHUTDOWN_REQUESTED: u8 = 6;
 const EXIT_REASON_STARTUP_COMMAND_FAILED: u8 = 7;
 
+/// Bounds how long an existing VMM can retain an obsolete fair share after membership changes.
+const WRITEBACK_PRESSURE_REFRESH_INTERVAL: Duration = Duration::from_millis(250);
+
 /// Fixed fd carrying the bulk `msb sandbox` config (argv overflow) as
 /// NUL-terminated argument records. Keeps the network-config blob and the
 /// repeated `--env` flags off the process argv — see issue #997.
@@ -114,10 +117,10 @@ pub struct Config {
     /// Internal directory containing process-held CPU allocation leases.
     pub cpu_lease_dir: PathBuf,
 
-    /// Internal directory containing process-held writeback admission leases.
+    /// Internal directory containing process-held writeback pressure leases.
     pub writeback_lease_dir: PathBuf,
 
-    /// Host-global dirty-credit pool used for spawn-time admission.
+    /// Host-global dirty-credit pool shared fairly by live writable disks.
     pub block_writeback_pool_bytes: Option<u64>,
 
     /// Path to the Unix domain socket for the agent relay.
@@ -566,15 +569,24 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         config.vm.block_writeback_limit_bytes,
         &writeback_disk_paths,
     )) {
-        Ok(guard) => Arc::new(guard),
+        Ok(guard) => guard,
         Err(error) => {
             if let Err(release_error) = tokio_rt.block_on(cpu_guard.release(&db)) {
-                tracing::warn!(%release_error, "release CPU placement after writeback admission failure");
+                tracing::warn!(%release_error, "release CPU placement after writeback pressure setup failure");
             }
             let _ = tokio_rt.block_on(mark_run_failed(&db, run_db_id));
             return Err(error);
         }
     };
+    let writeback_guard = Arc::new(writeback_guard);
+    let writeback_limit = writeback_guard.limit();
+    if writeback_guard.is_managed() {
+        let pressure_guard = Arc::clone(&writeback_guard);
+        let pressure_db = db.clone();
+        tokio_rt.spawn(async move {
+            monitor_writeback_pressure(pressure_guard, pressure_db).await;
+        });
+    }
 
     // Attach the exec.log writer so the ring reader can capture the
     // primary session's stdout/stderr. Failure to open the file is
@@ -667,7 +679,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                 let now = chrono::Utc::now().naive_utc();
 
                 if let Err(error) = exit_writeback_guard.release(&exit_db).await {
-                    tracing::warn!(%error, "release writeback admission at VM exit");
+                    tracing::warn!(%error, "release writeback pressure membership at VM exit");
                 }
                 if let Err(error) = exit_cpu_guard.release(&exit_db).await {
                     tracing::warn!(%error, "release CPU placement at VM exit");
@@ -748,6 +760,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         },
         tokio_rt.handle().clone(),
         cpu_guard.vcpu_targets(),
+        writeback_limit.as_ref(),
     );
     let (
         vm,
@@ -759,7 +772,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         Ok(vm) => vm,
         Err(e) => {
             if let Err(error) = tokio_rt.block_on(writeback_guard.release(&db)) {
-                tracing::warn!(%error, "release writeback admission after VM build failure");
+                tracing::warn!(%error, "release writeback pressure membership after VM build failure");
             }
             if let Err(error) = tokio_rt.block_on(cpu_guard.release(&db)) {
                 tracing::warn!(%error, "release CPU placement after VM build failure");
@@ -1141,7 +1154,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         Ok(infallible) => Ok(infallible),
         Err(e) => {
             if let Err(error) = cleanup_rt_handle.block_on(writeback_guard.release(&db)) {
-                tracing::warn!(%error, "release writeback admission after VM enter failure");
+                tracing::warn!(%error, "release writeback pressure membership after VM enter failure");
             }
             if let Err(error) = cleanup_rt_handle.block_on(cpu_guard.release(&db)) {
                 tracing::warn!(%error, "release CPU placement after VM enter failure");
@@ -1179,13 +1192,13 @@ fn apply_block_writeback_limit(
     mut disk: msb_krun::DiskBuilder,
     format: msb_krun::DiskImageFormat,
     read_only: bool,
-    limit_bytes: Option<u64>,
+    limit: Option<&msb_krun::WritebackLimit>,
 ) -> msb_krun::DiskBuilder {
     if !read_only
         && matches!(format, msb_krun::DiskImageFormat::Raw)
-        && let Some(limit_bytes) = limit_bytes
+        && let Some(limit) = limit
     {
-        disk = disk.writeback_limit_bytes(limit_bytes);
+        disk = disk.writeback_limit(limit.clone());
     }
     disk
 }
@@ -1234,6 +1247,7 @@ fn build_vm(
     on_exit: impl Fn(i32) + Send + 'static,
     tokio_handle: tokio::runtime::Handle,
     vcpu_targets: Option<&[crate::cpu::LogicalCpuId]>,
+    writeback_limit: Option<&msb_krun::WritebackLimit>,
 ) -> RuntimeResult<VmBuildOutput> {
     let mut exec_env = config.vm.env.clone();
     let vm = &config.vm;
@@ -1334,18 +1348,18 @@ fn build_vm(
             let primary = spec.primary.clone();
             let format = spec.format;
             let read_only = spec.read_only;
-            let writeback_limit_bytes = vm.block_writeback_limit_bytes;
+            let writeback_limit = writeback_limit.cloned();
             builder = builder.disk(move |d| {
                 let d = d.path(&primary).format(format).read_only(read_only);
-                apply_block_writeback_limit(d, format, read_only, writeback_limit_bytes)
+                apply_block_writeback_limit(d, format, read_only, writeback_limit.as_ref())
             });
         } else if let Some(ref upper) = vm.rootfs_upper {
             let upper = upper.clone();
             let format = msb_krun::DiskImageFormat::Raw;
-            let writeback_limit_bytes = vm.block_writeback_limit_bytes;
+            let writeback_limit = writeback_limit.cloned();
             builder = builder.disk(move |d| {
                 let d = d.path(&upper).format(format).read_only(false);
-                apply_block_writeback_limit(d, format, false, writeback_limit_bytes)
+                apply_block_writeback_limit(d, format, false, writeback_limit.as_ref())
             });
         }
 
@@ -1376,10 +1390,10 @@ fn build_vm(
             .map_err(|e| RuntimeError::Custom(format!("disk format: {e}")))?;
         let disk_path = disk_path.clone();
         let readonly = vm.rootfs_disk_readonly;
-        let writeback_limit_bytes = vm.block_writeback_limit_bytes;
+        let writeback_limit = writeback_limit.cloned();
         builder = builder.disk(move |d| {
             let d = d.path(&disk_path).format(format).read_only(readonly);
-            apply_block_writeback_limit(d, format, readonly, writeback_limit_bytes)
+            apply_block_writeback_limit(d, format, readonly, writeback_limit.as_ref())
         });
         append_block_root_env(&mut exec_env);
     }
@@ -1456,7 +1470,7 @@ fn build_vm(
         let host = disk.host.clone();
         let format = disk.format;
         let readonly = disk.readonly;
-        let writeback_limit_bytes = vm.block_writeback_limit_bytes;
+        let writeback_limit = writeback_limit.cloned();
         builder = builder.disk(move |d| {
             let mut d = d.id(&id).path(&host).format(format).read_only(readonly);
             if readonly {
@@ -1465,7 +1479,7 @@ fn build_vm(
                     .cache(msb_krun::CacheMode::Unsafe)
                     .sync(msb_krun::SyncMode::None);
             }
-            apply_block_writeback_limit(d, format, readonly, writeback_limit_bytes)
+            apply_block_writeback_limit(d, format, readonly, writeback_limit.as_ref())
         });
     }
 
@@ -1585,6 +1599,37 @@ fn build_vm(
 //--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
+
+async fn monitor_writeback_pressure(
+    guard: Arc<crate::writeback::WritebackPressureGuard>,
+    db: DbWriteConnection,
+) {
+    let mut interval = tokio::time::interval(WRITEBACK_PRESSURE_REFRESH_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Acquisition already installed the initial target, so avoid an unnecessary immediate query.
+    interval.tick().await;
+    let mut coordination_failed = false;
+
+    loop {
+        interval.tick().await;
+        match guard.refresh(&db).await {
+            Ok(()) if coordination_failed => {
+                tracing::info!("writeback pressure coordination recovered");
+                coordination_failed = false;
+            }
+            Ok(()) => {}
+            Err(error) => {
+                // Losing the coordinator must reduce throughput, never silently restore the full
+                // per-disk window while the active host membership is unknown.
+                guard.fail_closed();
+                if !coordination_failed {
+                    tracing::warn!(%error, "writeback pressure coordination failed closed");
+                    coordination_failed = true;
+                }
+            }
+        }
+    }
+}
 
 /// Raise `RLIMIT_NOFILE` to the hard limit, capped at 1M (the reference virtiofsd default). On macOS the soft limit is additionally clamped to
 /// `kern.maxfilesperproc`, which `setrlimit` enforces even when the hard limit is unlimited.

--- a/crates/runtime/lib/writeback/admission.rs
+++ b/crates/runtime/lib/writeback/admission.rs
@@ -1,4 +1,4 @@
-//! Crash-safe dirty-credit reservations acquired once per VM boot.
+//! Crash-safe membership and fair-share coordination for bounded block writeback.
 
 use std::fs::File;
 use std::io;
@@ -16,6 +16,7 @@ use std::os::unix::fs::MetadataExt;
 use microsandbox_db::DbWriteConnection;
 use microsandbox_db::entity::writeback_allocation;
 use microsandbox_utils::process_lock;
+use msb_krun::WritebackLimit;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
 
 use crate::{RuntimeError, RuntimeResult};
@@ -24,9 +25,10 @@ use crate::{RuntimeError, RuntimeResult};
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// Process-held reservation from the host-global buffered-writeback pool.
-pub(crate) struct WritebackAdmissionGuard {
+/// Process-held membership in the host-global buffered-writeback pool.
+pub(crate) struct WritebackPressureGuard {
     lease: Option<AllocationLease>,
+    limit: Option<WritebackLimit>,
 }
 
 struct AllocationLease {
@@ -61,8 +63,47 @@ struct RecoveryIdentity {
 // Methods
 //--------------------------------------------------------------------------------------------------
 
-impl WritebackAdmissionGuard {
-    /// Removes catalog state and releases the process-held reservation.
+impl WritebackPressureGuard {
+    pub(crate) fn is_managed(&self) -> bool {
+        self.lease.is_some()
+    }
+
+    /// Returns the live limit shared by every eligible disk in this VM.
+    pub(crate) fn limit(&self) -> Option<WritebackLimit> {
+        self.limit.clone()
+    }
+
+    /// Refreshes this VM's per-disk target from the current host-wide fair share.
+    pub(crate) async fn refresh(&self, db: &DbWriteConnection) -> RuntimeResult<()> {
+        let (Some(lease), Some(limit)) = (&self.lease, &self.limit) else {
+            return Ok(());
+        };
+        let allocations = writeback_allocation::Entity::find().all(db).await?;
+        let target_bytes = fair_target_bytes(&lease.allocation_id, &allocations)?;
+        let previous_target_bytes = limit.target_bytes();
+        limit.set_target_bytes(target_bytes).map_err(|error| {
+            RuntimeError::Custom(format!("update live writeback pressure target: {error}"))
+        })?;
+        if target_bytes != previous_target_bytes {
+            // Target transitions are infrequent and useful when diagnosing host-wide pressure.
+            tracing::debug!(
+                allocation_id = %lease.allocation_id,
+                previous_target_bytes,
+                target_bytes,
+                "writeback pressure target changed"
+            );
+        }
+        Ok(())
+    }
+
+    /// Moves this VM to its smallest forward-progress target after coordination fails.
+    pub(crate) fn fail_closed(&self) {
+        if let Some(limit) = &self.limit {
+            let _ = limit.set_target_bytes(1);
+        }
+    }
+
+    /// Removes catalog state and releases the process-held pressure lease.
     pub(crate) async fn release(&self, db: &DbWriteConnection) -> RuntimeResult<()> {
         if let Some(lease) = &self.lease {
             lease.release(db).await?;
@@ -101,7 +142,7 @@ impl AllocationLease {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Reserves aggregate dirty credit for every eligible disk attached to one VM.
+/// Registers every eligible disk and initializes this VM's live fair-share target.
 pub(crate) async fn acquire(
     db: &DbWriteConnection,
     run_id: i32,
@@ -109,27 +150,30 @@ pub(crate) async fn acquire(
     pool_bytes: Option<u64>,
     per_disk_limit_bytes: Option<u64>,
     disk_paths: &[PathBuf],
-) -> RuntimeResult<WritebackAdmissionGuard> {
-    let (Some(pool_bytes), Some(per_disk_limit_bytes)) = (pool_bytes, per_disk_limit_bytes) else {
-        return Ok(WritebackAdmissionGuard { lease: None });
+) -> RuntimeResult<WritebackPressureGuard> {
+    let Some(per_disk_limit_bytes) = per_disk_limit_bytes else {
+        return Ok(WritebackPressureGuard {
+            lease: None,
+            limit: None,
+        });
+    };
+    let limit = WritebackLimit::new(per_disk_limit_bytes);
+    let Some(pool_bytes) = pool_bytes else {
+        return Ok(WritebackPressureGuard {
+            lease: None,
+            limit: Some(limit),
+        });
     };
     if disk_paths.is_empty() {
-        return Ok(WritebackAdmissionGuard { lease: None });
+        return Ok(WritebackPressureGuard {
+            lease: None,
+            limit: None,
+        });
     }
 
     let disk_count = disk_paths.len();
     let recovery_identity = recovery_identity(disk_paths)?;
-    let requested_bytes = reservation_bytes(per_disk_limit_bytes, disk_count)?;
-    if requested_bytes > pool_bytes {
-        return Err(pool_exhausted_error(
-            requested_bytes,
-            0,
-            pool_bytes,
-            per_disk_limit_bytes,
-            disk_count,
-        ));
-    }
-
+    let requested_bytes = requested_max_bytes(per_disk_limit_bytes, disk_count)?;
     prepare_lease_dir(lease_dir)?;
     let allocation_id = format!("{:032x}", rand::random::<u128>());
     let lease_name = format!("{allocation_id}.lock");
@@ -168,31 +212,12 @@ pub(crate) async fn acquire(
                         .await?;
                 }
 
-                // The capacity check and insert share one retryable SQLite transaction. Concurrent
-                // spawns that read the same snapshot cannot both commit: the loser retries and
-                // observes the winner before deciding whether capacity remains.
+                // The insert remains serialized with stale cleanup. Capacity is intentionally not
+                // an admission gate: every live runtime converges to a weighted fair share instead.
                 let active = writeback_allocation::Entity::find()
                     .all(&transaction)
                     .await?;
-                let occupied_bytes = total_reserved_bytes(&active)?;
-                // A host policy change must not let a new runtime enlarge the pool out from under
-                // reservations that were admitted against a smaller live limit. Once those older
-                // reservations drain, their stored policy leaves the minimum and the larger pool
-                // becomes available without any generation switch or supervisor process.
-                let effective_pool_bytes = most_restrictive_pool_bytes(pool_bytes, &active)?;
-                let admitted_bytes =
-                    occupied_bytes.checked_add(requested_bytes).ok_or_else(|| {
-                        RuntimeError::Custom("writeback reservation total overflowed u64".into())
-                    })?;
-                if admitted_bytes > effective_pool_bytes {
-                    return Err(pool_exhausted_error(
-                        requested_bytes,
-                        occupied_bytes,
-                        effective_pool_bytes,
-                        per_disk_limit_bytes,
-                        disk_count,
-                    ));
-                }
+                let existing_requested_bytes = total_requested_bytes(&active)?;
 
                 writeback_allocation::Entity::insert(writeback_allocation::ActiveModel {
                     id: Set(allocation_id.clone()),
@@ -205,7 +230,7 @@ pub(crate) async fn acquire(
                     disk_count: Set(i32::try_from(disk_count).map_err(|_| {
                         RuntimeError::Custom("writeback disk count exceeds i32".into())
                     })?),
-                    reserved_bytes: Set(to_i64(requested_bytes, "writeback reservation")?),
+                    reserved_bytes: Set(to_i64(requested_bytes, "writeback requested maximum")?),
                     pool_bytes: Set(to_i64(pool_bytes, "writeback pool")?),
                     boot_id: Set(recovery_boot_id),
                     backing_devices: Set(recovery_backing_devices),
@@ -214,24 +239,33 @@ pub(crate) async fn acquire(
                 .exec(&transaction)
                 .await?;
 
-                Ok::<_, RuntimeError>((transaction, occupied_bytes))
+                let active = writeback_allocation::Entity::find()
+                    .all(&transaction)
+                    .await?;
+                let target_bytes = fair_target_bytes(&allocation_id, &active)?;
+
+                Ok::<_, RuntimeError>((transaction, (existing_requested_bytes, target_bytes)))
             }
         })
         .await;
 
     match transaction_result {
-        Ok(occupied_bytes) => {
+        Ok((existing_requested_bytes, target_bytes)) => {
             clean_stale_files(stale);
+            limit.set_target_bytes(target_bytes).map_err(|error| {
+                RuntimeError::Custom(format!("set initial writeback pressure target: {error}"))
+            })?;
             tracing::debug!(
                 pool_bytes,
-                occupied_bytes,
+                existing_requested_bytes,
                 requested_bytes,
                 per_disk_limit_bytes,
+                target_bytes,
                 disk_count,
                 elapsed_us = started.elapsed().as_micros(),
-                "writeback dirty credit admitted"
+                "writeback pressure lease acquired"
             );
-            Ok(WritebackAdmissionGuard {
+            Ok(WritebackPressureGuard {
                 lease: Some(AllocationLease {
                     allocation_id,
                     lease_path,
@@ -239,6 +273,7 @@ pub(crate) async fn acquire(
                     backing_files: recovery_identity.files,
                     released: AtomicBool::new(false),
                 }),
+                limit: Some(limit),
             })
         }
         Err(error) => {
@@ -248,25 +283,25 @@ pub(crate) async fn acquire(
     }
 }
 
-fn reservation_bytes(per_disk_limit_bytes: u64, disk_count: usize) -> RuntimeResult<u64> {
+fn requested_max_bytes(per_disk_limit_bytes: u64, disk_count: usize) -> RuntimeResult<u64> {
     let disk_count = u64::try_from(disk_count)
         .map_err(|_| RuntimeError::Custom("writeback disk count exceeds u64".into()))?;
     per_disk_limit_bytes
         .checked_mul(disk_count)
-        .ok_or_else(|| RuntimeError::Custom("writeback reservation overflowed u64".into()))
+        .ok_or_else(|| RuntimeError::Custom("writeback requested maximum overflowed u64".into()))
 }
 
-fn total_reserved_bytes(allocations: &[writeback_allocation::Model]) -> RuntimeResult<u64> {
+fn total_requested_bytes(allocations: &[writeback_allocation::Model]) -> RuntimeResult<u64> {
     allocations.iter().try_fold(0_u64, |total, allocation| {
         let reserved = u64::try_from(allocation.reserved_bytes).map_err(|_| {
             RuntimeError::Custom(format!(
-                "writeback allocation {} contains a negative reservation",
+                "writeback allocation {} contains a negative requested maximum",
                 allocation.id
             ))
         })?;
         total
             .checked_add(reserved)
-            .ok_or_else(|| RuntimeError::Custom("writeback allocation total overflowed u64".into()))
+            .ok_or_else(|| RuntimeError::Custom("writeback requested total overflowed u64".into()))
     })
 }
 
@@ -287,20 +322,93 @@ fn most_restrictive_pool_bytes(
         })
 }
 
-fn to_i64(value: u64, label: &str) -> RuntimeResult<i64> {
-    i64::try_from(value).map_err(|_| RuntimeError::Custom(format!("{label} exceeds i64")))
+/// Computes the weighted max-min fair target for one allocation.
+///
+/// Every disk receives the same waterline unless its configured maximum is lower. An allocation
+/// with multiple writable disks therefore consumes one share per disk rather than one share per
+/// sandbox. Integer division may leave a few bytes unused but never exceeds the active pool.
+fn fair_target_bytes(
+    allocation_id: &str,
+    allocations: &[writeback_allocation::Model],
+) -> RuntimeResult<u64> {
+    let allocation = allocations
+        .iter()
+        .find(|allocation| allocation.id == allocation_id)
+        .ok_or_else(|| {
+            RuntimeError::Custom(format!(
+                "writeback pressure allocation {allocation_id} disappeared"
+            ))
+        })?;
+    let requested_limit = allocation_limit_bytes(allocation)?;
+    let pool_bytes = most_restrictive_pool_bytes(u64::MAX, allocations)?;
+    let mut limits = allocations
+        .iter()
+        .map(|allocation| {
+            Ok((
+                allocation_limit_bytes(allocation)?,
+                allocation_disk_count(allocation)?,
+            ))
+        })
+        .collect::<RuntimeResult<Vec<_>>>()?;
+    limits.sort_unstable_by_key(|(limit, _)| *limit);
+
+    let mut remaining_pool = pool_bytes;
+    let mut remaining_disks = limits.iter().try_fold(0_u64, |total, (_, count)| {
+        total
+            .checked_add(*count)
+            .ok_or_else(|| RuntimeError::Custom("writeback disk total overflowed u64".into()))
+    })?;
+    if remaining_disks == 0 {
+        return Err(RuntimeError::Custom(
+            "writeback pressure allocation has no disks".into(),
+        ));
+    }
+
+    for (configured_limit, disk_count) in limits {
+        let waterline = remaining_pool / remaining_disks;
+        if configured_limit >= waterline {
+            return Ok(requested_limit.min(waterline.max(1)));
+        }
+        let allocation_bytes = configured_limit.checked_mul(disk_count).ok_or_else(|| {
+            RuntimeError::Custom("writeback fair-share total overflowed u64".into())
+        })?;
+        remaining_pool = remaining_pool.saturating_sub(allocation_bytes);
+        remaining_disks -= disk_count;
+        if remaining_disks == 0 {
+            return Ok(requested_limit);
+        }
+    }
+
+    Ok(requested_limit)
 }
 
-fn pool_exhausted_error(
-    requested_bytes: u64,
-    occupied_bytes: u64,
-    pool_bytes: u64,
-    per_disk_limit_bytes: u64,
-    disk_count: usize,
-) -> RuntimeError {
-    RuntimeError::Custom(format!(
-        "host writeback pool exhausted: requested {requested_bytes} bytes for {disk_count} disk(s) at {per_disk_limit_bytes} bytes each, but {occupied_bytes} of {pool_bytes} bytes is already reserved"
-    ))
+fn allocation_limit_bytes(allocation: &writeback_allocation::Model) -> RuntimeResult<u64> {
+    u64::try_from(allocation.per_disk_limit_bytes).map_err(|_| {
+        RuntimeError::Custom(format!(
+            "writeback allocation {} contains a negative per-disk limit",
+            allocation.id
+        ))
+    })
+}
+
+fn allocation_disk_count(allocation: &writeback_allocation::Model) -> RuntimeResult<u64> {
+    let disk_count = u64::try_from(allocation.disk_count).map_err(|_| {
+        RuntimeError::Custom(format!(
+            "writeback allocation {} contains a negative disk count",
+            allocation.id
+        ))
+    })?;
+    if disk_count == 0 {
+        return Err(RuntimeError::Custom(format!(
+            "writeback allocation {} contains no disks",
+            allocation.id
+        )));
+    }
+    Ok(disk_count)
+}
+
+fn to_i64(value: u64, label: &str) -> RuntimeResult<i64> {
+    i64::try_from(value).map_err(|_| RuntimeError::Custom(format!("{label} exceeds i64")))
 }
 
 fn recovery_identity(disk_paths: &[PathBuf]) -> RuntimeResult<RecoveryIdentity> {
@@ -325,7 +433,7 @@ fn recovery_identity(disk_paths: &[PathBuf]) -> RuntimeResult<RecoveryIdentity> 
         devices.dedup();
         if devices.is_empty() {
             return Err(RuntimeError::Custom(
-                "active writeback admission has no backing filesystem identity".into(),
+                "active writeback pressure policy has no backing filesystem identity".into(),
             ));
         }
         let backing_devices = devices
@@ -431,7 +539,7 @@ fn recover_stale_allocation(allocation: &writeback_allocation::Model) -> Runtime
         let recorded_boot_id = normalize_boot_id(&allocation.boot_id)?;
         if recorded_boot_id != current_boot_id {
             // The page cache and all process locks disappeared at reboot, so no abandoned dirty
-            // data from the recorded boot can still consume this boot's admission budget.
+            // data from the recorded boot can still affect this boot's pressure membership.
             return Ok(());
         }
         let devices = parse_backing_devices(&allocation.backing_devices)?;
@@ -685,7 +793,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     use super::{DeviceId, decode_mountinfo_path, normalize_boot_id, parse_backing_devices};
-    use super::{acquire, is_valid_lease_name, reservation_bytes};
+    use super::{acquire, is_valid_lease_name, requested_max_bytes};
 
     fn test_disks(dir: &TempDir, count: usize) -> Vec<PathBuf> {
         (0..count)
@@ -709,7 +817,7 @@ mod tests {
         Migrator::up(db.inner(), None).await.unwrap();
 
         let sandbox_id = sandbox::ActiveModel {
-            name: Set("writeback-admission-test".into()),
+            name: Set("writeback-pressure-test".into()),
             config: Set("{}".into()),
             status: Set(sandbox::SandboxStatus::Running),
             ephemeral: Set(false),
@@ -738,8 +846,8 @@ mod tests {
 
     #[test]
     fn reservation_multiplies_the_per_disk_limit() {
-        assert_eq!(reservation_bytes(1280, 3).unwrap(), 3840);
-        assert!(reservation_bytes(u64::MAX, 2).is_err());
+        assert_eq!(requested_max_bytes(1280, 3).unwrap(), 3840);
+        assert!(requested_max_bytes(u64::MAX, 2).is_err());
     }
 
     #[test]
@@ -780,7 +888,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn admission_rejects_overcommit_and_reuses_released_credit() {
+    async fn pressure_admits_overcommit_and_rebalances_live_limits() {
         let (dir, db, run_ids) = test_db().await;
         let lease_dir = dir.path().join("leases");
         let per_disk = 512 * 1024 * 1024;
@@ -807,31 +915,6 @@ mod tests {
         )
         .await
         .unwrap();
-        let error = match acquire(
-            &db,
-            run_ids[2],
-            &lease_dir,
-            Some(pool),
-            Some(per_disk),
-            &disks,
-        )
-        .await
-        {
-            Ok(_) => panic!("third reservation unexpectedly exceeded the global pool"),
-            Err(error) => error,
-        };
-
-        assert!(error.to_string().contains("host writeback pool exhausted"));
-        assert_eq!(
-            writeback_allocation::Entity::find()
-                .all(&db)
-                .await
-                .unwrap()
-                .len(),
-            2
-        );
-
-        first.release(&db).await.unwrap();
         let third = acquire(
             &db,
             run_ids[2],
@@ -842,21 +925,31 @@ mod tests {
         )
         .await
         .unwrap();
+
         assert_eq!(
             writeback_allocation::Entity::find()
                 .all(&db)
                 .await
                 .unwrap()
                 .len(),
-            2
+            3
         );
+        first.refresh(&db).await.unwrap();
+        second.refresh(&db).await.unwrap();
+        assert_eq!(first.limit().unwrap().target_bytes(), pool / 3);
+        assert_eq!(second.limit().unwrap().target_bytes(), pool / 3);
+        assert_eq!(third.limit().unwrap().target_bytes(), pool / 3);
 
-        second.release(&db).await.unwrap();
         third.release(&db).await.unwrap();
+        first.refresh(&db).await.unwrap();
+        assert_eq!(first.limit().unwrap().target_bytes(), per_disk);
+
+        first.release(&db).await.unwrap();
+        second.release(&db).await.unwrap();
     }
 
     #[tokio::test]
-    async fn admission_preserves_the_most_restrictive_live_pool() {
+    async fn pressure_preserves_the_most_restrictive_live_pool() {
         let (dir, db, run_ids) = test_db().await;
         let lease_dir = dir.path().join("leases");
         let limit = 512 * 1024 * 1024;
@@ -872,22 +965,6 @@ mod tests {
         )
         .await
         .unwrap();
-        let error = match acquire(
-            &db,
-            run_ids[1],
-            &lease_dir,
-            Some(2 * limit),
-            Some(limit),
-            &disks,
-        )
-        .await
-        {
-            Ok(_) => panic!("larger caller pool escaped the active smaller policy"),
-            Err(error) => error,
-        };
-        assert!(error.to_string().contains(&limit.to_string()));
-
-        first.release(&db).await.unwrap();
         let second = acquire(
             &db,
             run_ids[1],
@@ -898,11 +975,18 @@ mod tests {
         )
         .await
         .unwrap();
+        first.refresh(&db).await.unwrap();
+        assert_eq!(first.limit().unwrap().target_bytes(), limit / 2);
+        assert_eq!(second.limit().unwrap().target_bytes(), limit / 2);
+
+        first.release(&db).await.unwrap();
+        second.refresh(&db).await.unwrap();
+        assert_eq!(second.limit().unwrap().target_bytes(), limit);
         second.release(&db).await.unwrap();
     }
 
     #[tokio::test]
-    async fn disabled_admission_does_not_create_a_lease_or_catalog_row() {
+    async fn disabled_pressure_pool_does_not_create_a_lease_or_catalog_row() {
         let (dir, db, run_ids) = test_db().await;
         let lease_dir = dir.path().join("leases");
         let disks = test_disks(&dir, 1);
@@ -926,11 +1010,12 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+        assert_eq!(guard.limit().unwrap().target_bytes(), 512 * 1024 * 1024);
         guard.release(&db).await.unwrap();
     }
 
     #[tokio::test]
-    async fn admission_recovers_credit_after_owner_crash() {
+    async fn pressure_pool_recovers_membership_after_owner_crash() {
         let (dir, db, run_ids) = test_db().await;
         let lease_dir = dir.path().join("leases");
         let limit = 512 * 1024 * 1024;
@@ -966,7 +1051,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn admission_survives_run_cleanup_until_credit_is_safely_released() {
+    async fn pressure_membership_survives_run_cleanup_until_safely_released() {
         let (dir, db, run_ids) = test_db().await;
         let lease_dir = dir.path().join("leases");
         let limit = 512 * 1024 * 1024;
@@ -1002,7 +1087,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn concurrent_admission_cannot_overcommit_one_credit() {
+    async fn concurrent_pressure_membership_keeps_both_creators() {
         let (dir, first_db, run_ids) = test_db().await;
         let second_db = DbWriteConnection::open(
             &dir.path().join("catalog.db"),
@@ -1034,21 +1119,64 @@ mod tests {
             ),
         );
 
-        assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
+        assert!(first.is_ok());
+        assert!(second.is_ok());
         assert_eq!(
             writeback_allocation::Entity::find()
                 .all(&first_db)
                 .await
                 .unwrap()
                 .len(),
-            1
+            2
         );
 
-        if let Ok(guard) = first {
-            guard.release(&first_db).await.unwrap();
-        }
-        if let Ok(guard) = second {
-            guard.release(&second_db).await.unwrap();
-        }
+        let first = first.unwrap();
+        let second = second.unwrap();
+        first.refresh(&first_db).await.unwrap();
+        second.refresh(&second_db).await.unwrap();
+        assert_eq!(first.limit().unwrap().target_bytes(), limit / 2);
+        assert_eq!(second.limit().unwrap().target_bytes(), limit / 2);
+        first.release(&first_db).await.unwrap();
+        second.release(&second_db).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn pressure_counts_every_writable_disk_in_the_fair_share() {
+        let (dir, db, run_ids) = test_db().await;
+        let lease_dir = dir.path().join("leases");
+        let limit = 512 * 1024 * 1024;
+        let pool = 3 * 256 * 1024 * 1024;
+        let two_disks = test_disks(&dir, 2);
+        let one_disk = vec![two_disks[0].clone()];
+
+        let first = acquire(
+            &db,
+            run_ids[0],
+            &lease_dir,
+            Some(pool),
+            Some(limit),
+            &two_disks,
+        )
+        .await
+        .unwrap();
+        let second = acquire(
+            &db,
+            run_ids[1],
+            &lease_dir,
+            Some(pool),
+            Some(limit),
+            &one_disk,
+        )
+        .await
+        .unwrap();
+
+        first.refresh(&db).await.unwrap();
+        assert_eq!(first.limit().unwrap().target_bytes(), pool / 3);
+        assert_eq!(second.limit().unwrap().target_bytes(), pool / 3);
+
+        second.release(&db).await.unwrap();
+        first.refresh(&db).await.unwrap();
+        assert_eq!(first.limit().unwrap().target_bytes(), pool / 2);
+        first.release(&db).await.unwrap();
     }
 }

--- a/crates/runtime/lib/writeback/mod.rs
+++ b/crates/runtime/lib/writeback/mod.rs
@@ -1,4 +1,4 @@
-//! Host-global admission for bounded block writeback.
+//! Host-global pressure coordination for bounded block writeback.
 
 mod admission;
 
@@ -6,4 +6,4 @@ mod admission;
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
 
-pub(crate) use admission::acquire;
+pub(crate) use admission::{WritebackPressureGuard, acquire};

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -190,15 +190,15 @@ When the root-disk default is flat, plain `msb pull IMAGE` also prepares the reu
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `block_writeback` | `{ "mode": "off" }` | Buffered host writeback containment and admission. The compatibility default cannot reject sandbox creation because of host-global dirty-credit capacity. Operators can opt into `auto` or `fixed` after sizing the policy for their workload and node. |
+| `block_writeback` | `{ "mode": "auto" }` | Buffered host writeback containment and live pressure sharing on Linux. Pool pressure never rejects sandbox creation; unconfigured `auto` is a no-op on other hosts. |
 
 ### `runtime.block_writeback`
 
 | Field | Modes | Default | Description |
 |-------|-------|---------|-------------|
-| `mode` | all | `"off"` | `auto` uses the smaller of the measured 1536 MiB per-disk ceiling and the available aggregate pool, `fixed` requires an exact `per_disk_mib`, and `off` disables both the VMM hard bound and host-global admission. |
-| `per_disk_mib` | `fixed` | required | Explicit hard budget for each eligible writable raw disk. The minimum is 128 MiB. This field is rejected in `auto` and `off` modes. |
-| `pool_mib` | `auto`, `fixed` | `null` | Optional aggregate dirty-credit admission-pool override. `null` derives the pool as the lower of 10% of physical RAM and a conservative estimate of Linux's dirty-background threshold, using the exact byte threshold when configured or the ratio applied to current `MemAvailable`. In `auto`, the pool reduces the per-disk window when necessary but must fit libkrun's 128 MiB minimum. In `fixed`, it must fit at least one complete configured per-disk budget. This field is rejected in `off` mode. |
+| `mode` | all | `"auto"` | `auto` gives each eligible disk a measured 1536 MiB maximum and shares the aggregate pool when the host is busy, `fixed` requires an explicit maximum, and `off` disables both the VMM bound and host-global pressure coordination. |
+| `per_disk_mib` | `fixed` | required | Explicit maximum for each eligible writable raw disk. The boot-time maximum is at least 128 MiB; the live fair share may fall below it under aggregate pressure. This field is rejected in `auto` and `off` modes. |
+| `pool_mib` | `auto`, `fixed` | `null` | Optional aggregate dirty-credit pressure-pool override. `null` derives the pool as the lower of 10% of physical RAM and a conservative estimate of Linux's dirty-background threshold, using the exact byte threshold when configured or the ratio applied to current `MemAvailable`. This field is rejected in `off` mode. |
 
 Use a fixed policy only when representative measurements justify a different per-disk window:
 
@@ -214,7 +214,7 @@ Use a fixed policy only when representative measurements justify a different per
 }
 ```
 
-`pool_mib` is admission capacity, not eagerly allocated RAM. Each sandbox reserves `per-disk window × eligible disks` from it before boot, while actual host page-cache use follows guest writes. Linux rejects creation if the pool cannot admit the complete requested reservation. `fixed` and an explicitly pooled `auto` policy are unsupported on other hosts.
+`pool_mib` is a live pressure budget, not eagerly allocated RAM. Every eligible writable disk in the same `MSB_HOME` receives a weighted max-min fair share: disks with a smaller configured maximum keep that smaller value, and the remaining pool is divided equally across the rest. Creating another sandbox never fails merely because this pool is full. Existing VMMs observe membership changes within 250 ms; if a disk already owns more dirty data than its new share, libkrun retires accounted ranges and pauses later writes until it converges below the target. A guest write already reserved before the target changed is allowed to complete safely. `fixed` and an explicitly pooled `auto` policy are unsupported on other hosts.
 
 Hardware CRC32C, the guest kernel preemption model, x2APIC, APICv/AVIC capability, vCPU affinity mechanics, and the pure-Rust ext4 writer are implementation or capability details rather than user policy, so they intentionally have no global config keys. The [performance guide](/optimization/overview#optimizations-that-are-not-knobs) explains how those automatic layers interact with the configurable policy.
 

--- a/docs/optimization/overview.mdx
+++ b/docs/optimization/overview.mdx
@@ -23,7 +23,7 @@ Start with `msb doctor`, keep the workload and benchmark procedure unchanged, an
 | Flat `clone` strategy | `auto` | Controls whether private flat roots use a metadata-only copy-on-write clone or a sparse copy | Local storage provisioning |
 | `sandbox_defaults.cpu_placement` | `inherit` | Coordinates and pins vCPU threads to host logical processors | Linux and Windows hosts |
 | `sandbox_defaults.thp` | `madvise` | Sets the guest Linux transparent-huge-page boot policy | Every newly booted sandbox |
-| `runtime.block_writeback` | `off` | Opt-in bound for buffered host dirty data per writable raw disk and admission against one derived pool | Linux, writable raw disks using writeback caching |
+| `runtime.block_writeback` | `auto` | Bounds buffered host dirty data per writable raw disk and live-shares one derived pool without rejecting creates | Linux, writable raw disks using writeback caching |
 | x2APIC, CRC32C, PREEMPT_NONE | Selected by the compatible runtime and firmware | Reduces interrupt, checksum, and scheduler overhead | Applicable shipping guest builds |
 | AMD AVIC or Intel APICv | Host KVM policy | Accelerates virtual interrupt delivery used by the x86 guest | Linux x86 hosts with capable hardware |
 
@@ -34,7 +34,7 @@ Explicit CLI or SDK settings override `config.json`, which overrides built-in de
 | Root layout and clone strategy | `sandbox_defaults.oci.root_disk` | `--root-disk flat:8G,clone=auto` |
 | CPU placement | `sandbox_defaults.cpu_placement` | `--cpu-placement inherit|auto|spread|compact` |
 | Guest THP | `sandbox_defaults.thp` | `--thp always|madvise|never` |
-| Buffered block writeback limit and admission pool | `runtime.block_writeback` | Global runtime policy only |
+| Buffered block writeback limit and pressure pool | `runtime.block_writeback` | Global runtime policy only |
 
 The Rust, TypeScript, Python, and Go SDK builders expose the same per-sandbox choices. The block writeback limit and pool are global because they control host VMM storage policy rather than one guest-visible sandbox specification.
 
@@ -63,7 +63,7 @@ There is no universal fastest profile. The following is a reasonable starting po
 }
 ```
 
-`cpu_placement: auto` is intentionally not a portable macOS default: managed placement is unsupported on macOS because the operating system does not expose an equivalent public hard-affinity API. Use `inherit` on macOS. Keep `thp: madvise` unless a representative workload and density test justify another policy. The measured profile above explicitly opts into buffered-writeback containment: on Linux, `auto` uses up to the measured 1.5 GiB window that kept the unchanged OVH customer disk suite at containment-off throughput, reducing the hard per-disk limit when the bounded host pool is smaller. On macOS and Windows, an unpooled `auto` policy is a no-op because this controller governs Linux host page-cache writeback. The aggregate Linux pool remains derived from host capacity, so node density is bounded rather than hidden. Use `fixed` when the exact measured window is a deployment requirement.
+`cpu_placement: auto` is intentionally not a portable macOS default: managed placement is unsupported on macOS because the operating system does not expose an equivalent public hard-affinity API. Use `inherit` on macOS. Keep `thp: madvise` unless a representative workload and density test justify another policy. On Linux, the default writeback `auto` policy gives an idle disk the measured 1.5 GiB window that kept the unchanged OVH customer disk suite at containment-off throughput. When more writable disks join than the pool can support at that maximum, all live VMMs reduce their targets to a fair share and apply write pressure instead of rejecting the new sandbox. On macOS and Windows, unconfigured `auto` is a no-op because this controller governs Linux host page-cache writeback. Use `fixed` when a different per-disk maximum is justified by measurement.
 
 ## Storage layout: layered or flat
 
@@ -170,13 +170,13 @@ Enabling AVIC or APICv changes interrupt-delivery performance, not the sandbox i
 
 ## Buffered block writeback limit
 
-The opt-in `auto` policy uses up to a 1536 MiB hard budget for each writable raw disk on Linux. That window is the smallest tested final-scheduler profile that preserved the unchanged customer suite's approximately 1 GiB hot file at containment-off sequential-write throughput. Libkrun reserves exact page-aligned extents before each mutation and lets that finite cache window absorb hot rewrites. It starts bounded background retirement only when a new unique page would exceed the hard budget or the exact extent ledger reaches its fragmentation ceiling. Rewriting an already charged page consumes no new credit; a truly growing working set receives backpressure before it can cross the limit.
+The default `auto` policy uses up to a 1536 MiB hard budget for each writable raw disk on Linux. That window is the smallest tested final-scheduler profile that preserved the unchanged customer suite's approximately 1 GiB hot file at containment-off sequential-write throughput. Libkrun reserves exact page-aligned extents before each mutation and lets that finite cache window absorb hot rewrites. It starts bounded background retirement only when a new unique page would exceed the hard budget or the exact extent ledger reaches its fragmentation ceiling. Rewriting an already charged page consumes no new credit; a truly growing working set receives backpressure before it can cross the limit.
 
 When pressure does require retirement, the background worker kicks queued ranges before waiting for their page-cache writeback to complete, and it releases exact range credit only after that completion. It does not turn each internal batch into a durability barrier. Guest `FLUSH` still performs the existing full Imago flush and sync after all earlier block work, including the host-filesystem metadata required to retrieve the data; the controller does not acknowledge guest durability early. Controller, storage, worker, range-completion, or full-sync failures remain latched and fail future mutations and reactivations closed.
 
-Every active policy also enables spawn-time admission against one aggregate dirty-credit pool. The default pool is the lower of 10% of physical memory and a conservative estimate of the host's dirty-background threshold. An explicit `vm.dirty_background_bytes` is used directly; ratio mode applies `vm.dirty_background_ratio` to current `MemAvailable`, not `MemTotal`, because Linux explicitly excludes unavailable memory from its ratio denominator. `auto` never shrinks the tested 1536 MiB window to fit a small pool: creation fails clearly if the node cannot admit one complete per-disk budget. This preserves the performance meaning of `auto` instead of silently substituting the measured-slow 512 MiB behavior. A `fixed` policy likewise preserves its requested limit and fails if the pool cannot admit it. Set `pool_mib` only when an operator needs to override the derived aggregate capacity.
+Every active policy also joins one aggregate dirty-credit pressure pool. The default pool is the lower of 10% of physical memory and a conservative estimate of the host's dirty-background threshold. An explicit `vm.dirty_background_bytes` is used directly; ratio mode applies `vm.dirty_background_ratio` to current `MemAvailable`, not `MemTotal`, because Linux explicitly excludes unavailable memory from its ratio denominator. Each disk keeps its configured maximum while capacity is available. Under pressure, weighted max-min sharing gives every eligible writable disk the same target unless that disk's maximum is smaller. A new sandbox therefore starts under pressure instead of failing at the capacity boundary. Set `pool_mib` only when an operator needs to override the derived aggregate capacity.
 
-For example, this fixed profile admits at most eight one-disk VMs, four two-disk VMs, or another combination whose reservations fit 12 GiB:
+For example, this fixed profile gives up to eight active writable disks the complete 1.5 GiB window inside a 12 GiB pool. A ninth disk still starts, but all nine targets become roughly 1.33 GiB until one leaves:
 
 ```json
 {
@@ -190,24 +190,25 @@ For example, this fixed profile admits at most eight one-disk VMs, four two-disk
 }
 ```
 
-Each VM reserves `per-disk limit × eligible writable raw disks` in one retryable SQLite transaction before libkrun is built. Concurrent creators cannot both claim the last credit, and a live reservation admitted under a smaller pool keeps that more restrictive capacity until it drains. The reservation is held by an owner-only process lock. Normal release synchronizes retained descriptors for the exact verified backing files before recycling credit, so containment does not depend on a cooperative guest issuing `FLUSH`. After a process crash in the same boot, those process-held descriptors are gone; the next creator acquires the stale lease and performs `syncfs` on each identity-verified recorded backing filesystem before removing the reservation. After a host reboot, the old page cache is already gone. The reservation is deliberately independent of the transient run row, while missing, malformed, or unverifiable recovery state stays charged. This transaction and recovery path are not on the block-I/O path: libkrun enforces the admitted per-disk budgets locally after boot.
+Each VM records its requested per-disk maximum and eligible writable-disk count in one retryable SQLite transaction before libkrun is built. This is membership bookkeeping, not hard admission: concurrent creators all join, then weighted max-min sharing computes each live per-disk target from the active set. An owner-only process lock makes stale membership detectable. Normal release synchronizes retained descriptors for the exact verified backing files before leaving the pool, so containment does not depend on a cooperative guest issuing `FLUSH`. After a process crash in the same boot, those descriptors are gone; the next creator acquires the stale lease and performs `syncfs` on each identity-verified recorded backing filesystem before removing the membership. After a host reboot, the old page cache is already gone. This coordination and recovery path is not on the block-I/O path: libkrun enforces the current per-disk target locally after boot.
 
 ```mermaid
 flowchart LR
     A["Create VM"] --> B["Count eligible<br/>writable raw disks"]
-    B --> C["Reserve dirty credit<br/>SQLite transaction + process lease"]
-    C -->|"fits"| D["Build libkrun<br/>per-disk hard limits"]
-    C -->|"pool full"| E["Fail before boot<br/>with requested and occupied bytes"]
-    D --> F["Virtio-blk writeback<br/>local VMM enforcement"]
-    F --> G["VM exits<br/>release reservation"]
-    G -. "crash: next creator locks lease, syncs backing filesystems, then recycles credit" .-> C
+    B --> C["Join pressure pool<br/>SQLite transaction + process lease"]
+    C --> D["Compute fair share<br/>pool ÷ active disks"]
+    D --> E["Build libkrun<br/>live per-disk limits"]
+    E --> F["Membership changes<br/>refresh within 250 ms"]
+    F --> G["Over target?<br/>retire ranges, then continue"]
+    G --> H["VM exits<br/>leave pool; peers grow"]
+    H -. "crash: next creator locks lease, syncs backing filesystems, then removes stale membership" .-> C
 ```
 
-The allocation catalog and leases are shared by processes using the same `MSB_HOME`. Production processes contributing to one node budget therefore need the same runtime home and service identity; separate homes are separate administrative domains. This mechanism bounds aggregate Microsandbox dirty credit in that domain. It is not a substitute for sizing guest memory, storage capacity, or unrelated host workloads.
+The allocation catalog and leases are shared by processes using the same `MSB_HOME`. Production processes contributing to one node budget therefore need the same runtime home and service identity; separate homes are separate administrative domains. A lower target cannot erase dirty pages that already exist, so the aggregate pool is a convergence boundary rather than an instantaneous reservation invariant: after membership grows, existing controllers retire excess ownership before admitting more writes. It is not a substitute for sizing guest memory, storage capacity, or unrelated host workloads.
 
-`off` is the compatibility default and disables both the VMM-owned bound and admission for newly spawned sandboxes, so ordinary creation cannot fail because a derived host-global pool is full. It permits a long-running guest to accumulate more host dirty data and may worsen the final flush tail. It is not faster than the correctly sized pressure-triggered window in the focused OVH customer disk suite: final `auto` at 1536 MiB reached 8,933.5 MB/s sequential write versus 8,895 MB/s with containment off, while the same final scheduler at 512 MiB reached only 1,406.5 MB/s. Neither the per-disk controller nor admission depends on cgroups or guest cooperation. The policy has no effect on read-only disks, direct-I/O disks, non-raw formats, cache modes without writeback, or non-Linux VMM paths.
+`off` is an explicit compatibility escape hatch that disables both the VMM-owned bound and pressure coordination for newly spawned sandboxes. It permits a long-running guest to accumulate more host dirty data and may worsen the final flush tail. It is not faster than the correctly sized pressure-triggered window in the focused OVH customer disk suite: an idle 1536 MiB window reached 8,933.5 MB/s sequential write versus 8,895 MB/s with containment off, while a 512 MiB target reached only 1,406.5 MB/s. Pool pressure intentionally trades that cache-assisted burst performance for density without turning capacity into a sandbox-creation failure. Neither the per-disk controller nor coordination depends on cgroups or guest cooperation. The policy has no effect on read-only disks, direct-I/O disks, non-raw formats, cache modes without writeback, or non-Linux VMM paths.
 
-The first OVH staircase exposed why simply raising the hard ceiling did not help: every profile still retired hot data in eager 128–256 MiB generations and delivered approximately 1,668 MB/s sequential write against 8,783 MB/s with the controller off. The pressure-triggered design instead keeps a repeatedly overwritten 1 GiB fio file resident inside a 1.5 GiB finite window and retires data only when unique dirty coverage would cross the bound. In the unchanged exact-candidate follow-up, sequential write recovered to 8,933.5 MB/s versus 8,895 MB/s off, and all eight emitted metrics were at parity or above. The dated planning report records the original staircase, corrected customer-suite measurements, exact final candidate, host dirty telemetry and crash-safe multi-VM admission validation.
+The first OVH staircase exposed why simply raising the hard ceiling did not help: every profile still retired hot data in eager 128–256 MiB generations and delivered approximately 1,668 MB/s sequential write against 8,783 MB/s with the controller off. The pressure-triggered design instead keeps a repeatedly overwritten 1 GiB fio file resident inside a 1.5 GiB finite window and retires data only when unique dirty coverage would cross the bound. In the unchanged exact-candidate follow-up, sequential write recovered to 8,933.5 MB/s versus 8,895 MB/s off, and all eight emitted metrics were at parity or above. The dated planning report records the original staircase, corrected customer-suite measurements, exact final candidate, host dirty telemetry and crash-safe multi-VM pressure validation.
 
 ## Optimizations that are not knobs
 

--- a/sdk/rust/lib/config/mod.rs
+++ b/sdk/rust/lib/config/mod.rs
@@ -257,7 +257,7 @@ pub struct OciSandboxDefaults {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct RuntimeConfig {
-    /// Buffered host writeback containment and admission policy.
+    /// Buffered host writeback containment and pressure-sharing policy.
     pub block_writeback: BlockWritebackConfig,
 }
 
@@ -265,19 +265,19 @@ pub struct RuntimeConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "mode", rename_all = "lowercase", deny_unknown_fields)]
 pub enum BlockWritebackConfig {
-    /// Use up to the measured per-disk limit, bounded by the aggregate pool.
+    /// Use the measured per-disk maximum and share the aggregate pool under pressure.
     Auto {
-        /// Optional host-global dirty-credit pool override in MiB.
+        /// Optional host-global dirty-credit pressure-pool override in MiB.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pool_mib: Option<NonZero<u64>>,
     },
 
-    /// Use an explicit per-disk limit and derive the aggregate pool unless overridden.
+    /// Use an explicit per-disk maximum and derive the pressure pool unless overridden.
     Fixed {
         /// Maximum page-aligned dirty data charged to one writable raw disk, in MiB.
         per_disk_mib: NonZero<u64>,
 
-        /// Optional host-global dirty-credit pool override in MiB.
+        /// Optional host-global dirty-credit pressure-pool override in MiB.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pool_mib: Option<NonZero<u64>>,
     },
@@ -666,9 +666,9 @@ impl Default for SandboxDefaults {
 
 impl Default for BlockWritebackConfig {
     fn default() -> Self {
-        // Keep ordinary sandbox creation independent of host-global dirty-credit capacity.
-        // Operators can opt into bounded writeback after sizing it for their workload and node.
-        Self::Off {}
+        // Auto is portable: Linux bounds dirty data and shares a derived pool, while other hosts
+        // treat the unconfigured policy as a no-op.
+        Self::Auto { pool_mib: None }
     }
 }
 
@@ -1243,10 +1243,13 @@ mod tests {
         assert_eq!(cfg.database.max_connections, 5);
         assert_eq!(cfg.database.connect_timeout_secs, 30);
         assert_eq!(cfg.database.busy_timeout_secs, 5);
-        assert_eq!(cfg.runtime.block_writeback, BlockWritebackConfig::Off {});
+        assert_eq!(
+            cfg.runtime.block_writeback,
+            BlockWritebackConfig::Auto { pool_mib: None }
+        );
         assert_eq!(
             serde_json::to_value(cfg.runtime.block_writeback).unwrap(),
-            serde_json::json!({ "mode": "off" })
+            serde_json::json!({ "mode": "auto" })
         );
     }
 
@@ -1255,7 +1258,10 @@ mod tests {
         let cfg: LocalConfig = serde_json::from_str("{}").unwrap();
         assert_eq!(cfg.sandbox_defaults.cpus, 1);
         assert!(cfg.home.is_none());
-        assert_eq!(cfg.runtime.block_writeback, BlockWritebackConfig::Off {});
+        assert_eq!(
+            cfg.runtime.block_writeback,
+            BlockWritebackConfig::Auto { pool_mib: None }
+        );
     }
 
     #[test]

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -758,10 +758,8 @@ fn resolve_linux_block_writeback_policy(
     total_memory_bytes: u64,
     derived_pool_bytes: Option<u64>,
 ) -> MicrosandboxResult<(Option<u64>, Option<u64>)> {
-    let (requested_limit_bytes, explicit_pool_mib, is_auto) = match config {
-        BlockWritebackConfig::Auto { pool_mib } => {
-            (AUTO_BLOCK_WRITEBACK_LIMIT_BYTES, pool_mib, true)
-        }
+    let (limit_bytes, explicit_pool_mib) = match config {
+        BlockWritebackConfig::Auto { pool_mib } => (AUTO_BLOCK_WRITEBACK_LIMIT_BYTES, pool_mib),
         BlockWritebackConfig::Off {} => return Ok((None, None)),
         BlockWritebackConfig::Fixed {
             per_disk_mib,
@@ -778,7 +776,7 @@ fn resolve_linux_block_writeback_policy(
                     "runtime.block_writeback.per_disk_mib exceeds the supported byte range".into(),
                 )
             })?;
-            (limit_bytes, pool_mib, false)
+            (limit_bytes, pool_mib)
         }
     };
     let explicit_pool_bytes = explicit_pool_mib
@@ -798,35 +796,6 @@ fn resolve_linux_block_writeback_policy(
     if pool_bytes > total_memory_bytes {
         return Err(MicrosandboxError::InvalidConfig(format!(
             "writeback pool ({pool_bytes} bytes) exceeds physical host memory ({total_memory_bytes} bytes)"
-        )));
-    }
-
-    // Auto is capacity-sensitive by definition: retain the measured ceiling on large hosts while
-    // selecting a smaller hard bound on denser hosts. Fixed remains the opt-in exact-budget mode.
-    let limit_bytes = if is_auto {
-        requested_limit_bytes.min(pool_bytes)
-    } else {
-        requested_limit_bytes
-    };
-    if limit_bytes < MIN_BLOCK_WRITEBACK_LIMIT_BYTES {
-        let source = if explicit_pool_bytes.is_some() {
-            "configured runtime.block_writeback.pool_mib"
-        } else {
-            "derived writeback pool"
-        };
-        return Err(MicrosandboxError::InvalidConfig(format!(
-            "{source} provides {pool_bytes} bytes but auto requires at least the {}-byte minimum per-disk limit",
-            MIN_BLOCK_WRITEBACK_LIMIT_BYTES
-        )));
-    }
-    if pool_bytes < limit_bytes {
-        let source = if explicit_pool_bytes.is_some() {
-            "configured runtime.block_writeback.pool_mib"
-        } else {
-            "derived writeback pool"
-        };
-        return Err(MicrosandboxError::InvalidConfig(format!(
-            "{source} provides {pool_bytes} bytes but must fit the {limit_bytes}-byte fixed per-disk limit; increase the pool or lower the fixed per-disk limit"
         )));
     }
 
@@ -864,7 +833,9 @@ fn auto_block_writeback_pool_bytes(
             })?
             / 100
     };
-    Ok(conservative_cap.min(kernel_background))
+    // A zero background threshold is a valid host tuning. Preserve one byte of cooperative
+    // credit so libkrun can clamp it to one host page and retain forward progress.
+    Ok(conservative_cap.min(kernel_background).max(1))
 }
 
 #[cfg(target_os = "linux")]
@@ -890,7 +861,7 @@ fn linux_auto_block_writeback_pool_bytes(
 fn linux_meminfo_bytes(field: &str) -> MicrosandboxResult<u64> {
     let meminfo = std::fs::read_to_string("/proc/meminfo").map_err(|error| {
         MicrosandboxError::Runtime(format!(
-            "read /proc/meminfo for writeback admission: {error}"
+            "read /proc/meminfo for writeback pressure policy: {error}"
         ))
     })?;
     let value_kib = meminfo
@@ -903,7 +874,7 @@ fn linux_meminfo_bytes(field: &str) -> MicrosandboxResult<u64> {
         })
         .ok_or_else(|| {
             MicrosandboxError::Runtime(format!(
-                "parse {field} from /proc/meminfo for writeback admission"
+                "parse {field} from /proc/meminfo for writeback pressure policy"
             ))
         })?;
     value_kib.checked_mul(1024).ok_or_else(|| {
@@ -4743,18 +4714,23 @@ mod tests {
                     Some(constrained_pool),
                 )
                 .unwrap(),
-                (Some(constrained_pool), Some(constrained_pool))
+                (
+                    Some(AUTO_BLOCK_WRITEBACK_LIMIT_BYTES),
+                    Some(constrained_pool)
+                )
             );
 
-            assert!(
+            assert_eq!(
                 resolve_linux_block_writeback_policy(
                     BlockWritebackConfig::Auto { pool_mib: None },
                     64 * 1024 * 1024 * 1024,
                     Some(MIN_BLOCK_WRITEBACK_LIMIT_BYTES - 1),
                 )
-                .unwrap_err()
-                .to_string()
-                .contains("minimum per-disk limit")
+                .unwrap(),
+                (
+                    Some(AUTO_BLOCK_WRITEBACK_LIMIT_BYTES),
+                    Some(MIN_BLOCK_WRITEBACK_LIMIT_BYTES - 1)
+                )
             );
             assert_eq!(
                 auto_block_writeback_pool_bytes(
@@ -4796,6 +4772,16 @@ mod tests {
                 .unwrap(),
                 8 * 1024 * 1024 * 1024 / 10
             );
+            assert_eq!(
+                auto_block_writeback_pool_bytes(
+                    64 * 1024 * 1024 * 1024,
+                    60 * 1024 * 1024 * 1024,
+                    0,
+                    0,
+                )
+                .unwrap(),
+                1
+            );
             assert!(
                 auto_block_writeback_pool_bytes(
                     64 * 1024 * 1024 * 1024,
@@ -4808,12 +4794,16 @@ mod tests {
                 .contains("must not exceed 100")
             );
         }
-        // Default local execution must never reserve aggregate writeback credit or reject a
-        // second sandbox merely because the host's derived pool cannot fit another full window.
-        assert_eq!(
-            block_writeback_policy(&RuntimeConfig::default()).unwrap(),
-            (None, None)
-        );
+        // The portable default enables live pressure sharing on Linux and remains a no-op on
+        // platforms where this host page-cache controller does not apply.
+        let default_policy = block_writeback_policy(&RuntimeConfig::default()).unwrap();
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(default_policy.0, Some(AUTO_BLOCK_WRITEBACK_LIMIT_BYTES));
+            assert!(default_policy.1.is_some_and(|pool_bytes| pool_bytes > 0));
+        }
+        #[cfg(not(target_os = "linux"))]
+        assert_eq!(default_policy, (None, None));
 
         assert_eq!(
             block_writeback_policy(&RuntimeConfig {
@@ -4859,9 +4849,12 @@ mod tests {
                     None,
                 )
                 .unwrap(),
-                (Some(512 * 1024 * 1024), Some(512 * 1024 * 1024))
+                (
+                    Some(AUTO_BLOCK_WRITEBACK_LIMIT_BYTES),
+                    Some(512 * 1024 * 1024)
+                )
             );
-            assert!(
+            assert_eq!(
                 resolve_linux_block_writeback_policy(
                     BlockWritebackConfig::Fixed {
                         per_disk_mib: NonZero::new(1024).unwrap(),
@@ -4870,9 +4863,8 @@ mod tests {
                     64 * 1024 * 1024 * 1024,
                     None,
                 )
-                .unwrap_err()
-                .to_string()
-                .contains("fixed per-disk limit")
+                .unwrap(),
+                (Some(1024 * 1024 * 1024), Some(512 * 1024 * 1024))
             );
         }
     }


### PR DESCRIPTION
## TL;DR

Replaces hard writeback-pool admission with live weighted fair sharing, so new sandboxes start under pressure instead of failing when the aggregate pool is full.

## Description

- Gives every eligible writable disk one fair-share weight, including multiple disks attached to one sandbox.
- Refreshes running VMM targets within 250 ms as members join and leave.
- Lets already-reserved writes finish safely, then retires excess dirty ownership and pressures subsequent writes until the disk converges.
- Fails closed to a one-page forward-progress target if coordination is unavailable.
- Preserves crash-safe leases and identity-verified stale-member recovery.
- Makes unconfigured `auto` the default: active on Linux, portable no-op on macOS and Windows.
- Updates configuration and optimization documentation to describe pressure sharing and convergence rather than hard admission.

## Dependency status

- [x] superradcompany/libkrun#103 merged.
- [x] Live writeback controls released in `msb_krun` 0.1.28.
- [x] Temporary Git dependency replaced with the exact crates.io release.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] strict Clippy for `microsandbox-runtime` and `microsandbox`
- [x] repository pre-commit workspace Clippy, docs, agentd, and CLI build hooks
- [x] `cargo test --workspace --exclude microsandbox-agentd`
- [x] Full GitHub CI on the implementation head
- [x] `cargo check -p microsandbox-runtime` against released `msb_krun` 0.1.28
- [ ] Fresh GitHub CI on the released-dependency head
