### PR TITLE
fix(cli): parse dns network rules in release builds

### DIFF
--- a/crates/cli/lib/net_rule.rs
+++ b/crates/cli/lib/net_rule.rs
@@ -266,7 +266,8 @@ fn parse_dns_rule(
     }
 
     let mut parts = right.splitn(4, ':');
-    debug_assert_eq!(parts.next(), Some("dns"));
+    let target = parts.next();
+    debug_assert_eq!(target, Some("dns"));
     let proto_raw = parts.next();
     let ports_raw = parts.next();
     if parts.next().is_some() {


### PR DESCRIPTION
## TL;DR

Make `allow@dns` and qualified DNS network rules parse correctly in optimized `msb` builds by advancing the DNS target iterator outside the debug assertion.

## Description

- Consume the semantic `dns` target unconditionally before reading protocol and port qualifiers.
- Keep the parser invariant assertion without relying on debug-only side effects.
- Restore the documented DNS network-rule behavior in release builds.
- Fixes #1293.

```bash
msb run --net-default deny --net-rule "allow@dns" alpine -- nslookup example.com
```

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p microsandbox-cli --lib`
- [x] `cargo test --release -p microsandbox-cli --lib net_rule::tests::dns_target_expands_to_gateway_udp_and_tcp_port_53 -- --exact --nocapture`
- [x] `cargo clippy -p microsandbox-cli --lib -- -D warnings`
